### PR TITLE
Fix Git commits with commit message file paths that contain spaces

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -440,7 +440,7 @@ namespace MonoDevelop.VersionControl.Git
 			try {
 				File.WriteAllText (file, changeSet.GlobalComment);
 				string paths = ToCmdPathList (changeSet.Items.Select (it => it.LocalPath));
-				RunCommand ("commit -F " + file + " " + paths, true, monitor);
+				RunCommand ("commit -F \"" + file + "\" " + paths, true, monitor);
 			} finally {
 				File.Delete (file);
 			}


### PR DESCRIPTION
Trying to run a Commit from the Git addin on Windows doesn't work because the temporary file path that the commit message is written to contains spaces, and the path is passed unquoted to the git binary. This patch quotes the path (on all platforms).
