### PR TITLE
Support for Xsp4 in AspNetDebugger

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
@@ -69,6 +69,11 @@ namespace MonoDevelop.Debugger.Soft.AspNet
 			case ClrVersion.Net_4_0:
 				startInfo.Command = prefix.Combine ("lib", "mono", "4.0", subdirectory, "xsp4.exe");
 				break;
+			default:
+				MonoDevelop.Core.LoggingService.LogWarning ("Unknown clr version ({0}). Using the latest known xsp: xsp4.",
+					cmd.ClrVersion);
+				startInfo.Command = prefix.Combine ("lib", "mono", "4.0", subdirectory, "xsp4.exe");
+				break;
 			}
 		
 			string error;


### PR DESCRIPTION
Changed the if to switch. Reworked the flow to have only one switch. Emit the warning if ClrVersion is not known.

Untested on windows, but "should just work"(tm)
