### PR TITLE
20101016 bug635342 wrong view for visual diff

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -170,8 +170,27 @@ namespace MonoDevelop.VersionControl.Views
 			foreach (VersionControlItem item in items) {
 				var document = IdeApp.Workbench.OpenDocument (item.Path);
 				DiffView.AttachViewContents (document, item);
-				document.Window.SwitchView (1);
+				int viewNum = FindDiffView (document.Window.SubViewContents) + 1;
+				document.Window.SwitchView (viewNum);
 			}
+		}
+		
+		private static int FindDiffView (IEnumerable<IAttachableViewContent> subContents)
+		{
+			int idx = -1;
+			int i = 0;
+			
+			foreach (IAttachableViewContent item in subContents) {
+				if (item is DiffView)
+				{
+					idx = i;
+					break;
+				}
+				
+				i++;
+			}
+			
+			return idx;
 		}
 		
 		public static bool CanShow (VersionControlItemList items)


### PR DESCRIPTION
Fix for Bug 635342 (https://bugzilla.novell.com/show_bug.cgi?id=635342). Old code assumed that diff view was at index 1, but new layout of visual designer moves it compared to non-visual documents. Fix calculates the position instead of assuming.
