### PR TITLE
Git NodeBuilder Bug Fix

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitNodeBuilderExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitNodeBuilderExtension.cs
@@ -60,7 +60,7 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			IWorkspaceObject ob = (IWorkspaceObject) dataObject;
 			GitRepository rep = VersionControlService.GetRepository (ob) as GitRepository;
-			if (rep != null && rep.RootPath.CanonicalPath == ob.BaseDirectory.CanonicalPath) {
+			if (rep != null) {
 				IWorkspaceObject rob;
 				if (repos.TryGetValue (rep.RootPath.CanonicalPath, out rob)) {
 					if (ob == rob)


### PR DESCRIPTION
I like to put my solution files under a src directory and not at the same level as the .git directory.  Therefore the branch name would never show up beside the solution node for my project.  This fixes that issue by removing the check on whether the workspace item's directory is the same as the .git directory.
