### PR TITLE
The ConsoleView.Buffer property is exposed as public

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ConsoleView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ConsoleView.cs
@@ -217,7 +217,7 @@ namespace MonoDevelop.Components
 			get { return Buffer.GetIterAtMark (Buffer.InsertMark); }
 		}
 		
-		Gtk.TextBuffer Buffer {
+		public Gtk.TextBuffer Buffer {
 			get { return textView.Buffer; }
 		}
 		


### PR DESCRIPTION
Currently, F# interactive uses the ConsoleView component as a view. In order to support  advanced features of FSI (f# interactive), I exposed the ViewModel, i.e. the TextBuffer to the presenting components.
