### PR TITLE
Minor fix to make MD build again

### DIFF
--- a/main/src/core/MonoDevelop.Core/Makefile.am
+++ b/main/src/core/MonoDevelop.Core/Makefile.am
@@ -64,6 +64,7 @@ FILES =  \
 	MonoDevelop.Core.Execution/NativeExecutionCommand.cs \
 	MonoDevelop.Core.Execution/NativePlatformExecutionHandler.cs \
 	MonoDevelop.Core.Execution/ProcessExecutionCommand.cs \
+	MonoDevelop.Core.Execution/ProcessExtensions.cs \
 	MonoDevelop.Core.Execution/ProcessHostController.cs \
 	MonoDevelop.Core.Execution/ProcessService.cs \
 	MonoDevelop.Core.Execution/ProcessWrapper.cs \


### PR DESCRIPTION
Currently MD won't build because of changes made by Lluis today. The code is all there, but the Makefile doesn't include the extensions file that contains one of the required extension methods.
