### PR TITLE
GDB Backtrace leaves GDB at wrong frame

### DIFF
--- a/extras/MonoDevelop.Debugger.Gdb/GdbSession.cs
+++ b/extras/MonoDevelop.Debugger.Gdb/GdbSession.cs
@@ -253,8 +253,14 @@ namespace MonoDevelop.Debugger.Gdb
 		protected override void OnFinish ()
 		{
 			SelectThread (activeThread);
-			RunCommand ("-stack-select-frame", "0");
-			RunCommand ("-exec-finish");
+			
+			GdbCommandResult res = RunCommand ("-stack-info-depth", "2");
+			if (res.GetValue ("depth") == "1") {
+				RunCommand ("-exec-continue");
+			} else {
+				RunCommand ("-stack-select-frame", "0");
+				RunCommand ("-exec-finish");
+			}
 		}
 
 		protected override object OnInsertBreakEvent (BreakEvent be, bool activate)


### PR DESCRIPTION
When you step through a program using GDB, it iterates down through the frames to resolve arguments / local varaiables / etc. After it generates the backtrace, however, GDB is positioned at frame 0. Trying to step out (GDB 'finish') will cause an error.

The way I worked around this is every time we change the frame, restore it to its previous value when we are done. I track the previous value by looking at the member variable 'currentFrame' before switching, but it might be better to ask GDB what frame it is on rather than trying to track this variable (GDB could potentially be set to a different frame outside of the backtrace class).

Example program:
    void function() {
        return;
    }
    int main(int argc, char *\* argv) {
        function();
        return 0;
    }
place a breakpoint in the first line of main 'function();' and start debugging. Step into function 'function', then try and step out.
