### PR TITLE
Gdb working directory

### DIFF
--- a/extras/MonoDevelop.Debugger.Gdb/GdbSession.cs
+++ b/extras/MonoDevelop.Debugger.Gdb/GdbSession.cs
@@ -120,7 +120,7 @@ namespace MonoDevelop.Debugger.Gdb
 					throw;
 				}
 
-				RunCommand ("-environment-directory", Escape (startInfo.WorkingDirectory));
+				RunCommand ("-environment-cd", Escape (startInfo.WorkingDirectory));
 				
 				// Set inferior arguments
 				if (!string.IsNullOrEmpty (startInfo.Arguments))


### PR DESCRIPTION
The wrong command was being used to set the working directory for GDB: use '-environment-cd' instead of '-environment-directory'

See http://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Program-Context.html
