### PR TITLE
Fix zipfile generation of MonoDevelop.app on the 2.4 branch

### DIFF
--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -93,7 +93,7 @@ MonoDevelop.app:
 	@rm -f missing-stuff
 
 MonoDevelop.app.zip: MonoDevelop.app
-	zip -r9uq MonoDevelop.app.zip MonoDevelop.app
+	zip -r9uyq MonoDevelop.app.zip MonoDevelop.app
 
 update-png:
 	/Applications/Inkscape.app/Contents/Resources/script --without-gui --export-png=`pwd`/dmg-bg.png `pwd`/dmg-bg.svg


### PR DESCRIPTION
My apologies for the earlier duplicate pull request—this is what I had originally intended; I'm still figuring out Github's pull requests.
