### PR TITLE
Updating project not building in a clean environment

### DIFF
--- a/extras/MonoDevelop.Debugger.Win32/CorApi/CorApi.csproj
+++ b/extras/MonoDevelop.Debugger.Win32/CorApi/CorApi.csproj
@@ -65,9 +65,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call "$(FrameworkSDKDir)bin\ildasm.exe" /NOBAR "$(TargetDir)CorApi.dll" /OUT="$(TargetDir)CorApiMDImp.il"
+    <PostBuildEvent>call "C:\Program Files\Microsoft SDKs\Windows\v7.0A\bin\NETFX 4.0 Tools\ildasm.exe" /NOBAR "$(TargetDir)CorApi.dll" /OUT="$(TargetDir)CorApiMDImp.il"
 del /F /Q "$(TargetDir)CorApi.dll" 
-call "$(FrameworkDir)\ilasm.exe" /DLL /DEBUG /OUT="$(TargetDir)CorApi.dll" "$(ProjectDir)refs.il" "$(ProjectDir)context.il" "$(ProjectDir)cordblib.il" "$(ProjectDir)corpublib.il" "$(TargetDir)CorApiMDImp.il"
+call "$(FrameworkDir)$(FrameworkVersion)\ilasm.exe" /DLL /DEBUG /OUT="$(TargetDir)CorApi.dll" "$(ProjectDir)refs.il" "$(ProjectDir)context.il" "$(ProjectDir)cordblib.il" "$(ProjectDir)corpublib.il" "$(TargetDir)CorApiMDImp.il"
 del /F /Q "$(TargetDir)CorApiMDImp.il"
 del /F /Q "$(TargetDir)CorApiMDImp.res"</PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
While trying to bulid the MSI CorApi is built using msbuild. Sadly it makes use of environment variables which do not exist in a standard Visual Studio Command Prompt or other enviornment that I know of.

Applying these changes fixed the build for me. Hopefully it'll help the next guy too.
