### PR TITLE
C# Formatter dialog

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingProfileDialog.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingProfileDialog.cs
@@ -864,7 +864,7 @@ delegate void BarFoo ();
 		int[] test;
 	}";
 			category = AddOption (whiteSpaceOptions, upperCategory, null, GettextCatalog.GetString ("Array Declarations"), example);
-			AddOption (whiteSpaceOptions, category, "SpacesBeforeArrayDeclarationBrackets", GettextCatalog.GetString ("before opening bracket"), condOpExample);
+			AddOption (whiteSpaceOptions, category, "SpacesBeforeArrayDeclarationBrackets", GettextCatalog.GetString ("before opening bracket"), example);
 			/*
 			whiteSpaceOptions= new ListStore (typeof (Option), typeof (bool), typeof (bool)); 
 			column = new TreeViewColumn ();


### PR DESCRIPTION
Hey,

I noticed that there were some options missing in the formatter dialog, so I added them based on the already available settings in `CSharpFormattingPolicy`. While doing that I also fixed two copy-paste errors in the code.

poke
