### PR TITLE
add *.Master files highlight in non asp.net projects

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -50,7 +50,7 @@
 		<FileFilter id = "Html"
 		            insertbefore="AllFiles"
 		            _label = "Web Files"
-		            extensions = "*.htm,*.html,*.aspx,*.ascx,*.asp"/>
+		            extensions = "*.htm,*.html,*.aspx,*.ascx,*.asp,*.master"/>
 			    
 		<FileFilter id = "Xml"
 		            insertbefore="AllFiles"


### PR DESCRIPTION
this makes MD highlight Master page files in non asp.net projects. Actually MD currently does highlight but only for lowercased file names (i dunno why).  Can be helpful for those writing asp.net/asp.net mvc plugins etc.
