### PR TITLE
[C] Reorder linker args again, to fix another static linking bug.

### DIFF
--- a/main/src/addins/CBinding/Compiler/GNUCompiler.cs
+++ b/main/src/addins/CBinding/Compiler/GNUCompiler.cs
@@ -386,7 +386,7 @@ namespace CBinding
 			}
 			
 			string linker_args = string.Format ("-o \"{0}\" {1} {2} {3}",
-			    outputName, pkgargs, objectFiles, args.ToString ());
+			    outputName, objectFiles, pkgargs, args.ToString ());
 			
 			monitor.BeginTask (GettextCatalog.GetString ("Generating binary \"{0}\" from object files", Path.GetFileName (outputName)), 1);
 			
@@ -464,7 +464,7 @@ namespace CBinding
 			}
 			
 			string linker_args = string.Format ("-shared -o \"{0}\" {1} {2} {3}",
-			    outputName, pkgargs, objectFiles, args.ToString ());
+			    outputName, objectFiles, pkgargs, args.ToString ());
 			
 			monitor.BeginTask (GettextCatalog.GetString ("Generating shared object \"{0}\" from object files", Path.GetFileName (outputName)), 1);
 			


### PR DESCRIPTION
Bug 661570.
- Compiler/GNUCompiler.cs: Move object files first in linker command line.

License: MIT/X11
