### PR TITLE
Use DebuggerSession.OnDebuggerOutput rather than Console.WriteLine in ObjectValue.

### DIFF
--- a/main/src/core/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
+++ b/main/src/core/Mono.Debugging/Mono.Debugging.Client/ObjectValue.cs
@@ -489,7 +489,8 @@ namespace Mono.Debugging.Client
 							ConnectCallbacks (parentFrame, cs);
 							children.AddRange (cs);
 						} catch (Exception ex) {
-							Console.WriteLine (ex);
+							if (parentFrame != null)
+								parentFrame.DebuggerSession.OnDebuggerOutput( true, ex.ToString());
 							children.Add (CreateFatalError ("", ex.Message, ObjectValueFlags.ReadOnly));
 						}
 					}


### PR DESCRIPTION
Use DebuggerSession.OnDebuggerOutput rather than Console.WriteLine in ObjectValue.
