### PR TITLE
Append type as postfix in outline and classes pad.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpAmbience.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpAmbience.cs
@@ -269,10 +269,7 @@ namespace MonoDevelop.CSharp
 		{
 			StringBuilder result = new StringBuilder ();
 			result.Append (settings.EmitModifiers (base.GetString (property.Modifiers)));
-			if (settings.IncludeReturnType) {
-				result.Append (GetString (property.ReturnType, settings));
-				result.Append (settings.Markup (" "));
-			}
+
 			if (!settings.IncludeReturnType && settings.UseFullName) {
 				result.Append (GetString (property.DeclaringType, OutputFlags.UseFullName));
 				result.Append (settings.Markup ("."));
@@ -284,6 +281,12 @@ namespace MonoDevelop.CSharp
 				AppendParameterList (result, settings, property.Parameters);
 				result.Append (settings.Markup ("]"));
 			}
+
+			if (settings.IncludeReturnType) {
+				result.Append (settings.Markup (" : "));
+				result.Append (GetString (property.ReturnType, settings));
+			}
+
 			return result.ToString ();
 		}
 		
@@ -320,16 +323,17 @@ namespace MonoDevelop.CSharp
 			StringBuilder result = new StringBuilder ();
 			result.Append (settings.EmitModifiers (base.GetString (field.Modifiers)));
 			bool isEnum = field.DeclaringType != null && field.DeclaringType.ClassType == ClassType.Enum;
-			if (settings.IncludeReturnType && !isEnum) {
-				result.Append (GetString (field.ReturnType, settings));
-				result.Append (settings.Markup (" "));
-			}
 			
 			if (!settings.IncludeReturnType && settings.UseFullName) {
 				result.Append (GetString (field.DeclaringType, OutputFlags.UseFullName));
 				result.Append (settings.Markup ("."));
 			}
 			result.Append (settings.EmitName (field, FilterName (Format (field.Name))));
+
+			if (settings.IncludeReturnType && !isEnum) {
+				result.Append (settings.Markup (" : "));
+				result.Append (GetString (field.ReturnType, settings));
+			}
 			
 			return result.ToString ();
 		}
@@ -397,10 +401,6 @@ namespace MonoDevelop.CSharp
 			StringBuilder result = new StringBuilder ();
 			result.Append (settings.EmitModifiers (base.GetString (method.Modifiers)));
 			
-			if (settings.IncludeReturnType && !method.IsConstructor && !method.IsFinalizer) {
-				result.Append (GetString (method.ReturnType, settings));
-				result.Append (settings.Markup (" "));
-			}
 			if (!settings.IncludeReturnType && settings.UseFullName) {
 				result.Append (GetString (method.DeclaringType, OutputFlags.UseFullName));
 				result.Append (settings.Markup ("."));
@@ -474,6 +474,12 @@ namespace MonoDevelop.CSharp
 				result.Append (settings.Markup (")"));
 			}
 			OutputConstraints (result, settings, method.TypeParameters);
+
+			if (settings.IncludeReturnType && !method.IsConstructor && !method.IsFinalizer) {
+				result.Append (settings.Markup (" : "));
+				result.Append (GetString (method.ReturnType, settings));
+			}
+
 			return result.ToString ();
 		}
 		


### PR DESCRIPTION
Related to https://bugzilla.novell.com/show_bug.cgi?id=601001

The types of fields and properties and the return type of methods are now appended at the end in the outline and classes pads.

The formatting is similar to the one used in Eclipse/CDT. This is a screenshot of Eclipse/CDT

[<img src="http://img541.imageshack.us/img541/8360/eclipsecdtpostfixtypes.png">](http://img541.imageshack.us/img541/8360/eclipsecdtpostfixtypes.png)

This is the new Monodevelop formatting:

[<img src="http://img832.imageshack.us/img832/8607/monodeveloppostfixtypes.png">](http://img832.imageshack.us/img832/8607/monodeveloppostfixtypes.png)
