### PR TITLE
Little fixes to MonoDevelop.DocFood.

### DIFF
--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/DocFoodTextEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/DocFoodTextEditorExtension.cs
@@ -79,11 +79,18 @@ namespace MonoDevelop.DocFood
 			string documentationEmpty = GenerateEmptyDocumentation (member, textEditorData.Document.GetLineIndent (line));
 			
 			int offset = textEditorData.Caret.Offset;
-			textEditorData.Document.EndAtomicUndo ();
+			
+			bool wasInAtomicUndo = textEditorData.Document.IsInAtomicUndo;
+			if (wasInAtomicUndo)
+				textEditorData.Document.EndAtomicUndo ();
+			
 			int insertedLength = textEditorData.Insert (offset, documentationEmpty);
 			// important to set the caret position here for the undo step
 			textEditorData.Caret.Offset = offset + insertedLength;
-			textEditorData.Document.BeginAtomicUndo ();
+			
+			if (wasInAtomicUndo)
+				textEditorData.Document.BeginAtomicUndo ();
+			
 			insertedLength = textEditorData.Replace (offset, insertedLength, documentation);
 			textEditorData.Caret.Offset = offset + insertedLength;
 			return false;

--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/DocGenerator.cs
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/DocGenerator.cs
@@ -367,13 +367,16 @@ namespace MonoDevelop.DocFood
 				
 				if (type != null) {
 					IType resolvedType = type.SourceProjectDom.SearchType (type.CompilationUnit, type, type.Location, exceptionType);
-					string sentence = AmbienceService.GetDocumentationSummary (resolvedType).Trim ();
-					if (sentence.StartsWith ("<para>") && sentence.EndsWith ("</para>"))
-						sentence = sentence.Substring ("<para>".Length, sentence.Length - "<para>".Length - "</para>".Length).Trim ();
-					if (sentence.StartsWith ("Represents the error that occurs when"))
-						sentence = "Is thrown when" + sentence.Substring ("Represents the error that occurs when".Length);
-					if (!string.IsNullOrEmpty (sentence))
-						Set ("exception", curName, sentence);
+					string sentence = AmbienceService.GetDocumentationSummary (resolvedType);
+					if (! string.IsNullOrEmpty(sentence)) {
+						sentence = sentence.Trim ();
+						if (sentence.StartsWith ("<para>") && sentence.EndsWith ("</para>"))
+							sentence = sentence.Substring ("<para>".Length, sentence.Length - "<para>".Length - "</para>".Length).Trim ();
+						if (sentence.StartsWith ("Represents the error that occurs when"))
+							sentence = "Is thrown when" + sentence.Substring ("Represents the error that occurs when".Length);
+						if (!string.IsNullOrEmpty (sentence))
+							Set ("exception", curName, sentence);
+					}
 				}
 				
 				DocConfig.Instance.Rules.ForEach (r => r.Run (this));


### PR DESCRIPTION
DocFoodTextEditorExtension do not end (or begin) atomic undos that were not previously begun.
DocGenerator.GenerateDoc() do not throw NullReferenceException when the call to AmbienceService.GetDocumentationSummary() returns null.

This should fix the problems with documentation I experienced running MonoDevelop on Microsoft Windows.
