### PR TITLE
ILBinding: Don't highlight noappdomain, noprocess, and nomachine. These are not keywords.

### DIFF
--- a/main/src/core/Mono.Texteditor/SyntaxModes/ILSyntaxMode.xml
+++ b/main/src/core/Mono.Texteditor/SyntaxModes/ILSyntaxMode.xml
@@ -471,9 +471,6 @@
 		<Word>.hash</Word>
 		<Word>.assembly</Word>
 		<Word>implicitcom</Word>
-		<Word>noappdomain</Word>
-		<Word>noprocess</Word>
-		<Word>nomachine</Word>
 		<Word>.publickey</Word>
 		<Word>.publickeytoken</Word>
 		<Word>algorithm</Word>


### PR DESCRIPTION
ILBinding: Don't highlight noappdomain, noprocess, and nomachine. These are not keywords.
