### PR TITLE
ILBinding: Highlight 'object' and 'string' as types, and add 'legacy', 'library', 'x86', 'amd64', and 'ia64' as modifiers.

### DIFF
--- a/main/src/core/Mono.Texteditor/SyntaxModes/ILSyntaxMode.xml
+++ b/main/src/core/Mono.Texteditor/SyntaxModes/ILSyntaxMode.xml
@@ -392,6 +392,7 @@
 		<Word>serializable</Word>
 		<Word>at</Word>
 		<Word>tls</Word>
+		<Word>retargetable</Word>
 		<Word>x86</Word>
 		<Word>amd64</Word>
 		<Word>ia64</Word>


### PR DESCRIPTION
ILBinding: Highlight 'object' and 'string' as types, and add 'legacy', 'library', 'x86', 'amd64', and 'ia64' as modifiers.
