### PR TITLE
allow copy from datagrid to clipboard

### DIFF
--- a/extras/MonoDevelop.Database/MonoDevelop.Database.Components/MonoDevelop.Database.Components.addin.xml
+++ b/extras/MonoDevelop.Database/MonoDevelop.Database.Components/MonoDevelop.Database.Components.addin.xml
@@ -61,6 +61,9 @@
 	</Extension>
 	
 	<Extension path = "/MonoDevelop/Database/ContextMenu/DataGrid">
+		<CommandItem id = "MonoDevelop.Ide.Commands.EditCommands.Copy" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.EditCommands.SelectAll" />
+		<SeparatorItem id = "CopySelecSectionEnd" />
 		<ItemSet id = "MonoDevelop.Database.Components.VisualizeAs" _label = "Visualize Data">
 			<CommandItem id = "MonoDevelop.Database.Components.DataGridCommands.VisualizeAsList" />
 		</ItemSet>


### PR DESCRIPTION
this will help copy selected rows fom SQL query result into clipboard and make it easy e.g to paste into text editor or  LibreOffice calc. Columns are tab separated (that's how it's done in e.g SQL Server Management Studio)
