### PR TITLE
fix build on windows

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/QuickTaskStrip.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/QuickTaskStrip.cs
@@ -204,7 +204,8 @@ namespace MonoDevelop.SourceEditor
 			pattern.AddColorStop (1, GetIndicatorColor (severity));
 			cr.Pattern = pattern;
 			cr.FillPreserve ();
-			pattern.Dispose ();
+			IDisposable dispPattern = pattern;
+			dispPattern.Dispose ();
 			
 			cr.Color = darkColor;
 			cr.Stroke ();


### PR DESCRIPTION
I can't say why pattern.Dispose () on QuickTaskStrip.cs was dispatched to the Dispose(bool) private method of pattern.

BTW, using IDisposable fixed the build.
