### PR TITLE
[Debugger] Allow watch pad value deletion with any delete key.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -957,7 +957,42 @@ namespace MonoDevelop.Debugger
 				CleanPinIcon ();
 			return base.OnLeaveNotifyEvent (evnt);
 		}
-
+		
+		protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
+		{
+			// Ignore if editing a cell, or if not editable
+			if (!AllowEditing || !AllowAdding || editing)
+				return base.OnKeyPressEvent (evnt);
+			
+			// Delete the current item with any delete key
+			switch (evnt.Key) {
+			case Gdk.Key.Delete:
+			case Gdk.Key.KP_Delete:
+			case Gdk.Key.BackSpace:
+				TreePath path;
+				TreeViewColumn column;
+				TreeIter iter;
+				ObjectValue val;
+				string expression;
+				
+				// Get the expression and value at the cursor
+				GetCursor (out path, out column);
+				Model.GetIter (out iter, path);
+				val = (ObjectValue)store.GetValue (iter, ObjectCol);
+				expression = GetFullExpression (iter);
+				
+				// Lookup and remove
+				if (val != null && values.Contains (val)) {
+					RemoveValue (val);
+					return true;
+				} else if (!string.IsNullOrEmpty (expression) && valueNames.Contains (expression)) {
+					RemoveExpression (expression);
+					return true;
+				}
+				break;
+			}
+			return base.OnKeyPressEvent (evnt);
+		}
 
 		protected override bool OnButtonPressEvent (Gdk.EventButton evnt)
 		{
@@ -1133,10 +1168,13 @@ namespace MonoDevelop.Debugger
 		string GetFullExpression (TreeIter it)
 		{
 			string exp = "";
-			while (store.GetPath (it).Depth != 1) {
-				ObjectValue val = (ObjectValue) store.GetValue (it, ObjectCol);
+			TreePath path = store.GetPath (it);
+			
+			while (path != null && path.Depth != 1) {
+				ObjectValue val = (ObjectValue)store.GetValue (it, ObjectCol);
 				exp = val.ChildSelector + exp;
 				store.IterParent (out it, it);
+				path = store.GetPath (it);
 			}
 			string name = (string) store.GetValue (it, NameCol);
 			return name + exp;


### PR DESCRIPTION
- MonoDevelop.Debugger/ObjectValueTreeView.cs: Allow value deletion with any delete key.

License: MIT/X11
