### PR TITLE
fix stack overflow in CSharpSyntaxMode.cs

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/CSharpSyntaxMode.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/CSharpSyntaxMode.cs
@@ -355,7 +355,7 @@ namespace MonoDevelop.CSharp.Highlighting
 					if (semanticStyle != null) {
 						if (endLoc < chunk.EndOffset) {
 							base.AddRealChunk (new Chunk (chunk.Offset, endLoc - chunk.Offset, semanticStyle));
-							AddRealChunk (new Chunk (endLoc, chunk.EndOffset - endLoc, chunk.Style));
+							base.AddRealChunk (new Chunk (endLoc, chunk.EndOffset - endLoc, chunk.Style));
 							return;
 						}
 						chunk.Style = semanticStyle;


### PR DESCRIPTION
This change should fix a MonoDevelop's stackoverflow when loading a file containing (or any other containing generics):

```
using System.Collections.Generic;
namespace Sample
{
    public class CrashSample
    {
        private List<object> _mocks = new List<object>();
    }
}
```
