### PR TITLE
fix build on windows 7

### DIFF
--- a/main/src/addins/WindowsPlatform/RecentFiles.cs
+++ b/main/src/addins/WindowsPlatform/RecentFiles.cs
@@ -28,6 +28,7 @@ using System;
 using System.Runtime.InteropServices;
 using MonoDevelop.Ide.Desktop;
 using System.Collections.Generic;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Platform
 {


### PR DESCRIPTION
fix build on windows 7 

@mhutch I added a missing using of MonoDevelop.Core in RecentFiles.cs
