### PR TITLE
NRefactory's csproj point to the right snk path

### DIFF
--- a/main/contrib/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj
+++ b/main/contrib/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj
@@ -17,7 +17,7 @@
     <RunCodeAnalysis>False</RunCodeAnalysis>
     <CodeAnalysisRules>-Microsoft.Design#CA1026;-Microsoft.Security#CA2104</CodeAnalysisRules>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\ICSharpCode.NRefactory.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>ICSharpCode.NRefactory.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyMode>File</AssemblyOriginatorKeyMode>
   </PropertyGroup>


### PR DESCRIPTION
small build fix to NRefactory's csproj (wrong location of snk in csproj)
