### PR TITLE
Consider python2.7 and python2 in PythonHelper

### DIFF
--- a/extras/PyBinding/PyBinding/PyBinding/PythonHelper.cs
+++ b/extras/PyBinding/PyBinding/PyBinding/PythonHelper.cs
@@ -109,6 +109,13 @@ namespace PyBinding
 			// next preferred type.
 			
 			try {
+				return new Python27Runtime () {
+					Path = Which ("python2.7")
+				};
+			}
+			catch {}
+			
+			try {
 				return new Python26Runtime () {
 					Path = Which ("python2.6")
 				};
@@ -129,8 +136,10 @@ namespace PyBinding
 		
 		public static string FindPreferredPython ()
 		{
+			try { return Which ("python2.7"); } catch {}
 			try { return Which ("python2.6"); } catch {}
 			try { return Which ("python2.5"); } catch {}
+			try { return Which ("python2"); } catch {}
 			try { return Which ("python"); } catch {}
 			
 			throw new FileNotFoundException ("Could not locate python executable");


### PR DESCRIPTION
Consider Python 2.7 as preferred Python/Runtime. Possible fix to many issues on Arch Linux where the Python 2.x executable is /usr/bin/python2 (also /usr/bin/python2.7).
