### PR TITLE
Allow CreateMemberImplementation to do the logic of creating the implemention

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/CodeGenerationService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/CodeGenerationService.cs
@@ -91,7 +91,8 @@ namespace MonoDevelop.Ide
 
 			generator.IndentLevel = CalculateBodyIndentLevel (parsedDocument.CompilationUnit.GetTypeAt (type.Location));
 			var generatedCode = generator.CreateMemberImplementation (type, newMember, implementExplicit);
-			suitableInsertionPoint.Insert (data, generatedCode.Code);
+			var code = generatedCode.Code;
+			if (!String.IsNullOrEmpty(code)) suitableInsertionPoint.Insert (data, code);
 			if (!isOpen) {
 				try {
 					File.WriteAllText (type.CompilationUnit.FileName, data.Text);


### PR DESCRIPTION
Allow CreateMemberImplementation to do the logic of creating the implementation itself, needed for Pascal as it has two places where a method goes (in the interface section, and the implementation). When the "insert" api gets an empty code fragment, it inserts 2 empty lines, this change works around that.
