### PR TITLE
CompilationErrorTooltipProvider.GetItem blocks other custom ITooltipProvider

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/CompileErrorTooltipProvider.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/CompileErrorTooltipProvider.cs
@@ -43,8 +43,18 @@ namespace MonoDevelop.SourceEditor
 		
 		public TooltipItem GetItem (Mono.TextEditor.TextEditor editor, int offset)
 		{
-			ExtensibleTextEditor ed = (ExtensibleTextEditor) editor;
-			return new TooltipItem (ed.GetErrorInformationAt (offset), editor.Document.GetLineByOffset (offset));
+			ExtensibleTextEditor ed = editor as ExtensibleTextEditor;
+
+			if(ed==null)
+				return null;
+
+			string errorInformation=ed.GetErrorInformationAt (offset);
+
+			// If no error information were obtained, return.
+			if (string.IsNullOrEmpty(errorInformation))
+				return null;
+
+			return new TooltipItem (errorInformation, editor.Document.GetLineByOffset (offset));			
 		}
 		
 		public Gtk.Window CreateTooltipWindow (Mono.TextEditor.TextEditor editor, int offset, Gdk.ModifierType modifierState, TooltipItem item)


### PR DESCRIPTION
It seems that in custom implementations of ITooltipProvider(extention registered via "/MonoDevelop/SourceEditor2/TooltipProviders"), GetItem never gets called because the inner routine only takes the first non-null tooltip item object found. And CompilationErrorTooltipProvider is always provides a non-null TooltipItem object (although e.g. there is no compilation error) in its GetItem method. 

added a patch sent over from 
Alexander Bothe (http://sourceforge.net/users/abothe)
