### PR TITLE
Allow MD to open text files with incorrect encodings.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Text/TextFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Text/TextFile.cs
@@ -163,7 +163,7 @@ namespace MonoDevelop.Projects.Text
 							text = new StringBuilder (s);
 							return;
 						}
-					} catch (Exception ex) {
+					} catch (InvalidEncodingException ex) {
 						LoggingService.LogDebug (string.Format ("Skipping encoding {0}", co), ex);
 					}
 				} 


### PR DESCRIPTION
- MonoDevelop.Projects.Text/TextFile.cs: Handle exceptions when attempting encoding conversion.

License: MIT/X11

This fixes the "Unable to convert from UTF-8 to UTF-8" errors in the (majority, as far as I can tell) case where the source file is a valid encoding, but not the _first_ attempted encoding.
