### PR TITLE
Generate equality operators

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeGeneration/EqualityMembersGenerator.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeGeneration/EqualityMembersGenerator.cs
@@ -91,6 +91,35 @@ namespace MonoDevelop.CodeGeneration
 			
 			protected override IEnumerable<string> GenerateCode (INRefactoryASTProvider astProvider, string indent, List<IBaseMember> includedMembers)
 			{
+				bool isValueType = Options.EnclosingType.ClassType == MonoDevelop.Projects.Dom.ClassType.Struct;	
+				//Value types generate Equals method that takes concrete type, this
+				//avoids boxing/unboxing when value types are compared directly or called via generated equality operators
+				if (isValueType)
+					yield return GenerateDirectEqualsMethod (astProvider, indent, includedMembers);
+				yield return GenerateEqualsMethod (astProvider, indent, includedMembers, isValueType);
+				yield return GenerateGetHashCodeMethod (astProvider, indent, includedMembers);
+				yield return GenerateEqualsOperator (astProvider, indent, includedMembers, false, isValueType);
+				yield return GenerateEqualsOperator (astProvider, indent, includedMembers, true, isValueType);
+			}
+
+			protected string GenerateDirectEqualsMethod (INRefactoryASTProvider astProvider, string indent, List<IBaseMember> includedMembers)
+			{
+				var type = new DomReturnType (Options.EnclosingType).ConvertToTypeReference ();
+				// Genereate Equals
+				MethodDeclaration methodDeclaration = new MethodDeclaration ();
+				methodDeclaration.Name = "Equals";
+
+				methodDeclaration.ReturnType = DomReturnType.Bool.ConvertToTypeReference ();
+				methodDeclaration.Modifiers = ICSharpCode.NRefactory.CSharp.Modifiers.Public;
+				methodDeclaration.Body = new BlockStatement ();
+				methodDeclaration.Parameters.Add (new ParameterDeclaration (type, "obj"));
+				IdentifierExpression expr = new IdentifierExpression("obj");
+				methodDeclaration.Body.Add (new ReturnStatement(GenerateMembersEqualityTest (expr, includedMembers)));
+				return astProvider.OutputNode (this.Options.Dom, methodDeclaration, indent);
+			}
+			
+			private string GenerateEqualsMethod  (INRefactoryASTProvider astProvider, string indent, List<IBaseMember> includedMembers, bool isValueType)
+			{
 				// Genereate Equals
 				MethodDeclaration methodDeclaration = new MethodDeclaration ();
 				methodDeclaration.Name = "Equals";
@@ -123,27 +152,67 @@ namespace MonoDevelop.CodeGeneration
 				methodDeclaration.Body.Statements.Add (varDecl);
 				
 				IdentifierExpression otherId = new IdentifierExpression ("other");
+				//when generating Equals body for value type, use the Equals with concrete type
+				var returnExpr = isValueType ? new InvocationExpression (new IdentifierExpression ("Equals"), otherId.Clone ()) 
+					: GenerateMembersEqualityTest(otherId, includedMembers);
+				methodDeclaration.Body.Statements.Add (new ReturnStatement (returnExpr));
+				return astProvider.OutputNode (this.Options.Dom, methodDeclaration, indent);
+			}
+			
+			private Expression GenerateMembersEqualityTest (IdentifierExpression otherId, List<IBaseMember> includedMembers)
+			{
 				Expression binOp = null;
 				foreach (IMember member in includedMembers) {
-					Expression right = new BinaryOperatorExpression (new IdentifierExpression (member.Name), BinaryOperatorType.Equality, new MemberReferenceExpression (otherId, member.Name));
+					Expression right = new BinaryOperatorExpression (new IdentifierExpression (member.Name), BinaryOperatorType.Equality, new MemberReferenceExpression (otherId.Clone (), member.Name));
 					if (binOp == null) {
 						binOp = right;
 					} else {
 						binOp = new BinaryOperatorExpression (binOp, BinaryOperatorType.ConditionalAnd, right);
 					}
 				}
-
-				methodDeclaration.Body.Statements.Add (new ReturnStatement (binOp));
-				yield return astProvider.OutputNode (this.Options.Dom, methodDeclaration, indent);
-
-				methodDeclaration = new MethodDeclaration ();
+				return binOp;
+			}
+			
+			private string GenerateEqualsOperator (INRefactoryASTProvider astProvider, string indent, List<IBaseMember> includedMembers, bool negate, bool isValueType)
+			{
+				var leftId = new IdentifierExpression ("left");
+				var rightId = new IdentifierExpression ("right");
+				
+				var enclosingType = new DomReturnType (Options.EnclosingType).ConvertToTypeReference ();
+				var leftParam = new ParameterDeclaration (enclosingType, leftId.Identifier);
+				var rightParam = new ParameterDeclaration (enclosingType.Clone (), rightId.Identifier);
+				
+				var methodDeclaration = new MethodDeclaration ();
+				methodDeclaration.Name = negate ? "operator !=" : "operator ==";
+				
+				methodDeclaration.ReturnType = DomReturnType.Bool.ConvertToTypeReference ();
+				methodDeclaration.Modifiers = ICSharpCode.NRefactory.CSharp.Modifiers.Public | ICSharpCode.NRefactory.CSharp.Modifiers.Static;
+				methodDeclaration.Parameters.Add (leftParam);
+				methodDeclaration.Parameters.Add (rightParam);
+				methodDeclaration.Body = new BlockStatement ();
+				
+				Expression expr = null;
+				//for value type use Equals(..) with concrete type, this avoids pointless boxing/unboxing
+				if (isValueType)
+					expr = new InvocationExpression (new MemberReferenceExpression(leftId, "Equals"), rightId);
+				else
+					expr = new InvocationExpression (new IdentifierExpression ("Equals"), leftId, rightId);
+				if (negate)
+					expr = new UnaryOperatorExpression (UnaryOperatorType.Not, expr);
+				methodDeclaration.Body.Statements.Add (new ReturnStatement (expr));
+				return astProvider.OutputNode (this.Options.Dom, methodDeclaration, indent);
+			}
+			
+			private string GenerateGetHashCodeMethod (INRefactoryASTProvider astProvider, string indent, List<IBaseMember> includedMembers)
+			{
+				var methodDeclaration = new MethodDeclaration ();
 				methodDeclaration.Name = "GetHashCode";
 
 				methodDeclaration.ReturnType = DomReturnType.Int32.ConvertToTypeReference ();
 				methodDeclaration.Modifiers = ICSharpCode.NRefactory.CSharp.Modifiers.Public | ICSharpCode.NRefactory.CSharp.Modifiers.Override;
 				methodDeclaration.Body = new BlockStatement ();
 
-				binOp = null;
+				Expression binOp = null;
 				foreach (IMember member in includedMembers) {
 					Expression right;
 					right = new InvocationExpression (new MemberReferenceExpression (new IdentifierExpression (member.Name), "GetHashCode"));
@@ -162,7 +231,7 @@ namespace MonoDevelop.CodeGeneration
 				uncheckedBlock.Statements.Add (new ReturnStatement (binOp));
 
 				methodDeclaration.Body.Statements.Add (new UncheckedStatement (uncheckedBlock));
-				yield return astProvider.OutputNode (this.Options.Dom, methodDeclaration, indent);
+				return astProvider.OutputNode (this.Options.Dom, methodDeclaration, indent);
 			}
 		}
 	}


### PR DESCRIPTION
Patch adds equality operators generation to "Equality members" refactoring action. For value types (structs) additional Equals method is generated with parameter matching the enclosing type. This method is called from within equality operators body (avoids unnecessary boxing/unboxing) as well as from the Equals (object obj) method's body. Equals (SomeType type) can also be called from user code, which also improves performance by avoiding boxing when comparing two instances of the same value type.