### PR TITLE
Add ASSEMBLY_CONFIG to EXTRA_DIST in ValaBinding/Makefile.am

### DIFF
--- a/extras/ValaBinding/Makefile.am
+++ b/extras/ValaBinding/Makefile.am
@@ -96,7 +96,7 @@ valabindinglib_DATA = $(ASSEMBLY) $(ASSEMBLY_CONFIG)
 
 CLEANFILES = $(ASSEMBLY) $(ASSEMBLY).mdb
 
-EXTRA_DIST = $(FILES) $(RES)
+EXTRA_DIST = $(FILES) $(RES) $(ASSEMBLY_CONFIG)
 
 # include $(top_srcdir)/Makefile.include
 


### PR DESCRIPTION
Ensure ASSEMBLY_CONFIG is added to EXTRA_DIST. Otherwise MonoDevelop.ValaBinding.dll.config is missing from generated tarballs, causing build failure from tarballs.
