### PR TITLE
add targetframework attributes to web.config files

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/WebConfigApp.xft.xml
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/WebConfigApp.xft.xml
@@ -53,7 +53,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
 		    affects performance, set this value to true only 
 		    during development.
 		-->
-		<compilation defaultLanguage="${AspNetLanguage}" debug="false">
+		<compilation targetFramework="3.5" defaultLanguage="${AspNetLanguage}" debug="false">
 			<assemblies>
 				<add assembly="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=B77A5C561934E089"/>
 				<add assembly="System.Web.Extensions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>

--- a/main/src/addins/AspNet/MonoDevelop.AspNet/Templates/WebConfig-Application.xft.xml
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/Templates/WebConfig-Application.xft.xml
@@ -36,6 +36,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
 		<compilation 
 			defaultLanguage="${AspNetLanguage}"
 			debug="true"
+			targetFramework="3.5"
 		>
 			<assemblies>
 			</assemblies>


### PR DESCRIPTION
add targetframework attributes to web.config files to allow for automatic IIS apppool .NET version detection.
