### PR TITLE
Mono.Editor.Vi line jumping fix

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Vi/ViMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Vi/ViMode.cs
@@ -129,7 +129,7 @@ namespace Mono.TextEditor.Vi
 					statusText = value + " recording";
 				}
 			}
-		
+	
 		}
 		
 		protected virtual string RunExCommand (string command)
@@ -148,7 +148,7 @@ namespace Mono.TextEditor.Vi
 						return "Jumped to beginning of document.";
 					}
 					
-					Data.Caret.Line = line - 1;
+					Data.Caret.Line = line;
 					Editor.ScrollToCaret ();
 					return string.Format ("Jumped to line {0}.", line);
 				}


### PR DESCRIPTION
In vi-mode, jumping to a particular line using :N put the caret on line N-1 and jumping to line 1 using :1 caused the editor to crash. 
