### PR TITLE
Let 'third-party' tooltip providers create custom tooltip widgets

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/CompileErrorTooltipProvider.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/CompileErrorTooltipProvider.cs
@@ -43,8 +43,17 @@ namespace MonoDevelop.SourceEditor
 		
 		public TooltipItem GetItem (Mono.TextEditor.TextEditor editor, int offset)
 		{
-			ExtensibleTextEditor ed = (ExtensibleTextEditor) editor;
-			return new TooltipItem (ed.GetErrorInformationAt (offset), editor.Document.GetLineByOffset (offset));
+			ExtensibleTextEditor ed = editor as ExtensibleTextEditor;
+
+			if (ed == null)
+				return null;
+
+			string errorInformation = ed.GetErrorInformationAt(offset);
+
+			if (string.IsNullOrEmpty(errorInformation))
+				return null;
+
+			return new TooltipItem(errorInformation, editor.Document.GetLineByOffset(offset));
 		}
 		
 		public Gtk.Window CreateTooltipWindow (Mono.TextEditor.TextEditor editor, int offset, Gdk.ModifierType modifierState, TooltipItem item)


### PR DESCRIPTION
Made the compilation error tooltip provider not return null if no error data given. 
This let other providers be able to draw custom tooltips.
