### PR TITLE
Core: Prevent NRE when scanning Project references

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -793,6 +793,9 @@ namespace MonoDevelop.Projects
 					}
 					break;
 				case ReferenceType.Package:
+					if (pref.Package == null) {
+						break;
+					}
 					foreach (var assembly in pref.Package.Assemblies) {
 						try {
 							if (File.GetLastWriteTime (assembly.Location) > mtime)


### PR DESCRIPTION
There may be some references which have their
Package property with a null value (for instance
the dbus-sharp one in Banshee).

This fixes http://bugzilla.xamarin.com/show_bug.cgi?id=2648
