### PR TITLE
Bug 3636 Find references should find methods that implements/overrides the method

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ReferencesFinder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ReferencesFinder.cs
@@ -237,12 +237,16 @@ namespace MonoDevelop.Ide.FindInFiles
 				return new IEntity[] { member };
 			
 			// For renaming interface members search for all methods implementing the interface method.
+			// also search for overrides of the method
 			var declaringType = member.DeclaringType.GetDefinition ();
 			var methods = new List<IMethod> (declaringType.GetMethods (m => m.Name == member.Name));
 			var result = new List<IEntity> (methods);
-			if (declaringType.Kind == TypeKind.Interface) {
+			if (declaringType.Kind == TypeKind.Interface || (member.IsOverridable && declaringType.Kind == TypeKind.Class)) {
 				foreach (var p in solution.GetAllSolutionItems<Project> ()) {
 					foreach (var type in TypeSystemService.GetCompilation (p).GetAllTypeDefinitions ()) {
+						//avoid possible exception in IsDerivedFrom
+						if (type.Compilation != declaringType.Compilation)
+							continue;
 						if (!type.IsDerivedFrom (declaringType)) 
 							continue;
 						if (type.ReflectionName == declaringType.ReflectionName)


### PR DESCRIPTION
1. fixed a possible exception issue
2. search for overrides of the method when finding references.  
3. This should also fixed related renaming issues (part of Bug 2784 - Renaming a method does not account for virtual/override methods)
