### PR TITLE
Bug 3638 Preview dialog should use files that are already opened whenever possible

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringPreviewDialog.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringPreviewDialog.cs
@@ -133,9 +133,14 @@ namespace MonoDevelop.Refactoring
 				if (replaceChange == null) 
 					return;
 			
+				var openDocument = IdeApp.Workbench.GetDocument (replaceChange.FileName);
 				Mono.TextEditor.Document originalDocument = new Mono.TextEditor.Document ();
 				originalDocument.FileName = replaceChange.FileName;
-				originalDocument.Text = System.IO.File.ReadAllText (replaceChange.FileName);
+				if (openDocument == null) {
+					originalDocument.Text = System.IO.File.ReadAllText (replaceChange.FileName);
+				} else {
+					originalDocument.Text = openDocument.Editor.Document.Text;
+				}
 				
 				Mono.TextEditor.Document changedDocument = new Mono.TextEditor.Document ();
 				changedDocument.FileName = replaceChange.FileName;


### PR DESCRIPTION
If changes happen in files that haven't been saved, they are not correctly displayed in the dialog.
