### PR TITLE
Find references does not work for internal/internal-protected members/classes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ReferencesFinder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ReferencesFinder.cs
@@ -272,14 +272,24 @@ namespace MonoDevelop.Ide.FindInFiles
 			if (node.DeclaringTypeDefinition != null && node.DeclaringTypeDefinition.Kind == TypeKind.Interface)
 				return GetScope (node.DeclaringTypeDefinition);
 			
-			if ((node.Accessibility & Accessibility.Public) == Accessibility.Public)
-				return RefactoryScope.Solution;
+			//if ((node.Accessibility & Accessibility.Public) == Accessibility.Public)
+			//	return RefactoryScope.Solution;
 			
 			// TODO: RefactoringsScope.Hierarchy
-			if ((node.Accessibility & Accessibility.Protected) == Accessibility.Protected)
+			//if ((node.Accessibility & Accessibility.Protected) == Accessibility.Protected)
+			//	return RefactoryScope.Solution;
+			//if ((node.Accessibility & Accessibility.Internal) == Accessibility.Internal)
+			//	return RefactoryScope.Project;
+			
+			switch (node.Accessibility) {
+			case Accessibility.Public:
+			case Accessibility.Protected:
+			case Accessibility.ProtectedOrInternal:
 				return RefactoryScope.Solution;
-			if ((node.Accessibility & Accessibility.Internal) == Accessibility.Protected)
+			case Accessibility.Internal:
+			case Accessibility.ProtectedAndInternal:
 				return RefactoryScope.Project;
+			}
 			return RefactoryScope.DeclaringType;
 		}
 	}


### PR DESCRIPTION
1. There was a typo at line 281
2. The original code assumed Accessibility is a bit flags enum, but it fact it is not.
