### PR TITLE
Fixed Bug 3728 

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/ColorSheme.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/ColorSheme.cs
@@ -801,7 +801,6 @@ namespace Mono.TextEditor.Highlighting
 		{
 			ColorSheme clone = (ColorSheme)MemberwiseClone ();
 			clone.styleLookupTable = new Dictionary<string, ChunkStyle> (styleLookupTable);
-			clone.customPalette = new Dictionary<string, string> (customPalette);
 			return clone;
 		}
 		


### PR DESCRIPTION
Bug 3728 - Syntax Highlighting: Adding new Color scheme based off of 'Default' changes the default color scheme 
