### PR TITLE
Better T4 reference/include support

### DIFF
--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelopTemplatingHost.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelopTemplatingHost.cs
@@ -27,12 +27,20 @@
 using System;
 using Mono.TextTemplating;
 using MonoDevelop.Core;
+using MonoDevelop.Core.StringParsing;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.TextTemplating
 {
 	class MonoDevelopTemplatingHost : TemplateGenerator, IDisposable
 	{
 		TemplatingAppDomainRecycler.Handle domainHandle;
+		ProjectFile file;
+		
+		public MonoDevelopTemplatingHost (ProjectFile file)
+		{
+			this.file = file;
+		}
 		
 		public override AppDomain ProvideTemplatingAppDomain (string content)
 		{
@@ -45,14 +53,14 @@ namespace MonoDevelop.TextTemplating
 		protected override string ResolveAssemblyReference (string assemblyReference)
 		{
 			//FIXME: resolve from addins
-			var substituted = StringParserService.Parse (assemblyReference);
+			var substituted = StringParserService.Parse (assemblyReference, GetStringModel ());
 			return base.ResolveAssemblyReference (substituted);
 		}
 		
 		protected override bool LoadIncludeText (string requestFileName, out string content, out string location)
 		{
 			//FIXME: resolve from addins
-			var substituted = StringParserService.Parse (requestFileName);
+			var substituted = StringParserService.Parse (requestFileName, GetStringModel());
 			return base.LoadIncludeText (substituted, out content, out location);
 		}
 		
@@ -60,6 +68,11 @@ namespace MonoDevelop.TextTemplating
 		{
 			//FIXME: resolve from addins
 			return base.ResolveDirectiveProcessor (processorName);
+		}
+
+		protected IStringTagModel GetStringModel()
+		{
+			return file.Project.ParentSolution.GetStringTagModel();
 		}
 		
 		public void Dispose ()

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/TextTemplatingFileGenerator.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/TextTemplatingFileGenerator.cs
@@ -40,9 +40,11 @@ namespace MonoDevelop.TextTemplating
 		public IAsyncOperation Generate (IProgressMonitor monitor, ProjectFile file, SingleFileCustomToolResult result)
 		{
 			return new ThreadAsyncOperation (delegate {
-				using (var host = new MonoDevelopTemplatingHost ()) {
+				using (var host = new MonoDevelopTemplatingHost (file)) {
+					
 					
 					var defaultOutputName = file.FilePath.ChangeExtension (".cs"); //cs extension for VS compat
+
 					
 					string ns = TextTemplatingFilePreprocessor.GetNamespaceHint (file, defaultOutputName);
 					TextTemplatingFilePreprocessor.LogicalSetData ("NamespaceHint", ns, result.Errors);

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/TextTemplatingFilePreprocessor.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/TextTemplatingFilePreprocessor.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.TextTemplating
 		public IAsyncOperation Generate (IProgressMonitor monitor, ProjectFile file, SingleFileCustomToolResult result)
 		{
 			return new ThreadAsyncOperation (delegate {
-				var host = new MonoDevelopTemplatingHost ();
+				var host = new MonoDevelopTemplatingHost (file);
 				
 				var dnp = file.Project as DotNetProject;
 				if (dnp == null) {


### PR DESCRIPTION
T4 Files use the solution's string model when resolving references and loading includes
@mhutch is the current maintainer, as it seems from the comments...
