### PR TITLE
Gettext Po Editor Save Routine FIXMEs

### DIFF
--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext/Catalog.cs
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext/Catalog.cs
@@ -366,7 +366,7 @@ namespace MonoDevelop.Gettext
 				saved = true;
 			}
 			catch (Exception ex){
-				LoggingService.LogError ("Unhandled error replacing old Gettext Catalog '{0}': {1}", poFile, ex);
+				LoggingService.LogError ("Unhandled error saving Gettext Catalog to '{0}': {1}", poFile, ex);
 				saved = false;
 			}	
 			finally {


### PR DESCRIPTION
a) Change PO File Save routine to use StreamWriter
b) Override the default action of unicode encodings writing out a byte order mark at start of file
c) Perform safe write where it writes to a temp file and then copies to destination

As my last pull request was copied over manually there are extra commits listed in this one which don't result in any changes.
