### PR TITLE
Environment variables support when debuging with XSP

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/AspNetAppProject.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/AspNetAppProject.cs
@@ -207,6 +207,7 @@ namespace MonoDevelop.AspNet
 				TargetRuntime = TargetRuntime,
 				TargetFramework = TargetFramework,
 				UserAssemblyPaths = this.GetUserAssemblyPaths (config),
+				EnvironmentVariables = configuration.EnvironmentVariables,
 			};
 		}
 		

--- a/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/AspNetExecutionCommand.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/AspNetExecutionCommand.cs
@@ -34,6 +34,8 @@ namespace MonoDevelop.AspNet
 {
 	public class AspNetExecutionCommand: ExecutionCommand
 	{
+		IDictionary<string, string> environmentVariables;
+    
 		public AspNetExecutionCommand()
 		{
 		}
@@ -55,6 +57,17 @@ namespace MonoDevelop.AspNet
 		public override string CommandString {
 			get {
 				return "[asp-net]";
+			}
+		}
+
+		public IDictionary<string, string> EnvironmentVariables {
+			get {
+				if (environmentVariables == null)
+					environmentVariables = new Dictionary<string, string> ();
+				return environmentVariables;
+			}
+			set {
+				environmentVariables = value;
 			}
 		}
 	}

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
@@ -64,9 +64,16 @@ namespace MonoDevelop.Debugger.Soft.AspNet
 		public DebuggerStartInfo CreateDebuggerStartInfo (ExecutionCommand command)
 		{
 			var cmd = (AspNetExecutionCommand) command;
+			var evars = new Dictionary<string, string>(cmd.EnvironmentVariables);
+			var runtime = (MonoTargetRuntime) cmd.TargetRuntime;
+
+			foreach (var v in runtime.EnvironmentVariables)
+			{
+				if (!evars.ContainsKey (v.Key))
+					evars.Add (v.Key, v.Value);
+			}
 			
-			var runtime = (MonoTargetRuntime)cmd.TargetRuntime;
-			var startInfo = new SoftDebuggerStartInfo (runtime.Prefix, runtime.EnvironmentVariables) {
+			var startInfo = new SoftDebuggerStartInfo (runtime.Prefix, evars) {
 				WorkingDirectory = cmd.BaseDirectory,
 				Arguments = cmd.XspParameters.GetXspParameters ().Trim (),
 			};


### PR DESCRIPTION
With this change monodevelop will recognize and use environment variables that the user have specified under Project properties->Run->General when running and debugging an asp.net project
