### PR TITLE
extended duplicate line to also duplicate selected text

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Actions/MiscActions.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Actions/MiscActions.cs
@@ -464,10 +464,15 @@ namespace Mono.TextEditor
 
 		public static void DuplicateLine (TextEditorData data)
 		{
-			DocumentLine line = data.Document.GetLine (data.Caret.Line);
-			if (line == null)
-				return;
-			data.Insert (line.Offset, data.GetTextAt (line.SegmentIncludingDelimiter));
+			if (data.IsSomethingSelected) {
+				data.InsertAtCaret(data.SelectedText);
+			}
+			else {
+				DocumentLine line = data.Document.GetLine (data.Caret.Line);
+				if (line == null)
+					return;
+				data.Insert (line.Offset, data.GetTextAt (line.SegmentIncludingDelimiter));
+			}
 		}
 	}
 }

--- a/main/tests/UnitTests/Mono.TextEditor.Tests.DefaultEditActions/MiscActionsTest.cs
+++ b/main/tests/UnitTests/Mono.TextEditor.Tests.DefaultEditActions/MiscActionsTest.cs
@@ -226,6 +226,25 @@ dddddd$dddd
 eeeeeeeeee
 ffffffffff");
 		}
+
+		[Test()]
+		public void TestDuplicateSelectedText ()
+		{
+			var data = Create (@"aaaaaaaaa
+bbbbbbbbbb
+cccccccc<-cc
+dddddd->$dddd
+eeeeeeeeee
+ffffffffff");
+			MiscActions.DuplicateLine (data);
+			Check (data, @"aaaaaaaaa
+bbbbbbbbbb
+cccccccccc
+ddddddcc
+dddddd$dddd
+eeeeeeeeee
+ffffffffff");
+		}
 	}
 }
 


### PR DESCRIPTION
added functionality to duplicate selected text when applicable rather than duplicating the line the caret is on.
This time it's the right one, honest! (third time lucky)
