### PR TITLE
[MonoDevelop.Core] Don't save projects when saving the solution 

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
@@ -144,7 +144,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 		public void WriteFile (FilePath file, object obj, MonoDevelop.Core.IProgressMonitor monitor)
 		{
 			if (slnFileFormat.CanWriteFile (obj, this)) {
-				slnFileFormat.WriteFile (file, obj, this, true, monitor);
+				slnFileFormat.WriteFile (file, obj, this, false, monitor);
 			} else {
 				SolutionEntityItem item = (SolutionEntityItem) obj;
 				if (!(item.ItemHandler is MSBuildProjectHandler))


### PR DESCRIPTION
No need to save all the projects of a solution when saving the solution.
New projects are still created perfectly inside a solution after this
change, but without causing a timestamp change on the other projects
of the solution.

Fixes bug #5418
