### PR TITLE
[Autotools] Dispose the IProgressMonitor when done

### DIFF
--- a/main/src/addins/MonoDevelop.Autotools/MakefileOptionPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Autotools/MakefileOptionPanelWidget.cs
@@ -268,10 +268,11 @@ namespace MonoDevelop.Autotools
 				//FIXME: Do this only if there are changes b/w tmpData and Data
 				project.ExtendedProperties ["MonoDevelop.Autotools.MakefileInfo"] = tmpData;
 
-				IProgressMonitor monitor = IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (
-					GettextCatalog.GetString ("Updating project"), "gtk-run", true);
+				using (IProgressMonitor monitor = IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (
+					GettextCatalog.GetString ("Updating project"), "gtk-run", true)) {
 
-				tmpData.UpdateProject (monitor, oldData == null || (!oldData.IntegrationEnabled && tmpData.IntegrationEnabled));
+					tmpData.UpdateProject (monitor, oldData == null || (!oldData.IntegrationEnabled && tmpData.IntegrationEnabled));
+				}
 			} else {
 				if (oldData != null)
 					oldData.IntegrationEnabled = false;


### PR DESCRIPTION
Use a 'using' clause so the status monitor is disposed when the
updating operation finishes.

Fixes bug #5425.
