### PR TITLE
Fixed Bug 2489 - Preferences->Build->Assembly Folders buttons grayed out when removing folder.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/FolderListSelector.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/FolderListSelector.cs
@@ -108,7 +108,7 @@ namespace MonoDevelop.Components
 				string dir = (string) store.GetValue (it, 0);
 				directories.Remove (dir);
 				store.Remove (ref it);
-				if (!it.Equals (TreeIter.Zero))
+				if (store.IterIsValid (it))
 					FocusRow (it);
 				else
 					UpdateStatus ();

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Components.FolderListSelector.cs
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Components.FolderListSelector.cs
@@ -127,6 +127,7 @@ namespace MonoDevelop.Components
 				this.Child.ShowAll ();
 			}
 			this.Hide ();
+			this.folderentry.PathChanged += new global::System.EventHandler (this.OnFolderentryPathChanged);
 			this.buttonAdd.Clicked += new global::System.EventHandler (this.OnButtonAddClicked);
 			this.buttonRemove.Clicked += new global::System.EventHandler (this.OnButtonRemoveClicked);
 			this.buttonUpdate.Clicked += new global::System.EventHandler (this.OnButtonUpdateClicked);

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
@@ -10345,6 +10345,7 @@ Visual Studio generates a default ID for embedded resources, instead of simply u
             <child>
               <widget class="MonoDevelop.Components.FolderEntry" id="folderentry">
                 <property name="MemberName" />
+                <signal name="PathChanged" handler="OnFolderentryPathChanged" />
               </widget>
               <packing>
                 <property name="Position">0</property>


### PR DESCRIPTION
The resulting TreeIter from the remove was not being checked for validity properly prior to attempting to reselect the next item in the list. Also, the PathChanged event on the folder entry control was not mapped to UpdateStatus() so the Add button was not being reenabled when the box was populated.

I fixed the iterator check so that it no longer throws the errors described in the bug attachment.  I also added a handler for the PathChanged event so that as the user types or removes text in the folder entry box (or adds from the browse dialog) the status of the buttons is updated.
