### PR TITLE
Fix #5065 - 'MonoDevelop needs to track xsp location for ASP.NET debugging'

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
@@ -56,6 +56,8 @@ namespace MonoDevelop.Debugger.Soft.AspNet
 			case ClrVersion.Net_2_0:
 				return prefix.Combine ("lib", "mono", "2.0");
 			case ClrVersion.Net_4_0:
+				var net45Path = prefix.Combine ("lib", "mono", "4.5");
+				if (Directory.Exists (net45Path)) return net45Path;
 				return prefix.Combine ("lib", "mono", "4.0");
 			}
 			throw new InvalidOperationException (string.Format ("Unknown runtime version '{0}'", version));


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=5065 by checking if the 4.5 profile directory exists and using it if it does. This is necessary because Mono post-2.10.9 moves a lot of tools that were in the 4.0 directory into the 4.5 directory, including xsp4.
