### PR TITLE
Fix bug where "copy to output" for immediate references does not always happen

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -544,7 +544,7 @@ namespace MonoDevelop.Projects
 
 					//VS COMPAT: recursively copy references's "local copy" files
 					//but only copy the "copy to output" files from the immediate references
-					if (processedProjects.Add (p))
+					if (processedProjects.Add (p) || supportReferDistance == 1)
 						foreach (var f in p.GetSupportFileList (configuration))
 							list.Add (f.Src, f.CopyOnlyIfNewer, f.Target);
 


### PR DESCRIPTION
If a project was previously referenced by an immediate reference of the current project, it was added to processedProjects. When the immediate reference of the current project was processed after, it would be skipped and "copy to output" files would not be copied.

Fixes bug #5812
