### PR TITLE
[AspNet Mvc] Fixed bug 5890

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.Mvc/AspMvcProject.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.Mvc/AspMvcProject.cs
@@ -168,5 +168,10 @@ namespace MonoDevelop.AspNet.Mvc
 			: base (languageName, info, projectOptions)
 		{
 		}
+
+		public override bool SupportsFramework (MonoDevelop.Core.Assemblies.TargetFramework framework)
+		{
+			return framework.IsCompatibleWithFramework (MonoDevelop.Core.Assemblies.TargetFrameworkMoniker.NET_4_0);
+		}
 	}
 }


### PR DESCRIPTION
'ASP.NET MVC3 Template can be created with invalid project options
(that result in a failure to build)'.
Set required framework for mvc project to 4.0.

@mhutch
