### PR TITLE
Hide code completion word list when close expression evaluator dialog.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExpressionEvaluatorDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExpressionEvaluatorDialog.cs
@@ -41,11 +41,14 @@ namespace MonoDevelop.Debugger
 			valueTree.Frame = DebuggingService.CurrentFrame;
 			valueTree.AllowExpanding = true;
 			entry.KeyPressEvent += OnEditKeyPress;
+			entry.KeyReleaseEvent += OnEditKeyRelease;
 			CompletionWindowManager.WindowClosed += HandleCompletionWindowClosed;
 		}
 
 		protected override void OnDestroyed ()
 		{
+			entry.KeyPressEvent -= OnEditKeyPress;
+			entry.KeyReleaseEvent -= OnEditKeyRelease;
 			CompletionWindowManager.HideWindow();
 			CompletionWindowManager.WindowClosed -= HandleCompletionWindowClosed;
 			base.OnDestroyed ();
@@ -80,14 +83,28 @@ namespace MonoDevelop.Debugger
 		[GLib.ConnectBeforeAttribute]
 		void OnEditKeyPress (object s, Gtk.KeyPressEventArgs args)
 		{
-			Gtk.Entry entry = (Gtk.Entry)s;
-			
-			if (currentCompletionData != null) {
-				bool ret = CompletionWindowManager.PreProcessKeyEvent (args.Event.Key, (char)args.Event.Key, args.Event.State);
-				CompletionWindowManager.PostProcessKeyEvent (args.Event.Key, (char)args.Event.Key, args.Event.State);
-				args.RetVal = ret;
+			if (CompletionWindowManager.IsVisible) {
+				if ((args.Event.Key == Gdk.Key.Return ||
+					 args.Event.Key == Gdk.Key.Down || 
+				     args.Event.Key == Gdk.Key.Up)) {
+					args.RetVal = true;
+				}
 			}
-			
+		}
+
+		[GLib.ConnectBeforeAttribute]
+		void OnEditKeyRelease (object s, Gtk.KeyReleaseEventArgs args)
+		{
+			Gtk.Entry entry = (Gtk.Entry)s;
+
+			if (currentCompletionData != null) {
+				char keyChar = (char)args.Event.Key;
+				if ((args.Event.Key == Gdk.Key.Down || args.Event.Key == Gdk.Key.Up)) {
+					keyChar = '\0';
+				}
+				CompletionWindowManager.PreProcessKeyEvent (args.Event.Key, keyChar, args.Event.State);
+				CompletionWindowManager.PostProcessKeyEvent (args.Event.Key, keyChar, args.Event.State);
+			}
 			Gtk.Application.Invoke (delegate {
 				char c = (char)Gdk.Keyval.ToUnicode (args.Event.KeyValue);
 				if (currentCompletionData == null && IsCompletionChar (c)) {


### PR DESCRIPTION
1. Hi Lluis, I added a fix to hide completion window when closing the dialog. 
2. For the second one - the arrows do not working I found this: If you type "." the completion windows is opening and you can use arrows to navigate up and down, but if you continue typing name of field/property/method they stop working, after that arrows do not working at all even if you clear all text and start typing from scratch. 
   I observe the same behavior in the watch pad, I am not so good with completion system and currently I can't fix it :(.
