### PR TITLE
Fixed 'Bug 4919 - VS11 breaks sln files'

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
@@ -218,6 +218,10 @@ namespace MonoDevelop.Core.Assemblies
 		public static TargetFrameworkMoniker NET_4_0 {
 			get { return new TargetFrameworkMoniker ("4.0"); }
 		}
+
+		public static TargetFrameworkMoniker NET_4_5 {
+			get { return new TargetFrameworkMoniker ("4.5"); }
+		}
 		
 		public static TargetFrameworkMoniker PORTABLE_4_0 {
 			get { return new TargetFrameworkMoniker (ID_PORTABLE, "4.0", "Profile1"); }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
@@ -221,6 +221,10 @@
 			class = "MonoDevelop.Projects.Formats.MSBuild.MSBuildFileFormatVS10"
 			name = "MSBuild (Visual Studio 2010)"
 			canDefault = "true" />
+		<FileFormat id = "MSBuild11"
+			class = "MonoDevelop.Projects.Formats.MSBuild.MSBuildFileFormatVS11"
+			name = "MSBuild (Visual Studio 2012)"
+			canDefault = "true" />
 		<FileFormat id = "MD1" 
 			class = "MonoDevelop.Projects.Formats.MD1.MD1FileFormat"
 			name = "MonoDevelop 1.0 (deprecated)" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
@@ -257,6 +257,8 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 				return new MSBuildFileFormatVS08 ();
 			case "4.0":
 				return new MSBuildFileFormatVS10 ();
+			case "4.5":
+				return new MSBuildFileFormatVS11 ();
 			}
 			throw new Exception ("Unknown ToolsVersion '" + toolsVersion + "'");
 		}
@@ -334,4 +336,34 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 			get { return "MSBuild10"; }
 		}
 	}
+
+	class MSBuildFileFormatVS11: MSBuildFileFormat
+	{
+		public const string Version = "11.0.0";
+		const string toolsVersion = "4.0";
+		const string slnVersion = "12.00";
+		const string productComment = "Visual Studio 2012";
+		static TargetFrameworkMoniker[] frameworkVersions = {
+			TargetFrameworkMoniker.NET_2_0,
+			TargetFrameworkMoniker.NET_3_0,
+			TargetFrameworkMoniker.NET_3_5,
+			TargetFrameworkMoniker.NET_4_0,
+			TargetFrameworkMoniker.NET_4_5,
+			TargetFrameworkMoniker.SL_2_0,
+			TargetFrameworkMoniker.SL_3_0,
+			TargetFrameworkMoniker.SL_4_0,
+			TargetFrameworkMoniker.MONOTOUCH_1_0,
+			TargetFrameworkMoniker.PORTABLE_4_0
+		};
+		const bool supportsMonikers = true;
+		
+		public MSBuildFileFormatVS11 (): base (Version, toolsVersion, slnVersion, productComment, frameworkVersions, supportsMonikers)
+		{
+		}
+		
+		public override string Id {
+			get { return "MSBuild11"; }
+		}
+	}
+
 }


### PR DESCRIPTION
Add support for Visual Studio 2012 solution file format.

Thanks also to Jeffrey Stedfast for his patch.
