### PR TITLE
#8775 Mimic Visual Studio documentation without appending new lines for sections other than summary

### DIFF
--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.Options/ExpansionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.Options/ExpansionsPanelWidget.cs
@@ -41,10 +41,19 @@ namespace MonoDevelop.DocFood.Options
 	}
 	
 		
+	/// <summary>
+	/// Expansions panel.
+	/// </summary>
 	public class ExpansionsPanel : OptionsPanel
 	{
 		ExpansionsPanelWidget panel;
-		
+
+		/// <summary>
+		/// Creates the panel widget.
+		/// </summary>
+		/// <returns>
+		/// The panel widget.
+		/// </returns>
 		public override Gtk.Widget CreatePanelWidget ()
 		{
 			panel = new ExpansionsPanelWidget (DocConfig.Instance);

--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/Commands.cs
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/Commands.cs
@@ -154,14 +154,20 @@ namespace MonoDevelop.DocFood
 				foreach (var attr in section.Attributes) {
 					result.Append (" ");
 					result.Append (attr.Key);
-					result.Append ("='");
+					result.Append ("=\"");
 					result.Append (attr.Value);
-					result.Append ("'");
+					result.Append ("\"");
 				}
-				result.AppendLine (">");
-				
-				result.Append (indent);
-				result.Append (prefix);
+				if (section.Name == "summary")
+				{
+					result.AppendLine (">");
+					result.Append (indent);
+					result.Append (prefix);
+				}
+				else
+				{
+					result.Append (">");
+				}
 				bool inTag = false;
 				int column = indent.Length + prefix.Length;
 				StringBuilder curWord = new StringBuilder ();
@@ -195,10 +201,17 @@ namespace MonoDevelop.DocFood
 						curWord.Append (ch);
 					}
 				}
-				result.AppendLine (curWord.ToString ());
-				
-				result.Append (indent);
-				result.Append (prefix);
+				if (section.Name == "summary")
+				{
+					result.AppendLine(curWord.ToString ());
+					result.Append(indent);
+					result.Append(prefix);
+				}
+				else
+				{
+					result.Append(curWord.ToString ());
+				}
+
 				result.Append ("</");
 				result.Append (section.Name);
 				result.Append (">");
@@ -229,20 +242,28 @@ namespace MonoDevelop.DocFood
 				foreach (var attr in section.Attributes) {
 					result.Append (" ");
 					result.Append (attr.Key);
-					result.Append ("='");
+					result.Append ("=\"");
 					result.Append (attr.Value);
-					result.Append ("'");
+					result.Append ("\"");
 				}
-				result.AppendLine (">");
-				
-				result.Append (indent);
-				result.Append ("/// ");
+				if (section.Name == "summary")
+				{
+					result.AppendLine (">");
+					result.Append (indent);
+					result.Append ("/// ");
+					result.AppendLine ();
+					result.Append (indent);
+					result.Append ("/// ");
+				}
+				else
+				{
+					result.Append (">");
+				}
+
 //				bool inTag = false;
 //				int column = indent.Length + "/// ".Length;
-				
-				result.AppendLine ();
-				result.Append (indent);
-				result.Append ("/// </");
+
+				result.Append ("</");
 				result.Append (section.Name);
 				result.Append (">");
 			}

--- a/main/src/addins/MonoDevelop.DocFood/gtk-gui/gui.stetic
+++ b/main/src/addins/MonoDevelop.DocFood/gtk-gui/gui.stetic
@@ -8,6 +8,9 @@
     <widget-library name="../../../../build/bin/MonoDevelop.Ide.dll" />
     <widget-library name="../../../../build/AddIns/MonoDevelop.Refactoring/MonoDevelop.Refactoring.dll" />
     <widget-library name="../../../../build/bin/Mono.TextEditor.dll" />
+    <widget-library name="../../../../build/AddIns/DisplayBindings/SourceEditor/MonoDevelop.SourceEditor2.dll" />
+    <widget-library name="../../../../build/AddIns/MonoDevelop.Debugger/MonoDevelop.Debugger.dll" />
+    <widget-library name="../../../../build/AddIns/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.dll" />
     <widget-library name="../../../../build/AddIns/BackendBindings/MonoDevelop.DocFood.dll" internal="true" />
   </import>
   <widget class="Gtk.Bin" id="MonoDevelop.DocFood.Options.AcronymsPanelWidget" design-size="514 493">


### PR DESCRIPTION
Currently, when you use the XML documentation in MonoDevelop ala ///, this will
generate documentation that looks similar to the following:

/// &lt;summary&gt;
/// Summary here.
/// &lt;/summary&gt;
/// &lt;param name='id'&gt;
/// Identifier.
/// &lt;/param&gt;

This is different than the Visual Studio behavior of the following:

/// &lt;summary&gt;
/// Summary here.
/// &lt;/summary&gt;
/// &lt;param name="id"&gt;Identifier.&lt;/param&gt;

DocFood should be generating docs that mimic this behavior for ease of use.

https://bugzilla.xamarin.com/show_bug.cgi?id=8775
