### PR TITLE
fix a Typo in ProjectConfiguration.cs

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
@@ -151,7 +151,7 @@ namespace MonoDevelop.Projects
 		}
 
 		public new Project ParentItem {
-			get { return (Project) ParentItem; }
+			get { return (Project) base.ParentItem; }
 		}
 	}
 


### PR DESCRIPTION
@mhutch this fix a typo in ProjectConfiguration.cs from ffb387d7bc823da11b201f3278ed32f48097feff that causes a stack overflow.
