### PR TITLE
Fixed NullReferenceException with `implicit` operator

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/AstAmbience.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/AstAmbience.cs
@@ -148,7 +148,7 @@ namespace MonoDevelop.CSharp
 			} else if (e is OperatorDeclaration) {
 				var op = e as OperatorDeclaration;
 				sb.Append ("operator");
-				AppendEscaped (sb, op.OperatorTypeToken.GetText ());
+				AppendEscaped (sb, op.OperatorTypeToken.GetText () ?? string.Empty);
 				AppendParameter (sb, op.Parameters);
 			} else if (e is MethodDeclaration) {
 				var method = e as MethodDeclaration;


### PR DESCRIPTION
When the user typed `public static implicit` the parser would
recognize it as an operator, but would have null next for the
operator identifier. Coercing null to string.Empty prevents it
from choking.

Fixes Bug #9293

/cc @mkrueger, @slluis
