### PR TITLE
Fix a typo in pt-BR translation

### DIFF
--- a/main/po/pt_BR.po
+++ b/main/po/pt_BR.po
@@ -4,6 +4,7 @@
 # Copyright (C) 2006,2008, Rafael "Monoman" Teixeira <rafaelteixeirabr@hotmail.com>
 # Copyright (C) 2007, Renato Felipe Atilio <renatoat@gmail.com>
 # Copyright (C) 2012, Edison Henrique Andreassy <ehasis@hotmail.com>
+# Copyright (C) 2013, Felipe Bernardo Zorzo <felipe.b.zorzo@gmail.com>
 #
 # This file is distributed under the same license as the MonoDevelop package.
 # Edison Henrique Andreassy <ehasis@hotmail.com>, 2012.
@@ -13,8 +14,8 @@ msgstr ""
 "Project-Id-Version: MonoDevelop 0.10\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2010-05-21 20:55:03+0200\n"
-"PO-Revision-Date: 2012-06-23 22:52-0300\n"
-"Last-Translator: Edison Henrique Andreassy <ehasis@hotmail.com>\n"
+"PO-Revision-Date: 2013-02-23 16:37-0300\n"
+"Last-Translator: Felipe Bernardo Zorzo <felipe.b.zorzo@gmail.com>\n"
 "Language-Team: Português <>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16367,7 +16368,7 @@ msgstr "Alvos de Distribuição Web"
 #: ../src/addins/AspNet/MonoDevelop.AspNet/Templates/WebContentForm.xft.xml:9
 #: ../src/addins/AspNet/MonoDevelop.AspNet.Mvc/MonoDevelop.AspNet.Mvc.addin.xml:74
 msgid "ASP.NET"
-msgstr "ASP.NE"
+msgstr "ASP.NET"
 
 #: ../src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet.addin.xml:167
 #: ../src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet.addin.xml:177


### PR DESCRIPTION
This fixes a 5-year-old issue with Brazilian Portuguese translation.

![typo](https://f.cloud.github.com/assets/13829/188568/1aeecf6e-7df7-11e2-871c-24469908ebf4.png)
