### PR TITLE
[Debugger.Soft] Stop referencing Mono.Cecil.Mdb, to fix mono 2.10.x build

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Soft/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/Mono.Debugging.Soft/Mono.Debugging.Soft.csproj
@@ -44,11 +44,6 @@
       <Name>Mono.Cecil</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\external\cecil\symbols\mdb\Mono.Cecil.Mdb.csproj">
-      <Project>{8559DD7F-A16F-46D0-A05A-9139FAEBA8FD}</Project>
-      <Name>Mono.Cecil.Mdb</Name>
-      <Private>False</Private>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArrayAdaptor.cs" />

--- a/main/src/addins/MonoDevelop.Debugger.Soft/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -39,7 +39,6 @@ using System.Globalization;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-using Mono.Cecil.Mdb;
 using Mono.CompilerServices.SymbolWriter;
 using Mono.Debugging.Client;
 using Mono.Debugger.Soft;


### PR DESCRIPTION
When trying to build MonoDevelop master with stock Mono from Ubuntu 12.10
packages (2.10.8.1), a compiler error would happen:

SoftDebuggerSession.cs(59,36): error CS0433: The imported type
`Mono.CompilerServices.SymbolWriter.MonoSymbolFile' is defined multiple times
/.../monodevelop/main/external/cecil/bin/net_4_0_Debug/Mono.Cecil.Mdb.dll
(Location of the symbol related to previous error)
/.../monodevelop/main/build/bin/ICSharpCode.NRefactory.CSharp.dll
(Location of the symbol related to previous error)

Mono.Cecil.Mdb was indeed an unused reference. This fixes BXC#11134.
