### PR TITLE
Fix typo in da translation. 'indælst' -> 'indlæst'

### DIFF
--- a/main/po/da.po
+++ b/main/po/da.po
@@ -6452,7 +6452,7 @@ msgstr "Kunne ikke gemme løsning: {0}"
 
 #: ../src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs:611
 msgid "Solution loaded."
-msgstr "Løsning indælst."
+msgstr "Løsning indlæst."
 
 #: ../src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs:883
 msgid ""


### PR DESCRIPTION
The Danish translation files has a typo; there is no word in danish spelled 'indælst'. The correct word is 'indlæst'. This pull request fixes that.
