### PR TITLE
Bump md-addins, fixes breakage caused by Xcode 4.6.2

### DIFF
--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=f87f305b40ce5f5b33deee260108fe6c0f453047
+DEP_NEEDED_VERSION[0]=8d1676b869eaf0925aea33be6f176618a55416e3
 DEP_BRANCH_AND_REMOTE[0]="master origin/bs1"
 
 # heap-shot


### PR DESCRIPTION
Changes XcodeRevision to float.

This is needed due to a change in the CFBundleVersion in Xcode.app/Contents/Info.plist 

We are expecting the string to be parseable into ints in MonoDevelop.MacDev/MonoDevelop.MacDev/AppleSdkSettings.cs:183

XcodeRevision = int.Parse (value.Value);

4.6.2 
<key>CFBundleVersion</key>
    <string>2067.2</string>

4.6.0
<key>CFBundleVersion</key>
    <string>2066</string>
