### PR TITLE
Add missing files to "make dist" tarballs

### DIFF
--- a/main/src/core/Mono.Texteditor/Makefile.am
+++ b/main/src/core/Mono.Texteditor/Makefile.am
@@ -1,1 +1,12 @@
 include $(top_srcdir)/xbuild.include
+
+EXTRA_DIST += \
+		Styles/DefaultStyle.json \
+		Styles/MonokaiStyle.json \
+		Styles/NightshadeStyle.json \
+		Styles/OblivionStyle.json \
+		Styles/SolarizedDarkStyle.json \
+		Styles/SolarizedLightStyle.json \
+		Styles/TangoStyle.json \
+		Styles/VisualStudioStyle.json
+


### PR DESCRIPTION
Right now, it is not possible to build from a "make dist" tarball, as the build process bails out due to missing files. This commit adds those files to the tarball.
