### PR TITLE
Diff viewer

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffWidget.cs
@@ -142,8 +142,7 @@ namespace MonoDevelop.VersionControl.Views
 
 		void HandleButtonClosehandleClicked (object sender, EventArgs e)
 		{
-			var window = Ide.IdeApp.Workbench.ActiveDocument.Window;
-			window.SwitchView (0);
+			Ide.IdeApp.Workbench.ActiveDocument.Window.SwitchView (0);
 		}
 
 		public void UpdatePatchView ()


### PR DESCRIPTION
Added a close view button which sends you to the editor view.
Text was awkwardly changing from Unified Diff to Patch after the first click. Fixed this issue.
