### PR TITLE
Bug 5811 - AssemblyBrowser as default viewer for .dll and .exe

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/FileSelectorDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/FileSelectorDialog.cs
@@ -219,8 +219,11 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 				
 				if (closeWorkspaceCheck.Visible)
 					closeWorkspaceCheck.Active = true;
-				
-				selected = 0;
+
+				// Default exe/dll to AssemblyBrowser, solutions/projects to Solution Workbench.
+				// HACK: Couldn't make it a generic SolutionItemFile based conditional, .csproj fits under this category also.
+				if (!(Filename.EndsWith (".exe", StringComparison.OrdinalIgnoreCase) || Filename.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)))
+					selected = 0;
 				i++;
 			}
 			


### PR DESCRIPTION
Fixed bug 5811.
Although we support opening .dll and .exe as solution, it seems that a more used feature for opening these files
would be the AssemblyBrowser. Discussion is in the bug report which points that this is a preferred fix.
