### PR TITLE
Bug 10698 - Extension change modifies build action.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -702,8 +702,11 @@ namespace MonoDevelop.Projects
 		{
 			foreach (Project projectEntry in GetAllProjects()) {
 				foreach (ProjectFile fInfo in projectEntry.Files) {
-					if (fInfo.FilePath == oldName)
+					if (fInfo.FilePath == oldName) {
+						if (fInfo.BuildAction == projectEntry.GetDefaultBuildAction (oldName))
+							fInfo.BuildAction = projectEntry.GetDefaultBuildAction (newName);
 						fInfo.Name = newName;
+					}
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
@@ -167,7 +167,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			try {
 				if (file.Project != null)
 					newProjectFile = file.Project.Files.GetFileWithVirtualPath (newPath.ToRelative (file.Project.BaseDirectory));
-				
+
 				if (!FileService.IsValidPath (newPath)) {
 					MessageService.ShowWarning (GettextCatalog.GetString ("The name you have chosen contains illegal characters. Please choose a different name."));
 				} else if (newProjectFile != null && newProjectFile != file) {


### PR DESCRIPTION
Whenever we change extension, modify the file to have its BuildAction set to DefaultBuildAction.

Old version: Create two files, First.cs and First.Second. First.Second has BuildAction set to None on creation, and on renaming to First.Second.cs the action doesn't modify, therefore either the user has to set it manually or make a new file.

New version: Create two files, Files.cs and First.Second. On changing the extension, if the new DefaultBuildAction is not Compile, a dialog comes up and asks if you're sure to rename. Proceeding or if the action is compile, it is set to the file.

The location of the setting of BuildAction to a file was chosen in RootWorkspace to be sure to cover all possible renaming, not just through the Rename in the Project Viewer.
