### PR TITLE
Fixed bug 12094 - Open Containing Folder menu item on dock tab.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -489,10 +489,14 @@
 	<Command id = "MonoDevelop.Ide.Commands.FileTabCommands.ToggleMaximize"
 	         defaultHandler = "MonoDevelop.Ide.Commands.ToggleMaximizeHandler"
 			_label = "S_witch maximize/normal view"/>
-	<Command id ="MonoDevelop.Ide.Commands.FileTabCommands.ReopenClosedTab"
+	<Command id = "MonoDevelop.Ide.Commands.FileTabCommands.ReopenClosedTab"
 			defaultHandler = "MonoDevelop.Ide.Commands.ReopenClosedTabHandler"
 			_label = "Reopen Closed Tab"
 			_description = "Opens the last tab that has been closed"/>
+	<Command id = "MonoDevelop.Ide.Commands.FileTabCommands.OpenContainingFolder"
+			defaultHandler = "MonoDevelop.Ide.Commands.OpenContainingFolderHandler"
+			_label = "O_pen Containing Folder" 
+			_description = "Opens the folder that contains this file"/>
 	</Category>
 			
 	<!-- ViewCommands -->

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -260,6 +260,7 @@
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.Save" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.SaveAll" />
 		<SeparatorItem id = "SaveSeparator" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.FileTabCommands.OpenContainingFolder" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileTabCommands.CopyPathName" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileTabCommands.ToggleMaximize" />
 	</Extension>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileTabCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileTabCommands.cs
@@ -33,6 +33,7 @@ using Gtk;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Navigation;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Commands
 {
@@ -41,7 +42,8 @@ namespace MonoDevelop.Ide.Commands
 		CloseAllButThis,
 		CopyPathName,
 		ToggleMaximize,
-		ReopenClosedTab
+		ReopenClosedTab,
+		OpenContainingFolder
 	}
 	
 	class CloseAllButThisHandler : CommandHandler
@@ -85,6 +87,21 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			info.Enabled = NavigationHistoryService.HasClosedDocuments;
+		}
+	}
+
+	class OpenContainingFolderHandler : CommandHandler
+	{
+		protected override void Run ()
+		{
+			// A tab will always hold a file, never a folder.
+			FilePath path = System.IO.Path.GetDirectoryName (IdeApp.Workbench.ActiveDocument.FileName);
+			DesktopService.OpenFolder (path);
+		}
+
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = !IdeApp.Workbench.ActiveDocument.FileName.IsNullOrEmpty;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/SolutionNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/SolutionNodeBuilder.cs
@@ -286,7 +286,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		public void OnOpenFolder ()
 		{
 			Solution solution = (Solution) CurrentNode.DataItem;
-			System.Diagnostics.Process.Start ("file://" + solution.BaseDirectory);
+			DesktopService.OpenFolder (solution.BaseDirectory);
 		}
 		
 		[CommandHandler (SearchCommands.FindInFiles)]


### PR DESCRIPTION
This allows users to open a file's parent folder in the default file explorer,
using the menu bar on the dock tabs.

This also includes a small wrapper usage to unify code standards.
