### PR TITLE
Improved #290 - Open Containing Folder menu.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -493,10 +493,6 @@
 			defaultHandler = "MonoDevelop.Ide.Commands.ReopenClosedTabHandler"
 			_label = "Reopen Closed Tab"
 			_description = "Opens the last tab that has been closed"/>
-	<Command id = "MonoDevelop.Ide.Commands.FileTabCommands.OpenContainingFolder"
-			defaultHandler = "MonoDevelop.Ide.Commands.OpenContainingFolderHandler"
-			_label = "O_pen Containing Folder" 
-			_description = "Opens the folder that contains this file"/>
 	</Category>
 			
 	<!-- ViewCommands -->

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -260,7 +260,7 @@
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.Save" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.SaveAll" />
 		<SeparatorItem id = "SaveSeparator" />
-		<CommandItem id = "MonoDevelop.Ide.Commands.FileTabCommands.OpenContainingFolder" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.OpenContainingFolder" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileTabCommands.CopyPathName" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.FileTabCommands.ToggleMaximize" />
 	</Extension>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileTabCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileTabCommands.cs
@@ -43,7 +43,6 @@ namespace MonoDevelop.Ide.Commands
 		CopyPathName,
 		ToggleMaximize,
 		ReopenClosedTab,
-		OpenContainingFolder
 	}
 	
 	class CloseAllButThisHandler : CommandHandler
@@ -87,22 +86,6 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			info.Enabled = NavigationHistoryService.HasClosedDocuments;
-		}
-	}
-
-	class OpenContainingFolderHandler : CommandHandler
-	{
-		protected override void Run ()
-		{
-			// A tab will always hold a file, never a folder.
-			FilePath path = System.IO.Path.GetDirectoryName (IdeApp.Workbench.ActiveDocument.FileName);
-			DesktopService.OpenFolder (path);
-		}
-
-		protected override void Update (CommandInfo info)
-		{
-			var doc = IdeApp.Workbench.ActiveDocument;
-			info.Enabled = doc != null && !doc.FileName.IsNullOrEmpty;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
@@ -97,7 +97,22 @@ namespace MonoDevelop.Ide.Gui
 		{
 			info.Enabled = window.ViewContent.ContentName != null && !window.ViewContent.IsViewOnly;
 		}
+
+		[CommandHandler (FileCommands.OpenContainingFolder)]
+		protected void OnOpenFolder ()
+		{
+			// A tab will always hold a file, never a folder.
+			FilePath path = Path.GetDirectoryName (doc.FileName);
+			DesktopService.OpenFolder (path);
+		}
 		
+		[CommandUpdateHandler (FileCommands.OpenContainingFolder)]
+		protected void OnUpdateOpenFolder (CommandInfo info)
+		{
+			info.Visible = doc != null && !doc.FileName.IsNullOrEmpty;
+			info.Enabled = info.Visible;
+		}
+
 		
 		/*** Edit commands ***/
 		


### PR DESCRIPTION
No longer show the option for Open Containing Folder when we cannot do this
action.

Instead, hide the command to show less clutter.
