### PR TITLE
Fixed disassembly view Version Control Menu crash.

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.AssemblyBrowser
 		
 		public override void Load (string fileName)
 		{
-			this.ContentName = MonoDevelop.Core.GettextCatalog.GetString ("Assembly Browser");
+			ContentName = GettextCatalog.GetString ("Assembly Browser");
 			widget.AddReferenceByFileName (fileName);
 		}
 		

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DisassemblyView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DisassemblyView.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.Debugger
 	public class DisassemblyView: AbstractViewContent, IClipboardHandler
 	{
 		Gtk.ScrolledWindow sw;
-		Mono.TextEditor.TextEditor editor;
+		TextEditor editor;
 		int firstLine;
 		int lastLine;
 		Dictionary<string,int> addressLines = new Dictionary<string,int> ();
@@ -62,12 +62,12 @@ namespace MonoDevelop.Debugger
 		
 		public DisassemblyView ()
 		{
-			UntitledName = GettextCatalog.GetString ("Disassembly");
+			ContentName = GettextCatalog.GetString ("Disassembly");
 			sw = new Gtk.ScrolledWindow ();
-			editor = new Mono.TextEditor.TextEditor ();
+			editor = new TextEditor ();
 			editor.Document.ReadOnly = true;
 			
-			editor.Options = new MonoDevelop.Ide.Gui.CommonTextEditorOptions () {
+			editor.Options = new CommonTextEditorOptions {
 				ShowLineNumberMargin = false,
 			};
 			
@@ -102,7 +102,13 @@ namespace MonoDevelop.Debugger
 		public override void Load (string fileName)
 		{
 		}
-		
+
+		public override bool IsFile {
+			get {
+				return false;
+			}
+		}
+
 		public void Update ()
 		{
 			autoRefill = false;


### PR DESCRIPTION
This fixes Disassembly window from crashing MonoDevelop due to it being marked
as a file.
Also removed some redundant namespace usages.
