### PR TITLE
Call SetSearchOptions in SearchAndReplaceWidget constructor.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SearchAndReplaceWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SearchAndReplaceWidget.cs
@@ -172,7 +172,8 @@ namespace MonoDevelop.SourceEditor
 				//FireSearchPatternChanged ();
 			}
 			UpdateSearchPattern ();
-			
+			SetSearchOptions ();
+
 			//searchEntry.Model = searchHistory;
 			
 			searchEntry.Entry.KeyReleaseEvent += delegate {


### PR DESCRIPTION
This fixes following bug:
1. Search for pattern using regex or other option
2. Open other file and try to search for same pattern
3. Search widget doesn't consider selected option
