### PR TITLE
Fixes a bug with pasting expressions with multiple lines.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/TextEditorData.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/TextEditorData.cs
@@ -1199,10 +1199,10 @@ namespace Mono.TextEditor
 			if (TextPasteHandler != null) {
 				var newText = TextPasteHandler.FormatPlainText (offset, text, copyData);
 				if (newText != text) {
-					Insert (offset, text);
+					var inserted = Insert (offset, text);
 					undoGroup.Dispose ();
 					undoGroup = OpenUndoGroup ();
-					var result = Replace (offset, text.Length, newText);
+					var result = Replace (offset, inserted, newText);
 					if (Paste != null)
 						Paste (offset, text, result);
 					return result;


### PR DESCRIPTION
Example: Coping Code:
            return Enumerable.Range(1, 10)
                    .Where(true)
                    .Where(true)
                    .Where(true)
                    .FirstOrDefault();
Pasting:
            return Enumerable.Range(1, 10)
                .Where(true)
                    .Where(true)
                    .Where(true)
                    .FirstOrDefault();t();
