### PR TITLE
[Core] Handle $(CONFIGURATION) and $(PLATFORM) in OutputDirectory

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
@@ -167,17 +167,17 @@ namespace MonoDevelop.Projects
 					return null;
 			}
 		}
-		
+
 		public FilePath CompiledOutputName {
 			get {
-				FilePath fullPath = OutputDirectory.Combine (OutputAssembly);
+				FilePath fullPath = EvaluatedOutputDirectory.Combine (OutputAssembly);
 				if (OutputAssembly.EndsWith (".dll") || OutputAssembly.EndsWith (".exe"))
 					return fullPath;
 				else
 					return fullPath + (CompileTarget == CompileTarget.Library ? ".dll" : ".exe");
 			}
 		}
-		
+
 		public override void CopyFrom (ItemConfiguration configuration)
 		{
 			base.CopyFrom (configuration);
@@ -192,9 +192,24 @@ namespace MonoDevelop.Projects
 			delaySign = conf.delaySign;
 			assemblyKeyFile = conf.assemblyKeyFile;
 		}
-		
+
+		public override FilePath EvaluatedIntermediateOutputDirectory {
+			get { return ReplacePlaceholders (base.EvaluatedIntermediateOutputDirectory); }
+		}
+
+		public override FilePath EvaluatedOutputDirectory {
+			get { return ReplacePlaceholders (base.EvaluatedOutputDirectory); }
+		}
+
 		public new DotNetProject ParentItem {
 			get { return (DotNetProject) base.ParentItem; }
+		}
+
+		string ReplacePlaceholders (string path)
+		{
+			if (path == null)
+				return null;
+			return path.Replace ("$(Configuration)", Name).Replace ("$(Platform)", Platform);
 		}
 	}
 	

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
@@ -66,11 +66,19 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		public virtual FilePath EvaluatedIntermediateOutputDirectory {
+			get { return IntermediateOutputDirectory; }
+		}
+
 		[ProjectPathItemProperty("OutputPath")]
 		private FilePath outputDirectory = "." + Path.DirectorySeparatorChar;
 		public virtual FilePath OutputDirectory {
 			get { return outputDirectory; }
 			set { outputDirectory = value; }
+		}
+
+		public virtual FilePath EvaluatedOutputDirectory {
+			get { return outputDirectory; }
 		}
 
 		[ItemProperty("DebugSymbols", DefaultValue = false)]

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -131,7 +131,24 @@ namespace MonoDevelop.Projects
 //			sol.FileFormat = Services.ProjectService.FileFormats.GetFileFormat ("MSBuild08");
 //			sol.Save (Util.GetMonitor ());
 		}
-		
+
+		[Test]
+		public void PlaceholdersAreReplaced_OutputPath ()
+		{
+			var config = new DotNetProjectConfiguration {
+				Name = "Debug",
+				Platform = "x86",
+				IntermediateOutputDirectory = "intermediate/$(Configuration)/$(Platform)",
+				OutputDirectory = "full/$(Configuration)/$(Platform)",
+				OutputAssembly = "Baz.dll"
+			};
+			Assert.AreEqual ((FilePath) "intermediate/$(Configuration)/$(Platform)", config.IntermediateOutputDirectory, "#1a");
+			Assert.AreEqual ((FilePath) "intermediate/Debug/x86", config.EvaluatedIntermediateOutputDirectory, "#1b");
+			Assert.AreEqual ((FilePath) "full/$(Configuration)/$(Platform)", config.OutputDirectory, "#2a");
+			Assert.AreEqual ((FilePath) "full/Debug/x86", config.EvaluatedOutputDirectory, "#2b");
+			Assert.AreEqual ((FilePath) "full/Debug/x86/Baz.dll", config.CompiledOutputName, "#3");
+		}
+
 		[Test]
 		public void TestCreateLoadSaveConsoleProject ()
 		{


### PR DESCRIPTION
These placeholders need to be replaced so the full (correct) path
can be obtained inside monodevelop.

We will need to review everywhere we directly use 'IntermediateOutputDirectory' and 'OutputDirectory' to either leave them as-is (if they need the raw version) or port them to use the Evaluated\* versions if they need the processed version of the path.

Added test covering the change.
