### PR TITLE
Add System.Core.dll and add commonly used using statements to project templates

### DIFF
--- a/main/src/addins/CSharpBinding/templates/ConsoleProject.xpt.xml
+++ b/main/src/addins/CSharpBinding/templates/ConsoleProject.xpt.xml
@@ -28,9 +28,13 @@
 			<Options ExternalConsole="True"/>
 			<References>
 				<Reference type="Package" refto="System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+				<Reference type="Package" refto="System.Core, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			</References>
 			<Files>
 				<File name="Program.cs" AddStandardHeader="True"><![CDATA[using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace ${Namespace}
 {

--- a/main/src/addins/CSharpBinding/templates/GtkSharp2Project.xpt.xml
+++ b/main/src/addins/CSharpBinding/templates/GtkSharp2Project.xpt.xml
@@ -29,6 +29,7 @@
 			
 			<References>
 				<Reference type="Package" refto="System, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+				<Reference type="Package" refto="System.Core, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 				<Reference type="Package" SpecificVersion="false" refto="gtk-sharp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
 				<Reference type="Package" SpecificVersion="false" refto="gdk-sharp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
 				<Reference type="Package" SpecificVersion="false" refto="glib-sharp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />


### PR DESCRIPTION
This change adds **System.Core.dll** to the c# console project template and the gtk# project template.
It also adds the most commonly used using statements to Program.cs (Console Template)

Motivation:
Every time you create a console project you usually have to manually add System.Core.dll immediately after creating the project because Linq statements are used in most cases nowadays. Also generic collections and some text manipulation is very common, so I think this change will save time for everybody in the future.
