### PR TITLE
Use git readonly URL in debugger-libs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = git://github.com/mono/ikvm-fork.git
 [submodule "main/external/debugger-libs"]
 	path = main/external/debugger-libs
-	url = git@github.com:mono/debugger-libs.git
+	url = git://github.com/mono/debugger-libs.git


### PR DESCRIPTION
Use git readonly url for the debugger-libs submodule as defined in .gitmodules. This will allow for users with no access to the repository to be able to properly clone/read.
