### PR TITLE
1. Fix bug in EvaluatorDialog and arrows in code completion.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExpressionEvaluatorDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExpressionEvaluatorDialog.cs
@@ -83,9 +83,13 @@ namespace MonoDevelop.Debugger
 		void OnEditKeyPress (object sender, KeyPressEventArgs args)
 		{
 			if (currentCompletionData != null) {
-				bool ret = CompletionWindowManager.PreProcessKeyEvent (args.Event.Key, (char)args.Event.Key, args.Event.State);
-				CompletionWindowManager.PostProcessKeyEvent (args.Event.Key, (char)args.Event.Key, args.Event.State);
-				args.RetVal = ret;
+				char keyChar = (char)args.Event.Key;
+				if ((args.Event.Key == Gdk.Key.Down || args.Event.Key == Gdk.Key.Up)) {
+					keyChar = '\0';
+				}
+				var retVal = CompletionWindowManager.PreProcessKeyEvent (args.Event.Key, keyChar, args.Event.State);
+				CompletionWindowManager.PostProcessKeyEvent (args.Event.Key, keyChar, args.Event.State);
+				args.RetVal = retVal;
 			}
 			
 			Application.Invoke (delegate {
@@ -137,7 +141,7 @@ namespace MonoDevelop.Debugger
 		
 		string ICompletionWidget.GetText (int startOffset, int endOffset)
 		{
-			if (startOffset < 0) startOffset = 0;
+			if (startOffset < 0 || startOffset > entry.Text.Length) startOffset = 0;
 			if (endOffset > entry.Text.Length) endOffset = entry.Text.Length;
 			return entry.Text.Substring (startOffset, endOffset - startOffset);
 		}


### PR DESCRIPTION
1. Fix exception when deleting text in EvaluatorDialog

How to reproduce for fix 2: 
1. Write object name
2. Hit '.' - code completion widget is shown
3. Hit Backspace few times exception is thrown.

How to reproduce for fix 1;
1. Write object name
2. Hit '.' - code completion widget is shown
3. Select object property using arrows and hit enter
4. Delete selected property name up to the point
5. Try to use arrows in completion widget. They don't work.
