### PR TITLE
Attach process dialog refreshes available processes periodically

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/AttachToProcessDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/AttachToProcessDialog.cs
@@ -37,26 +37,55 @@ namespace MonoDevelop.Debugger
 	public partial class AttachToProcessDialog : Gtk.Dialog
 	{
 		List<DebuggerEngine> currentDebEngines;
-		Dictionary<long, List<DebuggerEngine>> procEngines = new Dictionary<long,List<DebuggerEngine>> ();
-		List<ProcessInfo> procs = new List<ProcessInfo> ();
+		Dictionary<long, List<DebuggerEngine>> procEngines;
+		List<ProcessInfo> procs;
 		Gtk.ListStore store;
 		TreeViewState state;
-		
+		uint timeoutHandler;
+
 		public AttachToProcessDialog()
 		{
 			this.Build();
-			
+
 			store = new Gtk.ListStore (typeof(ProcessInfo), typeof(string), typeof(string));
 			tree.Model = store;
 			tree.AppendColumn ("PID", new Gtk.CellRendererText (), "text", 1);
 			tree.AppendColumn ("Process Name", new Gtk.CellRendererText (), "text", 2);
-			
-			DebuggerEngine[] debEngines = DebuggingService.GetDebuggerEngines ();
-			foreach (DebuggerEngine de in debEngines) {
+
+			state = new TreeViewState (tree, 1);
+
+			Refresh ();
+
+			comboDebs.Sensitive = false;
+			buttonOk.Sensitive = false;
+			tree.Selection.UnselectAll ();
+			tree.Selection.Changed += OnSelectionChanged;
+
+			Gtk.TreeIter it;
+			if (store.GetIterFirst (out it))
+				tree.Selection.SelectIter (it);
+
+			timeoutHandler = GLib.Timeout.Add (3000, Refresh);
+		}
+
+		public override void Destroy ()
+		{
+			if (timeoutHandler != 0)
+				GLib.Source.Remove (timeoutHandler);
+			base.Destroy ();
+		}
+
+		bool Refresh ()
+		{
+			procEngines = new Dictionary<long,List<DebuggerEngine>> ();
+			procs = new List<ProcessInfo> ();
+
+			foreach (DebuggerEngine de in DebuggingService.GetDebuggerEngines ()) {
 				if ((de.SupportedFeatures & DebuggerFeatures.Attaching) == 0)
 					continue;
 				try {
-					foreach (ProcessInfo pi in de.GetAttachableProcesses ()) {
+					var infos = de.GetAttachableProcesses ();
+					foreach (ProcessInfo pi in infos) {
 						List<DebuggerEngine> engs;
 						if (!procEngines.TryGetValue (pi.Id, out engs)) {
 							engs = new List<DebuggerEngine> ();
@@ -66,50 +95,39 @@ namespace MonoDevelop.Debugger
 						engs.Add (de);
 					}
 				} catch (Exception ex) {
-					LoggingService.LogError ("Could not get attachablbe processes.", ex);
+					LoggingService.LogError ("Could not get attachable processes.", ex);
 				}
 				comboDebs.AppendText (de.Name);
 			}
-			
-			state = new TreeViewState (tree, 1);
-			
-			FillList ();
-			
-			comboDebs.Sensitive = false;
-			buttonOk.Sensitive = false;
-			tree.Selection.Changed += OnSelectionChanged;
-			
-			Gtk.TreeIter it;
-			if (store.GetIterFirst (out it))
-				tree.Selection.SelectIter (it);
 
-			OnSelectionChanged (null, null);
+			FillList ();
+			return true;
 		}
-		
+
 		void FillList ()
 		{
 			state.Save ();
-			
+
 			store.Clear ();
 			string filter = entryFilter.Text;
 			foreach (ProcessInfo pi in procs) {
 				if (filter.Length == 0 || pi.Id.ToString().Contains (filter) || pi.Name.Contains (filter))
 					store.AppendValues (pi, pi.Id.ToString (), pi.Name);
 			}
-			
+
 			state.Load ();
-			
+
 			if (tree.Selection.CountSelectedRows () == 0) {
 				Gtk.TreeIter it;
 				if (store.GetIterFirst (out it))
 					tree.Selection.SelectIter (it);
 			}
 		}
-		
+
 		void OnSelectionChanged (object s, EventArgs args)
 		{
 			((Gtk.ListStore)comboDebs.Model).Clear ();
-			
+
 			Gtk.TreeIter iter;
 			if (tree.Selection.GetSelected (out iter)) {
 				ProcessInfo pi = (ProcessInfo) store.GetValue (iter, 0);
@@ -131,7 +149,12 @@ namespace MonoDevelop.Debugger
 		{
 			FillList ();
 		}
-		
+
+		protected virtual void OnRowActivated (object o, Gtk.RowActivatedArgs args)
+		{
+			Respond (Gtk.ResponseType.Ok);
+		}
+
 		public ProcessInfo SelectedProcess {
 			get {
 				Gtk.TreeIter iter;
@@ -139,7 +162,7 @@ namespace MonoDevelop.Debugger
 				return (ProcessInfo) store.GetValue (iter, 0);
 			}
 		}
-		
+
 		public DebuggerEngine SelectedDebugger {
 			get {
 				return currentDebEngines [comboDebs.Active];

--- a/main/src/addins/MonoDevelop.Debugger/gtk-gui/MonoDevelop.Debugger.AttachToProcessDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/gtk-gui/MonoDevelop.Debugger.AttachToProcessDialog.cs
@@ -15,7 +15,7 @@ namespace MonoDevelop.Debugger
 		private global::Gtk.ComboBox comboDebs;
 		private global::Gtk.Button buttonCancel;
 		private global::Gtk.Button buttonOk;
-		
+
 		protected virtual void Build ()
 		{
 			global::Stetic.Gui.Initialize (this);

--- a/main/src/addins/MonoDevelop.Debugger/gtk-gui/generated.cs
+++ b/main/src/addins/MonoDevelop.Debugger/gtk-gui/generated.cs
@@ -5,7 +5,7 @@ namespace Stetic
 	internal class Gui
 	{
 		private static bool initialized;
-		
+
 		internal static void Initialize (Gtk.Widget iconRenderer)
 		{
 			if ((Stetic.Gui.initialized == false)) {
@@ -13,7 +13,7 @@ namespace Stetic
 			}
 		}
 	}
-	
+
 	internal class IconLoader
 	{
 		public static Gdk.Pixbuf LoadIcon (Gtk.Widget widget, string name, Gtk.IconSize size)
@@ -47,12 +47,12 @@ namespace Stetic
 			}
 		}
 	}
-	
+
 	internal class BinContainer
 	{
 		private Gtk.Widget child;
 		private Gtk.UIManager uimanager;
-		
+
 		public static BinContainer Attach (Gtk.Bin bin)
 		{
 			BinContainer bc = new BinContainer ();
@@ -61,32 +61,32 @@ namespace Stetic
 			bin.Added += new Gtk.AddedHandler (bc.OnAdded);
 			return bc;
 		}
-		
+
 		private void OnSizeRequested (object sender, Gtk.SizeRequestedArgs args)
 		{
 			if ((this.child != null)) {
 				args.Requisition = this.child.SizeRequest ();
 			}
 		}
-		
+
 		private void OnSizeAllocated (object sender, Gtk.SizeAllocatedArgs args)
 		{
 			if ((this.child != null)) {
 				this.child.Allocation = args.Allocation;
 			}
 		}
-		
+
 		private void OnAdded (object sender, Gtk.AddedArgs args)
 		{
 			this.child = args.Widget;
 		}
-		
+
 		public void SetUiManager (Gtk.UIManager uim)
 		{
 			this.uimanager = uim;
 			this.child.Realized += new System.EventHandler (this.OnRealized);
 		}
-		
+
 		private void OnRealized (object sender, System.EventArgs args)
 		{
 			if ((this.uimanager != null)) {
@@ -99,14 +99,14 @@ namespace Stetic
 			}
 		}
 	}
-	
+
 	internal class ActionGroups
 	{
 		public static Gtk.ActionGroup GetActionGroup (System.Type type)
 		{
 			return Stetic.ActionGroups.GetActionGroup (type.FullName);
 		}
-		
+
 		public static Gtk.ActionGroup GetActionGroup (string name)
 		{
 			return null;


### PR DESCRIPTION
Attach to process window will refresh with the list of available processes, and attaching process will properly initialize the Debug layout and restore once done debugging.

While attach to process is not currently supported in MonoDevelop, this workflow will support addins which enabled attaching to process, including the Unity soft debugger.
