### PR TITLE
Implement basic delete from movement actions.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Vi/ViCommandMap.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Vi/ViCommandMap.cs
@@ -45,6 +45,8 @@ namespace Mono.TextEditor.Vi
 				BuilderAction b;
 				if (builders.TryGetValue (ctx.LastKey, out b)) {
 					ctx.Builder = b.Builder;
+					ctx.Transformer = b.Transformer;
+					//ctx.Transformer = (Action<ViEditor> action) => b.Transformer(ctx.Transformer(action));
 					if (b.RunInstantly)
 						ctx.Builder (ctx);
 					return true;
@@ -57,7 +59,13 @@ namespace Mono.TextEditor.Vi
 		{
 			Add (key, map.Builder);
 		}
-		
+
+		public void Add (ViKey key, EditorActionTransformer transformer, ViCommandMap map, bool runInstantly = false)
+		{
+			Console.WriteLine ("Adding map with transformer");
+			Add (key, transformer, map.Builder, runInstantly);
+		}
+
 		public void Add (ViKey key, Action<ViEditor> action)
 		{
 			this.actions[key] = action;
@@ -75,7 +83,12 @@ namespace Mono.TextEditor.Vi
 		
 		public void Add (ViKey key, ViBuilder builder, bool runInstantly)
 		{
-			this.builders[key] = new BuilderAction (builder, runInstantly);
+			this.builders[key] = new BuilderAction (builder, runInstantly, ViBuilderContext.DefaultTransformer);
+		}
+
+		public void Add (ViKey key, EditorActionTransformer transformer, ViBuilder builder, bool runInstantly = false)
+		{
+			this.builders[key] = new BuilderAction (builder, runInstantly, transformer);
 		}
 		
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
@@ -90,13 +103,15 @@ namespace Mono.TextEditor.Vi
 		
 		struct BuilderAction
 		{
-			public BuilderAction (ViBuilder builder, bool runInstantly)
+			public BuilderAction (ViBuilder builder, bool runInstantly, EditorActionTransformer transformer)
 			{
 				this.Builder = builder;
 				this.RunInstantly = runInstantly;
+				this.Transformer = transformer;
 			}
 			
 			public readonly ViBuilder Builder;
+			public readonly EditorActionTransformer Transformer;
 			public readonly bool RunInstantly;
 		}
 	}


### PR DESCRIPTION
Allows actions like dw (delete word).

In order to do this, I established a framework where a command map may
associate a "transformer" with a nested command map. The transformer is
a delegate that converts the action retrieved from the nested command map into an action with
different behavior when it is finally executed.

For example, the 'd' key (for delete) contains the nested map of
motions. Associated with this is a transformer that changes a motion
into a delete action using that motion.

This is currently just a proof of concept - there are many bugs.

For one, commands like dj and dk do not behave as they should, and may
need special handling. It might be a good idea to separate motions that
operate within one line (h,j,k,l,w,b,e, ect.) into a different command
map than motions that operate between lines (j,k).

In addition, repeated deletion commands do not undo all at once. For
example, 3dw will take 3 presses of u to undo fully.