### PR TITLE
[CSharp] Fix cancellation propagation

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/CSharpSyntaxMode.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/CSharpSyntaxMode.cs
@@ -144,7 +144,7 @@ namespace MonoDevelop.CSharp.Highlighting
 						var newResolverTask = guiDocument.GetSharedResolver ();
 						var cancellationToken = src.Token;
 						System.Threading.Tasks.Task.Factory.StartNew (delegate {
-							var newResolver = newResolverTask.Result;
+							var newResolver = newResolverTask.IsCanceled ? null : newResolverTask.Result;
 							if (newResolver == null)
 								return;
 							unit = newResolver.RootNode as SyntaxTree;


### PR DESCRIPTION
We should check for IsCancelled before we get the result, otherwise
we will end up throwing an AggregateException which wraps the
TaskCanceledException. This is not what we want.
