### PR TITLE
[TextEditor] Treat escape sequences as regular expressions.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/Span.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/Span.cs
@@ -114,7 +114,7 @@ namespace Mono.TextEditor.Highlighting
 			}
 		}
 
-		public string Escape {
+		public Regex Escape {
 			get;
 			set;
 		}
@@ -156,7 +156,7 @@ namespace Mono.TextEditor.Highlighting
 
 		public override string ToString ()
 		{
-			return String.Format ("[Span: Color={0}, Rule={1}, Begin={2}, End={3}, Escape={4}, stopAtEol={5}]", Color, Rule, Begin, End, String.IsNullOrEmpty (Escape) ? "not set" : "'" + Escape +"'", StopAtEol);
+			return String.Format ("[Span: Color={0}, Rule={1}, Begin={2}, End={3}, Escape={4}, stopAtEol={5}]", Color, Rule, Begin, End, Escape == null ? "not set" : "'" + Escape +"'", StopAtEol);
 		}
 		
 		public Span Clone ()
@@ -201,7 +201,8 @@ namespace Mono.TextEditor.Highlighting
 			result.TagColor   = reader.GetAttribute ("tagColor");
 			result.NextColor  = reader.GetAttribute ("nextColor");
 
-			result.Escape = reader.GetAttribute ("escape");
+			string escape = reader.GetAttribute("escape");
+			result.Escape = string.IsNullOrEmpty(escape) ? null : new Regex(escape);
 
 			string stopateol = reader.GetAttribute ("stopateol");
 			if (!String.IsNullOrEmpty (stopateol)) {

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/SyntaxMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/SyntaxMode.cs
@@ -412,15 +412,9 @@ namespace Mono.TextEditor.Highlighting
 					Span cur = CurSpan;
 					if (cur != null) {
 						if (cur.Escape != null) {
-							bool mismatch = false;
-							for (int j = 0; j < cur.Escape.Length; j++) {
-								if (textIndex + j >= CurText.Length || CurText [textIndex + j] != cur.Escape [j]) {
-									mismatch = true;
-									break;
-								}
-							}
-							if (!mismatch) {
-								int j = i + cur.Escape.Length - 1;
+							RegexMatch match = cur.Escape.TryMatch(CurText, textIndex);
+							if (match.Success) {
+								int j = i + match.Length - 1;
 								ParseChar (ref i, CurText [textIndex]);
 								i = j;
 								continue;


### PR DESCRIPTION
Now, more than one escape sequence can be specified per span definition.

This solves a special syntax highlighting problem in my D addin.
