### PR TITLE
Fix issue where F# char literal colouring would be too long

### DIFF
--- a/main/src/core/Mono.Texteditor/SyntaxModes/FSharpSyntaxMode.xml
+++ b/main/src/core/Mono.Texteditor/SyntaxModes/FSharpSyntaxMode.xml
@@ -83,7 +83,7 @@
 	-->
 
 	<!-- ' is also used for type parameters therefore we need a regex match to find out if something is a string -->
-	<Match expression="(&apos;(.|(\\.)|\\u[0-9A-F]{4}|\\U[0-9A-F]{8})&apos;)">
+	<Match expression="(&apos;(.|(\\.)|\\u[0-9A-Fa-f]{4}|\\U[0-9A-Fa-f]{8})&apos;)">
 			<Group color = "String"/>
 			<Group color = "String"/>
 			<Group color = "String"/>


### PR DESCRIPTION
In this code, this match will catch too much and too much would be colored as `String`. Capturing "." or "\." should be enough for char literals, as they can only be one char long. 
Some text to test against

```
let trim (str:String) =
    str.Split( [| '\n' ; '\r' |], StringSplitOptions.RemoveEmptyEntries)
let unicodechar = '\u1234'
let utfchar = '\U1A343214'
let simplechar = 'a'
let ``shouldnt catch`` = '\uwert' // not legal
let var' = var + 1 // Shouldn't mess with var'
let sillychar = '\uabcd' // legal
let sillychar2 = '\uABCD' // legal

let chars = [| 's'; 'b'; 'c' |]
```

This is what it looks like in Xamarin Studio:
![screen shot 2013-07-09 at 11 00 59](https://f.cloud.github.com/assets/445888/767084/3b4196fe-e876-11e2-81f2-417c5e193893.png)
