### PR TITLE
Bug 10895 - Exception on solution update

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -95,13 +95,13 @@ namespace MonoDevelop.VersionControl.Git
 						using (IProgressMonitor monitor = VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Rebasing branch '{0}'...", dlg.SelectedBranch))) {
 							if (dlg.IsRemote)
 								repo.Fetch (monitor);
-							repo.Rebase (dlg.SelectedBranch, dlg.StageChanges, monitor);
+							repo.Rebase (dlg.SelectedBranch, dlg.StageChanges ? GitUpdateOptions.SaveLocalChanges : GitUpdateOptions.None, monitor);
 						}
 					} else {
 						using (IProgressMonitor monitor = VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Merging branch '{0}'...", dlg.SelectedBranch))) {
 							if (dlg.IsRemote)
 								repo.Fetch (monitor);
-							repo.Merge (dlg.SelectedBranch, dlg.StageChanges, monitor);
+							repo.Merge (dlg.SelectedBranch, dlg.StageChanges ? GitUpdateOptions.SaveLocalChanges : GitUpdateOptions.None, monitor);
 						}
 					}
 				}


### PR DESCRIPTION
Fixed an issue with submodules being out of date when issuing a repository update.

This is in fact a hacky fix that has to happen until NGit has submodules TreeWalking fixed.

The proper fix is found here:
https://gist.github.com/Therzok/7ef7b5889b853611d2bc

But this cannot be applied as stashes fail to apply with this patch. This would bring loss of user changes when a repository update is issued.

So currently, a workaround to issue a submodule update in both pre and post repositroy update is the only way. At least it works now and submodules don't get in the way. This issue will be revisited after the update of NGit.
