### PR TITLE
Linux: Proper pass arguments to mono and use sgen

### DIFF
--- a/main/monodevelop.in
+++ b/main/monodevelop.in
@@ -8,7 +8,7 @@ export LIBOVERLAY_SCROLLBAR=0
 
 
 #this script should be in $PREFIX/bin
-MONO_EXEC="exec mono"
+MONO_EXEC="exec mono-sgen"
 EXE_PATH="${0%%/bin/monodevelop}/lib/monodevelop/bin/MonoDevelop.exe"
 
 _MD_REDIRECT_LOG="${MD_REDIRECT_LOG:-${XDG_CONFIG_HOME:-$HOME/.config}/MonoDevelop/log}"
@@ -20,15 +20,9 @@ else
 	_MONO_OPTIONS=$MONO_OPTIONS
 fi
 
-MONO_RECOMMENDED_VERSION_FOR_SGEN=3.0
-if pkg-config --atleast-version=$MONO_RECOMMENDED_VERSION_FOR_SGEN mono; then
-	_MONO_OPTIONS="$_MONO_OPTIONS --gc=sgen"
-fi
-
 if [ -n "$_MD_REDIRECT_LOG" ]; then
 	mkdir -p `dirname "$_MD_REDIRECT_LOG"`
 	$MONO_EXEC $_MONO_OPTIONS "$EXE_PATH" $* 2>&1 | tee "$_MD_REDIRECT_LOG"
 else
 	$MONO_EXEC $_MONO_OPTIONS "$EXE_PATH" $*
 fi
-


### PR DESCRIPTION
Use sgen in monodevelop. Tested in Archlinux and OpenSuse. It runs monodevelop with command:
mono-sgen --debug --gc=sgen /usr/lib/monodevelop/bin/MonoDevelop.exe 
