### PR TITLE
Added support for error issues (issues that run on invalid contexts)

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/MDRefactoringContext.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/MDRefactoringContext.cs
@@ -39,6 +39,7 @@ using MonoDevelop.CSharp.Refactoring.CodeIssues;
 using Mono.TextEditor;
 using ICSharpCode.NRefactory.CSharp.Resolver;
 using MonoDevelop.CSharp.Formatting;
+using System.Linq;
 
 namespace MonoDevelop.CSharp.Refactoring.CodeActions
 {
@@ -160,7 +161,7 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 			return new MDRefactoringScript (this, formattingOptions);
 		}
 
-		public MDRefactoringContext (Document document, TextLocation loc, CancellationToken cancellationToken = default (CancellationToken)) : base (document.GetSharedResolver ().Result, cancellationToken)
+		public MDRefactoringContext (Document document, TextLocation loc, CancellationToken cancellationToken = default (CancellationToken)) : base (document.GetSharedResolver ().Result, document.ParsedDocument.Errors.ToList(), cancellationToken)
 		{
 			if (document == null)
 				throw new ArgumentNullException ("document");
@@ -173,7 +174,7 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 			Services.AddService (typeof(NamingConventionService), policy.CreateNRefactoryService ());
 		}
 
-		public MDRefactoringContext (DotNetProject project, TextEditorData data, ParsedDocument parsedDocument, CSharpAstResolver resolver, TextLocation loc, CancellationToken cancellationToken = default (CancellationToken)) : base (resolver, cancellationToken)
+		public MDRefactoringContext (DotNetProject project, TextEditorData data, ParsedDocument parsedDocument, CSharpAstResolver resolver, TextLocation loc, CancellationToken cancellationToken = default (CancellationToken)) : base (resolver, parsedDocument.Errors.ToList(), cancellationToken)
 		{
 			this.TextEditor = data;
 			this.ParsedDocument = parsedDocument;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeIssues/NRefactoryIssueProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeIssues/NRefactoryIssueProvider.cs
@@ -40,6 +40,7 @@ namespace MonoDevelop.CSharp.Refactoring.CodeIssues
 	{
 		ICSharpCode.NRefactory.CSharp.Refactoring.ICodeIssueProvider issueProvider;
 		readonly string providerIdString;
+		bool acceptsInvalidContexts;
 
 		public override string IdString {
 			get {
@@ -50,6 +51,7 @@ namespace MonoDevelop.CSharp.Refactoring.CodeIssues
 		public NRefactoryIssueProvider (ICSharpCode.NRefactory.CSharp.Refactoring.ICodeIssueProvider issue, IssueDescriptionAttribute attr)
 		{
 			issueProvider = issue;
+			acceptsInvalidContexts = attr.AcceptInvalidContexts;
 			providerIdString = issueProvider.GetType ().FullName;
 			Category = GettextCatalog.GetString (attr.Category ?? "");
 			Title = GettextCatalog.GetString (attr.Title ?? "");
@@ -62,7 +64,9 @@ namespace MonoDevelop.CSharp.Refactoring.CodeIssues
 		public override IEnumerable<CodeIssue> GetIssues (object ctx, CancellationToken cancellationToken)
 		{
 			var context = ctx as MDRefactoringContext;
-			if (context == null || context.IsInvalid || context.RootNode == null)
+			if (context == null || context.RootNode == null)
+				yield break;
+			if (context.IsInvalid && !acceptsInvalidContexts)
 				yield break;
 			foreach (var action in issueProvider.GetIssues (context)) {
 				if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
See also https://github.com/icsharpcode/NRefactory/pull/214

This adds support for issues that run on invalid contexts.

Note: The result is kind of weird, because now the error (CS1520) is underlined _twice_ - once because of the error, the second time because of the issue. I'm not sure how to fix this and accept suggestions.
