### PR TITLE
Review Solution Changes Dialog does not show any changes.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -412,10 +412,6 @@ namespace MonoDevelop.VersionControl.Views
 			
 			ThreadPool.QueueUserWorkItem (delegate {
 				List<VersionInfo> newList = new List<VersionInfo> ();
-				//filepath is path to .sln file, but Repostory.GetDirectoryVersionInfo expect solution folder.
-				if (!Directory.Exists (filepath) && File.Exists (filepath)) {
-					filepath = Path.GetDirectoryName (filepath);
-				}
 				newList.AddRange (vc.GetDirectoryVersionInfo(filepath, remoteStatus, true));
 				DispatchService.GuiDispatch (delegate {
 					if (!disposed)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -199,6 +199,10 @@ namespace MonoDevelop.VersionControl
 		public VersionInfo[] GetDirectoryVersionInfo (FilePath localDirectory, bool getRemoteStatus, bool recursive)
 		{
 			try {
+				//check if localDirectory is directory
+				if (!localDirectory.IsDirectory) {
+					localDirectory = localDirectory.ParentDirectory;
+				}
 				if (recursive)
 					return OnGetDirectoryVersionInfo (localDirectory, getRemoteStatus, recursive);
 


### PR DESCRIPTION
Today I found out that Review Solution Changes shows that there are no changes, but there are. The issue was that the variable filepath is the path to the solution file but GetDirectoryVersionInfo method of Repository expects directory path.
For me this is a dirty fix because I think that GetDirectoryVersionInfo should work with .sln and .csproj files and to check only for modified files that are included in the solution projects. 
