### PR TITLE
Add Edit File command to Project item and UnknownSolutionItem

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -319,9 +319,9 @@
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.Reload"
 			_description = "Reload selected project or solution"
 			_label = "Reload" />
-	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.EditProject"
-			_description = "Edit selected project"
-			_label = "Edit Project File" />			
+	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem"
+			_description = "Edit selected item"
+			_label = "Edit File" />			
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.ExportSolution"
 			defaultHandler = "MonoDevelop.Ide.Commands.ExportSolutionHandler"
 			_description = "Convert selected solution to another format"

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -86,7 +86,7 @@ namespace MonoDevelop.Ide.Commands
 		SpecificAssemblyVersion,
 		SelectActiveConfiguration,
 		SelectActiveRuntime,
-		EditProject
+		EditSolutionItem
 	}
 
 	internal class SolutionOptionsHandler : CommandHandler

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectNodeBuilder.cs
@@ -419,14 +419,14 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			}
 		}
 
-		[CommandHandler (ProjectCommands.EditProject)]
+		[CommandHandler (ProjectCommands.EditSolutionItem)]
 		public void OnEditProject ()
 		{
 			Project project = (Project) CurrentNode.DataItem;
 			IdeApp.Workbench.OpenDocument (project.FileName);
 		}
 
-		[CommandUpdateHandler (ProjectCommands.EditProject)]
+		[CommandUpdateHandler (ProjectCommands.EditSolutionItem)]
 		public void OnEditProjectUpdate (CommandInfo info)
 		{
 			var p = (Project) CurrentNode.DataItem;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -98,8 +98,8 @@
 		<Condition id="ItemType" value="IFolderItem">
 			<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.OpenInTerminal" />
 		</Condition>
-		<Condition id="ItemType" value="Project">
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditProject" />
+		<Condition id="ItemType" value="Project|UnknownSolutionItem">
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem" />
 		</Condition>
 	</ItemSet>
 	<Condition id="ItemType" value="IFolderItem">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/UnknownEntryNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/UnknownEntryNodeBuilder.cs
@@ -34,6 +34,7 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Gui.Pads;
 using MonoDevelop.Ide.Commands;
 using MonoDevelop.Ide.Gui.Components;
+using System.Linq;
 
 namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 {
@@ -112,6 +113,20 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 					return;
 				}
 			}
+		}
+
+		[CommandHandler (ProjectCommands.EditSolutionItem)]
+		public void OnEditUnknownSolutionItem ()
+		{
+			UnknownSolutionItem si = (UnknownSolutionItem) CurrentNode.DataItem;
+			IdeApp.Workbench.OpenDocument (si.FileName);
+		}
+
+		[CommandUpdateHandler (ProjectCommands.EditSolutionItem)]
+		public void OnEditUnknownSolutionItemUpdate (CommandInfo info)
+		{
+			var si = (UnknownSolutionItem) CurrentNode.DataItem;
+			info.Visible = !IdeApp.Workbench.Documents.Any (d => d.FileName == si.FileName);
 		}
 		
 		public override void DeleteItem ()


### PR DESCRIPTION
It is very useful to have Edit File Command for projects and for Projects that cannot be loaded thus we can fix the problem. Fortunately MonoDevelop unlike Visual Studio doesn't need to unload project and can edit project files on the fly.
