### PR TITLE
Small fix to Mono.TextTemplating to run under MS .Net

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -531,13 +531,11 @@ namespace Mono.TextTemplating
 			return ccu;
 		}
 
-		static bool isMono = Type.GetType ("Mono.Runtime") != null;
-
 		static CodeSnippetTypeMember CreateSnippetMember (string value, CodeLinePragma location = null)
 		{
-			//HACK: workaround for Mono not indenting first line of member snippet when inserting into class
+			//HACK: workaround for code generator not indenting first line of member snippet when inserting into class
 			const string indent = "\n        ";
-			if (isMono && !char.IsWhiteSpace (value[0]))
+			if (!char.IsWhiteSpace (value[0]))
 				value = indent + value;
 
 			return new CodeSnippetTypeMember (value) {


### PR DESCRIPTION
A "Mono hack" turns out to not be Mono-specific. Removing the restriction to Mono allows me to run the tests without errors under .Net / Win7.
