### PR TITLE
Bug 8445 - Fixed Gtk-Warning for SpinButton.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/gtk-gui/MonoDevelop.VersionControl.UrlBasedRepositoryEditor.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/gtk-gui/MonoDevelop.VersionControl.UrlBasedRepositoryEditor.cs
@@ -21,7 +21,7 @@ namespace MonoDevelop.VersionControl
 		private global::Gtk.Entry repositoryServerEntry;
 		private global::Gtk.Entry repositoryUrlEntry;
 		private global::Gtk.Entry repositoryUserEntry;
-		
+
 		protected virtual void Build ()
 		{
 			global::Stetic.Gui.Initialize (this);
@@ -58,14 +58,13 @@ namespace MonoDevelop.VersionControl
 			this.hbox2 = new global::Gtk.HBox ();
 			this.hbox2.Name = "hbox2";
 			// Container child hbox2.Gtk.Box+BoxChild
-			this.repositoryPortSpin = new global::Gtk.SpinButton (0, 99999, 1);
+			this.repositoryPortSpin = new global::Gtk.SpinButton (0D, 99999D, 1D);
 			this.repositoryPortSpin.CanFocus = true;
 			this.repositoryPortSpin.Name = "repositoryPortSpin";
-			this.repositoryPortSpin.Adjustment.PageIncrement = 10;
-			this.repositoryPortSpin.Adjustment.PageSize = 10;
-			this.repositoryPortSpin.ClimbRate = 1;
+			this.repositoryPortSpin.Adjustment.PageIncrement = 10D;
+			this.repositoryPortSpin.ClimbRate = 1D;
 			this.repositoryPortSpin.Numeric = true;
-			this.repositoryPortSpin.Value = 1;
+			this.repositoryPortSpin.Value = 1D;
 			this.hbox2.Add (this.repositoryPortSpin);
 			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.hbox2 [this.repositoryPortSpin]));
 			w3.Position = 0;
@@ -158,7 +157,7 @@ namespace MonoDevelop.VersionControl
 			this.labelError = new global::Gtk.Label ();
 			this.labelError.Name = "labelError";
 			this.labelError.Xalign = 0F;
-			this.labelError.LabelProp = global::Mono.Unix.Catalog.GetString ("<small><span color='red'>Invalid URL</span></small>");
+			this.labelError.LabelProp = global::Mono.Unix.Catalog.GetString ("<small><span color=\'red\'>Invalid URL</span></small>");
 			this.labelError.UseMarkup = true;
 			this.table1.Add (this.labelError);
 			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelError]));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/gtk-gui/gui.stetic
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/gtk-gui/gui.stetic
@@ -759,7 +759,6 @@
                 <property name="CanFocus">True</property>
                 <property name="Upper">99999</property>
                 <property name="PageIncrement">10</property>
-                <property name="PageSize">10</property>
                 <property name="StepIncrement">1</property>
                 <property name="ClimbRate">1</property>
                 <property name="Numeric">True</property>


### PR DESCRIPTION
WARNING [2012-11-15 18:21:03Z]: Gtk-Warning: GtkSpinButton: setting an
adjustment with non-zero page size is deprecated
