### PR TITLE
Fix colour coding for character literals in F#.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/SyntaxMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/SyntaxMode.cs
@@ -611,7 +611,7 @@ namespace Mono.TextEditor.Highlighting
 								var len = foundMatchLength [j];
 								if (len > 0) {
 									AddChunk (ref curChunk, len, GetChunkStyleColor (foundMatch.Groups [j - 1]));
-									i += len - 1;
+									i += len;
 									curChunk.Length = 0;
 								}
 							}
@@ -619,7 +619,7 @@ namespace Mono.TextEditor.Highlighting
 						}
 						if (foundMatchLength[0] > 0) {
 							AddChunk (ref curChunk, foundMatchLength[0], GetChunkStyleColor (foundMatch.Color));
-							i += foundMatchLength[0] - 1;
+							i += foundMatchLength[0];
 							curChunk.Length = 0;
 							return;
 						}

--- a/main/src/core/Mono.Texteditor/SyntaxModes/FSharpSyntaxMode.xml
+++ b/main/src/core/Mono.Texteditor/SyntaxModes/FSharpSyntaxMode.xml
@@ -28,8 +28,7 @@
 	<Property name="BlockCommentStart">(*</Property>
 	<Property name="BlockCommentEnd">*)</Property>
 	<Property name="StringQuote">"</Property>
-	<Property name="StringQuote">'</Property>
-	
+
 	<EolSpan tagColor = "Preprocessor" rule="text.preprocessor">#if</EolSpan>
 	<EolSpan tagColor = "Preprocessor" rule="text.preprocessor">#else</EolSpan>
 	<EolSpan tagColor = "Preprocessor" rule="text.preprocessor">#elif</EolSpan>
@@ -69,11 +68,6 @@
 		<End>"</End>
 	</Span>
 	
-	<Span color = "String" rule="String" stopateol = "true">
-		<Begin>&apos;</Begin>
-		<End>&apos;</End>
-	</Span>
-	
 	<Span rule="String" stopateol = "false">
 		<Begin color="Keyword(Iteration)" flags="NewWord">let</Begin>
 		<End>=</End>
@@ -87,11 +81,14 @@
 	</Span>
 	-->
 
-	<!-- ' is also used for type parameters therefore we need a regex match to find out if something is a string -->
-	<Match expression="(&apos;(.|(\\.+))&apos;)">
-			<Group color = "String"/>
-			<Group color = "String"/>
-			<Group color = "String"/>
+	<!-- ' is also used for type parameters therefore we need a regex match to find out if something is a char literal 
+         Here we capture unicode literals and escaped chars in a separate group for colouring. Char literals are not part
+         of the 'String' rule, and unicode literal matching will not happen. -->
+	<Match expression="(')(?:(apa|\\U[0-9a-fA-F]{8}|\\u[0-9a-fA-F]{4}|\\[\\'ntbrafv])|([^\\']))(')">
+       <Group color="String"/>
+       <Group color="String(Escape)"/>
+       <Group color="String"/>
+       <Group color="String"/>
 	</Match>
 
 	<Match color="Number">CSharpNumber</Match>
@@ -277,7 +274,7 @@
 
 	<Rule name="String">
 		<Delimiters></Delimiters>
-		<Match color ="String(Escape)">\\(["\\'ntbrafv]|u[0-9a-fA-F]{4,4}|U[0-9a-fA-F]{8,8}|\d\d\d)</Match>
+		<Match color ="String(Escape)">\\(U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4}|[\\'ntbrafv])</Match>
 	</Rule>
 	
 	<Rule name = "VerbatimString">


### PR DESCRIPTION
In this code, this match will catch too much and too much would be colored as `String`. Capturing "." or "\." should be enough for char literals, as they can only be one char long. 
Some text to test against

```
let trim (str:String) =
    str.Split( [| '\n' ; '\r' |], StringSplitOptions.RemoveEmptyEntries)
let unicodechar = '\u1234'
let utfchar = '\U1A343214'
let simplechar = 'a'
let ``shouldnt catch`` = '\uwert' // not legal
let var' = var + 1 // Shouldn't mess with var'
let sillychar = '\uabcd' // legal
let sillychar2 = '\uABCD' // legal

let chars = [| 's'; 'b'; 'c' |]
```

This is what it looks like in Xamarin Studio:
![screen shot 2013-07-09 at 11 00 59](https://f.cloud.github.com/assets/445888/767084/3b4196fe-e876-11e2-81f2-417c5e193893.png)

This is in MonoDevelop after applying the patch:

![screen shot 2013-07-19 at 01 20 40](https://f.cloud.github.com/assets/445888/823068/bf9cda80-f000-11e2-9393-9d680f31edcf.png)

cc @mkrueger
