### PR TITLE
First attempt at fixing some memory/speed issues with Version Control.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -295,7 +295,7 @@ namespace MonoDevelop.VersionControl.Git
 						paths = new FilePath [0];
 				}
 			} else {
-				paths = localFileNames.Select (f => f).ToArray ();
+				paths = localFileNames.ToArray ();
 			}
 
 			foreach (var group in paths.GroupBy (p => GetRepository (p))) {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -225,8 +225,7 @@ namespace MonoDevelop.VersionControl
 
 				if (status != null && status.RequiresRefresh && (!getRemoteStatus || status.HasRemoteStatus))
 					return status.FileInfo;
-				else
-					return new VersionInfo[0];
+				return new VersionInfo[0];
 			} finally {
 				//Console.WriteLine ("GetDirectoryVersionInfo " + localDirectory + " - " + (DateTime.Now - now).TotalMilliseconds);
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
@@ -54,7 +54,6 @@ namespace MonoDevelop.VersionControl
 				Repository rep = VersionControlService.GetRepository (ce);
 				if (rep != null) {
 					AddFolderOverlay (rep, ce.BaseDirectory, ref icon, ref closedIcon, false);
-					rep.GetDirectoryVersionInfo (ce.BaseDirectory, false, false);
 				}
 				return;
 			} else if (dataObject is ProjectFolder) {
@@ -63,7 +62,6 @@ namespace MonoDevelop.VersionControl
 					Repository rep = VersionControlService.GetRepository (ce.ParentWorkspaceObject);
 					if (rep != null) {
 						AddFolderOverlay (rep, ce.Path, ref icon, ref closedIcon, true);
-						rep.GetDirectoryVersionInfo (ce.Path, false, false);
 					}
 				}
 				return;


### PR DESCRIPTION
We are uselessly gathering DirectoryVersionInfo (and duplicating the items).

Tests on MD repo show that a minimum of 2300 VersionInfo's are created in current trunk. With this patch, the number is trimmed down to 340. This is a speed-up for loading. ( We also grabbed each directory multiple times: https://gist.github.com/Therzok/8bce3cf2b1f47b242b8a )

We also need to solve duplicate data that is done by DirectoryStatus and VersionInfo not being interdependent. We have VersionInfo for files at least twice now (once in directoryStatus, once in fileStatus in the cache)
