### PR TITLE
[NUnit] Bake in support for on the fly updates via GuiUnit

### DIFF
--- a/main/src/addins/NUnit/MonoDevelop.NUnit.csproj
+++ b/main/src/addins/NUnit/MonoDevelop.NUnit.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Services\NUnitProjectServiceExtension.cs" />
     <Compile Include="Gui\NUnitOptionsPanel.cs" />
     <Compile Include="gtk-gui\MonoDevelop.NUnit.NUnitOptionsWidget.cs" />
+    <Compile Include="Services\TcpTestListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
@@ -465,6 +465,8 @@ namespace MonoDevelop.NUnit
 			LocalConsole cons = new LocalConsole ();
 
 			try {
+				LocalTestMonitor localMonitor = new LocalTestMonitor (testContext, test, suiteName, testName != null);
+
 				if (!string.IsNullOrEmpty (cmd.Arguments))
 					cmd.Arguments += " ";
 				cmd.Arguments += "\"-xml=" + outFile + "\" " + AssemblyPath;
@@ -472,6 +474,10 @@ namespace MonoDevelop.NUnit
 					cmd.Arguments += " -run=" + suiteName + "." + testName;
 				else if (!string.IsNullOrEmpty (suiteName))
 					cmd.Arguments += " -run=" + suiteName;
+				if (cmd.Command.Contains ("GuiUnit")) {
+					var tcpListener = new MonoDevelop.NUnit.External.TcpTestListener (localMonitor);
+					cmd.Arguments += " -port=" + tcpListener.Port;
+				}
 				var p = testContext.ExecutionContext.Execute (cmd, cons);
 
 				testContext.Monitor.CancelRequested += p.Cancel;
@@ -482,7 +488,6 @@ namespace MonoDevelop.NUnit
 				if (new FileInfo (outFile).Length == 0)
 					throw new Exception ("Command failed");
 
-				LocalTestMonitor localMonitor = new LocalTestMonitor (testContext, test, suiteName, testName != null);
 				XDocument doc = XDocument.Load (outFile);
 				if (doc.Root != null) {
 					var root = doc.Root.Elements ("test-suite").FirstOrDefault ();

--- a/main/src/addins/NUnit/Services/TcpTestListener.cs
+++ b/main/src/addins/NUnit/Services/TcpTestListener.cs
@@ -1,0 +1,108 @@
+//
+// TcpTestListener.cs
+//
+// Author:
+//       Alan McGovern <alan.mcgovern@gmail.com>
+//
+// Copyright (c) 2013 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using MonoDevelop.NUnit.External;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoDevelop.NUnit.External
+{
+	class TcpTestListener
+	{
+		TcpListener TcpListener {
+			get; set;
+		}
+
+		public int Port {
+			get { return ((IPEndPoint) TcpListener.LocalEndpoint).Port; }
+		}
+
+
+		public TcpTestListener (IRemoteEventListener listener)
+		{
+			TcpListener = new TcpListener (new IPEndPoint (IPAddress.Loopback, 0));
+			TcpListener.Start ();
+			Task.Factory.StartNew (() => {
+				try {
+					using (var client = TcpListener.AcceptTcpClient ())
+					using (var socketStream = client.GetStream ())
+					using (var reader = new StreamReader (socketStream, Encoding.UTF8)) {
+
+						string line = null;
+						while ((line = reader.ReadLine ()) != null) {
+							var element = XElement.Parse (line);
+
+							Gtk.Application.Invoke (delegate {
+								var testName = element.Attribute ("name").Value;
+								if (element.Name.LocalName == "suite-started") {
+									listener.SuiteStarted (testName);
+								} else if (element.Name.LocalName == "test-started") {
+									listener.TestStarted (testName);
+								} else if (element.Name.LocalName == "test-finished") {
+									listener.TestFinished (testName, CreateResult (element.Attribute ("result").Value));
+								} else if (element.Name.LocalName == "suite-finished") {
+									listener.SuiteFinished (testName, CreateResult (element.Attribute ("result").Value));
+								}
+							});
+						}
+					}
+				} catch {
+
+				} finally {
+					TcpListener.Stop ();
+				}
+			});
+		}
+
+		UnitTestResult CreateResult (string result)
+		{
+			var testresult = new UnitTestResult { Status = (ResultStatus) Enum.Parse (typeof (ResultStatus), result) };
+			switch (testresult.Status) {
+			case ResultStatus.Failure:
+				testresult.Failures ++;
+				break;
+			case ResultStatus.Ignored:
+				testresult.Ignored ++;
+				break;
+			case ResultStatus.Inconclusive:
+				testresult.Inconclusive ++;
+				break;
+			case ResultStatus.Success:
+				testresult.Passed ++;
+				break;
+			}
+			return testresult;
+		}
+	}
+}
+


### PR DESCRIPTION
If the test runner is GuiUnit we can pass a port to it and receive
information on when tests are started/finished over a tcp socket
on that port.
