### PR TITLE
DO NOT MERGE THIS

### DIFF
--- a/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
@@ -474,7 +474,7 @@ namespace MonoDevelop.NUnit
 					cmd.Arguments += " -run=" + suiteName + "." + testName;
 				else if (!string.IsNullOrEmpty (suiteName))
 					cmd.Arguments += " -run=" + suiteName;
-				if (cmd.Command.Contains ("GuiUnit")) {
+				if (cmd.Command.Contains ("GuiUnit") || (cmd.Command.Contains ("mdtool.exe") && cmd.Arguments.Contains ("run-md-tests"))) {
 					var tcpListener = new MonoDevelop.NUnit.External.TcpTestListener (localMonitor);
 					cmd.Arguments += " -port=" + tcpListener.Port;
 				}

--- a/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
@@ -30,10 +30,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\..\external\mdtestharness\nunit.framework.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Private>False</Private>
     </Reference>
@@ -46,6 +42,9 @@
     <Reference Include="System.Core" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Private>False</Private>
+    </Reference>
+    <Reference Include="GuiUnit">
+      <HintPath>..\..\..\..\..\md-addins\external\guiunit\bin\GuiUnit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/tests/TestRunner/Runner.cs
+++ b/main/tests/TestRunner/Runner.cs
@@ -34,13 +34,30 @@ using Mono.Addins.Description;
 
 namespace MonoDevelop.Tests.TestRunner
 {
+	class GtkMainLoop : GuiUnit.IMainLoopIntegration
+	{
+		public void InitializeToolkit ()
+		{
+			Gtk.Application.Init ();
+		}
+		public void InvokeOnMainLoop (GuiUnit.InvokerHelper helper)
+		{
+			Gtk.Application.Invoke (delegate { helper.Invoke (); });
+		}
+		public void RunMainLoop ()
+		{
+			Gtk.Application.Run ();
+		}
+		public void Shutdown ()
+		{
+			Gtk.Application.Quit ();
+		}
+	}
+
 	public class Runer: IApplication
 	{
 		public int Run (string[] arguments)
 		{
-			var list = new List<string> (arguments);
-			list.Add ("-domain=None");
-
 			foreach (var ar in arguments) {
 				if ((ar.EndsWith (".dll") || ar.EndsWith (".exe")) && File.Exists (ar)) {
 					try {
@@ -57,7 +74,8 @@ namespace MonoDevelop.Tests.TestRunner
 					}
 				}
 			}
-			return NUnit.ConsoleRunner.Runner.Main (list.ToArray ());
+			GuiUnit.TestRunner.MainLoop = new GtkMainLoop ();
+			return GuiUnit.TestRunner.Main (arguments);
 		}
 
 		IEnumerable<string> GetAddinsFromReferences (AssemblyName aname)

--- a/main/tests/TestRunner/TestRunner.csproj
+++ b/main/tests/TestRunner/TestRunner.csproj
@@ -31,19 +31,10 @@
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Private>False</Private>
     </Reference>
-    <Reference Include="nunit-console-runner">
-      <HintPath>..\..\external\mdtestharness\lib\nunit-console-runner.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.core.interfaces">
-      <HintPath>..\..\external\mdtestharness\lib\nunit.core.interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.core">
-      <HintPath>..\..\external\mdtestharness\lib\nunit.core.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\external\mdtestharness\framework\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="GuiUnit">
+      <HintPath>..\..\..\..\md-addins\external\guiunit\bin\GuiUnit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
[test] Port mdtool run-md-tests to use GuiUnit

This allows us to
1) Use async tests, if we want.
2) Have our tests run inside the Gtk main loop (if we want)
3) Get updates on the fly as the tests execute

As we control GuiUnit we can add additional Assert methods to
keep API compatibility with nunit 2.6.x if we do not actually
want to change our tests to cope with the new api.

This is just to demonstrate the changes required.
