### PR TITLE
[AspNet] Allow XSP to use random ports

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/AspNetAppProject.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/AspNetAppProject.cs
@@ -246,13 +246,14 @@ namespace MonoDevelop.AspNet
 					console = context.ExternalConsoleFactory.CreateConsole (!configuration.PauseConsoleOutput);
 				else
 					console = context.ConsoleFactory.CreateConsole (!configuration.PauseConsoleOutput);
-				
-				string url = String.Format ("http://{0}:{1}", this.XspParameters.Address, this.XspParameters.Port);
+
+				// The running Port value is now captured in the XspBrowserLauncherConsole object
+				string url = String.Format ("http://{0}", this.XspParameters.Address);
 				
 				
 				if (isXsp) {
-					console = new XspBrowserLauncherConsole (console, delegate {
-						BrowserLauncher.LaunchDefaultBrowser (url);
+					console = new XspBrowserLauncherConsole (console, delegate (string port) {
+						BrowserLauncher.LaunchDefaultBrowser (String.Format("{0}:{1}", url, port));
 					});
 				}
 			
@@ -768,11 +769,11 @@ namespace MonoDevelop.AspNet
 	{
 		IConsole real;
 		LineInterceptingTextWriter outWriter;
-		Action launchBrowser;
+		Action <string> launchBrowser;
 		
 		const int MAX_WATCHED_LINES = 30;
 		
-		public XspBrowserLauncherConsole (IConsole real, Action launchBrowser)
+		public XspBrowserLauncherConsole (IConsole real, Action <string> launchBrowser)
 		{
 			this.real = real;
 			this.launchBrowser = launchBrowser;
@@ -796,8 +797,10 @@ namespace MonoDevelop.AspNet
 			get {
 				if (outWriter == null)
 					outWriter = new LineInterceptingTextWriter (real.Out, delegate {
-						if (outWriter.GetLine ().StartsWith ("Listening on port: ")) {
-							launchBrowser ();
+						string line = outWriter.GetLine();
+						if (line.StartsWith ("Listening on port: ")) {
+							string port = System.Text.RegularExpressions.Regex.Replace(line, "[^0-9]", "");
+							launchBrowser (port);
 							outWriter.FinishedIntercepting = true;
 						} else if (outWriter.LineCount > MAX_WATCHED_LINES) {
 							outWriter.FinishedIntercepting = true;

--- a/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/XspParameters.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/XspParameters.cs
@@ -139,8 +139,11 @@ namespace MonoDevelop.AspNet
 		public string GetXspParameters ()
 		{
 			System.Text.StringBuilder opt = new System.Text.StringBuilder ();
-			
-			opt.AppendFormat (" --port {0}", port);
+
+			if (port == 0)
+				opt.Append (" --random-port");
+			else
+				opt.AppendFormat (" --port {0}", port);
 			opt.AppendFormat (" --address {0}", address);
 			
 			switch (sslMode) {

--- a/main/src/addins/AspNet/MonoDevelop.AspNet/gtk-gui/MonoDevelop.AspNet.Gui.XspOptionsPanelWidget.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/gtk-gui/MonoDevelop.AspNet.Gui.XspOptionsPanelWidget.cs
@@ -11,6 +11,7 @@ namespace MonoDevelop.AspNet.Gui
 		private global::Gtk.VBox vbox2;
 		private global::Gtk.Table table2;
 		private global::Gtk.Entry ipAddress;
+		private global::Gtk.Label label15;
 		private global::Gtk.Label label7;
 		private global::Gtk.Label label8;
 		private global::Gtk.SpinButton portNumber;
@@ -38,7 +39,7 @@ namespace MonoDevelop.AspNet.Gui
 		private global::Gtk.Label label12;
 		private global::Gtk.Label label13;
 		private global::Gtk.Label label14;
-		
+
 		protected virtual void Build ()
 		{
 			global::Stetic.Gui.Initialize (this);
@@ -77,7 +78,7 @@ namespace MonoDevelop.AspNet.Gui
 			this.vbox2.Name = "vbox2";
 			this.vbox2.Spacing = 6;
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.table2 = new global::Gtk.Table (((uint)(2)), ((uint)(2)), false);
+			this.table2 = new global::Gtk.Table (((uint)(2)), ((uint)(3)), false);
 			this.table2.Name = "table2";
 			this.table2.RowSpacing = ((uint)(6));
 			this.table2.ColumnSpacing = ((uint)(6));
@@ -94,25 +95,37 @@ namespace MonoDevelop.AspNet.Gui
 			w3.XOptions = ((global::Gtk.AttachOptions)(4));
 			w3.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table2.Gtk.Table+TableChild
+			this.label15 = new global::Gtk.Label ();
+			this.label15.Name = "label15";
+			this.label15.LabelProp = global::Mono.Unix.Catalog.GetString ("0 = Random Port");
+			this.table2.Add (this.label15);
+			global::Gtk.Table.TableChild w4 = ((global::Gtk.Table.TableChild)(this.table2 [this.label15]));
+			w4.TopAttach = ((uint)(1));
+			w4.BottomAttach = ((uint)(2));
+			w4.LeftAttach = ((uint)(2));
+			w4.RightAttach = ((uint)(3));
+			w4.XOptions = ((global::Gtk.AttachOptions)(4));
+			w4.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table2.Gtk.Table+TableChild
 			this.label7 = new global::Gtk.Label ();
 			this.label7.Name = "label7";
 			this.label7.Xalign = 0F;
 			this.label7.LabelProp = global::Mono.Unix.Catalog.GetString ("Port number:");
 			this.table2.Add (this.label7);
-			global::Gtk.Table.TableChild w4 = ((global::Gtk.Table.TableChild)(this.table2 [this.label7]));
-			w4.TopAttach = ((uint)(1));
-			w4.BottomAttach = ((uint)(2));
-			w4.XOptions = ((global::Gtk.AttachOptions)(4));
-			w4.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w5 = ((global::Gtk.Table.TableChild)(this.table2 [this.label7]));
+			w5.TopAttach = ((uint)(1));
+			w5.BottomAttach = ((uint)(2));
+			w5.XOptions = ((global::Gtk.AttachOptions)(4));
+			w5.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table2.Gtk.Table+TableChild
 			this.label8 = new global::Gtk.Label ();
 			this.label8.Name = "label8";
 			this.label8.Xalign = 0F;
 			this.label8.LabelProp = global::Mono.Unix.Catalog.GetString ("IP address:");
 			this.table2.Add (this.label8);
-			global::Gtk.Table.TableChild w5 = ((global::Gtk.Table.TableChild)(this.table2 [this.label8]));
-			w5.XOptions = ((global::Gtk.AttachOptions)(4));
-			w5.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w6 = ((global::Gtk.Table.TableChild)(this.table2 [this.label8]));
+			w6.XOptions = ((global::Gtk.AttachOptions)(4));
+			w6.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table2.Gtk.Table+TableChild
 			this.portNumber = new global::Gtk.SpinButton (0, 32767, 1);
 			this.portNumber.CanFocus = true;
@@ -121,18 +134,18 @@ namespace MonoDevelop.AspNet.Gui
 			this.portNumber.ClimbRate = 1;
 			this.portNumber.Numeric = true;
 			this.table2.Add (this.portNumber);
-			global::Gtk.Table.TableChild w6 = ((global::Gtk.Table.TableChild)(this.table2 [this.portNumber]));
-			w6.TopAttach = ((uint)(1));
-			w6.BottomAttach = ((uint)(2));
-			w6.LeftAttach = ((uint)(1));
-			w6.RightAttach = ((uint)(2));
-			w6.XOptions = ((global::Gtk.AttachOptions)(4));
-			w6.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w7 = ((global::Gtk.Table.TableChild)(this.table2 [this.portNumber]));
+			w7.TopAttach = ((uint)(1));
+			w7.BottomAttach = ((uint)(2));
+			w7.LeftAttach = ((uint)(1));
+			w7.RightAttach = ((uint)(2));
+			w7.XOptions = ((global::Gtk.AttachOptions)(4));
+			w7.YOptions = ((global::Gtk.AttachOptions)(4));
 			this.vbox2.Add (this.table2);
-			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.table2]));
-			w7.Position = 0;
-			w7.Expand = false;
-			w7.Fill = false;
+			global::Gtk.Box.BoxChild w8 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.table2]));
+			w8.Position = 0;
+			w8.Expand = false;
+			w8.Fill = false;
 			// Container child vbox2.Gtk.Box+BoxChild
 			this.verboseCheck = new global::Gtk.CheckButton ();
 			this.verboseCheck.CanFocus = true;
@@ -141,20 +154,20 @@ namespace MonoDevelop.AspNet.Gui
 			this.verboseCheck.DrawIndicator = true;
 			this.verboseCheck.UseUnderline = true;
 			this.vbox2.Add (this.verboseCheck);
-			global::Gtk.Box.BoxChild w8 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.verboseCheck]));
-			w8.Position = 1;
-			w8.Expand = false;
-			w8.Fill = false;
-			this.hbox2.Add (this.vbox2);
-			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.hbox2 [this.vbox2]));
+			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.verboseCheck]));
 			w9.Position = 1;
 			w9.Expand = false;
 			w9.Fill = false;
-			this.vbox1.Add (this.hbox2);
-			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox2]));
+			this.hbox2.Add (this.vbox2);
+			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.hbox2 [this.vbox2]));
 			w10.Position = 1;
 			w10.Expand = false;
 			w10.Fill = false;
+			this.vbox1.Add (this.hbox2);
+			global::Gtk.Box.BoxChild w11 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox2]));
+			w11.Position = 1;
+			w11.Expand = false;
+			w11.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.label2 = new global::Gtk.Label ();
 			this.label2.Name = "label2";
@@ -162,10 +175,10 @@ namespace MonoDevelop.AspNet.Gui
 			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString ("<b>Security</b>");
 			this.label2.UseMarkup = true;
 			this.vbox1.Add (this.label2);
-			global::Gtk.Box.BoxChild w11 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.label2]));
-			w11.Position = 2;
-			w11.Expand = false;
-			w11.Fill = false;
+			global::Gtk.Box.BoxChild w12 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.label2]));
+			w12.Position = 2;
+			w12.Expand = false;
+			w12.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.hbox3 = new global::Gtk.HBox ();
 			this.hbox3.Name = "hbox3";
@@ -174,10 +187,10 @@ namespace MonoDevelop.AspNet.Gui
 			this.label5.WidthRequest = 18;
 			this.label5.Name = "label5";
 			this.hbox3.Add (this.label5);
-			global::Gtk.Box.BoxChild w12 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this.label5]));
-			w12.Position = 0;
-			w12.Expand = false;
-			w12.Fill = false;
+			global::Gtk.Box.BoxChild w13 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this.label5]));
+			w13.Position = 0;
+			w13.Expand = false;
+			w13.Fill = false;
 			// Container child hbox3.Gtk.Box+BoxChild
 			this.table3 = new global::Gtk.Table (((uint)(2)), ((uint)(2)), false);
 			this.table3.Name = "table3";
@@ -189,50 +202,50 @@ namespace MonoDevelop.AspNet.Gui
 			this.label10.Xalign = 0F;
 			this.label10.LabelProp = global::Mono.Unix.Catalog.GetString ("SSL mode:");
 			this.table3.Add (this.label10);
-			global::Gtk.Table.TableChild w13 = ((global::Gtk.Table.TableChild)(this.table3 [this.label10]));
-			w13.XOptions = ((global::Gtk.AttachOptions)(4));
-			w13.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table3 [this.label10]));
+			w14.XOptions = ((global::Gtk.AttachOptions)(4));
+			w14.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
 			this.label9 = new global::Gtk.Label ();
 			this.label9.Name = "label9";
 			this.label9.Xalign = 0F;
 			this.label9.LabelProp = global::Mono.Unix.Catalog.GetString ("SSL protocol:");
 			this.table3.Add (this.label9);
-			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table3 [this.label9]));
-			w14.TopAttach = ((uint)(1));
-			w14.BottomAttach = ((uint)(2));
-			w14.XOptions = ((global::Gtk.AttachOptions)(4));
-			w14.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w15 = ((global::Gtk.Table.TableChild)(this.table3 [this.label9]));
+			w15.TopAttach = ((uint)(1));
+			w15.BottomAttach = ((uint)(2));
+			w15.XOptions = ((global::Gtk.AttachOptions)(4));
+			w15.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
 			this.sslMode = global::Gtk.ComboBox.NewText ();
 			this.sslMode.Name = "sslMode";
 			this.table3.Add (this.sslMode);
-			global::Gtk.Table.TableChild w15 = ((global::Gtk.Table.TableChild)(this.table3 [this.sslMode]));
-			w15.LeftAttach = ((uint)(1));
-			w15.RightAttach = ((uint)(2));
-			w15.XOptions = ((global::Gtk.AttachOptions)(4));
-			w15.YOptions = ((global::Gtk.AttachOptions)(4));
-			// Container child table3.Gtk.Table+TableChild
-			this.sslProtocol = global::Gtk.ComboBox.NewText ();
-			this.sslProtocol.Name = "sslProtocol";
-			this.table3.Add (this.sslProtocol);
-			global::Gtk.Table.TableChild w16 = ((global::Gtk.Table.TableChild)(this.table3 [this.sslProtocol]));
-			w16.TopAttach = ((uint)(1));
-			w16.BottomAttach = ((uint)(2));
+			global::Gtk.Table.TableChild w16 = ((global::Gtk.Table.TableChild)(this.table3 [this.sslMode]));
 			w16.LeftAttach = ((uint)(1));
 			w16.RightAttach = ((uint)(2));
 			w16.XOptions = ((global::Gtk.AttachOptions)(4));
 			w16.YOptions = ((global::Gtk.AttachOptions)(4));
+			// Container child table3.Gtk.Table+TableChild
+			this.sslProtocol = global::Gtk.ComboBox.NewText ();
+			this.sslProtocol.Name = "sslProtocol";
+			this.table3.Add (this.sslProtocol);
+			global::Gtk.Table.TableChild w17 = ((global::Gtk.Table.TableChild)(this.table3 [this.sslProtocol]));
+			w17.TopAttach = ((uint)(1));
+			w17.BottomAttach = ((uint)(2));
+			w17.LeftAttach = ((uint)(1));
+			w17.RightAttach = ((uint)(2));
+			w17.XOptions = ((global::Gtk.AttachOptions)(4));
+			w17.YOptions = ((global::Gtk.AttachOptions)(4));
 			this.hbox3.Add (this.table3);
-			global::Gtk.Box.BoxChild w17 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this.table3]));
-			w17.Position = 1;
-			w17.Expand = false;
-			w17.Fill = false;
-			this.vbox1.Add (this.hbox3);
-			global::Gtk.Box.BoxChild w18 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox3]));
-			w18.Position = 3;
+			global::Gtk.Box.BoxChild w18 = ((global::Gtk.Box.BoxChild)(this.hbox3 [this.table3]));
+			w18.Position = 1;
 			w18.Expand = false;
 			w18.Fill = false;
+			this.vbox1.Add (this.hbox3);
+			global::Gtk.Box.BoxChild w19 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox3]));
+			w19.Position = 3;
+			w19.Expand = false;
+			w19.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.label3 = new global::Gtk.Label ();
 			this.label3.Name = "label3";
@@ -240,10 +253,10 @@ namespace MonoDevelop.AspNet.Gui
 			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString ("<b>SSL Key</b>");
 			this.label3.UseMarkup = true;
 			this.vbox1.Add (this.label3);
-			global::Gtk.Box.BoxChild w19 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.label3]));
-			w19.Position = 4;
-			w19.Expand = false;
-			w19.Fill = false;
+			global::Gtk.Box.BoxChild w20 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.label3]));
+			w20.Position = 4;
+			w20.Expand = false;
+			w20.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.hbox4 = new global::Gtk.HBox ();
 			this.hbox4.Name = "hbox4";
@@ -252,10 +265,10 @@ namespace MonoDevelop.AspNet.Gui
 			this.label6.WidthRequest = 18;
 			this.label6.Name = "label6";
 			this.hbox4.Add (this.label6);
-			global::Gtk.Box.BoxChild w20 = ((global::Gtk.Box.BoxChild)(this.hbox4 [this.label6]));
-			w20.Position = 0;
-			w20.Expand = false;
-			w20.Fill = false;
+			global::Gtk.Box.BoxChild w21 = ((global::Gtk.Box.BoxChild)(this.hbox4 [this.label6]));
+			w21.Position = 0;
+			w21.Expand = false;
+			w21.Fill = false;
 			// Container child hbox4.Gtk.Box+BoxChild
 			this.table4 = new global::Gtk.Table (((uint)(4)), ((uint)(2)), false);
 			this.table4.Name = "table4";
@@ -265,13 +278,13 @@ namespace MonoDevelop.AspNet.Gui
 			this.certLocation = new global::MonoDevelop.Components.FileEntry ();
 			this.certLocation.Name = "certLocation";
 			this.table4.Add (this.certLocation);
-			global::Gtk.Table.TableChild w21 = ((global::Gtk.Table.TableChild)(this.table4 [this.certLocation]));
-			w21.TopAttach = ((uint)(2));
-			w21.BottomAttach = ((uint)(3));
-			w21.LeftAttach = ((uint)(1));
-			w21.RightAttach = ((uint)(2));
-			w21.XOptions = ((global::Gtk.AttachOptions)(4));
-			w21.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w22 = ((global::Gtk.Table.TableChild)(this.table4 [this.certLocation]));
+			w22.TopAttach = ((uint)(2));
+			w22.BottomAttach = ((uint)(3));
+			w22.LeftAttach = ((uint)(1));
+			w22.RightAttach = ((uint)(2));
+			w22.XOptions = ((global::Gtk.AttachOptions)(4));
+			w22.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.hbox5 = new global::Gtk.HBox ();
 			this.hbox5.Name = "hbox5";
@@ -280,16 +293,16 @@ namespace MonoDevelop.AspNet.Gui
 			this.keyType = global::Gtk.ComboBox.NewText ();
 			this.keyType.Name = "keyType";
 			this.hbox5.Add (this.keyType);
-			global::Gtk.Box.BoxChild w22 = ((global::Gtk.Box.BoxChild)(this.hbox5 [this.keyType]));
-			w22.Position = 0;
-			w22.Expand = false;
-			w22.Fill = false;
+			global::Gtk.Box.BoxChild w23 = ((global::Gtk.Box.BoxChild)(this.hbox5 [this.keyType]));
+			w23.Position = 0;
+			w23.Expand = false;
+			w23.Fill = false;
 			this.table4.Add (this.hbox5);
-			global::Gtk.Table.TableChild w23 = ((global::Gtk.Table.TableChild)(this.table4 [this.hbox5]));
-			w23.LeftAttach = ((uint)(1));
-			w23.RightAttach = ((uint)(2));
-			w23.XOptions = ((global::Gtk.AttachOptions)(4));
-			w23.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w24 = ((global::Gtk.Table.TableChild)(this.table4 [this.hbox5]));
+			w24.LeftAttach = ((uint)(1));
+			w24.RightAttach = ((uint)(2));
+			w24.XOptions = ((global::Gtk.AttachOptions)(4));
+			w24.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.hbox6 = new global::Gtk.HBox ();
 			this.hbox6.Name = "hbox6";
@@ -298,10 +311,10 @@ namespace MonoDevelop.AspNet.Gui
 			this.passwordOptions = global::Gtk.ComboBox.NewText ();
 			this.passwordOptions.Name = "passwordOptions";
 			this.hbox6.Add (this.passwordOptions);
-			global::Gtk.Box.BoxChild w24 = ((global::Gtk.Box.BoxChild)(this.hbox6 [this.passwordOptions]));
-			w24.Position = 0;
-			w24.Expand = false;
-			w24.Fill = false;
+			global::Gtk.Box.BoxChild w25 = ((global::Gtk.Box.BoxChild)(this.hbox6 [this.passwordOptions]));
+			w25.Position = 0;
+			w25.Expand = false;
+			w25.Fill = false;
 			// Container child hbox6.Gtk.Box+BoxChild
 			this.passwordEntry = new global::Gtk.Entry ();
 			this.passwordEntry.CanFocus = true;
@@ -309,76 +322,76 @@ namespace MonoDevelop.AspNet.Gui
 			this.passwordEntry.IsEditable = true;
 			this.passwordEntry.InvisibleChar = '●';
 			this.hbox6.Add (this.passwordEntry);
-			global::Gtk.Box.BoxChild w25 = ((global::Gtk.Box.BoxChild)(this.hbox6 [this.passwordEntry]));
-			w25.Position = 1;
+			global::Gtk.Box.BoxChild w26 = ((global::Gtk.Box.BoxChild)(this.hbox6 [this.passwordEntry]));
+			w26.Position = 1;
 			this.table4.Add (this.hbox6);
-			global::Gtk.Table.TableChild w26 = ((global::Gtk.Table.TableChild)(this.table4 [this.hbox6]));
-			w26.TopAttach = ((uint)(3));
-			w26.BottomAttach = ((uint)(4));
-			w26.LeftAttach = ((uint)(1));
-			w26.RightAttach = ((uint)(2));
-			w26.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w27 = ((global::Gtk.Table.TableChild)(this.table4 [this.hbox6]));
+			w27.TopAttach = ((uint)(3));
+			w27.BottomAttach = ((uint)(4));
+			w27.LeftAttach = ((uint)(1));
+			w27.RightAttach = ((uint)(2));
+			w27.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.keyLocation = new global::MonoDevelop.Components.FileEntry ();
 			this.keyLocation.Name = "keyLocation";
 			this.table4.Add (this.keyLocation);
-			global::Gtk.Table.TableChild w27 = ((global::Gtk.Table.TableChild)(this.table4 [this.keyLocation]));
-			w27.TopAttach = ((uint)(1));
-			w27.BottomAttach = ((uint)(2));
-			w27.LeftAttach = ((uint)(1));
-			w27.RightAttach = ((uint)(2));
-			w27.XOptions = ((global::Gtk.AttachOptions)(4));
-			w27.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w28 = ((global::Gtk.Table.TableChild)(this.table4 [this.keyLocation]));
+			w28.TopAttach = ((uint)(1));
+			w28.BottomAttach = ((uint)(2));
+			w28.LeftAttach = ((uint)(1));
+			w28.RightAttach = ((uint)(2));
+			w28.XOptions = ((global::Gtk.AttachOptions)(4));
+			w28.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.label11 = new global::Gtk.Label ();
 			this.label11.Name = "label11";
 			this.label11.Xalign = 0F;
 			this.label11.LabelProp = global::Mono.Unix.Catalog.GetString ("Key type:");
 			this.table4.Add (this.label11);
-			global::Gtk.Table.TableChild w28 = ((global::Gtk.Table.TableChild)(this.table4 [this.label11]));
-			w28.XOptions = ((global::Gtk.AttachOptions)(4));
-			w28.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w29 = ((global::Gtk.Table.TableChild)(this.table4 [this.label11]));
+			w29.XOptions = ((global::Gtk.AttachOptions)(4));
+			w29.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.label12 = new global::Gtk.Label ();
 			this.label12.Name = "label12";
 			this.label12.Xalign = 0F;
 			this.label12.LabelProp = global::Mono.Unix.Catalog.GetString ("Key location:");
 			this.table4.Add (this.label12);
-			global::Gtk.Table.TableChild w29 = ((global::Gtk.Table.TableChild)(this.table4 [this.label12]));
-			w29.TopAttach = ((uint)(1));
-			w29.BottomAttach = ((uint)(2));
-			w29.XOptions = ((global::Gtk.AttachOptions)(4));
-			w29.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w30 = ((global::Gtk.Table.TableChild)(this.table4 [this.label12]));
+			w30.TopAttach = ((uint)(1));
+			w30.BottomAttach = ((uint)(2));
+			w30.XOptions = ((global::Gtk.AttachOptions)(4));
+			w30.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.label13 = new global::Gtk.Label ();
 			this.label13.Name = "label13";
 			this.label13.Xalign = 0F;
 			this.label13.LabelProp = global::Mono.Unix.Catalog.GetString ("Certificate location:");
 			this.table4.Add (this.label13);
-			global::Gtk.Table.TableChild w30 = ((global::Gtk.Table.TableChild)(this.table4 [this.label13]));
-			w30.TopAttach = ((uint)(2));
-			w30.BottomAttach = ((uint)(3));
-			w30.XOptions = ((global::Gtk.AttachOptions)(4));
-			w30.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w31 = ((global::Gtk.Table.TableChild)(this.table4 [this.label13]));
+			w31.TopAttach = ((uint)(2));
+			w31.BottomAttach = ((uint)(3));
+			w31.XOptions = ((global::Gtk.AttachOptions)(4));
+			w31.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table4.Gtk.Table+TableChild
 			this.label14 = new global::Gtk.Label ();
 			this.label14.Name = "label14";
 			this.label14.Xalign = 0F;
 			this.label14.LabelProp = global::Mono.Unix.Catalog.GetString ("Password:");
 			this.table4.Add (this.label14);
-			global::Gtk.Table.TableChild w31 = ((global::Gtk.Table.TableChild)(this.table4 [this.label14]));
-			w31.TopAttach = ((uint)(3));
-			w31.BottomAttach = ((uint)(4));
-			w31.XOptions = ((global::Gtk.AttachOptions)(4));
-			w31.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w32 = ((global::Gtk.Table.TableChild)(this.table4 [this.label14]));
+			w32.TopAttach = ((uint)(3));
+			w32.BottomAttach = ((uint)(4));
+			w32.XOptions = ((global::Gtk.AttachOptions)(4));
+			w32.YOptions = ((global::Gtk.AttachOptions)(4));
 			this.hbox4.Add (this.table4);
-			global::Gtk.Box.BoxChild w32 = ((global::Gtk.Box.BoxChild)(this.hbox4 [this.table4]));
-			w32.Position = 1;
+			global::Gtk.Box.BoxChild w33 = ((global::Gtk.Box.BoxChild)(this.hbox4 [this.table4]));
+			w33.Position = 1;
 			this.vbox1.Add (this.hbox4);
-			global::Gtk.Box.BoxChild w33 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox4]));
-			w33.Position = 5;
-			w33.Expand = false;
-			w33.Fill = false;
+			global::Gtk.Box.BoxChild w34 = ((global::Gtk.Box.BoxChild)(this.vbox1 [this.hbox4]));
+			w34.Position = 5;
+			w34.Expand = false;
+			w34.Fill = false;
 			this.Add (this.vbox1);
 			if ((this.Child != null)) {
 				this.Child.ShowAll ();

--- a/main/src/addins/AspNet/MonoDevelop.AspNet/gtk-gui/generated.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/gtk-gui/generated.cs
@@ -5,7 +5,7 @@ namespace Stetic
 	internal class Gui
 	{
 		private static bool initialized;
-		
+
 		internal static void Initialize (Gtk.Widget iconRenderer)
 		{
 			if ((Stetic.Gui.initialized == false)) {
@@ -13,12 +13,12 @@ namespace Stetic
 			}
 		}
 	}
-	
+
 	internal class BinContainer
 	{
 		private Gtk.Widget child;
 		private Gtk.UIManager uimanager;
-		
+
 		public static BinContainer Attach (Gtk.Bin bin)
 		{
 			BinContainer bc = new BinContainer ();
@@ -27,32 +27,32 @@ namespace Stetic
 			bin.Added += new Gtk.AddedHandler (bc.OnAdded);
 			return bc;
 		}
-		
+
 		private void OnSizeRequested (object sender, Gtk.SizeRequestedArgs args)
 		{
 			if ((this.child != null)) {
 				args.Requisition = this.child.SizeRequest ();
 			}
 		}
-		
+
 		private void OnSizeAllocated (object sender, Gtk.SizeAllocatedArgs args)
 		{
 			if ((this.child != null)) {
 				this.child.Allocation = args.Allocation;
 			}
 		}
-		
+
 		private void OnAdded (object sender, Gtk.AddedArgs args)
 		{
 			this.child = args.Widget;
 		}
-		
+
 		public void SetUiManager (Gtk.UIManager uim)
 		{
 			this.uimanager = uim;
 			this.child.Realized += new System.EventHandler (this.OnRealized);
 		}
-		
+
 		private void OnRealized (object sender, System.EventArgs args)
 		{
 			if ((this.uimanager != null)) {
@@ -65,7 +65,7 @@ namespace Stetic
 			}
 		}
 	}
-	
+
 	internal class IconLoader
 	{
 		public static Gdk.Pixbuf LoadIcon (Gtk.Widget widget, string name, Gtk.IconSize size)
@@ -99,14 +99,14 @@ namespace Stetic
 			}
 		}
 	}
-	
+
 	internal class ActionGroups
 	{
 		public static Gtk.ActionGroup GetActionGroup (System.Type type)
 		{
 			return Stetic.ActionGroups.GetActionGroup (type.FullName);
 		}
-		
+
 		public static Gtk.ActionGroup GetActionGroup (string name)
 		{
 			return null;

--- a/main/src/addins/AspNet/MonoDevelop.AspNet/gtk-gui/gui.stetic
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/gtk-gui/gui.stetic
@@ -143,9 +143,12 @@
                   <widget class="Gtk.Table" id="table2">
                     <property name="MemberName" />
                     <property name="NRows">2</property>
-                    <property name="NColumns">2</property>
+                    <property name="NColumns">3</property>
                     <property name="RowSpacing">6</property>
                     <property name="ColumnSpacing">6</property>
+                    <child>
+                      <placeholder />
+                    </child>
                     <child>
                       <widget class="Gtk.Entry" id="ipAddress">
                         <property name="MemberName" />
@@ -157,6 +160,27 @@
                         <property name="LeftAttach">1</property>
                         <property name="RightAttach">2</property>
                         <property name="AutoSize">False</property>
+                        <property name="XOptions">Fill</property>
+                        <property name="YOptions">Fill</property>
+                        <property name="XExpand">False</property>
+                        <property name="XFill">True</property>
+                        <property name="XShrink">False</property>
+                        <property name="YExpand">False</property>
+                        <property name="YFill">True</property>
+                        <property name="YShrink">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <widget class="Gtk.Label" id="label15">
+                        <property name="MemberName" />
+                        <property name="LabelProp" translatable="yes">0 = Random Port</property>
+                      </widget>
+                      <packing>
+                        <property name="TopAttach">1</property>
+                        <property name="BottomAttach">2</property>
+                        <property name="LeftAttach">2</property>
+                        <property name="RightAttach">3</property>
+                        <property name="AutoSize">True</property>
                         <property name="XOptions">Fill</property>
                         <property name="YOptions">Fill</property>
                         <property name="XExpand">False</property>


### PR DESCRIPTION
Fixed port value for XSP web server in project configuration causes conflict 
when multiple users work on a web project in MonoDevelop from a single 
machine. This change allows XSP to select a random port when XSP port 
value in project is set to 0.
