### PR TITLE
Remove the GTK+ focus hack

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -309,12 +309,7 @@ namespace MonoDevelop.MacIntegration
 				ApplicationEvents.Reopen += delegate (object sender, ApplicationEventArgs e) {
 					if (IdeApp.Workbench != null && IdeApp.Workbench.RootWindow != null) {
 						IdeApp.Workbench.RootWindow.Deiconify ();
-
-						// This is a workaround to a GTK+ bug. The HasTopLevelFocus flag is not properly
-						// set when the main window is restored. The workaround is to hide and re-show it.
-						// Since this happens before the next mainloop cycle, the window isn't actually affected.
-						IdeApp.Workbench.RootWindow.Hide ();
-						IdeApp.Workbench.RootWindow.Show ();
+						IdeApp.Workbench.RootWindow.Visible = true;
 
 						IdeApp.Workbench.RootWindow.Present ();
 						e.Handled = true;


### PR DESCRIPTION
Remove the GTK+ focus hack that was introduced in commits
2858e62204a1fabb92a6a6b09e2f7ba7fcff7cd8 and
33d656f29b18c805172ae8864cda9b358c8f92a3

This appears to be fixed in one of the more recent GTK+ Quartz
focus patches.
