### PR TITLE
[Version Control] Ensure we don't ever get false positives on repositories.

### DIFF
--- a/extras/VersionControl.Subversion.Win32/VersionControl.Subversion.Win32.Tests/BaseRepositoryTests.cs
+++ b/extras/VersionControl.Subversion.Win32/VersionControl.Subversion.Win32.Tests/BaseRepositoryTests.cs
@@ -54,6 +54,9 @@ namespace MonoDevelop.VersionControl.Tests
 		}
 
 		[Test]
+		public abstract void RightRepositoryDetection ();
+
+		[Test]
 		public virtual void CheckoutExists ()
 		{
 			Assert.True (Directory.Exists (rootCheckout + DOT_DIR));

--- a/extras/VersionControl.Subversion.Win32/VersionControl.Subversion.Win32.Tests/BaseSvnRepositoryTests.cs
+++ b/extras/VersionControl.Subversion.Win32/VersionControl.Subversion.Win32.Tests/BaseSvnRepositoryTests.cs
@@ -81,6 +81,13 @@ namespace MonoDevelop.VersionControl.Subversion.Tests
 			repo = GetRepo (rootCheckout, repoLocation);
 			DOT_DIR = ".svn";
 		}
+
+		[Test]
+		public override void RightRepositoryDetection ()
+		{
+			Repository repo = VersionControlService.GetRepositoryReference (rootCheckout + DOT_DIR, null);
+			Assert.True (repo is SubversionRepository);
+		}
 	}
 }
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -68,6 +68,13 @@ namespace MonoDevelop.VersionControl.Git.Tests
 		}
 
 		[Test]
+		public override void RightRepositoryDetection ()
+		{
+			Repository repo = VersionControlService.GetRepositoryReference (rootCheckout + DOT_DIR, null);
+			Assert.True (repo is GitRepository);
+		}
+
+		[Test]
 		public override void DiffIsProper ()
 		{
 			string added = rootCheckout + "testfile";

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseRepositoryTests.cs
@@ -54,6 +54,9 @@ namespace MonoDevelop.VersionControl.Tests
 		}
 
 		[Test]
+		public abstract void RightRepositoryDetection ();
+
+		[Test]
 		public virtual void CheckoutExists ()
 		{
 			Assert.True (Directory.Exists (rootCheckout + DOT_DIR));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Tests/BaseSvnRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Tests/BaseSvnRepositoryTests.cs
@@ -81,6 +81,13 @@ namespace MonoDevelop.VersionControl.Subversion.Tests
 			repo = GetRepo (rootCheckout, repoLocation);
 			DOT_DIR = ".svn";
 		}
+
+		[Test]
+		public override void RightRepositoryDetection ()
+		{
+			Repository repo = VersionControlService.GetRepositoryReference (rootCheckout + DOT_DIR, null);
+			Assert.True (repo is SubversionRepository);
+		}
 	}
 }
 


### PR DESCRIPTION
The VersionControlService action should not return wrong repository types.
