### PR TITLE
[Core] Fix boolean logic error in Equals override for IconId

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/IconId.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/IconId.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Core
 
 		public override bool Equals (object obj)
 		{
-			if (obj == null && !(obj is IconId))
+			if (!(obj is IconId))
 				return false;
 
 			IconId fn = (IconId) obj;


### PR DESCRIPTION
This change prevents the Equals override in IconId from throwing an InvalidCastException when the provided object is a non-null instance of a type other than IconId.

Previously, the null check was short-circuiting the if condition for a non-null object and bypassing the negated 'is' expression.  I believe '||' was meant meant instead of '&&'.

Since 'obj is IconId' will return 'false' when 'obj' is null, it is safe to remove the null check entirely.
