### PR TITLE
Update GdbSession.cs

### DIFF
--- a/extras/MonoDevelop.Debugger.Gdb/GdbSession.cs
+++ b/extras/MonoDevelop.Debugger.Gdb/GdbSession.cs
@@ -345,7 +345,7 @@ namespace MonoDevelop.Debugger.Gdb
 				RunCommand ("-break-condition", handle.ToString (), "(" + bp.ConditionExpression + ") != " + val);
 			}
 			
-			if (bp.HitAction == HitAction.PrintExpression) {
+			if (!string.IsNullOrEmpty (bp.TraceExpression) && bp.HitAction == HitAction.PrintExpression) {
 				GdbCommandResult res = RunCommand ("-data-evaluate-expression", Escape (bp.TraceExpression));
 				string val = res.GetValue ("value");
 				NotifyBreakEventUpdate (binfo, 0, val);


### PR DESCRIPTION
fix CheckBreakpoint function.
bp.TraceExpression sometime is empty or null, if that's happen, gdb will report an error System.InvalidOperationException: -data-evaluate-expression: Usage: -data-evaluate-expression expression.
