### PR TITLE
Fixed a bug where XSP would fail to launch when using .NET 4 configuration

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
@@ -57,7 +57,7 @@ namespace MonoDevelop.Debugger.Soft.AspNet
 				return prefix.Combine ("lib", "mono", "2.0");
 			case ClrVersion.Net_4_0:
 				var net45Path = prefix.Combine ("lib", "mono", "4.5");
-				if (Directory.Exists (net45Path)) return net45Path;
+				if (Directory.Exists (net45Path) && !MonoDevelop.Core.Platform.IsWindows) return net45Path;
 				return prefix.Combine ("lib", "mono", "4.0");
 			case ClrVersion.Net_4_5:
 				return prefix.Combine ("lib", "mono", "4.5");


### PR DESCRIPTION
On Windows. Path generator would generate the correct path, and then switch it out for the 4.5 library path instead. XSP isn't packaged into that directory on Windows, so MonoDevelop would throw an exception when it couldn't find it
