### PR TITLE
16307 - vi mode - reset motion after actions

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Vi/ViMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Vi/ViMode.cs
@@ -252,7 +252,7 @@ namespace Mono.TextEditor.Vi
 		{
 			CurState = State.Normal;
 			ResetEditorState (Data);
-			
+			motion = Motion.None;
 			commandBuffer.Length = 0;
 			Status = status;
 		}
@@ -617,6 +617,7 @@ namespace Mono.TextEditor.Vi
 						RunActions (action, ClipboardActions.Cut);
 					Status = "-- INSERT --";
 					CurState = State.Insert;
+					motion = Motion.None;
 					Caret.Mode = CaretMode.Insert;
 				} else {
 					Reset ("Unrecognised motion");


### PR DESCRIPTION
This is a fix for bug 16307 - after using 'inner' commands some commands such as 'dd' and 'yy' stop working. This resets the motion to Motion.None after each action.
