### PR TITLE
Bug 7155 - Add new Solution Folder

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -544,7 +544,10 @@ namespace MonoDevelop.VersionControl
 						repo.Add (v.LocalPath, false, monitor);
 				}
 			}
-			
+
+			if (entry is SolutionFolder && files.Count == 1)
+				return;
+
 			NotifyFileStatusChanged (new FileUpdateEventArgs (repo, parent.BaseDirectory, true));
 		}
 		


### PR DESCRIPTION
In case the project is under version control, if we add an empty
SolutionFolder item, we do a tree rebuild, which cancels the name
editing action.
