### PR TITLE
Bug 6097 - Add -> ASP.NET Directory Flyout Issue

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/ProjectFolderNodeBuilderExtension.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet/ProjectFolderNodeBuilderExtension.cs
@@ -80,6 +80,11 @@ namespace MonoDevelop.AspNet
 				CommandInfo cmd = info.Add (dir.Replace("_", "__"), dir);
 				cmd.Enabled = fullPaths.Contains (proj.BaseDirectory.Combine (dir));
 			}
+
+			if (info.Count == 0) {
+				CommandInfo cmd = info.Add ("None to add", null);
+				cmd.Enabled = false;
+			}
 		}
 
 		static void RemoveDirsNotInProject (List<FilePath> dirs, Project proj)


### PR DESCRIPTION
Temporary hackfix for flyout having no children.

Actual fix would be making menu items with submenus not be created when they have children. I have tried fixing that, but couldn't make it work.
