### PR TITLE
Fix to allow opening C# and F# projects newly created in VS2013

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
@@ -231,7 +231,7 @@
 			name = "MSBuild (Visual Studio 2010)"
 			canDefault = "true" />
 		<FileFormat id = "MSBuild12"
-			class = "MonoDevelop.Projects.Formats.MSBuild.MSBuildFileFormatVS12"
+			class = "MonoDevelop.Projects.Formats.MSBuild.MSBuildFileFormatVS12And13"
 			name = "MSBuild (Visual Studio 2012)"
 			canDefault = "true" />
 		<FileFormat id = "MD1" 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
@@ -80,6 +80,11 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 			return version == slnVersion;
 		}
 
+		internal virtual bool SupportsToolsVersion (string version)
+		{
+			return version == toolsVersion;
+		}
+
 		public FilePath GetValidFormatName (object obj, FilePath fileName)
 		{
 			if (slnFileFormat.CanWriteFile (obj, this))
@@ -263,7 +268,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 			case "4.0":
 				return new MSBuildFileFormatVS10 ();
 			case "4.5":
-				return new MSBuildFileFormatVS12 ();
+				return new MSBuildFileFormatVS12And13 ();
 			}
 			throw new Exception ("Unknown ToolsVersion '" + toolsVersion + "'");
 		}
@@ -342,7 +347,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 		}
 	}
 
-	class MSBuildFileFormatVS12: MSBuildFileFormat
+	class MSBuildFileFormatVS12And13: MSBuildFileFormat
 	{
 		public const string Version = "12.0.0";
 		const string toolsVersion = "4.0";
@@ -362,7 +367,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 		};
 		const bool supportsMonikers = true;
 		
-		public MSBuildFileFormatVS12 (): base (Version, toolsVersion, slnVersion, productComment, frameworkVersions, supportsMonikers)
+		public MSBuildFileFormatVS12And13 (): base (Version, toolsVersion, slnVersion, productComment, frameworkVersions, supportsMonikers)
 		{
 		}
 		
@@ -373,6 +378,11 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 		internal override bool SupportsSlnVersion (string version)
 		{
 			return version == "11.00" || version == "12.00";
+		}
+
+		internal override bool SupportsToolsVersion (string version)
+		{
+			return version == "4.0" || version == "12.0";
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectHandler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectHandler.cs
@@ -277,7 +277,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 			//determine the file format
 			MSBuildFileFormat format = null;
 			if (expectedFormat != null) {
-				if (p.ToolsVersion != expectedFormat.ToolsVersion) {
+				if (expectedFormat.SupportsToolsVersion(p.ToolsVersion)) {
 					monitor.ReportWarning (GettextCatalog.GetString ("Project '{0}' has different ToolsVersion than the containing solution.", Path.GetFileNameWithoutExtension (fileName)));
 				} else {
 					format = expectedFormat;


### PR DESCRIPTION
This is not the same as https://github.com/mono/monodevelop/pull/407
F# projects newly created in VS2013 have one extra difference from VS2012 projects upgraded to VS2013: the `ToolsVersion` on the `.fsproj` is set to `12.0` instead of `4.0`. C# projects newly created in VS2013 also have this problem (although there were no extra problem that affected both upgraded and new solutions like in F#)

Currently MonoDevelop has the tools version strongly connected to the .Net version, and VS2013/MSBuild12 breaks that. I tried to create a `MSBuildFileFormatVS13` with the right tools version, but then there were multiple problems because MonoDevelop was trying to find .NET 12.0, so I just did the same that was already done for `SlnVersion` and declared `MSBuildFileFormatVS12` to support both tools version `4.0` and `12.0`. It's a bit of a hack, but it works. I also renamed it to `MSBuildFileFormatVS13And13` to be more clear what it does. I did a similar fix for xBuild (https://github.com/mono/mono/pull/767) and there I was able to do it correctly, and with some work it's also possible to do the same for MonoDevelop, but as VS2013 RTM is already out and a lot of people are potentially hitting this problem, it would be nice to be able to get this temporary fix released even if there are plans to fix it in a better way later on.
