### PR TITLE
 Fix missing EXTRA_DIST in ASP.NET addin, causing build failure from tarball

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Makefile.am
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Makefile.am
@@ -1,2 +1,4 @@
 include $(top_srcdir)/xbuild.include
-EXTRA_DIST += $(wildcard lib/*)
+EXTRA_DIST += \
+		$(wildcard lib/*) \
+		$(wildcard Templates/Common/*.cshtml)


### PR DESCRIPTION
/usr/lib/mono/4.0/Microsoft.Common.targets: error : Cannot copy /tmp/buildd/monodevelop-4.2.1+dfsg/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/Common/Error.cshtml to /tmp/buildd/monodevelop-4.2.1+dfsg/build/AddIns/MonoDevelop.AspNet.Mvc/Templates/Common/Error.cshtml, as the source file doesn't exist.
/usr/lib/mono/4.0/Microsoft.Common.targets: error : Cannot copy /tmp/buildd/monodevelop-4.2.1+dfsg/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/Common/Index.cshtml to /tmp/buildd/monodevelop-4.2.1+dfsg/build/AddIns/MonoDevelop.AspNet.Mvc/Templates/Common/Index.cshtml, as the source file doesn't exist.
/usr/lib/mono/4.0/Microsoft.Common.targets: error : Cannot copy /tmp/buildd/monodevelop-4.2.1+dfsg/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/Common/ViewPageRazor.cshtml to /tmp/buildd/monodevelop-4.2.1+dfsg/build/AddIns/MonoDevelop.AspNet.Mvc/Templates/Common/ViewPageRazor.cshtml, as the source file doesn't exist.
/usr/lib/mono/4.0/Microsoft.Common.targets: error : Cannot copy /tmp/buildd/monodevelop-4.2.1+dfsg/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/Common/_Layout.cshtml to /tmp/buildd/monodevelop-4.2.1+dfsg/build/AddIns/MonoDevelop.AspNet.Mvc/Templates/Common/_Layout.cshtml, as the source file doesn't exist.
/usr/lib/mono/4.0/Microsoft.Common.targets: error : Cannot copy /tmp/buildd/monodevelop-4.2.1+dfsg/src/addins/AspNet/MonoDevelop.AspNet.Mvc/Templates/Common/_ViewStart.cshtml to /tmp/buildd/monodevelop-4.2.1+dfsg/build/AddIns/MonoDevelop.AspNet.Mvc/Templates/Common/_ViewStart.cshtml, as the source file doesn't exist.
