### PR TITLE
[Shell] Fix IDE building projects wrong

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -676,7 +676,7 @@ namespace MonoDevelop.Projects
 			foreach (ProjectReference pref in References) {
 				if (pref.ReferenceType == ReferenceType.Project) {
 					Project rp = ParentSolution.FindProjectByName (pref.Reference);
-					if (rp != null)
+					if (rp != null && ParentSolution.GetConfiguration (configuration).BuildEnabledForItem (rp))
 						items.Add (rp);
 				}
 			}


### PR DESCRIPTION
This fixes IDE building projects which are not built in the current
configuration.

The error is different from msbuild, because this says, when GuiUnit isn't built (with this commit applied):

Using MSBuild:
The type or namespace name 'TextfixtureSetUpAttribute' could not be found.

Using MD:
CSC: Error CS0006: Metadata file 'F:...\bin\net_4_5\GuiUnit.exe' could not be found (CS0006) (...)
