### PR TITLE
Added a using directive to ensure that the DllImportAttribute type gets ...

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
@@ -31,6 +31,7 @@ using System.IO;
 
 using Mono.Unix;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace MonoDevelop.Core


### PR DESCRIPTION
This fixes the DllImportAttribute type that was introduced without its associated using directive, or fully qualified type name on 3e9440dd80b165a4ad0bce5345843ef31182ff37.
