### PR TITLE
[Git] Improve hook about commit message length

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCommitDialogExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCommitDialogExtension.cs
@@ -167,6 +167,10 @@ namespace MonoDevelop.VersionControl.Git
 
 		void HighlightTextIfTooLong ()
 		{
+			Gtk.TextIter start, end, unused;
+			textView.Buffer.GetBounds (out start, out end);
+			textView.Buffer.RemoveTag (overflowTextTag, start, end);
+
 			var text = textView.Buffer.Text;
 			var lines = text.Split ('\n');
 			if (lines.Length > 0 && lines [0].Length > maxLengthConventionForFirstLineOfCommitMessage) {
@@ -175,7 +179,6 @@ namespace MonoDevelop.VersionControl.Git
 					maxLengthConventionForFirstLineOfCommitMessage);
 				textView.HasTooltip = true;
 
-				Gtk.TextIter start, end, unused;
 				textView.Buffer.GetBounds (out start, out unused);
 				start.ForwardChars (maxLengthConventionForFirstLineOfCommitMessage);
 


### PR DESCRIPTION
I found this bug in this feature that I recently committed:
1. Write a commit message that is too long.
2. See the overflow text being printed red.
3. To make the message shorter, instead of deleting chars from
the end of the message, delete characters at the beginning or
the middle of the message.

Expected results: less characters should be marked as red.
Results before this commit: the red characters were moving
backwards.
