### PR TITLE
Pressing Enter(Return) on keyboard in FindInFiles dialog FileMask entry

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -453,6 +453,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			
 			searchentryFileMask.Query = properties.Get ("MonoDevelop.FindReplaceDialogs.FileMask", "");
 			
+			searchentryFileMask.Entry.ActivatesDefault = true;
 			searchentryFileMask.Show ();
 			
 			TableAddRow (tableFindAndReplace, row, labelFileMask, searchentryFileMask);


### PR DESCRIPTION
As commit message says if user pressed Enter(Return) key after changing values in File Mask it didn't do anything...
Now it does default action which is start search...
