### PR TITLE
SearchEntry filter menu Y offset miscalcualted

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
@@ -237,7 +237,7 @@ namespace MonoDevelop.Components
 			GdkWindow.GetOrigin (out tmp, out origin_y);
 			
 			x = origin_x + filter_button.Allocation.X;
-			y = origin_y + SizeRequest ().Height;
+			y = origin_y + Allocation.Y + SizeRequest ().Height;
 			push_in = true;
 		}
 


### PR DESCRIPTION
I will let image talk(this are all usages of SearchEntry I could find (left is previous right is new):
![image](https://f.cloud.github.com/assets/774791/2209717/c5b0725e-998f-11e3-94b9-334c7efdf8ed.png)
