### PR TITLE
Command description is now set on CommandMenuItems as ToolTip

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandMenuItem.cs
@@ -219,7 +219,9 @@ namespace MonoDevelop.Components.Commands
 					label.Text = overrideLabel ?? cmdInfo.Text;
 					label.UseMarkup = false;
 				}
-				
+
+				if (!string.IsNullOrEmpty (cmdInfo.Description) && label.TooltipText != cmdInfo.Description)
+					label.TooltipText = cmdInfo.Description;
 				label.UseUnderline = true;
 				
 				this.Sensitive = cmdInfo.Enabled;


### PR DESCRIPTION
Main reason why I wanted to change this is because I have 2 MonoDevelop(Main) solutions under Recent solutions(my repo and upstream) both display as Main so I had to guess...
This change has effect on all items in "MenuStrip"... I'm adding SS to display changes notice that before was no tooltips on any of this.
(first 2 images left without change right after change)
![image](https://f.cloud.github.com/assets/774791/2240915/f3da4b8c-9cb4-11e3-81ce-558ae5c7eee7.png)
