### PR TITLE
[Core] Fix TargetFramework race

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -195,7 +195,14 @@ namespace MonoDevelop.Core.Assemblies
 			TargetFramework fx;
 			if (frameworks.TryGetValue (id, out fx))
 				return fx;
-			LoggingService.LogWarning ("Unregistered TargetFramework '{0}' is being requested from SystemAssemblyService", id);
+
+			LoggingService.LogDebug ("Unregistered TargetFramework '{0}' is being requested from SystemAssemblyService, ensuring rutimes initialized and trying again", id);
+			foreach (var r in runtimes)
+				r.EnsureInitialized ();
+			if (frameworks.TryGetValue (id, out fx))
+				return fx;
+			
+			LoggingService.LogWarning ("Unregistered TargetFramework '{0}' is being requested from SystemAssemblyService, returning empty TargetFramework", id);
 			UpdateFrameworks (new [] { new TargetFramework (id) });
 			return frameworks [id];
 		}


### PR DESCRIPTION
If something tries to request an unknown TargetFramework during
TargetRuntime initialization, ensure all the runtimes are initialized
and try again.

We have MonoTouch and MonoAndroid projects that reference PCL projects. Our CI builds would fail about half the time because the TargetFramework for the PCL project wasn't yet loaded when the MonoTouch project was loaded, resulting in the reference failing with the error:
`WARNING: The reference 'Libronix.Utility-Portable' is not valid for the target framework of the project.`
