### PR TITLE
Tooltip on MainToolbar

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
@@ -115,6 +115,26 @@ namespace MonoDevelop.Components.MainToolbar
 
 		public int MaxWidth { get; set; }
 
+		void messageBoxToolTip (object o, QueryTooltipArgs e)
+		{
+			if (theme.IsEllipsized && (e.X < messageBox.Allocation.Width)) {
+				var label = new Label ();
+				if (renderArg.CurrentTextIsMarkup) {
+					label.Markup = renderArg.CurrentText;
+				} else {
+					label.Text = renderArg.CurrentText;
+				}
+
+				label.Wrap = true;
+				label.WidthRequest = messageBox.Allocation.Width;
+				
+				e.Tooltip.Custom = label;
+				e.RetVal = true;
+			} else {
+				e.RetVal = false;
+			}
+		}
+
 		public StatusArea ()
 		{
 			theme = new StatusAreaTheme ();
@@ -162,6 +182,9 @@ namespace MonoDevelop.Components.MainToolbar
 			contentBox.PackEnd (statusIconBox, false, false, 0);
 			contentBox.PackEnd (statusIconSeparator = new StatusAreaSeparator (), false, false, 0);
 			contentBox.PackEnd (buildResultWidget = CreateBuildResultsWidget (Orientation.Horizontal), false, false, 0);
+
+			HasTooltip = true;
+			QueryTooltip += messageBoxToolTip;
 
 			mainAlign = new Alignment (0, 0.5f, 1, 0);
 			mainAlign.LeftPadding = 12;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusAreaTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusAreaTheme.cs
@@ -43,6 +43,11 @@ namespace MonoDevelop.Components.MainToolbar
 {
 	internal class StatusAreaTheme : IDisposable
 	{
+		public bool IsEllipsized {
+			get;
+			private set;
+		}
+
 		SurfaceWrapper backgroundSurface, errorSurface;
 		
 		public void Dispose ()
@@ -347,6 +352,9 @@ namespace MonoDevelop.Components.MainToolbar
 			context.SetSourceColor (Styles.WithAlpha (FontColor (), opacity));
 
 			Pango.CairoHelper.ShowLayout (context, pl);
+
+			IsEllipsized = pl.IsEllipsized;
+
 			pl.Dispose ();
 			context.Restore ();
 		}


### PR DESCRIPTION
Before this change there was no way to see full message at least not to my knowledge...
Now this SS has 2 options first is doable by this simple change in ShowMessage method:

``` csharp
if (isMarkup) {
    this.TooltipMarkup = message;
} else {
    this.TooltipText = message;
}
```

Second requires this whole pull request...
- TooltipPopoverWindow.cs functionality is same as before if not setting MaxWidth.
- I'm wonder if location of new code is correct or it should be in StatusBarContextImpl class in methods ShowMessage/Update.
- I think 2/3 of MainWindow is kind of good MaxWidth of tooltip...
- Is this proper way to obtain Width of MainWindow?
- Notice that if MainWindow is resized ToolTip will stay at 2/3 of old size until new message is set should something be done about it?(It doesn't look like a bug if old tooltip size is kept)
- this.TooltipText and this.TooltipMarkup have to be set in order to invoke tooltip...

![image](https://f.cloud.github.com/assets/774791/2287120/2e838a46-9fe9-11e3-96ef-537d2fdf106b.png)
