### PR TITLE
Directory properly moved.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1596,9 +1596,20 @@ namespace MonoDevelop.Ide
 			
 			bool sourceIsFolder = Directory.Exists (sourcePath);
 
+			bool containsOnlyProjectFiles = (sourceProject != null);
+
+			var sourceFiles = new List<ProjectFile> ();
+			var projectFileNames = new HashSet<string> (sourceProject.Files.Select (f => sourceProject.BaseDirectory.Combine (f.ProjectVirtualPath).ToString ()));
+			GetAllFilesRecursive (sourcePath, sourceFiles);
+			foreach (ProjectFile file in sourceFiles) {
+				if (!projectFileNames.Contains (file.Name))
+					containsOnlyProjectFiles = false;
+			}
+
 			bool movingFolder = (removeFromSource && sourceIsFolder && (
 					!copyOnlyProjectFiles ||
-					IsDirectoryHierarchyEmpty (sourcePath)));
+					IsDirectoryHierarchyEmpty (sourcePath) ||
+					containsOnlyProjectFiles));
 
 			// We need to remove all files + directories from the source project
 			// but when dealing with the VCS addins we need to process only the


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=17481&GoAheadAndLogIn=1 is now resolved. When a directory gets moved in the project explorer, the original gets deleted now, or, if it contains files not in the current project, those files will be kept.
