### PR TITLE
Fix ParsedTemplate to enable camelCase attributes

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
@@ -277,9 +277,10 @@ namespace Mono.TextTemplating
 		public string Extract (string key)
 		{
 			string value;
-			if (!Attributes.TryGetValue (key, out value))
+			var lowerKey = key.ToLower();
+			if (!Attributes.TryGetValue (lowerKey, out value))
 				return null;
-			Attributes.Remove (key);
+			Attributes.Remove (lowerKey);
 			return value;
 		}
 	}


### PR DESCRIPTION
As for now, directive.Attributes is filled with "attName.ToLower()".

"Extract" method works on unchanged values and TemplatingEngine asks
for camelCase.

VisualStudio disregards the casing of parameters, so we can compare with 
lower case.

This can be verified by using "linePragmas" attribute.
