### PR TITLE
Fix ParsedTemplate to enable camelCase attributes

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
@@ -130,7 +130,7 @@ namespace Mono.TextTemplating
 						switch (tokeniser.State) {
 						case State.DirectiveName:
 							if (directive == null) {
-								directive = new Directive (tokeniser.Value.ToLower (), tokeniser.Location);
+								directive = new Directive (tokeniser.Value, tokeniser.Location);
 								directive.TagStartLocation = tokeniser.TagStartLocation;
 								if (!parseIncludes || directive.Name != "include")
 									segments.Add (directive);
@@ -139,7 +139,7 @@ namespace Mono.TextTemplating
 							break;
 						case State.DirectiveValue:
 							if (attName != null && directive != null)
-								directive.Attributes[attName.ToLower ()] = tokeniser.Value;
+								directive.Attributes[attName] = tokeniser.Value;
 							else
 								LogError ("Directive value without name", tokeniser.Location);
 							attName = null;
@@ -264,7 +264,7 @@ namespace Mono.TextTemplating
 		public Directive (string name, Location start)
 		{
 			this.Name = name;
-			this.Attributes = new Dictionary<string, string> ();
+			this.Attributes = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 			this.StartLocation = start;
 		}
 		


### PR DESCRIPTION
As for now, directive.Attributes is filled with "attName.ToLower()".

"Extract" method works on unchanged values and TemplatingEngine asks
for camelCase.

VisualStudio disregards the casing of parameters, so we can compare with
lower case.

This can be verified by using "linePragmas" attribute.

According to mhutch suggestion, fixed to use
StringComparer.OrdinalIgnoreCase.
