### PR TITLE
[UnitTests] Only show test projects in active config

### DIFF
--- a/main/src/addins/NUnit/Services/NUnitProjectTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitProjectTestSuite.cs
@@ -63,6 +63,9 @@ namespace MonoDevelop.NUnit
 		
 		public static NUnitProjectTestSuite CreateTest (DotNetProject project)
 		{
+			if (!project.ParentSolution.GetConfiguration (IdeApp.Workspace.ActiveConfiguration).BuildEnabledForItem (project))
+				return null;
+
 			foreach (var p in project.References)
 				if (p.Reference.IndexOf ("GuiUnit", StringComparison.OrdinalIgnoreCase) != -1 || p.Reference.IndexOf ("nunit.framework") != -1 || p.Reference.IndexOf ("nunit.core") != -1)
 					return new NUnitProjectTestSuite (project);

--- a/main/src/addins/NUnit/Services/NUnitService.cs
+++ b/main/src/addins/NUnit/Services/NUnitService.cs
@@ -56,6 +56,7 @@ namespace MonoDevelop.NUnit
 			IdeApp.Workspace.WorkspaceItemClosed += OnWorkspaceChanged;
 			IdeApp.Workspace.ItemAddedToSolution += OnWorkspaceChanged;
 			IdeApp.Workspace.ItemRemovedFromSolution += OnWorkspaceChanged;
+			IdeApp.Workspace.ActiveConfigurationChanged += OnWorkspaceChanged;
 
 			Mono.Addins.AddinManager.AddExtensionNodeHandler ("/MonoDevelop/NUnit/TestProviders", OnExtensionChange);
 		}


### PR DESCRIPTION
Only showing test projects that are built in the active configuration.

That means, we're not going to be showing nodes for Subversion.Win32 under Mac and Subversion.Unix on Windows.
