### PR TITLE
[VersionControl] Fix concurrency in query.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -73,6 +73,14 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			return Is.InstanceOf<GitRepository> ();
 		}
 
+		protected override int RepoItemsCount {
+			get { return 1; }
+		}
+
+		protected override int RepoItemsCountRecursive {
+			get { return 13; }
+		}
+
 		protected override void TestDiff ()
 		{
 			string difftext = @"@@ -0,0 +1 @@

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Tests/BaseSvnRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Tests/BaseSvnRepositoryTests.cs
@@ -93,6 +93,10 @@ namespace MonoDevelop.VersionControl.Subversion.Tests
 			return Is.InstanceOf<SubversionRepository> ();
 		}
 
+		protected override VersionStatus InitialValue {
+			get { return VersionStatus.Unversioned; }
+		}
+
 		protected override void TestValidUrl ()
 		{
 			var repo2 = (SubversionRepository)Repo;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using MonoDevelop.Core.Serialization;
 using MonoDevelop.Core;
 using System.Linq;
+using System.Threading;
 
 namespace MonoDevelop.VersionControl
 {
@@ -205,8 +206,18 @@ namespace MonoDevelop.VersionControl
 		public VersionInfo[] GetDirectoryVersionInfo (FilePath localDirectory, bool getRemoteStatus, bool recursive)
 		{
 			try {
-				if (recursive)
-					return OnGetDirectoryVersionInfo (localDirectory, getRemoteStatus, recursive);
+				if (recursive) {
+					using (var mre = new ManualResetEvent (false)) {
+						var rq = new RecursiveDirectoryInfoQuery {
+							Directory = localDirectory,
+							GetRemoteStatus = getRemoteStatus,
+							ResetEvent = mre,
+						};
+						AddQuery (rq);
+						rq.ResetEvent.WaitOne ();
+						return rq.Result;
+					}
+				}
 
 				var status = infoCache.GetDirectoryStatus (localDirectory);
 				if (status != null && !status.RequiresRefresh && (!getRemoteStatus || status.HasRemoteStatus))
@@ -253,13 +264,21 @@ namespace MonoDevelop.VersionControl
 			public bool GetRemoteStatus;
 		}
 
+		class RecursiveDirectoryInfoQuery : DirectoryInfoQuery
+		{
+			public VersionInfo[] Result;
+			public ManualResetEvent ResetEvent;
+		}
+
 		Queue<VersionInfoQuery> fileQueryQueue = new Queue<VersionInfoQuery> ();
 		Queue<DirectoryInfoQuery> directoryQueryQueue = new Queue<DirectoryInfoQuery> ();
+		Queue<RecursiveDirectoryInfoQuery> recursiveDirectoryQueryQueue = new Queue<RecursiveDirectoryInfoQuery> ();
 		object queryLock = new object ();
 		bool queryRunning;
 		VersionInfoCache infoCache;
 		HashSet<FilePath> filesInQueryQueue = new HashSet<FilePath> ();
 		HashSet<FilePath> directoriesInQueryQueue = new HashSet<FilePath> ();
+		HashSet<FilePath> recursiveDirectoriesInQueryQueue = new HashSet<FilePath> ();
 
 		void AddQuery (object query)
 		{
@@ -271,18 +290,22 @@ namespace MonoDevelop.VersionControl
 						return;
 					filesInQueryQueue.UnionWith (vi.Paths);
 					fileQueryQueue.Enqueue (vi);
-				//	Console.WriteLine ("GetVersionInfo AddQuery " + string.Join (", ", vi.Paths.Select (p => p.FullPath)));
-				}
-				else if (query is DirectoryInfoQuery) {
+					//	Console.WriteLine ("GetVersionInfo AddQuery " + string.Join (", ", vi.Paths.Select (p => p.FullPath)));
+				} else if (query is RecursiveDirectoryInfoQuery) {
+					var di = (RecursiveDirectoryInfoQuery)query;
+					if (!recursiveDirectoriesInQueryQueue.Add (di.Directory))
+						return;
+					recursiveDirectoryQueryQueue.Enqueue (di);
+				} else if (query is DirectoryInfoQuery) {
 					DirectoryInfoQuery di = (DirectoryInfoQuery)query;
 					if (!directoriesInQueryQueue.Add (di.Directory))
 						return;
 					directoryQueryQueue.Enqueue (di);
-				//	Console.WriteLine ("GetDirectoryVersionInfo AddQuery " + ((DirectoryInfoQuery)query).Directory);
+					//	Console.WriteLine ("GetDirectoryVersionInfo AddQuery " + ((DirectoryInfoQuery)query).Directory);
 				}
 				if (!queryRunning) {
 					queryRunning = true;
-					System.Threading.ThreadPool.QueueUserWorkItem (RunQueries);
+					ThreadPool.QueueUserWorkItem (RunQueries);
 				}
 			}
 		}
@@ -290,14 +313,16 @@ namespace MonoDevelop.VersionControl
 		void RunQueries (object ob)
 		{
 		//	DateTime t = DateTime.Now;
-		//	Console.WriteLine ("RunQueries started");
+			//	Console.WriteLine ("RunQueries started");
+			VersionInfoQuery [] fileQueryQueueClone;
+			DirectoryInfoQuery [] directoryQueryQueueClone;
+			RecursiveDirectoryInfoQuery [] recursiveDirectoryQueryQueueClone = new RecursiveDirectoryInfoQuery[0];
 			try {
 				while (true) {
-					VersionInfoQuery [] fileQueryQueueClone;
-					DirectoryInfoQuery [] directoryQueryQueueClone;
-
 					lock (queryLock) {
-						if (fileQueryQueue.Count == 0 && directoryQueryQueue.Count == 0) {
+						if (fileQueryQueue.Count == 0 &&
+							directoryQueryQueue.Count == 0 &&
+							recursiveDirectoryQueryQueue.Count == 0) {
 							queryRunning = false;
 							return;
 						}
@@ -309,6 +334,10 @@ namespace MonoDevelop.VersionControl
 						directoryQueryQueueClone = directoryQueryQueue.ToArray ();
 						directoriesInQueryQueue.Clear ();
 						directoryQueryQueue.Clear ();
+
+						recursiveDirectoryQueryQueueClone = recursiveDirectoryQueryQueue.ToArray ();
+						recursiveDirectoriesInQueryQueue.Clear ();
+						recursiveDirectoryQueryQueue.Clear ();
 					}
 
 					// Ensure we do not execute this with the query lock held, otherwise the IDE can hang while trying to add
@@ -323,9 +352,20 @@ namespace MonoDevelop.VersionControl
 						var status = OnGetDirectoryVersionInfo (item.Directory, item.GetRemoteStatus, false);
 						infoCache.SetDirectoryStatus (item.Directory, status, item.GetRemoteStatus);
 					}
+
+					foreach (var item in recursiveDirectoryQueryQueueClone) {
+						try {
+							item.Result = OnGetDirectoryVersionInfo (item.Directory, item.GetRemoteStatus, true);
+						} finally {
+							item.ResetEvent.Set ();
+						}
+					}
 				}
 			} catch (Exception ex) {
 				LoggingService.LogError ("Version control status query failed", ex);
+
+				foreach (var item in recursiveDirectoryQueryQueueClone)
+					item.ResetEvent.Set ();
 			}
 			//Console.WriteLine ("RunQueries finished - " + (DateTime.Now - t).TotalMilliseconds);
 		}


### PR DESCRIPTION
When we did a recursive=true call, we didn't use the query thread, which
caused multiple entries in native libraries.
This fixes it so recursive=true will make the caller wait for the query
to finish.
