### PR TITLE
Destroying ISymUnmanagedReader in SymReader Dispose plus calling dispose

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/SymStore/SymReader.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/SymStore/SymReader.cs
@@ -19,6 +19,17 @@ namespace Microsoft.Samples.Debugging.CorSymbolStore
 
     [
         ComImport,
+        Guid("969708D2-05E5-4861-A3B0-96E473CDF63F"),
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+        ComVisible(false)
+    ]
+    public interface ISymUnmanagedDispose
+    {
+        int Destroy();
+    }
+
+    [
+        ComImport,
         Guid("B4CE6286-2A6B-3712-A3B7-1EE1DAD467B5"),
         InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
         ComVisible(false)
@@ -158,7 +169,9 @@ namespace Microsoft.Samples.Debugging.CorSymbolStore
 
         public void Dispose()
         {
-            // Release our unmanaged resources
+            var disposable = m_reader as ISymUnmanagedDispose;
+            if (disposable != null)
+                disposable.Destroy();
             m_reader = null;
         }
 

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
@@ -88,6 +88,20 @@ namespace MonoDevelop.Debugger.Win32
 			// There is no explicit way of disposing the metadata objects, so we have
 			// to rely on the GC to do it.
 
+			foreach (var module in modules.Values) {
+				var disposable = module.Reader as IDisposable;
+				if (disposable != null)
+					disposable.Dispose ();
+			}
+
+			//Same readers are already disposed in previous loop but
+			//seems more proper to do it again
+			foreach (var doc in documents.Values) {
+				var disposable = doc.Reader as IDisposable;
+				if (disposable != null)
+					disposable.Dispose ();
+			}
+
 			modules = null;
 			documents = null;
 			threads = null;
@@ -323,6 +337,9 @@ namespace MonoDevelop.Debugger.Win32
 			foreach (ISymbolDocument doc in reader.GetDocuments ()) {
 				Console.WriteLine (doc.URL);
 			}
+			var disposable = reader as IDisposable;
+			if (disposable != null)
+				disposable.Dispose ();
 			e.Continue = true;
 		}
 


### PR DESCRIPTION
This bug is not easy to reproduce but ever since I added this I can't reproduce but I can't be 100% if its luck or fix... If someone has good way of reproducing please confirm this fix...

I don't think this can bring any regression...

From what I checked new SymReader is created only in two places 1 is OnUpdateModuleSymbols where I now instantly dispose and other is in OnModuleLoad where is then put in list of modules and documents where is disposed in CorSessionDebugger dispose.
