### PR TITLE
Update VisualStudio shortcuts

### DIFF
--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
@@ -60,4 +60,5 @@
 	<binding command="MonoDevelop.Refactoring.RefactoryCommands.QuickFix" shortcut="Control+." />
 	<binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer" shortcut="Control+E|D" />
 	<binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatSelection" shortcut="Control+E|F" />
+	<binding command="MonoDevelop.Debugger.DebugCommands.SelectExceptions" shortcut="Control+Alt+E" />
 </scheme>


### PR DESCRIPTION
- Pause: I check documentation and everywhere I see only Control+Alt+Break...
- UppercaseSelection: Was just missing...
- ToggleCodeComment: Since VS doesn't know this command I was thinking of removing this shortcut but decided to keep Mono shortcut instead...
- Add/RemoveComment: VS has 2 shortcuts for this one is Control+E|C and other is Control+K|Control+C. From what I know Control+K|Control+C is from C++ times and Control+E|C was added only in C#. I used always used only Control+E|C hopeful most people as well...
- SwitchSplitWindow, DeleteToLineEnd, DeleteLine: Corrected spaces -> tabs
- ImmediatePad, FormatBuffer, FormatSelection added missing
