### PR TITLE
Registring Windows to CommandManager for keyboard shortcuts

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueWindow.cs
@@ -79,6 +79,7 @@ namespace MonoDevelop.SourceEditor
 			this.Decorated = false;
 
 			TransientFor = (Gtk.Window) editor.Toplevel;
+			IdeApp.CommandService.RegisterWindowForKeyboardShortcuts (this);
 			
 			// Avoid getting the focus when the window is shown. We'll get it when the mouse enters the window
 			AcceptFocus = false;
@@ -128,6 +129,19 @@ namespace MonoDevelop.SourceEditor
 
 			ShowArrow = true;
 			Theme.CornerRadius = 3;
+		}
+
+		protected override bool OnKeyPressEvent (EventKey evnt)
+		{
+			if (base.OnKeyPressEvent (evnt)) {
+				return true;
+			} else {
+				if (evnt.Key == Gdk.Key.Escape) {
+					Destroy ();
+					return true;
+				}
+			}
+			return false;
 		}
 
 //		void HandlePinWindowButtonPressEvent (object o, ButtonPressEventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -69,7 +69,6 @@ namespace MonoDevelop.Components.Commands
 		
 		// Fields used to keep track of the application focus
 		bool appHasFocus;
-		Gtk.Window lastFocused;
 		DateTime focusCheckDelayTimeout = DateTime.MinValue;
 		
 		internal static readonly object CommandRouteTerminator = new object ();
@@ -422,8 +421,6 @@ namespace MonoDevelop.Components.Commands
 			w.Destroyed -= TopLevelDestroyed;
 			w.KeyPressEvent -= OnKeyPressed;
 			topLevelWindows.Remove (w);
-			if (w == lastFocused)
-				lastFocused = null;
 			RegisterUserInteraction ();
 		}
 		
@@ -431,7 +428,6 @@ namespace MonoDevelop.Components.Commands
 		{
 			disposed = true;
 			bindings.Dispose ();
-			lastFocused = null;
 		}
 		
 		/// <summary>
@@ -1592,28 +1588,22 @@ namespace MonoDevelop.Components.Commands
 		Gtk.Window GetActiveWindow (Gtk.Window win)
 		{
 			Gtk.Window[] wins = Gtk.Window.ListToplevels ();
-			
+
 			bool hasFocus = false;
-			bool lastFocusedExists = lastFocused == null;
 			Gtk.Window newFocused = null;
 			foreach (Gtk.Window w in wins) {
 				if (w.Visible) {
 					if (w.HasToplevelFocus) {
 						hasFocus = true;
-						newFocused = w;
 					}
 					if (w.IsActive && w.Type == Gtk.WindowType.Toplevel && !(w is Gtk.Dialog)) {
 						if (win == null)
 							win = w;
 					}
-					if (lastFocused == w) {
-						lastFocusedExists = true;
-					}
 				}
 			}
-			
-			lastFocused = newFocused;
-			UpdateAppFocusStatus (hasFocus, lastFocusedExists);
+
+			UpdateAppFocusStatus (hasFocus);
 			
 			if (win != null && win.IsRealized) {
 				RegisterTopWindow (win);
@@ -1777,7 +1767,7 @@ namespace MonoDevelop.Components.Commands
 				VisitCommandTargets (v, null);
 		}
 
-		void UpdateAppFocusStatus (bool hasFocus, bool lastFocusedExists)
+		void UpdateAppFocusStatus (bool hasFocus)
 		{
 			if (hasFocus != appHasFocus) {
 				// The last focused window has been destroyed. Wait a few ms since another app's window


### PR DESCRIPTION
So I intentionally created 3(could be 2) commits 1st is Removing dead code I think that is clear...
Last "Registering DebugValueWindow..." as well since it only uses new method plus closing DebugValueWindow on Escape...
So commit "Adding Reg..."
So I'm not sure how this stuff should be handled in GTK if you want to be able to hook keys events before and after window I created two event hanlers one with [Gtk.ConnectBefore] and one without.

So why are 3 handlers? Well root window wants CommandManager to always handle keys before root window and we keep all code the same this way no possibility for regressions...
With "subwindows" like DebugWindow we don't want that because for example there is Ctrl+F command which is handled by TreeView inside DebugValueWindow so we want that to be handled after if subwindow didn't handle that key already...
So what is that OnWindowKeyPressedBefore doing? Well lets say we have chord Ctrl+W|E for opening errors window you press Ctrl+W and now you press E well if there was no OnWindowKeyPressedBefore E would be typed inside our subwindow(which will most likely handle this key) and result in chord not being finish... So that is there only so it can finish chords...

Main reason for starting this changes was annoying fact that when I left mouse cursor unattandant in middle of screen and I was stepping trough the code or pressing F3(next search) DebugValueWindow would appear if cursor became on top of variable and my F11 would stop reacting(or F3)... Well now if F11 is not handled by window and new step is executed(or search)....
Seem also that I'm used from VS that after viewing values with DebugValueWindow I don't bother closing it but instead just start pressing F11...