### PR TITLE
Fixed 'Bug 14530 - GUI Thread hangs a while while xml serialization'

### DIFF
--- a/main/src/addins/NUnit/MonoDevelop.NUnit.csproj
+++ b/main/src/addins/NUnit/MonoDevelop.NUnit.csproj
@@ -193,7 +193,6 @@
     <Compile Include="Services\NUnitOptions.cs" />
     <Compile Include="Services\IResultsStore.cs" />
     <Compile Include="Services\UnitTestResultsStore.cs" />
-    <Compile Include="Services\XmlResultsStore.cs" />
     <Compile Include="Services\WorkspaceTestGroup.cs" />
     <Compile Include="gtk-gui\generated.cs" />
     <Compile Include="Services\UnitTestResult.cs" />
@@ -204,6 +203,8 @@
     <Compile Include="Services\TcpTestListener.cs" />
     <Compile Include="AddinInfo.cs" />
     <Compile Include="Gui\AbstractUnitTestEditorExtension.cs" />
+    <Compile Include="Services\AbstractResultsStore.cs" />
+    <Compile Include="Services\BinaryResultsStore.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/addins/NUnit/Project/NUnitAssemblyGroupProject.cs
+++ b/main/src/addins/NUnit/Project/NUnitAssemblyGroupProject.cs
@@ -168,7 +168,7 @@ namespace MonoDevelop.NUnit
 		{
 			this.project = project;
 			resultsPath = GetTestResultsDirectory (project.BaseDirectory);
-			ResultsStore = new XmlResultsStore (resultsPath, Path.GetFileName (project.FileName));
+			ResultsStore = new BinaryResultsStore (resultsPath, Path.GetFileName (project.FileName));
 			
 			lastConfig = (NUnitAssemblyGroupProjectConfiguration) project.DefaultConfiguration;
 			if (lastConfig != null)

--- a/main/src/addins/NUnit/Services/BinaryResultsStore.cs
+++ b/main/src/addins/NUnit/Services/BinaryResultsStore.cs
@@ -1,0 +1,98 @@
+﻿//
+// BinaryResultsStore.cs
+//
+// Author:
+//       Sergey Khabibullin <sergey@khabibullin.com>
+//
+// Copyright (c) 2014 Sergey Khabibullin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using ICSharpCode.NRefactory.Utils;
+using System.Xml.Serialization;
+using System.IO;
+
+namespace MonoDevelop.NUnit
+{
+	/// <summary>
+	/// ResultsStore implementation that uses binary serializer
+	/// </summary>
+	public class BinaryResultsStore : AbstractResultsStore
+	{
+		static BinaryResultsStoreSerializer serializer = new BinaryResultsStoreSerializer();
+
+		public BinaryResultsStore (string directory, string storeId)
+			: base(serializer, directory, storeId)
+		{
+		}
+	}
+
+	/// <summary>
+	/// Serializer implementation that uses ICSharpCode.NRefactory.Utils.FastSerializer
+	/// as it's main method to serialize test records. The serializer is backward compatible
+	/// with the old xml-based serialization and will deserialize test record from xml
+	/// if the binary form is not yet present.
+	/// </summary>
+	public class BinaryResultsStoreSerializer : IResultsStoreSerializer
+	{
+		const string binaryExtension = ".test-result";
+		const string xmlExtension = ".xml";
+
+		FastSerializer fastSerializer = new FastSerializer();
+		XmlSerializer xmlSerializer = new XmlSerializer(typeof(TestRecord));
+
+		public void Serialize (string xmlFilePath, TestRecord testRecord)
+		{
+			// no need for xml serialization because next time it will be
+			// deserialized from the binary format
+			string binaryFilePath = GetBinaryFilePath (xmlFilePath);
+			using (var stream = File.OpenWrite(binaryFilePath)) {
+				fastSerializer.Serialize (stream, testRecord);
+			}
+		}
+
+		public TestRecord Deserialize (string xmlFilePath)
+		{
+			string binaryFilePath = GetBinaryFilePath (xmlFilePath);
+
+			// deserialize from the binary format if the file exists
+			if (File.Exists(binaryFilePath)) {
+				using (var stream = File.OpenRead (binaryFilePath)) {
+					return (TestRecord) fastSerializer.Deserialize (stream);
+				}
+			}
+
+			// deserialize from xml if the file exists
+			if (File.Exists(xmlFilePath)) {
+				using (var reader = new StreamReader (xmlFilePath)) {
+					return (TestRecord) xmlSerializer.Deserialize (reader);
+				}
+			}
+
+			return null;
+		}
+
+		string GetBinaryFilePath(string xmlFilePath)
+		{
+			// filename with the binary extension
+			return xmlFilePath.Substring (0, xmlFilePath.Length - xmlExtension.Length) + binaryExtension;
+		}
+	}
+}
+

--- a/main/src/addins/NUnit/Services/NUnitProjectTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitProjectTestSuite.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.NUnit
 		{
 			storeId = Path.GetFileName (project.FileName);
 			resultsPath = MonoDevelop.NUnit.RootTest.GetTestResultsDirectory (project.BaseDirectory);
-			ResultsStore = new XmlResultsStore (resultsPath, storeId);
+			ResultsStore = new BinaryResultsStore (resultsPath, storeId);
 			this.project = project;
 			project.NameChanged += new SolutionItemRenamedEventHandler (OnProjectRenamed);
 			IdeApp.ProjectOperations.EndBuild += new BuildEventHandler (OnProjectBuilt);

--- a/main/src/addins/NUnit/Services/SolutionFolderTestGroup.cs
+++ b/main/src/addins/NUnit/Services/SolutionFolderTestGroup.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.NUnit
 		{
 			string storeId = c.ItemId;
 			string resultsPath = MonoDevelop.NUnit.RootTest.GetTestResultsDirectory (c.BaseDirectory);
-			ResultsStore = new XmlResultsStore (resultsPath, storeId);
+			ResultsStore = new BinaryResultsStore (resultsPath, storeId);
 			
 			combine = c;
 			combine.ItemAdded += OnEntryChanged;

--- a/main/src/addins/NUnit/Services/WorkspaceTestGroup.cs
+++ b/main/src/addins/NUnit/Services/WorkspaceTestGroup.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.NUnit
 		{
 			string storeId = ws.Name;
 			string resultsPath = MonoDevelop.NUnit.RootTest.GetTestResultsDirectory (ws.BaseDirectory);
-			ResultsStore = new XmlResultsStore (resultsPath, storeId);
+			ResultsStore = new BinaryResultsStore (resultsPath, storeId);
 			
 			workspace = ws;
 			workspace.ItemAdded += OnEntryChanged;


### PR DESCRIPTION
> Xml Serialization is likely the >slowest< way to serialize data and shouldn't be used.
> (btw. nrefactory contains an optimized fast binary serializer - that should be used instead)

I changed the serialization method to the ICSharpCode.NRefactory.Utils.FastSerializer.
It stays backward compatible with the previous implementation (xml serialization) when there is a need for this.
