### PR TITLE
Always displaying first parameter discription in ParameterInfo tooltip

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ParameterInformationWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ParameterInformationWindow.cs
@@ -123,7 +123,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 			lastParam = currentParam;
 			ClearDescriptions ();
-			var o = provider.CreateTooltipInformation (overload, _currentParam, false);
+			var o = provider.CreateTooltipInformation (overload, currentParam, false);
 
 			Theme.NumPages = provider.Count;
 			Theme.CurrentPage = overload;


### PR DESCRIPTION
More information at https://github.com/icsharpcode/NRefactory/pull/390

About this change... This method correctly detect if method has at least 1 parameter set currentParam on 0 from -1(no paramters info). But than wrong variable is used _currentParam(which is still -1) instead of corrected currentParam(0). Resulting in not displaying parameter info.
