### PR TITLE
Fixed 'Bug 12911 - NUnit addin munges testcases containing data with dot...

### DIFF
--- a/main/src/addins/NUnit/NUnitRunner/NUnitTestRunner.cs
+++ b/main/src/addins/NUnit/NUnitRunner/NUnitTestRunner.cs
@@ -119,7 +119,9 @@ namespace MonoDevelop.NUnit.External
 			// The name of inherited tests include the base class name as prefix.
 			// That prefix has to be removed
 			string tname = test.TestName.Name;
-			int i = tname.LastIndexOf ('.');
+			// Find the last index of the dot character that is not a part of the test parameters
+			int j = tname.IndexOf ('(');
+			int i = tname.LastIndexOf ('.', (j == -1) ? (tname.Length - 1) : j);
 			if (i != -1)
 				tname = tname.Substring (i + 1);
 			if (test.FixtureType != null) {


### PR DESCRIPTION
Simple fix. NUnit addin now doesn't use dot characters passed as parameters for test tree building.
