### PR TITLE
Always set ExecutionTarget in case AddIn is checking if execution target exists

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -271,7 +271,7 @@ namespace MonoDevelop.Debugger
 		public static DebuggerFeatures GetSupportedFeatures (IBuildTarget target)
 		{
 			FeatureCheckerHandlerFactory fc = new FeatureCheckerHandlerFactory ();
-			ExecutionContext ctx = new ExecutionContext (fc, null);
+			ExecutionContext ctx = new ExecutionContext (fc, null, IdeApp.Workspace.ActiveExecutionTarget);
 			target.CanExecute (ctx, IdeApp.Workspace.ActiveConfiguration);
 			return fc.SupportedFeatures;
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
@@ -38,7 +38,7 @@ namespace MonoDevelop.Debugger
 	{
 		public static bool CanDebug (this ProjectOperations opers, IBuildTarget entry)
 		{
-			ExecutionContext context = new ExecutionContext (DebuggingService.GetExecutionHandler (), IdeApp.Workbench.ProgressMonitors);
+			ExecutionContext context = new ExecutionContext (DebuggingService.GetExecutionHandler (), IdeApp.Workbench.ProgressMonitors, IdeApp.Workspace.ActiveExecutionTarget);
 			return opers.CanExecute (entry, context);
 		}
 
@@ -56,13 +56,13 @@ namespace MonoDevelop.Debugger
 
 		public static bool CanDebugFile (this ProjectOperations opers, string file)
 		{
-			var context = new ExecutionContext (DebuggingService.GetExecutionHandler (), IdeApp.Workbench.ProgressMonitors);
+			var context = new ExecutionContext (DebuggingService.GetExecutionHandler (), IdeApp.Workbench.ProgressMonitors, IdeApp.Workspace.ActiveExecutionTarget);
 			return opers.CanExecuteFile (file, context);
 		}
 
 		public static IAsyncOperation DebugFile (this ProjectOperations opers, string file)
 		{
-			var context = new ExecutionContext (DebuggingService.GetExecutionHandler (), IdeApp.Workbench.ProgressMonitors);
+			var context = new ExecutionContext (DebuggingService.GetExecutionHandler (), IdeApp.Workbench.ProgressMonitors, IdeApp.Workspace.ActiveExecutionTarget);
 			return opers.ExecuteFile (file, context);
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CustomCommandExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CustomCommandExtension.cs
@@ -79,7 +79,7 @@ namespace MonoDevelop.Projects
 		{
 			SolutionItemConfiguration conf = entry.GetConfiguration (configuration) as SolutionItemConfiguration;
 			if (conf != null) {
-				ExecutionContext localContext = new ExecutionContext (Runtime.ProcessService.DefaultExecutionHandler, context.ConsoleFactory);
+				ExecutionContext localContext = new ExecutionContext (Runtime.ProcessService.DefaultExecutionHandler, context.ConsoleFactory, context.ExecutionTarget);
 				
 				if (conf.CustomCommands.CanExecute (entry, CustomCommandType.BeforeExecute, localContext, configuration))
 					conf.CustomCommands.ExecuteCommand (monitor, entry, CustomCommandType.BeforeExecute, localContext, configuration);
@@ -91,7 +91,7 @@ namespace MonoDevelop.Projects
 			base.Execute (monitor, entry, context, configuration);
 			
 			if (conf != null && !monitor.IsCancelRequested) {
-				ExecutionContext localContext = new ExecutionContext (Runtime.ProcessService.DefaultExecutionHandler, context.ConsoleFactory);
+				ExecutionContext localContext = new ExecutionContext (Runtime.ProcessService.DefaultExecutionHandler, context.ConsoleFactory, context.ExecutionTarget);
 				
 				if (conf.CustomCommands.CanExecute (entry, CustomCommandType.AfterExecute, localContext, configuration))
 					conf.CustomCommands.ExecuteCommand (monitor, entry, CustomCommandType.AfterExecute, localContext, configuration);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExecutionContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExecutionContext.cs
@@ -38,14 +38,14 @@ namespace MonoDevelop.Projects
 		IConsoleFactory consoleFactory;
 		ExecutionTarget executionTarget;
 		
-		public ExecutionContext (IExecutionMode executionMode, IConsoleFactory consoleFactory, ExecutionTarget target = null)
+		public ExecutionContext (IExecutionMode executionMode, IConsoleFactory consoleFactory, ExecutionTarget target)
 		{
 			this.executionHandler = executionMode.ExecutionHandler;
 			this.consoleFactory = consoleFactory;
 			this.executionTarget = target;
 		}
 		
-		public ExecutionContext (IExecutionHandler executionHandler, IConsoleFactory consoleFactory, ExecutionTarget target = null)
+		public ExecutionContext (IExecutionHandler executionHandler, IConsoleFactory consoleFactory, ExecutionTarget target)
 		{
 			this.executionHandler = executionHandler;
 			this.consoleFactory = consoleFactory;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/StartupOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/StartupOptionsPanel.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 					bool matched = false;
 					foreach (IExecutionMode mode in mset.ExecutionModes) {
 						foreach (SolutionConfiguration sc in sol.Configurations) {
-							if (it.CanExecute (new ExecutionContext (mode, null), sc.Selector)) {
+							if (it.CanExecute (new ExecutionContext (mode, null, IdeApp.Workspace.ActiveExecutionTarget), sc.Selector)) {
 								startupItems.Add (it);
 								matched = true;
 								break;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1026,7 +1026,7 @@ namespace MonoDevelop.Ide
 		
 		public bool CanExecuteFile (string file, IExecutionHandler handler)
 		{
-			ExecutionContext context = new ExecutionContext (handler, IdeApp.Workbench.ProgressMonitors);
+			ExecutionContext context = new ExecutionContext (handler, IdeApp.Workbench.ProgressMonitors, IdeApp.Workspace.ActiveExecutionTarget);
 			return CanExecuteFile (file, context);
 		}
 		
@@ -1048,7 +1048,7 @@ namespace MonoDevelop.Ide
 		
 		public IAsyncOperation ExecuteFile (string file, IExecutionHandler handler)
 		{
-			ExecutionContext context = new ExecutionContext (handler, IdeApp.Workbench.ProgressMonitors);
+			ExecutionContext context = new ExecutionContext (handler, IdeApp.Workbench.ProgressMonitors, IdeApp.Workspace.ActiveExecutionTarget);
 			return ExecuteFile (file, context);
 		}
 		


### PR DESCRIPTION
I'm working on https://github.com/DavidKarlas/MonoDevelop.MicroFramework AddIn and I ran in problem that F5 was not starting execution but Run button(in top left corner) was working just fine. After some debugging I figured that call from https://github.com/mono/monodevelop/blob/master/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs#L41 is not setting ExecutionTarget and my OnGetCanExecute is returning false if target is null...

I also removed default value _null_ from ExecutionContext.cs constructors to make developers in future aware that they should set ExecutionTarget(if they really can't they still put _null_ but at least they are aware of problem).

If I shouldn't be checking against ExecutionTarget don't take this pull request and I will remove check against ExecutionTarget in my OnGetCanExecute. But than when device is disconnected I will display option to Run(instead to Build) and Execution will always fail.
