### PR TITLE
Win32 debugger locking DLL/PDB files

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
@@ -338,7 +338,7 @@ namespace MonoDevelop.Debugger.Win32
 				binfo.IncrementHitCount();
 				if (!binfo.HitCountReached)
 					return;
-				
+
 				if (!string.IsNullOrEmpty (bp.ConditionExpression)) {
 					string res = EvaluateExpression (e.Thread, bp.ConditionExpression);
 					if (bp.BreakIfConditionChanges) {
@@ -404,6 +404,7 @@ namespace MonoDevelop.Debugger.Win32
 			// If the main thread stopped, terminate the debugger session
 			if (e.Process.Id == process.Id) {
 				lock (terminateLock) {
+					process.Dispose ();
 					process = null;
 					ThreadPool.QueueUserWorkItem (delegate
 					{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/MtaThread.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/MtaThread.cs
@@ -62,6 +62,9 @@ namespace MonoDevelop.Debugger.Win32
 					catch (Exception ex) {
 						workError = ex;
 					}
+					finally {
+						workDelegate = null;
+					}
 					wordDoneEvent.Set ();
 				}
 				while (Monitor.Wait (threadLock, 60000));

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -375,6 +375,7 @@ namespace MonoDevelop.Debugger
 				busyStatusIcon = null;
 				session = null;
 				console = null;
+				pinnedWatches.InvalidateAll ();
 			}
 
 			if (oldLayout != null) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -240,6 +240,10 @@ namespace MonoDevelop.Debugger
 			crtValue.Edited -= OnValueEdited;
 			crtValue.EditingCanceled -= OnEditingCancelled;
 
+			typeCol.RemoveNotification ("width", OnColumnWidthChanged);
+			valueCol.RemoveNotification ("width", OnColumnWidthChanged);
+			expCol.RemoveNotification ("width", OnColumnWidthChanged);
+
 			disposed = true;
 			cancellationTokenSource.Cancel ();
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueTooltipProvider.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueTooltipProvider.cs
@@ -72,8 +72,10 @@ namespace MonoDevelop.SourceEditor
 
 		void TargetProcessExited (object sender, EventArgs e)
 		{
-			if (tooltip != null)
-				tooltip.Hide ();
+			if (tooltip != null) {
+				tooltip.Dispose ();
+				tooltip = null;
+			}
 		}
 
 		#region ITooltipProvider implementation

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
@@ -2800,6 +2800,7 @@ namespace Mono.TextEditor
 				}
 				tipWindow.Destroy ();
 				tipWindow = null;
+				tipItem = null;
 			}
 		}
 		


### PR DESCRIPTION
I ran MonoDevelop in Memory profiler and checked what is holding CorSessionDebugger... Once CorSessionDebugger object was collected by GC. DLLs/PDBs were not locked anymore... Hopefully I tracked all cases... ;)
