### PR TITLE
Fix problem with infinite loop while resizing the text area on load.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextEditor.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextEditor.cs
@@ -277,7 +277,7 @@ namespace Mono.TextEditor
 		void SetChildrenPositions (Rectangle allocation)
 		{
 			foreach (EditorContainerChild child in containerChildren.ToArray ()) {
-				if (child.Child == textArea)
+				if (child.Child == textArea || child.Child is Mono.TextEditor.Vi.ViStatusArea)
 					continue;
 				ResizeChild (allocation, child);
 			}


### PR DESCRIPTION
The child node is of type ViStatusArea and causes the ResizeChild Event to fire which will cause an infinite loop. 
