### PR TITLE
Allow nunitlite to enable running unit tests within the IDE

### DIFF
--- a/main/src/addins/NUnit/Services/NUnitProjectTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitProjectTestSuite.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.NUnit
 				return null;
 
 			foreach (var p in project.References)
-				if (p.Reference.IndexOf ("GuiUnit", StringComparison.OrdinalIgnoreCase) != -1 || p.Reference.IndexOf ("nunit.framework") != -1 || p.Reference.IndexOf ("nunit.core") != -1)
+				if (p.Reference.IndexOf ("GuiUnit", StringComparison.OrdinalIgnoreCase) != -1 || p.Reference.IndexOf ("nunit.framework") != -1 || p.Reference.IndexOf ("nunit.core") != -1 || p.Reference.IndexOf ("nunitlite") != -1)
 					return new NUnitProjectTestSuite (project);
 			return null;
 		}


### PR DESCRIPTION
This enabled running unit tests within the IDE when using nunitlite vs. nunit.framework.
