### PR TITLE
[Win32] Viewing List<> and Dictionary<,> items + unit tests

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
         {
             get 
             {
-                throw new NotImplementedException();
+                return Type.GetType (FullName);
             }
         }
 

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorObjectAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorObjectAdaptor.cs
@@ -395,7 +395,11 @@ namespace MonoDevelop.Debugger.Win32
 						CorValue[] args = new CorValue[argValues.Length];
 						for (int n = 0; n < args.Length; n++)
 							args[n] = argValues[n].Val;
-						return ctx.RuntimeInvoke (func, new CorType[0], target != null ? target.Val : null, args);
+						if (targetType.Type == CorElementType.ELEMENT_TYPE_ARRAY || targetType.Type == CorElementType.ELEMENT_TYPE_SZARRAY) {
+							return ctx.RuntimeInvoke (func, new CorType[0], target != null ? target.Val : null, args);
+						} else {
+							return ctx.RuntimeInvoke (func, targetType.TypeParameters, target != null ? target.Val : null, args);
+						}
 					});
 					return v.Val == null ? null : v;
 				}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -79,6 +79,11 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			int intZero = 0, intOne = 1;
 			int n = 32;
 			decimal dec = 123.456m;
+			var stringList = new List<string> ();
+			stringList.Add ("aaa");
+			stringList.Add ("bbb");
+			stringList.Add ("ccc");
+
 			var alist = new ArrayList ();
 			alist.Add (1);
 			alist.Add ("two");
@@ -97,6 +102,7 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 			var numbersMulti = new int [3, 4, 5];
 
 			var dict = new Dictionary<int, string[]> ();
+			dict.Add (5, new string[]{ "a", "b" });
 			var dictArray = new Dictionary<int, string[]> [2, 3];
 			var thing = new Thing<string> ();
 			var done = new Thing<string>.Done<int> ();

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.cs
@@ -97,7 +97,10 @@ namespace MonoDevelop.Debugger.Tests
 				runtime = Runtime.SystemAssemblyService.GetTargetRuntime ("MS.NET");
 				break;
 			case "Mono.Debugger.Soft":
-				runtime = Runtime.SystemAssemblyService.GetTargetRuntimes ().OfType<MonoTargetRuntime> ().FirstOrDefault ();
+				runtime = Runtime.SystemAssemblyService.GetTargetRuntimes ()
+					.OfType<MonoTargetRuntime> ()
+					.OrderByDescending((o) => o.Version)
+					.FirstOrDefault ();
 				break;
 			default:
 				runtime = Runtime.SystemAssemblyService.DefaultRuntime;
@@ -106,6 +109,8 @@ namespace MonoDevelop.Debugger.Tests
 
 			if (runtime == null)
 				Assert.Ignore ("Runtime not found for: {0}", EngineId);
+
+			Console.WriteLine ("Target Runtime: " + runtime.DisplayRuntimeName + " " + runtime.Version);
 
 			// main/build/tests
 			FilePath path = Path.GetDirectoryName (GetType ().Assembly.Location);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
@@ -1306,5 +1306,51 @@ namespace MonoDevelop.Debugger.Tests
 			Assert.AreEqual ("int", val.TypeName);
 		}
 
+		[Test]
+		public void Lists()
+		{
+			if (!AllowTargetInvokes)
+				Assert.Ignore ("Evaluating lists is not working on NoTargetInvokes.");
+			ObjectValue val;
+			ObjectValue[] children;
+			val = Eval ("dict");
+			children = val.GetAllChildren ();
+			Assert.AreEqual (2, children.Length);
+			Assert.AreEqual ("[0]", children [0].Name);
+			Assert.AreEqual ("{[5, System.String[]]}", children [0].Value);
+			Assert.AreEqual ("Raw View", children [1].Name);
+			children = children [0].GetAllChildren ();
+			Assert.AreEqual ("Key", children [0].Name);
+			Assert.AreEqual ("5", children [0].Value);
+			Assert.AreEqual ("int", children [0].TypeName);
+			Assert.AreEqual ("Value", children [1].Name);
+			Assert.AreEqual ("{string[2]}", children [1].Value);
+			children = children [1].GetAllChildren ();
+			Assert.AreEqual ("\"a\"", children [0].Value);
+			Assert.AreEqual ("string", children [0].TypeName);
+			Assert.AreEqual ("\"b\"", children [1].Value);
+
+			val = Eval ("stringList");
+			children = val.GetAllChildren ();
+			Assert.AreEqual (4, children.Length);
+			Assert.AreEqual ("[0]", children [0].Name);
+			Assert.AreEqual ("[1]", children [1].Name);
+			Assert.AreEqual ("[2]", children [2].Name);
+			Assert.AreEqual ("Raw View", children [3].Name);
+			Assert.AreEqual ("\"aaa\"", children [0].Value);
+			Assert.AreEqual ("\"bbb\"", children [1].Value);
+			Assert.AreEqual ("\"ccc\"", children [2].Value);
+
+			val = Eval ("alist");
+			children = val.GetAllChildren ();
+			Assert.AreEqual (4, children.Length);
+			Assert.AreEqual ("[0]", children [0].Name);
+			Assert.AreEqual ("[1]", children [1].Name);
+			Assert.AreEqual ("[2]", children [2].Name);
+			Assert.AreEqual ("Raw View", children [3].Name);
+			Assert.AreEqual ("1", children [0].Value);
+			Assert.AreEqual ("\"two\"", children [1].Value);
+			Assert.AreEqual ("3", children [2].Value);
+		}
 	}
 }


### PR DESCRIPTION
- MetadataType.cs
  - This resolves problem that in previous pull request I solved with competing .FullName this is proper solution
- CorObjectAdaptor.cs
  - Improved generics support but just enough to be able to handle .ToString() on generic classes like KeyPair<,> so Dictionary entries are properly displayed
- Other files
  - Unit tests for lists, if AllowTargetInovation is disabled nothing is listed(same behaviour is in VS.Net) have to talk to jeff about this
