### PR TITLE
Win32 ObjectCreation, Enum compare & Unit tests

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -202,6 +202,23 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 
 class A
 {
+	public string ConstructedBy { get; private set; }
+
+	public A ()
+	{
+		ConstructedBy = "NoArg";
+	}
+
+	public A (int i)
+	{
+		ConstructedBy = "IntArg";
+	}
+
+	public A (string str)
+	{
+		ConstructedBy = "StringArg";
+	}
+
 	public virtual int Prop { get { return 1; } }
 
 	public int PropNoVirt1 { get { return 1; } }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
@@ -706,6 +706,30 @@ namespace MonoDevelop.Debugger.Tests
 			val = Eval ("(long)2 == (int)2");
 			Assert.AreEqual ("true", val.Value);
 			Assert.AreEqual ("bool", val.TypeName);
+
+			val = Eval ("SomeEnum.two == SomeEnum.one");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("false", val.Value);
+			Assert.AreEqual ("bool", val.TypeName);
+
+			val = Eval ("SomeEnum.one != SomeEnum.one");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("false", val.Value);
+			Assert.AreEqual ("bool", val.TypeName);
 			
 			// Arithmetic
 			
@@ -1077,15 +1101,63 @@ namespace MonoDevelop.Debugger.Tests
 			//When fixed put into MemberReference
 			val = Eval ("numbers.GetLength(0)");
 			if (!AllowTargetInvokes) {
-					var options = Session.Options.EvaluationOptions.Clone ();
-					options.AllowTargetInvoke = true;
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
 
-					Assert.IsTrue (val.IsNotSupported);
-					val.Refresh (options);
-					val = val.Sync ();
-				}
+				Assert.IsTrue (val.IsNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
 			Assert.AreEqual ("3", val.Value);
 			Assert.AreEqual ("int", val.TypeName);
+		}
+
+		[Test]
+		public void ObjectCreation ()
+		{
+			ObjectValue val;
+
+			val = Eval ("new A().ConstructedBy");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"NoArg\"", val.Value);
+
+			val = Eval ("new A(7).ConstructedBy");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"IntArg\"", val.Value);
+
+			val = Eval ("new A(\"someString\").ConstructedBy");
+			if (!AllowTargetInvokes) {
+				var options = Session.Options.EvaluationOptions.Clone ();
+				options.AllowTargetInvoke = true;
+
+				Assert.IsTrue (val.IsNotSupported);
+				val.Refresh (options);
+				val = val.Sync ();
+			}
+			Assert.AreEqual ("\"StringArg\"", val.Value);
+		}
+
+		[Test]
+		[Ignore ("TODO: Sdb and Win32")]
+		public void StructCreation ()
+		{
+			ObjectValue val;
+			val = Eval ("new SimpleStruct()");
+			Assert.AreEqual ("SimpleStruct", val.TypeName);
 		}
 
 		[Test]


### PR DESCRIPTION
- [UnitTest] Debugger eval compare enums
  - Added this because it didn't work on Win32
- [UnitTest] Create objects with different constructors and Struct which is ignored atm because not working
  - @jstedfast Can you take a look why is SoftDebugger Struct creation not working? I will check Win32...
- Fixed comparing of enums
  - (CorObjectAdaptor.cs:381) I'm not sure if this is proper solution but Boxing enums fails because Array creation fails if Enum is type not sure why... Will investigate but at least compare is now working
- [Win32] Fixed object creation
  - (CorObjectAdaptor.cs:709) Previous solution was working only for constructors with 1 constructor without checking overloads... Now works as excpected
