### PR TITLE
Nested and generic type resolving

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/TextEditorResolverProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/TextEditorResolverProvider.cs
@@ -111,7 +111,18 @@ namespace MonoDevelop.CSharp.Resolver
 			var resolver = new CSharpAstResolver (doc.Compilation, unit, parsedFile);
 			resolver.ApplyNavigator (new NodeListResolveVisitorNavigator (node), CancellationToken.None);
 			var state = resolver.GetResolverStateBefore (node, CancellationToken.None);
-			return state.LookupSimpleNameOrTypeName (expression, new List<IType> (), NameLookupMode.Expression);
+
+			var list = new List<IType> ();
+			int indexOf = expression.IndexOf ('`');
+			if (indexOf != -1) {
+				var intType = new PrimitiveType ("int").ToTypeReference ().Resolve (doc.Compilation);
+				var num = expression.Substring (indexOf + 1);
+				int number = int.Parse (num);
+				for (int i = 0; i < number; i++)
+					list.Add (intType);
+				expression = expression.Remove (indexOf);
+			}
+			return state.LookupSimpleNameOrTypeName (expression, list, NameLookupMode.Expression);
 		}
 		
 		

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -198,6 +198,11 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 
 			}
 		}
+
+		class NestedGenericClass<T1,T2>
+		{
+
+		}
 	}
 
 	public class SomeClassInNamespace


### PR DESCRIPTION
I will go trough changes file by file:

TextEditorResolverProvider:
Before this change LookupSimpleNameOrType was always called with new List() so there was no way to resolve generic types. What I did here is some kind of hack because always passing "int" as generic type. I tested this on various combinations like nested multiple types Dic>>...
What is cool about this solution is very backward compatible and does not require any API changes to pass generic types or need to resolve them.
@mkrueger Looking for your thoughts about this.

CorObjectAdaptor:
Here are 2 changes:

Before it was caching name which was something like "Dictionary`2" so resolving Dic and after that Dic would result in wrong resolving in second case because it would return cacged Dic...
if (t.FullName.Replace ('+', '.') == name) replacing '+' with '.' because Csharp type resolver is resolving nested classes with SomeClass.NestedClass and not SomeClass+NestedClass so type is not found... Why don't we make resolver resolve with +? I tried hardcoing this to see what happens... new CsharpParser("...") don't like seeing "+" in middle of expression and starts treating it as AddOperation... @jstedfast same problem is with SoftDebugger seems like runtime expects '+'... One new test is failing now have some idea how to solve?
Rest of files are just tests and adding TypeResolve mock method
This pull is dependent on mono/debugger-libs#26 and vice-versa so bump is required.
