### PR TITLE
[Ide] Fix for resx generator resource locating

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/ResXFileCodeGenerator.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/ResXFileCodeGenerator.cs
@@ -80,7 +80,7 @@ namespace MonoDevelop.Ide.CustomTools
 					r.UseResXDataNodes = true;
 					r.BasePath = Path.GetDirectoryName (file.FilePath.ParentDirectory);
 
-					foreach(DictionaryEntry e in r) {
+					foreach (DictionaryEntry e in r) {
 						rd.Add (e.Key, e.Value);
 					}
 				}


### PR DESCRIPTION
Stops ResXFileCodeGenerator from looking for files based off the IDE's path.
More specifically, when the StronglyTypedResourceBuilder comes in contact with say "..\Resources\Test.ico", since it has no base directory, it uses the exe's path (as is standard) as opposed to what it is supposed to do.

Fix for bug #19610
