### PR TITLE
Audit all instances of RunCustomDialog:

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet.Deployment/WebDeployService.cs
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet/MonoDevelop.AspNet.Deployment/WebDeployService.cs
@@ -123,15 +123,16 @@ namespace MonoDevelop.AspNet.Deployment
 			ICollection<WebDeployTarget> targets = null;
 			
 			var response = ResponseType.None;
-			do {
-				response = (ResponseType) MessageService.RunCustomDialog (dialog, MessageService.RootWindow);
-			} while (response != ResponseType.Ok && response != ResponseType.Cancel && response != ResponseType.DeleteEvent);
-			
-			if (response == Gtk.ResponseType.Ok)
-				targets = dialog.GetSelectedTargets ();
-			
-			dialog.Destroy ();
-			
+			try {
+				do {
+					response = (ResponseType) MessageService.RunCustomDialog (dialog, MessageService.RootWindow);
+				} while (response != ResponseType.Ok && response != ResponseType.Cancel && response != ResponseType.DeleteEvent);
+
+				if (response == Gtk.ResponseType.Ok)
+					targets = dialog.GetSelectedTargets ();
+			} finally {
+				dialog.Destroy ();
+			}
 			if (targets != null && targets.Count > 0)
 				Deploy (project, targets, IdeApp.Workspace.ActiveConfiguration);
 		}

--- a/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/MonoDevelop.Deployment.Linux/DotDesktopViewWidget.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/MonoDevelop.Deployment.Linux/DotDesktopViewWidget.cs
@@ -226,13 +226,16 @@ namespace MonoDevelop.Deployment.Linux
 		protected virtual void OnButtonAddCategoriesClicked(object sender, System.EventArgs e)
 		{
 			MenuCategorySelectorDialog dlg = new MenuCategorySelectorDialog ();
-			if (MessageService.RunCustomDialog (dlg) == (int) Gtk.ResponseType.Ok) {
-				foreach (string s in dlg.Selection)
-					entry.Categories.Add (s);
-				FillCategs ();
-				NotifyChanged ();
+			try {
+				if (MessageService.RunCustomDialog (dlg) == (int) Gtk.ResponseType.Ok) {
+					foreach (string s in dlg.Selection)
+						entry.Categories.Add (s);
+					FillCategs ();
+					NotifyChanged ();
+				}
+			} finally {
+				dlg.Destroy ();
 			}
-			dlg.Destroy ();
 		}
 
 		protected virtual void OnButtonRemoveCategoryClicked(object sender, System.EventArgs e)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -218,15 +218,18 @@ namespace MonoDevelop.Debugger
 		{
 			var dlg = new AddTracePointDialog ();
 
-			if (MessageService.RunCustomDialog (dlg) == (int) Gtk.ResponseType.Ok && dlg.Text.Length > 0) {
-				var bp = new Breakpoint (file, line);
-				bp.HitAction = HitAction.PrintExpression;
-				bp.TraceExpression = dlg.Text;
-				bp.ConditionExpression = dlg.Condition;
-				lock (breakpoints)
-					breakpoints.Add (bp);
+			try {
+				if (MessageService.RunCustomDialog (dlg) == (int) Gtk.ResponseType.Ok && dlg.Text.Length > 0) {
+					var bp = new Breakpoint (file, line);
+					bp.HitAction = HitAction.PrintExpression;
+					bp.TraceExpression = dlg.Text;
+					bp.ConditionExpression = dlg.Condition;
+					lock (breakpoints)
+						breakpoints.Add (bp);
+				}
+			} finally {
+				dlg.Destroy ();
 			}
-			dlg.Destroy ();
 		}
 		
 		public static void AddWatch (string expression)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/HighlightingPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/HighlightingPanel.cs
@@ -82,8 +82,7 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 		void HandleButtonNewClicked (object sender, EventArgs e)
 		{
 			var newShemeDialog = new NewColorShemeDialog ();
-			MessageService.RunCustomDialog (newShemeDialog, dialog);
-			newShemeDialog.Destroy ();
+			MessageService.ShowCustomDialog (newShemeDialog, dialog);
 			ShowStyles ();
 		}
 
@@ -113,8 +112,7 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 				var editor = new ColorShemeEditor (this);
 				var colorScheme = (Mono.TextEditor.Highlighting.ColorScheme)this.styleStore.GetValue (selectedIter, 1);
 				editor.SetSheme (colorScheme);
-				MessageService.RunCustomDialog (editor, dialog);
-				editor.Destroy ();
+				MessageService.ShowCustomDialog (editor, dialog);
 			}
 		}
 		

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -132,24 +132,27 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			var stashes = Repository.GetStashes ();
 			NewStashDialog dlg = new NewStashDialog ();
-			if (MessageService.RunCustomDialog (dlg) == (int) Gtk.ResponseType.Ok) {
-				string comment = dlg.Comment;
-				MessageDialogProgressMonitor monitor = new MessageDialogProgressMonitor (true, false, false, true);
-				var statusTracker = IdeApp.Workspace.GetFileStatusTracker ();
-				ThreadPool.QueueUserWorkItem (delegate {
-					try {
-						using (var gm = new GitMonitor (monitor))
-							stashes.Create (gm, comment);
-					} catch (Exception ex) {
-						MessageService.ShowException (ex);
-					}
-					finally {
-						monitor.Dispose ();
-						statusTracker.NotifyChanges ();
-					}
-				});
+			try {
+				if (MessageService.RunCustomDialog (dlg) == (int) Gtk.ResponseType.Ok) {
+					string comment = dlg.Comment;
+					MessageDialogProgressMonitor monitor = new MessageDialogProgressMonitor (true, false, false, true);
+					var statusTracker = IdeApp.Workspace.GetFileStatusTracker ();
+					ThreadPool.QueueUserWorkItem (delegate {
+						try {
+							using (var gm = new GitMonitor (monitor))
+								stashes.Create (gm, comment);
+						} catch (Exception ex) {
+							MessageService.ShowException (ex);
+						}
+						finally {
+							monitor.Dispose ();
+							statusTracker.NotifyChanges ();
+						}
+					});
+				}
+			} finally {
+				dlg.Destroy ();
 			}
-			dlg.Destroy ();
 		}
 	}
 	

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -563,8 +563,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Run ()
 		{
 			ApplyPolicyDialog dlg = new ApplyPolicyDialog ((IPolicyProvider)IdeApp.ProjectOperations.CurrentSelectedSolutionItem ?? (IPolicyProvider)IdeApp.ProjectOperations.CurrentSelectedSolution);
-			MessageService.RunCustomDialog (dlg);
-			dlg.Destroy ();
+			MessageService.ShowCustomDialog (dlg);
 		}
 	}
 	
@@ -578,8 +577,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Run ()
 		{
 			ExportProjectPolicyDialog dlg = new ExportProjectPolicyDialog ((IPolicyProvider)IdeApp.ProjectOperations.CurrentSelectedSolutionItem ?? (IPolicyProvider)IdeApp.ProjectOperations.CurrentSelectedSolution);
-			MessageService.RunCustomDialog (dlg);
-			dlg.Destroy ();
+			MessageService.ShowCustomDialog (dlg);
 		}
 	}
 }


### PR DESCRIPTION
This commit makes it so that every RunCustomDialog is wrapped in a try/finally.
In instances where we just had a Destroy call afterwards, I replaced with ShowCustomDialog.
