### PR TITLE
[StatusView] Disable File Status changes while doing other operations.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -928,10 +928,10 @@ namespace MonoDevelop.VersionControl.Views
 					if (!OnFileStatusChanged (f))
 						break;
 				}
+				UpdateControlStatus ();
 			} finally {
 				VersionControlService.FileStatusChanged += OnFileStatusChanged;
 			}
-			UpdateControlStatus ();
 		}
 
 		bool OnFileStatusChanged (FileUpdateEventInfo args)


### PR DESCRIPTION
It is now disabled during a Commit Dialog popup and a commit ending, so we don't trigger any other populations of the review changes view.
It is also disabled whilst doing a changed operation. (This could be restricted to just line 978 where we do the query for new data.)
