### PR TITLE
[Ide] Clear initialized hooked events after call.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -282,8 +282,10 @@ namespace MonoDevelop.Ide
 				}
 			}
 			
-			if (initializedEvent != null)
+			if (initializedEvent != null) {
 				initializedEvent (null, EventArgs.Empty);
+				initializedEvent = null;
+			}
 			
 			// load previous combine
 			if ((bool)PropertyService.Get("SharpDevelop.LoadPrevProjectOnStartup", false)) {


### PR DESCRIPTION
This event is a one-shot event. All calls that happen prior to this are going to be done without being added to this handler.
