### PR TITLE
[CorDebugger] Pdb locking and DebuggerSession memory leak

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
@@ -110,7 +110,15 @@ namespace MonoDevelop.Debugger.Win32
 			threads = null;
 			processes = null;
 			activeThread = null;
-			GC.Collect ();
+
+			ThreadPool.QueueUserWorkItem (delegate {
+				Thread.Sleep (2000);
+				GC.Collect ();
+				GC.WaitForPendingFinalizers ();
+				Thread.Sleep (20000);
+				GC.Collect ();
+				GC.WaitForPendingFinalizers ();
+			});
 		}
 
 		void TerminateDebugger ()

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/MtaThread.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/MtaThread.cs
@@ -12,20 +12,19 @@ namespace MonoDevelop.Debugger.Win32
 		static Exception workError;
 		static readonly object threadLock = new object ();
 
-		public static R Run<R> (Func<R> ts)
+		public static R Run<R> (Func<R> ts, int timeout = 15000)
 		{
 			if (Thread.CurrentThread.GetApartmentState () == ApartmentState.MTA)
 				return ts ();
 
 			R res = default (R);
-			Run (delegate
-			{
+			Run (delegate {
 				res = ts ();
-			});
+			}, timeout);
 			return res;
 		}
 
-		public static void Run (Action ts)
+		public static void Run (Action ts, int timeout = 15000)
 		{
 			if (Thread.CurrentThread.GetApartmentState () == ApartmentState.MTA) {
 				ts ();
@@ -41,12 +40,14 @@ namespace MonoDevelop.Debugger.Win32
 						workThread.SetApartmentState (ApartmentState.MTA);
 						workThread.IsBackground = true;
 						workThread.Start ();
-					}
-					else
+					} else
 						// Awaken the existing thread
 						Monitor.Pulse (threadLock);
 				}
-				wordDoneEvent.WaitOne ();
+				if (!wordDoneEvent.WaitOne (timeout)) {
+					workThread.Abort ();
+					throw new Exception ("Debugger operation timeout on MTA thread.");
+				}
 			}
 			if (workError != null)
 				throw new Exception ("Debugger operation failed", workError);
@@ -54,21 +55,25 @@ namespace MonoDevelop.Debugger.Win32
 
 		static void MtaRunner ()
 		{
-			lock (threadLock) {
-				do {
-					try {
-						workDelegate ();
-					}
-					catch (Exception ex) {
-						workError = ex;
-					}
-					finally {
-						workDelegate = null;
-					}
-					wordDoneEvent.Set ();
-				}
-				while (Monitor.Wait (threadLock, 60000));
+			try {
+				lock (threadLock) {
+					do {
+						try {
+							workDelegate ();
+						} catch (ThreadAbortException) {
+							return;
+						} catch (Exception ex) {
+							workError = ex;
+						} finally {
+							workDelegate = null;
+						}
+						wordDoneEvent.Set ();
+					} while (Monitor.Wait (threadLock, 60000));
 
+				}
+			} catch {
+				//Just in case if we abort just in moment when it leaves workDelegate ();
+			} finally {
 				workThread = null;
 			}
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValuePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValuePad.cs
@@ -133,6 +133,8 @@ namespace MonoDevelop.Debugger
 		protected virtual void OnDebuggerStopped (object s, EventArgs a)
 		{
 			tree.ResetChangeTracking ();
+			tree.Frame = null;
+			lastFrame = null;
 			initialResume = true;
 		}
 		

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -243,6 +243,10 @@ namespace MonoDevelop.Debugger
 			valueCol.RemoveNotification ("width", OnColumnWidthChanged);
 			expCol.RemoveNotification ("width", OnColumnWidthChanged);
 
+			values.Clear ();
+			valueNames.Clear ();
+			Frame = null;
+
 			disposed = true;
 			cancellationTokenSource.Cancel ();
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/StackTracePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/StackTracePad.cs
@@ -138,9 +138,17 @@ namespace MonoDevelop.Debugger
 			ShowAll ();
 			UpdateDisplay ();
 			
-			DebuggingService.CallStackChanged += DispatchService.GuiDispatch (new EventHandler (OnClassStackChanged));
-			DebuggingService.CurrentFrameChanged += DispatchService.GuiDispatch (new EventHandler (OnFrameChanged));
+			DebuggingService.CallStackChanged += OnClassStackChanged;
+			DebuggingService.CurrentFrameChanged += OnFrameChanged;
+			DebuggingService.StoppedEvent += OnDebuggingServiceStopped;
+
 			tree.RowActivated += OnRowActivated;
+		}
+
+		void OnDebuggingServiceStopped(object sender, EventArgs e)
+		{
+			if (store != null)
+				store.Clear();
 		}
 
 		static bool Search (TreeModel model, int column, string key, TreeIter iter)
@@ -391,6 +399,14 @@ namespace MonoDevelop.Debugger
 			clipboard.Text = txt.ToString ();
 			clipboard = Clipboard.Get (Gdk.Atom.Intern ("PRIMARY", false));
 			clipboard.Text = txt.ToString ();
-		}		
+		}
+
+		protected override void OnDestroyed ()
+		{
+			DebuggingService.CallStackChanged -= OnClassStackChanged;
+			DebuggingService.CurrentFrameChanged -= OnFrameChanged;
+			DebuggingService.StoppedEvent -= OnDebuggingServiceStopped;
+			base.OnDestroyed ();
+		}
 	}
 }


### PR DESCRIPTION
This is fixing 99% of pdb locking cases which is also reported here: [Bug 19708](https://bugzilla.xamarin.com/show_bug.cgi?id=19708)

What does 99% means:
- First commit "DebuggerSession memory leak fix so..." is handling releasing of StackFrame objects and ObjectValue objects which have reference to DebuggerSession in MD GUI components like StackPad, ObjectValuePad...
- Second commit "MTA Thread" is part of that 1%... When I ran MemoryProfiler once it happened that one call was stuck inside MTA Thread after debugging was complete... So I implemented this time-out with thread.Abort... I'm open for better solutions...
- Third commit 20sec timeout... I don't like using 1 pool thread for 22sec either... But this collect has to be done after CorDebuggerSession is without references so it has to be delayed abit... 20sec is for 15sec MTA timeout... Also open for better solutions...

Because running under MemoryProfiler is slow I stopped running after few days without pdb lock but after 1 week it happened again(before I had to restart **every hour**(if I was doing some debugging ofc))...
This is why I didn't commit this because I wanted to track down all this leaks...
But yesterday @mhutch noticed some StackFrame leaking so I told him I will commit this today so he don't have to track this leaks down because they are already fixed here...
