### PR TITLE
[WindowsPlatform] Prevent multiple credential dialogs on Windows.

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsProxyCredentialProvider.cs
+++ b/main/src/addins/WindowsPlatform/WindowsProxyCredentialProvider.cs
@@ -43,9 +43,16 @@ namespace MonoDevelop.Platform.Windows
 			if (uri == null)
 				throw new ArgumentNullException ("uri");
 
-			var form = new PlaceholderForm (credentialType, uri, null);
-			var result = GdkWin32.RunModalWin32Form (form, IdeApp.Workbench.RootWindow);
-			return result ? new NetworkCredential (form.Username, form.Password, form.Domain) : null;
+			NetworkCredential credential = null;
+
+			DispatchService.GuiSyncDispatch (() => {
+				var form = new PlaceholderForm (credentialType, uri, null);
+				var result = GdkWin32.RunModalWin32Form (form, IdeApp.Workbench.RootWindow);
+				if (result)
+					credential = new NetworkCredential (form.Username, form.Password, form.Domain);
+			});
+
+			return credential;
 		}
 	}
 


### PR DESCRIPTION
On Windows multiple dialogs asking for credentials were being shown together if multiple background threads requested credentials at the same time. On the Mac the dialogs are shown one at a time. Now Windows has the same behaviour as the Mac.

Tested this with a [simple addin](https://github.com/mrward/monodevelop-credential-provider-test) ([mpack](https://github.com/mrward/monodevelop-credential-provider-test/raw/master/MonoDevelop.CredentialProviderTest_0.1.mpack) provided) that requests credentials for the same url 5 times when the menu option **Credential Provider Test...** is selected from the **Project** menu.
