### PR TITLE
Immediate window CodeCompletion appeared above typing text fixing Bug 14578

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerConsoleView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerConsoleView.cs
@@ -384,7 +384,7 @@ namespace MonoDevelop.Debugger
 
 			var rect = GetIterLocation (Cursor);
 
-			c.TriggerYCoord = y + lineY + height;
+			c.TriggerYCoord = y + lineY + height - (int)Vadjustment.Value;
 			c.TriggerXCoord = x + rect.X;
 			c.TriggerTextHeight = height;
 


### PR DESCRIPTION
Problem was that calculated position for CodeCompletion did not include scrolled value of text...
