### PR TITLE
[CorDebugger] Fixed ArrayAdaptor.GetElements

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/ArrayAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/ArrayAdaptor.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.Debugger.Win32
 				idx[i] = indices[i];
 
 			for (int i = 0; i < count; i++) {
-				elements.Add (GetElement (idx));
+				elements.Add (GetElement ((int[])idx.Clone ()));
 				idx[idx.Length - 1]++;
 			}
 


### PR DESCRIPTION
Since idx array is used inside GetElement delayed its already modified before actually being used so it has to be cloned to ensure unmodified value..
