### PR TITLE
[DebuggerUnitTests] Moving time of invoking done.Set to ensure Frame is set

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.cs
@@ -157,10 +157,10 @@ namespace MonoDevelop.Debugger.Tests
 			var done = new ManualResetEvent (false);
 
 			Session.TargetHitBreakpoint += (sender, e) => {
-				done.Set ();
 				Frame = e.Backtrace.GetFrame (0);
 				lastStoppedPosition = Frame.SourceLocation;
 				targetStoppedEvent.Set ();
+				done.Set ();
 			};
 
 			Session.TargetExceptionThrown += (sender, e) => {


### PR DESCRIPTION
It often happens on CI when Debugger unit tests are ran that Frame is null. Seems to me that problem is that done.Set is called and unit tests are being executed before e.Backtrace.GetFrame (0) returns any value. With this change this can never happen...
