### PR TITLE
Win32 Private properties & GetAllChildren unit tests

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
 						break;
 					var prop = new MetadataPropertyInfo (m_importer, methodToken, this);
 					try {
-						MethodInfo mi = prop.GetGetMethod () ?? prop.GetSetMethod ();
+						MethodInfo mi = prop.GetGetMethod (true) ?? prop.GetSetMethod (true);
 						if (mi == null)
 							continue;
 						if (MetadataExtensions.TypeFlagsMatch (mi.IsPublic, mi.IsStatic, bindingAttr))

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorObjectAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorObjectAdaptor.cs
@@ -916,7 +916,7 @@ namespace MonoDevelop.Debugger.Win32
 				foreach (PropertyInfo prop in type.GetProperties (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
 					MethodInfo mi = null;
 					try {
-						mi = prop.CanRead ? prop.GetGetMethod () : null;
+						mi = prop.CanRead ? prop.GetGetMethod (true) : null;
 					}
 					catch {
 						// Ignore
@@ -1017,7 +1017,7 @@ namespace MonoDevelop.Debugger.Win32
 				foreach (PropertyInfo prop in type.GetProperties (bindingFlags)) {
 					MethodInfo mi = null;
 					try {
-						mi = prop.CanRead ? prop.GetGetMethod () : null;
+						mi = prop.CanRead ? prop.GetGetMethod (true) : null;
 					} catch {
 						// Ignore
 					}

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/PropertyReference.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/PropertyReference.cs
@@ -95,14 +95,14 @@ namespace MonoDevelop.Debugger.Win32
 				CorValue[] args;
 				if (index != null) {
 					args = new CorValue[index.Length];
-					ParameterInfo[] metArgs = prop.GetGetMethod ().GetParameters ();
+					ParameterInfo[] metArgs = prop.GetGetMethod (true).GetParameters ();
 					for (int n = 0; n < index.Length; n++)
 						args[n] = ctx.Adapter.GetBoxedArg (ctx, index[n], metArgs[n].ParameterType).Val;
 				}
 				else
 					args = new CorValue[0];
 
-				MethodInfo mi = prop.GetGetMethod ();
+				MethodInfo mi = prop.GetGetMethod (true);
 				CorFunction func = module.GetFunctionFromToken (mi.MetadataToken);
 				CorValue val = null;
 				if (declaringType.Type == CorElementType.ELEMENT_TYPE_ARRAY ||
@@ -115,10 +115,10 @@ namespace MonoDevelop.Debugger.Win32
 			}
 			set {
 				CorEvaluationContext ctx = (CorEvaluationContext)Context;
-				CorFunction func = module.GetFunctionFromToken (prop.GetSetMethod ().MetadataToken);
+				CorFunction func = module.GetFunctionFromToken (prop.GetSetMethod (true).MetadataToken);
 				CorValRef val = (CorValRef) value;
 				CorValue[] args;
-				ParameterInfo[] metArgs = prop.GetSetMethod ().GetParameters ();
+				ParameterInfo[] metArgs = prop.GetSetMethod (true).GetParameters ();
 
 				if (index == null)
 					args = new CorValue[1];
@@ -152,7 +152,7 @@ namespace MonoDevelop.Debugger.Win32
 		internal static ObjectValueFlags GetFlags (PropertyInfo prop)
 		{
 			ObjectValueFlags flags = ObjectValueFlags.Property;
-			MethodInfo mi = prop.GetGetMethod () ?? prop.GetSetMethod ();
+			MethodInfo mi = prop.GetGetMethod (true) ?? prop.GetSetMethod (true);
 
 			if (prop.GetSetMethod (true) == null)
 				flags |= ObjectValueFlags.ReadOnly;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests.TestApp/TestEvaluation.cs
@@ -128,6 +128,8 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 
 			var objWithMethodA = new ClassWithMethodA ();
 
+			var richObject = new RichClass ();
+
 			Console.WriteLine (n); /*break*/
 		}
 
@@ -220,6 +222,68 @@ namespace MonoDevelop.Debugger.Tests.TestApp
 	public class SomeClassInNamespace
 	{
 
+	}
+}
+
+class RichClass
+{
+	public int publicInt1 = 1;
+	public int publicInt2 = 2;
+	public int publicInt3 = 3;
+
+	public string publicStringA = "stringA";
+	public string publicStringB = "stringB";
+	public string publicStringC = "stringC";
+
+	private int privateInt1 = 1;
+	private int privateInt2 = 2;
+	private int privateInt3 = 3;
+
+	private string privateStringA = "stringA";
+	private string privateStringB = "stringB";
+	private string privateStringC = "stringC";
+
+	public int publicPropInt1  { get; set; }
+
+	public int publicPropInt2  { get; set; }
+
+	public int publicPropInt3  { get; set; }
+
+	public string publicPropStringA  { get; set; }
+
+	public string publicPropStringB { get; set; }
+
+	public string publicPropStringC  { get; set; }
+
+	private int privatePropInt1  { get; set; }
+
+	private int privatePropInt2 { get; set; }
+
+	private int privatePropInt3 { get; set; }
+
+	private string privatePropStringA { get; set; }
+
+	private string privatePropStringB { get; set; }
+
+	private string privatePropStringC { get; set; }
+
+	public RichClass()
+	{
+		publicPropInt1 = 1;
+		publicPropInt2 = 2;
+		publicPropInt3 = 3;
+
+		publicPropStringA = "stringA";
+		publicPropStringB = "stringB";
+		publicPropStringC = "stringC";
+
+		privatePropInt1 = 1;
+		privatePropInt2 = 2;
+		privatePropInt3 = 3;
+
+		privatePropStringA = "stringA";
+		privatePropStringB = "stringB";
+		privatePropStringC = "stringC";
 	}
 }
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
@@ -491,6 +491,14 @@ namespace MonoDevelop.Debugger.Tests
 			Assert.AreEqual ("int", val.TypeName);
 		}
 
+		void CheckValue (string expected, string actual)
+		{
+			if (AllowTargetInvokes)
+				Assert.AreEqual (expected, actual);
+			else
+				Assert.AreEqual ("Implicit evaluation is disabled", actual);
+		}
+
 		[Test]
 		public void MemberReference ()
 		{
@@ -590,6 +598,106 @@ namespace MonoDevelop.Debugger.Tests
 			val = Eval ("MonoDevelop.Debugger.Tests.TestApp.TestEvaluation.staticString");
 			Assert.AreEqual ("\"some static\"", val.Value);
 			Assert.AreEqual ("string", val.TypeName);
+
+			val = Eval ("richObject");
+			Assert.AreEqual ("{RichClass}", val.Value);
+			Assert.AreEqual ("RichClass", val.TypeName);
+
+			var richChildren = val.GetAllChildren ();
+			Assert.AreEqual (13, richChildren.Length);
+			Assert.AreEqual ("publicInt1", richChildren [0].Name);
+			Assert.AreEqual ("int", richChildren [0].TypeName);
+			Assert.AreEqual ("1", richChildren [0].Value);
+			Assert.AreEqual ("publicInt2", richChildren [1].Name);
+			Assert.AreEqual ("int", richChildren [1].TypeName);
+			Assert.AreEqual ("2", richChildren [1].Value);
+			Assert.AreEqual ("publicInt3", richChildren [2].Name);
+			Assert.AreEqual ("int", richChildren [2].TypeName);
+			Assert.AreEqual ("3", richChildren [2].Value);
+			Assert.AreEqual ("publicPropInt1", richChildren [3].Name);
+			Assert.AreEqual ("int", richChildren [3].TypeName);
+			CheckValue ("1", richChildren [3].Value);
+			Assert.AreEqual ("publicPropInt2", richChildren [4].Name);
+			Assert.AreEqual ("int", richChildren [4].TypeName);
+			CheckValue ("2", richChildren [4].Value);
+			Assert.AreEqual ("publicPropInt3", richChildren [5].Name);
+			Assert.AreEqual ("int", richChildren [5].TypeName);
+			CheckValue ("3", richChildren [5].Value);
+			Assert.AreEqual ("publicPropStringA", richChildren [6].Name);
+			Assert.AreEqual ("string", richChildren [6].TypeName);
+			CheckValue ("\"stringA\"", richChildren [6].Value);
+			Assert.AreEqual ("publicPropStringB", richChildren [7].Name);
+			Assert.AreEqual ("string", richChildren [7].TypeName);
+			CheckValue ("\"stringB\"", richChildren [7].Value);
+			Assert.AreEqual ("publicPropStringC", richChildren [8].Name);
+			Assert.AreEqual ("string", richChildren [8].TypeName);
+			CheckValue ("\"stringC\"", richChildren [8].Value);
+			Assert.AreEqual ("publicStringA", richChildren [9].Name);
+			Assert.AreEqual ("string", richChildren [9].TypeName);
+			Assert.AreEqual ("\"stringA\"", richChildren [9].Value);
+			Assert.AreEqual ("publicStringB", richChildren [10].Name);
+			Assert.AreEqual ("string", richChildren [10].TypeName);
+			Assert.AreEqual ("\"stringB\"", richChildren [10].Value);
+			Assert.AreEqual ("publicStringC", richChildren [11].Name);
+			Assert.AreEqual ("string", richChildren [11].TypeName);
+			Assert.AreEqual ("\"stringC\"", richChildren [11].Value);
+			Assert.AreEqual ("Non-public members", richChildren [12].Name);
+
+			richChildren = richChildren [12].GetAllChildren ();
+			Assert.AreEqual (12, richChildren.Length);
+			Assert.AreEqual ("privateInt1", richChildren [0].Name);
+			Assert.AreEqual ("int", richChildren [0].TypeName);
+			Assert.AreEqual ("1", richChildren [0].Value);
+			Assert.AreEqual ("privateInt2", richChildren [1].Name);
+			Assert.AreEqual ("int", richChildren [1].TypeName);
+			Assert.AreEqual ("2", richChildren [1].Value);
+			Assert.AreEqual ("privateInt3", richChildren [2].Name);
+			Assert.AreEqual ("int", richChildren [2].TypeName);
+			Assert.AreEqual ("3", richChildren [2].Value);
+			Assert.AreEqual ("privatePropInt1", richChildren [3].Name);
+			Assert.AreEqual ("int", richChildren [3].TypeName);
+			CheckValue ("1", richChildren [3].Value);
+			Assert.AreEqual ("privatePropInt2", richChildren [4].Name);
+			Assert.AreEqual ("int", richChildren [4].TypeName);
+			CheckValue ("2", richChildren [4].Value);
+			Assert.AreEqual ("privatePropInt3", richChildren [5].Name);
+			Assert.AreEqual ("int", richChildren [5].TypeName);
+			CheckValue ("3", richChildren [5].Value);
+			Assert.AreEqual ("privatePropStringA", richChildren [6].Name);
+			Assert.AreEqual ("string", richChildren [6].TypeName);
+			CheckValue ("\"stringA\"", richChildren [6].Value);
+			Assert.AreEqual ("privatePropStringB", richChildren [7].Name);
+			Assert.AreEqual ("string", richChildren [7].TypeName);
+			CheckValue ("\"stringB\"", richChildren [7].Value);
+			Assert.AreEqual ("privatePropStringC", richChildren [8].Name);
+			Assert.AreEqual ("string", richChildren [8].TypeName);
+			CheckValue ("\"stringC\"", richChildren [8].Value);
+			Assert.AreEqual ("privateStringA", richChildren [9].Name);
+			Assert.AreEqual ("string", richChildren [9].TypeName);
+			Assert.AreEqual ("\"stringA\"", richChildren [9].Value);
+			Assert.AreEqual ("privateStringB", richChildren [10].Name);
+			Assert.AreEqual ("string", richChildren [10].TypeName);
+			Assert.AreEqual ("\"stringB\"", richChildren [10].Value);
+			Assert.AreEqual ("privateStringC", richChildren [11].Name);
+			Assert.AreEqual ("string", richChildren [11].TypeName);
+			Assert.AreEqual ("\"stringC\"", richChildren [11].Value);
+
+			if (AllowTargetInvokes) {
+				val = Eval ("richObject.publicStringB=\"changedTextB\"");
+				Assert.AreEqual ("string", val.TypeName);
+				Assert.AreEqual ("\"changedTextB\"", val.Value);
+				val = Eval ("richObject.publicStringB");
+				Assert.AreEqual ("string", val.TypeName);
+				Assert.AreEqual ("\"changedTextB\"", val.Value);
+
+				val = Eval ("richObject");
+				Assert.AreEqual ("{RichClass}", val.Value);
+				Assert.AreEqual ("RichClass", val.TypeName);
+				richChildren = val.GetAllChildren ();
+				Assert.AreEqual ("publicPropStringB", richChildren [7].Name);
+				Assert.AreEqual ("string", richChildren [7].TypeName);
+				Assert.AreEqual ("\"stringB\"", richChildren [7].Value);
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
After adding some unit tests for GetAllChildren I noticed that private properties on Win32 are not working...
