### PR TITLE
[Ide] Ensure that the editor is initialised when changing views in the workspace window.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -132,7 +132,23 @@ namespace MonoDevelop.SourceEditor
 				base.Project = value;
 			}
 		}
-			
+
+		public override object GetContent (Type type)
+		{
+			var result = base.GetContent (type);
+			if (result != null)
+				return result;
+
+			var nextExtension = this.Extension;
+			while (nextExtension != null) {
+				if (type.IsAssignableFrom (nextExtension.GetType ()))
+					return nextExtension;
+				nextExtension = nextExtension.Next;
+			}
+
+			return null;
+		}
+
 		public override string TabPageLabel {
 			get { return GettextCatalog.GetString ("Source"); }
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -633,6 +633,9 @@ namespace MonoDevelop.Ide.Gui
 			subViewContent = viewContents[newIndex] as IAttachableViewContent;
 
 			DetachFromPathedDocument ();
+
+			if (Document != null)
+				Document.EnsureEditorIntialised ();
 			
 			MonoDevelop.Ide.Gui.Content.IPathedDocument pathedDocument;
 			if (newIndex < 0 || newIndex == viewContents.IndexOf (ViewContent)) {


### PR DESCRIPTION
If a view has an additional view that implements IExtensibleTextEditor, ensure that it is initialised. Some designer views are the primary view and the editor does
not get a chance to be initialised when the document is attached and can only be initialised when the "source" editor becomes the active view. This patch allows this bug to be fixed https://bugzilla.xamarin.com/show_bug.cgi?id=9875 (Layout files (axml) source code editing does not have intellisense)

It’s not practicable to initialise editor extensions during calls to InsertView in SdiWorkspace because of how extensions rely on Document.Editor and you can’t have an editor if the active view does not implement ITextEditorDataProvider. So the initialisation check was moved to when the window changed active views. By ensuring that any editor that is displayed in a view has been initialised we get the desired result of having an extension chain for each view that implements (or by GetContent returns an) IExtensibleTextEditor.

The removal of editorExtension had a couple of side effects that we need to avoid. The first is any use of ExtendedCommandTargetChain, EditorExtension and GetContent. We know that editorExtension was the extension chain of the “primary” view - “ViewContent”. This chain is initialised when the document is attached to the workspace window and, if ViewContent implements or proxies an IExtensibleTextEditor then editorExtension is the same chain as 

ViewContent.GetContent(typeof(IExtensibleTextEditor)).Extension

ExtendedCommandTargetChain, EditorExtension and GetContent are reimplemented by using the above code to get “editorExtension”. We should have no change in behaviour.

SourceEditorView implements IExtensibleTextEditor so I think it makes sense for it to check its own extensions in GetContent. We need the iteration for other views because when SdiWorkspaceWindow changes the content view, for secondary views it interrogates not Document.GetContent but ActiveViewContent.GetContent and that view will need to iterate over its extensions in order to find an IPathedDocument.
