### PR TITLE
add missing files to the tarball

### DIFF
--- a/main/configure.in
+++ b/main/configure.in
@@ -279,6 +279,7 @@ src/core/MonoDevelop.Core/Makefile
 src/core/MonoDevelop.Projects.Formats.MSBuild/Makefile
 src/core/MonoDevelop.Ide/Makefile
 src/core/MonoDevelop.Startup/Makefile
+src/core/MonoDevelop.TextEditor.Tests/Makefile
 src/tools/Makefile
 src/tools/mdhost/Makefile
 src/tools/mdtool/Makefile
@@ -340,6 +341,8 @@ src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/Mak
 tests/Makefile
 tests/UnitTests/Makefile
 tests/UserInterfaceTests/Makefile
+tests/TestRunner/Makefile
+tests/Ide.Tests/Makefile
 tests/MacPlatform.Tests/Makefile
 Makefile
 monodevelop

--- a/main/src/core/Makefile.am
+++ b/main/src/core/Makefile.am
@@ -2,5 +2,6 @@ SUBDIRS = \
 	MonoDevelop.Projects.Formats.MSBuild \
 	MonoDevelop.Core \
 	Mono.Texteditor \
-	MonoDevelop.Ide MonoDevelop.Startup 
+	MonoDevelop.Ide MonoDevelop.Startup \
+	MonoDevelop.TextEditor.Tests
 

--- a/main/src/core/MonoDevelop.Core/Makefile.am
+++ b/main/src/core/MonoDevelop.Core/Makefile.am
@@ -1,1 +1,4 @@
 include $(top_srcdir)/xbuild.include
+
+EXTRA_DIST += \
+	BuildVariables.cs.in

--- a/main/src/core/MonoDevelop.Ide/Makefile.am
+++ b/main/src/core/MonoDevelop.Ide/Makefile.am
@@ -1,1 +1,7 @@
 include $(top_srcdir)/xbuild.include
+
+EXTRA_DIST += \
+	gtkrc \
+	gtkrc.mac \
+	gtkrc.win32 \
+	gtkrc.win32-vista

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Makefile.am
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include

--- a/main/tests/Ide.Tests/Makefile.am
+++ b/main/tests/Ide.Tests/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/xbuild.include
 
-SUBDIRS=UnitTests MacPlatform.Tests UserInterfaceTests
+SUBDIRS=UnitTests MacPlatform.Tests UserInterfaceTests TestRunner Ide.Tests
 
 MONO=mono
 HARNESS=$(top_srcdir)/external/mdtestharness/nunit-console-x86.exe -domain=multiple

--- a/main/tests/TestRunner/Makefile.am
+++ b/main/tests/TestRunner/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include


### PR DESCRIPTION
These files are added:
from src/core/MonoDevelop.Ide:
gtkrc
gtkrc.win32
gtkrc.win32-vista
gtkrc.mac

the file src/core/MonoDevelop.Core/BuildVariables.cs.in

the projects:
tests\TestRunner\TestRunner.csproj
src\core\MonoDevelop.TextEditor.Tests\MonoDevelop.TextEditor.Tests.csproj
tests\Ide.Tests\Ide.Tests.csproj
