### PR TITLE
Fix refactoring issues with shared projects

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/Actions/MoveTypeToFile.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/Actions/MoveTypeToFile.cs
@@ -71,8 +71,8 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 				string correctFileName = GetCorrectFileName (ctx, type);
 				if (IsSingleType (ctx)) {
 					FileService.RenameFile (ctx.TextEditor.FileName, correctFileName);
-					if (ctx.Project != null)
-						ctx.Project.Save (new NullProgressMonitor ());
+					if (ctx.FileContainerProject != null)
+						ctx.FileContainerProject.Save (new NullProgressMonitor ());
 					return;
 				}
 				
@@ -94,16 +94,16 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 				content = content.Remove (start, end - start);
 			}
 			
-			if (context.Project != null) {
-				string header = StandardHeaderService.GetHeader (context.Project, correctFileName, true);
+			if (context.FileContainerProject != null) {
+				string header = StandardHeaderService.GetHeader (context.FileContainerProject, correctFileName, true);
 				if (!string.IsNullOrEmpty (header))
 					content = header + context.TextEditor.EolMarker + StripHeader (content);
 			}
 			content = StripDoubleBlankLines (content);
 			
 			File.WriteAllText (correctFileName, content);
-			context.Project.AddFile (correctFileName);
-			MonoDevelop.Ide.IdeApp.ProjectOperations.Save (context.Project);
+			context.FileContainerProject.AddFile (correctFileName);
+			MonoDevelop.Ide.IdeApp.ProjectOperations.Save (context.FileContainerProject);
 		}
 
 		static bool IsBlankLine (TextDocument doc, int i)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/MDRefactoringContext.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/MDRefactoringContext.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using ICSharpCode.NRefactory.CSharp;
 using MonoDevelop.Projects;
 using MonoDevelop.Core;
@@ -45,6 +46,8 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 {
 	public class MDRefactoringContext : RefactoringContext, IRefactoringContext
 	{
+		MonoDevelop.Projects.Project fileContainerProject;
+
 		public TextEditorData TextEditor {
 			get;
 			private set;
@@ -53,6 +56,33 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 		public DotNetProject Project {
 			get;
 			private set;
+		}
+
+		public MonoDevelop.Projects.Project FileContainerProject {
+			get {
+				if (fileContainerProject == null)
+					fileContainerProject = FindProjectContainingFile () ?? Project;
+				return fileContainerProject;
+			}
+		}
+
+		MonoDevelop.Projects.Project FindProjectContainingFile ()
+		{
+			var file = TextEditor.FileName;
+			if (string.IsNullOrEmpty (file) || Project == null)
+				return null;
+
+			var pf = Project.GetProjectFile (file);
+			if (pf != null && (pf.Flags & ProjectItemFlags.Hidden) != 0) {
+				// The file is hidden in this project, so it may also be part of another project.
+				// Try to find a project in which this file is not hidden
+				foreach (var p in Project.ParentSolution.GetAllProjects ()) {
+					pf = p.GetProjectFile (file);
+					if (pf != null && (pf.Flags & ProjectItemFlags.Hidden) == 0)
+						return p;
+				}
+			}
+			return null;
 		}
 
 		public bool IsInvalid {
@@ -217,7 +247,7 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 			this.Project = document.Project as DotNetProject;
 			this.formattingOptions = document.GetFormattingOptions ();
 			this.location = loc;
-			var policy = document.HasProject ? Project.Policies.Get<NameConventionPolicy> () : MonoDevelop.Projects.Policies.PolicyService.GetDefaultPolicy<NameConventionPolicy> ();
+			var policy = document.HasProject ? document.Project.Policies.Get<NameConventionPolicy> () : MonoDevelop.Projects.Policies.PolicyService.GetDefaultPolicy<NameConventionPolicy> ();
 			Services.AddService (typeof(NamingConventionService), policy.CreateNRefactoryService ());
 			Services.AddService (typeof(ICSharpCode.NRefactory.CSharp.CodeGenerationService), new CSharpCodeGenerationService());
 		}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/MDRefactoringScript.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring.CodeActions/MDRefactoringScript.cs
@@ -352,7 +352,7 @@ namespace MonoDevelop.CSharp.Refactoring.CodeActions
 				insertLocation = content.Length;
 			content = content.Substring (0, insertLocation) + newType.ToString (FormattingOptions) + content.Substring (insertLocation);
 
-			var project = context.Project;
+			var project = context.FileContainerProject;
 			if (project != null) {
 				var policy = project.Policies.Get<CSharpFormattingPolicy> ();
 				var textPolicy = project.Policies.Get<TextStylePolicy> ();


### PR DESCRIPTION
When creating a new file as a result of a refactoring operation in a shared
project make sure the file is added to the shared project, not the referencing
project.

Fixes bug 19531 - Moving class to its own file from Shared
Asset Project adds the file to the wrong project
