### PR TITLE
Allow opening projects with ToolsVersion v12.0

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildFileFormat.cs
@@ -347,7 +347,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 
 		protected override bool SupportsToolsVersion (string version)
 		{
-			return version == "4.0" || version == DefaultToolsVersion;
+			return version == "4.0" || version == "12.0";
 		}
 	}
 }


### PR DESCRIPTION
Fixes bug #20046 - Projects take from VS make XS crash
