### PR TITLE
[Debugger] Calling FetchFrames in ThreadsPad to fetch all frames in bulk

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ThreadsPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ThreadsPad.cs
@@ -183,6 +183,7 @@ namespace MonoDevelop.Debugger
 			Array.Sort (threads, delegate (ThreadInfo t1, ThreadInfo t2) {
 				return t1.Id.CompareTo (t2.Id);
 			});
+			DebuggingService.DebuggerSession.FetchFrames (threads);
 			foreach (ThreadInfo t in threads) {
 				ThreadInfo activeThread = DebuggingService.DebuggerSession.ActiveThread;
 				Pango.Weight wi = t == activeThread ? Pango.Weight.Bold : Pango.Weight.Normal;


### PR DESCRIPTION
https://github.com/mono/debugger-libs/pull/35 must be merged + debugger-libs submodule bumped before this pull request can be merged
