### PR TITLE
Bug 20294 - User should not able to write in any file, if About is open

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/CommonAboutDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/CommonAboutDialog.cs
@@ -112,24 +112,9 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 					ChangeColor (cw);
 			}
 		}
-		
-		static CommonAboutDialog instance;
-		
+
 		public static void ShowAboutDialog ()
 		{
-			if (Platform.IsMac) {
-				if (instance == null) {
-					instance = new CommonAboutDialog ();
-					MessageService.PlaceDialog (instance, IdeApp.Workbench.RootWindow);
-					instance.Response += delegate {
-						instance.Destroy ();
-						instance = null;
-					};
-				}
-				instance.Present ();
-				return;
-			}
-			
 			MessageService.ShowCustomDialog (new CommonAboutDialog ());
 		}
 	}


### PR DESCRIPTION
@mhutch Can you please review this... MacOS specific code was introduce here https://github.com/mono/monodevelop/commit/349676cc7a498859b7c66c52c64bb5857deb9195 to make it modal but then month later this was solved for all dialogs here https://github.com/mono/monodevelop/commit/6be5cc671860258a81f189b427e961f5f41b1ace or am I misunderstanding something?

Based on my testing only difference with applying this commit is that user can not interact with XS main window when About is open(hence can't write to files).

Link to bug: https://bugzilla.xamarin.com/show_bug.cgi?id=20294
