### PR TITLE
F# syntax highlighting had duplicate 'sig' keyword

### DIFF
--- a/main/src/core/Mono.Texteditor/SyntaxModes/FSharpSyntaxMode.xml
+++ b/main/src/core/Mono.Texteditor/SyntaxModes/FSharpSyntaxMode.xml
@@ -158,7 +158,6 @@
 		<Word>type</Word>
 
 		<Word>of</Word>
-		<Word>sig</Word>
 		<Word>class</Word>
 		<Word>delegate</Word>
 		<Word>exception</Word>


### PR DESCRIPTION
Removed the duplicate! This is an OCaml reserved word, see:
http://msdn.microsoft.com/en-us/library/dd233249.aspx
