### PR TITLE
[IDE] Bug fix 19422 - Unable to see Android logs according to "Filter by" option in "Android Log" window

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBox.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBox.cs
@@ -251,7 +251,7 @@ namespace MonoDevelop.Components
 					if (DataProvider != null) {
 						DataProvider.Reset ();
 						if (DataProvider.IconCount > 0) {
-							window = new DropDownBoxListWindow (DataProvider);
+							window = new DropDownBoxListWindow (DataProvider, WindowType.Popup);
 							window.list.SelectItem += delegate {
 								SetItem (window.list.Selection);
 							};

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
@@ -62,7 +62,11 @@ namespace MonoDevelop.Components
 			}
 		}
 
-		public DropDownBoxListWindow (IListDataProvider provider) : base (WindowType.Toplevel)
+		public DropDownBoxListWindow (IListDataProvider provider) : this (provider, WindowType.Toplevel)
+		{
+		}
+
+		public DropDownBoxListWindow (IListDataProvider provider, WindowType windowType) : base (windowType)
 		{
 			this.DataProvider = provider;
 			this.TransientFor = IdeApp.Workbench.RootWindow;


### PR DESCRIPTION
This patch didn't make it into master when it was done earlier.

Quick fix to handle a regression where the drop down window used by DropDownBox would not show. The drop down window being a TopLevel (which was done to support the path bread crumb) causes a focus issue with makes the DropDownBox close the window. There is a focus handler in DropDownBox that destroys the drop down window, and removing that is also an option, but using a Popup works better. A better approach needs to be investigated, similar to combo box with a gtk grab.
