### PR TITLE
[Ide] Do not show all files in solution folders.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
@@ -51,6 +51,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		public override bool CanBuildNode (Type dataType)
 		{
+			if (typeof(SolutionFolder).IsAssignableFrom (dataType))
+				return false;
+
 			return typeof(IFolderItem).IsAssignableFrom (dataType);
 		}
 		


### PR DESCRIPTION
Addresses bug 19704 - Exception displayed if show all files options is active and user tries to create new folder in newly added solution.

Showing all files in solution files can lead to confusing behaviour when a project is shown as being a child of a solution folder when, in fact, it is not. Solution folders should only show projects that have been explicitly added to that folder.
