### PR TITLE
add MonoDevelop.Debugger.Gdb so that it becomes part of the tarball

### DIFF
--- a/main/src/addins/Makefile.am
+++ b/main/src/addins/Makefile.am
@@ -5,6 +5,7 @@ SUBDIRS = \
 	GnomePlatform \
 	MonoDevelop.DesignerSupport \
 	MonoDevelop.Debugger \
+	MonoDevelop.Debugger.Gdb \
 	Deployment \
 	MonoDevelop.SourceEditor2 \
 	MonoDevelop.Refactoring \


### PR DESCRIPTION
this commit https://github.com/mono/monodevelop/commit/d60a13af675e68705083ec78861ea7ec0d9a9a7b#diff-11 moved the gdb debugger to the main solution, but the gdb debugger was not added to the tarball.

So when building from the tarball, you would get:

```
[00518] config.status: creating src/addins/MonoDevelop.XmlEditor/Makefile
[00518] config.status: creating src/addins/MonoDevelop.Refactoring/Makefile
[00518] config.status: creating src/addins/MonoDevelop.Debugger/Makefile
[00518] config.status: error: cannot find input file: `src/addins/MonoDevelop.Debugger.Gdb/Makefile.in'
[00518] error: Bad exit status from /var/tmp/rpm-tmp.5MPNEg (%build)
```

My commit adds the gdb debugger to the tarball.
I have tested it on my build server.
