### PR TITLE
[Ide] Fix for ResxGenerator parent directory issue

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/ResXFileCodeGenerator.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/ResXFileCodeGenerator.cs
@@ -5,6 +5,7 @@
 //   Kenneth Skovhede <kenneth@hexad.dk>
 //   Michael Hutchinson <m.j.hutchinson@gmail.com>
 //   Bernhard Johannessen <bernhard@voytsje.com>
+//   Matthew Diamond <matthewdiamond96@gmail.com>
 //
 // Copyright (C) 2013 Kenneth Skovhede
 // Copyright (C) 2013 Xamarin Inc.
@@ -78,7 +79,7 @@ namespace MonoDevelop.Ide.CustomTools
 
 				using (var r = new ResXResourceReader (file.FilePath)) {
 					r.UseResXDataNodes = true;
-					r.BasePath = Path.GetDirectoryName (file.FilePath.ParentDirectory);
+					r.BasePath = file.FilePath.ParentDirectory;
 
 					foreach (DictionaryEntry e in r) {
 						rd.Add (e.Key, e.Value);


### PR DESCRIPTION
There was a mistake in my last bug fix causing it to look in the parent directory of the intended directory for its files.
