### PR TITLE
Fix tar ball debugger gdb missing branch5.1

### DIFF
--- a/main/src/addins/Makefile.am
+++ b/main/src/addins/Makefile.am
@@ -5,6 +5,7 @@ SUBDIRS = \
 	GnomePlatform \
 	MonoDevelop.DesignerSupport \
 	MonoDevelop.Debugger \
+	MonoDevelop.Debugger.Gdb \
 	Deployment \
 	MonoDevelop.SourceEditor2 \
 	MonoDevelop.Refactoring \


### PR DESCRIPTION
the same fix that was applied to master in https://github.com/mono/monodevelop/pull/586
please also apply to branch 5.1, so the tarballs will be useful that are generated on that branch
