### PR TITLE
[Ide] Fixing disabled OSX ContextMenus in Modal dialogs(Bug 20683)

### DIFF
--- a/main/src/addins/MacPlatform/MacMenu/MDMenu.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenu.cs
@@ -38,7 +38,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 	{
 		static readonly string servicesID = (string) CommandManager.ToCommandId (MacIntegrationCommands.Services);
 
-		public MDMenu (CommandManager manager, CommandEntrySet ces)
+		public MDMenu (CommandManager manager, CommandEntrySet ces, CommandSource commandSource, object initialCommandTarget)
 		{
 			this.WeakDelegate = this;
 
@@ -59,7 +59,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 
 				var subset = ce as CommandEntrySet;
 				if (subset != null) {
-					AddItem (new MDSubMenuItem (manager, subset));
+					AddItem (new MDSubMenuItem (manager, subset, commandSource, initialCommandTarget));
 					continue;
 				}
 
@@ -86,7 +86,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 					continue;
 				}
 
-				AddItem (new MDMenuItem (manager, ce, acmd));
+				AddItem (new MDMenuItem (manager, ce, acmd, commandSource, initialCommandTarget));
 			}
 		}
 

--- a/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
@@ -45,11 +45,15 @@ namespace MonoDevelop.MacIntegration.MacMenu
 		CommandManager manager;
 
 		bool isArrayItem;
+		object initialCommandTarget;
+		CommandSource commandSource;
 
-		public MDMenuItem (CommandManager manager, CommandEntry ce, ActionCommand command)
+		public MDMenuItem (CommandManager manager, CommandEntry ce, ActionCommand command, CommandSource commandSource, object initialCommandTarget)
 		{
 			this.ce = ce;
 			this.manager = manager;
+			this.initialCommandTarget = initialCommandTarget;
+			this.commandSource = commandSource;
 
 			isArrayItem = command.CommandArray;
 
@@ -66,9 +70,9 @@ namespace MonoDevelop.MacIntegration.MacMenu
 			//if the command opens a modal subloop, give cocoa a chance to unhighlight the menu item
 			GLib.Timeout.Add (1, () => {
 				if (a != null) {
-					manager.DispatchCommand (ce.CommandId, a.Info.DataItem, CommandSource.MainMenu);
+					manager.DispatchCommand (ce.CommandId, a.Info.DataItem, initialCommandTarget, commandSource);
 				} else {
-					manager.DispatchCommand (ce.CommandId, CommandSource.MainMenu);
+					manager.DispatchCommand (ce.CommandId, null, initialCommandTarget, commandSource);
 				}
 				return false;
 			});
@@ -84,7 +88,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 
 		public void Update (MDMenu parent, ref NSMenuItem lastSeparator, ref int index)
 		{
-			var info = manager.GetCommandInfo (ce.CommandId);
+			var info = manager.GetCommandInfo (ce.CommandId, new CommandTargetRoute (initialCommandTarget));
 
 			if (!isArrayItem) {
 				SetItemValues (this, info);
@@ -148,10 +152,12 @@ namespace MonoDevelop.MacIntegration.MacMenu
 			public CommandInfo Info;
 		}
 
-		static void SetItemValues (NSMenuItem item, CommandInfo info)
+		void SetItemValues (NSMenuItem item, CommandInfo info)
 		{
 			item.SetTitleWithMnemonic (GetCleanCommandText (info));
-			item.Enabled = !IsGloballyDisabled && info.Enabled;
+			if (commandSource != CommandSource.ContextMenu) {
+				item.Enabled = !IsGloballyDisabled && info.Enabled;
+			}
 			item.Hidden = !info.Visible;
 			SetAccel (item, info.AccelKey);
 

--- a/main/src/addins/MacPlatform/MacMenu/MDSubMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDSubMenuItem.cs
@@ -34,11 +34,11 @@ namespace MonoDevelop.MacIntegration.MacMenu
 	{
 		CommandEntrySet ces;
 
-		public MDSubMenuItem (CommandManager manager, CommandEntrySet ces)
+		public MDSubMenuItem (CommandManager manager, CommandEntrySet ces, CommandSource commandSource = CommandSource.MainMenu, object initialCommandTarget = null)
 		{
 			this.ces = ces;
 
-			this.Submenu = new MDMenu (manager, ces);
+			this.Submenu = new MDMenu (manager, ces, commandSource, initialCommandTarget);
 			this.Title = this.Submenu.Title;
 		}
 

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -203,12 +203,12 @@ namespace MonoDevelop.MacIntegration
 			return map;
 		}
 
-		public override bool ShowContextMenu (CommandManager commandManager, Gtk.Widget widget, double x, double y, CommandEntrySet entrySet)
+		public override bool ShowContextMenu (CommandManager commandManager, Gtk.Widget widget, double x, double y, CommandEntrySet entrySet, object initialCommandTarget = null)
 		{
 			Gtk.Application.Invoke (delegate {
 				// Explicitly release the grab because the menu is shown on the mouse position, and the widget doesn't get the mouse release event
 				Gdk.Pointer.Ungrab (Gtk.Global.CurrentEventTime);
-				var menu = new MDMenu (commandManager, entrySet);
+				var menu = new MDMenu (commandManager, entrySet, CommandSource.ContextMenu, initialCommandTarget);
 				var nsview = MacInterop.GtkQuartz.GetView (widget);
 				var toplevel = widget.Toplevel as Gtk.Window;
 				int trans_x, trans_y;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -709,7 +709,7 @@ namespace MonoDevelop.Components.Commands
 		{
 			if (Platform.IsMac) {
 				parent.GrabFocus ();
-				return DesktopService.ShowContextMenu (this, parent, evt.X, evt.Y, entrySet);
+				return DesktopService.ShowContextMenu (this, parent, evt.X, evt.Y, entrySet, initialCommandTarget);
 			} else {
 				var menu = CreateMenu (entrySet);
 				if (menu != null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -329,7 +329,7 @@ namespace MonoDevelop.Ide.Desktop
 		}
 
 		public virtual bool ShowContextMenu (MonoDevelop.Components.Commands.CommandManager commandManager,
-			Gtk.Widget widget, double x, double y, MonoDevelop.Components.Commands.CommandEntrySet entrySet)
+			Gtk.Widget widget, double x, double y, MonoDevelop.Components.Commands.CommandEntrySet entrySet, object initialCommandTarget = null)
 		{
 			return false;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -200,9 +200,9 @@ namespace MonoDevelop.Ide
 		}
 
 		public static bool ShowContextMenu (MonoDevelop.Components.Commands.CommandManager commandManager,
-			Gtk.Widget widget, double x, double y, MonoDevelop.Components.Commands.CommandEntrySet entrySet)
+			Gtk.Widget widget, double x, double y, MonoDevelop.Components.Commands.CommandEntrySet entrySet, object initialCommandTarget = null)
 		{
-			return PlatformService.ShowContextMenu (commandManager, widget, x, y, entrySet);
+			return PlatformService.ShowContextMenu (commandManager, widget, x, y, entrySet, initialCommandTarget);
 		}
 
 		public static bool SetGlobalMenu (MonoDevelop.Components.Commands.CommandManager commandManager,


### PR DESCRIPTION
Only thing I'm not sure is if

``` csharp
if (commandSource != CommandSource.ContextMenu) {
   item.Enabled = !IsGloballyDisabled && info.Enabled;
}
```

should be

``` csharp
if (commandSource == CommandSource.MainMenu) {
   item.Enabled = !IsGloballyDisabled && info.Enabled;
}
```

or something more complex...
