### PR TITLE
[Debugger.Gdb] Use configured environment variables.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Gdb/GdbSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Gdb/GdbSession.cs
@@ -125,6 +125,11 @@ namespace MonoDevelop.Debugger.Gdb
 				// Set inferior arguments
 				if (!string.IsNullOrEmpty (startInfo.Arguments))
 					RunCommand ("-exec-arguments", startInfo.Arguments);
+
+				if (startInfo.EnvironmentVariables != null) {
+					foreach (var v in startInfo.EnvironmentVariables)
+						RunCommand ("-gdb-set", "environment", v.Key, v.Value);
+				}
 				
 				currentProcessName = startInfo.Command + " " + startInfo.Arguments;
 				


### PR DESCRIPTION
The gdb debugger so far ignored environment variables in the start information.
