### PR TITLE
[Debugger] Bug 11544: Cannot get rid of exception popup

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -557,7 +557,7 @@ namespace MonoDevelop.Debugger
 		}
 
 		public int Line {
-			get; private set;
+			get; set;
 		}
 
 		public bool IsMinimized {
@@ -650,9 +650,16 @@ namespace MonoDevelop.Debugger
 			closeSelOverImage = ImageService.GetIcon ("md-popup-close-hover", IconSize.Menu);
 		}
 
+		protected override void OnLineChanged ()
+		{
+			base.OnLineChanged ();
+			dlg.Line = Line;
+		}
+
 		protected override void OnLineDeleted ()
 		{
-			dlg.Dispose ();
+			base.OnLineDeleted ();
+			Line++;
 		}
 
 		public override Widget CreateWidget ()
@@ -737,9 +744,16 @@ namespace MonoDevelop.Debugger
 			Line = line;
 		}
 
+		protected override void OnLineChanged ()
+		{
+			base.OnLineChanged ();
+			dlg.Line = Line;
+		}
+
 		protected override void OnLineDeleted ()
 		{
-			dlg.Dispose ();
+			base.OnLineDeleted ();
+			Line++;
 		}
 
 		public override Widget CreateWidget ()


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=11544

This bug occured when line where execption occured was deleted
Also added logic when lines above exception are added/removed switcing between MiniDialog and Dialog appears on correct line
