### PR TITLE
[Ide] Fix window focusing issue when showing a message dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -35,6 +35,7 @@ using System.Collections.Generic;
 using MonoDevelop.Components.Extensions;
 using Mono.Addins;
 using System.Threading;
+using System.Linq;
 
 namespace MonoDevelop.Ide
 {
@@ -463,6 +464,7 @@ namespace MonoDevelop.Ide
 			public AlertButton GenericAlert (MessageDescription message)
 			{
 				var dialog = new AlertDialog (message);
+				dialog.TransientFor = Gtk.Window.ListToplevels ().FirstOrDefault (w => w.HasToplevelFocus) ?? MessageService.RootWindow;
 				OnPopupDialog (EventArgs.Empty);
 				return dialog.Run ();
 			}


### PR DESCRIPTION
When showing a message dialog, use the current top level window
as TransientFor window. Without this, message dialogs are always
parented to the main window, and that causes focusing problems
when working with other top level windows, such as floating
documents.

Fixes bug #21008 - On Canceling close action for floating window,
floating editor window should not disappear from top
