### PR TITLE
Bug 20602 - Typo in SVN log

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/CellRendererDiff.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/CellRendererDiff.cs
@@ -188,9 +188,9 @@ namespace MonoDevelop.VersionControl.Views
 						int l = ParseCurrentLine (line);
 						if (l != -1) cline = l - 1;
 						inHeader = false;
-					} else if (tag != '-' && !inHeader)
+					} else if (tag == '+' && !inHeader)
 						cline++;
-					
+
 					BlockType type;
 					switch (tag) {
 						case '-': type = BlockType.Removed; break;


### PR DESCRIPTION
That check was totally unneeded. It only stripped whitespace or first character, never a -/+ line. The conditional was also weird, so I removed it totally.
