### PR TITLE
[Debugger] Bug 21540 - User is unable to select exception type

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
@@ -258,6 +258,31 @@ namespace MonoDevelop.Debugger
 			entryPrintExpression.Changed += OnUpdateText;
 
 			buttonOk.Clicked += OnSave;
+
+			CompletionWindowManager.WindowShown += HandleCompletionWindowShown;
+			CompletionWindowManager.WindowClosed += HandleCompletionWindowClosed;
+		}
+
+		void HandleCompletionWindowClosed (object sender, EventArgs e)
+		{
+			var gtkWidget = Xwt.Toolkit.CurrentEngine.GetNativeWidget (vboxLocation) as Gtk.Widget;//Any widget is fine
+			if (gtkWidget != null) {
+				var topWindow = gtkWidget.Toplevel as Gtk.Window;
+				if (topWindow != null) {
+					topWindow.Modal = true;
+				}
+			}
+		}
+
+		void HandleCompletionWindowShown (object sender, EventArgs e)
+		{
+			var gtkWidget = Xwt.Toolkit.CurrentEngine.GetNativeWidget (vboxLocation) as Gtk.Widget;//Any widget is fine
+			if (gtkWidget != null) {
+				var topWindow = gtkWidget.Toplevel as Gtk.Window;
+				if (topWindow != null) {
+					topWindow.Modal = false;
+				}
+			}
 		}
 
 		void SetInitialFunctionBreakpointData (FunctionBreakpoint fb)
@@ -757,6 +782,12 @@ namespace MonoDevelop.Debugger
 			}
 
 			OnUpdateControls (null, null);
+		}
+		protected override void Dispose (bool disposing)
+		{
+			CompletionWindowManager.WindowShown -= HandleCompletionWindowShown;
+			CompletionWindowManager.WindowClosed -= HandleCompletionWindowClosed;
+			base.Dispose (disposing);
 		}
 	}
 }


### PR DESCRIPTION
[Bug 21540](https://bugzilla.xamarin.com/show_bug.cgi?id=21540) - User is unable to select exception type from auto completion using mouse in 'Breakpoint' window

When BreakpointPropertiesDialog is in Modal = true state it doesn't allow other windows to handle mouse events(hence CodeCompletion list is not responding to mouse events).
This change works perfectly around this problem because as soon as user clicks on MainWindow(of MD), codecompletion loses focus -> closes -> enables Modal again so user never notices that Modal was ever off...

@lluis is there any better way to access native implementation of Window? Like "Xwt.Toolkit.CurrentEngine.GetNativeWindow"? So I can set Modal...
