### PR TITLE
[Ide] Bug21849-Xaml CodeCompletionWindow closes after char added(SharedProject)

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -638,6 +638,7 @@ namespace MonoDevelop.Ide.Gui
 			ExtensionNodeList extensions = window.ExtensionContext.GetExtensionNodes ("/MonoDevelop/Ide/TextEditorExtensions", typeof(TextEditorExtensionNode));
 			editorExtension = null;
 			TextEditorExtension last = null;
+			TextEditorExtension first = null;
 			var mimetypeChain = DesktopService.GetMimeTypeInheritanceChainForFile (FileName).ToArray ();
 			foreach (TextEditorExtensionNode extNode in extensions) {
 				if (!extNode.Supports (FileName, mimetypeChain))
@@ -655,10 +656,20 @@ namespace MonoDevelop.Ide.Gui
 						last.Next = ext;
 						last = ext;
 					} else {
-						editorExtension = last = ext;
+						editorExtension = first = last = ext;
 						last.Next = editor.AttachExtension (editorExtension);
 					}
 					ext.Initialize (this);
+				}
+			}
+			if (first != editorExtension) {
+				while (first != null) {
+					try {
+						first.Dispose ();
+					} catch (Exception ex) {
+						LoggingService.LogError ("Exception while disposing extension:" + editorExtension, ex);
+					}
+					first = first.Next as TextEditorExtension;
 				}
 			}
 			if (window is SdiWorkspaceWindow)


### PR DESCRIPTION
CodeCompletionWindows closed after first char was typed because there were two undisposed instances of FormsEditorExtension. First instance displayed window and marked that it shouldn't autoHide but second instance didn't mark this(because it didn't show window) it hid window. Hence bug.

This happened because when .xaml file opens it calls InitializeExtensionChain. Problem occurred when ((FormsEditorExtension)ext).Initialize (this); was which calls SetProject(to set owner project of document instead of SharedProject) and SetProject calls InitializeExtensionChain again.
So in middle of InitializeExtensionChain loop of adding editorExtensions new InitializeExtensionChain came in and disposed 1st editorExtensions chain. But when 2nd loop finished rest of 1st loop continued(extensions after FormsEditorExtension).

So what this commit does it checks if documents editorExtension is different from this InitializeExtensionChain call. And if different it disposes all editorExtensions in this call.
