### PR TITLE
[Ide] Bug21992 - Open File dialog error when selecting text encoding

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/SelectEncodingPopUpButton.cs
+++ b/main/src/addins/MacPlatform/Dialogs/SelectEncodingPopUpButton.cs
@@ -101,9 +101,7 @@ namespace MonoDevelop.MacIntegration
 			if (clear)
 				Menu.RemoveAllItems ();
 				
-			encodings = SelectedEncodings.ConversionEncodings;
-			if (encodings == null || encodings.Length == 0)
-				encodings = SelectedEncodings.DefaultEncodings;
+			encodings = TextEncoding.ConversionEncodings.Select ((e) => e.CodePage).ToArray ();
 			
 			if (autoDetectedItem != null) {
 				Menu.AddItem (autoDetectedItem);

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/Dialogs/OpenFileDialogHandler.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/Dialogs/OpenFileDialogHandler.cs
@@ -47,8 +47,6 @@ namespace MonoDevelop.Platform
 {
 	public class OpenFileDialogHandler : IOpenFileDialogHandler
 	{
-		static int[] encodings;
-
 		public bool Run (OpenFileDialogData data)
 		{
 			var parent = data.TransientFor ?? MessageService.RootWindow;
@@ -175,39 +173,35 @@ namespace MonoDevelop.Platform
 			int i = 0;
 
 			if (showAutoDetected) {
-				combo.Items.Add (new EncodingComboItem (-1, GettextCatalog.GetString ("Auto Detected")));
+				combo.Items.Add (new EncodingComboItem (null, GettextCatalog.GetString ("Auto Detected")));
 				combo.SelectedIndex = 0;
 				i = 1;
 			}
 
-			encodings = SelectedEncodings.ConversionEncodings;
-			if (encodings == null || encodings.Length == 0)
-				encodings = SelectedEncodings.DefaultEncodings;
-
 			int j = 1;
 			foreach (var e in TextEncoding.ConversionEncodings) {
-				combo.Items.Add (new EncodingComboItem (j++, string.Format ("{0} ({1})", e.Name, e.Id)));
+				combo.Items.Add (new EncodingComboItem (Encoding.GetEncoding (e.CodePage), string.Format ("{0} ({1})", e.Name, e.Id)));
 				if (selectedEncoding != null && e.CodePage == selectedEncoding.WindowsCodePage)
 					combo.SelectedIndex = i;
 				i++;
 			}
 			if (combo.SelectedIndex == -1)
 				combo.SelectedIndex = 0;
-			combo.Items.Add (new EncodingComboItem (-1, GettextCatalog.GetString ("Add or Remove...")));
+			combo.Items.Add (new EncodingComboItem (null, GettextCatalog.GetString ("Add or Remove...")));
 		}
 
 		class EncodingComboItem : CommonFileDialogComboBoxItem
 		{
-			int tag;
+			Encoding encoding;
 
-			public EncodingComboItem (int tag, string label) : base (label)
+			public EncodingComboItem (Encoding encoding, string label) : base (label)
 			{
-				this.tag = tag;
+				this.encoding = encoding;
 			}
 
 			public Encoding Encoding {
 				get {
-					return tag <= 0 ? null : Encoding.GetEncoding (encodings [tag - 1]);
+					return encoding;
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Text/TextEncoding.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Text/TextEncoding.cs
@@ -121,11 +121,20 @@ namespace MonoDevelop.Projects.Text
 				PropertyService.SaveProperties ();
 			}
 		}
-		
+
 		public static TextEncoding GetEncoding (string id)
 		{
 			foreach (TextEncoding e in SupportedEncodings) {
 				if (e.Id == id)
+					return e;
+			}
+			return null;
+		}
+
+		public static TextEncoding GetEncoding (int codePage)
+		{
+			foreach (TextEncoding e in SupportedEncodings) {
+				if (e.CodePage == codePage)
 					return e;
 			}
 			return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/FileSelectorDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/FileSelectorDialog.cs
@@ -114,11 +114,11 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 					return -1;
 				else if (encodingMenu.History < firstEncIndex || encodingMenu.History == selectOption)
 					return -1;
-				return SelectedEncodings.ConversionEncodings [encodingMenu.History - firstEncIndex];
+				return TextEncoding.ConversionEncodings [encodingMenu.History - firstEncIndex].CodePage;
 			}
 			set {
-				for (uint n=0; n < SelectedEncodings.ConversionEncodings.Length; n++) {
-					if (SelectedEncodings.ConversionEncodings [n] == value) {
+				for (uint n=0; n < TextEncoding.ConversionEncodings.Length; n++) {
+					if (TextEncoding.ConversionEncodings [n].CodePage == value) {
 						encodingMenu.SetHistory (n + (uint)firstEncIndex);
 						Menu menu = (Menu)encodingMenu.Menu;
 						RadioMenuItem rm = (RadioMenuItem) menu.Children [n + firstEncIndex];
@@ -164,8 +164,8 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			} else
 				firstEncIndex = 0;
 			
-			foreach (var codePage in SelectedEncodings.ConversionEncodings) {
-				var enc = Encoding.GetEncoding (codePage);
+			foreach (var textEncoding in TextEncoding.ConversionEncodings) {
+				var enc = Encoding.GetEncoding (textEncoding.CodePage);
 				RadioMenuItem mitem = new RadioMenuItem (enc.EncodingName + " (" + enc.WebName + ")");
 				menu.Append (mitem);
 				if (defaultActivated == null) {
@@ -190,7 +190,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			
 			encodingMenu.SetHistory (0);
 					
-			selectOption = firstEncIndex + SelectedEncodings.ConversionEncodings.Length + 1;
+			selectOption = firstEncIndex + TextEncoding.ConversionEncodings.Length + 1;
 		}
 		
 		void EncodingChanged (object s, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/SelectEncodingsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/SelectEncodingsDialog.cs
@@ -32,40 +32,10 @@ using Gtk;
 using MonoDevelop.Core;
 using System.Text;
 using System.Collections.Generic;
+using MonoDevelop.Projects.Text;
 
 namespace MonoDevelop.Ide
 {
-	public static class SelectedEncodings
-	{
-		static int[] conversionEncodings = null;
-		public static int[] ConversionEncodings {
-			get {
-				if (conversionEncodings == null) {
-					string propertyEncodings = PropertyService.Get ("MonoDevelop.Ide.SelectEncodingsDialog.ConversionEncodings", string.Join (",", DefaultEncodings));
-					try {
-						conversionEncodings = propertyEncodings.Split (',').Select (e => int.Parse (e.Trim ())).ToArray ();
-					} catch (Exception) {
-						conversionEncodings = DefaultEncodings;
-					}
-				}
-
-				return conversionEncodings;
-			}
-			set {
-				conversionEncodings = value;
-				PropertyService.Set ("MonoDevelop.Ide.SelectEncodingsDialog.ConversionEncodings", string.Join (",", value));
-				Console.WriteLine ("set to:" + string.Join (",", value));
-			}
-		}
-		
-		const int ISO_8859_15 = 28605;
-		public readonly static int[] DefaultEncodings = new int[] { 
-			Encoding.UTF8.CodePage,
-			ISO_8859_15,
-			Encoding.Unicode.CodePage
-		};
-	}
-	
 	internal partial class SelectEncodingsDialog: Gtk.Dialog
 	{
 		ListStore storeAvail;
@@ -86,13 +56,12 @@ namespace MonoDevelop.Ide
 				listSelected.AppendColumn ("Encoding", new Gtk.CellRendererText (), "text", 1);
 				
 				foreach (var e in Encoding.GetEncodings ()) {
-					//					if (!((IList)TextEncoding.ConversionEncodings).Contains (e))
 					var enc = e.GetEncoding ();
 					storeAvail.AppendValues (enc.EncodingName, enc.WebName, e.CodePage);
 				}
 				
-				foreach (var e in SelectedEncodings.ConversionEncodings) {
-					var enc = Encoding.GetEncoding (e);
+				foreach (var e in TextEncoding.ConversionEncodings) {
+					var enc = Encoding.GetEncoding (e.CodePage);
 					storeSelected.AppendValues (enc.EncodingName, enc.WebName, enc.CodePage);
 				}
 			} catch (Exception  ex) {
@@ -115,7 +84,7 @@ namespace MonoDevelop.Ide
 					list.Add (enc);
 				} while (storeSelected.IterNext (ref iter));
 			}
-			SelectedEncodings.ConversionEncodings = list.ToArray ();
+			TextEncoding.ConversionEncodings = list.Select ((id) => TextEncoding.GetEncoding (id)).ToArray ();
 		}
 		
 		protected void OnAddClicked (object ob, EventArgs args)


### PR DESCRIPTION
Problem was that some code used "MonoDevelop.Ide.SelectEncodingsDialog.ConversionEncodings" and some "MonoDevelop.Projects.Text.ConversionEncodings" property... So I removed "MonoDevelop.Ide.SelectEncodingsDialog.ConversionEncodings".

Since SelectedEncodings.ConversionEncodings  was int[] and TextEncoding.ConversionEncodings is TextEncoding I had to do some conversions...
