### PR TITLE
[Mac] Displaying commands Description as Tooltips on MenuItems in MenuBar

### DIFF
--- a/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
@@ -155,6 +155,8 @@ namespace MonoDevelop.MacIntegration.MacMenu
 		void SetItemValues (NSMenuItem item, CommandInfo info, bool disabledVisible)
 		{
 			item.SetTitleWithMnemonic (GetCleanCommandText (info));
+			if (!string.IsNullOrEmpty (info.Description) && item.ToolTip != info.Description)
+				item.ToolTip = info.Description;
 
 			bool enabled = info.Enabled && (!IsGloballyDisabled || commandSource == CommandSource.ContextMenu);
 			bool visible = info.Visible && (disabledVisible || info.Enabled);


### PR DESCRIPTION
This is basically same as https://github.com/mono/monodevelop/pull/487 but for OSX...
![image](https://cloud.githubusercontent.com/assets/774791/4045235/fbdaccd6-2d27-11e4-83b6-f10641bb8c77.png)

![image](https://cloud.githubusercontent.com/assets/774791/4045248/2cff445e-2d28-11e4-870a-743b41e4a016.png)

...
