### PR TITLE
Removed unnecessary assembly redirect for Mono.Cairo

### DIFF
--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -6,11 +6,6 @@
 				<assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
 				<bindingRedirect oldVersion="0.84.0.0" newVersion="2.84.0.0"/>
 			</dependentAssembly>
-			<dependentAssembly>
-				<!-- This is required on Windows, since the GTK# installer only includes Mono.Cairo 2.0 -->
-				<assemblyIdentity name="Mono.Cairo" publicKeyToken="0738eb9f132ed756" culture="neutral" />
-				<bindingRedirect oldVersion="4.0.0.0" newVersion="2.0.0.0"/>
-			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 	


### PR DESCRIPTION
This was originally added because the GTK# installer didn't ship Mono.Cairo 4.0 on Windows.
This is no longer the case, so the assembly redirect can be removed.
