### PR TITLE
Fix test failure when gtk-sharp2 is not a GAC package

### DIFF
--- a/main/tests/UnitTests/MonoDevelop.Projects/LocalCopyTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/LocalCopyTests.cs
@@ -214,6 +214,10 @@ namespace MonoDevelop.Projects
 			var p = (DotNetProject)sol.Items [0];
 
 			var ar = p.References.First (r => r.Reference.Contains ("gtk"));
+			
+			if (!ar.Package.IsGacPackage)
+				Assert.Ignore ("This test only works with gtk-sharp as a GAC package.");
+
 			Assert.AreEqual (false, ar.LocalCopy);
 			ar.LocalCopy = true;
 			Assert.AreEqual (true, ar.LocalCopy);


### PR DESCRIPTION
When gtk-sharp-2.0 is loaded from pkg-config an additional "Package" tag is written to the csproj (see e.g. http://www.mergely.com/f1U30MI8/).
We need to either strip this out or ignore the test in that case, otherwise the XML won't match the expectation and the test would fail.

//cc @directhex 
