### PR TITLE
Ensure that a valid document line index is used.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/CodeDomFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/CodeDomFileDescriptionTemplate.cs
@@ -115,7 +115,7 @@ namespace MonoDevelop.Ide.Templates
 				}
 			}
 			
-			int offset = doc.GetLine (realStartLine).Offset;
+			int offset = doc.GetLine (Math.Max(Mono.TextEditor.DocumentLocation.MinLine, realStartLine)).Offset;
 			return doc.GetTextAt (offset, doc.TextLength - offset);
 		}
 


### PR DESCRIPTION
If no CodeDom header is present then a value of 0 will be used which is invalid.  This occurs in F# where the CodeDom generator can return clean code with no headers present.
