### PR TITLE
fix paths with %20 in them for uri scheme open

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -380,7 +380,7 @@ namespace MonoDevelop.MacIntegration
 								if (!Int32.TryParse (qs ["column"], out column))
 									column = 1;
 
-								return new FileOpenInformation (fileUri.AbsolutePath,
+								return new FileOpenInformation (Uri.UnescapeDataString(fileUri.AbsolutePath),
 									line, column, OpenDocumentOptions.DefaultInternal);
 							} catch (Exception ex) {
 								LoggingService.LogError ("Invalid TextMate URI: " + url, ex);


### PR DESCRIPTION
This would fail because %20 was not properly decoded to a space, `monodevelop://open?file=file:///path%20to%20file.txt`
