### PR TITLE
[Subversion] Fix spam of TooOld/Upgrading dialogs.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Unix/MonoDevelop.VersionControl.Subversion.Unix/SvnClient.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Unix/MonoDevelop.VersionControl.Subversion.Unix/SvnClient.cs
@@ -1478,8 +1478,8 @@ namespace MonoDevelop.VersionControl.Subversion.Unix
 				lockFileList.Add (file);
 		}
 
-		bool Upgrading;
-		bool TooOld;
+		static bool Upgrading;
+		static bool TooOld;
 		internal string GetDirectoryDotSvnInternal (FilePath path)
 		{
 			if (Upgrading || TooOld)


### PR DESCRIPTION
Due to SvnClient initializing a new Backend on every check, the value wasn't retained between Status queries.
This is only a temporary fix, the actual fix for this would be abstracting the backend into actual backend code and interop wrappers to simulate SvnSharp.
