### PR TITLE
[Refactoring] Enhance GotoDeclaration to support multiple open solutions...

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/GotoDeclarationHandler.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/GotoDeclarationHandler.cs
@@ -33,6 +33,12 @@ using MonoDevelop.Ide;
 using ICSharpCode.NRefactory.CSharp.Resolver;
 using ICSharpCode.NRefactory.TypeSystem;
 using ICSharpCode.NRefactory.Semantics;
+using System.Linq;
+using ICSharpCode.NRefactory.Analysis;
+using MonoDevelop.Projects;
+using System.Collections.Generic;
+using MonoDevelop.Ide.TypeSystem;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Refactoring
 {
@@ -48,12 +54,88 @@ namespace MonoDevelop.Refactoring
 			object item = CurrentRefactoryOperationsHandler.GetItem (doc, out resolveResoult);
 			var entity = item as INamedElement;
 			if (entity != null) {
-				IdeApp.ProjectOperations.JumpToDeclaration (entity);
+				Task.Factory.StartNew (() => {
+					entity = CheckIfDefinedInOtherOpenSolution (entity);
+					Xwt.Application.Invoke (() => IdeApp.ProjectOperations.JumpToDeclaration (entity));
+				});
 			} else {
 				var v = item as IVariable;
 				if (v != null)
 					IdeApp.ProjectOperations.JumpToDeclaration (v);
 			}
+		}
+
+		/// <summary>
+		/// Gets a set of all the assemblies that are built from the given solution
+		/// </summary>
+		static HashSet<IAssembly> GetAllAssemblies (Solution solution)
+		{
+			var assemblies = new HashSet<IAssembly> ();
+
+			foreach (var project in solution.GetAllProjects ()) {
+				var comp = TypeSystemService.GetCompilation (project);
+				if (comp == null)
+					continue;
+				assemblies.Add (comp.MainAssembly);
+			}
+
+			return assemblies;
+		}
+
+		/// <summary>
+		/// Checks if the INamedElement is actually defined in another open solution and returns a INamedElement from that solution instead.
+		/// Provides support for going to the source code definition of an element instead of the Assembly Browser.
+		/// Returns the original entity if no suitable open solution was found
+		/// </summary>
+		static INamedElement CheckIfDefinedInOtherOpenSolution (INamedElement entity)
+		{
+			var ex = entity as IEntity;
+
+			if (ex != null && ex.Region.IsEmpty) {
+				// the entity was not found as a file in the current solution (no region)
+				// let's see if we can find in another open solution
+
+				if (IdeApp.Workspace != null) {
+					Solution[] solutions;
+
+					// do we have workspace? check the workspace for solution items
+					var workspace = IdeApp.Workspace.Items.OfType<Workspace> ().FirstOrDefault ();
+					if (workspace != null) 
+						solutions = workspace.Items.OfType<Solution> ().ToArray ();
+					else 
+						solutions = IdeApp.Workspace.Items.OfType<Solution> ().ToArray ();
+
+					foreach (var solution in solutions) {
+						// skip the current solution
+						if (IdeApp.ProjectOperations.CurrentSelectedSolution == solution)
+							continue;
+
+						var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
+						using (monitor) {
+							monitor.BeginTask (GettextCatalog.GetString ("Building type graph in solution ..."), 1); 
+
+							var assemblies = GetAllAssemblies (solution);
+							var tg = new TypeGraph (assemblies);
+							var node = tg.GetNode (ex.DeclaringTypeDefinition); 
+							if (node != null) {
+								// look for the member that we're after
+								var foundMember = node.TypeDefinition.Members.FirstOrDefault (x => x.FullName == entity.FullName);
+
+								if (foundMember != null)
+									return foundMember;
+
+								// fall back to just the type, at least we're part way there
+								return node.TypeDefinition;
+							}
+
+							monitor.EndTask ();
+						}
+
+					}
+				}
+			}
+
+			return entity;
 		}
 	}
 }


### PR DESCRIPTION
....

If you have more than one open solution, using GotoDeclaration for a type in the other, non-active solution, results in that type being displayed in the Assembly Browser. This change changes that behaviour to search for the type in any of the other open solutions and open the source file for the type instead.
