### PR TITLE
[Windows] Use App Name as ID only

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.Platform
 		{
 			// Only initialize elements for Win7+.
 			if (TaskbarManager.IsPlatformSupported) {
-				TaskbarManager.Instance.ApplicationId = BrandingService.ProfileDirectoryName + "." + IdeApp.Version;
+				TaskbarManager.Instance.ApplicationId = BrandingService.ProfileDirectoryName;
 			}
 		}
 


### PR DESCRIPTION
No other installed executable notes its version in the registry for open commands. So don't do it for us either.
