### PR TITLE
[TextEditor] Folding screen background rendered wrong.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/FoldingScreenbackgroundRenderer.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/FoldingScreenbackgroundRenderer.cs
@@ -139,7 +139,7 @@ namespace Mono.TextEditor
 				}
 
 				y = editor.LineToY (segment.StartLine.LineNumber);
-				var yEnd = editor.LineToY (segment.EndLine.LineNumber + 1);
+				var yEnd = editor.LineToY (segment.EndLine.LineNumber + 1) + (segment.EndLine.LineNumber == editor.LineCount ? editor.LineHeight : 0);
 				if (yEnd == 0)
 					yEnd = editor.VAdjustment.Upper;
 				rectangleHeight = yEnd - y;

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/FoldingScreenbackgroundRenderer.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/FoldingScreenbackgroundRenderer.cs
@@ -148,6 +148,7 @@ namespace Mono.TextEditor
 			}
 
 			for (int i = 0; i < foldSegments.Count; i++) {
+				Cairo.Rectangle clampedRect;
 				var rect = rectangles[i];
 
 				if (i == foldSegments.Count - 1) {
@@ -187,13 +188,15 @@ namespace Mono.TextEditor
 
 					var bg = editor.ColorStyle.PlainText.Foreground;
 					cr.SetSourceRGBA (bg.R, bg.G, bg.B, alpha);
-					DrawRoundRectangle (cr, true, true, rect.X - editor.HAdjustment.Value - curPadSize , rect.Y - editor.VAdjustment.Value - curPadSize, editor.LineHeight / 2, rect.Width + curPadSize * 2, rect.Height + curPadSize * 2);
+					clampedRect = ClampRect (rect.X - editor.HAdjustment.Value - curPadSize , rect.Y - editor.VAdjustment.Value - curPadSize, editor.LineHeight / 2, rect.Width + curPadSize * 2, rect.Height + curPadSize * 2, area);
+					DrawRoundRectangle (cr, true, true, clampedRect.X, clampedRect.Y, editor.LineHeight / 2, clampedRect.Width, clampedRect.Height);
 					cr.Fill ();
 
 					if (age < animationLength) {
 						var animationState = age / (double)animationLength;
 						curPadSize = (int)(2 + System.Math.Sin (System.Math.PI * animationState) * 2);
-						DrawRoundRectangle (cr, true, true, rect.X - editor.HAdjustment.Value - curPadSize, rect.Y - editor.VAdjustment.Value - curPadSize, editor.LineHeight / 2, rect.Width + curPadSize * 2, rect.Height + curPadSize * 2);
+						clampedRect = ClampRect (rect.X - editor.HAdjustment.Value - curPadSize, rect.Y - editor.VAdjustment.Value - curPadSize, editor.LineHeight / 2, rect.Width + curPadSize * 2, rect.Height + curPadSize * 2, area);
+						DrawRoundRectangle (cr, true, true, clampedRect.X, clampedRect.Y, editor.LineHeight / 2, clampedRect.Width, clampedRect.Height);
 						cr.SetSourceColor (GetColor (i, brightness, colorCount));
 						cr.Fill ();
 
@@ -201,7 +204,8 @@ namespace Mono.TextEditor
 					}
 				}
 
-				DrawRoundRectangle (cr, true, true, rect.X - editor.HAdjustment.Value, rect.Y - editor.VAdjustment.Value, editor.LineHeight / 2, rect.Width, rect.Height);
+				clampedRect = ClampRect (rect.X - editor.HAdjustment.Value, rect.Y - editor.VAdjustment.Value, editor.LineHeight / 2, rect.Width, rect.Height, area);
+				DrawRoundRectangle (cr, true, true,  clampedRect.X, clampedRect.Y, editor.LineHeight / 2, clampedRect.Width, clampedRect.Height);
 				
 				cr.SetSourceColor (GetColor (i, brightness, colorCount));
 				cr.Fill ();
@@ -268,7 +272,19 @@ namespace Mono.TextEditor
 			}
 			cr.ClosePath ();
 		}
-		
+
+		public static Cairo.Rectangle ClampRect (double x, double y, double r, double w, double h, Cairo.Rectangle area){
+			var x1 = x;
+			var y1 = y;
+			var x2 = x + w;
+			var y2 = y + h;
+			x1 = System.Math.Max (x1, area.X - r);
+			y1 = System.Math.Max (y1, area.Y - r);
+			x2 = System.Math.Min (x2, area.Width + r);
+			y2 = System.Math.Min (y2, area.Height + r);
+			return new Cairo.Rectangle (x1, y1, x2-x1, y2-y1);
+		}
+
 		int GetFirstNonWsIdx (string text)
 		{
 			for (int i = 0; i < text.Length; i++) {

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
@@ -1741,8 +1741,10 @@ namespace Mono.TextEditor
 			double curY = startY - this.textEditorData.VAdjustment.Value;
 			bool setLongestLine = false;
 			foreach (var margin in this.margins) {
-				if (margin.BackgroundRenderer != null)
-					margin.BackgroundRenderer.Draw (cr, cairoRectangle);
+				if (margin.BackgroundRenderer != null) {
+					var area = new Cairo.Rectangle(0, 0, Allocation.Width, Allocation.Height);
+					margin.BackgroundRenderer.Draw (cr, area);
+				}
 			}
 
 


### PR DESCRIPTION
Folding screen background ends on previous line, when last line of FoldSegment ends with < eof >.
![screen shot 2014-12-05 at 2 30 05 am](https://cloud.githubusercontent.com/assets/1479065/5309822/81cc004a-7c32-11e4-919e-b10ef4bdc13c.png)

Should be:
![screen shot 2014-12-05 at 2 30 42 am](https://cloud.githubusercontent.com/assets/1479065/5309823/84d4e914-7c32-11e4-8d5f-3f36d854d047.png)

Folding screen background rendered wrong on big collapse segments.
Its easy to hit Cairo coordinate limits (+/- 8,388,608 https://developer.gnome.org/goocanvas/stable/goocanvas-coordinates.html) for top level folding segments, in relatively big source files. That's causing rendering artifacts. Issue resolved by clamping source folding rectangle with visible screen area.

![untitled](https://cloud.githubusercontent.com/assets/1479065/5325375/4abfcdf0-7cf2-11e4-8dff-7cf143ed9964.png)

![screen shot 2014-12-06 at 1 52 02 am](https://cloud.githubusercontent.com/assets/1479065/5325377/58495c84-7cf2-11e4-9843-4cca6445c729.png)

Should be:
![screen shot 2014-12-06 at 2 19 12 am](https://cloud.githubusercontent.com/assets/1479065/5325383/631cd528-7cf2-11e4-824d-836ff437417d.png)

