### PR TITLE
[Shell] Propose telling addins to use the other overload.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -832,6 +832,7 @@ namespace MonoDevelop.Components.Commands
 		/// <param name='initialCommandTarget'>
 		/// Initial command route target. The command handler will start looking for command handlers in this object.
 		/// </param>
+		[Obsolete ("This will be removed in future revisions. Please use the overload with ShowContextMenu(Gtk.Widget, Gdk.EventButton, CommandEntrySet, object)")]
 		public void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, Gtk.Menu menu,
 			object initialCommandTarget = null)
 		{


### PR DESCRIPTION
This creates a Gtk.Menu on Mac, which means we don't make use of the awesome native Menu we have implemented in the other overload.
Propose hiding this API (not fully removing it).

/cc @slluis @mhutch @alanmcgovern @bratsche @DavidKarlas 