### PR TITLE
[Core] PointToLocation starts/ends at start/end of char instead middle of char

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -2912,9 +2912,6 @@ namespace Mono.TextEditor
 					layoutWrapper.Layout.IndexToLineX (index, false, out lineNr, out xp1);
 					layoutWrapper.Layout.IndexToLineX (index + 1, false, out lineNr, out xp2);
 					index = TranslateIndexToUTF8 (layoutWrapper.Layout.Text, index);
-
-					if (!IsNearX1 (xp, xp1, xp2))
-						index++;
 					return true;
 				}
 				index = line.Length;
@@ -3017,11 +3014,6 @@ namespace Mono.TextEditor
 		public DocumentLocation PointToLocation (Cairo.PointD p, bool endAtEol = false)
 		{
 			return new VisualLocationTranslator (this).PointToLocation (p.X, p.Y, endAtEol);
-		}
-		
-		static bool IsNearX1 (int pos, int x1, int x2)
-		{
-			return System.Math.Abs (x1 - pos) < System.Math.Abs (x2 - pos);
 		}
 		
 		public Cairo.Point LocationToPoint (int line, int column)


### PR DESCRIPTION
This logic was added here: https://github.com/mono/monodevelop/commit/f7f17fe73066d3b181d7a0f2a87653b3e75d69fd#diff-2d27ddec65e6cd76bcb8bd8083311dd0R1830
I have no idea why it's good to start/end text Location in middle of character...(I'm maybe making regression, hence PR)

@mkrueger Any idea?

So what this change does it calculates position like this:
![image](https://cloud.githubusercontent.com/assets/774791/5418766/5e2cdf9c-8245-11e4-913c-fea20cefd6be.png)
![image](https://cloud.githubusercontent.com/assets/774791/5418762/4c2e66a8-8245-11e4-97b1-a1a8a692ff84.png)

How I noticed this... If you try to hover mouse to see debug value of variable 'l' and you are just one pixel to right of middle(so still above 'l', but one pixel to right of middle) debug tooltip won't show up because IsNearX1 will be false and make index++ resulting into space(between 'l' and '=') instead of 'l', hence not displaying debug tooltip...

Red rectangle indicates hit area for debug tooltip(before/after).