### PR TITLE
added missing $(TargetPath) macro

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
@@ -233,6 +233,7 @@ namespace MonoDevelop.Projects
 			yield return new StringTagDescription ("ProjectConfigName", GettextCatalog.GetString ("Project Configuration Name"));
 			yield return new StringTagDescription ("ProjectConfigPlat", GettextCatalog.GetString ("Project Configuration Platform"));
 			yield return new StringTagDescription ("TargetFile", GettextCatalog.GetString ("Target File"));
+			yield return new StringTagDescription ("TargetPath", GettextCatalog.GetString ("Target Path"));
 			yield return new StringTagDescription ("TargetName", GettextCatalog.GetString ("Target Name"));
 			yield return new StringTagDescription ("TargetDir", GettextCatalog.GetString ("Target Directory"));
 			yield return new StringTagDescription ("TargetExt", GettextCatalog.GetString ("Target Extension"));


### PR DESCRIPTION
For macros that supported by Visual Studio, see ref http://msdn.microsoft.com/en-us/library/42x5kfw4.aspx

The code handles "TARGETPATH" in the DotNetProjectConfiguration.cs file (see switch below), but the description for this tag was missed.