### PR TITLE
[T4] all templates processing for Solution/Project

### DIFF
--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/GenerateCommandHandler.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/GenerateCommandHandler.cs
@@ -1,0 +1,77 @@
+﻿//
+// GenerateCommand.cs
+//
+// Author:
+//       Sergey Zhukov <>
+//
+// Copyright (c) 2015 Sergey Zhukov
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using MonoDevelop.Components.Commands;
+using MonoDevelop.Projects;
+using MonoDevelop.Ide;
+using MonoDevelop.Ide.CustomTools;
+
+namespace MonoDevelop.TextTemplating
+{
+	public enum Commands
+	{
+		Generate
+	}
+
+	public class GenerateCommandHandler : CommandHandler
+	{
+		protected override void Run ()
+		{
+			IWorkspaceObject wob = IdeApp.ProjectOperations.CurrentSelectedItem as IWorkspaceObject;
+
+			Solution solution = wob as Solution;
+			if (solution != null) {
+				foreach(Project p in solution.GetAllProjects ())
+					UpdateFilesInProject(p);
+			} else {
+				Project proj = wob as Project;
+
+				if (proj != null) {
+					UpdateFilesInProject (proj);
+				}
+			}
+
+			base.Run ();
+
+		}
+
+		private void UpdateFilesInProject(Project project)
+		{
+			foreach (ProjectFile file in project.Files) {
+				if (file.Generator == typeof(TextTemplatingFileGenerator).Name
+					|| file.Generator == typeof(TextTemplatingFilePreprocessor).Name) {
+					CustomToolService.Update (file, true);
+				}
+			}
+		}
+
+		protected override void Update (CommandInfo info)
+		{
+			base.Update (info);
+		}
+	}
+}
+

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.addin.xml
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.addin.xml
@@ -48,12 +48,10 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/ContextMenu/ProjectPad/Tools">
-		<Condition id="ItemType" value="Solution|Project">
-			<CommandItem id = "MonoDevelop.TextTemplating.Commands.Generate" 
-						 _label = "Process Templates"
-						 defaultHandler = "MonoDevelop.TextTemplating.GenerateCommandHandler"
-			/>
-		</Condition>
+		<CommandItem id = "MonoDevelop.TextTemplating.Commands.Generate" 
+					 _label = "Process Templates"
+					 defaultHandler = "MonoDevelop.TextTemplating.GenerateCommandHandler"
+		/>
 	</Extension>
 
 

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.addin.xml
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.addin.xml
@@ -40,4 +40,21 @@
 		<Tool name="TextTemplatingFilePreprocessor" type="MonoDevelop.TextTemplating.TextTemplatingFilePreprocessor"/>
 	</Extension>
 
+	<Extension path = "/MonoDevelop/Ide/Commands">
+		<Command id = "MonoDevelop.TextTemplating.Commands.Generate"
+			_label = "Process Templates..."
+			defaultHandler = "MonoDevelop.TextTemplating.GenerateCommandHandler"
+			description = "Process all T4 templates."/>
+	</Extension>
+
+	<Extension path = "/MonoDevelop/Ide/ContextMenu/ProjectPad/Tools">
+		<Condition id="ItemType" value="Solution|Project">
+			<CommandItem id = "MonoDevelop.TextTemplating.Commands.Generate" 
+						 _label = "Process Templates"
+						 defaultHandler = "MonoDevelop.TextTemplating.GenerateCommandHandler"
+			/>
+		</Condition>
+	</Extension>
+
+
 </ExtensionModel>

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.csproj
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.csproj
@@ -53,6 +53,7 @@
     <Compile Include="MonoDevelopTemplatingHost.cs" />
     <Compile Include="ProjectFileTemplatingHost.cs" />
     <Compile Include="AddinInfo.cs" />
+    <Compile Include="GenerateCommandHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomTool.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomTool.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.Ide.CustomTools
 		
 		public bool SuccessWithWarnings {
 			get {
-				return UnhandledException == null && !Errors.HasErrors;
+				return UnhandledException == null && !Errors.HasErrors && Errors.HasWarnings;
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
@@ -107,26 +107,35 @@ namespace MonoDevelop.Ide.CustomTools
 		{
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetToolOutputProgressMonitor (false);
 
-			var fileEnumerator = files.GetEnumerator ();
+			IEnumerator<ProjectFile> fileEnumerator;
 
-			if (fileEnumerator.MoveNext())
-				Update (monitor, fileEnumerator, force, false, false);
+			//begin root task
+			monitor.BeginTask (GettextCatalog.GetString ("Generate templates"), 1);
+
+			if (files == null || !(fileEnumerator = files.GetEnumerator ()).MoveNext ()) {
+				monitor.EndTask ();
+				monitor.ReportSuccess (GettextCatalog.GetString ("There is no files to generate"));
+				monitor.Dispose ();
+			} else {
+				Update (monitor, fileEnumerator, force, 0, 0, 0);
+			}
+
 		}
 
-		private static void Update(IProgressMonitor monitor, IEnumerator<ProjectFile> fileEnumerator, bool force, bool hasErrors, bool hasWarnings)
+		static void Update (IProgressMonitor monitor, IEnumerator<ProjectFile> fileEnumerator, bool force, int successed, int warnings, int errors)
 		{
 			ProjectFile file = fileEnumerator.Current;
 			ProjectFile genFile = null;
 			ISingleFileCustomTool tool = null;
 
 			//Find the first file in the collection, which has got generator tool
-			while (((tool = GetGenerator (file.Generator)) == null 
-				|| (genFile = GetGeneratedFile (file, force)) == null)
-				&& fileEnumerator.MoveNext());
+			while (((tool = GetGenerator (file.Generator)) == null
+			       || (genFile = GetGeneratedFile (file, force)) == null)
+			       && fileEnumerator.MoveNext ());
 
 			//no files which can be generated in remaining elements of the collection, nothing to do
 			if (tool == null || genFile == null) {
-				WriteSummaryResults (monitor, hasErrors, hasWarnings);
+				WriteSummaryResults (monitor, successed, warnings, errors);
 				return;
 			}
 
@@ -138,13 +147,22 @@ namespace MonoDevelop.Ide.CustomTools
 			try {
 				IAsyncOperation op = tool.Generate (monitor, file, result);
 				op.Completed += delegate {
-					if (result.Success)
-						monitor.Log.WriteLine(GettextCatalog.GetString("File {0} has generated successfully.", result.GeneratedFilePath));
+					if (result.Success) {
+						monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' has generated successfully.", result.GeneratedFilePath));
+						successed++;
+					} else if (result.SuccessWithWarnings) {
+						monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' has generated with warnings.", result.GeneratedFilePath));
+						warnings++;
+					} else {
+						monitor.Log.WriteLine (GettextCatalog.GetString ("Errors in file '{0}' generation.", result.GeneratedFilePath));
+						errors++;
+					}
 
-					if (UpdateCompleted (monitor, null, file, genFile, result, true) && fileEnumerator.MoveNext()) 
-						Update(monitor, fileEnumerator, force, hasErrors || !result.Success, hasWarnings || result.SuccessWithWarnings );
-					else 
-						WriteSummaryResults (monitor, hasErrors, hasWarnings);
+					//check that we can process further. If UpdateCompleted returns `true` this means no errors or non-fatal errors occured
+					if (UpdateCompleted (monitor, null, file, genFile, result, true) && fileEnumerator.MoveNext ())
+						Update (monitor, fileEnumerator, force, successed, warnings, errors);
+					else
+						WriteSummaryResults (monitor, successed, warnings, errors);
 				};
 			} catch (Exception ex) {
 				result.UnhandledException = ex;
@@ -152,27 +170,33 @@ namespace MonoDevelop.Ide.CustomTools
 			}
 		}
 
-		static void WriteSummaryResults(IProgressMonitor monitor, bool hasErrors, bool hasWarnings)
+		static void WriteSummaryResults (IProgressMonitor monitor, int succeded, int warnings, int errors)
 		{
-			if (hasErrors)
-				monitor.ReportError (GettextCatalog.GetString("Errors in files generation."), null);
-			else if (hasWarnings)
-				monitor.ReportSuccess (GettextCatalog.GetString("Warnings in files generation."));
+			monitor.Log.WriteLine ();
+			monitor.Log.WriteLine (GettextCatalog.GetString ("{0} files processed total. {1} generated sucessfully, {2} with warnings, {3} with errors"),
+				succeded + warnings + errors, succeded, warnings, errors);
+			//ends the root task
+			monitor.EndTask ();
+
+			if (errors > 0)
+				monitor.ReportError (GettextCatalog.GetString ("Errors in files generation."), null);
+			else if (warnings > 0)
+				monitor.ReportSuccess (GettextCatalog.GetString ("Warnings in files generation."));
 			else
-				monitor.ReportSuccess (GettextCatalog.GetString("Generated files successfully."));
+				monitor.ReportSuccess (GettextCatalog.GetString ("Generated files successfully."));
 
 			monitor.Dispose ();
 		}
 
-		static ProjectFile GetGeneratedFile(ProjectFile file, bool force)
+		static ProjectFile GetGeneratedFile (ProjectFile file, bool force)
 		{
 			ProjectFile genFile = null;
 
 			if (!string.IsNullOrEmpty (file.LastGenOutput))
 				genFile = file.Project.Files.GetFile (file.FilePath.ParentDirectory.Combine (file.LastGenOutput));
 
-			if (!force && genFile != null && File.Exists (genFile.FilePath) && 
-				File.GetLastWriteTime (file.FilePath) < File.GetLastWriteTime (genFile.FilePath)) {
+			if (!force && genFile != null && File.Exists (genFile.FilePath) &&
+			    File.GetLastWriteTime (file.FilePath) < File.GetLastWriteTime (genFile.FilePath)) {
 				return null;
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
@@ -114,7 +114,7 @@ namespace MonoDevelop.Ide.CustomTools
 
 			if (files == null || !(fileEnumerator = files.GetEnumerator ()).MoveNext ()) {
 				monitor.EndTask ();
-				monitor.ReportSuccess (GettextCatalog.GetString ("There is no files to generate"));
+				monitor.ReportSuccess (GettextCatalog.GetString ("No templates found"));
 				monitor.Dispose ();
 			} else {
 				Update (monitor, fileEnumerator, force, 0, 0, 0);
@@ -122,7 +122,7 @@ namespace MonoDevelop.Ide.CustomTools
 
 		}
 
-		static void Update (IProgressMonitor monitor, IEnumerator<ProjectFile> fileEnumerator, bool force, int successed, int warnings, int errors)
+		static void Update (IProgressMonitor monitor, IEnumerator<ProjectFile> fileEnumerator, bool force, int succeeded, int warnings, int errors)
 		{
 			ProjectFile file = fileEnumerator.Current;
 			ProjectFile genFile = null;
@@ -135,7 +135,7 @@ namespace MonoDevelop.Ide.CustomTools
 
 			//no files which can be generated in remaining elements of the collection, nothing to do
 			if (tool == null || genFile == null) {
-				WriteSummaryResults (monitor, successed, warnings, errors);
+				WriteSummaryResults (monitor, succeeded, warnings, errors);
 				return;
 			}
 
@@ -148,10 +148,10 @@ namespace MonoDevelop.Ide.CustomTools
 				IAsyncOperation op = tool.Generate (monitor, file, result);
 				op.Completed += delegate {
 					if (result.Success) {
-						monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' has generated successfully.", result.GeneratedFilePath));
-						successed++;
+						monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' was generated successfully.", result.GeneratedFilePath));
+						succeeded++;
 					} else if (result.SuccessWithWarnings) {
-						monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' has generated with warnings.", result.GeneratedFilePath));
+						monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' was generated with warnings.", result.GeneratedFilePath));
 						warnings++;
 					} else {
 						monitor.Log.WriteLine (GettextCatalog.GetString ("Errors in file '{0}' generation.", result.GeneratedFilePath));
@@ -160,9 +160,9 @@ namespace MonoDevelop.Ide.CustomTools
 
 					//check that we can process further. If UpdateCompleted returns `true` this means no errors or non-fatal errors occured
 					if (UpdateCompleted (monitor, null, file, genFile, result, true) && fileEnumerator.MoveNext ())
-						Update (monitor, fileEnumerator, force, successed, warnings, errors);
+						Update (monitor, fileEnumerator, force, succeeded, warnings, errors);
 					else
-						WriteSummaryResults (monitor, successed, warnings, errors);
+						WriteSummaryResults (monitor, succeeded, warnings, errors);
 				};
 			} catch (Exception ex) {
 				result.UnhandledException = ex;
@@ -170,18 +170,18 @@ namespace MonoDevelop.Ide.CustomTools
 			}
 		}
 
-		static void WriteSummaryResults (IProgressMonitor monitor, int succeded, int warnings, int errors)
+		static void WriteSummaryResults (IProgressMonitor monitor, int succeeded, int warnings, int errors)
 		{
 			monitor.Log.WriteLine ();
-			monitor.Log.WriteLine (GettextCatalog.GetString ("{0} files processed total. {1} generated sucessfully, {2} with warnings, {3} with errors"),
-				succeded + warnings + errors, succeded, warnings, errors);
+			monitor.Log.WriteLine (GettextCatalog.GetString ("{0} files processed total. {1} generated successfully, {2} with warnings, {3} with errors"),
+				succeeded + warnings + errors, succeeded, warnings, errors);
 			//ends the root task
 			monitor.EndTask ();
 
 			if (errors > 0)
-				monitor.ReportError (GettextCatalog.GetString ("Errors in files generation."), null);
+				monitor.ReportError (GettextCatalog.GetString ("Errors in file generation."), null);
 			else if (warnings > 0)
-				monitor.ReportSuccess (GettextCatalog.GetString ("Warnings in files generation."));
+				monitor.ReportSuccess (GettextCatalog.GetString ("Warnings in file generation."));
 			else
 				monitor.ReportSuccess (GettextCatalog.GetString ("Generated files successfully."));
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
@@ -102,6 +102,82 @@ namespace MonoDevelop.Ide.CustomTools
 			}
 			return null;
 		}
+
+		public static void Update (IEnumerable<ProjectFile> files, bool force)
+		{
+			var monitor = IdeApp.Workbench.ProgressMonitors.GetToolOutputProgressMonitor (false);
+
+			var fileEnumerator = files.GetEnumerator ();
+
+			if (fileEnumerator.MoveNext())
+				Update (monitor, fileEnumerator, force, false, false);
+		}
+
+		private static void Update(IProgressMonitor monitor, IEnumerator<ProjectFile> fileEnumerator, bool force, bool hasErrors, bool hasWarnings)
+		{
+			ProjectFile file = fileEnumerator.Current;
+			ProjectFile genFile = null;
+			ISingleFileCustomTool tool = null;
+
+			//Find the first file in the collection, which has got generator tool
+			while (((tool = GetGenerator (file.Generator)) == null 
+				|| (genFile = GetGeneratedFile (file, force)) == null)
+				&& fileEnumerator.MoveNext());
+
+			//no files which can be generated in remaining elements of the collection, nothing to do
+			if (tool == null || genFile == null) {
+				WriteSummaryResults (monitor, hasErrors, hasWarnings);
+				return;
+			}
+
+			TaskService.Errors.ClearByOwner (file);
+
+			var result = new SingleFileCustomToolResult ();
+			monitor.BeginTask (GettextCatalog.GetString ("Running generator '{0}' on file '{1}'...", file.Generator, file.Name), 1);
+
+			try {
+				IAsyncOperation op = tool.Generate (monitor, file, result);
+				op.Completed += delegate {
+					if (result.Success)
+						monitor.Log.WriteLine(GettextCatalog.GetString("File {0} has generated successfully.", result.GeneratedFilePath));
+
+					if (UpdateCompleted (monitor, null, file, genFile, result, true) && fileEnumerator.MoveNext()) 
+						Update(monitor, fileEnumerator, force, hasErrors || !result.Success, hasWarnings || result.SuccessWithWarnings );
+					else 
+						WriteSummaryResults (monitor, hasErrors, hasWarnings);
+				};
+			} catch (Exception ex) {
+				result.UnhandledException = ex;
+				UpdateCompleted (monitor, null, file, genFile, result, true);
+			}
+		}
+
+		static void WriteSummaryResults(IProgressMonitor monitor, bool hasErrors, bool hasWarnings)
+		{
+			if (hasErrors)
+				monitor.ReportError (GettextCatalog.GetString("Errors in files generation."), null);
+			else if (hasWarnings)
+				monitor.ReportSuccess (GettextCatalog.GetString("Warnings in files generation."));
+			else
+				monitor.ReportSuccess (GettextCatalog.GetString("Generated files successfully."));
+
+			monitor.Dispose ();
+		}
+
+		static ProjectFile GetGeneratedFile(ProjectFile file, bool force)
+		{
+			ProjectFile genFile = null;
+
+			if (!string.IsNullOrEmpty (file.LastGenOutput))
+				genFile = file.Project.Files.GetFile (file.FilePath.ParentDirectory.Combine (file.LastGenOutput));
+
+			if (!force && genFile != null && File.Exists (genFile.FilePath) && 
+				File.GetLastWriteTime (file.FilePath) < File.GetLastWriteTime (genFile.FilePath)) {
+				return null;
+			}
+
+			return genFile;
+		}
 		
 		public static void Update (ProjectFile file, bool force)
 		{
@@ -109,15 +185,8 @@ namespace MonoDevelop.Ide.CustomTools
 			if (tool == null)
 				return;
 			
-			ProjectFile genFile = null;
-			if (!string.IsNullOrEmpty (file.LastGenOutput))
-				genFile = file.Project.Files.GetFile (file.FilePath.ParentDirectory.Combine (file.LastGenOutput));
-			
-			if (!force && genFile != null && File.Exists (genFile.FilePath) && 
-			    File.GetLastWriteTime (file.FilePath) < File.GetLastWriteTime (genFile.FilePath)) {
-				return;
-			}
-			
+			ProjectFile genFile = GetGeneratedFile(file, force);
+
 			TaskService.Errors.ClearByOwner (file);
 			
 			//if this file is already being run, cancel it
@@ -142,7 +211,7 @@ namespace MonoDevelop.Ide.CustomTools
 						IAsyncOperation runningTask;
 						if (runningTasks.TryGetValue (file.FilePath, out runningTask) && runningTask == op) {
 							runningTasks.Remove (file.FilePath);
-							UpdateCompleted (monitor, aggOp, file, genFile, result);
+							UpdateCompleted (monitor, aggOp, file, genFile, result, false);
 						} else {
 							//it was cancelled because another was run for the same file, so just clean up
 							aggOp.Dispose ();
@@ -154,20 +223,22 @@ namespace MonoDevelop.Ide.CustomTools
 				};
 			} catch (Exception ex) {
 				result.UnhandledException = ex;
-				UpdateCompleted (monitor, aggOp, file, genFile, result);
+				UpdateCompleted (monitor, aggOp, file, genFile, result, false);
 			}
 		}
 		
-		static void UpdateCompleted (IProgressMonitor monitor, AggregatedOperationMonitor aggOp,
-		                             ProjectFile file, ProjectFile genFile, SingleFileCustomToolResult result)
+		static bool UpdateCompleted (IProgressMonitor monitor, AggregatedOperationMonitor aggOp,
+		                             ProjectFile file, ProjectFile genFile, SingleFileCustomToolResult result,
+		                             bool runMultipleFiles)
 		{
 			monitor.EndTask ();
-			aggOp.Dispose ();
+			if (aggOp != null)
+				aggOp.Dispose ();
 			
 			if (monitor.IsCancelRequested) {
 				monitor.ReportError (GettextCatalog.GetString ("Cancelled"), null);
 				monitor.Dispose ();
-				return;
+				return false;
 			}
 			
 			string genFileName;
@@ -209,21 +280,23 @@ namespace MonoDevelop.Ide.CustomTools
 				}
 				
 				if (broken)
-					return;
+					return true;
 
-				if (result.Success)
-					monitor.ReportSuccess ("Generated file successfully.");
-				else if (result.SuccessWithWarnings)
-					monitor.ReportSuccess ("Warnings in file generation.");
-				else
-					monitor.ReportError ("Errors in file generation.", null);
-				
+				if (!runMultipleFiles) {
+					if (result.Success)
+						monitor.ReportSuccess ("Generated file successfully.");
+					else if (result.SuccessWithWarnings)
+						monitor.ReportSuccess ("Warnings in file generation.");
+					else
+						monitor.ReportError ("Errors in file generation.", null);
+				}
 			} finally {
-				monitor.Dispose ();
+				if (!runMultipleFiles) 
+					monitor.Dispose ();
 			}
 
 			if (result.GeneratedFilePath.IsNullOrEmpty || !File.Exists (result.GeneratedFilePath))
-				return;
+				return true;
 
 			// broadcast a change event so text editors etc reload the file
 			FileService.NotifyFileChanged (result.GeneratedFilePath);
@@ -252,6 +325,8 @@ namespace MonoDevelop.Ide.CustomTools
 				if (projectChanged)
 					IdeApp.ProjectOperations.Save (file.Project);
 			});
+
+			return true;
 		}
 		
 		static void HandleRename (ProjectFileRenamedEventArgs e)


### PR DESCRIPTION
This is new feature, which allows to update all T4 templates in Solution or selected Project.
To use it, select in Solution View Solution or Project node, right click to open context menu, select Tools/Process Teplates. 

It's very usefull when you have base template and alot of derived templates from it. 
Before this feature is implemented you have to change every derived T4 template and resave it to regenerate the content after changing base template.
With this feature you can do it in one click.

Knowing issue: after regeneration "Tool output" window is created for every templat was processed. 
It would be much better if all information about tool generation process be created in one "Tool output" window, but I don't know now how to do it inside monodevelop. If someone point me how it can be done, I'll do it.