### PR TITLE
[ErrorReporting] Add ApplicationException as whitelist.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -212,7 +212,7 @@ namespace MonoDevelop.Ide
 				LoggingService.LogError (msg, ex);
 			}
 
-			if (string.IsNullOrEmpty (secondaryText) && (ex is System.IO.IOException)) {
+			if (string.IsNullOrEmpty (secondaryText) && ((ex is System.IO.IOException) || (ex is ApplicationException))) {
 				secondaryText = ex.Message;
 			}
 


### PR DESCRIPTION
ApplicationExceptions should be non-fatal errors and informative to the user.

Should we also add a check in the LoggingService where we filter this exception as non-fatal and always show it as an Error Dialog?