### PR TITLE
Langugae defaults to C# + unit test

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -69,6 +69,17 @@ namespace Mono.TextTemplating.Tests
 			string WinOutput = OutputSample1.Replace ("\\n", "\\r\\n").Replace ("\n", "\r\n");
 			Generate (WinInput, WinOutput, "\r\n");
 		}
+
+		[Test]
+		public void DefaultLanguage ()
+		{
+			DummyHost host = new DummyHost ();
+			string template = @"<#= DateTime.Now #>";
+			ParsedTemplate pt = ParsedTemplate.FromText (template, host);
+			Assert.AreEqual (0, host.Errors.Count);
+			TemplateSettings settings = TemplatingEngine.GetSettings (host, pt);
+			Assert.AreEqual (settings.Language, "C#");
+		}
 		
 		//NOTE: we set the newline property on the code generator so that the whole files has matching newlines,
 		// in order to match the newlines in the verbatim code blocks

--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -312,8 +312,7 @@ namespace Mono.TextTemplating
 			
 			//resolve the CodeDOM provider
 			if (String.IsNullOrEmpty (settings.Language)) {
-				pt.LogError ("No language was specified for the template");
-				return settings;
+				settings.Language = "C#";
 			}
 			
 			if (settings.Language == "C#v3.5") {


### PR DESCRIPTION
As discussed with @mhutch in another thread, this change makes 'C#' the default language setting.

I've also had a stab at a unit test for this change, however I can't get the unit tests to compile, apparently because I'm missing some of the stuff in main/external.  If I figure out how to get this set up, I'll check the unit tests and report back here.