### PR TITLE
Bug 25586 - Unable to access Git log for Storyboard files

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/BlameCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/BlameCommand.cs
@@ -49,7 +49,12 @@ namespace MonoDevelop.VersionControl
 				return items.All (CanShow);
 			
 			foreach (var item in items) {
-				var document = IdeApp.Workbench.OpenDocument (item.Path, OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer);
+				var document = IdeApp.Workbench.OpenDocument (new FileOpenInformation (item.Path, null) {
+					Line = -1,
+					Column = -1,
+					Options = OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer,
+					DisplayBinding = DisplayBindingService.GetBindings<SourceEditor.SourceEditorDisplayBinding>().Single(),
+				});
 				if (document != null)
 					document.Window.SwitchView (document.Window.FindView<IBlameView> ());
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DiffCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DiffCommand.cs
@@ -49,7 +49,13 @@ namespace MonoDevelop.VersionControl
 				return items.All (CanShow);
 			
 			foreach (var item in items) {
-				var document = IdeApp.Workbench.OpenDocument (item.Path, OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer);
+				var document = IdeApp.Workbench.OpenDocument (new FileOpenInformation (item.Path, null) {
+					Line = -1,
+					Column = -1,
+					Options = OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer,
+					DisplayBinding = DisplayBindingService.GetBindings<SourceEditor.SourceEditorDisplayBinding>().Single(),
+				});
+
 				if (document != null)
 					document.Window.SwitchView (document.Window.FindView<IDiffView> ());
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/LogCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/LogCommand.cs
@@ -52,7 +52,12 @@ namespace MonoDevelop.VersionControl
 			foreach (var item in items) {
 				Document document = null;
 				if (!item.IsDirectory)
-					document = IdeApp.Workbench.OpenDocument (item.Path, OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer);
+					document = IdeApp.Workbench.OpenDocument (new FileOpenInformation (item.Path, null) {
+						Line = -1,
+						Column = -1,
+						Options = OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer,
+						DisplayBinding = DisplayBindingService.GetBindings<SourceEditor.SourceEditorDisplayBinding>().Single(),
+					});
 
 				if (document != null) {
 					document.Window.SwitchView (document.Window.FindView<ILogView> ());

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/MergeCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/MergeCommand.cs
@@ -49,7 +49,12 @@ namespace MonoDevelop.VersionControl
 				return items.All (CanShow);
 			
 			foreach (var item in items) {
-				var document = IdeApp.Workbench.OpenDocument (item.Path, OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer);
+				var document = IdeApp.Workbench.OpenDocument (new FileOpenInformation (item.Path, null) {
+					Line = -1,
+					Column = -1,
+					Options = OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer,
+					DisplayBinding = DisplayBindingService.GetBindings<SourceEditor.SourceEditorDisplayBinding>().Single(),
+				});
 				if (document != null)
 					document.Window.SwitchView (document.Window.FindView<IMergeView> ());
 			}


### PR DESCRIPTION
We need to use a display binding that we know is a File for this to work.

The downside on this commit? We're attaching a source view _and_ we're not attaching the designer view for things like the iOS/Android designer, instead a Source view. (That means the user will have to close the document then reopen it.)

This should be handled differently:
1. We need a VCS display binding in case the Document we're attaching to is a File Document which won't include anything else other than the VCS tabs?
2. We need to make the designers only become non-file documents when more files are open.
