### PR TITLE
updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**MonoDevelop** is a full-featured integrated development environment (IDE) for mono
+**MonoDevelop**(now **Xamarin Studio**) is a full-featured integrated development environment (IDE) for mono
 using Gtk#.
 
 See http://www.monodevelop.com for more info.  


### PR DESCRIPTION
In this commit, its just been mentioned that monodevelop is now xamarin studio(for windows and mac OS).. Whenever you download monodevelop,its shows an option to download xamarin studio. So, this commit is just to remove this confusion..