### PR TITLE
[AddIns] Disable Gtk addin by default.

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/AddinInfo.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/AddinInfo.cs
@@ -6,6 +6,7 @@ using Mono.Addins.Description;
 [assembly:Addin ("GtkCore", 
 	Namespace = "MonoDevelop",
 	Version = MonoDevelop.BuildInfo.Version,
+	EnabledByDefault = false,
 	Category = "IDE extensions")]
 
 [assembly:AddinName ("GTK# Visual Designer")]


### PR DESCRIPTION
It's a common source of memory leaks and it will take quite some time to patch up. Disable it by default for now, let's not make others suffer because of an AddIn they'll never use.