### PR TITLE
[build] Make Mavericks the minimum supported version of MacOSX

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -185,7 +185,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6</string>
+	<string>10.9</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.monodevelop</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
The vast majority of our users are using Mavericks or higher so
we are going to make Mavericks the minimum requirement for future
releases.

This should be clearly communicated before we merge and ship this.