### PR TITLE
[Ide] Change minimum size of the window.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -64,8 +64,8 @@ namespace MonoDevelop.Ide.Gui
 		static string configFile = UserProfile.Current.ConfigDir.Combine ("EditingLayout.xml");
 		const string fullViewModeTag = "[FullViewMode]";
 		const int MAX_LASTACTIVEWINDOWS = 10;
-		const int MinimumWidth = 1000;
-		const int MinimumHeight = 600;
+		const int MinimumWidth = 800;
+		const int MinimumHeight = 540;
 		
 		// list of layout names for the current context, without the context prefix
 		List<string> layouts = new List<string> ();


### PR DESCRIPTION
1000 is just some arbitrary value, and it's too big to allow Windows
users to snap MonoDevelop windows left/right. So I'm choosing new
arbitrary sizes here. The new minimum width is 800, which means we'll
be able to snap left/right for resolutions as small as 1600px wide.
If we go much smaller than this, the toolbar is totally non-functional.
The new height is 540px, which is chosen because it's half of
1920x1080.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=22146