### PR TITLE
Fix find derived symbols

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.addin.xml
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.addin.xml
@@ -90,7 +90,7 @@
 					_label = "_Find References of All Overloads" />
 		<Command id = "MonoDevelop.Refactoring.RefactoryCommands.FindDerivedClasses"
 					defaultHandler = "MonoDevelop.Refactoring.FindDerivedClassesHandler"
-					_label = "Find _Derived Classes" />
+					_label = "Find _Derived Symbols" />
 		</Category>
 		
 		<Category _name = "Refactoring" id = "Refactoring">

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/FindDerivedClassesHandler.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/FindDerivedClassesHandler.cs
@@ -1,21 +1,21 @@
-// 
+//
 // FindDerivedClassesHandler.cs
-//  
+//
 // Author:
 //       Mike Krüger <mkrueger@novell.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,6 +39,7 @@ using MonoDevelop.Ide.FindInFiles;
 using Mono.TextEditor;
 using ICSharpCode.NRefactory.Semantics;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace MonoDevelop.Refactoring
 {
@@ -46,64 +47,68 @@ namespace MonoDevelop.Refactoring
 	{
 		public static void FindDerivedClasses (ITypeDefinition cls)
 		{
+			FindDerivedSymbols (cls, null);
+		}
+
+		public static void FindDerivedMembers (IMember member)
+		{
+			var cls = member.DeclaringTypeDefinition;
+			if (cls == null)
+				return;
+			FindDerivedSymbols (cls, member);
+		}
+
+		static void FindDerivedSymbols (ITypeDefinition cls, IMember member)
+		{
 			var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
 			if (solution == null)
 				return;
-			
+
 			var sourceProject = TypeSystemService.GetProject (cls);
 			if (sourceProject == null)
 				return;
-			
+
 			var projects = ReferenceFinder.GetAllReferencingProjects (solution, sourceProject);
 			ThreadPool.QueueUserWorkItem (delegate {
 				using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)) {
 					var cache = new Dictionary<string, TextEditorData> ();
-					monitor.BeginTask (GettextCatalog.GetString ("Searching for derived classes in solution..."), projects.Count);
+					var label = member == null
+						? GettextCatalog.GetString ("Searching for derived classes in solution...")
+						: GettextCatalog.GetString ("Searching for derived members in solution...");
+					monitor.BeginTask (label, projects.Count);
 
 					Parallel.ForEach (projects, p => {
 						var comp = TypeSystemService.GetCompilation (p);
 						if (comp == null)
 							return;
+
 						var importedType = comp.Import (cls);
 						if (importedType == null) {
 							return;
 						}
-						foreach (var type in comp.MainAssembly.GetAllTypeDefinitions ()) {
-							if (!type.IsDerivedFrom (importedType)) 
+
+						IMember impMember = null;
+						if (member != null) {
+							impMember = comp.Import (member);
+							if (impMember == null) {
+								return;
+							}
+						}
+
+						foreach (var derivedType in comp.MainAssembly.GetAllTypeDefinitions ()) {
+							if (!derivedType.IsDerivedFrom (importedType))
 								continue;
-							TextEditorData textFile;
-							if (!cache.TryGetValue (type.Region.FileName, out textFile)) {
-								cache [type.Region.FileName] = textFile = TextFileProvider.Instance.GetTextEditorData (type.Region.FileName);
+
+							IEntity result;
+							if (member != null) {
+								result = FindDerivedMember (impMember, derivedType);
+								if (result == null)
+									continue;
+							} else {
+								result = derivedType;
 							}
-							int position = textFile.LocationToOffset (type.Region.Begin);
-							string keyword;
-							switch (type.Kind) {
-							case TypeKind.Interface:
-								keyword = "interface";
-								break;
-							case TypeKind.Struct:
-								keyword = "struct";
-								break;
-							case TypeKind.Delegate:
-								keyword = "delegate";
-								break;
-							case TypeKind.Enum:
-								keyword = "enum";
-								break;
-							default:
-								keyword = "class";
-								break;
-							}
-							while (position < textFile.Length - keyword.Length) {
-								if (textFile.GetTextAt (position, keyword.Length) == keyword) {
-									position += keyword.Length;
-									while (position < textFile.Length && textFile.GetCharAt (position) == ' ' || textFile.GetCharAt (position) == '\t')
-										position++;
-									break;
-								}
-								position++;
-							}
-							monitor.ReportResult (new MonoDevelop.Ide.FindInFiles.SearchResult (new FileProvider (type.Region.FileName, p), position, 0));
+
+							ReportResult (monitor, result, cache);
 						}
 						monitor.Step (1);
 					});
@@ -115,7 +120,40 @@ namespace MonoDevelop.Refactoring
 				}
 			});
 		}
-		
+
+		static IMember FindDerivedMember (IMember importedMember, ITypeDefinition derivedType)
+		{
+			IMember derivedMember;
+			if (importedMember.DeclaringTypeDefinition.Kind == TypeKind.Interface) {
+				derivedMember = derivedType.GetMembers (null, GetMemberOptions.IgnoreInheritedMembers)
+					.FirstOrDefault (m => m.ImplementedInterfaceMembers.Any (im => im.Region == importedMember.Region));
+			}
+			else {
+				derivedMember = InheritanceHelper.GetDerivedMember (importedMember, derivedType);
+			}
+			return derivedMember;
+		}
+
+		static void ReportResult (ISearchProgressMonitor monitor, IEntity result, Dictionary<string, TextEditorData> cache)
+		{
+			string filename = result.Region.FileName;
+			if (string.IsNullOrEmpty (filename))
+				return;
+
+			TextEditorData textFile;
+			if (!cache.TryGetValue (filename, out textFile)) {
+				cache [filename] = textFile = TextFileProvider.Instance.GetTextEditorData (filename);
+			}
+
+			var start = textFile.LocationToOffset (result.Region.Begin);
+			textFile.SearchRequest.SearchPattern = result.Name;
+			var sr = textFile.SearchForward (start);
+			if (sr != null)
+				start = sr.Offset;
+
+			monitor.ReportResult (new MemberReference (result, result.Region, start, result.Name.Length));
+		}
+
 		protected override void Run (object data)
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
@@ -132,8 +170,8 @@ namespace MonoDevelop.Refactoring
 			}
 
 			var member = item as IMember;
-			if (member != null && (member.IsVirtual || member.IsAbstract || member.DeclaringType.Kind == TypeKind.Interface)) {
-				var handler = new FindDerivedSymbolsHandler (doc, member);
+			var handler = new FindDerivedSymbolsHandler (member);
+			if (handler.IsValid) {
 				handler.Run ();
 				return;
 			}

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoryCommands.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoryCommands.cs
@@ -353,7 +353,8 @@ namespace MonoDevelop.Refactoring
 				if (member.IsVirtual || member.IsAbstract || member.DeclaringType.Kind == TypeKind.Interface) {
 					var handler = new FindDerivedSymbolsHandler (doc, member);
 					if (handler.IsValid) {
-						ainfo.Add (GettextCatalog.GetString ("Find Derived Symbols"), new System.Action (handler.Run));
+						var a = ainfo.Add (GettextCatalog.GetString ("Find Derived Symbols"), new Action (handler.Run));
+						a.AccelKey = IdeApp.CommandService.GetCommandInfo (RefactoryCommands.FindDerivedClasses).AccelKey;
 						added = true;
 					}
 				}
@@ -378,7 +379,9 @@ namespace MonoDevelop.Refactoring
 					}
 				}
 				if ((cls.Kind == TypeKind.Class && !cls.IsSealed) || cls.Kind == TypeKind.Interface) {
-					ainfo.Add (cls.Kind != TypeKind.Interface ? GettextCatalog.GetString ("Find _derived classes") : GettextCatalog.GetString ("Find _implementor classes"), new System.Action (new FindDerivedClasses (cls).Run));
+					var label = cls.Kind != TypeKind.Interface ? GettextCatalog.GetString ("Find _derived classes") : GettextCatalog.GetString ("Find _implementor classes");
+					var a = ainfo.Add (label, new System.Action (new FindDerivedClasses (cls).Run));
+					a.AccelKey = IdeApp.CommandService.GetCommandInfo (RefactoryCommands.FindDerivedClasses).AccelKey;
 				}
 				ainfo.Add (GettextCatalog.GetString ("Find Extension Methods"), new System.Action (new FindExtensionMethodHandler (doc, cls).Run));
 				added = true;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoryCommands.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoryCommands.cs
@@ -350,13 +350,11 @@ namespace MonoDevelop.Refactoring
 
 			if (item is IMember) {
 				var member = (IMember)item;
-				if (member.IsVirtual || member.IsAbstract || member.DeclaringType.Kind == TypeKind.Interface) {
-					var handler = new FindDerivedSymbolsHandler (doc, member);
-					if (handler.IsValid) {
-						var a = ainfo.Add (GettextCatalog.GetString ("Find Derived Symbols"), new Action (handler.Run));
-						a.AccelKey = IdeApp.CommandService.GetCommandInfo (RefactoryCommands.FindDerivedClasses).AccelKey;
-						added = true;
-					}
+				var handler = new FindDerivedSymbolsHandler (member);
+				if (handler.IsValid) {
+					var a = ainfo.Add (GettextCatalog.GetString ("Find Derived Symbols"), new Action (handler.Run));
+					a.AccelKey = IdeApp.CommandService.GetCommandInfo (RefactoryCommands.FindDerivedClasses).AccelKey;
+					added = true;
 				}
 			}
 			if (item is IMember) {


### PR DESCRIPTION
* Fix the "Find Derived Symbols" navigation command to search in referencing projects
* Fix keybindable FindDerivedClasses command to actually do something
* Make FindDerivedClasses command find derived symbols when used on a member