### PR TITLE
Added support for selecting files when using "Open containing folder"

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -842,5 +842,14 @@ namespace MonoDevelop.MacIntegration
 			}
 			return desktopBounds;
 		}
+
+		public override void OpenFolder (FilePath folderPath, FilePath[] selectFiles)
+		{
+			if (selectFiles.Length == 0) {
+				System.Diagnostics.Process.Start (folderPath);
+			} else {
+				NSWorkspace.SharedWorkspace.ActivateFileViewer (selectFiles.Select ((f) => NSUrl.FromFilename (f)).ToArray ());
+			}
+		}
 	}
 }

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
@@ -401,6 +401,39 @@ namespace MonoDevelop.Platform
 			return null;
 		}
 
+		#region OpenFolder
+
+		[DllImport ("shell32.dll", ExactSpelling = true)]
+		static extern int SHOpenFolderAndSelectItems (
+			IntPtr pidlFolder,
+			uint cidl,
+			[In, MarshalAs (UnmanagedType.LPArray)] IntPtr[] apidl,
+			uint dwFlags);
+
+		[DllImport ("shell32.dll", CharSet = CharSet.Auto)]
+		static extern IntPtr ILCreateFromPath ([MarshalAs (UnmanagedType.LPTStr)] string pszPath);
+
+		[DllImport ("shell32.dll", CharSet = CharSet.None)]
+		static extern void ILFree (IntPtr pidl);
+
+		public override void OpenFolder (FilePath folderPath, FilePath[] selectFiles)
+		{
+			if (selectFiles.Length == 0) {
+				Process.Start (folderPath);
+			} else {
+				var dir = ILCreateFromPath (folderPath);
+				var files = selectFiles.Select ((f) => ILCreateFromPath (f)).ToArray ();
+				try {
+					SHOpenFolderAndSelectItems (dir, (uint)files.Length, files, 0);
+				} finally {
+					ILFree (dir);
+					files.ToList ().ForEach (ILFree);
+				}
+			}
+		}
+
+		#endregion
+
 		class WindowsDesktopApplication : DesktopApplication
 		{
 			public WindowsDesktopApplication (string id, string displayName, string exePath, bool isDefault) : base (id, displayName, isDefault)

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
@@ -403,17 +403,17 @@ namespace MonoDevelop.Platform
 
 		#region OpenFolder
 
-		[DllImport ("shell32.dll", ExactSpelling = true)]
+		[DllImport ("shell32.dll")]
 		static extern int SHOpenFolderAndSelectItems (
 			IntPtr pidlFolder,
 			uint cidl,
 			[In, MarshalAs (UnmanagedType.LPArray)] IntPtr[] apidl,
 			uint dwFlags);
 
-		[DllImport ("shell32.dll", CharSet = CharSet.Auto)]
+		[DllImport ("shell32.dll")]
 		static extern IntPtr ILCreateFromPath ([MarshalAs (UnmanagedType.LPTStr)] string pszPath);
 
-		[DllImport ("shell32.dll", CharSet = CharSet.None)]
+		[DllImport ("shell32.dll")]
 		static extern void ILFree (IntPtr pidl);
 
 		public override void OpenFolder (FilePath folderPath, FilePath[] selectFiles)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -83,7 +83,7 @@ namespace MonoDevelop.Ide.Desktop
 			Process.Start (filename);
 		}
 		
-		public virtual void OpenFolder (FilePath folderPath)
+		public virtual void OpenFolder (FilePath folderPath, FilePath[] selectFiles)
 		{
 			Process.Start (folderPath);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/SolutionNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/SolutionNodeBuilder.cs
@@ -286,7 +286,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		public void OnOpenFolder ()
 		{
 			Solution solution = (Solution) CurrentNode.DataItem;
-			DesktopService.OpenFolder (solution.BaseDirectory);
+			DesktopService.OpenFolder (solution.BaseDirectory, solution.FileName);
 		}
 		
 		[CommandHandler (SearchCommands.FindInFiles)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FileOperationsBuilderExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FileOperationsBuilderExtension.cs
@@ -67,16 +67,33 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		[AllowMultiSelection]
 		public void OnOpenFolder ()
 		{
-			var paths = new HashSet<string> ();
-			foreach (ITreeNavigator node in CurrentNodes) {
-				FilePath path = GetDir (node.DataItem);
-
-				//if folder doesn't exist, walk up to parent that does
-				while (!path.IsNullOrEmpty && !path.IsDirectory)
-					path = path.ParentDirectory;
-
-				if (!path.IsNullOrEmpty && paths.Add (path))
-					DesktopService.OpenFolder (path);
+			var paths = new Dictionary<string, HashSet<string>> ();
+			foreach (var ob in CurrentNodes.Select((node)=>node.DataItem)) {
+				if (ob is IFileItem) {
+					string path = ((IFileItem)ob).FileName;
+					if (!string.IsNullOrEmpty (path)) {
+						var dirPath = (FilePath)System.IO.Path.GetDirectoryName (path);
+						//if folder doesn't exist, walk up to parent that does
+						while (!dirPath.IsNullOrEmpty && !dirPath.IsDirectory)
+							dirPath = dirPath.ParentDirectory;
+						if (!string.IsNullOrEmpty (dirPath)) {
+							if (!paths.ContainsKey (dirPath))
+								paths.Add (dirPath, new HashSet<string> ());
+							paths [dirPath].Add (path);
+						}
+					}
+				} else if (ob is IFolderItem) {
+					var path = ((IFolderItem)ob).BaseDirectory;
+					//if folder doesn't exist, walk up to parent that does
+					while (!path.IsNullOrEmpty && !path.IsDirectory)
+						path = path.ParentDirectory;
+					if (!paths.ContainsKey (path)) {
+						paths.Add (path, new HashSet<string> ());
+					}
+				}
+			}
+			foreach (var folder in paths) {
+				DesktopService.OpenFolder (folder.Key, folder.Value.Select ((f) => (FilePath)f).ToArray ());
 			}
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FileOperationsBuilderExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FileOperationsBuilderExtension.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		public void OnOpenFolder ()
 		{
 			var paths = new Dictionary<string, HashSet<string>> ();
-			foreach (var ob in CurrentNodes.Select((node)=>node.DataItem)) {
+			foreach (var ob in CurrentNodes.Select(node => node.DataItem)) {
 				if (ob is IFileItem) {
 					string path = ((IFileItem)ob).FileName;
 					if (!string.IsNullOrEmpty (path)) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
@@ -103,7 +103,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			// A tab will always hold a file, never a folder.
 			FilePath path = Path.GetDirectoryName (doc.FileName);
-			DesktopService.OpenFolder (path);
+			DesktopService.OpenFolder (path, doc.FileName);
 		}
 		
 		[CommandUpdateHandler (FileCommands.OpenContainingFolder)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -134,9 +134,9 @@ namespace MonoDevelop.Ide
 			PlatformService.OpenFile (filename);
 		}
 
-		public static void OpenFolder (FilePath folderPath)
+		public static void OpenFolder (FilePath folderPath, params FilePath[] selectFiles)
 		{
-			PlatformService.OpenFolder (folderPath);
+			PlatformService.OpenFolder (folderPath, selectFiles);
 		}
 
 		public static string GetMimeTypeForUri (string uri)


### PR DESCRIPTION
This is very useful when folder has many files since it highlights and scrolls to file(s) user is interested in...

Linux is messed up... There is DBus command for this: "org.freedesktop.FileManager1.ShowItems" but it seems only Nautilus supports it... I could probably special case(detect if nautilus is main file browser) or any other file browser(dolphin) but then... Nautilus doesn't support selecting multiple files(it opens multiple windows for files in same folder).

So for now Linux doesn't support this :(