### PR TITLE
[Ide] Resolve full path of fileName before opening in Workbench

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -1285,7 +1285,7 @@ namespace MonoDevelop.Ide.Gui
 				return fileName;
 			}
 			set {
-				fileName = value.CanonicalPath;
+				fileName = FileService.ResolveFullPath (value.CanonicalPath);
 				if (fileName.IsNullOrEmpty)
 					LoggingService.LogError ("FileName == null\n" + Environment.StackTrace);
 			}


### PR DESCRIPTION
Opening the realpath of a file prevents problems with debugging symlinked
files, such as the case https://bugzilla.xamarin.com/show_bug.cgi?id=27098