### PR TITLE
[FindInFiles] Use relative paths in the Path column, when possible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -39,6 +39,7 @@ namespace MonoDevelop.Ide.FindInFiles
 {
 	public enum PathMode {
 		Absolute,
+		Relative,
 		Hidden
 	}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ISearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ISearchProgressMonitor.cs
@@ -34,7 +34,6 @@ namespace MonoDevelop.Ide.FindInFiles
 {
 	public interface ISearchProgressMonitor: IProgressMonitor
 	{
-		void SetBasePath (string path);
 		void ReportResult (SearchResult result);
 		void ReportResults (IEnumerable<SearchResult> result);
 		void ReportStatus (string resultMessage);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -45,7 +45,15 @@ namespace MonoDevelop.Ide.FindInFiles
 		}
 
 		public virtual PathMode PathMode {
-			get { return PathMode.Absolute; }
+			get {
+				var workspace = IdeApp.Workspace;
+				var solutions = workspace != null ? workspace.GetAllSolutions () : null;
+
+				if (solutions != null && solutions.Count == 1)
+					return PathMode.Relative;
+
+				return PathMode.Absolute;
+			}
 		}
 
 		public abstract int GetTotalWork (FilterOptions filterOptions);
@@ -227,7 +235,11 @@ namespace MonoDevelop.Ide.FindInFiles
 	{
 		readonly string path;
 		readonly bool recurse;
-		
+
+		public override PathMode PathMode {
+			get { return PathMode.Absolute; }
+		}
+
 		public bool IncludeHiddenFiles {
 			get;
 			set;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
@@ -51,12 +51,6 @@ namespace MonoDevelop.Ide.FindInFiles
 		public bool AllowReuse {
 			get { return outputPad.AllowReuse; }
 		}
-		
-		[FreeDispatch]
-		public void SetBasePath (string path)
-		{
-			outputPad.BasePath = path;
-		}
 
 		public PathMode PathMode {
 			set { outputPad.PathMode = value; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultPad.cs
@@ -72,15 +72,6 @@ namespace MonoDevelop.Ide.FindInFiles
 				return widget.AllowReuse; 
 			}
 		}
-		
-		public string BasePath {
-			get {
-				return widget.BasePath;
-			}
-			set {
-				widget.BasePath = value;
-			}
-		}
 
 		internal PathMode PathMode {
 			set {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
@@ -64,8 +64,11 @@ namespace MonoDevelop.Ide.FindInFiles
 		TextView textviewLog;
 		TreeViewColumn pathColumn;
 
+		private PathMode pathMode;
 		internal PathMode PathMode {
 			set {
+				pathMode = value;
+
 				pathColumn.Visible = (value != PathMode.Hidden);
 			}
 		}
@@ -454,7 +457,19 @@ namespace MonoDevelop.Ide.FindInFiles
 			string pathMarkup = searchResult.PathMarkup;
 			if (pathMarkup == null) {
 				bool didRead = (bool)store.GetValue (iter, DidReadColumn);
-				pathMarkup = MarkupText (System.IO.Path.GetDirectoryName (searchResult.FileName), didRead);
+
+				var fileName = searchResult.FileName;
+				string baseSolutionPath = null;
+				if (pathMode == PathMode.Relative) {
+					var workspace = IdeApp.Workspace;
+					var solutions = workspace != null ? workspace.GetAllSolutions () : null;
+					baseSolutionPath = solutions != null && solutions.Count == 1 ? solutions [0].BaseDirectory : null;
+				}
+				var finalFileName = baseSolutionPath == null ? fileName :
+					FileService.AbsoluteToRelativePath (baseSolutionPath, fileName);
+				var directory = System.IO.Path.GetDirectoryName (finalFileName);
+
+				pathMarkup = MarkupText (directory, didRead);
 				searchResult.PathMarkup = pathMarkup;
 			}
 			pathRenderer.Markup = pathMarkup;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
@@ -64,11 +64,6 @@ namespace MonoDevelop.Ide.FindInFiles
 		TextView textviewLog;
 		TreeViewColumn pathColumn;
 
-		public string BasePath {
-			get;
-			set;
-		}
-
 		internal PathMode PathMode {
 			set {
 				pathColumn.Visible = (value != PathMode.Hidden);


### PR DESCRIPTION
Relative paths to the solution base directory are easier to read
without horizontal scrolling.