### PR TITLE
PropertyGrid fixup

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/ExpandableObjectEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/ExpandableObjectEditor.cs
@@ -32,11 +32,7 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-using System;
 using Gtk;
-using System.ComponentModel;
-using System.ComponentModel.Design;
-using System.Collections;
 
 namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/ExpandableObjectEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/ExpandableObjectEditor.cs
@@ -41,8 +41,8 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 		protected override string GetValueMarkup ()
 		{
 			string val;
-			if (Property.Converter.CanConvertTo (typeof(string)))
-				val = Property.Converter.ConvertToString (Value);
+			if (Property.Converter.CanConvertTo (Context, typeof(string)))
+				val = Property.Converter.ConvertToString (Context, Value);
 			else
 				val = Value != null ? Value.ToString () : "";
 			
@@ -51,7 +51,7 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 		
 		protected override IPropertyEditor CreateEditor (Gdk.Rectangle cell_area, StateType state)
 		{
-			if (Property.Converter.CanConvertTo (typeof(string)) && Property.Converter.CanConvertFrom (typeof(string)))
+			if (Property.Converter.CanConvertTo (Context, typeof(string)) && Property.Converter.CanConvertFrom (Context, typeof(string)))
 				return new TextEditor ();
 			else
 				return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
@@ -143,6 +143,8 @@ namespace MonoDevelop.Components.PropertyGrid
 			Populate ();
 			UpdateTabs ();
 		}
+
+		public ISite Site { get; set; }
 		
 		public void SetToolbarProvider (IToolbarProvider toolbarProvider)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Components.PropertyGrid
 		{
 			public bool IsCategory;
 			public string Label;
-			public object Instace;
+			public object Instance;
 			public PropertyDescriptor Property;
 			public List<TableRow> ChildRows;
 			public bool Expanded;
@@ -206,7 +206,7 @@ namespace MonoDevelop.Components.PropertyGrid
 		bool UpdateProperty (PropertyDescriptor pd, object instance, IEnumerable<TableRow> rowList)
 		{
 			foreach (var row in rowList) {
-				if (row.Property != null && row.Property.Name == pd.Name && row.Instace == instance) {
+				if (row.Property != null && row.Property.Name == pd.Name && row.Instance == instance) {
 					row.Property = pd;
 					return true;
 				}
@@ -229,7 +229,7 @@ namespace MonoDevelop.Components.PropertyGrid
 				IsCategory = false,
 				Property = prop,
 				Label = prop.DisplayName,
-				Instace = instance
+				Instance = instance
 			};
 			rowList.Add (row);
 
@@ -246,7 +246,7 @@ namespace MonoDevelop.Components.PropertyGrid
 		PropertyEditorCell GetCell (TableRow row)
 		{
 			var e = editorManager.GetEditor (row.Property);
-			e.Initialize (this, editorManager, row.Property, row.Instace);
+			e.Initialize (this, editorManager, row.Property, row.Instance);
 			return e;
 		}
 
@@ -585,7 +585,7 @@ namespace MonoDevelop.Components.PropertyGrid
 				s.AppendLine ();
 				s.Append (GLib.Markup.EscapeText (row.Property.Description));
 				if (row.Property.Converter.CanConvertTo (typeof(string))) {
-					var value = Convert.ToString (row.Property.GetValue (row.Instace));
+					var value = Convert.ToString (row.Property.GetValue (row.Instance));
 					if (!string.IsNullOrEmpty (value)) {
 						const int chunkLength = 200;
 						var multiLineValue = string.Join (Environment.NewLine, Enumerable.Range (0, (int)Math.Ceiling ((double)value.Length / chunkLength)).Select (n => string.Concat (value.Skip (n * chunkLength).Take (chunkLength))));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
@@ -234,10 +234,11 @@ namespace MonoDevelop.Components.PropertyGrid
 			rowList.Add (row);
 
 			TypeConverter tc = prop.Converter;
-			if (typeof (ExpandableObjectConverter).IsAssignableFrom (tc.GetType ())) {
+			if (tc.GetPropertiesSupported ()) {
 				object cob = prop.GetValue (instance);
 				row.ChildRows = new List<TableRow> ();
-				foreach (PropertyDescriptor cprop in TypeDescriptor.GetProperties (cob))
+				//TODO: should we support TypeDescriptor extensibility? how to merge with TypeConverter?
+				foreach (PropertyDescriptor cprop in tc.GetProperties (cob))
 					AppendProperty (row.ChildRows, cprop, cob);
 			}
 		}


### PR DESCRIPTION
Miscellaneous PropertyGrid fixes.

* Allow any TypeConverter to provider children, not just ExpandableObjectConverter
* Restores support for expanding child rows
* More consistently provides ITypeDescriptorContext to TypeConverters