### PR TITLE
[FindInFiles] Hide the "Path" column if scope is current doc or selection

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -37,6 +37,11 @@ using MonoDevelop.Ide.Gui.Content;
 
 namespace MonoDevelop.Ide.FindInFiles
 {
+	public enum PathMode {
+		Absolute,
+		Hidden
+	}
+
 	public partial class FindInFilesDialog : Gtk.Dialog
 	{
 		readonly bool writeScope = true;
@@ -783,6 +788,9 @@ namespace MonoDevelop.Ide.FindInFiles
 
 			ThreadPool.QueueUserWorkItem (delegate {
 				using (ISearchProgressMonitor searchMonitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true)) {
+
+					searchMonitor.PathMode = scope.PathMode;
+
 					searchMonitor.ReportStatus (scope.GetDescription (options, pattern, null));
 
 					lock (searchesInProgress)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ISearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/ISearchProgressMonitor.cs
@@ -38,5 +38,6 @@ namespace MonoDevelop.Ide.FindInFiles
 		void ReportResult (SearchResult result);
 		void ReportResults (IEnumerable<SearchResult> result);
 		void ReportStatus (string resultMessage);
+		PathMode PathMode { set; }
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -43,7 +43,11 @@ namespace MonoDevelop.Ide.FindInFiles
 			get;
 			set;
 		}
-		
+
+		public virtual PathMode PathMode {
+			get { return PathMode.Absolute; }
+		}
+
 		public abstract int GetTotalWork (FilterOptions filterOptions);
 		public abstract IEnumerable<FileProvider> GetFiles (IProgressMonitor monitor, FilterOptions filterOptions);
 		public abstract string GetDescription (FilterOptions filterOptions, string pattern, string replacePattern);
@@ -51,6 +55,10 @@ namespace MonoDevelop.Ide.FindInFiles
 
 	public class DocumentScope : Scope
 	{
+		public override PathMode PathMode {
+			get { return PathMode.Hidden; }
+		}
+
 		public override int GetTotalWork (FilterOptions filterOptions)
 		{
 			return 1;
@@ -73,6 +81,10 @@ namespace MonoDevelop.Ide.FindInFiles
 
 	public class SelectionScope : Scope
 	{
+		public override PathMode PathMode {
+			get { return PathMode.Hidden; }
+		}
+
 		public override int GetTotalWork (FilterOptions filterOptions)
 		{
 			return 1;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
@@ -57,7 +57,11 @@ namespace MonoDevelop.Ide.FindInFiles
 		{
 			outputPad.BasePath = path;
 		}
-		
+
+		public PathMode PathMode {
+			set { outputPad.PathMode = value; }
+		}
+
 		[AsyncDispatch]
 		public void ReportResult (SearchResult result)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultPad.cs
@@ -81,6 +81,12 @@ namespace MonoDevelop.Ide.FindInFiles
 				widget.BasePath = value;
 			}
 		}
+
+		internal PathMode PathMode {
+			set {
+				widget.PathMode = value;
+			}
+		}
 		
 		public SearchResultPad (int instanceNum)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
@@ -62,12 +62,19 @@ namespace MonoDevelop.Ide.FindInFiles
 		PadTreeView treeviewSearchResults;
 		Label labelStatus;
 		TextView textviewLog;
-		
+		TreeViewColumn pathColumn;
+
 		public string BasePath {
 			get;
 			set;
 		}
-		
+
+		internal PathMode PathMode {
+			set {
+				pathColumn.Visible = (value != PathMode.Hidden);
+			}
+		}
+
 		public IAsyncOperation AsyncOperation {
 			get;
 			set;
@@ -159,8 +166,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			textColumn.Sizing = TreeViewColumnSizing.Fixed;
 			textColumn.FixedWidth = 300;
 
-			
-			TreeViewColumn pathColumn = treeviewSearchResults.AppendColumn (GettextCatalog.GetString ("Path"),
+			pathColumn = treeviewSearchResults.AppendColumn (GettextCatalog.GetString ("Path"),
 				                            renderer, ResultPathDataFunc);
 			pathColumn.SortColumnId = 3;
 			pathColumn.Resizable = true;


### PR DESCRIPTION
There's no much point in showing the Path column when the scope of
the FindInFiles search is "Current document" or "Selection" because
its value is going to be the same across all rows.

This is developed with a PathMode enum which will be useful too, for
a future commit that will allow using relative paths in certain
situations.