### PR TITLE
Fixed Bug 2187- Ignore creation of solution if it has special characters

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
@@ -153,7 +153,7 @@ namespace MonoDevelop.Ide.Projects
 				!FileService.IsValidPath (ProjectLocation);
 		}
 
-		static readonly char [] InvalidProjectNameCharacters = "&*;".ToCharArray ();
+		static readonly char [] InvalidProjectNameCharacters = "&<*;?>%:#*|".ToCharArray ();
 
 		public static bool IsValidProjectName (string name)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
@@ -153,7 +153,7 @@ namespace MonoDevelop.Ide.Projects
 				!FileService.IsValidPath (ProjectLocation);
 		}
 
-		static readonly char [] InvalidProjectNameCharacters = "&<*;?>%:#*|".ToCharArray ();
+		static readonly char [] InvalidProjectNameCharacters = "&<*;?>%:#|".ToCharArray ();
 
 		public static bool IsValidProjectName (string name)
 		{

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -252,12 +252,11 @@ namespace MonoDevelop.Ide.Templates
 		[TestCase("a:b", false)]
 		[TestCase("a#b", false)]
 		[TestCase("a|b", false)]
-		public void CreateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (bool valid)
+		public void CreateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";
-			config.ProjectName = "b";
-			
+			config.ProjectName = projectname;
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
@@ -271,12 +270,11 @@ namespace MonoDevelop.Ide.Templates
 		[TestCase("a:b", false)]
 		[TestCase("a#b", false)]
 		[TestCase("a|b", false)]
-		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (bool valid)
+		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)		
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";
-			config.ProjectName = "b";
-			
+			config.ProjectName = projectname;
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
@@ -294,10 +292,13 @@ namespace MonoDevelop.Ide.Templates
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";
-			config.ProjectName ="b";
-			
+
+			config.ProjectName = "a";
+			Assert.IsTrue (config.IsValid());
+			config.ProjectName =projectName;
 			Assert.AreEqual (valid, config.IsValid ());
 		}
+		
 		[Test]
 		public void NewProjectOnlyAndCreateProjectDirectory ()
 		{

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -296,7 +296,7 @@ namespace MonoDevelop.Ide.Templates
 		[TestCase("a:b", false)]
 		[TestCase("a#b", false)]
 		[TestCase("a|b", false)]
-		public void InvalidProjectNameCharactersCauseConfigToBeInvalid(string projectName, bool valid)
+		public void InvalidProjectNameCharactersCauseConfigToBeInvalid (string projectName, bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -278,6 +278,7 @@ namespace MonoDevelop.Ide.Templates
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.CreateSolution = true;
+			config.CreateProjectDirectoryInsideSolutionDirectory = false;
 			config.SolutionName = "a";
 			config.ProjectName = projectname;
 			

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -300,10 +300,8 @@ namespace MonoDevelop.Ide.Templates
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";
-			
-			config.ProjectName = "a";
-                	Assert.IsTrue (config.IsValid());
 			config.ProjectName =projectName;
+			
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -242,7 +242,7 @@ namespace MonoDevelop.Ide.Templates
 			Assert.IsFalse (result);
 		}
                 
-	        [TestCase("a",true)]
+	 	[TestCase("a",true)]
 		[TestCase("a&b", false)]
 		[TestCase("a<b", false)]
 		[TestCase("a*b", false)]
@@ -251,7 +251,7 @@ namespace MonoDevelop.Ide.Templates
 		[TestCase("a>b", false)]
 		[TestCase("a%b", false)]
 		[TestCase("a:b", false)]
-		[TestCase("a#b", false)]
+		[TestCase("a#b", false)]	
 		[TestCase("a|b", false)]
 		public void CreateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)
 		{
@@ -272,9 +272,9 @@ namespace MonoDevelop.Ide.Templates
 		[TestCase("a>b", false)]
 		[TestCase("a%b", false)]
 		[TestCase("a:b", false)]
-		[TestCase("a#b", false)]
+		[TestCase("a#b", false)]	
 		[TestCase("a|b", false)]
-		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)
+		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)		
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.CreateSolution = true;
@@ -301,10 +301,10 @@ namespace MonoDevelop.Ide.Templates
 			CreateProjectConfig (@"d:\projects");
 		    	config.SolutionName = "a";
 			
-		        config.ProjectName = "a";
-                        Assert.IsTrue (config.IsValid());
+		   	config.ProjectName = "a";
+                       	Assert.IsTrue (config.IsValid());
 			config.ProjectName =projectName;
-			Assert.AreEqual (valid, config.IsValid ());
+		     	Assert.AreEqual (valid, config.IsValid ());
 		}
 		
 		[Test]

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -242,57 +242,62 @@ namespace MonoDevelop.Ide.Templates
 			Assert.IsFalse (result);
 		}
 
-		[Test]
-		public void CreateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid ()
+	        [TestCase("a&b", false)]
+		[TestCase("a<b", false)]
+		[TestCase("a*b", false)]
+		[TestCase("a;b", false)]
+		[TestCase("a?b", false)]
+		[TestCase("a>b", false)]
+		[TestCase("a%b", false)]
+		[TestCase("a:b", false)]
+		[TestCase("a#b", false)]
+		[TestCase("a|b", false)]
+		public void CreateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
-			config.CreateSolution = true;
+			config.SolutionName = "a";
 			config.ProjectName = "b";
-
-			config.SolutionName = "a";
-			Assert.IsTrue (config.IsValid ());
-			config.SolutionName = "a&b";
-			Assert.IsFalse (config.IsValid ());
-			config.SolutionName = "a*b";
-			Assert.IsFalse (config.IsValid ());
-			config.SolutionName = "a;b";
-			Assert.IsFalse (config.IsValid ());
+			
+			Assert.AreEqual (valid, config.IsValid ());
 		}
-
-		[Test]
-		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid ()
+		
+		[TestCase("a&b", false)]
+		[TestCase("a<b", false)]
+		[TestCase("a*b", false)]
+		[TestCase("a;b", false)]
+		[TestCase("a?b", false)]
+		[TestCase("a>b", false)]
+		[TestCase("a%b", false)]
+		[TestCase("a:b", false)]
+		[TestCase("a#b", false)]
+		[TestCase("a|b", false)]
+		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
-			config.CreateSolution = true;
-			config.CreateProjectDirectoryInsideSolutionDirectory = false;
+			config.SolutionName = "a";
 			config.ProjectName = "b";
-
-			config.SolutionName = "a";
-			Assert.IsTrue (config.IsValid ());
-			config.SolutionName = "a&b";
-			Assert.IsFalse (config.IsValid ());
-			config.SolutionName = "a*b";
-			Assert.IsFalse (config.IsValid ());
-			config.SolutionName = "a;b";
-			Assert.IsFalse (config.IsValid ());
+			
+			Assert.AreEqual (valid, config.IsValid ());
 		}
-
-		[Test]
-		public void InvalidProjectNameCharactersCauseConfigToBeInvalid ()
+		
+		[TestCase("a&b", false)]
+		[TestCase("a<b", false)]
+		[TestCase("a*b", false)]
+		[TestCase("a;b", false)]
+		[TestCase("a?b", false)]
+		[TestCase("a>b", false)]
+		[TestCase("a%b", false)]
+		[TestCase("a:b", false)]
+		[TestCase("a#b", false)]
+		[TestCase("a|b", false)]
+		public void InvalidProjectNameCharactersCauseConfigToBeInvalid(string projectName, bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";
-
-			config.ProjectName = "a";
-			Assert.IsTrue (config.IsValid ());
-			config.ProjectName = "a&b";
-			Assert.IsFalse (config.IsValid ());
-			config.ProjectName = "a*b";
-			Assert.IsFalse (config.IsValid ());
-			config.ProjectName = "a;b";
-			Assert.IsFalse (config.IsValid ());
+			config.ProjectName ="b";
+			
+			Assert.AreEqual (valid, config.IsValid ());
 		}
-
 		[Test]
 		public void NewProjectOnlyAndCreateProjectDirectory ()
 		{

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -242,7 +242,7 @@ namespace MonoDevelop.Ide.Templates
 			Assert.IsFalse (result);
 		}
                 
-	 	[TestCase("a",true)]
+		[TestCase("a",true)]
 		[TestCase("a&b", false)]
 		[TestCase("a<b", false)]
 		[TestCase("a*b", false)]
@@ -299,12 +299,12 @@ namespace MonoDevelop.Ide.Templates
 		public void InvalidProjectNameCharactersCauseConfigToBeInvalid(string projectName, bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
-		    	config.SolutionName = "a";
+			config.SolutionName = "a";
 			
-		   	config.ProjectName = "a";
-                       	Assert.IsTrue (config.IsValid());
+			config.ProjectName = "a";
+                	Assert.IsTrue (config.IsValid());
 			config.ProjectName =projectName;
-		     	Assert.AreEqual (valid, config.IsValid ());
+			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
 		[Test]

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -241,8 +241,9 @@ namespace MonoDevelop.Ide.Templates
 
 			Assert.IsFalse (result);
 		}
-
-	        [TestCase("a&b", false)]
+                
+	        [TestCase("a",true)]
+		[TestCase("a&b", false)]
 		[TestCase("a<b", false)]
 		[TestCase("a*b", false)]
 		[TestCase("a;b", false)]
@@ -260,6 +261,7 @@ namespace MonoDevelop.Ide.Templates
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
+		[TestCase("a",true)]
 		[TestCase("a&b", false)]
 		[TestCase("a<b", false)]
 		[TestCase("a*b", false)]
@@ -270,7 +272,7 @@ namespace MonoDevelop.Ide.Templates
 		[TestCase("a:b", false)]
 		[TestCase("a#b", false)]
 		[TestCase("a|b", false)]
-		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)		
+		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
 			config.SolutionName = "a";
@@ -278,6 +280,7 @@ namespace MonoDevelop.Ide.Templates
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
+		[TestCase("a",true)]
 		[TestCase("a&b", false)]
 		[TestCase("a<b", false)]
 		[TestCase("a*b", false)]

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -256,8 +256,10 @@ namespace MonoDevelop.Ide.Templates
 		public void CreateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
+			config.CreateSolution = true;
 			config.SolutionName = "a";
 			config.ProjectName = projectname;
+			
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
@@ -275,8 +277,10 @@ namespace MonoDevelop.Ide.Templates
 		public void CreateSolutionWithoutSeparateSolutionDirectoryWhenInvalidSolutionNameCharactersCauseConfigToBeInvalid (string projectname,bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
+			config.CreateSolution = true;
 			config.SolutionName = "a";
 			config.ProjectName = projectname;
+			
 			Assert.AreEqual (valid, config.IsValid ());
 		}
 		
@@ -294,10 +298,10 @@ namespace MonoDevelop.Ide.Templates
 		public void InvalidProjectNameCharactersCauseConfigToBeInvalid(string projectName, bool valid)
 		{
 			CreateProjectConfig (@"d:\projects");
-			config.SolutionName = "a";
-
-			config.ProjectName = "a";
-			Assert.IsTrue (config.IsValid());
+		    	config.SolutionName = "a";
+			
+		        config.ProjectName = "a";
+                        Assert.IsTrue (config.IsValid());
 			config.ProjectName =projectName;
 			Assert.AreEqual (valid, config.IsValid ());
 		}


### PR DESCRIPTION
In xamarin studio, it creates solution for all the project names(including special characters). I have fixed this bug, so that it will create solution only when its name does not have special characters.I  have included those special characters that are parallely ignored in visual studio 2013