### PR TITLE
 [Core] Resolve full path of workspaceItem before reading

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -248,7 +248,7 @@ namespace MonoDevelop.Projects
 
 		public WorkspaceItem ReadWorkspaceItem (IProgressMonitor monitor, FilePath file)
 		{
-			string fullpath = file.FullPath;
+			string fullpath = FileService.ResolveFullPath (file).FullPath;
 			using (Counters.ReadWorkspaceItem.BeginTiming ("Read solution " + file)) {
 				fullpath = GetTargetFile (fullpath);
 				WorkspaceItem item = GetExtensionChain (null).LoadWorkspaceItem (monitor, fullpath) as WorkspaceItem;


### PR DESCRIPTION
Opening the realpath of a file prevents problems when using solutions
inside symlinked paths, such as:
- compilation problems [1].
- rendering of ugly relative paths (cosmetic) [2].
    
This is a similar fix to [3].
    
[1] https://bugzilla.xamarin.com/show_bug.cgi?id=27097
[2] https://bugzilla.xamarin.com/show_bug.cgi?id=27331
[3] https://github.com/mono/monodevelop/commit/32e25ea
