### PR TITLE
[Ide] show warning info if project for unsupported framework is created

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
@@ -314,6 +314,16 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 				}
 			}
 		}
+
+		public void SelectPanel (string id, string parentId)
+		{
+			foreach (OptionsDialogSection section in pages.Keys) {
+				if (section.Id == id && section.Parent != null && section.Parent.Id == parentId) {
+					ShowPage (section);
+					return;
+				}
+			}
+		}
 		
 		public void AddChildSection (IOptionsPanel parent, OptionsDialogSection section, object dataObject)
 		{


### PR DESCRIPTION
Add SelectPanel method with three arguments. Section Id can be treated as
identifier only inside one section. For searching through a few sections
level, parent Id might be necessary.

This commit fixes bug #24458