### PR TITLE
[Core/Ide] Sanitize file:// URIs in FilePath ctor

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -43,6 +43,9 @@ namespace MonoDevelop.Core
 
 		public FilePath (string name)
 		{
+			if (name != null && name.StartsWith ("file://", StringComparison.Ordinal))
+				name = new Uri (name).LocalPath;
+
 			fileName = name;
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -245,13 +245,13 @@ namespace MonoDevelop.Projects
 					return sol.GetSolutionItem (reference.Id);
 			}
 		}
-		
-		public WorkspaceItem ReadWorkspaceItem (IProgressMonitor monitor, string file)
+
+		public WorkspaceItem ReadWorkspaceItem (IProgressMonitor monitor, FilePath file)
 		{
-			file = Path.GetFullPath (file);
+			string fullpath = file.FullPath;
 			using (Counters.ReadWorkspaceItem.BeginTiming ("Read solution " + file)) {
-				file = GetTargetFile (file);
-				WorkspaceItem item = GetExtensionChain (null).LoadWorkspaceItem (monitor, file) as WorkspaceItem;
+				fullpath = GetTargetFile (fullpath);
+				WorkspaceItem item = GetExtensionChain (null).LoadWorkspaceItem (monitor, fullpath) as WorkspaceItem;
 				if (item != null)
 					item.NeedsReload = false;
 				else
@@ -533,23 +533,45 @@ namespace MonoDevelop.Projects
 				return tempSolution;
 			}
 		}
-		
+
+		public bool IsSolutionItemFile (FilePath file)
+		{
+			return IsSolutionItemFileImpl (file.ToString ());
+		}
+
+		[Obsolete ("Use IsSolutionItemFile (FilePath file)")]
 		public bool IsSolutionItemFile (string filename)
 		{
 			if (filename.StartsWith ("file://"))
 				filename = new Uri(filename).LocalPath;
+			return IsSolutionItemFileImpl (filename);
+		}
+
+		private bool IsSolutionItemFileImpl (string filename)
+		{
 			filename = GetTargetFile (filename);
 			return GetExtensionChain (null).IsSolutionItemFile (filename);
 		}
-		
+
+		public bool IsWorkspaceItemFile (FilePath file)
+		{
+			return IsWorkspaceItemFileImpl (file.ToString ());
+		}
+
+		[Obsolete ("Use IsWorkspaceItemFile (FilePath file)")]
 		public bool IsWorkspaceItemFile (string filename)
 		{
 			if (filename.StartsWith ("file://"))
 				filename = new Uri(filename).LocalPath;
+			return IsWorkspaceItemFileImpl (filename);
+		}
+
+		private bool IsWorkspaceItemFileImpl (string filename)
+		{
 			filename = GetTargetFile (filename);
 			return GetExtensionChain (null).IsWorkspaceItemFile (filename);
 		}
-		
+
 		internal bool IsSolutionItemFileInternal (string filename)
 		{
 			return formatManager.GetFileFormats (filename, typeof(SolutionItem)).Length > 0;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
@@ -251,13 +251,13 @@ namespace MonoDevelop.Components.DockNotebook
 			foreach (string individualFile in fullData.Split ('\n')) {
 				string file = individualFile.Trim ();
 				if (file.StartsWith ("file://")) {
-					file = new Uri(file).LocalPath;
+					var filePath = new FilePath (file);
 
 					try {
-						if (Services.ProjectService.IsWorkspaceItemFile (file))
-							IdeApp.Workspace.OpenWorkspaceItem(file);
+						if (Services.ProjectService.IsWorkspaceItemFile (filePath))
+							IdeApp.Workspace.OpenWorkspaceItem(filePath);
 						else
-							IdeApp.Workbench.OpenDocument (file, null, -1, -1, MonoDevelop.Ide.Gui.OpenDocumentOptions.Default, null, null, this);
+							IdeApp.Workbench.OpenDocument (filePath, null, -1, -1, MonoDevelop.Ide.Gui.OpenDocumentOptions.Default, null, null, this);
 					} catch (Exception e) {
 						MonoDevelop.Core.LoggingService.LogError ("unable to open file {0} exception was :\n{1}", file, e.ToString());
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -839,12 +839,7 @@ namespace MonoDevelop.Ide.Gui
 				monitor.ReportError (GettextCatalog.GetString ("Invalid file name"), null);
 				return;
 			}
-			
-			if (origName.StartsWith ("file://", StringComparison.Ordinal))
-				fileName = new Uri (origName).LocalPath;
-			else
-				fileName = origName;
-			
+
 			if (!origName.StartsWith ("http://", StringComparison.Ordinal))
 				fileName = fileName.FullPath;
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -530,25 +530,22 @@ namespace MonoDevelop.Ide
 			get { return openingItemOper != null && !openingItemOper.IsCompleted; }
 		}
 
-		public IAsyncOperation OpenWorkspaceItem (string filename)
+		public IAsyncOperation OpenWorkspaceItem (FilePath file)
 		{
-			return OpenWorkspaceItem (filename, true);
+			return OpenWorkspaceItem (file, true);
 		}
 		
-		public IAsyncOperation OpenWorkspaceItem (string filename, bool closeCurrent)
+		public IAsyncOperation OpenWorkspaceItem (FilePath file, bool closeCurrent)
 		{
-			return OpenWorkspaceItem (filename, closeCurrent, true);
+			return OpenWorkspaceItem (file, closeCurrent, true);
 		}
-		
-		public IAsyncOperation OpenWorkspaceItem (string filename, bool closeCurrent, bool loadPreferences)
+
+		public IAsyncOperation OpenWorkspaceItem (FilePath file, bool closeCurrent, bool loadPreferences)
 		{
 			if (openingItemOper != null && !openingItemOper.IsCompleted && closeCurrent)
 				openingItemOper.Cancel ();
 
-			if (filename.StartsWith ("file://", StringComparison.Ordinal))
-				filename = new Uri(filename).LocalPath;
-
-			var item = GetAllItems<WorkspaceItem> ().FirstOrDefault (w => w.FileName == filename);
+			var item = GetAllItems<WorkspaceItem> ().FirstOrDefault (w => w.FileName == file.FullPath);
 			if (item != null) {
 				IdeApp.ProjectOperations.CurrentSelectedWorkspaceItem = item;
 				IdeApp.Workbench.StatusBar.ShowWarning (GettextCatalog.GetString ("{0} is already opened", item.FileName.FileName));
@@ -572,7 +569,7 @@ namespace MonoDevelop.Ide
 			IdeApp.Workbench.LockGui ();
 
 			DispatchService.BackgroundDispatch (delegate {
-				BackgroundLoadWorkspace (monitor, filename, loadPreferences, reloading);
+				BackgroundLoadWorkspace (monitor, file, loadPreferences, reloading);
 			});
 			return oper;
 		}
@@ -593,7 +590,7 @@ namespace MonoDevelop.Ide
 			}
 		}
 		
-		void BackgroundLoadWorkspace (IProgressMonitor monitor, string filename, bool loadPreferences, bool reloading)
+		void BackgroundLoadWorkspace (IProgressMonitor monitor, FilePath file, bool loadPreferences, bool reloading)
 		{
 			WorkspaceItem item = null;
 			ITimeTracker timer = Counters.OpenWorkspaceItemTimer.BeginTiming ();
@@ -602,15 +599,15 @@ namespace MonoDevelop.Ide
 				if (reloading)
 					SetReloading (true);
 
-				if (!File.Exists (filename)) {
-					monitor.ReportError (GettextCatalog.GetString ("File not found: {0}", filename), null);
+				if (!File.Exists (file)) {
+					monitor.ReportError (GettextCatalog.GetString ("File not found: {0}", file), null);
 					monitor.Dispose ();
 					return;
 				}
 
-				if (!Services.ProjectService.IsWorkspaceItemFile (filename)) {
-					if (!Services.ProjectService.IsSolutionItemFile (filename)) {
-						monitor.ReportError (GettextCatalog.GetString ("File is not a project or solution: {0}", filename), null);
+				if (!Services.ProjectService.IsWorkspaceItemFile (file)) {
+					if (!Services.ProjectService.IsSolutionItemFile (file)) {
+						monitor.ReportError (GettextCatalog.GetString ("File is not a project or solution: {0}", file), null);
 						monitor.Dispose ();
 						return;
 					}
@@ -618,12 +615,12 @@ namespace MonoDevelop.Ide
 					// It is a project, not a solution. Try to create a dummy solution and add the project to it
 					
 					timer.Trace ("Getting wrapper solution");
-					item = IdeApp.Services.ProjectService.GetWrapperSolution (monitor, filename);
+					item = IdeApp.Services.ProjectService.GetWrapperSolution (monitor, file.ToString());
 				}
 				
 				if (item == null) {
 					timer.Trace ("Reading item");
-					item = Services.ProjectService.ReadWorkspaceItem (monitor, filename);
+					item = Services.ProjectService.ReadWorkspaceItem (monitor, file);
 					if (monitor.IsCancelRequested) {
 						monitor.Dispose ();
 						return;


### PR DESCRIPTION
This file:/// translation pattern happens in many places:

 if (filename.StartsWith ("file://", StringComparison.Ordinal))
     filename = new Uri(filename).LocalPath;

All of them use strings for paths, which is a smell
(http://c2.com/cgi/wiki?PrimitiveObsession) so we can kill two
birds with one stone if we change them to use FilePath instead,
and move this path sanitization to the FilePath ctor.