### PR TITLE
Removed redundancy

### DIFF
--- a/main/src/addins/AspNet/Projects/AspNetAppProject.cs
+++ b/main/src/addins/AspNet/Projects/AspNetAppProject.cs
@@ -742,7 +742,7 @@ namespace MonoDevelop.AspNet.Projects
 		protected override IEnumerable<ExecutionTarget> OnGetExecutionTargets (ConfigurationSelector configuration)
 		{
 			var apps = new List<ExecutionTarget> ();
-			foreach (var browser in MonoDevelop.Ide.DesktopService.GetApplications ("test.html")) {
+			foreach (var browser in DesktopService.GetApplications ("test.html")) {
 				if (browser.IsDefault)
 					apps.Insert (0, new BrowserExecutionTarget (browser.Id,browser.DisplayName,browser));
 				else


### PR DESCRIPTION
Monodevelop.Ide is already referenced in the beginning..