### PR TITLE
[Ide] display message when no file is selected in "Add files from folder...

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -443,6 +443,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				return;
 				
 			var srcFiles = impdlg.SelectedFiles;
+			if(!srcFiles.Any())
+				MessageService.ShowMessage("No files selected");
+				
 			var targetFiles = srcFiles.Select (f => targetRoot.Combine (f.ToRelative (srcRoot)));
 
 			var added = IdeApp.ProjectOperations.AddFilesToProject (project, srcFiles.ToArray (), targetFiles.ToArray (), null).Any ();


### PR DESCRIPTION
..."

This patch fixes a part of bug 20291 . When no file is selected in the dialog box, both  'ok' and 'cancel' buttons simply close the dialog box. So , i have added a message dialog for 'ok' button, that displays a "No files selected" message . that simply distinguishes the two., and also help the user ..