### PR TITLE
[5.9][Gtk] Fix a NRE with Gtk projects creation.

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GtkProjectServiceExtension.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GtkProjectServiceExtension.cs
@@ -15,7 +15,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 				return false;
 			
 			DotNetProject project = item as DotNetProject;
-			return project != null && GtkDesignInfo.HasDesignedObjects (project);
+			return project != null && project.References.Count != 0 && GtkDesignInfo.HasDesignedObjects (project);
 		}
 
 		protected override BuildResult Build (IProgressMonitor monitor, SolutionEntityItem entry, ConfigurationSelector configuration)


### PR DESCRIPTION
I accidentally pushed to 5.9 and reverted this fix.

I'm re-reverting in a PR to apply the fix. This stops a NRE from happening when creating a Gtk project through the new Solution Dialog in case the gtk-sharp reference isn't set.