### PR TITLE
[Ide] Fix tree icon rendering issue

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs
@@ -823,7 +823,7 @@ namespace MonoDevelop.Ide
 				UnregisterTreeAnimation (ainfo);
 			}
 			if (iconId == null) {
-				treeStore.SetValue (iter, column, null);
+				treeStore.SetValue (iter, column, CellRendererImage.NullImage);
 			} else if (IsAnimation (iconId, size)) {
 				var anim = GetAnimatedIcon (iconId);
 				ainfo = new AnimatedTreeStoreIconInfo (treeStore, iter, column, anim, iconId);


### PR DESCRIPTION
CellRendererImage can't take null images. CellRendererImage.NullImage has
to be used instead.

Fixes bug #27323 - Lots of GtkTreeView errors due to new debugger visualizers