### PR TITLE
[5.9] Git version control disabled by default in New Project Dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
@@ -51,7 +51,7 @@ namespace MonoDevelop.Ide.Projects
 			CreateProjectDirectoryInsideSolutionDirectory = true;
 
 			CreateGitIgnoreFile = true;
-			UseGit = true;
+			UseGit = false;
 
 			Parameters = new ProjectCreateParameters ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -199,7 +199,7 @@ namespace MonoDevelop.Ide.Projects
 
 		void SetDefaultGitSettings ()
 		{
-			projectConfiguration.UseGit = PropertyService.Get (UseGitPropertyName, true);
+			projectConfiguration.UseGit = PropertyService.Get (UseGitPropertyName, false);
 			projectConfiguration.CreateGitIgnoreFile = PropertyService.Get (CreateGitIgnoreFilePropertyName, true);
 		}
 


### PR DESCRIPTION
The "Use git for version control" option is now disabled by default in the New Project dialog.