### PR TITLE
[NuGet] Prevent TaskCanceledException when check for updates cancelled

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdatedPackagesInSolutionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdatedPackagesInSolutionTests.cs
@@ -562,6 +562,25 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (0, updatedPackages.GetPackages ().Count ());
 		}
+
+		[Test]
+		public void CheckForUpdates_TaskCancelled_TaskResultIsNotReferenced ()
+		{
+			CreateUpdatedPackagesInSolution ();
+			taskFactory.RunTasksSynchronously = false;
+			FakePackageManagementProject project = AddProjectToSolution ();
+			project.AddPackageReference ("MyPackage", "1.0");
+			updatedPackagesInSolution.CheckForUpdates ();
+
+			var task = taskFactory.FakeTasksCreated [0] as FakeTask<CheckForUpdatesTask>;
+			task.IsCancelled = true;
+			task.ExecuteTaskButNotContinueWith ();
+			task.Result = null;
+
+			Assert.DoesNotThrow (() => {
+				task.ExecuteContinueWith ();
+			});
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForUpdatesTaskRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForUpdatesTaskRunner.cs
@@ -112,8 +112,10 @@ namespace MonoDevelop.PackageManagement
 				} else {
 					LoggingService.LogInternalError ("Check for updates task error.", task.Exception);
 				}
-			} else if (task.IsCancelled || !IsCurrentTask (task.Result)) {
+			} else if (task.IsCancelled) {
 				// Ignore.
+				return;
+			} else if (!IsCurrentTask (task.Result)) {
 				task.Result.Dispose ();
 				return;
 			} else {


### PR DESCRIPTION
The NuGet addin was accessing the Task's Result when the task was cancelled causing the TaskCanceledException to be thrown.