### PR TITLE
[Ide] Fix New Project dialog browse button truncated on Linux.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Ide.Projects.GtkProjectConfigurationWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Ide.Projects.GtkProjectConfigurationWidget.cs
@@ -120,7 +120,7 @@ namespace MonoDevelop.Ide.Projects
 			w4.TopAttach = ((uint)(7));
 			w4.BottomAttach = ((uint)(8));
 			w4.LeftAttach = ((uint)(1));
-			w4.RightAttach = ((uint)(2));
+			w4.RightAttach = ((uint)(3));
 			w4.XOptions = ((global::Gtk.AttachOptions)(4));
 			w4.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child projectConfigurationTable.Gtk.Table+TableChild
@@ -136,7 +136,7 @@ namespace MonoDevelop.Ide.Projects
 			w5.TopAttach = ((uint)(4));
 			w5.BottomAttach = ((uint)(5));
 			w5.LeftAttach = ((uint)(1));
-			w5.RightAttach = ((uint)(2));
+			w5.RightAttach = ((uint)(3));
 			w5.XOptions = ((global::Gtk.AttachOptions)(4));
 			w5.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child projectConfigurationTable.Gtk.Table+TableChild

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
@@ -11545,12 +11545,6 @@ Visual Studio generates a default ID for embedded resources, instead of simply u
                       <placeholder />
                     </child>
                     <child>
-                      <placeholder />
-                    </child>
-                    <child>
-                      <placeholder />
-                    </child>
-                    <child>
                       <widget class="Gtk.Button" id="browseButton">
                         <property name="MemberName" />
                         <property name="CanFocus">True</property>
@@ -11590,7 +11584,7 @@ Visual Studio generates a default ID for embedded resources, instead of simply u
                         <property name="TopAttach">7</property>
                         <property name="BottomAttach">8</property>
                         <property name="LeftAttach">1</property>
-                        <property name="RightAttach">2</property>
+                        <property name="RightAttach">3</property>
                         <property name="AutoSize">True</property>
                         <property name="XOptions">Fill</property>
                         <property name="YOptions">Fill</property>
@@ -11616,7 +11610,7 @@ Visual Studio generates a default ID for embedded resources, instead of simply u
                         <property name="TopAttach">4</property>
                         <property name="BottomAttach">5</property>
                         <property name="LeftAttach">1</property>
-                        <property name="RightAttach">2</property>
+                        <property name="RightAttach">3</property>
                         <property name="AutoSize">True</property>
                         <property name="XOptions">Fill</property>
                         <property name="YOptions">Fill</property>


### PR DESCRIPTION
Fixed bug 27652 - New "New solution" dialog has a button "Browse..." which is cut off
https://bugzilla.xamarin.com/show_bug.cgi?id=27652

On Linux the font is larger and the text for the create gitignore label was causing the Browse button to be truncated. Now the labels extend into the last table column which contains the Browse button so the button is no longer truncated.