### PR TITLE
[Windows] Fix null reference exception when registry key is missing.

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
@@ -362,6 +362,8 @@ namespace MonoDevelop.Platform
 							apps[defaultProgid] = defaultApp = WindowsAppFromName (defaultProgid, true, AssociationFlags.None);
 					}
 					using (var sk = key.OpenSubKey ("OpenWithProgids")) {
+						if (sk == null)
+							continue;
 						foreach (var progid in sk.GetValueNames ()) {
 							if (!apps.ContainsKey (progid))
 								apps[progid] = WindowsAppFromName (progid, false, AssociationFlags.None);


### PR DESCRIPTION
[Fixed bug 26622](https://bugzilla.xamarin.com/show_bug.cgi?id=26622) - Getting error "Save failed. Object reference not set to an instance of an object" when create ASP.NET MVC Razor Project template.

Handle a missing OpenWithProgids registry key when finding apps for a particular file extension.