### PR TITLE
[Coverage] Add a make coverage option to run coverage tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ run-gdb:
 test:
 	cd main && $(MAKE) test assembly=$(assembly)
 
+coverage:
+	cd main && $(MAKE) coverage
+
 check-addins:
 	cd main && $(MAKE) check-addins
 

--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -152,6 +152,9 @@ check-addins:
 test:
 	cd tests && $(MAKE) test assembly=$(assembly)
 
+coverage:
+	cd tests && $(MAKE) coverage
+
 app-dir: all
 	cd build && make app-dir
 #mkdir -p $(MAC_APP_DIR)/Contents/{MacOS,Resources}

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -69,6 +69,14 @@ test:
 		fi; \
 	fi
 
+coverage:
+	if ! test -n "$(assembly)"; then \
+		for asm in $(TEST_ASSEMBLIES); do \
+			echo Generating coverage for `basename $$asm`...; \
+			($(MD_LAUNCH_SETUP) exec -a "mdtool" $(RUNTIME) --debug --profile=log:coverage,output=CoverageResult_`basename $$asm`.mlpd "$(MD_BIN_PATH)/mdtool.exe" run-md-tests $$asm); \
+		done; \
+	fi
+
 include $(top_srcdir)/Makefile.include
 
 EXTRA_DIST = \


### PR DESCRIPTION
Requires the patch set in https://github.com/mono/mono/pull/1616 to be applied to mono so the log profiler has coverage support