### PR TITLE
[Ide] Fix carriage return added to project name in New Project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
@@ -56,6 +56,11 @@ namespace MonoDevelop.Ide.Projects
 			projectNameTextBox.ActivatesDefault = true;
 			solutionNameTextBox.ActivatesDefault = true;
 			locationTextBox.ActivatesDefault = true;
+
+			projectNameTextBox.TruncateMultiline = true;
+			solutionNameTextBox.TruncateMultiline = true;
+			locationTextBox.TruncateMultiline = true;
+
 			RegisterEvents ();
 		}
 
@@ -75,6 +80,7 @@ namespace MonoDevelop.Ide.Projects
 		void RegisterEvents ()
 		{
 			locationTextBox.Changed += (sender, e) => OnLocationTextBoxChanged ();
+			projectNameTextBox.TextInserted += ProjectNameTextInserted;
 			projectNameTextBox.Changed += (sender, e) => OnProjectNameTextBoxChanged ();
 			solutionNameTextBox.Changed += (sender, e) => OnSolutionNameTextBoxChanged ();
 			createGitIgnoreFileCheckBox.Clicked += (sender, e) => OnCreateGitIgnoreFileCheckBoxClicked ();
@@ -87,6 +93,14 @@ namespace MonoDevelop.Ide.Projects
 		{
 			projectConfiguration.Location = locationTextBox.Text;
 			projectFolderPreviewWidget.UpdateLocation ();
+		}
+
+		void ProjectNameTextInserted (object o, TextInsertedArgs args)
+		{
+			if (args.Text.IndexOf ('\r') >= 0) {
+				var textBox = (Entry)o;
+				textBox.Text = textBox.Text.Replace ("\r", string.Empty);
+			}
 		}
 
 		void OnProjectNameTextBoxChanged ()


### PR DESCRIPTION
Fixed [bug 27872](https://bugzilla.xamarin.com/show_bug.cgi?id=27872) - Pressing enter twice in New Project dialog adds new line to project name

On the Mac pressing the enter/return key twice quickly when the New Project dialog was first shown would insert a carriage return \r into the project name text box. The carriage return is now removed from the text box. Also pasting in multiple lines into any of the text boxes will not insert any new line characters but only
the first line of pasted text.