### PR TITLE
[Docking] Don't disable AcceptFocus on the window or it confuses focus.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -862,7 +862,6 @@ namespace MonoDevelop.Components.Docking
 
 			if (UseWindowsForTopLevelFrames) {
 				var win = new Gtk.Window (Gtk.WindowType.Toplevel);
-				win.AcceptFocus = false;
 				win.SkipTaskbarHint = true;
 				win.Decorated = false;
 				win.TypeHint = Gdk.WindowTypeHint.Toolbar;


### PR DESCRIPTION
When a pad is shown (for example Toolbox) it appears to have focus, but
in reality it doesn't because it's been blocked from accepting. At this
point we visually have input in the pad, but it's actually in the text
editor, and the only way to correct it (and get auto-hiding to work again)
is to click/focus the widget that already visually appears to have focus
so that it actually *does* have focus.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=27917