### PR TITLE
[Ide] When window is unfocused, let most system commands fall through

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -374,12 +374,26 @@ namespace MonoDevelop.Components.Commands
 			}
 			
 			bool bypass = false;
+			List<string> catchInAllWindows = new List<string> {
+				"MonoDevelop.Ide.Commands.EditCommands.SelectAll",
+				"MonoDevelop.Ide.Commands.EditCommands.Cut",
+				"MonoDevelop.Ide.Commands.EditCommands.Paste",
+				"MonoDevelop.Ide.Commands.EditCommands.Copy"
+			};
 			for (int i = 0; i < commands.Count; i++) {
 				CommandInfo cinfo = GetCommandInfo (commands[i].Id, new CommandTargetRoute ());
 				if (cinfo.Bypass) {
 					bypass = true;
 					continue;
 				}
+
+				var focusSkip = !catchInAllWindows.Contains (commands [i].Id.ToString ()) && !IdeApp.Workbench.HasToplevelFocus;
+
+				if (focusSkip) {
+					bypass = true;
+					continue;
+				}
+
 				if (cinfo.Enabled && cinfo.Visible && DispatchCommand (commands[i].Id, CommandSource.Keybinding))
 					return result;
 			}


### PR DESCRIPTION
When our main window isn't focused, most system commands should
just pass through. For example, Cmd-Shift-G in the file open
dialog should open the "Go to folder" sheet.

Exceptions to this are made for SelectAll, Cut, Copy, Paste.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=27940