### PR TITLE
Revert "[Debugger] Set tooltip window types/hints based on platform"

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueWindow.cs
@@ -70,11 +70,10 @@ namespace MonoDevelop.SourceEditor
 		ScrolledWindow sw;
 //		PinWindow pinWindow;
 //		TreeIter currentPinIter;
-
-		public DebugValueWindow (Mono.TextEditor.TextEditor editor, int offset, StackFrame frame, ObjectValue value, PinnedWatch watch)
-			: base (MonoDevelop.Core.Platform.IsMac ? Gtk.WindowType.Toplevel : Gtk.WindowType.Popup)
+		
+		public DebugValueWindow (Mono.TextEditor.TextEditor editor, int offset, StackFrame frame, ObjectValue value, PinnedWatch watch): base (Gtk.WindowType.Toplevel)
 		{
-			this.TypeHint = MonoDevelop.Core.Platform.IsMac ? WindowTypeHint.PopupMenu : WindowTypeHint.Tooltip;
+			this.TypeHint = WindowTypeHint.PopupMenu;
 			this.AllowShrink = false;
 			this.AllowGrow = false;
 			this.Decorated = false;


### PR DESCRIPTION
This reverts commit b627818f26dfb37b39b1a6ac60299f09bd83b7ed.

This causes a bigger problem than the one it solves. This PR is to revert it for 5.9