### PR TITLE
[Mac] Check that the dialog is visible before raising over native docks

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -881,7 +881,7 @@ namespace MonoDevelop.Components.Docking
 				/* When we use real windows for frames, it's possible for pads to be over other
 				 * windows. For some reason simply presenting or raising those dialogs doesn't
 				 * seem to work, so we hide/show them in order to force them above the pad. */
-				var toplevels = Gtk.Window.ListToplevels ().Where (t => t.IsRealized && t.TypeHint == WindowTypeHint.Dialog); // && t.TransientFor != null);
+				var toplevels = Gtk.Window.ListToplevels ().Where (t => t.IsRealized && t.Visible && t.TypeHint == WindowTypeHint.Dialog); // && t.TransientFor != null);
 				foreach (var t in toplevels) {
 					t.Hide ();
 					t.Show ();


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=27868