### PR TITLE
5.9 last xmtoolbar fixes

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/GtkQuartz.cs
+++ b/main/src/addins/MacPlatform/MacInterop/GtkQuartz.cs
@@ -49,6 +49,9 @@ namespace MonoDevelop.MacInterop
 
 		public static Gtk.Window GetGtkWindow (NSWindow window)
 		{
+			if (window == null)
+				return null;
+
 			var toplevels = Gtk.Window.ListToplevels ();
 			return toplevels.FirstOrDefault (w => w.IsRealized && (gdk_quartz_window_get_nswindow (w.GdkWindow.Handle) == window.Handle));
 		}

--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Components.MainToolbar;
 using MonoDevelop.Core;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
@@ -176,11 +177,19 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		NSToolbarItem CreateStatusBarToolbarItem ()
 		{
-			return new NSToolbarItem (StatusBarId) {
-				View = new StatusBar (),
+			var bar = new StatusBar ();
+			var item = new NSToolbarItem (StatusBarId) {
+				View = bar,
+				// Place some temporary values in there.
 				MinSize = new CGSize (360, 22),
 				MaxSize = new CGSize (360, 22),
 			};
+
+			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidResizeNotification, notif => {
+				item.MinSize = new CGSize ((nfloat)Math.Round (bar.Window.Frame.Width * 0.25f), 22);
+				item.MaxSize = new CGSize ((nfloat)Math.Round (bar.Window.Screen.Frame.Width * 0.25f), 22);
+			});
+			return item;
 		}
 
 		NSToolbarItem CreateCenteringSpaceItem ()

--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -149,6 +149,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				if (SearchEntryLostFocus != null)
 					SearchEntryLostFocus (o, e);
 			};
+			bar.Activated += (o, e) => {
+				if (SearchEntryActivated != null)
+					SearchEntryActivated (o, e);
+			};
 			bar.EventsAttached = true;
 		}
 
@@ -251,21 +255,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				var menu = clipItem.Menu;
 				var searchItem = menu.ItemAt (0);
 				var searchView = (SearchBar)searchItem.View;
-				if (!searchView.EventsAttached) {
-						searchView.Changed += (o, e) => {
-						if (SearchEntryChanged != null)
-							SearchEntryChanged (o, e);
-					};
-					searchView.KeyPressed += (o, e) => {
-						if (SearchEntryKeyPressed != null)
-							SearchEntryKeyPressed (o, e);
-					};
-					searchView.LostFocus += (o, e) => {
-						if (SearchEntryLostFocus != null)
-							SearchEntryLostFocus (o, e);
-					};
-					searchView.EventsAttached = true;
-				}
+				AttachToolbarEvents (searchView);
 				menu.PopUpMenu (menu.ItemAt (0), new CGPoint (0, -5), clipItem);
 				searchView.SelectText (searchView);
 			}

--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -169,7 +169,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					View = menuBar,
 				},
 				MinSize = new CGSize (180, bar.FittingSize.Height),
-				MaxSize = new CGSize (180, bar.FittingSize.Height),
+				MaxSize = new CGSize (270, bar.FittingSize.Height),
 			};
 			AttachToolbarEvents (bar);
 			return item;

--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -186,8 +186,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			};
 
 			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidResizeNotification, notif => {
-				item.MinSize = new CGSize ((nfloat)Math.Round (bar.Window.Frame.Width * 0.25f), 22);
-				item.MaxSize = new CGSize ((nfloat)Math.Round (bar.Window.Screen.Frame.Width * 0.25f), 22);
+				double size = Math.Round (bar.Window.Frame.Width * 0.25f);
+				item.MinSize = new CGSize ((nfloat)Math.Max (300, size), 22);
+				item.MaxSize = new CGSize ((nfloat)Math.Min (600, size), 22);
+				bar.RepositionStatusLayers ();
 			});
 			return item;
 		}

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		internal Widget gtkWidget;
 		internal event EventHandler<Xwt.KeyEventArgs> KeyPressed;
 		internal event EventHandler LostFocus;
+		new internal event EventHandler Activated;
 
 		/// <summary>
 		/// This tells whether events have been attached when created from the menu.
@@ -132,13 +133,17 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public override void DidEndEditing (NSNotification notification)
 		{
-			nint value = ((NSNumber)notification.UserInfo.ValueForKey ((NSString)"NSTextMovement")).LongValue;
-			if (value == (nint)(long)NSTextMovement.Return ||
-				value == (nint)(long)NSTextMovement.Tab) {
-				if (value == (nint)(long)NSTextMovement.Return)
-					SendKeyPressed (Xwt.Key.Return, Xwt.ModifierKeys.None);
+			base.DidEndEditing (notification);
 
+			nint value = ((NSNumber)notification.UserInfo.ValueForKey ((NSString)"NSTextMovement")).LongValue;
+			if (value == (nint)(long)NSTextMovement.Tab) {
 				SelectText (this);
+				return;
+			}
+
+			if (value == (nint)(long)NSTextMovement.Return) {
+				if (Activated != null)
+					Activated (this, null);
 				return;
 			}
 
@@ -146,8 +151,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			var replacedWith = notification.UserInfo.ValueForKey ((NSString)"_NSFirstResponderReplacingFieldEditor");
 			if (replacedWith != this && LostFocus != null)
 				LostFocus (this, null);
-
-			base.DidEndEditing (notification);
 		}
 
 		public override void ViewDidMoveToWindow ()

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -211,7 +211,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			if (imageView.Frame == CGRect.Empty)
 				imageView.Frame = new CGRect (6, 0, 16, Frame.Height);
 			if (textField.Frame == CGRect.Empty)
-				textField.Frame = new CGRect (imageView.Frame.Right, 0, Frame.Width, Frame.Height);
+				textField.Frame = new CGRect (imageView.Frame.Right, 0, Frame.Width - 16, Frame.Height);
 
 			base.DrawRect (dirtyRect);
 		}

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -167,25 +167,27 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 						wc++;
 				}
 
-				if (ec > 0) {
-					buildResultVisible = true;
-					buildResultText.AttributedString = new NSAttributedString (ec.ToString (), foregroundColor: NSColor.Text,
-						font: NSFont.SystemFontOfSize (NSFont.SmallSystemFontSize - 1));
-					buildResultText.ContentsScale = Window.BackingScaleFactor;
-					buildResultIcon.SetImage (buildImageId = "md-status-error-count", Window.BackingScaleFactor);
-				} else if (wc > 0) {
-					buildResultVisible = true;
-					buildResultText.AttributedString = new NSAttributedString (wc.ToString (), foregroundColor: NSColor.Text,
-						font: NSFont.SystemFontOfSize (NSFont.SmallSystemFontSize - 1));
-					buildResultText.ContentsScale = Window.BackingScaleFactor;
-					buildResultIcon.SetImage (buildImageId = "md-status-warning-count", Window.BackingScaleFactor);
-				} else
-					buildResultVisible = false;
+				DispatchService.GuiDispatch (delegate {
+					if (ec > 0) {
+						buildResultVisible = true;
+						buildResultText.AttributedString = new NSAttributedString (ec.ToString (), foregroundColor: NSColor.Text,
+							font: NSFont.SystemFontOfSize (NSFont.SmallSystemFontSize - 1));
+						buildResultText.ContentsScale = Window.BackingScaleFactor;
+						buildResultIcon.SetImage (buildImageId = "md-status-error-count", Window.BackingScaleFactor);
+					} else if (wc > 0) {
+						buildResultVisible = true;
+						buildResultText.AttributedString = new NSAttributedString (wc.ToString (), foregroundColor: NSColor.Text,
+							font: NSFont.SystemFontOfSize (NSFont.SmallSystemFontSize - 1));
+						buildResultText.ContentsScale = Window.BackingScaleFactor;
+						buildResultIcon.SetImage (buildImageId = "md-status-warning-count", Window.BackingScaleFactor);
+					} else
+						buildResultVisible = false;
 
-				nfloat buildResultPosition = DrawBuildResults ();
-				if (buildResultPosition == nfloat.PositiveInfinity)
-					return;
-				textField.SetFrameSize (new CGSize (buildResultPosition - 6 - textField.Frame.Left, Frame.Height));
+					nfloat buildResultPosition = DrawBuildResults ();
+					if (buildResultPosition == nfloat.PositiveInfinity)
+						return;
+					textField.SetFrameSize (new CGSize (buildResultPosition - 6 - textField.Frame.Left, Frame.Height));
+				});
 			};
 
 			updateHandler (null, null);

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -350,7 +350,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			nfloat buildResultPosition = DrawBuildResults ();
 			if (buildResultPosition < right) { // We have a build result layer.
-				textField.SetFrameSize (new CGSize (right - 6 - textField.Frame.Left, Frame.Height));
+				textField.SetFrameSize (new CGSize (buildResultPosition - 6 - textField.Frame.Left, Frame.Height));
 			} else if (last != null) { // We only have status icons.
 				textField.SetFrameSize (new CGSize (right - 6 - textField.Frame.Left, Frame.Height));
 			} else { // Fill the bar.

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -334,6 +334,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		internal void RepositionStatusLayers ()
 		{
 			nfloat right = Layer.Frame.Width;
+			CATransaction.DisableActions = true;
 			foreach (var item in Layer.Sublayers) {
 				if (item.Name != null && item.Name.StartsWith (StatusIconPrefixId, StringComparison.Ordinal)) {
 					var icon = layerToStatus [item.Name];
@@ -350,6 +351,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 
 			nfloat buildResultPosition = DrawBuildResults ();
+			CATransaction.DisableActions = false;
 			if (buildResultPosition < right) { // We have a build result layer.
 				textField.SetFrameSize (new CGSize (buildResultPosition - 6 - textField.Frame.Left, Frame.Height));
 			} else

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
@@ -60,6 +60,9 @@ namespace MonoDevelop.Components.Mac
 
 		public static Gtk.Window GetGtkWindow (NSWindow window)
 		{
+			if (window == null)
+				return null;
+
 			var toplevels = Gtk.Window.ListToplevels ();
 			return toplevels.FirstOrDefault (w => w.IsRealized && gdk_quartz_window_get_nswindow (w.GdkWindow.Handle) == window.Handle);
 		}


### PR DESCRIPTION
There are a few items remaining, but I can't fix them:

Undo/redo for NSTextField
https://bugzilla.xamarin.com/show_bug.cgi?id=27920

Reopened branch as-per no-force-push policy. Will start using forks from now on.