### PR TITLE
[DesignerSupport] Use outline sort model to get the first item instead of the outline model.

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs
@@ -308,8 +308,14 @@ namespace MonoDevelop.DesignerSupport
 			if (lastCU != null) {
 				BuildTreeChildren (outlineTreeStore, TreeIter.Zero, lastCU);
 				TreeIter it;
-				if (outlineTreeModelSort.GetIterFirst (out it))
-					outlineTreeView.Selection.SelectIter (it);
+				if (IsSorting ()) {
+					if (outlineTreeModelSort.GetIterFirst (out it))
+						outlineTreeView.Selection.SelectIter (it);
+				} else {
+					if (outlineTreeStore.GetIterFirst (out it))
+						outlineTreeView.Selection.SelectIter (it);
+				}
+
 				outlineTreeView.ExpandAll ();
 			}
 			outlineReady = true;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs
@@ -308,7 +308,7 @@ namespace MonoDevelop.DesignerSupport
 			if (lastCU != null) {
 				BuildTreeChildren (outlineTreeStore, TreeIter.Zero, lastCU);
 				TreeIter it;
-				if (outlineTreeStore.GetIterFirst (out it))
+				if (outlineTreeModelSort.GetIterFirst (out it))
 					outlineTreeView.Selection.SelectIter (it);
 				outlineTreeView.ExpandAll ();
 			}


### PR DESCRIPTION
Addresses the warnings that flood the ide.log in the form of

ERROR [2015-03-16 14:33:51Z]: Gtk-Critical: GtkTreePath *gtk_tree_model_sort_get_path(GtkTreeModel *, GtkTreeIter *): assertion `tree_model_sort->stamp == iter->stamp' failed
Stack trace:
   at Gtk.TreeSelection.gtk_tree_selection_select_iter(IntPtr , IntPtr )
   at Gtk.TreeSelection.SelectIter(TreeIter iter) in /private/tmp/source-mono-mac-4.0.0-branch/bockbuild-mono-4.0.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-2.12.21/gtk/generated/TreeSelection.cs:line 133
   at MonoDevelop.DesignerSupport.ClassOutlineTextEditorExtension.RefillOutlineStore() in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs:line 312
   at GLib.Timeout+TimeoutProxy.Handler() in /private/tmp/source-mono-mac-4.0.0-branch/bockbuild-mono-4.0.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-2.12.21/glib/Timeout.cs:line 70
   at Gtk.Application.gtk_main()
   at Gtk.Application.Run() in /private/tmp/source-mono-mac-4.0.0-branch/bockbuild-mono-4.0.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-2.12.21/gtk/Application.cs:line 135
   at MonoDevelop.Ide.IdeApp.Run() in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs:line 374
   at MonoDevelop.Ide.IdeStartup.Run(MonoDevelop.Ide.MonoDevelopOptions options) in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:line 288
   at MonoDevelop.Ide.IdeStartup.Main(System.String[] args, MonoDevelop.Ide.Extensions.IdeCustomizer customizer) in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:line 649
   at Xamarin.Startup.MainClass.Main(System.String[] args) in /Users/builder/data/lanes/1494/9ebd512b/source/md-addins/Xamarin.Startup/Main.cs:line 11

and

ERROR [2015-03-16 14:34:02Z]: Gtk-Critical: GtkTreePath *gtk_tree_model_sort_get_path(GtkTreeModel *, GtkTreeIter *): assertion `tree_model_sort->stamp == iter->stamp' failed
Stack trace:
   at Gtk.TreeSelection.gtk_tree_selection_select_iter(IntPtr , IntPtr )
   at Gtk.TreeSelection.SelectIter(TreeIter iter) in /private/tmp/source-mono-mac-4.0.0-branch/bockbuild-mono-4.0.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-2.12.21/gtk/generated/TreeSelection.cs:line 133
   at MonoDevelop.DesignerSupport.ClassOutlineTextEditorExtension.RefillOutlineStore() in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs:line 312
   at GLib.Timeout+TimeoutProxy.Handler() in /private/tmp/source-mono-mac-4.0.0-branch/bockbuild-mono-4.0.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-2.12.21/glib/Timeout.cs:line 70
   at Gtk.Application.gtk_main()
   at Gtk.Application.Run() in /private/tmp/source-mono-mac-4.0.0-branch/bockbuild-mono-4.0.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-2.12.21/gtk/Application.cs:line 135
   at MonoDevelop.Ide.IdeApp.Run() in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs:line 374
   at MonoDevelop.Ide.IdeStartup.Run(MonoDevelop.Ide.MonoDevelopOptions options) in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:line 288
   at MonoDevelop.Ide.IdeStartup.Main(System.String[] args, MonoDevelop.Ide.Extensions.IdeCustomizer customizer) in /Users/builder/data/lanes/1494/9ebd512b/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:line 649
   at Xamarin.Startup.MainClass.Main(System.String[] args) in /Users/builder/data/lanes/1494/9ebd512b/source/md-addins/Xamarin.Startup/Main.cs:line 11