### PR TITLE
[DesignerSupport] Use outline sort model to get the first item instead o...

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ClassOutlineTextEditorExtension.cs
@@ -308,8 +308,14 @@ namespace MonoDevelop.DesignerSupport
 			if (lastCU != null) {
 				BuildTreeChildren (outlineTreeStore, TreeIter.Zero, lastCU);
 				TreeIter it;
-				if (outlineTreeStore.GetIterFirst (out it))
-					outlineTreeView.Selection.SelectIter (it);
+				if (IsSorting ()) {
+					if (outlineTreeModelSort.GetIterFirst (out it))
+						outlineTreeView.Selection.SelectIter (it);
+				} else {
+					if (outlineTreeStore.GetIterFirst (out it))
+						outlineTreeView.Selection.SelectIter (it);
+				}
+
 				outlineTreeView.ExpandAll ();
 			}
 			outlineReady = true;


### PR DESCRIPTION
...f the outline model when the outline is sorted.

Addresses the warnings that flood the ide.log in the form of

ERROR [2015-03-16 14:33:51Z]: Gtk-Critical: GtkTreePath *gtk_tree_model_sort_get_path(GtkTreeModel *, GtkTreeIter *): assertion `tree_model_sort->stamp == iter->stamp' failed