### PR TITLE
Added a WindowRole for WorkbenchWindows

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchWindow.cs
@@ -36,6 +36,7 @@ namespace MonoDevelop.Ide.Gui
 		public WorkbenchWindow (): base (Gtk.WindowType.Toplevel)
 		{
 			Mono.TextEditor.GtkWorkarounds.FixContainerLeak (this);
+			this.Role = "workbench";
 		}
 
 		class TopLevelChild


### PR DESCRIPTION
Added a WindowRole for WorkbenchWindows of Monodevelop to allow target-oriented Rule-Creation in Windowmanagers like KWin.
This implements [FeatureRequest#23062](https://bugzilla.xamarin.com/show_bug.cgi?id=23062)