### PR TITLE
[Core] Fix terminating error when creating new solution.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectService.cs
@@ -559,6 +559,9 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 						string responseKey = "[MonoDevelop]";
 						string sref = null;
 						p.ErrorDataReceived += (sender, e) => {
+							if (e.Data == null)
+								return;
+
 							if (e.Data.StartsWith (responseKey, StringComparison.Ordinal)) {
 								sref = e.Data.Substring (responseKey.Length);
 								ev.Set ();


### PR DESCRIPTION
Fixed bug [28323](https://bugzilla.xamarin.com/show_bug.cgi?id=28323) - MonoDevelop terminating error when creating new solution with solution already opened.

The DataReceivedEventArgs passed to the event handler for the Process.ErrorDataReceived event can have a null Data property on Windows.