### PR TITLE
Monodevelop 5.9 branch bug 19640

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -381,7 +381,9 @@ namespace MonoDevelop.Ide.Gui
 				if (doc != null && doc.ParsedFile != null) {
 					string fileName = Window.ViewContent.ContentName;
 					try {
-						doc.ParsedFile.LastWriteTime = File.GetLastWriteTimeUtc (fileName);
+						// filename could be null if the user cancelled SaveAs and this is a new & unsaved file
+						if (fileName != null)
+							doc.ParsedFile.LastWriteTime = File.GetLastWriteTimeUtc (fileName);
 					} catch (Exception e) {
 						doc.ParsedFile.LastWriteTime = DateTime.UtcNow;
 						LoggingService.LogWarning ("Exception while getting the write time from " + fileName, e); 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -761,23 +761,8 @@ namespace MonoDevelop.Ide.Gui
 				    GettextCatalog.GetString ("If you don't save, all changes will be permanently lost."),
 				    AlertButton.CloseWithoutSave, AlertButton.Cancel, window.ViewContent.IsUntitled ? AlertButton.SaveAs : AlertButton.Save);
 				if (result == AlertButton.Save || result == AlertButton.SaveAs) {
-					if (window.ViewContent.ContentName == null) {
-						FindDocument (window).Save ();
-						args.Cancel = window.ViewContent.IsDirty;
-					} else {
-						try {
-							if (window.ViewContent.IsFile)
-								window.ViewContent.Save (window.ViewContent.ContentName);
-							else
-								window.ViewContent.Save ();
-							args.Cancel |= window.ViewContent.IsDirty;
-
-						}
-						catch (Exception ex) {
-							args.Cancel = true;
-							MessageService.ShowError (GettextCatalog.GetString ("The document could not be saved."), ex);
-						}
-					}
+					FindDocument (window).Save ();
+					args.Cancel = window.ViewContent.IsDirty;
 					if (args.Cancel)
 						FindDocument (window).Select ();
 				} else {


### PR DESCRIPTION
Fixes bug 19640 - Resource.designer.cs not recompiled on close-and-save

When prompting the user to save the file if the user closes the document, we don't send a file change event. We should really be calling Document.Save() rather than replicating part of the save logic here.

Also addresses a minor error where, if the file is unsaved, and the user cancels the SaveAs, we get an ArgumentNullException.