### PR TITLE
[Core] Fix fast-build-check issue

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionEntityItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionEntityItem.cs
@@ -355,6 +355,7 @@ namespace MonoDevelop.Projects
 					return new BuildResult ();
 				}
 			} else if (target == ProjectService.CleanTarget) {
+				SetFastBuildCheckDirty ();
 				SolutionItemConfiguration config = GetConfiguration (configuration) as SolutionItemConfiguration;
 				if (config != null && config.CustomCommands.HasCommands (CustomCommandType.Clean)) {
 					config.CustomCommands.ExecuteCommand (monitor, this, CustomCommandType.Clean, configuration);


### PR DESCRIPTION
Mark a project as dirty for fast-build-check when it is cleaned.
Fixes bug #28449