### PR TITLE
Update UserInterfaceTests with template tests

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -125,6 +125,12 @@ namespace MonoDevelop.Components.AutoTest
 			return session.SelectWidget (name, focus);
 		}
 
+		public object GetPropertyValue (string propertyName)
+		{
+			ClearEventQueue ();
+			return session.GetPropertyValue (propertyName);
+		}
+
 		public bool SetPropertyValue (string propertyName, object value, object[] index = null)
 		{
 			ClearEventQueue ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -125,6 +125,12 @@ namespace MonoDevelop.Components.AutoTest
 			return session.SelectWidget (name, focus);
 		}
 
+		public bool SetPropertyValue (string propertyName, object value, object[] index = null)
+		{
+			ClearEventQueue ();
+			return session.SetPropertyValue (propertyName, value, index);
+		}
+
 		public object GlobalInvoke (string name, params object[] args)
 		{
 			ClearEventQueue ();
@@ -164,10 +170,10 @@ namespace MonoDevelop.Components.AutoTest
 			session.TypeText (text);
 		}
 
-		public void SelectTreeviewItem (string name)
+		public bool SelectTreeviewItem (string treeName, string name, string after = null)
 		{
 			ClearEventQueue ();
-			session.SelectTreeviewItem (name);
+			return session.SelectTreeviewItem (treeName, name, after);
 		}
 
 		public string[] GetTreeviewCells ()
@@ -175,6 +181,11 @@ namespace MonoDevelop.Components.AutoTest
 
 			ClearEventQueue ();
 			return session.GetTreeviewCells ();
+		}
+
+		public bool IsBuildSuccessful ()
+		{
+			return session.IsBuildSuccessful ();
 		}
 
 		public void PressKey (Gdk.Key key)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -326,6 +326,20 @@ namespace MonoDevelop.Components.AutoTest
 			});
 		}
 
+		public object GetPropertyValue (string propertyName)
+		{
+			return Sync (delegate {
+				PropertyInfo propertyInfo = CurrentObject.GetType().GetProperty(propertyName);
+				if (propertyInfo != null) {
+					var propertyValue = propertyInfo.GetValue (CurrentObject);
+					if (propertyValue != null)
+						return propertyValue;
+				}
+
+				return false;
+			});
+		}
+
 		public bool SetPropertyValue (string propertyName, object value, object[] index = null)
 		{
 			return (bool)Sync (delegate {

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -56,22 +56,12 @@ namespace UserInterfaceTests
 				var newProject = new NewProjectController ();
 				newProject.Open ();
 
-				Assert.IsTrue (newProject.SelectTemplateType (category, categoryRoot));
-				Thread.Sleep (3000);
-				Assert.IsTrue (newProject.SelectTemplate (kind));
-				Thread.Sleep (3000);
+				SelectTemplate (newProject, kind, category, categoryRoot);
 
 				Assert.IsTrue (newProject.Next ());
 				Thread.Sleep (3000);
 
-				Assert.IsTrue (newProject.SetProjectName (projectName));
-				Thread.Sleep (2000);
-
-				Assert.IsTrue (newProject.SetSolutionName (projectName));
-				Thread.Sleep (2000);
-
-				Assert.IsTrue (newProject.SetSolutionLocation (solutionParentDirectory));
-				Thread.Sleep (2000);
+				EnterProjectDetails (newProject, projectName, projectName, solutionParentDirectory);
 
 				Assert.IsTrue (newProject.CreateProjectInSolutionDirectory (false));
 				Thread.Sleep (2000);
@@ -90,6 +80,26 @@ namespace UserInterfaceTests
 				Directory.Delete (solutionParentDirectory, true);
 				Ide.CloseAll ();
 			}
+		}
+
+		public void SelectTemplate (NewProjectController newProject, string kind, string category, string categoryRoot)
+		{
+			Assert.IsTrue (newProject.SelectTemplateType (category, categoryRoot));
+			Thread.Sleep (3000);
+			Assert.IsTrue (newProject.SelectTemplate (kind));
+			Thread.Sleep (3000);
+		}
+
+		public void EnterProjectDetails (NewProjectController newProject, string projectName, string solutionName, string solutionLocation)
+		{
+			Assert.IsTrue (newProject.SetProjectName (projectName));
+			Thread.Sleep (2000);
+
+			Assert.IsTrue (newProject.SetSolutionName (solutionName));
+			Thread.Sleep (2000);
+
+			Assert.IsTrue (newProject.SetSolutionLocation (solutionLocation));
+			Thread.Sleep (2000);
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -52,6 +52,7 @@ namespace UserInterfaceTests
 		public void CreateBuildProject (string projectName, string kind, string category, string categoryRoot, Action beforeBuild)
 		{
 			var solutionParentDirectory = Util.CreateTmpDir (projectName);
+			string actualSolutionDirectory = string.Empty;
 			try {
 				var newProject = new NewProjectController ();
 				newProject.Open ();
@@ -72,13 +73,18 @@ namespace UserInterfaceTests
 				Assert.IsTrue (newProject.Next ());
 				Thread.Sleep (2000);
 
+				actualSolutionDirectory = GetSolutionDirectory ();
+
 				beforeBuild ();
 				Thread.Sleep (1000);
 
 				Assert.IsTrue (Ide.BuildSolution ());
 			} finally {
-				Directory.Delete (solutionParentDirectory, true);
 				Ide.CloseAll ();
+				try {
+					if (Directory.Exists (actualSolutionDirectory))
+						Directory.Delete (actualSolutionDirectory, true);
+				} catch (IOException) { }
 			}
 		}
 
@@ -95,11 +101,20 @@ namespace UserInterfaceTests
 			Assert.IsTrue (newProject.SetProjectName (projectName));
 			Thread.Sleep (2000);
 
-			Assert.IsTrue (newProject.SetSolutionName (solutionName));
-			Thread.Sleep (2000);
+			if (!string.IsNullOrEmpty (solutionName)) {
+				Assert.IsTrue (newProject.SetSolutionName (solutionName));
+				Thread.Sleep (2000);
+			}
 
-			Assert.IsTrue (newProject.SetSolutionLocation (solutionLocation));
-			Thread.Sleep (2000);
+			if (!string.IsNullOrEmpty (solutionLocation)) {
+				Assert.IsTrue (newProject.SetSolutionLocation (solutionLocation));
+				Thread.Sleep (2000);
+			}
+		}
+
+		public string GetSolutionDirectory ()
+		{
+			return Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.ProjectOperations.CurrentSelectedSolution.RootFolder.BaseDirectory").ToString ();
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -26,12 +26,16 @@
 
 using System;
 using System.Threading;
+
 using MonoDevelop.Core;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide.Commands;
-using NUnit.Framework;
 using MonoDevelop.Components.AutoTest;
-using System.Linq;
+
+using NUnit.Framework;
+
+using Gdk;
+
 
 namespace UserInterfaceTests
 {
@@ -70,18 +74,18 @@ namespace UserInterfaceTests
 			return Session.GetGlobalValue<FilePath> ("MonoDevelop.Ide.IdeApp.Workbench.ActiveDocument.FileName");
 		}
 
-		public static void BuildSolution ()
+		public static bool BuildSolution (bool isPass = true)
 		{
 			RunAndWaitForTimer (
 				() => Session.ExecuteCommand (ProjectCommands.BuildSolution),
 				"MonoDevelop.Ide.Counters.BuildItemTimer"
 			);
 
-			var status = GetStatusMessage ();
-			Assert.AreEqual (status, "Build successful.");
+			var status = IsBuildSuccessful ();
+			return isPass == status;
 		}
 
-		static void WaitUntil (Func<bool> done, int timeout = 20000, int pollStep = 200)
+		public static void WaitUntil (Func<bool> done, int timeout = 20000, int pollStep = 200)
 		{
 			do {
 				if (done ())
@@ -96,12 +100,25 @@ namespace UserInterfaceTests
 		//no saner way to do this
 		public static string GetStatusMessage (int timeout = 20000)
 		{
-			//wait for any queued messages to pop
+			if (Platform.IsMac) {
+				WaitUntil (
+					() => Session.GetGlobalValue<string> ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.text") != string.Empty,
+					timeout
+				);
+				return (string)Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.text");
+			}
+
 			WaitUntil (
-				() => Session.GetGlobalValue<int> ("MonoDevelop.Ide.IdeApp.Workbench.Toolbar.statusArea.messageQueue.Count") == 0,
+				() => Session.GetGlobalValue<int> ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.messageQueue.Count") == 0,
 				timeout
 			);
-			return (string) Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.Toolbar.statusArea.renderArg.CurrentText");
+			return (string) Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.renderArg.CurrentText");
+		}
+
+		public static bool IsBuildSuccessful (int timeout = 3000)
+		{
+			Thread.Sleep (timeout);
+			return Session.IsBuildSuccessful ();
 		}
 
 		public static void RunAndWaitForTimer (Action action, string counter, int timeout = 20000)
@@ -112,28 +129,6 @@ namespace UserInterfaceTests
 			action ();
 
 			WaitUntil (() => c.TotalTime > tt, timeout);
-		}
-
-		public static void CreateProject (string name, string category, string kind, FilePath directory)
-		{
-			Session.ExecuteCommand (FileCommands.NewProject);
-			Session.WaitForWindow ("MonoDevelop.Ide.Projects.NewProjectDialog");
-
-			Session.SelectWidget ("lst_template_types");
-			Session.SelectTreeviewItem (category);
-
-			Session.SelectWidget ("boxTemplates");
-			var cells = Session.GetTreeviewCells ();
-			var cellName = cells.First (c => c!= null && c.StartsWith (kind + "\n", StringComparison.Ordinal));
-			Session.SelectTreeviewItem (cellName);
-
-			Gui.EnterText ("txt_name", name);
-			Gui.EnterText ("entry_location", directory);
-
-			RunAndWaitForTimer (
-				() => Gui.PressButton ("btn_new"),
-				"MonoDevelop.Ide.Counters.OpenDocumentTimer"
-			);
 		}
 	}
 

--- a/main/tests/UserInterfaceTests/MonoDevelopTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTemplatesTest.cs
@@ -24,18 +24,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System.Threading;
-
 using NUnit.Framework;
 
 namespace UserInterfaceTests
 {
-	/*
-	 * Project templates to be tested - Console Project, Library, Portable Library, NUnit Library, F# Tutorial
-	 * Projects which cannot be tested
-	 *  - Empty Project: They do not have a build target set
-	 *  - Gtk# 2.0 Project - Throws an error when created, though builds fine
-	 */
 	public class MonoDevelopTemplatesTest : CreateBuildTemplatesTestBase
 	{
 		readonly static string DotNetProjectKind = ".NET";

--- a/main/tests/UserInterfaceTests/MonoDevelopTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTemplatesTest.cs
@@ -1,0 +1,71 @@
+﻿//
+// MonoDevelopTemplatesTest.cs
+//
+// Author:
+//       Manish Sinha <manish.sinha@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Threading;
+
+using NUnit.Framework;
+
+namespace UserInterfaceTests
+{
+	/*
+	 * Project templates to be tested - Console Project, Library, Portable Library, NUnit Library, F# Tutorial
+	 * Projects which cannot be tested
+	 *  - Empty Project: They do not have a build target set
+	 *  - Gtk# 2.0 Project - Throws an error when created, though builds fine
+	 */
+	public class MonoDevelopTemplatesTest : CreateBuildTemplatesTestBase
+	{
+		readonly static string DotNetProjectKind = ".NET";
+
+		readonly static string CategoryRoot = "Other";
+
+		[Test]
+		public void TestCreateBuildConsoleProject ()
+		{
+			CreateBuildProject ("ConsoleProject", "Console Project", DotNetProjectKind, CategoryRoot, EmptyAction);
+		}
+
+		[Test]
+		public void TestCreateBuildGtkSharp20Project ()
+		{
+			CreateBuildProject ("Gtk20Project", "Gtk# 2.0 Project", DotNetProjectKind, CategoryRoot, EmptyAction);
+		}
+
+		[Test]
+		public void TestCreateBuildLibrary ()
+		{
+			CreateBuildProject ("Library", "Library", DotNetProjectKind, CategoryRoot, EmptyAction);
+		}
+
+		[Test]
+		public void TestCreateBuildNUnitLibraryProject ()
+		{
+			CreateBuildProject ("NUnitLibraryProject", "NUnit Library Project", DotNetProjectKind, CategoryRoot, delegate {
+				Ide.WaitUntil (() => Ide.GetStatusMessage () == "Package updates are available.", pollStep: 1000);
+			});
+		}
+	}
+}

--- a/main/tests/UserInterfaceTests/NewProjectController.cs
+++ b/main/tests/UserInterfaceTests/NewProjectController.cs
@@ -1,0 +1,112 @@
+﻿//
+// NewProjectController.cs
+//
+// Author:
+//       Manish Sinha <manish.sinha@xamarin.com>
+//
+// Copyright (c) 2015 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using MonoDevelop.Components.AutoTest;
+using MonoDevelop.Ide.Commands;
+using NUnit.Framework;
+using System.Threading;
+
+namespace UserInterfaceTests
+{
+	public class NewProjectController
+	{
+		static AutoTestClientSession Session {
+			get { return TestService.Session; }
+		}
+
+		public void Open (int delay = 2000)
+		{
+			Session.ExecuteCommand (FileCommands.NewProject);
+			Session.WaitForWindow ("MonoDevelop.Ide.Projects.GtkNewProjectDialogBackend");
+			Thread.Sleep (delay);
+		}
+
+		public bool SelectTemplateType (string type, string category)
+		{
+			return Session.SelectTreeviewItem ("templateCategoriesTreeView", type, category);
+		}
+
+		public bool SelectTemplate (string templateName)
+		{
+			return Session.SelectTreeviewItem ("templatesTreeView", templateName, null);
+		}
+
+		public bool Next ()
+		{
+			return Session.SelectWidget ("nextButton") && (bool)Session.Invoke ("Activate");
+		}
+
+		public bool Previous ()
+		{
+			return Session.SelectWidget ("previousButton") && (bool)Session.Invoke ("Activate");
+		}
+
+		public bool SetProjectName (string projectName)
+		{
+			return TypeTextInGtkEntry ("projectNameTextBox", projectName);
+		}
+
+		public bool SetSolutionName (string solutionName)
+		{
+			return TypeTextInGtkEntry ("solutionNameTextBox", solutionName);
+		}
+
+		public bool SetSolutionLocation (string solutionLocation)
+		{
+			return TypeTextInGtkEntry ("locationTextBox", solutionLocation);
+		}
+
+		public bool CreateProjectInSolutionDirectory (bool projectInSolution)
+		{
+			return SetCheckBox ("createProjectWithinSolutionDirectoryCheckBox", projectInSolution);
+		}
+
+		public bool UseGit (bool useGit, bool useGitIgnore = true)
+		{
+			var gitSelectionSuccess = SetCheckBox ("useGitCheckBox", useGit);
+			if (gitSelectionSuccess && useGit)
+				return gitSelectionSuccess && SetCheckBox ("createGitIgnoreFileCheckBox", useGitIgnore);
+			return gitSelectionSuccess;
+		}
+
+		bool SetCheckBox (string checkBoxName, bool active)
+		{
+			var widgetSelected = Session.SelectWidget (checkBoxName);
+			if (widgetSelected)
+				Session.SetPropertyValue ("Active", active);
+			return widgetSelected;
+		}
+
+		bool TypeTextInGtkEntry (string widgetName, string text)
+		{
+			var widgetSelected = Session.SelectWidget (widgetName);
+			if (widgetSelected)
+				Session.TypeText (text);
+			return widgetSelected;
+		}
+	}
+}
+

--- a/main/tests/UserInterfaceTests/NewProjectController.cs
+++ b/main/tests/UserInterfaceTests/NewProjectController.cs
@@ -92,20 +92,28 @@ namespace UserInterfaceTests
 			return gitSelectionSuccess;
 		}
 
-		bool SetCheckBox (string checkBoxName, bool active)
+		public bool SetCheckBox (string checkBoxName, bool active)
 		{
-			var widgetSelected = Session.SelectWidget (checkBoxName);
-			if (widgetSelected)
-				Session.SetPropertyValue ("Active", active);
-			return widgetSelected;
+			var setSuccess = Session.SelectWidget (checkBoxName);
+			if (setSuccess)
+				return setSuccess && Session.SetPropertyValue ("Active", active);
+			return setSuccess;
 		}
 
-		bool TypeTextInGtkEntry (string widgetName, string text)
+		public bool GetSensitivity (string widgetName)
 		{
-			var widgetSelected = Session.SelectWidget (widgetName);
-			if (widgetSelected)
+			var sensitiveSuccess = Session.SelectWidget (widgetName);
+			if (sensitiveSuccess)
+				return sensitiveSuccess && (bool)Session.GetPropertyValue ("Sensitive");
+			return sensitiveSuccess;
+		}
+
+		public bool TypeTextInGtkEntry (string widgetName, string text)
+		{
+			var typeSuccess = Session.SelectWidget (widgetName);
+			if (typeSuccess)
 				Session.TypeText (text);
-			return widgetSelected;
+			return typeSuccess;
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -39,15 +39,18 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\external\mdtestharness\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="UITestBase.cs" />
     <Compile Include="TestService.cs" />
     <Compile Include="Util.cs" />
-    <Compile Include="SimpleTest.cs" />
     <Compile Include="ProcessUtils.cs" />
     <Compile Include="Gui.cs" />
     <Compile Include="Ide.cs" />
+    <Compile Include="CreateBuildTemplatesTestBase.cs" />
+    <Compile Include="MonoDevelopTemplatesTest.cs" />
+    <Compile Include="NewProjectController.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/tests/UserInterfaceTests/Util.cs
+++ b/main/tests/UserInterfaceTests/Util.cs
@@ -81,12 +81,11 @@ namespace UserInterfaceTests
 
 		public static FilePath CreateTmpDir (string hint)
 		{
-			FilePath tmpDir = TmpDir.Combine (hint + "-" + projectId);
-			projectId++;
+			string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), hint);
 
-			if (!Directory.Exists (tmpDir))
-				Directory.CreateDirectory (tmpDir);
-			return tmpDir;
+			if (!Directory.Exists (tempDirectory))
+				Directory.CreateDirectory (tempDirectory);
+			return tempDirectory;
 		}
 
 		static void CopyDir (string src, string dst)


### PR DESCRIPTION
Fixes UserInterfaceTests

Tests templates for templates in file `MonoDevelopTemplatesTest.cs`
* Console Project
* Gtk# 2.0 Project
* Library
* NUnit Library Project

Steps taken for all the template tests
* Open `New Solution` dialog
* Select `.NET`
* Select the template type
* Click `OK`
* Enter `Project Name`
* Enter `Solution Name`
* Enter `Location`
* Asserts that `Create a project within the solution directory` is enable and visible. If yes, then unchecks it.
* Asserts that `Create a .gitignore file to ignore inessential files` is enabled and visible. If yes, then unchecks it.
* calls `beforeBuild` action, which is the action to be taken before the solution is built. In case of NUnit Project, that delegate blocks waiting for `Package updates are available.` to be visible in Status Bar
* Builds the project
* Check if there any error
* Closes the solution
* Tries to delete the solution folder. 