### PR TITLE
[Debugger] Bug 28550 and Hashtable values display on Mono4/.Net

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/SoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/SoftDebuggerEngine.cs
@@ -112,7 +112,7 @@ namespace MonoDevelop.Debugger.Soft
 				if (!File.Exists (file)) {
 					dsi.LogMessage = GettextCatalog.GetString ("User assembly '{0}' is missing. " +
 						"Debugger will now debug all code, not just user code.", file);
-					return;
+					continue;
 				}
 				
 				try {
@@ -128,7 +128,7 @@ namespace MonoDevelop.Debugger.Soft
 					dsi.LogMessage = GettextCatalog.GetString ("Could not get assembly name for user assembly '{0}'. " +
 						"Debugger will now debug all code, not just user code.", file);
 					LoggingService.LogError ("Error getting assembly name for user assembly '" + file + "'", ex);
-					return;
+					continue;
 				}
 			}
 			


### PR DESCRIPTION
[Bug 28550](https://bugzilla.xamarin.com/show_bug.cgi?id=28550) was discovered only now because UITests project was added and it's not referenced(hence built) on F5 bring this bug up...

Debugger bump is bringing only this commit: https://github.com/mono/debugger-libs/commit/c937df078222f1f910758d60adeda06ae706dc36