### PR TITLE
[code] Fix Generic collection argument type return for code template

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs
@@ -143,6 +143,7 @@ namespace MonoDevelop.Ide.CodeTemplates
 		
 		IType GetElementType (IType result)
 		{
+			IType tmp = null;
 			foreach (var baseType in result.GetAllBaseTypes ()) {
 				var baseTypeDef = baseType.GetDefinition();
 				if (baseTypeDef != null && baseTypeDef.Name == "IEnumerable") {
@@ -150,11 +151,11 @@ namespace MonoDevelop.Ide.CodeTemplates
 						if (baseType.TypeArguments.Count > 0)
 							return baseType.TypeArguments[0];
 					} else if (baseTypeDef.Namespace == "System.Collections" && baseTypeDef.TypeParameterCount == 0) {
-						return CurrentContext.Compilation.FindType (KnownTypeCode.Object);
+						tmp = CurrentContext.Compilation.FindType (KnownTypeCode.Object);
 					}
 				}
 			}
-			return new UnknownType ("", "", 0);
+			return tmp == null ? new UnknownType ("", "", 0) : tmp;
 		}
 		
 		


### PR DESCRIPTION
Fix codeTemplate **GetComponentTypeOf** bug for generic collections.

**note**
Default 'foreach' template does not handle automatic type by default.
to add it you have to:
- add type to template:  'foreach($type$ $id$ in $collection$)'
- set function parameter for type to: GetComponentTypeOf("collection")

I'm not sure where to add this in the MD/src tree, changes to 'MonoDevelop-templates.xml' does not seem to have effect.

*Details:*
IType.GetAllBaseType() extention method returns 'System.Collections ' prior to 'System.Collections.Generic'
which causes fetching Generic Collection parameter's type to fail in CodeTemplate mechanic.

	modified:         core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs