### PR TITLE
Allow Monodevelop executable path to be overridden from UITestBase

### DIFF
--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -39,6 +39,15 @@ namespace UserInterfaceTests
 	{
 		public readonly static Action EmptyAction = () => { };
 
+		public readonly static Action WaitForPackageUpdate = delegate {
+			Ide.WaitUntil (() => Ide.GetStatusMessage () == "Package updates are available.",
+				pollStep: 1000, timeout: 30000);
+		};
+
+		public CreateBuildTemplatesTestBase () {}
+
+		public CreateBuildTemplatesTestBase (string mdBinPath) : base (mdBinPath) {}
+
 		public void AssertExeHasOutput (string exe, string expectedOutput)
 		{
 			var sw = new StringWriter ();

--- a/main/tests/UserInterfaceTests/TestService.cs
+++ b/main/tests/UserInterfaceTests/TestService.cs
@@ -34,7 +34,7 @@ namespace UserInterfaceTests
 	{
 		public static AutoTestClientSession Session { get; private set; }
 
-		public static void StartSession ()
+		public static void StartSession (string monoDevelopBinPath = null)
 		{
 			Console.WriteLine ("Starting application");
 
@@ -42,7 +42,7 @@ namespace UserInterfaceTests
 
 			//TODO: support for testing the installed app
 
-			Session.StartApplication (environment: new Dictionary<string,string> {
+			Session.StartApplication (file: monoDevelopBinPath, environment: new Dictionary<string,string> {
 				{ "MONODEVELOP_TEST_PROFILE", Util.CreateTmpDir ("profile") }
 			});
 

--- a/main/tests/UserInterfaceTests/UITestBase.cs
+++ b/main/tests/UserInterfaceTests/UITestBase.cs
@@ -36,12 +36,21 @@ namespace UserInterfaceTests
 			get { return TestService.Session; }
 		}
 
+		public string MonoDevelopBinPath { get; set; }
+
+		public UITestBase () {}
+
+		public UITestBase (string mdBinPath)
+		{
+			MonoDevelopBinPath = mdBinPath;
+		}
+
 		[SetUp]
 		public virtual void SetUp ()
 		{
 			Util.ClearTmpDir ();
 
-			TestService.StartSession ();
+			TestService.StartSession (MonoDevelopBinPath);
 		}
 
 		[TearDown]


### PR DESCRIPTION
This would allow the addins to use UITestBase to create their own UITest and specify the MonoDevelop.exe location