### PR TITLE
5.9 [NUnit] Fix prompt always displayed when running NUnit project.

### DIFF
--- a/main/src/addins/NUnit/Services/NUnitProjectServiceExtension.cs
+++ b/main/src/addins/NUnit/Services/NUnitProjectServiceExtension.cs
@@ -44,14 +44,14 @@ namespace MonoDevelop.NUnit
 				if (test != null) {
 					IAsyncOperation oper = null;
 					DispatchService.GuiSyncDispatch (delegate {
-						oper = NUnitService.Instance.RunTest (test, context.ExecutionHandler, false);
+						oper = NUnitService.Instance.RunTest (test, context.ExecutionHandler, false, false);
 					});
-//					if (oper != null) {
-//						monitor.CancelRequested += delegate {
-//							oper.Cancel ();
-//						};
-//						oper.WaitForCompleted ();
-//					}
+					if (oper != null) {
+						monitor.CancelRequested += delegate {
+							oper.Cancel ();
+						};
+						oper.WaitForCompleted ();
+					}
 				}
 			}
 		}

--- a/main/src/addins/NUnit/Services/NUnitService.cs
+++ b/main/src/addins/NUnit/Services/NUnitService.cs
@@ -108,6 +108,11 @@ namespace MonoDevelop.NUnit
 		
 		public IAsyncOperation RunTest (UnitTest test, IExecutionHandler context, bool buildOwnerObject)
 		{
+			return RunTest (test, context, buildOwnerObject, true);
+		}
+
+		internal IAsyncOperation RunTest (UnitTest test, IExecutionHandler context, bool buildOwnerObject, bool checkCurrentRunOperation)
+		{
 			string testName = test.FullName;
 			
 			if (buildOwnerObject) {
@@ -146,7 +151,7 @@ namespace MonoDevelop.NUnit
 				}
 			}
 			
-			if (!IdeApp.ProjectOperations.ConfirmExecutionOperation ())
+			if (checkCurrentRunOperation && !IdeApp.ProjectOperations.ConfirmExecutionOperation ())
 				return NullProcessAsyncOperation.Failure;
 			
 			Pad resultsPad = IdeApp.Workbench.GetPad <TestResultsPad>();
@@ -171,8 +176,9 @@ namespace MonoDevelop.NUnit
 			OnTestSessionStarting (new TestSessionEventArgs { Session = session, Test = test });
 
 			session.Start ();
-			
-			IdeApp.ProjectOperations.CurrentRunOperation = session;
+
+			if (checkCurrentRunOperation)
+				IdeApp.ProjectOperations.CurrentRunOperation = session;
 			
 			return session;
 		}


### PR DESCRIPTION
Fixed bug [#28083](https://bugzilla.xamarin.com/show_bug.cgi?id=28083) - When running an NUnit project, Xamarin Studio always asks "An application is already running and will have to be stopped. Do you want to continue?"

When an NUnit project was run, either from the main toolbar menu or from the Run menu, with Start Debugging or Start Without Debugging, the NUnit addin was treating the running of the tests as a separate run operation which would cause a prompt to be displayed to the user. Now when the NUnit project is run the ProjectOperation's CurrentRunOperation is not checked, nor modified by, the NUnit addin since it is part of the CurrentRunOperation and not a separate operation.

The user will still be prompted if they are debugging another project in the solution and then try to run the unit tests from the Unit Tests pad.

The NUnitProjectServiceExtension now uses code that was previously commented out to fix bug [#18130](https://bugzilla.xamarin.com/show_bug.cgi?id=18130). With the change made to the NUnitService to prevent it from changing the CurrentRunOperation the bug 18130 is still fixed.
