### PR TITLE
[Ide] Use DefaultHeight instead of HeightRequest when setting the height  of the project options dialog.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/ProjectOptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/ProjectOptionsDialog.cs
@@ -46,7 +46,7 @@ namespace MonoDevelop.Ide.Projects
 		public ProjectOptionsDialog (Gtk.Window parentWindow, SolutionEntityItem project) : base (parentWindow, project)
 		{
 			this.Title = GettextCatalog.GetString ("Project Options") + " - " + project.Name;
-			this.HeightRequest = 620;
+			this.DefaultHeight = 640;
 		}
 		
 		public static void RenameItem (IWorkspaceFileObject item, string newName)


### PR DESCRIPTION
Fixes #28437 as well as a minor rendering issue for the iOS build options.