### PR TITLE
[Ide] Minor tweak to runtime combo for windows

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
@@ -115,6 +115,9 @@ namespace MonoDevelop.Components.MainToolbar
 			renderer.Xpad = (uint)(runtime.IsIndented ? 18 : 3);
 
 			if (!runtimeCombo.PopupShown) {
+				// no need to ident text when the combo dropdown is not showing
+				if (Platform.IsWindows)
+					renderer.Xpad = 3;
 				renderer.Text = runtime.FullDisplayString;
 				renderer.Attributes = normalAttributes;
 			} else {
@@ -274,7 +277,8 @@ namespace MonoDevelop.Components.MainToolbar
 		void SetDefaultSizes (int comboHeight, int height)
 		{
 			configurationCombo.SetSizeRequest (150, comboHeight);
-			runtimeCombo.SetSizeRequest (150, comboHeight);
+			// make the windows runtime slightly wider to accomodate select devices text
+			runtimeCombo.SetSizeRequest (Platform.IsWindows ? 175 : 150, comboHeight);
 			statusArea.SetSizeRequest (32, 32);
 			matchEntry.HeightRequest = height + 4;
 			buttonBar.HeightRequest = height + 2;


### PR DESCRIPTION
Fixes (well, partly) #23507

- slightly wider on windows to accommodate more text, especially "Manage Android Devices...".
- don't indent the text when the drop down is closed (same as config combo).