### PR TITLE
[Debugger] If exception is thrown and there is no user code in stack

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -325,19 +325,23 @@ namespace MonoDevelop.Debugger
 
 			MessageService.ShowCustomDialog (dlg);
 		}
-		
+
 		public static void ShowExceptionCaughtDialog ()
 		{
 			var ops = session.EvaluationOptions.Clone ();
 			ops.MemberEvaluationTimeout = 0;
 			ops.EvaluationTimeout = 0;
 			ops.EllipsizeStrings = false;
-			
+
 			var val = CurrentFrame.GetException (ops);
 			if (val != null) {
 				HideExceptionCaughtDialog ();
 				exceptionDialog = new ExceptionCaughtMessage (val, CurrentFrame.SourceLocation.FileName, CurrentFrame.SourceLocation.Line, CurrentFrame.SourceLocation.Column);
-				exceptionDialog.ShowButton ();
+				if (CurrentFrame.SourceLocation.FileName != null) {
+					exceptionDialog.ShowButton ();
+				} else {
+					exceptionDialog.ShowDialog ();
+				}
 				exceptionDialog.Closed += (o, args) => exceptionDialog = null;
 			}
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -232,6 +232,7 @@ namespace MonoDevelop.Debugger
 			OnlyShowMyCodeCheckbox = new CheckButton (GettextCatalog.GetString ("_Only show my code."));
 			OnlyShowMyCodeCheckbox.Toggled += OnlyShowMyCodeToggled;
 			OnlyShowMyCodeCheckbox.Show ();
+			OnlyShowMyCodeCheckbox.Active = DebuggingService.GetUserOptions ().ProjectAssembliesOnly;
 
 			var alignment = new Alignment (0.0f, 0.5f, 0.0f, 0.0f) { Child = OnlyShowMyCodeCheckbox };
 			alignment.Show ();


### PR DESCRIPTION
Open exception dialog window

Also setting OnlyShowMyCode in exception dialog if user has OnlyMyCode enabled in debugger settings

Includes https://github.com/mono/debugger-libs/commit/5660243990e8c8483988ac31fac701a008379f27

https://bugzilla.xamarin.com/show_bug.cgi?id=24975