### PR TITLE
T4 - use lowercased template directive names

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/ParsedTemplate.cs
@@ -263,7 +263,7 @@ namespace Mono.TextTemplating
 	{
 		public Directive (string name, Location start)
 		{
-			this.Name = name;
+			this.Name = name.ToLowerInvariant ();
 			this.Attributes = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 			this.StartLocation = start;
 		}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=28767

Recreated #847 to pull request on top of master