### PR TITLE
MacPlatform: bxc#28829: fix crash in toolbar

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -217,7 +217,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			void RealignTexts ()
 			{
-				if (Window == null)
+				if (Window == null || Window.Screen == null)
 					return;
 
 				// fix the icon alignment, move it slightly up


### PR DESCRIPTION
When `Window.Screen` is null, which appears possible initially when running with multiple screens, skip the `RealignTexts` logic.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=28829.