### PR TITLE
Bug 28834 - Exception windows is not working properly

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1107,8 +1107,8 @@ namespace MonoDevelop.Debugger
 				if (oldValue != null && strval != oldValue)
 					nameColor = valueColor = modifiedColor;
 			}
-			
-			strval = strval.Replace (Environment.NewLine, " ");
+
+			strval = strval.Replace ("\r\n", " ").Replace ("\n", " ");
 
 			bool hasChildren = val.HasChildren;
 			string icon = GetIcon (val.Flags);


### PR DESCRIPTION
In case of exception message.ToString() on Android it produced stacktrace message with \n as new line which was not trimmed on Windows

This is meant for Cycle5 SR1