### PR TITLE
[Ide] Handle native menus from ExtensibleTreeView's context menu

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/GtkWorkarounds.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/GtkWorkarounds.cs
@@ -440,9 +440,15 @@ namespace Mono.TextEditor
 		/// <param name='parent'>The parent widget.</param>
 		/// <param name='evt'>The mouse event. May be null if triggered by keyboard.</param>
 		/// <param name='caret'>The caret/selection position within the parent, if the EventButton is null.</param>
-		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.EventButton evt, Gdk.Rectangle caret)
+		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.EventButton evt, Gdk.Rectangle caret, System.Action hide_action = null)
 		{
 			Gtk.MenuPositionFunc posFunc = null;
+
+			menu.Hidden += (sender, e) => {
+				if (hide_action != null) {
+					hide_action ();
+				}
+			};
 
 			if (parent != null) {
 				menu.AttachToWidget (parent, null);
@@ -519,14 +525,14 @@ namespace Mono.TextEditor
 			menu.Popup (null, null, posFunc, button, time);
 		}
 		
-		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.EventButton evt)
+		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.EventButton evt, System.Action hide_action = null)
 		{
-			ShowContextMenu (menu, parent, evt, Gdk.Rectangle.Zero);
+			ShowContextMenu (menu, parent, evt, Gdk.Rectangle.Zero, hide_action);
 		}
 		
-		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.Rectangle caret)
+		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.Rectangle caret, System.Action hide_action = null)
 		{
-			ShowContextMenu (menu, parent, null, caret);
+			ShowContextMenu (menu, parent, null, caret, hide_action);
 		}
 		
 		struct MappedKeys

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -813,15 +813,15 @@ namespace MonoDevelop.Components.Commands
 		/// Initial command route target. The command handler will start looking for command handlers in this object.
 		/// </param>
 		public bool ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, CommandEntrySet entrySet,
-			object initialCommandTarget = null)
+			object initialCommandTarget = null, Action hide_action = null)
 		{
 #if MAC
 			var menu = CreateNSMenu (entrySet, initialCommandTarget);
-			ContextMenuExtensionsMac.ShowContextMenu (parent, evt, menu);
+			ContextMenuExtensionsMac.ShowContextMenu (parent, evt, menu, hide_action);
 #else
 			var menu = CreateMenu (entrySet);
 			if (menu != null)
-				ShowContextMenu (parent, evt, menu, initialCommandTarget);
+				ShowContextMenu (parent, evt, menu, initialCommandTarget, hide_action);
 #endif
 			return true;
 		}
@@ -842,13 +842,13 @@ namespace MonoDevelop.Components.Commands
 		/// Initial command route target. The command handler will start looking for command handlers in this object.
 		/// </param>
 		public void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, Gtk.Menu menu,
-			object initialCommandTarget = null)
+			object initialCommandTarget = null, Action hide_action = null)
 		{
 			if (menu is CommandMenu) {
 				((CommandMenu)menu).InitialCommandTarget = initialCommandTarget ?? parent;
 			}
 
-			Mono.TextEditor.GtkWorkarounds.ShowContextMenu (menu, parent, evt);
+			Mono.TextEditor.GtkWorkarounds.ShowContextMenu (menu, parent, evt, hide_action);
 		}
 		
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -32,6 +32,26 @@ using AppKit;
 namespace MonoDevelop.Components
 {
 	#if MAC
+	class ClosingDelegate : NSMenuDelegate
+	{
+		Action hide_action;
+
+		public ClosingDelegate (Action hide_action)
+		{
+			this.hide_action = hide_action;
+		}
+
+		public override void MenuWillHighlightItem (NSMenu menu, NSMenuItem item)
+		{
+		}
+
+		public override void MenuDidClose (NSMenu menu)
+		{
+			if (hide_action != null)
+				hide_action ();
+		}
+	}
+
 	static class ContextMenuExtensionsMac
 	{
 		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, ContextMenu menu)
@@ -45,12 +65,16 @@ namespace MonoDevelop.Components
 			ShowContextMenu (parent, evt, nsMenu);
 		}
 
-		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, NSMenu menu)
+		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, NSMenu menu, Action hide_action = null)
 		{
 			if (parent == null)
 				throw new ArgumentNullException ("parent");
 			if (menu == null)
 				throw new ArgumentNullException ("menu");
+
+			if (hide_action != null) {
+				menu.Delegate = new ClosingDelegate (hide_action);
+			}
 
 			parent.GrabFocus ();
 			int x, y;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -416,12 +416,13 @@ namespace MonoDevelop.Ide.Gui.Components
 			if (ShowSelectionPopupButton && text_render.PointerInButton ((int)args.Event.XRoot, (int)args.Event.YRoot)) {
 				text_render.Pushed = true;
 				args.RetVal = true;
+				QueueDraw ();
 				var entryset = BuildEntrySet ();
-				var menu = IdeApp.CommandService.CreateMenu (entryset, this);
-				if (menu != null) {
-					menu.Hidden += HandleMenuHidden;
-					GtkWorkarounds.ShowContextMenu (menu, tree, text_render.PopupAllocation);
-				}
+
+				IdeApp.CommandService.ShowContextMenu (this, args.Event, entryset, this, () => {
+					text_render.Pushed = false;
+					QueueDraw ();
+				});
 			}
 		}
 


### PR DESCRIPTION
This adds an optional Action to handle when the context menu is closed so that the treeview can maintain the 'pushed' state on the gear button.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=26957