### PR TITLE
5.9 - Fix New Project dialog closing when auto-hide window closes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -75,7 +75,6 @@ namespace MonoDevelop.Ide.Projects
 			WidthRequest = 901;
 			HeightRequest = 632;
 
-			Modal = true;
 			Name = "wizard_dialog";
 			Title = GettextCatalog.GetString ("New Project");
 			WindowPosition = WindowPosition.CenterOnParent;


### PR DESCRIPTION
Fixed bug #28971 - New project window disappears if pads
(e.g. Application output, solution window) set to auto hide
https://bugzilla.xamarin.com/show_bug.cgi?id=28971

Simplest way to reproduce the problem is to configure the
solution window to be auto-hide and then right click the solution
and select Add - Add New Project. The New Project dialog will
open and then as the Solution window hides the New Project dialog
will be closed. This happens on the Mac but not on Windows.