### PR TITLE
5.9.1 NuGet reduce status text length

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/CheckForUpdatesProgressMonitorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/CheckForUpdatesProgressMonitorTests.cs
@@ -97,7 +97,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			progressMonitor.ReportError (exception);
 
 			fakeProgressMonitor.AssertMessageIsLogged ("Error");
-			Assert.AreEqual (GettextCatalog.GetString ("Could not check for package updates. Please see Package Console for details."), fakeProgressMonitor.ReportedErrorMessage);
+			Assert.AreEqual (GettextCatalog.GetString ("Could not check for package updates."), fakeProgressMonitor.ReportedErrorMessage);
 			Assert.IsTrue (progressMonitor.IsPackageConsoleShown);
 		}
 
@@ -142,7 +142,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			progressMonitor.ReportSuccess (false);
 
-			Assert.AreEqual (GettextCatalog.GetString ("No updates found but warnings were reported. Please see Package Console for details."), fakeProgressMonitor.ReportedWarningMessage);
+			Assert.AreEqual (GettextCatalog.GetString ("No updates found but warnings were reported."), fakeProgressMonitor.ReportedWarningMessage);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageCompatibilityRunnerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageCompatibilityRunnerTests.cs
@@ -372,7 +372,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Run ();
 
-			Assert.AreEqual ("Incompatible packages found. Please see Package Console for details.", progressMonitor.ReportedErrorMessage);
+			Assert.AreEqual ("Incompatible packages found.", progressMonitor.ReportedErrorMessage);
 			Assert.IsTrue (runner.PackageConsoleIsShown);
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdatedPackagesInSolutionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdatedPackagesInSolutionTests.cs
@@ -468,7 +468,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			task.Result = null;
 			task.ExecuteContinueWith ();
 
-			Assert.AreEqual (GettextCatalog.GetString ("Could not check for package updates. Please see Package Console for details."), progressMonitorFactory.ProgressMonitor.ReportedErrorMessage);
+			Assert.AreEqual (GettextCatalog.GetString ("Could not check for package updates."), progressMonitorFactory.ProgressMonitor.ReportedErrorMessage);
 			Assert.IsTrue (checkForUpdatesTaskRunner.ProgressMonitorCreated.IsPackageConsoleShown);
 			progressMonitorFactory.ProgressMonitor.AssertMessageIsLogged ("Inner exception error message");
 			Assert.IsTrue (progressMonitorFactory.ProgressMonitor.IsDisposed);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageCompatibilityRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageCompatibilityRunner.cs
@@ -150,7 +150,7 @@ namespace MonoDevelop.PackageManagement
 		{
 			checker.GenerateReport (progressMonitor.Log);
 			if (checker.AnyIncompatiblePackages ()) {
-				progressMonitor.ReportError (GettextCatalog.GetString ("Incompatible packages found. Please see Package Console for details."), null);
+				progressMonitor.ReportError (GettextCatalog.GetString ("Incompatible packages found."), null);
 			} else {
 				progressMonitor.ReportWarning (progressMessage.Warning);
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProgressMonitorStatusMessageFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProgressMonitorStatusMessageFactory.cs
@@ -38,8 +38,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Adding {0}...", packageId),
 				GetString ("{0} successfully added.", packageId),
-				GetString ("Could not add {0}. Please see Package Console for details.", packageId),
-				GetString ("{0} added with warnings. Please see Package Console for details.", packageId)
+				GetString ("Could not add {0}.", packageId),
+				GetString ("{0} added with warnings.", packageId)
 			);
 		}
 
@@ -48,8 +48,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Adding packages..."),
 				GetString ("Packages successfully added."),
-				GetString ("Could not add packages. Please see Package Console for details."),
-				GetString ("Packages added with warnings. Please see Package Console for details.")
+				GetString ("Could not add packages."),
+				GetString ("Packages added with warnings.")
 			);
 		}
 
@@ -58,8 +58,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Adding {0} packages...", count),
 				GetString ("{0} packages successfully added.", count),
-				GetString ("Could not add packages. Please see Package Console for details."),
-				GetString ("{0} packages added with warnings. Please see Package Console for details.", count)
+				GetString ("Could not add packages."),
+				GetString ("{0} packages added with warnings.", count)
 			);
 		}
 
@@ -68,8 +68,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Updating packages in solution..."),
 				GetString ("Packages successfully updated."),
-				GetString ("Could not update packages. Please see Package Console for details."),
-				GetString ("Packages updated with warnings. Please see Package Console for details.")
+				GetString ("Could not update packages."),
+				GetString ("Packages updated with warnings.")
 			);
 		}
 
@@ -79,7 +79,7 @@ namespace MonoDevelop.PackageManagement
 			return new UpdatePackagesProgressMonitorStatusMessage (
 				projects,
 				GetString ("Packages are up to date."),
-				GetString ("No updates found but warnings were reported. Please see Package Console for details."),
+				GetString ("No updates found but warnings were reported."),
 				message);
 		}
 
@@ -88,8 +88,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Updating {0} packages in project...", count),
 				GetString ("{0} packages successfully updated.", count),
-				GetString ("Could not update packages. Please see Package Console for details."),
-				GetString ("{0} packages updated with warnings. Please see Package Console for details.", count)
+				GetString ("Could not update packages."),
+				GetString ("{0} packages updated with warnings.", count)
 			);
 		}
 
@@ -99,7 +99,7 @@ namespace MonoDevelop.PackageManagement
 			return new UpdatePackagesProgressMonitorStatusMessage (
 				project,
 				GetString ("Packages are up to date."),
-				GetString ("No updates found but warnings were reported. Please see Package Console for details."),
+				GetString ("No updates found but warnings were reported."),
 				message);
 		}
 
@@ -108,8 +108,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Updating packages in project..."),
 				GetString ("Packages successfully updated."),
-				GetString ("Could not update packages. Please see Package Console for details."),
-				GetString ("Packages updated with warnings. Please see Package Console for details.")
+				GetString ("Could not update packages."),
+				GetString ("Packages updated with warnings.")
 			);
 		}
 
@@ -118,8 +118,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Updating {0}...", packageId),
 				GetString ("{0} successfully updated.", packageId),
-				GetString ("Could not update {0}. Please see Package Console for details.", packageId),
-				GetString ("{0} updated with warnings. Please see Package Console for details.", packageId)
+				GetString ("Could not update {0}.", packageId),
+				GetString ("{0} updated with warnings.", packageId)
 			);
 		}
 
@@ -129,7 +129,7 @@ namespace MonoDevelop.PackageManagement
 			return new UpdatePackagesProgressMonitorStatusMessage (
 				project,
 				GetString ("{0} is up to date.", packageId),
-				GetString ("No update found but warnings were reported. Please see Package Console for details."),
+				GetString ("No update found but warnings were reported."),
 				message);
 		}
 
@@ -138,8 +138,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Removing {0}...", packageId),
 				GetString ("{0} successfully removed.", packageId),
-				GetString ("Could not remove {0}. Please see Package Console for details.", packageId),
-				GetString ("{0} removed with warnings. Please see Package Console for details.", packageId)
+				GetString ("Could not remove {0}.", packageId),
+				GetString ("{0} removed with warnings.", packageId)
 			);
 		}
 
@@ -148,8 +148,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Restoring packages for solution..."),
 				GetString ("Packages successfully restored."),
-				GetString ("Could not restore packages. Please see Package Console for details."),
-				GetString ("Packages restored with warnings. Please see Package Console for details.")
+				GetString ("Could not restore packages."),
+				GetString ("Packages restored with warnings.")
 			);
 		}
 
@@ -158,8 +158,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Restoring packages before update..."),
 				GetString ("Packages successfully restored."),
-				GetString ("Could not restore packages. Please see Package Console for details."),
-				GetString ("Packages restored with warnings. Please see Package Console for details.")
+				GetString ("Could not restore packages."),
+				GetString ("Packages restored with warnings.")
 			);
 		}
 
@@ -168,8 +168,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Restoring packages for project..."),
 				GetString ("Packages successfully restored."),
-				GetString ("Could not restore packages. Please see Package Console for details."),
-				GetString ("Packages restored with warnings. Please see Package Console for details.")
+				GetString ("Could not restore packages."),
+				GetString ("Packages restored with warnings.")
 			);
 		}
 
@@ -178,8 +178,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Checking package compatibility with new target framework..."),
 				GetString ("Packages are compatible."),
-				GetString ("Could not check package compatibility. Please see Package Console for details."),
-				GetString ("Package retargeting required. Please see Package Console for details.")
+				GetString ("Could not check package compatibility."),
+				GetString ("Package retargeting required.")
 			);
 		}
 
@@ -188,8 +188,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Retargeting {0}...", packageId),
 				GetString ("{0} successfully retargeted.", packageId),
-				GetString ("Could not retarget {0}. Please see Package Console for details.", packageId),
-				GetString ("{0} retargeted with warnings. Please see Package Console for details.", packageId)
+				GetString ("Could not retarget {0}.", packageId),
+				GetString ("{0} retargeted with warnings.", packageId)
 			);
 		}
 
@@ -198,8 +198,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Retargeting {0} packages...", count),
 				GetString ("{0} packages successfully retargeted.", count),
-				GetString ("Could not retarget packages. Please see Package Console for details."),
-				GetString ("{0} packages retargeted with warnings. Please see Package Console for details.", count)
+				GetString ("Could not retarget packages."),
+				GetString ("{0} packages retargeted with warnings.", count)
 			);
 		}
 
@@ -208,8 +208,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Retargeting packages..."),
 				GetString ("Packages successfully retargeted."),
-				GetString ("Could not retarget packages. Please see Package Console for details."),
-				GetString ("Packages retarget with warnings. Please see Package Console for details.")
+				GetString ("Could not retarget packages."),
+				GetString ("Packages retarget with warnings.")
 			);
 		}
 
@@ -218,8 +218,8 @@ namespace MonoDevelop.PackageManagement
 			return new ProgressMonitorStatusMessage (
 				GetString ("Checking for package updates..."),
 				GetString ("Packages are up to date."),
-				GetString ("Could not check for package updates. Please see Package Console for details."),
-				GetString ("No updates found but warnings were reported. Please see Package Console for details."));
+				GetString ("Could not check for package updates."),
+				GetString ("No updates found but warnings were reported."));
 		}
 
 		static string GetString (string phrase)


### PR DESCRIPTION
Fixed bug #28730 - Status bar text from NuGet addin is too long
to fix in the status bar
https://bugzilla.xamarin.com/show_bug.cgi?id=28730

The new native status bar for Mac has a smaller width and the
status bar text from the NuGet addin would be too long to be
displayed. To reduce the length of the status bar text the
'Please see the Package Console for details.' text has been
removed.