### PR TITLE
Added UITest for ASP.NET and Miscellaneous templates

### DIFF
--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -58,7 +58,7 @@ namespace UserInterfaceTests
 			Assert.AreEqual (expectedOutput, output.Trim ());
 		}
 
-		public void CreateBuildProject (string projectName, string kind, string category, string categoryRoot, Action beforeBuild)
+		public void CreateBuildProject (string projectName, string categoryRoot, string category, string kindRoot, string kind, Action beforeBuild)
 		{
 			var solutionParentDirectory = Util.CreateTmpDir (projectName);
 			string actualSolutionDirectory = string.Empty;
@@ -66,7 +66,7 @@ namespace UserInterfaceTests
 				var newProject = new NewProjectController ();
 				newProject.Open ();
 
-				SelectTemplate (newProject, kind, category, categoryRoot);
+				SelectTemplate (newProject, categoryRoot, category, kindRoot, kind);
 
 				Assert.IsTrue (newProject.Next ());
 
@@ -94,10 +94,10 @@ namespace UserInterfaceTests
 			}
 		}
 
-		public void SelectTemplate (NewProjectController newProject, string kind, string category, string categoryRoot)
+		public void SelectTemplate (NewProjectController newProject, string categoryRoot, string category, string kindRoot, string kind)
 		{
-			Assert.IsTrue (newProject.SelectTemplateType (category, categoryRoot));
-			Assert.IsTrue (newProject.SelectTemplate (kind));
+			Assert.IsTrue (newProject.SelectTemplateType (categoryRoot, category));
+			Assert.IsTrue (newProject.SelectTemplate (kindRoot, kind));
 		}
 
 		public void EnterProjectDetails (NewProjectController newProject, string projectName, string solutionName, string solutionLocation)

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -27,16 +27,20 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 using MonoDevelop.Core;
-
 using NUnit.Framework;
 
 namespace UserInterfaceTests
 {
 	public abstract class CreateBuildTemplatesTestBase: UITestBase
 	{
+		public string GeneralKindRoot { get; private set; } = "General";
+
+		public string OtherCategoryRoot { get; private set; } = "Other";
+
 		public readonly static Action EmptyAction = () => { };
 
 		public readonly static Action WaitForPackageUpdate = delegate {
@@ -44,9 +48,16 @@ namespace UserInterfaceTests
 				pollStep: 1000, timeout: 30000);
 		};
 
+		static Regex cleanSpecialChars = new Regex ("[^0-9a-zA-Z]+", RegexOptions.Compiled);
+
 		public CreateBuildTemplatesTestBase () {}
 
 		public CreateBuildTemplatesTestBase (string mdBinPath) : base (mdBinPath) {}
+
+		public string GenerateProjectName (string templateName)
+		{
+			return cleanSpecialChars.Replace (templateName, string.Empty);
+		}
 
 		public void AssertExeHasOutput (string exe, string expectedOutput)
 		{

--- a/main/tests/UserInterfaceTests/MonoDevelopTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTemplatesTest.cs
@@ -35,32 +35,31 @@ namespace UserInterfaceTests
 	{
 		readonly static string DotNetProjectKind = ".NET";
 
-		readonly static string CategoryRoot = "Other";
+		readonly static string categoryRoot = "Other";
+		readonly static string generalKindRoot = "General";
 
 		[Test]
 		public void TestCreateBuildConsoleProject ()
 		{
-			CreateBuildProject ("ConsoleProject", "Console Project", DotNetProjectKind, CategoryRoot, EmptyAction);
+			CreateBuildProject ("ConsoleProject", categoryRoot, DotNetProjectKind, generalKindRoot ,"Console Project", EmptyAction);
 		}
 
 		[Test]
 		public void TestCreateBuildGtkSharp20Project ()
 		{
-			CreateBuildProject ("Gtk20Project", "Gtk# 2.0 Project", DotNetProjectKind, CategoryRoot, EmptyAction);
+			CreateBuildProject ("Gtk20Project", categoryRoot, DotNetProjectKind, generalKindRoot, "Gtk# 2.0 Project", EmptyAction);
 		}
 
 		[Test]
 		public void TestCreateBuildLibrary ()
 		{
-			CreateBuildProject ("Library", "Library", DotNetProjectKind, CategoryRoot, EmptyAction);
+			CreateBuildProject ("Library", categoryRoot, DotNetProjectKind, generalKindRoot,"Library", EmptyAction);
 		}
 
 		[Test]
 		public void TestCreateBuildNUnitLibraryProject ()
 		{
-			CreateBuildProject ("NUnitLibraryProject", "NUnit Library Project", DotNetProjectKind, CategoryRoot, delegate {
-				Ide.WaitUntil (() => Ide.GetStatusMessage () == "Package updates are available.", pollStep: 1000);
-			});
+			CreateBuildProject ("NUnitLibraryProject", categoryRoot, DotNetProjectKind, generalKindRoot, "NUnit Library Project", WaitForPackageUpdate);
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
@@ -1,0 +1,83 @@
+﻿//
+// ASPNetTemplatesTest.cs
+//
+// Author:
+//       Manish Sinha <manish.sinha@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+
+namespace UserInterfaceTests
+{
+	public class ASPNetTemplatesTest : CreateBuildTemplatesTestBase
+	{
+		readonly string aspCategory = "ASP.NET";
+
+		[Test]
+		public void TestEmptyASPMVCProject ()
+		{
+			RunASPTest ("Empty ASP.NET MVC Project", WaitForPackageUpdate);
+		}
+
+		[Test]
+		public void TestEmptyASPProject ()
+		{
+			RunASPTest ("Empty ASP.NET Project", EmptyAction);
+		}
+
+		[Test]
+		public void TestASPMVCProject ()
+		{
+			RunASPTest ("ASP.NET MVC Project", WaitForPackageUpdate);
+		}
+
+		[Test]
+		public void TestASPMVCProjectWithUnitTests ()
+		{
+			RunASPTest ("ASP.NET MVC Project with Unit Tests", WaitForPackageUpdate);
+		}
+
+		[Test]
+		public void TestASPMVCMazorProject ()
+		{
+			RunASPTest ("ASP.NET MVC Razor Project", WaitForPackageUpdate);
+		}
+
+		[Test]
+		public void TestASPMVCMazorProjectWithUnitTests ()
+		{
+			RunASPTest ("ASP.NET MVC Razor Project with Unit Tests", WaitForPackageUpdate);
+		}
+
+		[Test]
+		public void TestASPProject ()
+		{
+			RunASPTest ("ASP.NET Project", EmptyAction);
+		}
+
+		void RunASPTest (string templateName, Action beforeBuild)
+		{
+			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, aspCategory, GeneralKindRoot, templateName, beforeBuild);
+		}
+	}
+}

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/DotNetTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/DotNetTemplatesTest.cs
@@ -33,33 +33,35 @@ namespace UserInterfaceTests
 {
 	public class MonoDevelopTemplatesTest : CreateBuildTemplatesTestBase
 	{
-		readonly static string DotNetProjectKind = ".NET";
-
-		readonly static string categoryRoot = "Other";
-		readonly static string generalKindRoot = "General";
+		readonly string dotNetCategory = ".NET";
 
 		[Test]
 		public void TestCreateBuildConsoleProject ()
 		{
-			CreateBuildProject ("ConsoleProject", categoryRoot, DotNetProjectKind, generalKindRoot ,"Console Project", EmptyAction);
+			RunDotNetTests ("Console Project", EmptyAction);
 		}
 
 		[Test]
 		public void TestCreateBuildGtkSharp20Project ()
 		{
-			CreateBuildProject ("Gtk20Project", categoryRoot, DotNetProjectKind, generalKindRoot, "Gtk# 2.0 Project", EmptyAction);
+			RunDotNetTests ("Gtk# 2.0 Project", EmptyAction);
 		}
 
 		[Test]
 		public void TestCreateBuildLibrary ()
 		{
-			CreateBuildProject ("Library", categoryRoot, DotNetProjectKind, generalKindRoot,"Library", EmptyAction);
+			RunDotNetTests ("Library", EmptyAction);
 		}
 
 		[Test]
 		public void TestCreateBuildNUnitLibraryProject ()
 		{
-			CreateBuildProject ("NUnitLibraryProject", categoryRoot, DotNetProjectKind, generalKindRoot, "NUnit Library Project", WaitForPackageUpdate);
+			RunDotNetTests ("NUnit Library Project", WaitForPackageUpdate);
+		}
+
+		void RunDotNetTests (string templateName, Action beforeBuild)
+		{
+			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, dotNetCategory, GeneralKindRoot, templateName, beforeBuild);
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
@@ -1,0 +1,86 @@
+﻿//
+// MiscTemplatesTest.cs
+//
+// Author:
+//       Manish Sinha <manish.sinha@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace UserInterfaceTests
+{
+	public class MiscTemplatesTest : CreateBuildTemplatesTestBase
+	{
+		readonly string miscCategory = "Miscellaneous";
+
+		readonly string genericKindRoot = "Generic";
+		readonly string cCPlusKindRoot = "C/C++";
+
+		#region Generic
+
+		[Test]
+		public void TestMiscGenericProject ()
+		{
+			RunMiscGenericTests ("Generic Project");
+		}
+
+		[Test]
+		public void TestMiscPackagingProject ()
+		{
+			RunMiscGenericTests ("Packaging project");
+		}
+
+		void RunMiscGenericTests (string templateName)
+		{
+			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, miscCategory, genericKindRoot, templateName, EmptyAction);
+		}
+
+		#endregion
+
+		#region C/C++
+
+		[Test]
+		public void TestMiscCCPlusSharedLibrary ()
+		{
+			RunCCPlusTests ("Shared Library");
+		}
+
+		[Test]
+		public void TestMiscCCPlusStaticLibrary ()
+		{
+			RunCCPlusTests ("Static Library");
+		}
+
+		[Test]
+		public void TestMiscCCPlusConsoleProject ()
+		{
+			RunCCPlusTests ("Console Project");
+		}
+
+		void RunCCPlusTests (string templateName)
+		{
+			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, miscCategory, cCPlusKindRoot, templateName, EmptyAction);
+		}
+
+		#endregion
+	}
+}

--- a/main/tests/UserInterfaceTests/NewProjectController.cs
+++ b/main/tests/UserInterfaceTests/NewProjectController.cs
@@ -43,14 +43,14 @@ namespace UserInterfaceTests
 			Session.WaitForElement (c => c.Window ().Marked ("MonoDevelop.Ide.Projects.GtkNewProjectDialogBackend"));
 		}
 
-		public bool SelectTemplateType (string type, string category)
+		public bool SelectTemplateType (string categoryRoot, string category)
 		{
-			return Session.SelectElement (c => c.TreeView ().Marked ("templateCategoriesTreeView").Model ("templateCategoriesListStore__Name").Contains (category).NextSiblings ().Text (type));
+			return Session.SelectElement (c => c.TreeView ().Marked ("templateCategoriesTreeView").Model ("templateCategoriesListStore__Name").Contains (categoryRoot).NextSiblings ().Text (category));
 		}
 
-		public bool SelectTemplate (string templateName)
+		public bool SelectTemplate (string kindRoot, string kind)
 		{
-			return Session.SelectElement (c => c.TreeView ().Marked ("templatesTreeView").Model ("templateListStore__Name").Text (templateName));
+			return Session.SelectElement (c => c.TreeView ().Marked ("templatesTreeView").Model ("templateListStore__Name").Contains (kindRoot).NextSiblings ().Text (kind));
 		}
 
 		public bool Next ()

--- a/main/tests/UserInterfaceTests/NewProjectController.cs
+++ b/main/tests/UserInterfaceTests/NewProjectController.cs
@@ -37,7 +37,7 @@ namespace UserInterfaceTests
 			get { return TestService.Session; }
 		}
 
-		public void Open (int delay = 2000)
+		public void Open ()
 		{
 			Session.ExecuteCommand (FileCommands.NewProject);
 			Session.WaitForElement (c => c.Window ().Marked ("MonoDevelop.Ide.Projects.GtkNewProjectDialogBackend"));

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="UITestDebug.cs" />
     <Compile Include="MonoDevelopTests\DotNetTemplatesTest.cs" />
     <Compile Include="MonoDevelopTests\ASPNETTemplateTests.cs" />
+    <Compile Include="MonoDevelopTests\MiscTemplatesTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -48,9 +48,10 @@
     <Compile Include="ProcessUtils.cs" />
     <Compile Include="Ide.cs" />
     <Compile Include="CreateBuildTemplatesTestBase.cs" />
-    <Compile Include="MonoDevelopTemplatesTest.cs" />
     <Compile Include="NewProjectController.cs" />
     <Compile Include="UITestDebug.cs" />
+    <Compile Include="MonoDevelopTests\DotNetTemplatesTest.cs" />
+    <Compile Include="MonoDevelopTests\ASPNETTemplateTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -64,5 +65,8 @@
       <Name>MonoDevelop.Core</Name>
       <Private>False</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="MonoDevelopTests\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Refactor and extract functionality in CreateBuildTemplatesTestBase so that it can be used in other tests
* Added ASP.NET tests for all templates
  * Extracted General and Other category in TestBase
  * Create a method which generates projectname from template name by cleaning it of any special chars
  * Refactored MonoDevelopTemplatesTest to remove redundant information
* Added tests for Generic and C/C++ Miscellaneous templates
  * Generic Kind
    * Generic Project
    * Packaging project
  * C/C++ Kind
    * Shared Library
    * Static Library
    * Console Project