### PR TITLE
[Ide] When disposing, fire pending change request.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/TextEditor.cs
@@ -255,10 +255,9 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 
 		void IDisposable.Dispose ()
 		{
-			if (!disposed) {
-				disposed = true;
+			if (disposed)
 				return;
-			}
+			
 			if (entry != null) {
 				TextChanged (null, null);
 				FirePendingChangeEvent (null, null);


### PR DESCRIPTION
This logic seemed wrong, Dispose would never fire the pending change request unless it was called a second time.

Fixes bug#29070