### PR TITLE
Remove check for UserName equal to IntPtr.Zero

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsSecureStoragePasswordProvider.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsSecureStoragePasswordProvider.cs
@@ -223,13 +223,13 @@ namespace MonoDevelop.Platform.Windows
 
 			var ncred = (NativeCredential)Marshal.PtrToStructure (handle, typeof (NativeCredential));
 
-			if (ncred.CredentialBlob == IntPtr.Zero || ncred.UserName == IntPtr.Zero || ncred.TargetName == IntPtr.Zero)
+			if (ncred.CredentialBlob == IntPtr.Zero || ncred.TargetName == IntPtr.Zero)
 				return null;
 
 			return new Credential {
 				CredentialBlobSize = ncred.CredentialBlobSize,
 				CredentialBlob = Marshal.PtrToStringUni (ncred.CredentialBlob, (int)ncred.CredentialBlobSize / 2),
-				UserName = Marshal.PtrToStringUni (ncred.UserName),
+				UserName = ncred.UserName == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUni (ncred.UserName),
 				TargetName = Marshal.PtrToStringUni (ncred.TargetName),
 				TargetAlias = ncred.TargetAlias == IntPtr.Zero ? string.Empty : Marshal.PtrToStringUni (ncred.TargetAlias),
 				Type = ncred.Type,


### PR DESCRIPTION
Hi,
    I have a problem with PasswordService. I can add a password but can not retrieve it. Here is my pull request to fix the problem. 
More info: I'm using Windows 8.1 and when I use the method PasswordService.AddWebPassword(url, password); MonoDevelop creates credentials with empty UserName. When I try to get back the password it is empty string this is because ncred.UserName is equal to IntPtr.Zero.