### PR TITLE
Call IdeApp.Exit() instead of letting Process to kill it

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -127,9 +127,9 @@ namespace MonoDevelop.Components.AutoTest
 			session.ExitApp ();
 		}
 
-		public void ExecuteCommand (object cmd)
+		public void ExecuteCommand (object cmd, object dataItem = null)
 		{
-			session.ExecuteCommand (cmd);
+			session.ExecuteCommand (cmd, dataItem);
 		}
 
 		/*

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -114,7 +114,17 @@ namespace MonoDevelop.Components.AutoTest
 			if (service != null)
 				service.DetachClient (this);
 			else
-				process.Kill ();
+				try {
+					process.Kill ();
+				} catch (InvalidOperationException invalidExp) {
+					Console.WriteLine ("Process has already exited");
+				}
+		}
+
+		public void ExitApp ()
+		{
+			ClearEventQueue ();
+			session.ExitApp ();
 		}
 
 		public void ExecuteCommand (object cmd)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -102,6 +102,15 @@ namespace MonoDevelop.Components.AutoTest
 			return Sync (del, false);
 		}
 
+		public void ExitApp ()
+		{
+			try {
+				IdeApp.Exit ();
+			} catch (Exception e) {
+				Console.WriteLine (e);
+			}
+		}
+
 		public object GlobalInvoke (string name, object[] args)
 		{
 			return Sync (delegate {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -54,10 +54,10 @@ namespace MonoDevelop.Components.AutoTest
 			return null;
 		}
 
-		public void ExecuteCommand (object cmd)
+		public void ExecuteCommand (object cmd, object dataItem = null)
 		{
 			Gtk.Application.Invoke (delegate {
-				AutoTestService.CommandManager.DispatchCommand (cmd, null, null);
+				AutoTestService.CommandManager.DispatchCommand (cmd, dataItem, null);
 			});
 		}
 		

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -45,7 +45,7 @@ namespace UserInterfaceTests
 
 		public readonly static Action WaitForPackageUpdate = delegate {
 			Ide.WaitUntil (() => Ide.GetStatusMessage () == "Package updates are available.",
-				pollStep: 1000, timeout: 30000);
+				pollStep: 1000, timeout: 120000);
 		};
 
 		static Regex cleanSpecialChars = new Regex ("[^0-9a-zA-Z]+", RegexOptions.Compiled);

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -76,7 +76,8 @@ namespace UserInterfaceTests
 
 		public static bool BuildSolution (bool isPass = true)
 		{
-			Session.RunAndWaitForTimer (() => Session.ExecuteCommand (ProjectCommands.BuildSolution), "Ide.Shell.ProjectBuilt");
+			Session.RunAndWaitForTimer (() => Session.ExecuteCommand (ProjectCommands.BuildSolution),
+				"Ide.Shell.ProjectBuilt", timeout: 60000);
 			var status = IsBuildSuccessful ();
 			return isPass == status;
 		}
@@ -111,7 +112,7 @@ namespace UserInterfaceTests
 			return (string) Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.renderArg.CurrentText");
 		}
 
-		public static bool IsBuildSuccessful (int timeout = 3000)
+		public static bool IsBuildSuccessful ()
 		{
 			return Session.IsBuildSuccessful ();
 		}

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -66,7 +66,7 @@ namespace UserInterfaceTests
 		public static void CloseAll ()
 		{
 			Session.ExecuteCommand (FileCommands.CloseWorkspace);
-			Session.ExecuteCommand (FileCommands.CloseAllFiles);
+			Session.ExitApp ();
 		}
 
 		public static FilePath GetActiveDocumentFilename ()


### PR DESCRIPTION
* GetCommandArrayInfoValues (Command) returns the arrayInfo values
    of a command as a List<object>
* Added support to pass the dataItem argument with ExecuteCommand
* Ide.GetSolutionConfigurations () to get list of configurations
    available for a solution created by the template

---

Call IdeApp.Exit() instead of letting Process to kill it

    When IdeApp.Exit () is called, MonoDevelop goes through
    proper code paths to properly shut down itself. Going
    through Process.Kill () is not the correct method since
    it does not hit the correct code paths. There were instances
    where csproxy was not exiting and ended up holding a lot of
    memory thereby hitting 15.96/16GB of memory.

    Thanks to Alan for tracking down the issue

---

Update timeouts

    * Package update timeout is now 120s to account for network slowness
    * Build timeout is at 60s to account for complex solutions
