### PR TITLE
Create a new test target named uitest to run UITests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ run-gdb:
 test:
 	cd main && $(MAKE) test assembly=$(assembly)
 
+uitest:
+	cd main && $(MAKE) uitest assembly=$(assembly)
+
 coverage:
 	cd main && $(MAKE) coverage
 

--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -152,6 +152,9 @@ check-addins:
 test:
 	cd tests && $(MAKE) test assembly=$(assembly)
 
+uitest:
+	cd tests && $(MAKE) uitest assembly=$(assembly)
+
 coverage:
 	cd tests && $(MAKE) coverage
 

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -81,6 +81,11 @@ uitest:
 		done; \
 	fi
 
+	@if ! test -n "$(assembly)"; then \
+		echo "You must pass 'assembly' argument"; \
+		exit 1; \
+	fi
+
 coverage:
 	if ! test -n "$(assembly)"; then \
 		for asm in $(TEST_ASSEMBLIES); do \

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -46,6 +46,9 @@ if ENABLE_WINDOWSPLATFORM
 TEST_ASSEMBLIES += $(TEST_ASSEMBLIES_WINDOWS)
 endif
 
+UITEST_ASSEMBLIES = \
+	$(TEST_DIR)/UserInterfaceTests.dll
+
 test:
 	@if test -n "$(assembly)"; then \
 		for asm in $(TEST_ASSEMBLIES); do \
@@ -67,6 +70,15 @@ test:
 		if [ $${fail} = 1 ]; then \
 			exit 1; \
 		fi; \
+	fi
+
+uitest:
+	@if test -n "$(assembly)"; then \
+		for asm in $(UITEST_ASSEMBLIES); do \
+			if test `basename $$asm` = $(assembly); then \
+				($(RUN_TEST) -xml=TestResult_`basename $$asm`.xml -labels $$asm) || exit $?; \
+			fi; \
+		done; \
 	fi
 
 coverage:


### PR DESCRIPTION
Instead of updating the existing `test` make target, created a new `uitest` make target which can be used to run UserInterfaceTests