### PR TITLE
Bug 29181 - Avoid changing case of project guid in <ProjectReference> when saving.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProject.cs
@@ -809,11 +809,11 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 			SetMetadata (name, value ? "True" : "False");
 		}
 
-		public void SetMetadata (string name, string value, bool isXml = false)
+		public void SetMetadata (string name, string value, bool isXml = false, StringComparison oldValueComparison = StringComparison.Ordinal)
 		{
 			// Don't overwrite the metadata value if the new value is the same as the old
 			// This will keep the old metadata string, which can contain property references
-			if (GetMetadata (name, isXml) == value)
+			if (string.Equals(GetMetadata (name, isXml), value, oldValueComparison))
 				return;
 
 			XmlElement elem = Element [name, MSBuildProject.Schema];

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectHandler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectHandler.cs
@@ -1656,7 +1656,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 					buildItem = AddOrGetBuildItem (msproject, oldItems, "ProjectReference", MSBuildProjectService.ToMSBuildPath (Item.ItemDirectory, refProj.FileName), pref.Condition);
 					MSBuildProjectHandler handler = refProj.ItemHandler as MSBuildProjectHandler;
 					if (handler != null)
-						buildItem.SetMetadata ("Project", handler.Item.ItemId);
+						buildItem.SetMetadata ("Project", handler.Item.ItemId, oldValueComparison: StringComparison.OrdinalIgnoreCase);
 					else
 						buildItem.UnsetMetadata ("Project");
 					buildItem.SetMetadata ("Name", refProj.Name);


### PR DESCRIPTION
Description from https://bugzilla.xamarin.com/show_bug.cgi?id=29181
--

This is not really a big deal, just a trivial annoyance.

When first opening and then saving a (.csproj) project in monodevelop that has
a `<ProjectReference>` the casing of existing guid inside <Project> element will
be forced to upper case.

```
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLibrary1\ClassLibrary1.csproj">
-      <Project>{f40a92b2-99f3-44e7-a1b8-02584de2bfc7}</Project>
+      <Project>{F40A92B2-99F3-44E7-A1B8-02584DE2BFC7}</Project>
       <Name>ClassLibrary1</Name>
     </ProjectReference>
   </ItemGroup>
```

Visual Studio 2013 saves the guids as lowercase, so fixing this will reduce
noise in source control.