### PR TITLE
[UITest] Add WaitForElement before accessing it

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -230,7 +230,12 @@ namespace MonoDevelop.Components.AutoTest
 
 		public AppResult[] ExecuteQuery (AppQuery query)
 		{
-			return query.Execute ();
+			var results = query.Execute ();
+			Sync (() => {
+				DispatchService.RunPendingEvents ();
+				return true;
+			});
+			return results;
 		}
 
 		public AppResult[] WaitForElement (AppQuery query, int timeout)

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -81,9 +81,6 @@ namespace UserInterfaceTests
 
 				Assert.IsTrue (newProject.Next ());
 
-				// Wait until the next page is displayed
-				Session.WaitForElement (c => c.Textfield ().Marked ("solutionNameTextBox"));
-
 				EnterProjectDetails (newProject, projectName, projectName, solutionParentDirectory);
 
 				Assert.IsTrue (newProject.CreateProjectInSolutionDirectory (false));


### PR DESCRIPTION
It is important to wait for an Element before accessing it. I had to add this because I noticed that when calling `SelectTemplateType`+`SelectTemplate` in quick succession, the widgets end up being accessed  even before the widgets are drawn and ready for interaction.