### PR TITLE
Audit all usages of Path.GetInvalid*Chars

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerSession.cs
@@ -491,7 +491,7 @@ namespace MonoDevelop.Debugger.Win32
 			string file = e.Module.Assembly.Name;
 			lock (documents) {
 				ISymbolReader reader = null;
-				char[] badPathChars = System.IO.Path.GetInvalidPathChars();
+				char[] badPathChars = MonoDevelop.Core.FilePath.GetInvalidPathCharacters ();
 				if (file.IndexOfAny (badPathChars) == -1 && System.IO.File.Exists (System.IO.Path.ChangeExtension (file, ".pdb"))) {
 					try {
 						reader = symbolBinder.GetReaderForFile (mi.RawCOMObject, file, ".");

--- a/main/src/addins/NUnit/Services/AbstractResultsStore.cs
+++ b/main/src/addins/NUnit/Services/AbstractResultsStore.cs
@@ -279,7 +279,7 @@ namespace MonoDevelop.NUnit
 		// Bug 3023 - Running NUnit tests throws ArgumentException: Illegal Characters in path
 		static string EscapeFilename (string str)
 		{
-			var pc = Path.GetInvalidPathChars ();
+			var pc = FilePath.GetInvalidPathChars ();
 			char[] specialCharacters = new char[pc.Length + 1];
 			pc.CopyTo (specialCharacters, 0);
 			specialCharacters [specialCharacters.Length - 1] = '%';

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Linq;
 
 namespace MonoDevelop.Core
 {
@@ -67,6 +68,18 @@ namespace MonoDevelop.Core
 		}
 
 		const int PATHMAX = 4096 + 1;
+
+		static readonly char[] invalidPathChars = Path.GetInvalidPathChars ().Concat ("#%&").ToArray ();
+		public static char[] GetInvalidPathChars()
+		{
+			return (char[])invalidPathChars.Clone();
+		}
+
+		static readonly char[] invalidFileNameChars = Path.GetInvalidFileNameChars ().Concat ("#%&").ToArray ();
+		public static char[] GetInvalidFileNameChars ()
+		{
+			return (char[])invalidFileNameChars.Clone ();
+		}
 
 		[DllImport ("libc")]
 		static extern IntPtr realpath (string path, IntPtr buffer);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -434,23 +434,22 @@ namespace MonoDevelop.Core
 		{
 			return Path.GetFullPath (Path.Combine (baseDirectoryPath, relPath));
 		}
-
-		static readonly char [] InvalidPathCharacters = Path.GetInvalidPathChars ().Concat ("#%&").ToArray ();
+			
 		public static bool IsValidPath (string fileName)
 		{
 			if (String.IsNullOrEmpty (fileName) || fileName.Trim() == string.Empty) 
 				return false;
-			if (fileName.IndexOfAny (InvalidPathCharacters) >= 0)
+			if (fileName.IndexOfAny (FilePath.GetInvalidPathChars ()) >= 0)
 				return false;
 			return true;
 		}
 
-		static readonly char[] InvalidFileNamecharacters = Path.GetInvalidFileNameChars ().Concat ("#%&").ToArray ();
+
 		public static bool IsValidFileName (string fileName)
 		{
 			if (String.IsNullOrEmpty (fileName) || fileName.Trim() == string.Empty) 
 				return false;
-			if (fileName.IndexOfAny (InvalidFileNamecharacters) >= 0)
+			if (fileName.IndexOfAny (FilePath.GetInvalidFileNameChars ()) >= 0)
 				return false;
 			return true;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
@@ -120,7 +120,7 @@ namespace MonoDevelop.Ide.Projects
 			var sb = new StringBuilder ();
 			for (int n = 0; n < name.Length; n++) {
 				char c = name [n];
-				if (Array.IndexOf (Path.GetInvalidPathChars(), c) != -1)
+				if (Array.IndexOf (FilePath.GetInvalidPathChars (), c) != -1)
 					continue;
 				if (c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar || c == Path.VolumeSeparatorChar)
 					continue;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectOptionsWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectOptionsWidget.cs
@@ -183,7 +183,7 @@ namespace MonoDevelop.Ide.Projects
 			var sb = new StringBuilder ();
 			for (int n=0; n<name.Length; n++) {
 				char c = name [n];
-				if (Array.IndexOf (System.IO.Path.GetInvalidPathChars(), c) != -1)
+				if (Array.IndexOf (FilePath.GetInvalidPathChars (), c) != -1)
 					continue;
 				if (c == System.IO.Path.DirectorySeparatorChar || c == System.IO.Path.AltDirectorySeparatorChar || c == System.IO.Path.VolumeSeparatorChar)
 					continue;

--- a/main/tests/UnitTests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/FilePathTests.cs
@@ -24,14 +24,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
 
 namespace MonoDevelop.Core
 {
+	[TestFixture]
 	public class FilePathTests
 	{
-		public FilePathTests ()
+		[Test]
+		public void InvalidCharactersTests ()
 		{
+			// Assert compatibility so we know something changed over here.
+			Assert.That (FilePath.GetInvalidFileNameChars (), Is.EquivalentTo (Path.GetInvalidFileNameChars ().Concat ("#%&")));
+			Assert.That (FilePath.GetInvalidPathChars (), Is.EquivalentTo (Path.GetInvalidPathChars ().Concat ("#%&")));
 		}
+
+		// TODO: more tests
 	}
 }
 

--- a/main/tests/UnitTests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/FilePathTests.cs
@@ -1,0 +1,37 @@
+﻿//
+// FilePathTests.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace MonoDevelop.Core
+{
+	public class FilePathTests
+	{
+		public FilePathTests ()
+		{
+		}
+	}
+}
+

--- a/main/tests/UnitTests/MonoDevelop.Core/FileServiceTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/FileServiceTests.cs
@@ -1,0 +1,37 @@
+﻿//
+// FileServiceTests.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace MonoDevelop.Core
+{
+	public class FileServiceTests
+	{
+		public FileServiceTests ()
+		{
+		}
+	}
+}
+

--- a/main/tests/UnitTests/MonoDevelop.Core/FileServiceTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/FileServiceTests.cs
@@ -24,13 +24,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using NUnit.Framework;
 
 namespace MonoDevelop.Core
 {
+	[TestFixture]
 	public class FileServiceTests
 	{
-		public FileServiceTests ()
+		[Test]
+		public void InvalidFileCharsTests ()
 		{
+			Assert.True (FileService.IsValidFileName ("file"), "Empty string");
+			Assert.True (FileService.IsValidFileName ("text.txt"), "Empty string");
+			Assert.True (FileService.IsValidFileName (".gitignore"), "Empty string");
+
+			Assert.False (FileService.IsValidFileName (""), "Empty string");
+			Assert.False (FileService.IsValidFileName ("  "), "Empty string");
+
+			// Test strings containing an invalid character.
+			foreach (var c in FilePath.GetInvalidFileNameChars ())
+				Assert.False (FileService.IsValidFileName (c.ToString ()),
+					string.Format ("String with {0} (charcode: {1})", Char.IsControl (c) ? "<Control Char>" : c.ToString (), Convert.ToInt32 (c)));
+		}
+
+		[Test]
+		public void InvalidPathCharsTests ()
+		{
+			Assert.True (FileService.IsValidPath ("./relative_file"), "Empty string");
+			Assert.True (FileService.IsValidPath ("/path/to/file"), "Empty string");
+			Assert.True (FileService.IsValidPath ("Drive:\\some\\path\\here"), "Empty string");
+
+			Assert.False (FileService.IsValidPath (""), "Empty string");
+			Assert.False (FileService.IsValidPath ("  "), "Empty string");
+
+			// Test strings containing an invalid character.
+			foreach (var c in FilePath.GetInvalidPathChars ())
+				Assert.True (FileService.IsValidPath (c.ToString ()),
+					string.Format ("String with {0} (charcode: {1})", c, Convert.ToInt32 (c)));
 		}
 	}
 }

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -265,6 +265,8 @@
     <Compile Include="MonoDevelop.Ide.Templates\TestableTemplateWizardProvider.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\FileTemplateParserTests.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\ProjectCreateInformationTests.cs" />
+    <Compile Include="MonoDevelop.Core\FileServiceTests.cs" />
+    <Compile Include="MonoDevelop.Core\FilePathTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\md.targets" />


### PR DESCRIPTION
Use FilePath variant to ensure correctness.