### PR TITLE
Refactor CreateBuildProject by breaking it into multiple virtual methods

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -239,7 +239,12 @@ namespace MonoDevelop.Components.AutoTest
 
 		public AppResult[] ExecuteQuery (AppQuery query)
 		{
-			return query.Execute ();
+			var results = query.Execute ();
+			Sync (() => {
+				DispatchService.RunPendingEvents ();
+				return true;
+			});
+			return results;
 		}
 
 		public AppResult[] WaitForElement (AppQuery query, int timeout)

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -81,9 +81,6 @@ namespace UserInterfaceTests
 
 				Assert.IsTrue (newProject.Next ());
 
-				// Wait until the next page is displayed
-				Session.WaitForElement (c => c.Textfield ().Marked ("solutionNameTextBox"));
-
 				EnterProjectDetails (newProject, projectName, projectName, solutionParentDirectory);
 
 				Assert.IsTrue (newProject.CreateProjectInSolutionDirectory (false));

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -73,7 +73,7 @@ namespace UserInterfaceTests
 			GitOptions gitOptions = null, object miscOptions = null)
 		{
 			var templateName = templateOptions.TemplateKind;
-			var projectName = GenerateProjectName (templateName);
+			var projectName = !string.IsNullOrEmpty (templateOptions.ProjectName) ? templateOptions.ProjectName: GenerateProjectName (templateName);
 			var solutionParentDirectory = Util.CreateTmpDir (projectName);
 			try {
 				var newProject = new NewProjectController ();

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
@@ -77,7 +77,13 @@ namespace UserInterfaceTests
 
 		void RunASPTest (string templateName, Action beforeBuild)
 		{
-			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, aspCategory, GeneralKindRoot, templateName, beforeBuild);
+			var templateOptions = new TemplateSelectionOptions {
+				CategoryRoot = OtherCategoryRoot,
+				Category = aspCategory,
+				TemplateKindRoot = GeneralKindRoot,
+				TemplateKind = templateName
+			};
+			CreateBuildProject (templateOptions, beforeBuild);
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
@@ -51,7 +51,13 @@ namespace UserInterfaceTests
 
 		void RunMiscGenericTests (string templateName)
 		{
-			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, miscCategory, genericKindRoot, templateName, EmptyAction);
+			var templateOptions = new TemplateSelectionOptions {
+				CategoryRoot = OtherCategoryRoot,
+				Category = miscCategory,
+				TemplateKindRoot = genericKindRoot,
+				TemplateKind = templateName
+			};
+			CreateBuildProject (templateOptions, EmptyAction);
 		}
 
 		#endregion
@@ -78,7 +84,13 @@ namespace UserInterfaceTests
 
 		void RunCCPlusTests (string templateName)
 		{
-			CreateBuildProject (GenerateProjectName (templateName), OtherCategoryRoot, miscCategory, cCPlusKindRoot, templateName, EmptyAction);
+			var templateOptions = new TemplateSelectionOptions {
+				CategoryRoot = OtherCategoryRoot,
+				Category = miscCategory,
+				TemplateKindRoot = cCPlusKindRoot,
+				TemplateKind = templateName
+			};
+			CreateBuildProject (templateOptions, EmptyAction);
 		}
 
 		#endregion

--- a/main/tests/UserInterfaceTests/NewProjectController.cs
+++ b/main/tests/UserInterfaceTests/NewProjectController.cs
@@ -83,11 +83,11 @@ namespace UserInterfaceTests
 			return SetCheckBox ("createProjectWithinSolutionDirectoryCheckBox", projectInSolution);
 		}
 
-		public bool UseGit (bool useGit, bool useGitIgnore = true)
+		public bool UseGit (GitOptions options)
 		{
-			var gitSelectionSuccess = SetCheckBox ("useGitCheckBox", useGit);
-			if (gitSelectionSuccess && useGit)
-				return gitSelectionSuccess && SetCheckBox ("createGitIgnoreFileCheckBox", useGitIgnore);
+			var gitSelectionSuccess = SetCheckBox ("useGitCheckBox", options.UseGit);
+			if (gitSelectionSuccess && options.UseGit)
+				return gitSelectionSuccess && SetCheckBox ("createGitIgnoreFileCheckBox", options.UseGitIgnore);
 			return gitSelectionSuccess;
 		}
 

--- a/main/tests/UserInterfaceTests/TemplateTestOptions.cs
+++ b/main/tests/UserInterfaceTests/TemplateTestOptions.cs
@@ -50,6 +50,8 @@ namespace UserInterfaceTests
 		public string TemplateKindRoot { get; set; }
 
 		public string TemplateKind { get; set; }
+
+		public string ProjectName { get; set; }
 	}
 
 	public class GitOptions

--- a/main/tests/UserInterfaceTests/TemplateTestOptions.cs
+++ b/main/tests/UserInterfaceTests/TemplateTestOptions.cs
@@ -1,5 +1,5 @@
 ﻿//
-// MonoDevelopTemplatesTest.cs
+// TemplateTestOptions.cs
 //
 // Author:
 //       Manish Sinha <manish.sinha@xamarin.com>
@@ -23,51 +23,46 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 using System;
-using MonoDevelop.Components.AutoTest;
-using MonoDevelop.Ide.Commands;
-using NUnit.Framework;
 
 namespace UserInterfaceTests
 {
-	public class MonoDevelopTemplatesTest : CreateBuildTemplatesTestBase
+	[Flags]
+	public enum Platforms
 	{
-		readonly string dotNetCategory = ".NET";
+		None = 0x0,
+		IOS = 0x1,
+		Android = 0x2
+	}
 
-		[Test]
-		public void TestCreateBuildConsoleProject ()
+	public enum CodeSharingType
+	{
+		PortableClassLibrary,
+		SharedProject
+	}
+
+	public class TemplateSelectionOptions
+	{
+		public string CategoryRoot { get; set; }
+
+		public string Category { get; set; }
+
+		public string TemplateKindRoot { get; set; }
+
+		public string TemplateKind { get; set; }
+	}
+
+	public class GitOptions
+	{
+		public GitOptions ()
 		{
-			RunDotNetTests ("Console Project", EmptyAction);
+			UseGit = true;
+			UseGitIgnore = true;
 		}
 
-		[Test]
-		public void TestCreateBuildGtkSharp20Project ()
-		{
-			RunDotNetTests ("Gtk# 2.0 Project", EmptyAction);
-		}
+		public bool UseGit { get; set; }
 
-		[Test]
-		public void TestCreateBuildLibrary ()
-		{
-			RunDotNetTests ("Library", EmptyAction);
-		}
-
-		[Test]
-		public void TestCreateBuildNUnitLibraryProject ()
-		{
-			RunDotNetTests ("NUnit Library Project", WaitForPackageUpdate);
-		}
-
-		void RunDotNetTests (string templateName, Action beforeBuild)
-		{
-			var templateOptions = new TemplateSelectionOptions {
-				CategoryRoot = OtherCategoryRoot,
-				Category = dotNetCategory,
-				TemplateKindRoot = GeneralKindRoot,
-				TemplateKind = templateName
-			};
-			CreateBuildProject (templateOptions, beforeBuild);
-		}
+		public bool UseGitIgnore { get; set; }
 	}
 }
+

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="MonoDevelopTests\DotNetTemplatesTest.cs" />
     <Compile Include="MonoDevelopTests\ASPNETTemplateTests.cs" />
     <Compile Include="MonoDevelopTests\MiscTemplatesTest.cs" />
+    <Compile Include="TemplateTestOptions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
The goal is to make improve `CreateBuildTemplatesTestBase` class and break down the `CreateBuildProject` method into multiple virtual methods so that the subclass tests can override with their specific implementation.

This PR contains code from PR #886 to with merge conflicts resolved.