### PR TITLE
Fix NRE when clicking on the statusbar in wrong places.

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -772,11 +772,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					layerToStatus [layer.Name].NotifyClicked (button);
 					return;
 				}
-			}
 
-			if (layer.Name == BuildIconLayerId || layer.Name == BuildTextLayerId) { // We clicked error icon.
-				IdeApp.Workbench.GetPad<MonoDevelop.Ide.Gui.Pads.ErrorListPad> ().BringToFront ();
-				return;
+				if (layer.Name == BuildIconLayerId || layer.Name == BuildTextLayerId) { // We clicked error icon.
+					IdeApp.Workbench.GetPad<MonoDevelop.Ide.Gui.Pads.ErrorListPad> ().BringToFront ();
+					return;
+				}
 			}
 
 			if (sourcePad != null)


### PR DESCRIPTION
Bug 28930 - NullReferenceException in status bar terminated Xamarin Studio