### PR TITLE
Update SqlQueryView.cs

### DIFF
--- a/extras/MonoDevelop.Database/MonoDevelop.Database.Query/SqlQueryView.cs
+++ b/extras/MonoDevelop.Database/MonoDevelop.Database.Query/SqlQueryView.cs
@@ -135,6 +135,7 @@ namespace MonoDevelop.Database.Query
 					Document.MimeType = GetMimeType ();
 				
 			};
+			Document.Text = string.Empty;
 			notebook.Hide ();
 		}
 


### PR DESCRIPTION
This prevent a bug that position the second character typed at first of the line on new query because reload the mime type.
Initialize the Document.Text property set the mime type before any character typed.