### PR TITLE
[NewProjectDialog] Fixed #29342

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -429,7 +429,7 @@ namespace MonoDevelop.Ide.Projects
 				if (wizardProvider.MoveToPreviousPage ()) {
 					return;
 				}
-			} else if (IsLastPage && wizardProvider.HasWizard) {
+			} else if (IsLastPage && wizardProvider.HasWizard && wizardProvider.CurrentWizard.TotalPages != 0) {
 				IsLastPage = false;
 				return;
 			}


### PR DESCRIPTION
Previous button not working with Empty Wizard.
Bug: https://bugzilla.xamarin.com/show_bug.cgi?id=29342
Trello Card: https://trello.com/c/E0ZkXubS/137-xs-bug-29342-macwizard-clicking-previous-on-configure-your-new-project-whens-selecting-spritekit-game-does-not-work-the-first-ti