### PR TITLE
[NUnit] Properly report unhandled exceptions

### DIFF
--- a/main/src/addins/NUnit/Gui/TestResultsPad.cs
+++ b/main/src/addins/NUnit/Gui/TestResultsPad.cs
@@ -44,6 +44,7 @@ using System.Text.RegularExpressions;
 using MonoDevelop.Components;
 using MonoDevelop.Ide.Commands;
 using MonoDevelop.Ide.Fonts;
+using MonoDevelop.NUnit.External;
 
 namespace MonoDevelop.NUnit
 {
@@ -369,13 +370,19 @@ namespace MonoDevelop.NUnit
 
 		public void AddErrorMessage ()
 		{
-			string msg = GettextCatalog.GetString ("Internal error");
-			if (errorMessage != null)
-				msg += ": " + Escape (errorMessage);
+			string msg;
+			if (error is RemoteUnhandledException)
+				msg = Escape (errorMessage);
+			else {
+				msg = GettextCatalog.GetString ("Internal error");
+				if (errorMessage != null)
+					msg += ": " + Escape (errorMessage);
+			}
 
 			var stock = ImageService.GetIcon (Ide.Gui.Stock.Error, Gtk.IconSize.Menu);
 			TreeIter testRow = failuresStore.AppendValues (stock, msg, null, null, 0);
-			failuresStore.AppendValues (testRow, null, Escape (error.GetType ().Name + ": " + error.Message), null);
+			string name = error is RemoteUnhandledException ? ((RemoteUnhandledException)error).RemoteExceptionName : error.GetType ().Name;
+			failuresStore.AppendValues (testRow, null, Escape (name + ": " + error.Message), null);
 			TreeIter row = failuresStore.AppendValues (testRow, null, GettextCatalog.GetString ("Stack Trace"), null, null, 0);
 			AddStackTrace (row, error.StackTrace, null);
 		}

--- a/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
@@ -414,6 +414,7 @@ namespace MonoDevelop.NUnit
 			testContext.Monitor.CancelRequested += new TestHandler (rd.Cancel);
 
 			UnitTestResult result;
+			var crashLogFile = Path.GetTempFileName ();
 
 			try {
 				if (string.IsNullOrEmpty (AssemblyPath)) {
@@ -425,11 +426,17 @@ namespace MonoDevelop.NUnit
 				string testRunnerAssembly, testRunnerType;
 				GetCustomTestRunner (out testRunnerAssembly, out testRunnerType);
 
-				result = runner.Run (localMonitor, filter, AssemblyPath, "", new List<string> (SupportAssemblies), testRunnerType, testRunnerAssembly);
+				result = runner.Run (localMonitor, filter, AssemblyPath, "", new List<string> (SupportAssemblies), testRunnerType, testRunnerAssembly, crashLogFile);
 				if (testName != null)
 					result = localMonitor.SingleTestResult;
+				
+				ReportCrash (testContext, crashLogFile);
+				
 			} catch (Exception ex) {
-				if (!localMonitor.Canceled) {
+				if (ReportCrash (testContext, crashLogFile)) {
+					result = UnitTestResult.CreateFailure (GettextCatalog.GetString ("Undhandled exception"), null);
+				}
+				else if (!localMonitor.Canceled) {
 					LoggingService.LogError (ex.ToString ());
 					if (localMonitor.RunningTest != null) {
 						RuntimeErrorCleanup (testContext, localMonitor.RunningTest, ex);
@@ -442,6 +449,7 @@ namespace MonoDevelop.NUnit
 					result = UnitTestResult.CreateFailure (GettextCatalog.GetString ("Canceled"), null);
 				}
 			} finally {
+				File.Delete (crashLogFile);
 				testContext.Monitor.CancelRequested -= new TestHandler (rd.Cancel);
 				runner.Dispose ();
 				System.Runtime.Remoting.RemotingServices.Disconnect (localMonitor);
@@ -449,7 +457,18 @@ namespace MonoDevelop.NUnit
 			
 			return result;
 		}
-		
+
+		bool ReportCrash (TestContext testContext, string crashLogFile)
+		{
+			var crash = File.ReadAllText (crashLogFile);
+			if (crash.Length == 0)
+				return false;
+
+			var ex = RemoteUnhandledException.Parse (crash);
+			testContext.Monitor.ReportRuntimeError (GettextCatalog.GetString ("Unhandled exception"), ex);
+			return true;
+		}
+
 		void RuntimeErrorCleanup (TestContext testContext, UnitTest t, Exception ex)
 		{
 			UnitTestResult result = UnitTestResult.CreateFailure (ex);


### PR DESCRIPTION
Fixes bug 29457 - Uncaught exceptions from test can bring down the test runner.

Unhandled exceptions still bring down the test runner, but at least they
are now properly reported.