### PR TITLE
[Build] Don't fail tests for windows if dll is not found.

### DIFF
--- a/main/wintest.sh
+++ b/main/wintest.sh
@@ -10,6 +10,8 @@ else
 			arg="build/tests/$arg"
 		fi
 
-		(build/bin/mdtool run-md-tests $arg) || exit $?
+		if [ -f $arg ]; then
+			(build/bin/mdtool run-md-tests $arg) || exit $?
+		fi
 	done
 fi


### PR DESCRIPTION
Matches Mac and Linux behaviour from makefiles.