### PR TITLE
Add screenshots to the unit tests for Mac platform

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -161,6 +161,11 @@ namespace MonoDevelop.Components.AutoTest
 			return session.GetGlobalValue (name);
 		}
 
+		public void TakeScreenshot (string screenshotPath)
+		{
+			session.TakeScreenshot (screenshotPath);
+		}
+
 		public T GetGlobalValue<T> (string name)
 		{
 			return (T) session.GetGlobalValue (name);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -104,11 +104,14 @@ namespace MonoDevelop.Components.AutoTest
 
 		public void ExitApp ()
 		{
-			try {
-				IdeApp.Exit ();
-			} catch (Exception e) {
-				Console.WriteLine (e);
-			}
+			Sync (delegate {
+				try {
+					IdeApp.Exit ();
+				} catch (Exception e) {
+					Console.WriteLine (e);
+				}
+				return true;
+			});
 		}
 
 		public object GlobalInvoke (string name, object[] args)

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -41,6 +41,8 @@ namespace UserInterfaceTests
 
 		public string OtherCategoryRoot { get { return "Other"; } }
 
+		public string ScreenshotsPath { get; private set; }
+
 		public readonly static Action EmptyAction = () => { };
 
 		public readonly static Action WaitForPackageUpdate = delegate {
@@ -50,9 +52,27 @@ namespace UserInterfaceTests
 
 		static Regex cleanSpecialChars = new Regex ("[^0-9a-zA-Z]+", RegexOptions.Compiled);
 
-		public CreateBuildTemplatesTestBase () {}
+		string projectScreenshotFolder;
 
-		public CreateBuildTemplatesTestBase (string mdBinPath) : base (mdBinPath) {}
+		protected CreateBuildTemplatesTestBase (string folderName)
+		{
+			Init (folderName);
+		}
+
+		protected CreateBuildTemplatesTestBase (string mdBinPath, string folderName) : base (mdBinPath)
+		{
+			Init (folderName);
+		}
+
+		void Init (string folderName)
+		{
+			var pictureFolderName = Environment.GetFolderPath (Environment.SpecialFolder.MyPictures);
+			folderName = folderName ?? DateTime.Now.ToLongDateString ().Replace (",", "").Replace (' ', '-');
+			ScreenshotsPath = Path.Combine (pictureFolderName, "XamarinStudioUITests", folderName, GetType ().Name);
+			if (Directory.Exists (ScreenshotsPath))
+				Directory.Delete (ScreenshotsPath, true);
+			Directory.CreateDirectory (ScreenshotsPath);
+		}
 
 		public string GenerateProjectName (string templateName)
 		{
@@ -70,14 +90,17 @@ namespace UserInterfaceTests
 		}
 
 		public void CreateBuildProject (TemplateSelectionOptions templateOptions, Action beforeBuild,
-			GitOptions gitOptions = null, object miscOptions = null, bool rethrowException = false)
+			GitOptions gitOptions = null, object miscOptions = null)
 		{
 			var templateName = templateOptions.TemplateKind;
 			var projectName = !string.IsNullOrEmpty (templateOptions.ProjectName) ? templateOptions.ProjectName: GenerateProjectName (templateName);
+
+			SetUpTemplateScreenshot (projectName);
 			var solutionParentDirectory = Util.CreateTmpDir (projectName);
 			try {
 				var newProject = new NewProjectController ();
 				newProject.Open ();
+				TakeScreenShot ("Open");
 
 				OnSelectTemplate (newProject, templateOptions);
 
@@ -85,13 +108,17 @@ namespace UserInterfaceTests
 
 				OnEnterProjectDetails (newProject, projectName, projectName, solutionParentDirectory, gitOptions);
 
-				beforeBuild ();
+				try {
+					beforeBuild ();
+					TakeScreenShot ("BeforeBuild");
+				} catch (TimeoutException e) {
+					TakeScreenShot ("BeforeBuildActionFailed");
+					Assert.Fail (e.ToString ());
+				}
 
-				Assert.IsTrue (Ide.BuildSolution ());
+				OnBuildTemplate ();
 			} catch (Exception e) {
 				Assert.Fail (e.StackTrace);
-				if (rethrowException)
-					throw;
 			} finally {
 				var actualSolutionDirectory = GetSolutionDirectory ();
 				Ide.CloseAll ();
@@ -105,8 +132,11 @@ namespace UserInterfaceTests
 		protected virtual void OnSelectTemplate (NewProjectController newProject, TemplateSelectionOptions templateOptions)
 		{
 			Assert.IsTrue (newProject.SelectTemplateType (templateOptions.CategoryRoot, templateOptions.Category));
+			TakeScreenShot ("TemplateCategorySelected");
 			Assert.IsTrue (newProject.SelectTemplate (templateOptions.TemplateKindRoot, templateOptions.TemplateKind));
+			TakeScreenShot ("TemplateSelected");
 			Assert.IsTrue (newProject.Next ());
+			TakeScreenShot ("NextAfterTemplateSelected");
 		}
 
 		protected virtual void OnEnterTemplateSpecificOptions (NewProjectController newProject, string projectName, object miscOptions) {}
@@ -129,12 +159,39 @@ namespace UserInterfaceTests
 			if (gitOptions != null)
 				Assert.IsTrue (newProject.UseGit (gitOptions));
 
+			TakeScreenShot ("AfterProjectDetailsFilled");
+
 			Session.RunAndWaitForTimer (() => newProject.Next(), "Ide.Shell.SolutionOpened");
+		}
+
+		protected virtual void OnBuildTemplate ()
+		{
+			try {
+				Assert.IsTrue (Ide.BuildSolution ());
+				TakeScreenShot ("AfterBuildFinishedSuccessfully");
+			} catch (TimeoutException e) {
+				TakeScreenShot ("AfterBuildFailed");
+				Assert.Fail (e.ToString ());
+			}
 		}
 
 		protected string GetSolutionDirectory ()
 		{
 			return Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.ProjectOperations.CurrentSelectedSolution.RootFolder.BaseDirectory").ToString ();
+		}
+
+		void SetUpTemplateScreenshot (string projectName)
+		{
+			projectScreenshotFolder = Path.Combine (ScreenshotsPath, projectName);
+			if (Directory.Exists (projectScreenshotFolder))
+				Directory.Delete (projectScreenshotFolder, true);
+			Directory.CreateDirectory (projectScreenshotFolder);
+		}
+
+		protected void TakeScreenShot (string stepName)
+		{
+			var screenshotPath = Path.Combine (projectScreenshotFolder, stepName) + ".png";
+			Session.TakeScreenshot (screenshotPath);
 		}
 	}
 }

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -91,7 +91,7 @@ namespace UserInterfaceTests
 				Thread.Sleep (pollStep);
 			} while (timeout > 0);
 
-			throw new Exception ("Timed out waiting for event");
+			throw new TimeoutException ("Timed out waiting for Function: "+done.Method.Name);
 		}
 
 		//no saner way to do this

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
@@ -33,6 +33,8 @@ namespace UserInterfaceTests
 	{
 		readonly string aspCategory = "ASP.NET";
 
+		public ASPNetTemplatesTest () : base (Util.TestRunId) {}
+
 		[Test]
 		public void TestEmptyASPMVCProject ()
 		{

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/DotNetTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/DotNetTemplatesTest.cs
@@ -33,6 +33,8 @@ namespace UserInterfaceTests
 {
 	public class MonoDevelopTemplatesTest : CreateBuildTemplatesTestBase
 	{
+		public MonoDevelopTemplatesTest () : base (Util.TestRunId) {}
+
 		readonly string dotNetCategory = ".NET";
 
 		[Test]

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
@@ -35,6 +35,8 @@ namespace UserInterfaceTests
 		readonly string genericKindRoot = "Generic";
 		readonly string cCPlusKindRoot = "C/C++";
 
+		public MiscTemplatesTest () : base (Util.TestRunId) {}
+
 		#region Generic
 
 		[Test]

--- a/main/tests/UserInterfaceTests/Util.cs
+++ b/main/tests/UserInterfaceTests/Util.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.IO;
 using MonoDevelop.Core;
 
@@ -33,6 +34,14 @@ namespace UserInterfaceTests
 	{
 		static FilePath rootDir;
 		static int projectId = 1;
+
+		static string testRunIdentifier = DateTime.Now.ToString ("dddd-MMMM-dd-yyyy-HH-mm-ss");
+
+		public static string TestRunId {
+			get {
+				return testRunIdentifier;
+			}
+		}
 
 		public static FilePath TestsRootDir {
 			get {


### PR DESCRIPTION
Adds support for Mac screenshots using native `Foundation` and `AppKit` support. There are instances where the tests are failing in XS, so having screenshots is the only reliable way to track down the issues

Thanks to Chris Hamons for the `DllImport` section.