### PR TITLE
[Debugger] Removed valueNames.Clear() to prevent WatchPad entries removal

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -741,7 +741,6 @@ namespace MonoDevelop.Debugger
 		public void ClearAll ()
 		{
 			values.Clear ();
-			valueNames.Clear ();
 			cachedValues.Clear ();
 			frame = null;
 			Refresh (true);


### PR DESCRIPTION
Fixing https://bugzilla.xamarin.com/show_bug.cgi?id=29725