### PR TITLE
Fix some gtk assertion spew in the logs that began

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -1192,7 +1192,7 @@ namespace MonoDevelop.SourceEditor
 		void UpdatePinnedWatches ()
 		{
 			foreach (PinnedWatchInfo wi in pinnedWatches) {
-				widget.TextEditor.Remove (wi.Widget);
+				widget.TextEditor.TextArea.Remove (wi.Widget);
 				wi.Widget.Destroy ();
 			}
 			pinnedWatches.Clear ();


### PR DESCRIPTION
with 14dad72ef710e0267a985c5b5ffc53100282f31d

For reference, http://forums.xamarin.com/discussion/39714/version-5-9-is-very-slow