### PR TITLE
[AutoTest] Add support for ComboBoxes.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ModelOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ModelOperation.cs
@@ -31,7 +31,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 	public class ModelOperation : Operation
 	{
 		string ColumnName;
-		public ModelOperation (string columnName)
+		public ModelOperation (string columnName = null)
 		{
 			ColumnName = columnName;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -31,22 +31,22 @@ namespace MonoDevelop.Components.AutoTest.Results
 {
 	public class GtkTreeModelResult : AppResult
 	{
-		TreeView TView;
+		Widget ParentWidget;
 		TreeModel TModel;
 		int Column;
 		TreeIter? resultIter;
 		string DesiredText;
 
-		public GtkTreeModelResult (TreeView treeView, TreeModel treeModel, int column)
+		public GtkTreeModelResult (Widget parent, TreeModel treeModel, int column)
 		{
-			TView = treeView;
+			ParentWidget = parent;
 			TModel = treeModel;
 			Column = column;
 		}
 
-		public GtkTreeModelResult (TreeView treeView, TreeModel treeModel, int column, TreeIter iter)
+		public GtkTreeModelResult (Widget parent, TreeModel treeModel, int column, TreeIter iter)
 		{
-			TView = treeView;
+			ParentWidget = parent;
 			TModel = treeModel;
 			Column = column;
 			resultIter = iter;
@@ -119,7 +119,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 				TreeIter currentIter = (TreeIter) resultIter;
 
 				while (TModel.IterNext (ref currentIter)) {
-					newList.Add (new GtkTreeModelResult (TView, TModel, Column, currentIter));
+					newList.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, currentIter));
 				}
 
 				return newList;
@@ -133,8 +133,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 
 			return (bool) AutoTestService.CurrentSession.UnsafeSync (delegate {
-				TView.Selection.SelectIter ((TreeIter)resultIter);
-
+				if (ParentWidget is TreeView) {
+					TreeView treeView = (TreeView) ParentWidget;
+					treeView.Selection.SelectIter ((TreeIter) resultIter);
+				} else if (ParentWidget is ComboBox) {
+					ComboBox comboBox = (ComboBox) ParentWidget;
+					comboBox.SetActiveIter ((TreeIter) resultIter);
+				}
 				return true;
 			});
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -136,6 +136,10 @@ namespace MonoDevelop.Components.AutoTest.Results
 				return null;
 			}
 
+			if (column == null) {
+				return new GtkTreeModelResult (resultWidget, model, 0);
+			}
+
 			// Check if the class has the SemanticModelAttribute
 			Type modelType = model.GetType ();
 			SemanticModelAttribute attr = modelType.GetCustomAttribute<SemanticModelAttribute> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -81,6 +81,18 @@ namespace MonoDevelop.Components.AutoTest.Results
 			// FIXME: Are there other property names?
 
 			return (AppResult) AutoTestService.CurrentSession.UnsafeSync (delegate {
+				// Check for the combobox first and try to use the active text.
+				// If the active text fails then
+				ComboBox cb = resultWidget as ComboBox;
+				if (cb != null) {
+					string activeText = cb.ActiveText;
+					if (activeText == null) {
+						return null;
+					}
+
+					return CheckForText (activeText, text, exact) ? this : null;
+				}
+
 				// Look for a Text property on the widget.
 				PropertyInfo pinfo = resultWidget.GetType ().GetProperty ("Text");
 				if (pinfo != null) {
@@ -102,14 +114,24 @@ namespace MonoDevelop.Components.AutoTest.Results
 			});
 		}
 
-		public override AppResult Model (string column)
+		TreeModel ModelFromWidget (Widget widget)
 		{
-			TreeView tv = resultWidget as TreeView;
-			if (tv == null) {
+			TreeView tv = widget as TreeView;
+			if (tv != null) {
+				return (TreeModel)AutoTestService.CurrentSession.UnsafeSync (() => tv.Model);
+			}
+
+			ComboBox cb = widget as ComboBox;
+			if (cb == null) {
 				return null;
 			}
 
-			TreeModel model = (TreeModel) AutoTestService.CurrentSession.UnsafeSync (() => tv.Model);
+			return (TreeModel)AutoTestService.CurrentSession.UnsafeSync (() => cb.Model);
+		}
+
+		public override AppResult Model (string column)
+		{
+			TreeModel model = ModelFromWidget (resultWidget);
 			if (model == null) {
 				return null;
 			}
@@ -135,7 +157,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 
 			//AutoTestService.CurrentSession.SessionDebug.SendDebugMessage ("{0} has {1} at column {2}", resultWidget, column, columnNumber);
-			return new GtkTreeModelResult (tv, model, columnNumber);
+			return new GtkTreeModelResult (resultWidget, model, columnNumber);
 		}
 
 		object GetPropertyValue (string propertyName)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -172,7 +172,7 @@ namespace MonoDevelop.Components.AutoTest
 			return this;
 		}
 
-		public AppQuery Model (string column)
+		public AppQuery Model (string column = null)
 		{
 			operations.Add (new ModelOperation (column));
 			return this;


### PR DESCRIPTION
If the combobox has been created with Gtk.ComboBox.NewText or the Gtk.TreeModel has a string as its first column then the Text operator will operate on it directly, using that first column.
If the combobox has been created by specifying a different type of model, or the required string is not the first column, then the Model operator will have to be used, and the combobox's Gtk.TreeModel will have to have the SemanticModelAttribute added to it.