### PR TITLE
[UITest] Add filtering of uitest target by 'categories' argument

### DIFF
--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -153,7 +153,7 @@ test:
 	cd tests && $(MAKE) test assembly=$(assembly)
 
 uitest:
-	cd tests && $(MAKE) uitest assembly=$(assembly)
+	cd tests && $(MAKE) uitest assembly=$(assembly) categories=$(categories)
 
 coverage:
 	cd tests && $(MAKE) coverage

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -76,7 +76,12 @@ uitest:
 	@if test -n "$(assembly)"; then \
 		for asm in $(UITEST_ASSEMBLIES); do \
 			if test `basename $$asm` = $(assembly); then \
-				($(RUN_TEST) -xml=TestResult_`basename $$asm`.xml -labels $$asm) || exit $?; \
+				if test -n "$(categories)"; then \
+					($(RUN_TEST) -xml=TestResult_`basename $$asm`.xml -labels -include=$(categories) $$asm) || exit $?; \
+				fi; \
+				if ! test -n "$(categories)"; then \
+					($(RUN_TEST) -xml=TestResult_`basename $$asm`.xml -labels $$asm) || exit $?; \
+				fi; \
 			fi; \
 		done; \
 	fi

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/ASPNETTemplateTests.cs
@@ -29,6 +29,8 @@ using NUnit.Framework;
 
 namespace UserInterfaceTests
 {
+	[TestFixture]
+	[Category("ASP")]
 	public class ASPNetTemplatesTest : CreateBuildTemplatesTestBase
 	{
 		readonly string aspCategory = "ASP.NET";

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/DotNetTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/DotNetTemplatesTest.cs
@@ -31,6 +31,8 @@ using NUnit.Framework;
 
 namespace UserInterfaceTests
 {
+	[TestFixture]
+	[Category("DotNet")]
 	public class MonoDevelopTemplatesTest : CreateBuildTemplatesTestBase
 	{
 		public MonoDevelopTemplatesTest () : base (Util.TestRunId) {}

--- a/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
+++ b/main/tests/UserInterfaceTests/MonoDevelopTests/MiscTemplatesTest.cs
@@ -28,6 +28,8 @@ using NUnit.Framework;
 
 namespace UserInterfaceTests
 {
+	[TestFixture]
+	[Category("Misc")]
 	public class MiscTemplatesTest : CreateBuildTemplatesTestBase
 	{
 		readonly string miscCategory = "Miscellaneous";


### PR DESCRIPTION
Now when running
`make uitest assembly=assemblyname.dll`

it is possible to selectively run certain tests by passing another
optional argument named categories which is a comma seperated list
of NUnit categories
`make uitest assembly=UserInterfaceTests.dll categories=DotNet,Misc`