### PR TITLE
[Ide] Don't call Present() on the window here

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -262,8 +262,6 @@ namespace MonoDevelop.Ide.Gui
 		{
 			var window = tabControl.Toplevel as Gtk.Window;
 			if (window != null) {
-				window.Present ();
-
 				#if MAC
 				AppKit.NSWindow nswindow = MonoDevelop.Components.Mac.GtkMacInterop.GetNSWindow (window);
 				if (nswindow != null)


### PR DESCRIPTION
Calling Present() causes windows that have been snapped to the edge on Win32 to revert to their normal size.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=22570

@mhutch thought the reason for this `Present()` was maybe to focus XS in the event of double-clicking a .cs file in Windows Explorer, but after testing it I found it didn't actually do that. I tried replacing it with `DesktopService.GrabDesktopFocus (window)` but that also caused window snapping to break.

Does anyone know of anything else that might be affected by this change?