### PR TITLE
[AutoTest] Add support for passing CommandSource to CommandManager.DispatchCommand

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -32,6 +32,7 @@ using System.IO;
 using System.Threading;
 using System.Collections.Generic;
 using MonoDevelop.Core.Instrumentation;
+using MonoDevelop.Components.Commands;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -127,9 +128,9 @@ namespace MonoDevelop.Components.AutoTest
 			session.ExitApp ();
 		}
 
-		public void ExecuteCommand (object cmd, object dataItem = null)
+		public void ExecuteCommand (object cmd, object dataItem = null, CommandSource source = CommandSource.Unknown)
 		{
-			session.ExecuteCommand (cmd, dataItem);
+			session.ExecuteCommand (cmd, dataItem, source);
 		}
 
 		/*

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Tasks;
+using MonoDevelop.Components.Commands;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -60,10 +61,10 @@ namespace MonoDevelop.Components.AutoTest
 			return null;
 		}
 
-		public void ExecuteCommand (object cmd, object dataItem = null)
+		public void ExecuteCommand (object cmd, object dataItem = null, CommandSource source = CommandSource.Unknown)
 		{
 			Gtk.Application.Invoke (delegate {
-				AutoTestService.CommandManager.DispatchCommand (cmd, dataItem, null);
+				AutoTestService.CommandManager.DispatchCommand (cmd, dataItem, null, source);
 			});
 		}
 		


### PR DESCRIPTION
During writing UITest it is important to more closely imitate the working of the UI. `CommandManager.DispatchCommand` takes another argument named `CommandSource source` which tells from the source of the request like `MainMenu` or `ContextMenu`. This is important as some commands can only be called from one source and not from another