### PR TITLE
[5.9][Mac] Fix the processing of NSKeys in searchbar

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -83,25 +83,25 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			return xwtMask;
 		}
 
-		static Xwt.Key TranslateKey (NSFunctionKey key)
+		static Xwt.Key TranslateKey (int key)
 		{
 			switch (key)
 			{
-			case NSFunctionKey.UpArrow:
+			case 63232: //case NSFunctionKey.UpArrow:
 				return Xwt.Key.Up;
-			case NSFunctionKey.DownArrow:
+			case 63233: //case NSFunctionKey.DownArrow:
 				return Xwt.Key.Down;
-			case NSFunctionKey.LeftArrow:
+			case 63234: //case NSFunctionKey.LeftArrow:
 				return Xwt.Key.Left;
-			case NSFunctionKey.RightArrow:
+			case 63235: //case NSFunctionKey.RightArrow:
 				return Xwt.Key.Right;
-			case NSFunctionKey.Home:
+			case 63273: //case NSFunctionKey.Home:
 				return Xwt.Key.Home;
-			case NSFunctionKey.End:
+			case 63275: //case NSFunctionKey.End:
 				return Xwt.Key.End;
-			case NSFunctionKey.PageUp:
+			case 63276: //case NSFunctionKey.PageUp:
 				return Xwt.Key.PageUp;
-			case NSFunctionKey.PageDown:
+			case 63277: //NSFunctionKey.PageDown:
 				return Xwt.Key.PageDown;
 			}
 			return 0;
@@ -118,15 +118,15 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public override bool PerformKeyEquivalent (NSEvent theEvent)
 		{
-			NSFunctionKey charKey = (NSFunctionKey)theEvent.CharactersIgnoringModifiers[0];
-			if (charKey == (NSFunctionKey)27) {
+			int charKey = (int)theEvent.CharactersIgnoringModifiers[0];
+			if (charKey == 27) {
 				SendKeyPressed (Xwt.Key.Escape, Xwt.ModifierKeys.None);
 				base.PerformKeyEquivalent (theEvent);
 				return true;
 			}
 
 			// Use CharactersIgnoringModifiers instead of KeyCode. They don't match Xwt anyway.
-			if (SendKeyPressed (TranslateKey ((NSFunctionKey)theEvent.CharactersIgnoringModifiers[0]), TranslateMask (theEvent.ModifierFlags)))
+			if (SendKeyPressed (TranslateKey ((int)theEvent.CharactersIgnoringModifiers[0]), TranslateMask (theEvent.ModifierFlags)))
 				return true;
 
 			return base.PerformKeyEquivalent (theEvent);

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -83,25 +83,25 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			return xwtMask;
 		}
 
-		static Xwt.Key TranslateKey (NSKey key)
+		static Xwt.Key TranslateKey (NSFunctionKey key)
 		{
 			switch (key)
 			{
-			case NSKey.UpArrow:
+			case NSFunctionKey.UpArrow:
 				return Xwt.Key.Up;
-			case NSKey.DownArrow:
+			case NSFunctionKey.DownArrow:
 				return Xwt.Key.Down;
-			case NSKey.LeftArrow:
+			case NSFunctionKey.LeftArrow:
 				return Xwt.Key.Left;
-			case NSKey.RightArrow:
+			case NSFunctionKey.RightArrow:
 				return Xwt.Key.Right;
-			case NSKey.Home:
+			case NSFunctionKey.Home:
 				return Xwt.Key.Home;
-			case NSKey.End:
+			case NSFunctionKey.End:
 				return Xwt.Key.End;
-			case NSKey.PageUp:
+			case NSFunctionKey.PageUp:
 				return Xwt.Key.PageUp;
-			case NSKey.PageDown:
+			case NSFunctionKey.PageDown:
 				return Xwt.Key.PageDown;
 			}
 			return 0;
@@ -118,14 +118,15 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public override bool PerformKeyEquivalent (NSEvent theEvent)
 		{
-			if (theEvent.KeyCode == (ushort)NSKey.Escape) {
+			NSFunctionKey charKey = (NSFunctionKey)theEvent.CharactersIgnoringModifiers[0];
+			if (charKey == (NSFunctionKey)27) {
 				SendKeyPressed (Xwt.Key.Escape, Xwt.ModifierKeys.None);
 				base.PerformKeyEquivalent (theEvent);
 				return true;
 			}
 
 			// Use CharactersIgnoringModifiers instead of KeyCode. They don't match Xwt anyway.
-			if (SendKeyPressed (TranslateKey ((NSKey)theEvent.CharactersIgnoringModifiers[0]), TranslateMask (theEvent.ModifierFlags)))
+			if (SendKeyPressed (TranslateKey ((NSFunctionKey)theEvent.CharactersIgnoringModifiers[0]), TranslateMask (theEvent.ModifierFlags)))
 				return true;
 
 			return base.PerformKeyEquivalent (theEvent);


### PR DESCRIPTION
NSKey to Character is not a one to one mapping. Characters
such as 'w' were getting processed as End. This works better
and ensures that keys are mapped correctly.

Bug 30070 - cannot type into the search box in the top right