### PR TITLE
Revert "[AspNet] Load bundled ASP.NET MVC assemblies"

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
@@ -452,34 +452,6 @@
     <None Include="Templates\Projects\WebApplication.xpt.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\..\packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll">
-      <Link>System.Web.Mvc.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\..\packages\Microsoft.AspNet.Razor.3.2.2\lib\net45\System.Web.Razor.dll">
-      <Link>System.Web.Razor.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.Helpers.dll">
-      <Link>System.Web.Helpers.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Deployment.dll">
-      <Link>System.Web.WebPages.Deployment.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.dll">
-      <Link>System.Web.WebPages.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Razor.dll">
-      <Link>System.Web.WebPages.Razor.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll">
-      <Link>Microsoft.Web.Infrastructure.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
+++ b/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
@@ -1,13 +1,6 @@
 <ExtensionModel>
 	
 	<Runtime>
-		<Import assembly = "System.Web.Helpers.dll" />
-		<Import assembly = "System.Web.Mvc.dll" />
-		<Import assembly = "System.Web.Razor.dll" />
-		<Import assembly = "System.Web.WebPages.Deployment.dll" />
-		<Import assembly = "System.Web.WebPages.dll" />
-		<Import assembly = "System.Web.WebPages.Razor.dll" />
-
 		<Import file = "Html/Schemas/xhtml1-strict.xsd" />
 		<Import file = "Html/Schemas/xhtml1-transitional.xsd" />
 		<Import file = "Html/Schemas/xhtml1-frameset.xsd" />


### PR DESCRIPTION
This reverts commit 12d610fb3f6dce121df538e36f21d8c2eeb0a6e3.

This commit broke xbuild's ability to find DLLs using pkg-config.