### PR TITLE
[NuGet] Extend project API to make it simpler to use.

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -372,6 +372,7 @@
     <Compile Include="MonoDevelop.PackageManagement\OpenPackageReadmeMonitor.cs" />
     <Compile Include="MonoDevelop.PackageManagement\IOpenPackageReadMeMonitor.cs" />
     <Compile Include="MonoDevelop.PackageManagement\NullOpenPackageReadMeMonitor.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\PackageManagementSolutionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementSolutionExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementSolutionExtensions.cs
@@ -1,0 +1,43 @@
+﻿//
+// PackageManagementSolutionExtensions.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using MonoDevelop.PackageManagement;
+using MonoDevelop.Projects;
+
+namespace ICSharpCode.PackageManagement
+{
+	public static class PackageManagementSolutionExtensions
+	{
+		public static IPackageManagementProject GetProject (this IPackageManagementSolution solution, DotNetProject project)
+		{
+			var projectProxy = new DotNetProjectProxy (project);
+			var repository = PackageManagementServices.PackageRepositoryCache.CreateAggregateWithPriorityMachineCacheRepository ();
+			return solution.GetProject (repository, projectProxy);
+		}
+	}
+}
+


### PR DESCRIPTION
Allow a PackageManagementProject to be obtained given just a
DotNetProject.