### PR TITLE
[AutoTest] When a timeout occours, raise TimeoutException instead of generic Exception

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -114,7 +114,7 @@ namespace MonoDevelop.Components.AutoTest
 				}
 			});
 			if (!syncEvent.WaitOne (20000))
-				throw new Exception ("Timeout while executing synchronized call");
+				throw new TimeoutException ("Timeout while executing synchronized call");
 			if (error != null)
 				throw error;
 			return safe ? SafeObject (res) : res;
@@ -300,7 +300,7 @@ namespace MonoDevelop.Components.AutoTest
 			});
 
 			if (!syncEvent.WaitOne (timeout)) {
-				throw new Exception ("Timeout while executing ExecuteOnIdleAndWait");
+				throw new TimeoutException ("Timeout while executing ExecuteOnIdleAndWait");
 			}
 		}
 
@@ -347,7 +347,7 @@ namespace MonoDevelop.Components.AutoTest
 			});
 
 			if (!syncEvent.WaitOne (timeout)) {
-				throw new Exception (String.Format ("Timeout while executing WaitForElement: {0}", query));
+				throw new TimeoutException (String.Format ("Timeout while executing WaitForElement: {0}", query));
 			}
 
 			return resultSet;
@@ -371,7 +371,7 @@ namespace MonoDevelop.Components.AutoTest
 			});
 
 			if (!syncEvent.WaitOne (timeout)) {
-				throw new Exception (String.Format ("Timeout while executing WaitForNoElement: {0}", query));
+				throw new TimeoutException (String.Format ("Timeout while executing WaitForNoElement: {0}", query));
 			}
 		}
 
@@ -418,7 +418,7 @@ namespace MonoDevelop.Components.AutoTest
 				Thread.Sleep (pollStep);
 			} while (timeout > 0);
 
-			throw new Exception ("Timed out waiting for event");
+			throw new TimeoutException ("Timed out waiting for event");
 		}
 
 		public bool Select (AppResult result)


### PR DESCRIPTION
Raising TimeoutException in the case of timeout can help us narrow down the
causes of failures because such exceptions can be filtered and analyzed
separately. Lots of timeout exception happen because the test machine
is slower or the network is slower which leads to test failures even when
there is nothing wrong with the tests.

cc: @iainx 