### PR TITLE
MacPlatform: MacSelectFileDialogHandler: preserve symlinks (bxc#30655)

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
@@ -56,6 +56,7 @@ namespace MonoDevelop.MacIntegration
 					panel = new NSOpenPanel {
 						CanChooseDirectories = directoryMode,
 						CanChooseFiles = !directoryMode,
+						ResolvesAliases = false,
 					};
 				}
 				


### PR DESCRIPTION
Set `NSOpenPanel.ResolvesAliases = false` so that paths selected by the user are returned as-is and not resolved (in the case of an alias/symlink).

This matches `Gtk.FileChooserDialog`’s behavior, which does not resolve symlinks and simply returns the path exactly as the user selected.

This also fixes [bxc#30655](https://bugzilla.xamarin.com/show_bug.cgi?id=30655) where the dialog causes symlinks to resolve and therefore persist in preferences for custom .NET runtimes.
