### PR TITLE
Added more debugging support to AutoTest

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ChildrenOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ChildrenOperation.cs
@@ -43,6 +43,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("Children ()");
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/IndexOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/IndexOperation.cs
@@ -47,6 +47,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 			newResults.Add (resultSet [Index]);
 			return newResults;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("Index ({0})", Index);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/MarkedOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/MarkedOperation.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("Mark ({0})", Mark);
+			return string.Format ("Marked (\"{0}\")", Mark);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ModelOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ModelOperation.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("Model ({0})", ColumnName);
+			return string.Format ("Model (\"{0}\")", ColumnName);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/NextSiblingsOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/NextSiblingsOperation.cs
@@ -43,6 +43,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("NextSiblings ()");
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/PropertyOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/PropertyOperation.cs
@@ -51,6 +51,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("{0} ({1})", PropertyName, DesiredValue);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TextOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TextOperation.cs
@@ -53,6 +53,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("Text (\"{0}\", {1})", Text, Exact);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
@@ -50,6 +50,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("CheckType (\"{0}\")", DesiredType.FullName);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
@@ -31,10 +31,12 @@ namespace MonoDevelop.Components.AutoTest.Operations
 	public class TypeOperation : Operation
 	{
 		Type DesiredType;
+		string Name;
 
-		public TypeOperation (Type desiredType)
+		public TypeOperation (Type desiredType, string name)
 		{
 			DesiredType = desiredType;
+			Name = name;
 		}
 
 		public override List<AppResult> Execute (List<AppResult> resultSet)
@@ -53,7 +55,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("CheckType (\"{0}\")", DesiredType.FullName);
+			return Name != null ? string.Format ("{0} ()", Name) : string.Format ("CheckType (\"{0}\")", DesiredType.FullName);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -224,40 +224,40 @@ namespace MonoDevelop.Components.AutoTest
 			return this;
 		}
 
-		public AppQuery CheckType (Type desiredType)
+		public AppQuery CheckType (Type desiredType, string name = null)
 		{
-			operations.Add (new TypeOperation (desiredType));
+			operations.Add (new TypeOperation (desiredType, name));
 			return this;
 		}
 
 		public AppQuery Button ()
 		{
-			return CheckType (typeof(Button));
+			return CheckType (typeof(Button), "Button");
 		}
 
 		public AppQuery Textfield ()
 		{
-			return CheckType (typeof(Entry));
+			return CheckType (typeof(Entry), "Textfield");
 		}
 
 		public AppQuery CheckButton ()
 		{
-			return CheckType (typeof(CheckButton));
+			return CheckType (typeof(CheckButton), "CheckButton");
 		}
 
 		public AppQuery RadioButton ()
 		{
-			return CheckType (typeof(RadioButton));
+			return CheckType (typeof(RadioButton), "RadioButton");
 		}
 
 		public AppQuery TreeView ()
 		{
-			return CheckType (typeof(TreeView));
+			return CheckType (typeof(TreeView), "TreeView");
 		}
 
 		public AppQuery Window ()
 		{
-			return CheckType (typeof(Window));
+			return CheckType (typeof(Window), "Window");
 		}
 
 		public AppQuery Text (string text)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -29,6 +29,7 @@ using System.Text;
 using Gtk;
 using MonoDevelop.Components.AutoTest.Operations;
 using MonoDevelop.Components.AutoTest.Results;
+using System.Linq;
 
 #if MAC
 using AppKit;
@@ -321,12 +322,8 @@ namespace MonoDevelop.Components.AutoTest
 
 		public override string ToString ()
 		{
-			StringBuilder builder = new StringBuilder ();
-			foreach (var subquery in operations) {
-				builder.Append (subquery.ToString ());
-			}
-
-			return builder.ToString ();
+			var operationChain = string.Join (".", operations.Select (x => x.ToString ()));
+			return string.Format ("c => c.{0};", operationChain);
 		}		
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -326,11 +326,8 @@ namespace MonoDevelop.Components.AutoTest
 				ExecuteOnIdleAndWait (() => {
 					resultSet = ExecuteQueryNoWait (query);
 				});
-			} catch (Exception e) {
-				LoggingService.LogError ("AutoTest failed at ExecuteQuery for Query:\n\t");
-				LoggingService.LogError (query.ToString ());
-				LoggingService.LogError (e.ToString ());
-				throw;
+			} catch (TimeoutException e) {
+				throw new TimeoutException (string.Format ("Timeout while executing ExecuteQuery: {0}", query), e);
 			}
 
 			return resultSet;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Tasks;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -321,9 +322,16 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			AppResult[] resultSet = null;
 
-			ExecuteOnIdleAndWait (() => {
-				resultSet = ExecuteQueryNoWait (query);
-			});
+			try {
+				ExecuteOnIdleAndWait (() => {
+					resultSet = ExecuteQueryNoWait (query);
+				});
+			} catch (Exception e) {
+				LoggingService.LogError ("AutoTest failed at ExecuteQuery for Query:\n\t");
+				LoggingService.LogError (query.ToString ());
+				LoggingService.LogError (e.ToString ());
+				throw;
+			}
 
 			return resultSet;
 		}


### PR DESCRIPTION
* Overridden `ToString ()` for all subclasses of `Operation` so that the original Query can be reconstructed
* For `AppQuery.ExecuteQuery` method, handle the call in a `try-catch` block and throw another `TimeoutException` with the caught `TimeoutException` as InnerException
* Added a Name argument to `CheckOperation` ctor so that wrappers over it can led `CheckOperation` about the actual Query syntax.