### PR TITLE
Added SourceQuery to QueryResult so that actual query can be known during timeout

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ChildrenOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ChildrenOperation.cs
@@ -43,6 +43,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("Children ()");
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/IndexOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/IndexOperation.cs
@@ -47,6 +47,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 			newResults.Add (resultSet [Index]);
 			return newResults;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("Index ({0})", Index);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/MarkedOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/MarkedOperation.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("Mark ({0})", Mark);
+			return string.Format ("Marked (\"{0}\")", Mark);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ModelOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ModelOperation.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("Model ({0})", ColumnName);
+			return string.Format ("Model (\"{0}\")", ColumnName);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/NextSiblingsOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/NextSiblingsOperation.cs
@@ -43,6 +43,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("NextSiblings ()");
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/PropertyOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/PropertyOperation.cs
@@ -51,6 +51,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("{0} ({1})", PropertyName, DesiredValue);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TextOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TextOperation.cs
@@ -53,6 +53,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("Text (\"{0}\", {1})", Text, Exact);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
@@ -50,6 +50,11 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 			return newResultSet;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("CheckType (\"{0}\")", DesiredType.FullName);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/TypeOperation.cs
@@ -31,10 +31,12 @@ namespace MonoDevelop.Components.AutoTest.Operations
 	public class TypeOperation : Operation
 	{
 		Type DesiredType;
+		string Name;
 
-		public TypeOperation (Type desiredType)
+		public TypeOperation (Type desiredType, string name)
 		{
 			DesiredType = desiredType;
+			Name = name;
 		}
 
 		public override List<AppResult> Execute (List<AppResult> resultSet)
@@ -53,7 +55,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("CheckType (\"{0}\")", DesiredType.FullName);
+			return Name != null ? string.Format ("{0} ()", Name) : string.Format ("CheckType (\"{0}\")", DesiredType.FullName);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -116,7 +116,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			TreeIter currentIter = (TreeIter) resultIter;
 
 			while (TModel.IterNext (ref currentIter)) {
-				newList.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, currentIter));
+				newList.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, currentIter) { SourceQuery = this.SourceQuery });
 			}
 
 			return newList;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -160,7 +160,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 
 			if (column == null) {
-				return new GtkTreeModelResult (resultWidget, model, 0);
+				return new GtkTreeModelResult (resultWidget, model, 0) { SourceQuery = this.SourceQuery };
 			}
 
 			// Check if the class has the SemanticModelAttribute
@@ -182,7 +182,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 				return null;
 			}
 
-			return new GtkTreeModelResult (resultWidget, model, columnNumber);
+			return new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery };
 		}
 
 		object GetPropertyValue (string propertyName)
@@ -227,7 +227,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 					continue;
 				}
 
-				siblingResults.Add (new GtkWidgetResult (child));
+				siblingResults.Add (new GtkWidgetResult (child) { SourceQuery = this.SourceQuery });
 			}
 
 			return siblingResults;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Components.AutoTest
 			AppResult firstChild = null, lastChild = null;
 
 			foreach (var child in container.Children) {
-				AppResult node = new GtkWidgetResult (child);
+				AppResult node = new GtkWidgetResult (child) { SourceQuery = ToString () };
 				resultSet.Add (node);
 
 				// FIXME: Do we need to recreate the tree structure of the AppResults?
@@ -77,7 +77,7 @@ namespace MonoDevelop.Components.AutoTest
 			AppResult firstChild = null, lastChild = null;
 
 			foreach (var child in view.Subviews) {
-				AppResult node = new NSObjectResult (child);
+				AppResult node = new NSObjectResult (child) { SourceQuery = ToString () };
 				resultSet.Add (node);
 
 				if (firstChild == null) {
@@ -104,13 +104,13 @@ namespace MonoDevelop.Components.AutoTest
 			Gtk.Window[] windows = Gtk.Window.ListToplevels ();
 
 			// null for AppResult signifies root node
-			rootNode = new GtkWidgetResult (null);
+			rootNode = new GtkWidgetResult (null) { SourceQuery = ToString () };
 			List<AppResult> fullResultSet = new List<AppResult> ();
 
 			// Build the tree and full result set recursively
 			AppResult lastChild = null;
 			foreach (var window in windows) {
-				AppResult node = new GtkWidgetResult (window);
+				AppResult node = new GtkWidgetResult (window) { SourceQuery = ToString () };
 				fullResultSet.Add (node);
 
 				if (rootNode.FirstChild == null) {
@@ -132,7 +132,7 @@ namespace MonoDevelop.Components.AutoTest
 			NSWindow[] nswindows = NSApplication.SharedApplication.Windows;
 			if (nswindows != null) {
 				foreach (var window in nswindows) {
-					AppResult node = new NSObjectResult (window);
+					AppResult node = new NSObjectResult (window) { SourceQuery = ToString () };
 					AppResult nsWindowLastNode = null;
 					fullResultSet.Add (node);
 
@@ -146,7 +146,7 @@ namespace MonoDevelop.Components.AutoTest
 					}
 
 					foreach (var child in window.ContentView.Subviews) {
-						AppResult childNode = new NSObjectResult (child);
+						AppResult childNode = new NSObjectResult (child) { SourceQuery = ToString () };
 						fullResultSet.Add (childNode);
 
 						if (node.FirstChild == null) {
@@ -165,7 +165,7 @@ namespace MonoDevelop.Components.AutoTest
 					}
 
 					NSToolbar toolbar = window.Toolbar;
-					AppResult toolbarNode = new NSObjectResult (toolbar);
+					AppResult toolbarNode = new NSObjectResult (toolbar) { SourceQuery = ToString () };
 
 					if (node.FirstChild == null) {
 						node.FirstChild = toolbarNode;
@@ -179,7 +179,7 @@ namespace MonoDevelop.Components.AutoTest
 					if (toolbar != null) {
 						foreach (var item in toolbar.Items) {
 							if (item.View != null) {
-								AppResult itemNode = new NSObjectResult (item.View);
+								AppResult itemNode = new NSObjectResult (item.View) { SourceQuery = ToString () };
 								fullResultSet.Add (itemNode);
 
 								if (item.View.Subviews != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -224,40 +224,40 @@ namespace MonoDevelop.Components.AutoTest
 			return this;
 		}
 
-		public AppQuery CheckType (Type desiredType)
+		public AppQuery CheckType (Type desiredType, string name = null)
 		{
-			operations.Add (new TypeOperation (desiredType));
+			operations.Add (new TypeOperation (desiredType, name));
 			return this;
 		}
 
 		public AppQuery Button ()
 		{
-			return CheckType (typeof(Button));
+			return CheckType (typeof(Button), "Button");
 		}
 
 		public AppQuery Textfield ()
 		{
-			return CheckType (typeof(Entry));
+			return CheckType (typeof(Entry), "Textfield");
 		}
 
 		public AppQuery CheckButton ()
 		{
-			return CheckType (typeof(CheckButton));
+			return CheckType (typeof(CheckButton), "CheckButton");
 		}
 
 		public AppQuery RadioButton ()
 		{
-			return CheckType (typeof(RadioButton));
+			return CheckType (typeof(RadioButton), "RadioButton");
 		}
 
 		public AppQuery TreeView ()
 		{
-			return CheckType (typeof(TreeView));
+			return CheckType (typeof(TreeView), "TreeView");
 		}
 
 		public AppQuery Window ()
 		{
-			return CheckType (typeof(Window));
+			return CheckType (typeof(Window), "Window");
 		}
 
 		public AppQuery Text (string text)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -29,6 +29,7 @@ using System.Text;
 using Gtk;
 using MonoDevelop.Components.AutoTest.Operations;
 using MonoDevelop.Components.AutoTest.Results;
+using System.Linq;
 
 #if MAC
 using AppKit;
@@ -321,12 +322,8 @@ namespace MonoDevelop.Components.AutoTest
 
 		public override string ToString ()
 		{
-			StringBuilder builder = new StringBuilder ();
-			foreach (var subquery in operations) {
-				builder.Append (subquery.ToString ());
-			}
-
-			return builder.ToString ();
+			var operationChain = string.Join (".", operations.Select (x => x.ToString ()));
+			return string.Format ("c => c.{0};", operationChain);
 		}		
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -53,6 +53,8 @@ namespace MonoDevelop.Components.AutoTest
 		public abstract bool EnterText (string text);
 		public abstract bool Toggle (bool active);
 
+		public string SourceQuery { get; set; }
+
 		void AddChildrenToList (List<AppResult> children, AppResult child)
 		{
 			AppResult node = child.FirstChild;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -326,11 +326,8 @@ namespace MonoDevelop.Components.AutoTest
 				ExecuteOnIdleAndWait (() => {
 					resultSet = ExecuteQueryNoWait (query);
 				});
-			} catch (Exception e) {
-				LoggingService.LogError ("AutoTest failed at ExecuteQuery for Query:\n\t");
-				LoggingService.LogError (query.ToString ());
-				LoggingService.LogError (e.ToString ());
-				throw;
+			} catch (TimeoutException e) {
+				throw new TimeoutException (string.Format ("Timeout while executing ExecuteQuery: {0}", query), e);
 			}
 
 			return resultSet;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Tasks;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -321,9 +322,16 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			AppResult[] resultSet = null;
 
-			ExecuteOnIdleAndWait (() => {
-				resultSet = ExecuteQueryNoWait (query);
-			});
+			try {
+				ExecuteOnIdleAndWait (() => {
+					resultSet = ExecuteQueryNoWait (query);
+				});
+			} catch (Exception e) {
+				LoggingService.LogError ("AutoTest failed at ExecuteQuery for Query:\n\t");
+				LoggingService.LogError (query.ToString ());
+				LoggingService.LogError (e.ToString ());
+				throw;
+			}
 
 			return resultSet;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -430,9 +430,13 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			bool success = false;
 
-			ExecuteOnIdleAndWait (() => {
-				success = result.Select ();
-			});
+			try {
+				ExecuteOnIdleAndWait (() => {
+					success = result.Select ();
+				});
+			} catch (TimeoutException e) {
+				ThrowOperationTimeoutException ("Select", result.SourceQuery, result, e);
+			}
 
 			return success;
 		}
@@ -441,16 +445,24 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			bool success = false;
 
-			ExecuteOnIdleAndWait (() => {
-				success = result.Click ();
-			});
+			try {
+				ExecuteOnIdleAndWait (() => {
+					success = result.Click ();
+				});
+			} catch (TimeoutException e) {
+				ThrowOperationTimeoutException ("Click", result.SourceQuery, result, e);
+			}
 
 			return success;
 		}
 
 		public bool EnterText (AppResult result, string text)
 		{
-			ExecuteOnIdleAndWait (() => result.EnterText (text));
+			try {
+				ExecuteOnIdleAndWait (() => result.EnterText (text));
+			} catch (TimeoutException e) {
+				ThrowOperationTimeoutException ("EnterText", result.SourceQuery, result, e);
+			}
 
 			return true;
 		}
@@ -459,11 +471,20 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			bool success = false;
 
-			ExecuteOnIdleAndWait (() => {
-				success = result.Toggle (active);
-			});
+			try {
+				ExecuteOnIdleAndWait (() => {
+					success = result.Toggle (active);
+				});
+			} catch (TimeoutException e) {
+				ThrowOperationTimeoutException ("Toggle", result.SourceQuery, result, e);
+			}
 
 			return success;
+		}
+
+		void ThrowOperationTimeoutException (string operation, string query, AppResult result, Exception innerException)
+		{
+			throw new TimeoutException (string.Format ("Timeout while executing {0}: {1}\n\ton Element: {2}", operation, query, result), innerException);
 		}
 	}
 


### PR DESCRIPTION
### Dependency

Depends on https://github.com/mono/monodevelop/pull/926 first

### Commit Info

This PR contains just one commit, which needs to be added on top over PR #926 - https://github.com/mono/monodevelop/commit/e4949ff7d6c443a0ab552bf9ee6c59917e3f03b8

### Commit Details

Right now we can catch the exception and know the exact query only in method ExecuteQuery, WaitForElement and WaitForNoElement because in those methods we are provided with original AppQuery.

In methods like Select, Click, EnterText and Toggle, we just get the AppResult and hence it becomes hard to figure out the exact query which led to this result.

In this commit, SourceQuery is a string which holds the original string query which was assigned to it during evaluation. This is an additional data useful for debugging when there is a timeout in the above four methods mentioned