### PR TITLE
Added interpreter path to configure.sh for freebsd builds

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -1,3 +1,5 @@
+#!bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ ! -f $DIR/configure.exe ]; then


### PR DESCRIPTION
Without this freebsd will treat the file as a /bin/sh file