### PR TITLE
[Test Framework] Export the widget hierarchy via HTTP

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using System.Xml;
 using Gtk;
 
 namespace MonoDevelop.Components.AutoTest.Results
@@ -52,6 +53,10 @@ namespace MonoDevelop.Components.AutoTest.Results
 			resultIter = iter;
 		}
 			
+		public override void ToXml (XmlElement element)
+		{
+		}
+
 		public override AppResult Marked (string mark)
 		{
 			return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -29,6 +29,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Xml;
 using Gtk;
 
 namespace MonoDevelop.Components.AutoTest.Results
@@ -45,6 +46,28 @@ namespace MonoDevelop.Components.AutoTest.Results
 		public override string ToString ()
 		{
 			return String.Format ("{0} - {1} - {2} - {3}, - {4}", resultWidget, resultWidget.Allocation, resultWidget.Name, resultWidget.GetType ().FullName, resultWidget.Toplevel.Name);
+		}
+
+		void AddAttribute (XmlElement childElement, string name, string value)
+		{
+			XmlDocument doc = childElement.OwnerDocument;
+			XmlAttribute attr = doc.CreateAttribute (name);
+			attr.Value = value;
+			childElement.Attributes.Append (attr);
+		}
+
+		public override void ToXml (XmlElement element)
+		{
+			AddAttribute (element, "type", resultWidget.GetType ().ToString ());
+			AddAttribute (element, "fulltype", resultWidget.GetType ().FullName);
+
+			if (resultWidget.Name != null) {
+				AddAttribute (element, "name", resultWidget.Name);
+			}
+
+			AddAttribute (element, "visible", resultWidget.Visible.ToString ());
+			AddAttribute (element, "sensitive", resultWidget.Sensitive.ToString ());
+			AddAttribute (element, "allocation", resultWidget.Allocation.ToString ());
 		}
 
 		public override AppResult Marked (string mark)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Xml;
 using AppKit;
 using Foundation;
 
@@ -39,6 +40,32 @@ namespace MonoDevelop.Components.AutoTest.Results
 		public NSObjectResult (NSObject resultObject)
 		{
 			ResultObject = resultObject;
+		}
+
+		void AddAttribute (XmlElement childElement, string name, string value)
+		{
+			XmlDocument doc = childElement.OwnerDocument;
+			XmlAttribute attr = doc.CreateAttribute (name);
+			attr.Value = value;
+			childElement.Attributes.Append (attr);
+		}
+
+		public override void ToXml (XmlElement element)
+		{
+			AddAttribute (element, "type", ResultObject.GetType ().ToString ());
+			AddAttribute (element, "fulltype", ResultObject.GetType ().FullName);
+
+			NSView view = ResultObject as NSView;
+			if (view == null) {
+				return;
+			}
+
+			if (view.Identifier != null) {
+				AddAttribute (element, "name", view.Identifier);
+			}
+
+			AddAttribute (element, "visible", view.Hidden.ToString ());
+			AddAttribute (element, "allocation", view.Frame.ToString ());
 		}
 
 		public override AppResult Marked (string mark)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -26,7 +26,10 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Xml;
+
 using Gtk;
+
 using MonoDevelop.Components.AutoTest.Operations;
 using MonoDevelop.Components.AutoTest.Results;
 using System.Linq;
@@ -226,6 +229,33 @@ namespace MonoDevelop.Components.AutoTest
 			resultSet.CopyTo (results);
 
 			return results;
+		}
+
+		void AddChildrenToDocument (XmlDocument doc, XmlElement parentElement, AppResult children)
+		{
+			while (children != null) {
+				XmlElement childElement = doc.CreateElement ("result");
+				children.ToXml (childElement);
+				parentElement.AppendChild (childElement);
+
+				if (children.FirstChild != null) {
+					AddChildrenToDocument (doc, childElement, children.FirstChild);
+				}
+
+				children = children.NextSibling;
+			}
+		}
+
+		public XmlDocument ExecuteAndGenerateXml ()
+		{
+			Execute ();
+			XmlDocument doc = new XmlDocument ();
+
+			XmlElement rootElement = doc.CreateElement ("results");
+			doc.AppendChild (rootElement);
+
+			AddChildrenToDocument (doc, rootElement, rootNode.FirstChild);
+			return doc;
 		}
 
 		public AppQuery Marked (string mark)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Xml;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -37,6 +38,8 @@ namespace MonoDevelop.Components.AutoTest
 		public AppResult FirstChild { get; set; }
 		public AppResult PreviousSibling { get; set; }
 		public AppResult NextSibling { get; set; }
+
+		public abstract void ToXml (XmlElement element);
 
 		// Operations
 		public abstract AppResult Marked (string mark);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestHTTPServer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestHTTPServer.cs
@@ -1,0 +1,92 @@
+﻿//
+// AutoTestHTTPServer.cs
+//
+// Author:
+//       iain holmes <iain@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Net;
+using System.IO;
+using System.Text;
+using System.Xml;
+
+namespace MonoDevelop.Components.AutoTest
+{
+	public class AutoTestHTTPServer
+	{
+		HttpListener listener;
+		bool running;
+
+		public AutoTestHTTPServer ()
+		{
+			listener = new HttpListener ();
+			listener.Prefixes.Add ("http://localhost:12698/AutoTest/");
+		}
+
+		private class UTF8StringWriter : StringWriter
+		{
+			public override Encoding Encoding {
+				get {
+					return Encoding.UTF8;
+				}
+			}
+		}
+
+		public async void Start ()
+		{
+			listener.Start ();
+
+			running = true;
+			while (running) {
+				HttpListenerContext context = await listener.GetContextAsync ();
+
+				AppQuery q = new AppQuery ();
+				XmlDocument doc = q.ExecuteAndGenerateXml ();
+
+				string msg;
+				using (var sw = new UTF8StringWriter ()) {
+					using (var xw = XmlWriter.Create (sw, new XmlWriterSettings {Indent = true})) {
+						doc.WriteTo (xw);
+					}
+
+					msg = sw.ToString ();
+				}
+					
+				context.Response.ContentLength64 = Encoding.UTF8.GetByteCount (msg);
+				context.Response.StatusCode = (int)HttpStatusCode.OK;
+
+				using (Stream s = context.Response.OutputStream) {
+					using (StreamWriter sw = new StreamWriter (s)) {
+						await sw.WriteAsync (msg);
+					}
+				}
+			}
+		}
+
+		public void Stop ()
+		{
+			running = false;
+			listener.Stop ();
+		}
+	}
+}
+

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
@@ -41,6 +41,8 @@ namespace MonoDevelop.Components.AutoTest
 			get { return manager.currentSession; } 
 		}
 
+		static AutoTestHTTPServer httpServer;
+
 		public static void Start (CommandManager commandManager, bool publishServer)
 		{
 			AutoTestService.commandManager = commandManager;
@@ -64,6 +66,9 @@ namespace MonoDevelop.Components.AutoTest
 				sref = Convert.ToBase64String (ms.ToArray ());
 				File.WriteAllText (SessionReferenceFile, sref);
 			}
+				
+			httpServer = new AutoTestHTTPServer ();
+			httpServer.Start ();
 		}
 		
 		public static SessionRecord StartRecordingSession ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -30,6 +30,8 @@ using System.Runtime.InteropServices;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Xml;
+
 using System.Collections.Generic;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide;
@@ -331,6 +333,21 @@ namespace MonoDevelop.Components.AutoTest
 			}
 
 			return resultSet;
+		}
+
+		public XmlDocument ExecuteQueryAndGenerateXml (AppQuery query, int timeout = 20000)
+		{
+			XmlDocument doc = null;
+
+			ExecuteOnIdleAndWait (() => {
+				doc = query.ExecuteAndGenerateXml ();
+				Sync (() => {
+					DispatchService.RunPendingEvents ();
+					return true;
+				});
+			});
+
+			return doc;
 		}
 
 		public AppResult[] WaitForElement (AppQuery query, int timeout)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -3366,6 +3366,7 @@
     <Compile Include="MonoDevelop.Components.AutoTest.Results\GtkWidgetResult.cs" />
     <Compile Include="MonoDevelop.Components.AutoTest.Operations\ChildrenOperation.cs" />
     <Compile Include="MonoDevelop.Components.AutoTest.Results\NSObjectResult.cs" />
+    <Compile Include="MonoDevelop.Components.AutoTest\AutoTestHTTPServer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
This might be a bit of a weird one, so I'll defer judgement to @slluis 

Create a web server that listens on port 12698 and exports the widget hierarchy to any client that requests /AutoTest/ to aid in writing tests.

An example of the client is https://github.com/iainx/UIBuddy 

![screen shot 2015-06-03 at 12 27 00 pm](https://cloud.githubusercontent.com/assets/1253364/7967855/e45e18ee-0a24-11e5-956c-ce205ba90cf8.png)
