### PR TITLE
[PropertyPad] Query tooltip on whole row

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
@@ -698,7 +698,7 @@ namespace MonoDevelop.Components.PropertyGrid
 		void ShowTooltipWindow (int x, int y)
 		{
 			tooltipTimeout = 0;
-			int dx = (int)((double)Allocation.Width * dividerPosition);
+			int dx = (int)((double)Allocation.Width);
 			if (x >= dx)
 				return;
 			var row = GetAllRows (true).FirstOrDefault (r => !r.IsCategory && y >= r.EditorBounds.Y && y <= r.EditorBounds.Bottom);


### PR DESCRIPTION
the previous logic was unintuitive, so now show the tooltip while hovering the whole row
Bug 30545 - Properties Pad could use a tool tip for long property values