### PR TITLE
Add UITests for NewProjectDialog's Project preview

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -122,6 +122,28 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return newList;
 		}
 
+		public override List<AppResult> FlattenChildren ()
+		{
+			if (!resultIter.HasValue) {
+				return null;
+			}
+
+			TreeIter currentIter = (TreeIter) resultIter;
+			if (!TModel.IterHasChild (currentIter))
+			{
+				return null;
+			}
+
+			List<AppResult> newList = new List<AppResult> ();
+			for (int i = 0; i < TModel.IterNChildren (currentIter); i++) {
+				TreeIter childIter;
+				if (TModel.IterNthChild (out childIter, currentIter, i)) {
+					newList.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, childIter));
+				}
+			}
+			return newList;
+		}
+
 		public override bool Select ()
 		{
 			if (!resultIter.HasValue) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.Components.AutoTest
 			}
 		}
 
-		public List<AppResult> FlattenChildren ()
+		public virtual List<AppResult> FlattenChildren ()
 		{
 			List<AppResult> children = new List<AppResult> ();
 			AddChildrenToList (children, FirstChild);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -217,6 +217,7 @@ namespace MonoDevelop.Ide.Projects
 			cancelButtonBox.Name = "cancelButtonBox";
 			cancelButtonBox.BorderWidth = 16;
 			cancelButton = new Button ();
+			cancelButton.Name = "cancelButton";
 			cancelButton.Label = "gtk-cancel";
 			cancelButton.UseStock = true;
 			cancelButtonBox.PackStart (cancelButton, false, false, 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectFolderPreviewWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectFolderPreviewWidget.cs
@@ -29,6 +29,8 @@ using Gdk;
 using Gtk;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
+using MonoDevelop.Components.AutoTest;
+using System.ComponentModel;
 
 namespace MonoDevelop.Ide.Projects
 {
@@ -66,6 +68,9 @@ namespace MonoDevelop.Ide.Projects
 			folderTreeView.ShowExpanders = false;
 			folderTreeView.LevelIndentation = 10;
 			folderTreeView.CanFocus = false;
+
+			SemanticModelAttribute modelAttr = new SemanticModelAttribute ("folderTreeStore__IconId", "folderTreeStore__NodeName", "folderTreeStore__Image");
+			TypeDescriptor.AddAttributes (folderTreeStore, modelAttr);
 
 			var column = new TreeViewColumn ();
 			var iconRenderer = new CellRendererImage ();

--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -82,7 +82,9 @@ namespace UserInterfaceTests
 
 				OnEnterTemplateSpecificOptions (newProject, projectName, miscOptions);
 
-				OnEnterProjectDetails (newProject, projectName, projectName, solutionParentDirectory, gitOptions);
+				OnEnterProjectDetails (newProject, projectName, projectName, solutionParentDirectory, true, gitOptions);
+
+				OnClickCreate (newProject);
 
 				try {
 					beforeBuild ();
@@ -112,7 +114,7 @@ namespace UserInterfaceTests
 		protected virtual void OnEnterTemplateSpecificOptions (NewProjectController newProject, string projectName, object miscOptions) {}
 
 		protected virtual void OnEnterProjectDetails (NewProjectController newProject, string projectName,
-			string solutionName, string solutionLocation, GitOptions gitOptions = null)
+			string solutionName, string solutionLocation, bool createProjectInSolution = true, GitOptions gitOptions = null)
 		{
 			Assert.IsTrue (newProject.SetProjectName (projectName));
 
@@ -124,13 +126,16 @@ namespace UserInterfaceTests
 				Assert.IsTrue (newProject.SetSolutionLocation (solutionLocation));
 			}
 
-			Assert.IsTrue (newProject.CreateProjectInSolutionDirectory (true));
+			Assert.IsTrue (newProject.CreateProjectInSolutionDirectory (createProjectInSolution));
 
 			if (gitOptions != null)
 				Assert.IsTrue (newProject.UseGit (gitOptions));
 
 			TakeScreenShot ("AfterProjectDetailsFilled");
+		}
 
+		protected virtual void OnClickCreate (NewProjectController newProject)
+		{
 			Session.RunAndWaitForTimer (() => newProject.Next(), "Ide.Shell.SolutionOpened");
 		}
 

--- a/main/tests/UserInterfaceTests/DialogTests/NewProjectDialogTests.cs
+++ b/main/tests/UserInterfaceTests/DialogTests/NewProjectDialogTests.cs
@@ -1,0 +1,76 @@
+﻿//
+// NewProjectDialogTests.cs
+//
+// Author:
+//       Manish Sinha <manish.sinha@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace UserInterfaceTests
+{
+	[TestFixture]
+	[Category ("Dialog")]
+	[Category ("ProjectDialog")]
+	public class NewProjectDialogTests : CreateBuildTemplatesTestBase
+	{
+		readonly TemplateSelectionOptions templateOptions = new TemplateSelectionOptions {
+			CategoryRoot = "Other",
+			Category = ".NET",
+			TemplateKindRoot = "General",
+			TemplateKind = "Console Project",
+			ProjectName = "ConsoleProject"
+		};
+
+		readonly string solutionName = "ConsoleSolution";
+
+		readonly NewProjectController ctrl = new NewProjectController ();
+
+		readonly string solutionLocation = Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments);
+
+		[Test]
+		[TestCase (true, true, true, TestName = "WithGit--WithGitIgnore--WithProjectWithinSolution")]
+		[TestCase (true, true, false, TestName = "WithGit--WithGitIgnore--WithoutProjectWithinSolution")]
+		[TestCase (true, true, true, TestName = "WithGit--WithGitIgnore--WithProjectWithinSolution")]
+		[TestCase (false, false, false, TestName = "WithoutGit--WithoutGitIgnore--WithoutProjectWithinSolution")]
+		[TestCase (true, false, true, TestName = "WithGit--WithoutGitIgnore--WithProjectWithinSolution")]
+		[TestCase (false, true, false, TestName = "WithoutGit--WithGitIgnore--WithoutProjectWithinSolution")]
+		[TestCase (false, true, true, TestName = "WithoutGit--WithGitIgnore--WithProjectWithinSolution")]
+		[TestCase (true, false, false, TestName = "WithGit--WithoutGitIgnore--WithoutProjectWithinSolution")]
+		public void TestFolderPreview (bool useGit, bool useGitIgnore, bool projectWithinSolution)
+		{
+			TestFolderPreview (new GitOptions {
+				UseGit = useGit,
+				UseGitIgnore = useGitIgnore
+			}, projectWithinSolution);
+		}
+
+		void TestFolderPreview (GitOptions gitOptions, bool projectWithinSolution)
+		{
+			ctrl.Open ();
+			OnSelectTemplate (ctrl, templateOptions);
+			OnEnterProjectDetails (ctrl, templateOptions.ProjectName, solutionName, solutionLocation, projectWithinSolution, gitOptions);
+			ctrl.ValidatePreviewTree (templateOptions, solutionName, solutionLocation, projectWithinSolution, gitOptions);
+			ctrl.Close ();
+		}
+	}
+}

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="VersionControlTests\VCSBase.cs" />
     <Compile Include="VersionControlTests\SvnTests.cs" />
     <Compile Include="VersionControlTests\GitRepositoryConfigurationTests.cs" />
+    <Compile Include="DialogTests\NewProjectDialogTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -100,4 +101,7 @@
     </PropertyGroup>
     <Exec Command="$(NuGet) restore -SolutionDirectory $(SolutionDir)" />
   </Target>
+  <ItemGroup>
+    <Folder Include="DialogTests\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
For Cycle 6 we have a small UI enhancement for folder/project preview. This suite tests the preview by using 8 different combination of

* Create a project within solution directory - Checked and Unchecked
* Use git for version control - Checked and Unchecked
* Create a .gitignore file to ignore inessential files - Checked and Unchecked

the 8 tests are:

* WithoutGit--WithGitIgnore--WithProjectWithinSolution
* WithoutGit--WithGitIgnore--WithoutProjectWithinSolution
* WithGit--WithoutGitIgnore--WithProjectWithinSolution
* WithoutGit--WithoutGitIgnore--WithoutProjectWithinSolution
* WithGit--WithGitIgnore--WithProjectWithinSolution
* WithGit--WithGitIgnore--WithoutProjectWithinSolution
* WithGit--WithGitIgnore--WithProjectWithinSolution