### PR TITLE
[Test Framework] Delay the test framework startup until MD has finish…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.Components.AutoTest
 
 			process = Process.Start (pi);
 
-			if (!waitEvent.WaitOne (15000)) {
+			if (!waitEvent.WaitOne (120000)) {
 				try {
 					process.Kill ();
 				} catch { }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -177,7 +177,6 @@ namespace MonoDevelop.Ide
 			commandService = new CommandManager ();
 			ideServices = new IdeServices ();
 			CustomToolService.Init ();
-			AutoTestService.Start (commandService, Preferences.EnableAutomatedTesting);
 			
 			commandService.CommandTargetScanStarted += CommandServiceCommandTargetScanStarted;
 			commandService.CommandTargetScanFinished += CommandServiceCommandTargetScanFinished;
@@ -294,6 +293,7 @@ namespace MonoDevelop.Ide
 			IdeApp.Preferences.EnableInstrumentationChanged += delegate {
 				UpdateInstrumentationIcon ();
 			};
+			AutoTestService.Start (commandService, Preferences.EnableAutomatedTesting);
 			AutoTestService.NotifyEvent ("MonoDevelop.Ide.IdeStart");
 		}
 


### PR DESCRIPTION
…ed starting

When the AutoTestSession starts early in the startup process, there is a possible race condition if the test that is running attempts to do something before Monodevelop has finished starting. This patch starts AutoTestSession as the final part of the start up process