### PR TITLE
Reset listen_socket if connecting to existing endpoint fails.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -197,6 +197,15 @@ namespace MonoDevelop.Ide
 					// Reset the socket
 					if (null != socket_filename && File.Exists (socket_filename))
 						File.Delete (socket_filename);
+
+					if (options.IpcTcp) {
+						try {
+							listen_socket.Close();
+							listen_socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
+						} catch (Exception exc) {
+							LoggingService.LogError("Error resetting TCP socket", exc);
+						}
+					}
 				}
 			}
 			


### PR DESCRIPTION
Fixes issue with a new window always being created on Windows if the first instance of MonoDevelop was started with an open file argument.