### PR TITLE
[AutoTest] Fix AppQuery.Property by using object.Equals instead of ==

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -201,7 +201,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override AppResult Property (string propertyName, object value)
 		{
-			return (GetPropertyValue (propertyName) == value) ? this : null;			
+			return (object.Equals (GetPropertyValue (propertyName), value)) ? this : null;
 		}
 
 		public override List<AppResult> NextSiblings ()


### PR DESCRIPTION
Since we are comparing two objects which won't ever reference to
the same object, we should use object.Equals instead of using
the equality operator which on base object just resolves to
`object.ReferencesEqual`
http://stackoverflow.com/questions/814878/c-sharp-difference-between-and-equals