### PR TITLE
[AutoTest] Use Button.Label for GtkWidgetResult's MarkedOperation

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -62,6 +62,14 @@ namespace MonoDevelop.Components.AutoTest.Results
 					return this;
 				}
 			}
+
+			Button button = resultWidget as Button;
+			if (button != null) {
+				if (button.Label != null && button.Label.IndexOf (mark) > -1) {
+					return this;
+				}
+			}
+
 			return null;
 		}
 


### PR DESCRIPTION
It would be useful to have Gtk.Button's label for filtering in MarkedOperation.