### PR TITLE
[AutoTest] Match AppQuery.Text (text) on TreeModel with TreePath

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -98,6 +98,15 @@ namespace MonoDevelop.Components.AutoTest.Results
 				return false;
 			});
 
+			TModel.Foreach ((m, p, i) => {
+				if (text == p.ToString ()) {
+					resultIter = i;
+					return true;
+				}
+
+				return false;
+			});
+
 			return resultIter.HasValue ? this : null;
 		}
 


### PR DESCRIPTION
At the moment there is a small shortcoming with the current API for selecting `TreeView` rows. The only way to select a row if to know the string value of one of the `TreeModel` row.

There are scenarios, where none of the `TreeModel`/`TreeStore` rows are string or we do not know the string value of the row we are going to select. In such a case indexed selection is all we can do. In this patch, we use TreePath value as another way of selecting a row. We can use `0`, `1`, `2` etc to select first, second or third row respectively or even select child rows by using colon separated values like `2:3:1:2` which would select the third row, then it's fourth child row, then it's second child row, then its third child row