### PR TITLE
[Core] Remove project binding when addin is disabled.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -610,6 +610,8 @@ namespace MonoDevelop.Projects
 		{
 			if (args.Change == ExtensionChange.Add)
 				projectBindings.Add (args.ExtensionNode);
+			else if (args.Change == ExtensionChange.Remove)
+				projectBindings.Remove (args.ExtensionNode);
 		}
 		
 		void OnExtensionChanged (object s, ExtensionEventArgs args)


### PR DESCRIPTION
For Cycle 5 SR 3.

Fixed [bug #30299](https://bugzilla.xamarin.com/show_bug.cgi?id=30299) - User is unable to create iOS and other projects when Android addin is disabled.

To reproduce the original bug, open Xamarin Studio, disable the Android addin in the Add-in Manager, then try to create a new Xamarin.Forms solution. Clicking the Next button would not show
the Xamarin.Forms wizard page. In the logs there would be an error "Disabled add-ins can't be loaded" as the MonoDevelop.MonoAndroid addin was trying to be used.

The problem was that the Xamarin.Forms wizard checks that iOS and Android projects are supported using the ProjectService's CanCreateProject. This method was trying to load the Android addin's ProjectBinding but failing since the addin was disabled.

Now when an addin is disabled its project bindings are also removed from the ProjectService. This prevents a disabled addin from being used by the ProjectService.