### PR TITLE
[AutoTest] Return the child TreeIter for TreeView when Children () is called

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -125,7 +125,12 @@ namespace MonoDevelop.Components.AutoTest.Results
 		public override List<AppResult> FlattenChildren ()
 		{
 			if (!resultIter.HasValue) {
-				return null;
+				List<AppResult> children = new List<AppResult> ();
+				TModel.Foreach ((m, p, i) => {
+					children.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, i));
+					return false;
+				});
+				return children;
 			}
 
 			TreeIter currentIter = (TreeIter) resultIter;


### PR DESCRIPTION
If a `Children ()` operation is called on a TreeView, then instead of returning null, return its immediate children, subsequent `Children ()` operation would be needed to child the child of the currently selected TreeIter