### PR TITLE
[AutoTest] Use GtkTreeModelResult.Property to match IterValue properties

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -184,12 +184,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery };
 		}
 
-		object GetPropertyValue (string propertyName)
+		protected object GetPropertyValue (string propertyName, object requestedObject = null)
 		{
 			return AutoTestService.CurrentSession.UnsafeSync (delegate {
-				PropertyInfo propertyInfo = resultWidget.GetType().GetProperty(propertyName);
+				requestedObject = requestedObject ?? resultWidget;
+				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName);
 				if (propertyInfo != null) {
-					var propertyValue = propertyInfo.GetValue (resultWidget);
+					var propertyValue = propertyInfo.GetValue (requestedObject);
 					if (propertyValue != null) {
 						return propertyValue;
 					}


### PR DESCRIPTION
This is a partial solution to select `TreeView` row when the `TreeModel` to `CellRenderer` mapping is done using `SetCellDataFunc` method instead of regular method of adding attributes.

This would work only when TreeModel contains complex type whose specific property are known. If `SetCellDataFunc` method has some code where a method is invoked to fetch the values, this won't work.

This patch would solve most of the common scenarios of selection. e.g. OptionsDialog has the Model which contains `OptionsDialogSection` as the first column. We can use `OptionsDialogSection.Label` to select the specific row.

If `OptionsDialogSection` has a complex type as it's label say `Date` which is of type `DateTime` and we want to match year, then we would need to use this query

```
Session.Select (c => c.Window ().Marked ("Options")Children ().TreeView (
).Marked ("optionsTree").Model ().Property ("Date.Time", "2007"));
```