### PR TITLE
MDEntry widget (native context menu for entry widgets)

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.EditBranchDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.EditBranchDialog.cs
@@ -8,7 +8,7 @@ namespace MonoDevelop.VersionControl.Git
 		
 		private global::Gtk.Table table4;
 		
-		private global::Gtk.Entry entryName;
+		private global::MonoDevelop.Components.MDEntry entryName;
 		
 		private global::Gtk.Label label4;
 		
@@ -46,7 +46,7 @@ namespace MonoDevelop.VersionControl.Git
 			this.table4.RowSpacing = ((uint)(6));
 			this.table4.ColumnSpacing = ((uint)(6));
 			// Container child table4.Gtk.Table+TableChild
-			this.entryName = new global::Gtk.Entry ();
+			this.entryName = new global::MonoDevelop.Components.MDEntry ();
 			this.entryName.CanFocus = true;
 			this.entryName.Name = "entryName";
 			this.entryName.IsEditable = true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.EditRemoteDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.EditRemoteDialog.cs
@@ -8,11 +8,11 @@ namespace MonoDevelop.VersionControl.Git
 
 		private global::Gtk.Table table3;
 
-		private global::Gtk.Entry entryName;
+		private global::MonoDevelop.Components.MDEntry entryName;
 
-		private global::Gtk.Entry entryPushUrl;
+		private global::MonoDevelop.Components.MDEntry entryPushUrl;
 
-		private global::Gtk.Entry entryUrl;
+		private global::MonoDevelop.Components.MDEntry entryUrl;
 
 		private global::Gtk.Label label7;
 
@@ -48,7 +48,7 @@ namespace MonoDevelop.VersionControl.Git
 			this.table3.RowSpacing = ((uint)(6));
 			this.table3.ColumnSpacing = ((uint)(6));
 			// Container child table3.Gtk.Table+TableChild
-			this.entryName = new global::Gtk.Entry ();
+			this.entryName = new global::MonoDevelop.Components.MDEntry ();
 			this.entryName.CanFocus = true;
 			this.entryName.Name = "entryName";
 			this.entryName.IsEditable = true;
@@ -57,9 +57,10 @@ namespace MonoDevelop.VersionControl.Git
 			global::Gtk.Table.TableChild w2 = ((global::Gtk.Table.TableChild)(this.table3 [this.entryName]));
 			w2.LeftAttach = ((uint)(1));
 			w2.RightAttach = ((uint)(2));
+			w2.XOptions = ((global::Gtk.AttachOptions)(4));
 			w2.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.entryPushUrl = new global::Gtk.Entry ();
+			this.entryPushUrl = new global::MonoDevelop.Components.MDEntry ();
 			this.entryPushUrl.CanFocus = true;
 			this.entryPushUrl.Name = "entryPushUrl";
 			this.entryPushUrl.IsEditable = true;
@@ -70,9 +71,10 @@ namespace MonoDevelop.VersionControl.Git
 			w3.BottomAttach = ((uint)(3));
 			w3.LeftAttach = ((uint)(1));
 			w3.RightAttach = ((uint)(2));
+			w3.XOptions = ((global::Gtk.AttachOptions)(4));
 			w3.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
-			this.entryUrl = new global::Gtk.Entry ();
+			this.entryUrl = new global::MonoDevelop.Components.MDEntry ();
 			this.entryUrl.CanFocus = true;
 			this.entryUrl.Name = "entryUrl";
 			this.entryUrl.IsEditable = true;
@@ -83,6 +85,7 @@ namespace MonoDevelop.VersionControl.Git
 			w4.BottomAttach = ((uint)(2));
 			w4.LeftAttach = ((uint)(1));
 			w4.RightAttach = ((uint)(2));
+			w4.XOptions = ((global::Gtk.AttachOptions)(4));
 			w4.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table3.Gtk.Table+TableChild
 			this.label7 = new global::Gtk.Label ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.GitCommitDialogExtensionWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.GitCommitDialogExtensionWidget.cs
@@ -9,8 +9,8 @@ namespace MonoDevelop.VersionControl.Git
 		private global::Gtk.CheckButton checkAuthor;
 		private global::Gtk.Alignment authorBox;
 		private global::Gtk.Table table1;
-		private global::Gtk.Entry entryEmail;
-		private global::Gtk.Entry entryName;
+		private global::MonoDevelop.Components.MDEntry entryEmail;
+		private global::MonoDevelop.Components.MDEntry entryName;
 		private global::Gtk.Label labelMail;
 		private global::Gtk.Label labelName;
 		
@@ -58,7 +58,7 @@ namespace MonoDevelop.VersionControl.Git
 			this.table1.RowSpacing = ((uint)(6));
 			this.table1.ColumnSpacing = ((uint)(6));
 			// Container child table1.Gtk.Table+TableChild
-			this.entryEmail = new global::Gtk.Entry ();
+			this.entryEmail = new global::MonoDevelop.Components.MDEntry ();
 			this.entryEmail.CanFocus = true;
 			this.entryEmail.Name = "entryEmail";
 			this.entryEmail.IsEditable = true;
@@ -71,7 +71,7 @@ namespace MonoDevelop.VersionControl.Git
 			w3.RightAttach = ((uint)(2));
 			w3.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
-			this.entryName = new global::Gtk.Entry ();
+			this.entryName = new global::MonoDevelop.Components.MDEntry ();
 			this.entryName.CanFocus = true;
 			this.entryName.Name = "entryName";
 			this.entryName.IsEditable = true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.NewStashDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.NewStashDialog.cs
@@ -6,7 +6,7 @@ namespace MonoDevelop.VersionControl.Git
 	{
 		private global::Gtk.HBox hbox3;
 		private global::Gtk.Label label3;
-		private global::Gtk.Entry entryComment;
+		private global::MonoDevelop.Components.MDEntry entryComment;
 		private global::Gtk.Button buttonCancel;
 		private global::Gtk.Button buttonOk;
 		
@@ -36,7 +36,7 @@ namespace MonoDevelop.VersionControl.Git
 			w2.Expand = false;
 			w2.Fill = false;
 			// Container child hbox3.Gtk.Box+BoxChild
-			this.entryComment = new global::Gtk.Entry ();
+			this.entryComment = new global::MonoDevelop.Components.MDEntry ();
 			this.entryComment.CanFocus = true;
 			this.entryComment.Name = "entryComment";
 			this.entryComment.IsEditable = true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.UserGitConfigDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.UserGitConfigDialog.cs
@@ -12,7 +12,7 @@ namespace MonoDevelop.VersionControl.Git
 		
 		private global::Gtk.Alignment alignment8;
 		
-		private global::Gtk.Entry usernameEntry;
+		private global::MonoDevelop.Components.MDEntry usernameEntry;
 		
 		private global::Gtk.HBox hbox6;
 		
@@ -20,7 +20,7 @@ namespace MonoDevelop.VersionControl.Git
 		
 		private global::Gtk.Alignment alignment7;
 		
-		private global::Gtk.Entry emailEntry;
+		private global::MonoDevelop.Components.MDEntry emailEntry;
 		
 		private global::Gtk.Button buttonCancel;
 		
@@ -57,7 +57,7 @@ namespace MonoDevelop.VersionControl.Git
 			this.alignment8 = new global::Gtk.Alignment (1F, 1F, 0.9F, 1F);
 			this.alignment8.Name = "alignment8";
 			// Container child alignment8.Gtk.Container+ContainerChild
-			this.usernameEntry = new global::Gtk.Entry ();
+			this.usernameEntry = new global::MonoDevelop.Components.MDEntry ();
 			this.usernameEntry.CanFocus = true;
 			this.usernameEntry.Name = "usernameEntry";
 			this.usernameEntry.IsEditable = true;
@@ -88,7 +88,7 @@ namespace MonoDevelop.VersionControl.Git
 			this.alignment7 = new global::Gtk.Alignment (1F, 1F, 0.71F, 1F);
 			this.alignment7.Name = "alignment7";
 			// Container child alignment7.Gtk.Container+ContainerChild
-			this.emailEntry = new global::Gtk.Entry ();
+			this.emailEntry = new global::MonoDevelop.Components.MDEntry ();
 			this.emailEntry.CanFocus = true;
 			this.emailEntry.Name = "emailEntry";
 			this.emailEntry.IsEditable = true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/gui.stetic
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/gui.stetic
@@ -895,7 +895,7 @@
                   <placeholder />
                 </child>
                 <child>
-                  <widget class="Gtk.Entry" id="entryName">
+                  <widget class="MonoDevelop.Components.MDEntry" id="entryName">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
                     <property name="IsEditable">True</property>
@@ -1075,7 +1075,7 @@
                 <property name="RowSpacing">6</property>
                 <property name="ColumnSpacing">6</property>
                 <child>
-                  <widget class="Gtk.Entry" id="entryName">
+                  <widget class="MonoDevelop.Components.MDEntry" id="entryName">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
                     <property name="IsEditable">True</property>
@@ -1086,8 +1086,9 @@
                     <property name="LeftAttach">1</property>
                     <property name="RightAttach">2</property>
                     <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
                     <property name="YOptions">Fill</property>
-                    <property name="XExpand">True</property>
+                    <property name="XExpand">False</property>
                     <property name="XFill">True</property>
                     <property name="XShrink">False</property>
                     <property name="YExpand">False</property>
@@ -1096,7 +1097,7 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="Gtk.Entry" id="entryPushUrl">
+                  <widget class="MonoDevelop.Components.MDEntry" id="entryPushUrl">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
                     <property name="IsEditable">True</property>
@@ -1109,8 +1110,9 @@
                     <property name="LeftAttach">1</property>
                     <property name="RightAttach">2</property>
                     <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
                     <property name="YOptions">Fill</property>
-                    <property name="XExpand">True</property>
+                    <property name="XExpand">False</property>
                     <property name="XFill">True</property>
                     <property name="XShrink">False</property>
                     <property name="YExpand">False</property>
@@ -1119,7 +1121,7 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="Gtk.Entry" id="entryUrl">
+                  <widget class="MonoDevelop.Components.MDEntry" id="entryUrl">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
                     <property name="IsEditable">True</property>
@@ -1132,8 +1134,9 @@
                     <property name="LeftAttach">1</property>
                     <property name="RightAttach">2</property>
                     <property name="AutoSize">True</property>
+                    <property name="XOptions">Fill</property>
                     <property name="YOptions">Fill</property>
-                    <property name="XExpand">True</property>
+                    <property name="XExpand">False</property>
                     <property name="XFill">True</property>
                     <property name="XShrink">False</property>
                     <property name="YExpand">False</property>
@@ -1768,9 +1771,10 @@
               </packing>
             </child>
             <child>
-              <widget class="Gtk.Entry" id="entryComment">
+              <widget class="MonoDevelop.Components.MDEntry" id="entryComment">
                 <property name="MemberName" />
                 <property name="CanFocus">True</property>
+                <property name="Type">Custom</property>
                 <property name="IsEditable">True</property>
                 <property name="InvisibleChar">●</property>
               </widget>
@@ -1886,9 +1890,10 @@
                 <property name="RowSpacing">6</property>
                 <property name="ColumnSpacing">6</property>
                 <child>
-                  <widget class="Gtk.Entry" id="entryEmail">
+                  <widget class="MonoDevelop.Components.MDEntry" id="entryEmail">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
+                    <property name="Type">Custom</property>
                     <property name="IsEditable">True</property>
                     <property name="InvisibleChar">●</property>
                     <signal name="Changed" handler="OnChanged" />
@@ -1909,9 +1914,10 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="Gtk.Entry" id="entryName">
+                  <widget class="MonoDevelop.Components.MDEntry" id="entryName">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
+                    <property name="Type">Custom</property>
                     <property name="IsEditable">True</property>
                     <property name="InvisibleChar">●</property>
                     <signal name="Changed" handler="OnChanged" />
@@ -2017,9 +2023,10 @@
                     <property name="Xalign">1</property>
                     <property name="Yalign">1</property>
                     <child>
-                      <widget class="Gtk.Entry" id="usernameEntry">
+                      <widget class="MonoDevelop.Components.MDEntry" id="usernameEntry">
                         <property name="MemberName" />
                         <property name="CanFocus">True</property>
+                        <property name="Type">Custom</property>
                         <property name="IsEditable">True</property>
                         <property name="InvisibleChar">●</property>
                         <signal name="Changed" handler="OnChanged" />
@@ -2062,9 +2069,10 @@
                     <property name="Xalign">1</property>
                     <property name="Yalign">1</property>
                     <child>
-                      <widget class="Gtk.Entry" id="emailEntry">
+                      <widget class="MonoDevelop.Components.MDEntry" id="emailEntry">
                         <property name="MemberName" />
                         <property name="CanFocus">True</property>
+                        <property name="Type">Custom</property>
                         <property name="IsEditable">True</property>
                         <property name="InvisibleChar">●</property>
                         <signal name="Changed" handler="OnChanged" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/MDEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/MDEntry.cs
@@ -115,6 +115,11 @@ namespace MonoDevelop.Components
 		void PasteText ()
 		{
 			if (IsEditable) {
+				var clipboard = Gtk.Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
+
+				clipboard.RequestText ((cb, text) => {
+					InsertText (text);
+				});
 			} else {
 				ErrorBell ();
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/MDEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/MDEntry.cs
@@ -1,0 +1,153 @@
+﻿//
+// MDEntry.cs
+//
+// Author:
+//       Cody Russell <cody@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin, Inc (https://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Components
+{
+	[System.ComponentModel.Category ("MonoDevelop.Components")]
+	[System.ComponentModel.ToolboxItem(true)]
+	public class MDEntry : Gtk.Entry
+	{
+		public MDEntry ()
+		{
+			SetupMenu ();
+		}
+
+		public MDEntry (IntPtr raw) : base (raw)
+		{
+			SetupMenu ();
+		}
+
+		public MDEntry (string initial_text) : base (initial_text)
+		{
+			SetupMenu ();
+		}
+
+		protected override bool OnButtonPressEvent (Gdk.EventButton evt)
+		{
+			if (evt.Type == Gdk.EventType.ButtonPress && evt.Button == 3) {
+				UpdateMenuItemSensitivities ();
+				context_menu.Show (this, evt);
+				return false;
+			}
+
+			return base.OnButtonPressEvent (evt);
+		}
+
+		void SetupMenu ()
+		{
+			context_menu = new ContextMenu ();
+			cut = new ContextMenuItem { Label = GettextCatalog.GetString ("Cut") };
+			cut.Clicked += (sender, e) => CutSelectedText ();
+			context_menu.Items.Add (cut);
+
+			copy = new ContextMenuItem { Label = GettextCatalog.GetString ("Copy") };
+			copy.Clicked += (sender, e) => CopyText ();
+			context_menu.Items.Add (copy);
+
+			paste = new ContextMenuItem { Label = GettextCatalog.GetString ("Paste") };
+			paste.Clicked += (sender, e) => PasteText ();
+			context_menu.Items.Add (paste);
+
+			delete = new ContextMenuItem { Label = GettextCatalog.GetString ("Delete") };
+			delete.Clicked += (sender, e) => DeleteSelectedText ();
+
+			select_all = new ContextMenuItem { Label = GettextCatalog.GetString ("Select All") };
+			select_all.Clicked += (sender, e) => SelectAllText ();
+			context_menu.Items.Add (select_all);
+		}
+
+		void CutSelectedText ()
+		{
+			if (IsEditable) {
+				int selection_start, selection_end;
+
+				if (GetSelectionBounds (out selection_start, out selection_end)) {
+					var text = GetChars (selection_start, selection_end);
+					var clipboard = Gtk.Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
+
+					clipboard.Text = text;
+					DeleteText (selection_start, selection_end);
+				}
+			} else {
+				ErrorBell ();
+			}
+		}
+
+		void CopyText ()
+		{
+			int selection_start, selection_end;
+
+			if (GetSelectionBounds (out selection_start, out selection_end)) {
+				var text = GetChars (selection_start, selection_end);
+				var clipboard = Gtk.Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
+
+				clipboard.Text = text;
+			}
+		}
+
+		void PasteText ()
+		{
+			if (IsEditable) {
+			} else {
+				ErrorBell ();
+			}
+		}
+
+		void DeleteSelectedText ()
+		{
+			if (IsEditable) {
+				int selection_start, selection_end;
+
+				if (GetSelectionBounds (out selection_start, out selection_end)) {
+					DeleteText (selection_start, selection_end);
+				}
+			}
+		}
+
+		void SelectAllText ()
+		{
+			SelectRegion (0, Text.Length - 1);
+		}
+
+		void UpdateMenuItemSensitivities ()
+		{
+			copy.Sensitive = select_all.Sensitive = (Text.Length > 0);
+			cut.Sensitive = (Text.Length > 0 && IsEditable);
+			paste.Sensitive = this.IsEditable;
+		}
+
+		ContextMenu context_menu;
+		ContextMenuItem cut;
+		ContextMenuItem copy;
+		ContextMenuItem paste;
+		ContextMenuItem delete;
+		ContextMenuItem select_all;
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -3368,6 +3368,7 @@
     <Compile Include="MonoDevelop.Components.AutoTest.Results\NSObjectResult.cs" />
     <Compile Include="MonoDevelop.Components.AutoTest.Results\GtkNotebookResult.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\ProjectConfigurationControl.cs" />
+    <Compile Include="MonoDevelop.Components\MDEntry.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
This is related to this bug:

https://bugzilla.xamarin.com/show_bug.cgi?id=29751

This is a subclass of GtkEntry that uses our ContextMenu component to give us native menus on OSX.