### PR TITLE
Add an extension method to Gtk.Window to have it hijack right-click

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/ConflictResolutionDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/ConflictResolutionDialog.cs
@@ -26,6 +26,7 @@
 
 using MonoDevelop.Projects.Text;
 using MonoDevelop.Core;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -35,6 +36,8 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			this.Build ();
 			HasSeparator = false;
+
+			this.UseNativeContextMenus ();
 		}
 
 		public void Load (string file)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/CredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/CredentialsDialog.cs
@@ -23,9 +23,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using Gtk;
 using System;
 using LibGit2Sharp;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -35,6 +37,8 @@ namespace MonoDevelop.VersionControl.Git
 		public CredentialsDialog (string uri, SupportedCredentialTypes type, Credentials cred)
 		{
 			this.Build ();
+
+			this.UseNativeContextMenus ();
 
 			labelTop.Text = string.Format (labelTop.Text, uri);
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditBranchDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditBranchDialog.cs
@@ -53,6 +53,8 @@ namespace MonoDevelop.VersionControl.Git
 			oldName = name;
 			currentTracking = tracking;
 
+			this.UseNativeContextMenus ();
+
 			comboStore = new ListStore (typeof(string), typeof(Xwt.Drawing.Image), typeof (string), typeof(string));
 			comboSources.Model = comboStore;
 			var crp = new CellRendererImage ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditRemoteDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditRemoteDialog.cs
@@ -23,8 +23,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using LibGit2Sharp;
 
+using LibGit2Sharp;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -38,6 +39,10 @@ namespace MonoDevelop.VersionControl.Git
 		public EditRemoteDialog (Remote remote)
 		{
 			this.Build ();
+
+			var window = (Gtk.Window)this;
+			window.UseNativeContextMenus ();
+
 			if (remote != null) {
 				entryName.Text = remote.Name;
 				entryUrl.Text = remote.Url ?? "";

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditRemoteDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditRemoteDialog.cs
@@ -40,8 +40,7 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			this.Build ();
 
-			var window = (Gtk.Window)this;
-			window.UseNativeContextMenus ();
+			this.UseNativeContextMenus ();
 
 			if (remote != null) {
 				entryName.Text = remote.Name;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -48,6 +48,8 @@ namespace MonoDevelop.VersionControl.Git
 			this.repo = repo;
 			this.HasSeparator = false;
 
+			this.UseNativeContextMenus ();
+
 			// Branches list
 
 			storeBranches = new ListStore (typeof(Branch), typeof(string), typeof(string), typeof(string));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/MergeDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/MergeDialog.cs
@@ -46,6 +46,8 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			this.Build ();
 
+			this.UseNativeContextMenus ();
+
 			this.repo = repo;
 			this.rebasing = rebasing;
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/NewStashDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/NewStashDialog.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using MonoDevelop.Components;
+
 namespace MonoDevelop.VersionControl.Git
 {
 	partial class NewStashDialog : Gtk.Dialog
@@ -31,6 +33,8 @@ namespace MonoDevelop.VersionControl.Git
 		public NewStashDialog ()
 		{
 			this.Build ();
+
+			this.UseNativeContextMenus ();
 
 			entryComment.Activated += (o, e) => Respond (Gtk.ResponseType.Ok);
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/PushDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/PushDialog.cs
@@ -23,9 +23,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using System.Linq;
 using System.Collections.Generic;
 using MonoDevelop.Core;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -38,6 +40,8 @@ namespace MonoDevelop.VersionControl.Git
 			this.Build ();
 			this.repo = repo;
 			HasSeparator = false;
+
+			this.UseNativeContextMenus ();
 
 			changeList.DiffLoader = DiffLoader;
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
@@ -40,6 +40,7 @@ namespace MonoDevelop.VersionControl.Git
 		public StashManagerDialog (GitRepository repo)
 		{
 			this.Build ();
+			this.UseNativeContextMenus ();
 			repository = repo;
 
 			stashes = repo.GetStashes ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/UserGitConfigDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/UserGitConfigDialog.cs
@@ -23,7 +23,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using System;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -32,6 +34,7 @@ namespace MonoDevelop.VersionControl.Git
 		public UserGitConfigDialog ()
 		{
 			this.Build ();
+			this.UseNativeContextMenus ();
 			SetResponseSensitive (Gtk.ResponseType.Ok, false);
 		}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/UserInfoConflictDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/UserInfoConflictDialog.cs
@@ -23,8 +23,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using MonoDevelop.Core;
 
+using MonoDevelop.Core;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -33,6 +34,7 @@ namespace MonoDevelop.VersionControl.Git
 		public UserInfoConflictDialog (string mdInfo, string gitInfo)
 		{
 			this.Build ();
+			this.UseNativeContextMenus ();
 			label1.LabelProp = BrandingService.BrandApplicationName (label1.LabelProp);
 			radioMD.Label = BrandingService.BrandApplicationName (radioMD.Label);
 			labelMD.Markup = "<b>" + GLib.Markup.EscapeText (mdInfo) + "</b>";

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.EditRemoteDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/gtk-gui/MonoDevelop.VersionControl.Git.EditRemoteDialog.cs
@@ -5,25 +5,25 @@ namespace MonoDevelop.VersionControl.Git
 	internal partial class EditRemoteDialog
 	{
 		private global::Gtk.VBox vbox7;
-
+		
 		private global::Gtk.Table table3;
-
+		
 		private global::Gtk.Entry entryName;
-
+		
 		private global::Gtk.Entry entryPushUrl;
-
+		
 		private global::Gtk.Entry entryUrl;
-
+		
 		private global::Gtk.Label label7;
-
+		
 		private global::Gtk.Label label8;
-
+		
 		private global::Gtk.Label label9;
-
+		
 		private global::Gtk.CheckButton checkImportTags;
-
+		
 		private global::Gtk.Button buttonCancel;
-
+		
 		private global::Gtk.Button buttonOk;
 
 		protected virtual void Build ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuItem.cs
@@ -28,6 +28,26 @@ using System;
 
 namespace MonoDevelop.Components
 {
+	public class ContextMenuItemClickedEventArgs : EventArgs
+	{
+		public object Context {
+			get { return context; }
+		}
+
+		public ContextMenuItemClickedEventArgs (object context)
+		{
+			this.context = context;
+		}
+
+		public ContextMenuItemClickedEventArgs ()
+		{
+		}
+
+		object context;
+	}
+
+	public delegate void ContextMenuItemClickedEventHandler (object sender, ContextMenuItemClickedEventArgs e);
+
 	public class ContextMenuItem
 	{
 		ContextMenu subMenu;
@@ -52,6 +72,7 @@ namespace MonoDevelop.Components
 		}
 
 		public string Label { get; set; }
+		public object Context { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="MonoDevelop.Components.ContextMenuItem"/> uses a mnemonic.
@@ -85,7 +106,7 @@ namespace MonoDevelop.Components
 			}
 		}
 
-		public event EventHandler Clicked;
+		public event ContextMenuItemClickedEventHandler Clicked;
 
 		public void Show ()
 		{
@@ -104,10 +125,10 @@ namespace MonoDevelop.Components
 
 		protected virtual void DoClick ()
 		{
-			OnClicked (EventArgs.Empty);
+			OnClicked (new ContextMenuItemClickedEventArgs (Context));
 		}
 
-		protected virtual void OnClicked (EventArgs e)
+		protected virtual void OnClicked (ContextMenuItemClickedEventArgs e)
 		{
 			if (Clicked != null)
 				Clicked (this, e);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -499,38 +499,29 @@ namespace MonoDevelop.Components
 			#endif
 		}
 
-		static ContextMenu context_menu;
-		static ContextMenuItem cut;
-		static ContextMenuItem copy;
-		static ContextMenuItem paste;
-		static ContextMenuItem delete;
-		static ContextMenuItem select_all;
-
 		static void ShowNativeContextMenu (this Gtk.Entry entry, Gdk.EventButton evt)
 		{
-			if (context_menu == null) {
-				context_menu = new ContextMenu ();
+			var context_menu = new ContextMenu ();
 
-				cut = new ContextMenuItem { Label = GettextCatalog.GetString ("Cut"), Context = entry };
-				cut.Clicked += CutClicked;
-				context_menu.Items.Add (cut);
+			var cut = new ContextMenuItem { Label = GettextCatalog.GetString ("Cut"), Context = entry };
+			cut.Clicked += CutClicked;
+			context_menu.Items.Add (cut);
 
-				copy = new ContextMenuItem { Label = GettextCatalog.GetString ("Copy"), Context = entry };
-				copy.Clicked += CopyClicked;
-				context_menu.Items.Add (copy);
+			var copy = new ContextMenuItem { Label = GettextCatalog.GetString ("Copy"), Context = entry };
+			copy.Clicked += CopyClicked;
+			context_menu.Items.Add (copy);
 
-				paste = new ContextMenuItem { Label = GettextCatalog.GetString ("Paste"), Context = entry };
-				paste.Clicked += PasteClicked;
-				context_menu.Items.Add (paste);
+			var paste = new ContextMenuItem { Label = GettextCatalog.GetString ("Paste"), Context = entry };
+			paste.Clicked += PasteClicked;
+			context_menu.Items.Add (paste);
 
-				delete = new ContextMenuItem { Label = GettextCatalog.GetString ("Delete"), Context = entry };
-				delete.Clicked += DeleteClicked;
-				context_menu.Items.Add (delete);
+			var delete = new ContextMenuItem { Label = GettextCatalog.GetString ("Delete"), Context = entry };
+			delete.Clicked += DeleteClicked;
+			context_menu.Items.Add (delete);
 
-				select_all = new ContextMenuItem { Label = GettextCatalog.GetString ("Select All"), Context = entry };
-				select_all.Clicked += SelectAllClicked;
-				context_menu.Items.Add (select_all);
-			}
+			var select_all = new ContextMenuItem { Label = GettextCatalog.GetString ("Select All"), Context = entry };
+			select_all.Clicked += SelectAllClicked;
+			context_menu.Items.Add (select_all);
 
 			/* Update the menu items' sensitivities */
 			copy.Sensitive = select_all.Sensitive = (entry.Text.Length > 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -472,7 +472,7 @@ namespace MonoDevelop.Components
 			return new EventKeyWrapper (ptr);
 		}
 
-		public static IEnumerable<Gtk.Widget> FindAllChildWidgets (this Gtk.Container container)
+		static IEnumerable<Gtk.Widget> FindAllChildWidgets (this Gtk.Container container)
 		{
 			var widgets = new Stack<Widget> (new[] { container });
 
@@ -480,10 +480,7 @@ namespace MonoDevelop.Components
 				var widget = widgets.Pop ();
 				yield return widget;
 
-				if (widget is Gtk.Bin) {
-					var bin = (Gtk.Bin)widget;
-					widgets.Push (bin.Child);
-				} else if (widget is Gtk.Container) {
+				if (widget is Gtk.Container) {
 					var c = (Gtk.Container)widget;
 					foreach (var w in c.Children) {
 						widgets.Push (w);


### PR DESCRIPTION
events on all Gtk.Entry widgets in its child tree and to manage
the context menu using MonoDevelop's ContextMenu component so we
have native context menus on OSX.

https://bugzilla.xamarin.com/show_bug.cgi?id=29751