### PR TITLE
[AutoTest] Property Operation now looks at Static and Non-Public members

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/PropertyOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/PropertyOperation.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Components.AutoTest.Operations
 
 		public override string ToString ()
 		{
-			return string.Format ("{0} ({1})", PropertyName, DesiredValue);
+			return string.Format ("Property ({0}, {1})", PropertyName, DesiredValue);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -188,7 +188,8 @@ namespace MonoDevelop.Components.AutoTest.Results
 		{
 			return AutoTestService.CurrentSession.UnsafeSync (delegate {
 				requestedObject = requestedObject ?? resultWidget;
-				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName);
+				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName,
+					BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
 				if (propertyInfo != null) {
 					var propertyValue = propertyInfo.GetValue (requestedObject);
 					if (propertyValue != null) {


### PR DESCRIPTION
* Also Fix PropertyOperation.ToString ()