### PR TITLE
[AutoTest] Add Property Debugging Support

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -74,15 +74,6 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return null;
 		}
 
-		protected bool CheckForText (string haystack, string needle, bool exact)
-		{
-			if (exact) {
-				return haystack == needle;
-			} else {
-				return (haystack.IndexOf (needle) > -1);
-			}
-		}
-
 		public override AppResult Text (string text, bool exact)
 		{
 			// Entries and Labels have Text, Buttons have Label.
@@ -184,38 +175,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery };
 		}
 
-		protected object GetPropertyValue (string propertyName, object requestedObject = null)
-		{
-			return AutoTestService.CurrentSession.UnsafeSync (delegate {
-				requestedObject = requestedObject ?? resultWidget;
-				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName,
-					BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
-				if (propertyInfo != null) {
-					var propertyValue = propertyInfo.GetValue (requestedObject);
-					if (propertyValue != null) {
-						return propertyValue;
-					}
-				}
-
-				return null;
-			});
-		}
-
 		public override AppResult Property (string propertyName, object value)
 		{
 			return MatchProperty (propertyName, resultWidget, value);
-		}
-
-		protected AppResult MatchProperty (string propertyName, object objectToCompare, object value)
-		{
-			foreach (var singleProperty in propertyName.Split (new [] { '.' })) {
-				objectToCompare = GetPropertyValue (singleProperty, objectToCompare);
-			}
-			if (objectToCompare != null && value != null &&
-				CheckForText (objectToCompare.ToString (), value.ToString (), false)) {
-				return this;
-			}
-			return null;
 		}
 
 		public override List<AppResult> NextSiblings ()
@@ -244,6 +206,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 
 			return siblingResults;
+		}
+
+		public override ObjectProperties Properties ()
+		{
+			return GetProperties (resultWidget);
 		}
 
 		public override bool Select ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -116,6 +116,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return null;
 		}
 
+		public override ObjectProperties Properties ()
+		{
+			return GetProperties (ResultObject);
+		}
+
 		public override bool Select ()
 		{
 			return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
@@ -33,16 +33,24 @@ namespace MonoDevelop.Components.AutoTest.Results
 	{
 		PropertyInfo propertyInfo;
 		object value;
+		PropertyMetaData metaData;
 
 		internal ObjectResult (PropertyInfo propertyInfo, object value)
 		{
 			this.propertyInfo = propertyInfo;
 			this.value = value;
+			this.metaData = new PropertyMetaData (propertyInfo);
 		}
 
 		public override string ToString ()
 		{
 			return value != null ? value.ToString () : "null";
+		}
+
+		public PropertyMetaData PropertyMetaData {
+			get {
+				return metaData;
+			}
 		}
 
 		#region implemented abstract members of AppResult
@@ -79,7 +87,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override ObjectProperties Properties ()
 		{
-			return null;
+			return GetProperties (value);
 		}
 
 		public override bool Select ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
@@ -1,0 +1,118 @@
+﻿//
+// ObjectResult.cs
+//
+// Author:
+//       Manish Sinha <manish.sinha@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace MonoDevelop.Components.AutoTest.Results
+{
+	public class ObjectResult : AppResult
+	{
+		PropertyInfo propertyInfo;
+		object value;
+
+		internal ObjectResult (PropertyInfo propertyInfo, object value)
+		{
+			this.propertyInfo = propertyInfo;
+			this.value = value;
+		}
+
+		public override string ToString ()
+		{
+			return value != null ? value.ToString () : "null";
+		}
+
+		#region implemented abstract members of AppResult
+
+		public override AppResult Marked (string mark)
+		{
+			return null;
+		}
+
+		public override AppResult CheckType (Type desiredType)
+		{
+			return null;
+		}
+
+		public override AppResult Text (string text, bool exact)
+		{
+			return null;
+		}
+
+		public override AppResult Model (string column)
+		{
+			return null;
+		}
+
+		public override AppResult Property (string propertyName, object value)
+		{
+			return null;
+		}
+
+		public override List<AppResult> NextSiblings ()
+		{
+			return null;
+		}
+
+		public override ObjectProperties Properties ()
+		{
+			return null;
+		}
+
+		public override bool Select ()
+		{
+			return false;
+		}
+
+		public override bool Click ()
+		{
+			return false;
+		}
+
+		public override bool TypeKey (char key, string state = "")
+		{
+			return false;
+		}
+
+		public override bool TypeKey (string keyString, string state = "")
+		{
+			return false;
+		}
+
+		public override bool EnterText (string text)
+		{
+			return false;
+		}
+
+		public override bool Toggle (bool active)
+		{
+			return false;
+		}
+
+		#endregion
+	}
+}
+

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -86,7 +86,7 @@ namespace MonoDevelop.Components.AutoTest
 			return AutoTestService.CurrentSession.UnsafeSync (delegate {
 				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName,
 					BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
-				if (propertyInfo != null) {
+				if (propertyInfo != null && propertyInfo.CanRead) {
 					var propertyValue = propertyInfo.GetValue (requestedObject);
 					if (propertyValue != null) {
 						return propertyValue;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -25,7 +25,11 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
+using System.Linq;
+using MonoDevelop.Components.AutoTest.Results;
+using System.Reflection;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -45,6 +49,8 @@ namespace MonoDevelop.Components.AutoTest
 		public abstract AppResult Model (string column);
 		public abstract AppResult Property (string propertyName, object value);
 		public abstract List<AppResult> NextSiblings ();
+
+		public abstract ObjectProperties Properties ();
 
 		// Actions
 		public abstract bool Select ();
@@ -73,6 +79,117 @@ namespace MonoDevelop.Components.AutoTest
 			AddChildrenToList (children, FirstChild);
 
 			return children;
+		}
+
+		protected object GetPropertyValue (string propertyName, object requestedObject)
+		{
+			return AutoTestService.CurrentSession.UnsafeSync (delegate {
+				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName,
+					BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
+				if (propertyInfo != null) {
+					var propertyValue = propertyInfo.GetValue (requestedObject);
+					if (propertyValue != null) {
+						return propertyValue;
+					}
+				}
+
+				return null;
+			});
+		}
+
+		protected AppResult MatchProperty (string propertyName, object objectToCompare, object value)
+		{
+			foreach (var singleProperty in propertyName.Split (new [] { '.' })) {
+				objectToCompare = GetPropertyValue (singleProperty, objectToCompare);
+			}
+			if (objectToCompare != null && value != null &&
+				CheckForText (objectToCompare.ToString (), value.ToString (), false)) {
+				return this;
+			}
+			return null;
+		}
+
+		protected bool CheckForText (string haystack, string needle, bool exact)
+		{
+			if (exact) {
+				return haystack == needle;
+			} else {
+				return (haystack.IndexOf (needle) > -1);
+			}
+		}
+
+		protected ObjectProperties GetProperties (object resultObject)
+		{
+			var propertiesObject = new ObjectProperties ();
+			var properties = resultObject.GetType ().GetProperties (
+				BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+			foreach (var property in properties) {
+				propertiesObject.Add (property.Name, new ObjectResult (property, GetPropertyValue (property.Name, resultObject)));
+			}
+
+			return propertiesObject;
+		}
+	}
+
+	public class ObjectProperties : MarshalByRefObject
+	{
+		readonly Dictionary<string,ObjectResult> propertyMap = new Dictionary<string,ObjectResult> ();
+
+		internal ObjectProperties () { }
+
+		internal void Add (string propertyName, ObjectResult propertyValue)
+		{
+			propertyMap.Add (propertyName, propertyValue);
+		}
+
+		public ReadOnlyCollection<string> GetPropertyNames ()
+		{
+			return propertyMap.Keys.ToList ().AsReadOnly ();
+		}
+
+		public ObjectResult this [string key]
+		{
+			get {
+				return propertyMap [key];
+			}
+		}
+	}
+
+	public class PropertyMetaData : MarshalByRefObject
+	{
+		readonly PropertyInfo propertyInfo;
+
+		internal PropertyMetaData (PropertyInfo propertyInfo)
+		{
+			this.propertyInfo = propertyInfo;
+		}
+
+		public string Name
+		{
+			get {
+				return propertyInfo.Name;
+			}
+		}
+
+		public bool CanRead
+		{
+			get {
+				return propertyInfo.CanRead;
+			}
+		}
+
+		public bool CanWrite
+		{
+			get {
+				return propertyInfo.CanWrite;
+			}
+		}
+
+		public string PropertyType
+		{
+			get {
+				return propertyInfo.PropertyType.FullName;
+			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -121,10 +121,12 @@ namespace MonoDevelop.Components.AutoTest
 		protected ObjectProperties GetProperties (object resultObject)
 		{
 			var propertiesObject = new ObjectProperties ();
-			var properties = resultObject.GetType ().GetProperties (
-				BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-			foreach (var property in properties) {
-				propertiesObject.Add (property.Name, new ObjectResult (property, GetPropertyValue (property.Name, resultObject)));
+			if (resultObject != null) {
+				var properties = resultObject.GetType ().GetProperties (
+					                BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+				foreach (var property in properties) {
+					propertiesObject.Add (property.Name, new ObjectResult (property, GetPropertyValue (property.Name, resultObject)));
+				}
 			}
 
 			return propertiesObject;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -86,7 +86,7 @@ namespace MonoDevelop.Components.AutoTest
 			return AutoTestService.CurrentSession.UnsafeSync (delegate {
 				PropertyInfo propertyInfo = requestedObject.GetType().GetProperty(propertyName,
 					BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
-				if (propertyInfo != null && propertyInfo.CanRead) {
+				if (propertyInfo != null && propertyInfo.CanRead && !propertyInfo.GetIndexParameters ().Any ()) {
 					var propertyValue = propertyInfo.GetValue (requestedObject);
 					if (propertyValue != null) {
 						return propertyValue;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -3368,6 +3368,7 @@
     <Compile Include="MonoDevelop.Components.AutoTest.Results\NSObjectResult.cs" />
     <Compile Include="MonoDevelop.Components.AutoTest.Results\GtkNotebookResult.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\ProjectConfigurationControl.cs" />
+    <Compile Include="MonoDevelop.Components.AutoTest.Results\ObjectResult.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
**DO NOT MERGE - DISCUSSION REQUIRED**

---

As discussed, one of the biggest shortcoming of current test infrastructure is that there is no way to know the properties/values of a widget or an object. ObjectResult is the class which contains generic `System.object` and only implement `Properties ()` to recursively look into properties.

Do not call `Properties ()` recursively, it might lead to StackOverflow exception

---

Usage

```
TestService.StartSession (path); // path is MonoDevelop.exe path
TestService.Session.ExecuteCommand (FileCommands.NewProject);
    TestService.Session.WaitForElement (c => c.Window ().Marked ("MonoDevelop.Ide.Projects.GtkNewProjectDialogBackend"));
    var queryResults = TestService.Session.Query (c => c.Window ().Marked ("MonoDevelop.Ide.Projects.GtkNewProjectDialogBackend"));
    var res = queryResults [0];
    var properties = res.Properties ();
    foreach (var property in properties.GetPropertyNames ()) {
        var propertyValue = properties [property];
    Console.WriteLine ("{0}: {1} [{2}]", property, propertyValue, propertyValue.PropertyMetaData.PropertyType);
}
```

Result

---

CanMoveToNextPage: True [System.Boolean]
HasSeparator: False [System.Boolean]
ActionArea: Gtk.HButtonBox [Gtk.HButtonBox]
VBox: Gtk.VBox [Gtk.VBox]
DefaultResponse: null [Gtk.ResponseType]
AlternativeButtonOrder: null [System.Int32[]]
Screen: Gdk.Screen [Gdk.Screen]
Resizable: False [System.Boolean]
IconName: null [System.String]
TypeHint: Dialog [Gdk.WindowTypeHint]
IsActive: True [System.Boolean]
SkipPagerHint: False [System.Boolean]
DestroyWithParent: True [System.Boolean]
Title: New Project [System.String]
HasToplevelFocus: True [System.Boolean]
WindowPosition: CenterOnParent [Gtk.WindowPosition]
DefaultHeight: -1 [System.Int32]
...
...
...