### PR TITLE
CSharpBinding/Autotools | make produces a msc warning CS2029

### DIFF
--- a/main/src/addins/CSharpBinding/Autotools/CSharpAutotoolsSetup.cs
+++ b/main/src/addins/CSharpBinding/Autotools/CSharpAutotoolsSetup.cs
@@ -6,6 +6,7 @@ using MonoDevelop.Autotools;
 using MonoDevelop.Projects;
 using CSharpBinding;
 using MonoDevelop.CSharp.Project;
+using System.Text.RegularExpressions;
 
 namespace CSharpBinding.Autotools
 {
@@ -97,7 +98,7 @@ namespace CSharpBinding.Autotools
 			//}
 			
 			if (parameters.DefineSymbols.Length > 0) {
-				writer.Write (" \"-define:" + parameters.DefineSymbols + '"');
+				writer.Write (string.Format (" \"-define:{0}\"", Regex.Replace (parameters.DefineSymbols, ";$", "")));
 			}
 				
 			if (projectParameters.MainClass != null && projectParameters.MainClass != "") {


### PR DESCRIPTION
[Bug 31334](https://bugzilla.xamarin.com/show_bug.cgi?id=31334)

CSharpBinding/Autotools * make produces a msc warning CS2029: Invalid conditional define symbol

This removes the *-defines=* trailing semi-colon if there is one. 
