### PR TITLE
[Test Framework] Add ability to flash the AppResults

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -201,6 +201,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 		{
 			return false;
 		}
+
+		public override void Flash (System.Action completionHandler)
+		{
+			completionHandler ();
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -210,6 +210,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 			button.State = active ? NSCellStateValue.On : NSCellStateValue.Off;
 			return true;
 		}
+
+		public override void Flash (Action completionHandler)
+		{
+			completionHandler ();
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -59,6 +59,8 @@ namespace MonoDevelop.Components.AutoTest
 		public abstract bool EnterText (string text);
 		public abstract bool Toggle (bool active);
 
+		public abstract void Flash (Action completionHandler);
+
 		public string SourceQuery { get; set; }
 
 		void AddChildrenToList (List<AppResult> children, AppResult child)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -347,6 +347,14 @@ namespace MonoDevelop.Components.AutoTest
 			return session.Toggle (results [0], active);
 		}
 
+		public void Flash (Func<AppQuery, AppQuery> query)
+		{
+			AppResult[] results = Query (query);
+			foreach (var result in results) {
+				session.Flash (result);
+			}
+		}
+
 		public void RunAndWaitForTimer (Action action, string counterName, int timeout = 20000)
 		{
 			AutoTestSession.TimerCounterContext context = session.CreateNewTimerContext (counterName);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -521,6 +521,15 @@ namespace MonoDevelop.Components.AutoTest
 			return success;
 		}
 
+		public void Flash (AppResult result)
+		{
+			try {
+				ExecuteOnIdle (() => result.Flash (() => AutoTestService.NotifyEvent ("FlashCompleted")));
+			} catch (TimeoutException e) {
+				ThrowOperationTimeoutException ("Flash", result.SourceQuery, result, e);
+			}
+		}
+
 		void ThrowOperationTimeoutException (string operation, string query, AppResult result, Exception innerException)
 		{
 			throw new TimeoutException (string.Format ("Timeout while executing {0}: {1}\n\ton Element: {2}", operation, query, result), innerException);


### PR DESCRIPTION
A better flash implementation.

Flash is only an outline rather than solid red.
caller can use WaitForEvent ("FlashCompleted") to delay execution until the flash is completed