### PR TITLE
[AutoTest] Use string Type.FullName for ResultType instead of System.Type

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -61,9 +61,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 			AddAttribute (element, "allocation", resultWidget.Allocation.ToString ());
 		}
 
-		public override Type GetResultType  ()
+		public override string GetResultType  ()
 		{
-			return resultWidget.GetType ();
+			return resultWidget.GetType ().FullName;
 		}
 
 		public override AppResult Marked (string mark)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -62,9 +62,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 			AddAttribute (element, "allocation", view.Frame.ToString ());
 		}
 
-		public override Type GetResultType  ()
+		public override string GetResultType  ()
 		{
-			return ResultObject.GetType ();
+			return ResultObject.GetType ().FullName;
 		}
 
 		public override AppResult Marked (string mark)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
@@ -43,9 +43,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return value != null ? value.ToString () : "null";
 		}
 
-		public override Type GetResultType  ()
+		public override string GetResultType  ()
 		{
-			return value.GetType ();
+			return value.GetType ().FullName;
 		}
 
 		public override AppResult Marked (string mark)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.Components.AutoTest
 
 		// Inspection Operations
 		public abstract ObjectProperties Properties ();
-		public abstract Type GetResultType  ();
+		public abstract string GetResultType  ();
 
 		public string SourceQuery { get; set; }
 


### PR DESCRIPTION
After trying to explore the API, I realized that passing System.Type over remoting would randomly fail. This patch just  changes `AppResult. GetResultType` such that it just returns `System.Type.FullName` instead of `System.Type`