### PR TITLE
[Test Framework] Remove the IsBuildSuccessful calls from AutoTestSession

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.Xml;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Ide.Tasks;
 
 namespace MonoDevelop.Components.AutoTest
 {
@@ -199,10 +200,9 @@ namespace MonoDevelop.Components.AutoTest
 		}
 		*/
 
-		// FIXME: This shouldn't be here
-		public bool IsBuildSuccessful ()
+		public int ErrorCount (TaskSeverity severity)
 		{
-			return session.IsBuildSuccessful ();
+			return session.ErrorCount (severity);
 		}
 
 		public void WaitForEvent (string name)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -216,9 +216,9 @@ namespace MonoDevelop.Components.AutoTest
 		}
 			
 		// FIXME: This shouldn't be here.
-		public bool IsBuildSuccessful ()
+		public int ErrorCount (TaskSeverity severity)
 		{
-			return TaskService.Errors.Count (x => x.Severity == TaskSeverity.Error) == 0;
+			return TaskService.Errors.Count (x => x.Severity == severity);
 		}
 
 		object SafeObject (object ob)

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -103,7 +103,7 @@ namespace UserInterfaceTests
 
 		public static bool IsBuildSuccessful ()
 		{
-			return Session.IsBuildSuccessful ();
+			return Session.ErrorCount (MonoDevelop.Ide.Tasks.TaskSeverity.Error) == 0;
 		}
 
 		public static void RunAndWaitForTimer (Action action, string counter, int timeout = 20000)


### PR DESCRIPTION
IsBuildSuccessful is not right for being in AutoTestSession as it is an
interpretation of the data, which should be left up to the tests to decide. It
has been replaced with a method called ErrorCount which returns the number of
errors reported at a specified severity. It is then up to the caller to decide
what to do with this data.