### PR TITLE
[Core] Remove the duplicated Gestalt reading code

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Platform.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Platform.cs
@@ -88,30 +88,12 @@ namespace MonoDevelop.Core
 		static void InitMacFoundation ()
 		{
 			dlopen ("/System/Library/Frameworks/Foundation.framework/Foundation", 0x1);
-			OSVersion = new Version (Gestalt ("sys1"), Gestalt ("sys2"), Gestalt ("sys3"));
+			OSVersion = MacSystemInformation.OsVersion;
 		}
 
 		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
 		[return: MarshalAs(UnmanagedType.Bool)]
 		static extern bool SetDllDirectory (string lpPathName);
-
-		[System.Runtime.InteropServices.DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-		static extern int Gestalt (int selector, out int result);
-
-		//TODO: there are other gestalt selectors that return info we might want to display
-		//mac API for obtaining info about the system
-		static int Gestalt (string selector)
-		{
-			System.Diagnostics.Debug.Assert (selector != null && selector.Length == 4);
-			int cc = selector[3] | (selector[2] << 8) | (selector[1] << 16) | (selector[0] << 24);
-			int result;
-			int ret = Gestalt (cc, out result);
-			if (ret != 0) {
-				LoggingService.LogError ("Error reading gestalt for selector '{0}': {1}", selector, ret);
-				return 0;
-			}
-			return result;
-		}
 
 		static void InitWindowsNativeLibs ()
 		{


### PR DESCRIPTION
The code to call Gestalt is duplicated in both Platform.cs and MacSystemInformation.cs. Make the Platform method use the MacSystemInformation method.