### PR TITLE
[AutoTest] Remove Action from Flash methods and redundant CheckForText

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -201,11 +201,6 @@ namespace MonoDevelop.Components.AutoTest.Results
 		{
 			return false;
 		}
-
-		public override void Flash (System.Action completionHandler)
-		{
-			completionHandler ();
-		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -445,7 +445,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			cr.Stroke ();
 		}
 
-		public override void Flash (System.Action completionHandler)
+		public override void Flash ()
 		{
 			int flashCount = 10;
 
@@ -458,7 +458,6 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 				if (flashCount == 0) {
 					resultWidget.ExposeEvent -= OnFlashWidget;
-					completionHandler ();
 					return false;
 				}
 				return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -90,15 +90,6 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return null;
 		}
 
-		bool CheckForText (string haystack, string needle, bool exact)
-		{
-			if (exact) {
-				return haystack == needle;
-			} else {
-				return (haystack.IndexOf (needle) > -1);
-			}
-		}
-
 		public override AppResult Text (string text, bool exact)
 		{
 			if (ResultObject is NSControl) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -221,9 +221,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return true;
 		}
 
-		public override void Flash (Action completionHandler)
+		public override void Flash ()
 		{
-			completionHandler ();
+			
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
@@ -113,9 +113,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return false;
 		}
 
-		public override void Flash (Action completionHandler)
+		public override void Flash ()
 		{
-			completionHandler ();
+			
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.Components.AutoTest
 		public abstract bool EnterText (string text);
 		public abstract bool Toggle (bool active);
 
-		public abstract void Flash (Action completionHandler);
+		public abstract void Flash ();
 
 		// Inspection Operations
 		public abstract ObjectProperties Properties ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -524,7 +524,7 @@ namespace MonoDevelop.Components.AutoTest
 		public void Flash (AppResult result)
 		{
 			try {
-				ExecuteOnIdle (() => result.Flash (() => AutoTestService.NotifyEvent ("FlashCompleted")));
+				ExecuteOnIdle (() => result.Flash ());
 			} catch (TimeoutException e) {
 				ThrowOperationTimeoutException ("Flash", result.SourceQuery, result, e);
 			}


### PR DESCRIPTION
I am able to flash it properly without the `System.Action`

![Gif of flash](http://g.recordit.co/obSlv396qu.gif)
