### PR TITLE
[Ide] Disabling BringToFront for "Application Output" pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
@@ -77,7 +77,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public IProgressMonitor GetRunProgressMonitor ()
 		{
-			return GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.RunProgramIcon, true, true);
+			return GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.RunProgramIcon, false, true);
 		}
 		
 		public IProgressMonitor GetToolOutputProgressMonitor (bool bringToFront)
@@ -102,7 +102,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public IConsole CreateConsole (bool closeOnDispose)
 		{
-			return (IConsole) GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, true, true);
+			return (IConsole) GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, false, true);
 		}
 		
 		/******************************/


### PR DESCRIPTION
If BringToFront=true and LocalsPad(or any other Pad) shares same space as "Application Output" it's always hidden by "Application Output" when debugging starts which can be very annoying

At first I thought there is bug in Layout switching which forgets which pad was displayed/selected last and only later realised that "Application Output" is always throwing itself in front of LocalsPad or other pads...
So every time that I restart debugging I have to switch back to LocalsPad...

If user likes watching Application Output... no problem he can always switch to it... and it will stay in front in next debug session...(aka same behaviour as now unless he changes to some other pad)...

/cc @slluis 