### PR TITLE
Support packages.ProjectName.config file if present.

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -87,7 +87,8 @@ namespace ICSharpCode.PackageManagement
 
 		public static string GetPackagesConfigFilePath (this DotNetProject project)
 		{
-			return Path.Combine (project.BaseDirectory, Constants.PackageReferenceFile);
+			string path = Path.Combine (project.BaseDirectory, string.Format("packages.{0}.config", project.Name));
+			return File.Exists (path) ? path : Path.Combine (project.BaseDirectory, Constants.PackageReferenceFile);
 		}
 
 		public static bool HasPackages (this IDotNetProject project)
@@ -97,7 +98,8 @@ namespace ICSharpCode.PackageManagement
 
 		public static string GetPackagesConfigFilePath (this IDotNetProject project)
 		{
-			return Path.Combine (project.BaseDirectory, Constants.PackageReferenceFile);
+			string path = Path.Combine (project.BaseDirectory, string.Format("packages.{0}.config", project.Name));
+			return File.Exists (path) ? path : Path.Combine (project.BaseDirectory, Constants.PackageReferenceFile);
 		}
 	}
 }


### PR DESCRIPTION
If a file of the format packages.ProjectName.config is present, it should be used instead of packages.config.

Documentation: http://docs.nuget.org/release-notes/nuget-2.8#user-content-individual-packagesconfig-files-for-different-platforms.
Reference implementation: https://github.com/NuGet/NuGet.PackageManagement/blob/3.0-rtm/src/ProjectManagement/Projects/PackagesConfigNuGetProject.cs