### PR TITLE
[Components] Use the ContextMenu system to build the popup menu for MenuButton

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
@@ -79,22 +79,16 @@ namespace MonoDevelop.Components.DockNotebook
 
 			tabStrip.DropDownButton.Sensitive = false;
 
-			tabStrip.DropDownButton.MenuCreator = delegate {
-				Gtk.Menu menu = new Menu ();
+			tabStrip.DropDownButton.ContextMenuRequested = delegate {
+				ContextMenu menu = new ContextMenu ();
 				foreach (var tab in pages) {
-					var mi = new Gtk.ImageMenuItem ("");
-					menu.Insert (mi, -1);
-					var label = (Gtk.AccelLabel) mi.Child;
-					if (tab.Markup != null)
-						label.Markup = tab.Markup;
-					else
-						label.Text = tab.Text;
+					var item = new ContextMenuItem (tab.Markup ?? tab.Text);
 					var locTab = tab;
-					mi.Activated += delegate {
-						CurrentTab = locTab;
+					item.Clicked += (object sender, ContextMenuItemClickedEventArgs e) => {
+						currentTab = locTab;
 					};
+					menu.Items.Add (item);
 				}
-				menu.ShowAll ();
 				return menu;
 			};
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsGtk.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsGtk.cs
@@ -33,14 +33,36 @@ namespace MonoDevelop.Components
 	{
 		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, ContextMenu menu)
 		{
+			ShowContextMenu (parent, evt, menu, null);
+		}
+
+		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, ContextMenu menu, Action closeHandler)
+		{
 			if (parent == null)
 				throw new ArgumentNullException ("parent");
 			if (menu == null)
 				throw new ArgumentNullException ("menu");
 
-			var gtkMenu = FromMenu (menu);
+			var gtkMenu = FromMenu (menu, closeHandler);
 			gtkMenu.ShowAll ();
 			ShowContextMenu (parent, evt, gtkMenu);
+		}
+
+		public static void ShowContextMenu (Gtk.Widget parent, int x, int y, ContextMenu menu)
+		{
+			ShowContextMenu (parent, x, y, menu, null);
+		}
+
+		public static void ShowContextMenu (Gtk.Widget parent, int x, int y, ContextMenu menu, Action closeHandler)
+		{
+			if (parent == null)
+				throw new ArgumentNullException ("parent");
+			if (menu == null)
+				throw new ArgumentNullException ("menu");
+
+			var gtkMenu = FromMenu (menu, closeHandler);
+			gtkMenu.ShowAll ();
+			ShowContextMenu (parent, x, y, gtkMenu);
 		}
 
 		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, Gtk.Menu menu)
@@ -51,6 +73,16 @@ namespace MonoDevelop.Components
 				throw new ArgumentNullException ("menu");
 
 			Mono.TextEditor.GtkWorkarounds.ShowContextMenu (menu, parent, evt);
+		}
+
+		public static void ShowContextMenu (Gtk.Widget parent, int x, int y, Gtk.Menu menu)
+		{
+			if (parent == null)
+				throw new ArgumentNullException ("parent");
+			if (menu == null)
+				throw new ArgumentNullException ("menu");
+
+			Mono.TextEditor.GtkWorkarounds.ShowContextMenu (menu, parent, x, y, parent.Allocation);
 		}
 
 		static Gtk.MenuItem CreateMenuItem (ContextMenuItem item)
@@ -74,7 +106,7 @@ namespace MonoDevelop.Components
 			} 
 
 			if (item.SubMenu != null && item.SubMenu.Items.Count > 0) {
-				menuItem.Submenu = FromMenu (item.SubMenu);
+				menuItem.Submenu = FromMenu (item.SubMenu, null);
 			}
 			else {
 				menuItem.Activated += (sender, e) => item.Click ();
@@ -100,7 +132,7 @@ namespace MonoDevelop.Components
 			return menuItem;
 		}
 
-		static Gtk.Menu FromMenu (ContextMenu menu)
+		static Gtk.Menu FromMenu (ContextMenu menu, Action closeHandler)
 		{
 			var result = new Gtk.Menu ();
 
@@ -110,6 +142,9 @@ namespace MonoDevelop.Components
 					result.Append (item);
 			}
 
+			if (closeHandler != null) {
+				result.Hidden += (sender, e) => closeHandler ();
+			}
 			return result;
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
@@ -431,25 +431,29 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 				return;
 			}
 			globalWarningBox.Show ();
-			conflicButton.MenuCreator = delegate {
-				Menu menu = new Menu ();
+
+			conflicButton.ContextMenuRequested = delegate {
+				ContextMenu menu = new ContextMenu ();
+				bool first = true;
+
 				foreach (KeyBindingConflict conf in conflicts) {
-					if (menu.Children.Length > 0) {
-						SeparatorMenuItem it = new SeparatorMenuItem ();
-						it.Show ();
-						menu.Insert (it, -1);
+					if (first == false) {
+						ContextMenuItem item = new SeparatorContextMenuItem ();
+						menu.Items.Add (item);
 					}
+
 					foreach (Command cmd in conf.Commands) {
 						string txt = currentBindings.GetBinding (cmd) + " - " + cmd.Text;
-						MenuItem item = new MenuItem (txt);
+						ContextMenuItem item = new ContextMenuItem (txt);
 						Command localCmd = cmd;
-						item.Activated += delegate {
-							SelectCommand (localCmd);
-						};
-						item.Show ();
-						menu.Insert (item, -1);
+
+						item.Clicked += (sender, e) => SelectCommand (localCmd);
+
+						menu.Items.Add (item);
+						first = false;
 					}
 				}
+
 				return menu;
 			};
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/DefaultPolicyOptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/DefaultPolicyOptionsDialog.cs
@@ -72,37 +72,44 @@ namespace MonoDevelop.Ide.Projects
 			
 			exportButton = new MenuButton ();
 			exportButton.Label = GettextCatalog.GetString ("Export");
-			exportButton.MenuCreator = delegate {
-				Gtk.Menu menu = new Gtk.Menu ();
-				MenuItem mi = new MenuItem (GettextCatalog.GetString ("To file..."));
-				mi.Activated += HandleToFile;
-				menu.Insert (mi, -1);
-				mi = new MenuItem (GettextCatalog.GetString ("To project or solution..."));
-				mi.Activated += HandleToProject;
-				if (!IdeApp.Workspace.IsOpen)
-					mi.Sensitive = false;
-				menu.Insert (mi, -1);
-				menu.ShowAll ();
+			exportButton.ContextMenuRequested = delegate {
+				ContextMenu menu = new ContextMenu ();
+
+				ContextMenuItem item = new ContextMenuItem (GettextCatalog.GetString ("To file..."));
+				item.Clicked += HandleToFile;
+				menu.Items.Add (item);
+
+				item = new ContextMenuItem (GettextCatalog.GetString ("To project or solution..."));
+				item.Clicked += HandleToProject;
+				if (!IdeApp.Workspace.IsOpen) {
+					item.Sensitive = false;
+				}
+				menu.Items.Add (item);
+
 				return menu;
 			};
 			topBar.PackEnd (exportButton, false, false, 0);
 			
 			newButton = new MenuButton ();
 			newButton.Label = GettextCatalog.GetString ("Add Policy");
-			newButton.MenuCreator = delegate {
-				Gtk.Menu menu = new Gtk.Menu ();
-				MenuItem mi = new MenuItem (GettextCatalog.GetString ("New policy..."));
-				mi.Activated += HandleNewButtonClicked;
-				menu.Insert (mi, -1);
-				mi = new MenuItem (GettextCatalog.GetString ("From file..."));
-				mi.Activated += HandleFromFile;
-				menu.Insert (mi, -1);
-				mi = new MenuItem (GettextCatalog.GetString ("From project or solution..."));
-				mi.Activated += HandleFromProject;
-				if (!IdeApp.Workspace.IsOpen)
-					mi.Sensitive = false;
-				menu.Insert (mi, -1);
-				menu.ShowAll ();
+			newButton.ContextMenuRequested = delegate {
+				ContextMenu menu = new ContextMenu ();
+
+				ContextMenuItem item = new ContextMenuItem (GettextCatalog.GetString ("New policy..."));
+				item.Clicked += HandleNewButtonClicked;
+				menu.Items.Add (item);
+
+				item = new ContextMenuItem (GettextCatalog.GetString ("From file..."));
+				item.Clicked += HandleFromFile;
+				menu.Items.Add (item);
+
+				item = new ContextMenuItem (GettextCatalog.GetString ("From project or solution..."));
+				item.Clicked += HandleFromProject;
+				if (!IdeApp.Workspace.IsOpen) {
+					item.Sensitive = false;
+				}
+				menu.Items.Add (item);
+
 				return menu;
 			};
 			topBar.PackEnd (newButton, false, false, 0);


### PR DESCRIPTION
There are multiple systems for building menus in MonoDevelop
 - Using the standard Gtk.Menu functions like MenuButton uses
 - MonoDevelop.Components ContextMenu system where menus are described in an object model, and Gtk.Menu and NSMenus can be created from them
 - By using CommandEntrySets, another model that can then generate Gtk.Menu or NSMenu

This patch ports MenuButton to use the MonoDevelop.Components.ContextMenu system and deprecates the old Gtk.Menu methods. This should make it possible to switch to using NSMenu for these popup menus on the Mac