### PR TITLE
[MacPlatform] Prevent editor and search bar both having focus

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -175,6 +175,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		NSToolbarItem CreateSearchBarToolbarItem ()
 		{
 			var bar = new SearchBar ();
+
+			// Remove the focus from the Gtk system when Cocoa has focus
+			// Fixes BXC #29601
+			bar.GainedFocus += (o, e) => IdeApp.Workbench.RootWindow.Focus = null;
+
 			viewCache.Add (bar);
 			var menuBar = new SearchBar {
 				Frame = new CGRect (0, 0, 180, bar.FittingSize.Height),
@@ -280,6 +285,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public void FocusSearchBar ()
 		{
+			searchEntry.Focus ();
+
 			var entry = searchEntry;
 			if (!IsSearchEntryInOverflow)
 				entry.SelectText (entry);

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -40,6 +40,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		internal event EventHandler<Xwt.KeyEventArgs> KeyPressed;
 		internal event EventHandler LostFocus;
 		new internal event EventHandler Activated;
+		public event EventHandler GainedFocus;
 
 		/// <summary>
 		/// This tells whether events have been attached when created from the menu.
@@ -112,6 +113,21 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			// Needs to be grabbed after it's parented.
 			gtkWidget = GtkMacInterop.NSViewToGtkWidget (this);
+		}
+
+		public override bool BecomeFirstResponder ()
+		{
+			bool firstResponder = base.BecomeFirstResponder ();
+			if (firstResponder)
+				Focus ();
+
+			return firstResponder;
+		}
+
+		public void Focus ()
+		{
+			if (GainedFocus != null)
+				GainedFocus (this, EventArgs.Empty);
 		}
 	}
 }


### PR DESCRIPTION
Remove the focus from the Gtk focus system when the searchbar is focused.
Fixes BXC #29601 Pressing a shortcut key to the search in the top right moves the cursor to both the search box and text editor simultaneously