### PR TITLE
[AutoTest] Override Properties () for GtkTreeModelResult and allow non-recursive Children with proper handling of TreeIter in GtkTreeViewResult

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ChildrenOperation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Operations/ChildrenOperation.cs
@@ -30,12 +30,19 @@ namespace MonoDevelop.Components.AutoTest.Operations
 {
 	public class ChildrenOperation : Operation
 	{
+		bool recursive;
+
+		public ChildrenOperation (bool recursive = true)
+		{
+			this.recursive = recursive;
+		}
+
 		public override List<AppResult> Execute (List<AppResult> resultSet)
 		{
 			List<AppResult> newResultSet = new List<AppResult> ();
 
 			foreach (var result in resultSet) {
-				List<AppResult> flattenedChildren = result.Children ();
+				List<AppResult> flattenedChildren = result.Children (recursive);
 				if (flattenedChildren != null) {
 					newResultSet.AddRange (flattenedChildren);
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -111,6 +111,15 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return null;
 		}
 
+		public override ObjectProperties Properties ()
+		{
+			if (resultIter != null && resultIter.HasValue) {
+				var objectForProperties = TModel.GetValue (resultIter.Value, Column);
+				return base.GetProperties (objectForProperties);
+			}
+			return base.Properties ();
+		}
+
 		public override List<AppResult> NextSiblings ()
 		{
 			if (!resultIter.HasValue) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using Gtk;
+using System.Linq;
 
 namespace MonoDevelop.Components.AutoTest.Results
 {
@@ -140,26 +141,72 @@ namespace MonoDevelop.Components.AutoTest.Results
 		{
 			if (resultIter == null || !resultIter.HasValue) {
 				List<AppResult> children = new List<AppResult> ();
-				TModel.Foreach ((m, p, i) => {
-					children.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, i));
-					return false;
-				});
+				TreeIter topIter;
+				if (TModel.GetIterFirst (out topIter)) {
+					var child = new GtkTreeModelResult (ParentWidget, TModel, Column, topIter);
+					children.Add (child);
+					this.FirstChild = child;
+					child.ParentNode = this;
+
+					if (recursive) {
+						var topIterChildren = FetchIterChildren (topIter, child, recursive);
+						child.FirstChild = topIterChildren.FirstOrDefault ();
+						children.AddRange (topIterChildren);
+					}
+
+					GtkTreeModelResult previousSibling = child;
+					while (TModel.IterNext (ref topIter)) {
+						var nextSibling = new GtkTreeModelResult (ParentWidget, TModel, Column, topIter);
+						children.Add (nextSibling);
+
+						nextSibling.PreviousSibling = previousSibling;
+						previousSibling.NextSibling = nextSibling;
+						nextSibling.ParentNode = this;
+
+						if (recursive) {
+							var topIterChildren = FetchIterChildren (topIter, nextSibling, recursive);
+							nextSibling.FirstChild = topIterChildren.FirstOrDefault ();
+							children.AddRange (topIterChildren);
+						}
+					}
+				}
 				return children;
 			}
 
 			TreeIter currentIter = (TreeIter) resultIter;
-			if (!TModel.IterHasChild (currentIter))
+			return FetchIterChildren (currentIter, this, recursive);
+		}
+
+		List<AppResult> FetchIterChildren (TreeIter iter, GtkTreeModelResult result, bool recursive)
+		{
+			List<AppResult> newList = new List<AppResult> ();
+			if (!TModel.IterHasChild (iter))
 			{
-				return null;
+				return newList;
 			}
 
-			List<AppResult> newList = new List<AppResult> ();
-			for (int i = 0; i < TModel.IterNChildren (currentIter); i++) {
+			GtkTreeModelResult previousSibling = null;
+			for (int i = 0; i < TModel.IterNChildren (iter); i++) {
 				TreeIter childIter;
-				if (TModel.IterNthChild (out childIter, currentIter, i)) {
-					newList.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, childIter));
+				if (TModel.IterNthChild (out childIter, iter, i)) {
+					var child = new GtkTreeModelResult (ParentWidget, TModel, Column, childIter);
+
+					child.ParentNode = this;
+					child.PreviousSibling = previousSibling;
+					if (previousSibling != null)
+						previousSibling.NextSibling = child;
+					
+					newList.Add (child);
+					if (recursive) {
+						var childrenIter = FetchIterChildren (childIter, child, recursive);
+						newList.AddRange (childrenIter);
+						child.FirstChild = childrenIter.FirstOrDefault ();
+					}
+
+					previousSibling = child;
 				}
 			}
+			result.FirstChild = newList.FirstOrDefault ();
 			return newList;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -335,9 +335,9 @@ namespace MonoDevelop.Components.AutoTest
 			return this;
 		}
 
-		public AppQuery Children ()
+		public AppQuery Children (bool recursive = true)
 		{
-			operations.Add (new ChildrenOperation ());
+			operations.Add (new ChildrenOperation (recursive));
 			return this;
 		}
 


### PR DESCRIPTION
This allows us to inspect individual row of TreeView