### PR TITLE
[MSBuild] Fix NRE on MSBuild (exposed when building a Generic Project Template)

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectHandler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Formats.MSBuild/MSBuildProjectHandler.cs
@@ -312,7 +312,7 @@ namespace MonoDevelop.Projects.Formats.MSBuild
 					newContext = new TargetEvaluationContext (newContext);
 				var res = RunTarget (monitor, target, configuration, (TargetEvaluationContext) newContext);
 				CallContext.SetData ("MonoDevelop.Projects.TargetEvaluationResult", res);
-				return res.BuildResult;
+				return res != null ? res.BuildResult : null;
 			} finally {
 				if (newContext != currentContext)
 					CallContext.SetData ("MonoDevelop.Projects.ProjectOperationContext", currentContext);


### PR DESCRIPTION
Bug 30802 - [Generic Project] Generic Project template cannot be built,
fails with Build failed. Object reference not set to an instance of an object

The variable `res` is set by `RunTarget` method which can return null