### PR TITLE
[AutoTest] GtkTreeView should be focused before any Iter is selected

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -212,6 +212,8 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override bool Select ()
 		{
+			base.Select ();
+
 			if (!resultIter.HasValue) {
 				return false;
 			}


### PR DESCRIPTION
Kind of embarrassing that I missed out this small call when updating Select last time.

Thanks to mhutch