### PR TITLE
[NUnit] Do not clear test results when active config changed.

### DIFF
--- a/main/src/addins/NUnit/Gui/TestResultsPad.cs
+++ b/main/src/addins/NUnit/Gui/TestResultsPad.cs
@@ -105,6 +105,7 @@ namespace MonoDevelop.NUnit
 		public TestResultsPad ()
 		{
 			testService.TestSuiteChanged += new EventHandler (OnTestSuiteChanged);
+			IdeApp.Workspace.WorkspaceItemClosed += OnWorkspaceItemClosed;
 			
 			panel = new VBox ();
 			
@@ -259,14 +260,28 @@ namespace MonoDevelop.NUnit
 		
 		public void OnTestSuiteChanged (object sender, EventArgs e)
 		{
+			if (rootTest != null) {
+				rootTest = testService.SearchTest (rootTest.FullName);
+				if (rootTest == null)
+					buttonRun.Sensitive = false;
+			}
+		}
+
+		void OnWorkspaceItemClosed (object sender, EventArgs e)
+		{
+			ClearResults ();
+		}
+
+		void ClearResults ()
+		{
 			if (failuresTreeView.IsRealized)
 				failuresTreeView.ScrollToPoint (0, 0);
 
 			results.Clear ();
-			
+
 			error = null;
 			errorMessage = null;
-			
+
 			failuresStore.Clear ();
 			outputView.Buffer.Clear ();
 			outIters.Clear ();
@@ -276,11 +291,6 @@ namespace MonoDevelop.NUnit
 			resultSummary = new UnitTestResult ();
 			resultLabel.Markup = GetResultsMarkup ();
 			UpdateCounters ();
-			if (rootTest != null) {
-				rootTest = testService.SearchTest (rootTest.FullName);
-				if (rootTest == null)
-					buttonRun.Sensitive = false;
-			}
 		}
 		
 		bool Running {


### PR DESCRIPTION
Fixed [bug #31272](https://bugzilla.xamarin.com/show_bug.cgi?id=31272) - Test results disappear randomly after running a test.

Only clear the results in the Test Results window when a workspace item is closed or a new test run is started. Previously the Test Results window would be cleared when the active configuration
changed. The active configuration can be changed manually or if the SolutionItem's OnExecutionTargetsChanged method is called and the project does not use Debug as its default target. The Unit Tests window is still refreshed when the active configuration is changed.