### PR TITLE
[Ide] Set Gtk.LinkButton's URI handler

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -295,6 +295,8 @@ namespace MonoDevelop.Ide
 			};
 			AutoTestService.Start (commandService, Preferences.EnableAutomatedTesting);
 			AutoTestService.NotifyEvent ("MonoDevelop.Ide.IdeStart");
+
+			Gtk.LinkButton.SetUriHook ((button, uri) => Xwt.Desktop.OpenUrl (uri));
 		}
 
 		static void KeyBindingFailed (object sender, KeyBindingFailedEventArgs e)


### PR DESCRIPTION
Needed to resolve bug #29481 - "Supported List" should be a hyperlink instead of a button under Target Framework for Mac projects