### PR TITLE
[IDE] Bypass Focus Document if the current document is already focused

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
@@ -374,7 +374,10 @@ namespace MonoDevelop.Ide.Commands
 	{
 		protected override void Update (CommandInfo info)
 		{
-			info.Enabled = IdeApp.Workbench.ActiveDocument != null && IdeApp.Workbench.ActiveDocument.Editor != null;
+			var activeDoc = IdeApp.Workbench.ActiveDocument;
+			bool editorCanBeFocused = activeDoc != null && activeDoc.Editor != null && activeDoc.Editor.Parent != null && !activeDoc.Editor.Parent.TextArea.HasFocus;
+			info.Enabled = activeDoc != null && activeDoc.Editor != null;
+			info.Bypass = !editorCanBeFocused;
 		}
 
 		protected override void Run ()


### PR DESCRIPTION
If we bypass the Focus Document command when the current document is already focused
then the keypress is passed on down the event chain

Would it be better to implement a more generic system with the command manager asking the focused widget if it wants to handle a keypress before passing it to command dispatch, or will just just make the whole system more complicated than it needs to be?

Fixes BXC #29887