### PR TITLE
[MacPlatform] Don't assume the search bar is the 1st item in overflow

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -434,9 +434,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 				clipItem.PerformSelector (sel);
 
-				var menuBar = (SearchBar)clipItem.Menu.ItemAt (0).View;
-				AttachToolbarEvents (menuBar);
-				menuBar.StringValue = value;
+				foreach (NSMenuItem item in clipItem.Menu.ItemArray ()) {
+					if (item.View is SearchBar) {
+						var menuBar = (SearchBar)item.View;
+						AttachToolbarEvents (menuBar);
+						menuBar.StringValue = value;
+						break;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Search through the overflow menu items to find the SearchBar rather than assuming it is the first one. Fixes BXC #32002