### PR TITLE
Fix 29887 take 2

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.csproj
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Mono.TextEditor\Gui\LayoutCache.cs" />
     <Compile Include="Mono.TextEditor\Gui\GtkUtil.cs" />
     <Compile Include="Mono.TextEditor\EditModeChangedEventArgs.cs" />
+    <Compile Include="Mono.TextEditor\IKeyHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Mono.TextEditor.dll.config">

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/EditMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/EditMode.cs
@@ -52,7 +52,13 @@ namespace Mono.TextEditor
 			this.textEditorData = null;
 			this.editor = null;
 		}
-		
+
+		internal virtual bool WillHandleKeypress (Gdk.Key key, Gdk.ModifierType modifier)
+		{
+			// Default doesn't reserve any keys
+			return false;
+		}
+
 		internal virtual void InternalSelectionChanged (TextEditor editor, TextEditorData data)
 		{
 			// only trigger SelectionChanged when event is a result of external stimuli, i.e. when 

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
@@ -44,7 +44,7 @@ using Gtk;
 
 namespace Mono.TextEditor
 {
-	public class TextArea : Container, ITextEditorDataProvider
+	public class TextArea : Container, ITextEditorDataProvider, IKeyHandler
 	{
 		TextEditorData textEditorData;
 		
@@ -3244,6 +3244,13 @@ namespace Mono.TextEditor
 		}
 		#endregion
 
+		#region IKeyHandler
+		public bool WillHandleKey (Gdk.Key key, Gdk.ModifierType modifier)
+		{
+			return textEditorData.CurrentMode.WillHandleKeypress (key, modifier);;
+		}
+
+		#endregion
 	}
 
 	public interface ITextEditorDataProvider

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/IKeyHandler.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/IKeyHandler.cs
@@ -1,0 +1,35 @@
+﻿//
+// IKeyHandler.cs
+//
+// Author:
+//       iain holmes <iain@xamarin.com>
+//
+// Copyright (c) 2015 Xamarin, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace Mono.TextEditor
+{
+	public interface IKeyHandler
+	{
+		bool WillHandleKey (Gdk.Key key, Gdk.ModifierType modifier);
+	}
+}
+

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/InsertionCursorEditMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/InsertionCursorEditMode.cs
@@ -236,6 +236,21 @@ namespace Mono.TextEditor
 				break;
 			}
 		}
+
+		internal override bool WillHandleKeypress (Gdk.Key key, Gdk.ModifierType modifier)
+		{
+			switch (key) {
+			case Gdk.Key.Up:
+			case Gdk.Key.Down:
+			case Gdk.Key.KP_Enter:
+			case Gdk.Key.Return:
+			case Gdk.Key.Escape:
+				return true;
+
+			default:
+				return false;
+			}
+		}
 		
 		EditMode oldMode;
 		public void StartMode ()

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/SimpleEditMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/SimpleEditMode.cs
@@ -427,5 +427,20 @@ namespace Mono.TextEditor
 				InsertCharacter (unicodeKey);
 			}
 		}
+
+		internal override bool WillHandleKeypress (Gdk.Key key, Gdk.ModifierType modifier)
+		{
+			bool isReservedKey = false;
+
+			// Reserve unmodified Escape, Return, Backspace and the cursor keys
+			if (key == Key.Escape || key == Key.Return || key == Key.BackSpace ||
+				key == Key.Up || key == Key.Down || key == Key.Left || key == Key.Right) {
+				isReservedKey = (modifier == ModifierType.None);
+			}
+
+			uint unicode = Gdk.Keyval.ToUnicode ((uint)key);
+			// Handle unmodified printable chars by default
+			return (unicode != 0 && modifier == ModifierType.None) || isReservedKey;
+		}
 	}
 }

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/TextLinkEditMode.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/TextLinkEditMode.cs
@@ -474,6 +474,25 @@ namespace Mono.TextEditor
 			Editor.Document.CommitUpdateAll ();*/
 		}
 
+		internal override bool WillHandleKeypress (Gdk.Key key, Gdk.ModifierType modifier)
+		{
+			bool reservedKey = false;
+
+			switch (key) {
+			case Gdk.Key.BackSpace:
+			case Gdk.Key.space:
+			case Gdk.Key.Delete:
+			case Gdk.Key.Tab:
+			case Gdk.Key.Escape:
+			case Gdk.Key.Return:
+			case Gdk.Key.KP_Enter:
+				reservedKey = true;
+				break;
+			}
+
+			return reservedKey || base.WillHandleKeypress (key, modifier);
+		}
+
 		ListWindow<string> window;
 
 		void DestroyWindow ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -345,6 +345,16 @@ namespace MonoDevelop.Components.Commands
 		[GLib.ConnectBefore]
 		void OnKeyPressed (object o, Gtk.KeyPressEventArgs e)
 		{
+			// Check if the focused widget wants to handle this key
+			var focusedWidget = IdeApp.Workbench.RootWindow.Focus;
+			if (focusedWidget != null) {
+				IKeyHandler keyHandler = focusedWidget as IKeyHandler;
+				if (keyHandler != null && keyHandler.WillHandleKey (e.Event.Key, e.Event.State)) {
+					e.RetVal = false;
+					return;
+				}
+			}
+
 			e.RetVal = ProcessKeyEvent (e.Event);
 		}
 


### PR DESCRIPTION
This is the more generic version of https://github.com/mono/monodevelop/pull/995 where the TextEditor has implemented the IKeyHandler interface, which the command manager then checks to see if the text editor is currently overriding the key press.

Fixes the issues where Escape wouldn't close the Insert Extracted Method overlay, or wouldn't close the autocompletion dialog if it was assigned to a command. (Bug 29887)

It also prevents essential keys from being overridden if they are assigned to a command such as alphanumeric keys or Tab, Return or Backspace.
