### PR TITLE
[AutoTest] Expand the row in TreeView when it is selected

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -234,6 +234,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			if (ParentWidget is TreeView) {
 				TreeView treeView = (TreeView) ParentWidget;
 				treeView.Selection.UnselectAll ();
+				treeView.ExpandRow (TModel.GetPath (resultIter.Value), false);
 				treeView.Selection.SelectIter ((TreeIter) resultIter);
 				treeView.SetCursor (TModel.GetPath ((TreeIter) resultIter), treeView.Columns [0], false);
 

--- a/main/tests/UserInterfaceTests/Controllers/SolutionExplorerController.cs
+++ b/main/tests/UserInterfaceTests/Controllers/SolutionExplorerController.cs
@@ -51,13 +51,19 @@ namespace UserInterfaceTests
 
 		public static bool Select (params string[] selectionTree)
 		{
+			Func<AppQuery, AppQuery> query = GetNodeQuery (selectionTree);
+			return Session.SelectElement (GetNodeQuery (selectionTree)) && Session.WaitForElement (c => query (c).Selected ()).Any ();
+		}
+
+		public static Func<AppQuery, AppQuery> GetNodeQuery (params string[] selectionTree)
+		{
 			var funcs = new List<Func<AppQuery, AppQuery>> ();
 			funcs.Add (topLevel);
 			foreach (var nodeName in selectionTree) {
 				var lastFunc = funcs.Last ();
-				funcs.Add (c => lastFunc (c).Children (false).Index (0).Property ("Label", nodeName));
+				funcs.Add (c => lastFunc (c).Children (false).Property ("Label", nodeName).Index (0));
 			}
-			return Session.SelectElement (funcs.Last ());
+			return funcs.Last ();
 		}
 
 		public static bool SelectSolution (string solutionName)
@@ -72,7 +78,7 @@ namespace UserInterfaceTests
 
 		public static bool SelectReferenceFolder (string solutionName, string projectName)
 		{
-			return Select (solutionName, projectName);
+			return Select (solutionName, projectName, "References");
 		}
 
 		public static bool SelectSingleReference (string solutionName, string projectName, string referenceName, bool fromPackage = false)


### PR DESCRIPTION
It is needed for scenarios like SolutionTree because the children rows are not made available for the first time unless the row is expanded.

Also update SolutionExplorerController to fully utilize this fix