### PR TITLE
Updated to run on FreeBSD 10.1

### DIFF
--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -20,7 +20,8 @@ clean: clean-local
 clean-local: sln_clean
 
 restore-packages:
-	nuget restore
+	mozroots --import --sync
+	mono /usr/home/rhaley/git/monodevelop/main/external/nuget-binary/NuGet.exe restore
 
 vcrevision:
 	touch vcrevision

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -1,3 +1,5 @@
+env SHELL=/usr/local/bin/bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ ! -f $DIR/configure.exe ]; then


### PR DESCRIPTION
Updated the Makefile.am to run mozroots and execute mono using explicit syntax. Also updated the configure.sh to set SHELL env. Not sure how best to do that without breaking the script for Linux. 