### PR TITLE
[MacPlatform] Stop statusbar's popovers not going away

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -213,6 +213,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				if (bar.Window == null)
 					return;
 
+				// We're getting notified about all windows in the application (for example, NSPopovers) that change size when really we only care about
+				// the window the bar is in.
+				if (notif.Object != bar.Window)
+					return;
+
 				double maxSize = Math.Round (bar.Window.Frame.Width * 0.30f);
 				double minSize = Math.Round (bar.Window.Frame.Width * 0.25f);
 				item.MinSize = new CGSize ((nfloat)Math.Max (280, minSize), 22);


### PR DESCRIPTION
When the NSPopover appeared MainToolbar was receiving a NSWindowDidResizeNotification for the NSPopover, but it was causing the NSTrackingAreas in the StatusBar to be regenerated. This could cause a race condition when the old tracking area was
removed and the mouse exited the area before the new tracking area was installed.

Fixed the race condition by Only processing the NSWindowDidResizeNotification whenever it was the window that the statusbar was contained in.