### PR TITLE
[Mac] Register UTIs for .cs and .fs files

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -71,6 +71,12 @@
 			<string>Editor</string>
 			<key>LSIsAppleDefaultForType</key>
 			<true/>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.microsoft.c-sharp</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>Editor</string>
 		</dict>
 		<dict>
 			<key>CFBundleTypeExtensions</key>
@@ -115,6 +121,12 @@
 			<string>Editor</string>
 			<key>LSIsAppleDefaultForType</key>
 			<true/>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.fsharp.f-sharp</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>Editor</string>
 		</dict>
 		<dict>
 			<key>CFBundleTypeExtensions</key>
@@ -208,5 +220,46 @@
 	<true/>
 	<key>ReleaseId</key>
 	<string>@RELEASE_ID@</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.microsoft.c-sharp</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://www.microsoft.com/en-us/download/details.aspx?id=7029</string>
+			<key>UTTypeDescription</key>
+			<string>C# source</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cs</string>
+				</array>
+			</dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+			</array>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.fsharp.f-sharp</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://fsharp.org/specs/language-spec/</string>
+			<key>UTTypeDescription</key>
+			<string>F# source</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>fs</string>
+				</array>
+			</dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Registering the UTIs for .cs and .fs files and marking them as conforming to public.source-code allows QuickLook to display the files as text when you press <space>

Once installed newly created .cs files will be registered as being of the UTI com.microsoft.c-sharp, old files will still
be registered with their old dynamic type.

You can check a file's UTI with:
> mdls file.cs

which will give

kMDItemContentTypeTree         = (
    "com.microsoft.c-sharp",
    "public.source-code",
    "public.plain-text",
    "public.text",
    "public.data",
    "public.item",
    "public.content"
)

To register an existing .cs file as being of UTI com.microsoft.c-sharp you need to run mdimport
> mdimport file.cs

It is possible to wildcard this and use find to run it on all .cs files in the system. I don't know if not updating existing file associations is policy, or if Spotlight just hadn't got round to updating them.

NB: This would also work on .fs files, and this patch adds the UTI org.fsharp.f-sharp to the system, but on my OSX at least, the .fs extension has already been registered to the UTI org.khronos.glsl.fragment-shader, which takes seems to take precedence over ours.

Also the fantastically well hidden commandline tool:
/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister

is very useful when debugging.

Fixes BXC #32734