### PR TITLE
Fixed "Bug 33065 - Dangerous: refactoring operations drop the null

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -314,7 +314,7 @@ to ""."", a simple dereference, which can cause unexpected NullReferenceExceptio
 				message.Buttons.Add (useRefactoringsButton);
 				message.Buttons.Add (AlertButton.Cancel);
 				message.Icon = Gtk.Stock.DialogWarning;
-				message.DefaultButton = 2;
+				message.DefaultButton = 1;
 
 				var result = MessageService.AskQuestion (message);
 				if (result == AlertButton.Cancel)

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -306,10 +306,7 @@ namespace MonoDevelop.Refactoring
 				var text = GettextCatalog.GetString (
 @"WARNING: The Xamarin Studio refactoring operations do not yet support C# 6.
 
-You may continue to use refactoring operations with C# 6, however you should check the results carefully to make sure that
-they have not made incorrect changes to your code. In particular, the ""?."" null propagating dereference will be changed
-to ""."", a simple dereference, which can cause unexpected NullReferenceExceptions at runtime.
-");
+You may continue to use refactoring operations with C# 6, however you should check the results carefully to make sure that they have not made incorrect changes to your code. In particular, the ""?."" null propagating dereference will be changed to ""."", a simple dereference, which can cause unexpected NullReferenceExceptions at runtime.");
 				var message = new QuestionMessage (text);
 				message.Buttons.Add (useRefactoringsButton);
 				message.Buttons.Add (AlertButton.Cancel);


### PR DESCRIPTION
propagation operator"
The default button was wrong because one button got removed. That
caused the dialog not to appear on windows.