### PR TITLE
[Core] Fix a NRE exception when opening the unit test margin menu

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/GtkWorkarounds.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/GtkWorkarounds.cs
@@ -489,8 +489,15 @@ namespace Mono.TextEditor
 		public static void ShowContextMenu (Gtk.Menu menu, Gtk.Widget parent, Gdk.EventButton evt, Gdk.Rectangle caret)
 		{
 			int x, y;
+			if (evt == null) {
+				evt = (Gdk.EventButton) Global.CurrentEvent;
+			}
+
 			var window = evt.Window;
 
+			if (window == null)
+				return;
+			
 			window.GetOrigin (out x, out y);
 			x += (int)evt.X;
 			y += (int)evt.Y;


### PR DESCRIPTION
Clicking on the unit test margin was passing a null event to a method that was not expecting one.