### PR TITLE
Make "NuGet.exe restore" conditional on git.

### DIFF
--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -130,7 +130,7 @@
       <NuGet>$(SolutionDir)\external\nuget-binary\NuGet.exe</NuGet>
       <NuGet Condition="$(OS)=='Unix'">mono $(NuGet)</NuGet>
     </PropertyGroup>
-    <Exec Command="$(NuGet) restore -SolutionDirectory $(SolutionDir)" />
+    <Exec Condition="Exists('$(SolutionDir)\..\.git')" Command="$(NuGet) restore -SolutionDirectory $(SolutionDir)" />
   </Target>
   <ItemGroup>
     <Folder Include="DialogTests\" />


### PR DESCRIPTION
As per 6e7f2dfcbc80271fdebdee5418b5ed80fe046086, "nuget restore" should not be called in xbuilds in Tarball builds (due to missing NuGet.exe bundle)