### PR TITLE
[UITest] Adding 'Project Saved' message to array of expected messages…

### DIFF
--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -102,6 +102,7 @@ namespace UserInterfaceTests
 		public readonly static Action EmptyAction = delegate { };
 
 		static string[] waitForNuGetMessages = {
+			"Project Saved.",
 			"Package updates are available.",
 			"Packages are up to date.",
 			"No updates found but warnings were reported.",

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -103,6 +103,7 @@ namespace UserInterfaceTests
 
 		static string[] waitForNuGetMessages = {
 			"Project Saved.",
+			"Solution loaded.",
 			"Package updates are available.",
 			"Packages are up to date.",
 			"No updates found but warnings were reported.",

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -102,7 +102,7 @@ namespace UserInterfaceTests
 		public readonly static Action EmptyAction = delegate { };
 
 		static string[] waitForNuGetMessages = {
-			"Project Saved.",
+			"Project saved.",
 			"Solution loaded.",
 			"Package updates are available.",
 			"Packages are up to date.",


### PR DESCRIPTION
… in WaitForPackageUpdate

Sometimes during UITests when packages are updated, the IDE message is
‘Project Saved.’ This needs to be added so UITests tests don’t hang at
this step 

@manish 