### PR TITLE
[AutoTest] Remove loading of gail:atk-bridge

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -77,7 +77,6 @@ namespace MonoDevelop.Components.AutoTest
 
 			var pi = new ProcessStartInfo (file, args) { UseShellExecute = false };
 			pi.EnvironmentVariables ["MONO_AUTOTEST_CLIENT"] = sref;
-			pi.EnvironmentVariables ["GTK_MODULES"] = "gail:atk-bridge";
 			if (environment != null)
 				foreach (var e in environment)
 					pi.EnvironmentVariables [e.Key] = e.Value;


### PR DESCRIPTION
This module doesn't load on mac and only adds annoying warnings to Ide log

cc @iainx 