### PR TITLE
[Ide] Allow copy/pasting of read-only properties

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/TextEditor.cs
@@ -88,6 +88,7 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 			// no standard values, so just use an entry
 			else {
 				entry = new Entry ();
+				entry.IsEditable = !session.Property.IsReadOnly;
 				PackStart (entry, true, true, 0);
 			}
 
@@ -96,9 +97,11 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 				entry.HasFrame = false;
 				entry.Changed += TextChanged;
 				entry.FocusOutEvent += FirePendingChangeEvent;
+				if (!entry.IsEditable)
+					entry.ModifyText (StateType.Normal, entry.Style.Text (Gtk.StateType.Insensitive));
 			}
 
-			if (entry != null && ShouldShowDialogButton ()) {
+			if (entry != null && ShouldShowDialogButton () && entry.IsEditable) {
 				var button = new Button ("...");
 				PackStart (button, false, false, 0);
 				button.Clicked += ButtonClicked;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
@@ -609,7 +609,7 @@ namespace MonoDevelop.Components.PropertyGrid
 
 			if (row != null && editSession == null) {
 				var bounds = GetInactiveEditorBounds (row);
-				if (!bounds.IsEmpty && bounds.Contains ((int)evnt.X, (int)evnt.Y) && row.Enabled) {
+				if (!bounds.IsEmpty && bounds.Contains ((int)evnt.X, (int)evnt.Y)) {
 					StartEditing (row);
 					return true;
 				}


### PR DESCRIPTION
This enables interaction with text in read-only properties in the property
pad.

Bug 15161 - Cannot copy disabled property values to clipboard