### PR TITLE
[UITest] Remove forward slashes from Ide log path during test setup

### DIFF
--- a/main/tests/UserInterfaceTests/UITestBase.cs
+++ b/main/tests/UserInterfaceTests/UITestBase.cs
@@ -153,7 +153,7 @@ namespace UserInterfaceTests
 
 		void SetupIdeLogFolder ()
 		{
-			var currentXSIdeLog = Path.Combine (currentTestResultFolder, string.Format ("{0}.Ide.log", TestContext.CurrentContext.Test.FullName));
+			var currentXSIdeLog = Path.Combine (currentTestResultFolder, string.Format ("{0}.Ide.log", TestContext.CurrentContext.Test.FullName.Replace ('/','_').Replace ('\\','_')));
 			Environment.SetEnvironmentVariable ("MONODEVELOP_LOG_FILE", currentXSIdeLog);
 			Environment.SetEnvironmentVariable ("MONODEVELOP_FILE_LOG_LEVEL", "UpToInfo");
 		}


### PR DESCRIPTION
The name of the test is used to create the log file path, if a forward slash is present, the path gets corrupted. This change removes forward slash from test name when creating the IDE log path during test setup.