### PR TITLE
Handle spaces in F# test names

### DIFF
--- a/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
@@ -483,7 +483,7 @@ namespace MonoDevelop.NUnit
 
 				bool automaticUpdates = cmd.Command != null && (cmd.Command.Contains ("GuiUnit") || (cmd.Command.Contains ("mdtool.exe") && cmd.Arguments.Contains ("run-md-tests")));
 				if (!string.IsNullOrEmpty(pathName))
-					cmd.Arguments += " -run=" + test.TestId;
+					cmd.Arguments += " -run=\"" + test.TestId + "\"";
 				if (automaticUpdates) {
 					tcpListener = new MonoDevelop.NUnit.External.TcpTestListener (localMonitor, suiteName);
 					cmd.Arguments += " -port=" + tcpListener.Port;


### PR DESCRIPTION
Fixes tests that have spaces inside the function name such as :-

```
[<Test>]
member this.``Formats forall2 tooltip right aligned``() =

XS shows this error :-

NUnit-Console version 2.6.4.14350
Copyright (C) 2002-2012 Charlie Poole.
Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.
Copyright (C) 2000-2002 Philip Craig.
All Rights Reserved.

Runtime Environment - 
   OS Version: Unix 14.3.0.0
  CLR Version: 4.0.30319.17020 ( Mono 4.0 ( 4.2.1 (explicit/9871c89 Wed Sep  2
17:21:48 EDT 2015) ) )

File type not known: forall2
```