### PR TITLE
Reorder buttons for folder delete dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
@@ -198,8 +198,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				"The Delete option permanently removes the directory and any files it contains from your hard disk. " +
 				"Click Remove from Project if you only want to remove it from your current solution.")
 			};
-			question.Buttons.Add (AlertButton.Cancel);
 			question.Buttons.Add (AlertButton.Delete);
+			question.Buttons.Add (AlertButton.Cancel);
 			question.Buttons.Add (removeButton);
 
 			var deleteOnlyQuestion = new QuestionMessage () {


### PR DESCRIPTION
The order of buttons was different to the one in file removal dialog, which was confusing.