### PR TITLE
[Mac] Fix NRE with accessory view on El Capitan

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
@@ -60,7 +60,8 @@ namespace MonoDevelop.MacIntegration
 					};
 					box.Layout ();
 					panel.AccessoryView = box.View;
-					box.Layout (box.View.Superview.Frame.Size);
+					if (box.View.Superview != null)
+						box.Layout (box.View.Superview.Frame.Size);
 				} else {
 					dropdownBox.Layout ();
 					panel.AccessoryView = dropdownBox.View;


### PR DESCRIPTION
Bug 33897 - Add Files operation stopped working in 5.9.5 / Mac OS X
10.11