### PR TITLE
Revert "[FSharp] Bump fsharpbinding submodule to fix #31456"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
 [submodule "main/external/fsharpbinding"]
 	path = main/external/fsharpbinding
 	url = git://github.com/fsharp/fsharpbinding.git
-	branch = 5.9-c5sr4
+	branch = master
 [submodule "main/external/nuget-binary"]
 	path = main/external/nuget-binary
 	url = git://github.com/mono/nuget-binary.git


### PR DESCRIPTION
Reverts mono/monodevelop#1037

Looks like this commit doesn't fix the bug.