### PR TITLE
[AutoTest] Adding logic in StartApplication for running windows UI Te…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -65,6 +65,15 @@ namespace MonoDevelop.Components.AutoTest
 			if (file == null) {
 				var binDir = Path.GetDirectoryName (typeof(AutoTestClientSession).Assembly.Location);
 				file = Path.Combine (binDir, "MonoDevelop.exe");
+				if (!File.Exists (file)) {
+					file = Path.Combine (binDir, "XamarinStudio.exe");
+				}
+			} else if (!File.Exists (file)) {
+				file = file.Replace ("MonoDevelop.exe", "XamarinStudio.exe");
+			}
+
+			if (!File.Exists (file)) {
+				throw new FileNotFoundException (file);
 			}
 
 			MonoDevelop.Core.Execution.RemotingService.RegisterRemotingChannel ();


### PR DESCRIPTION
…sts on wrench

When you build on wrench, the executable is XamarinStudio.exe. The logic still looks for MonoDevelop.exe first, but if it's not found, will use XamarinStudio.exe instead.