### PR TITLE
[UITest] Change LogMessageValidator to allow access to the log on win…

### DIFF
--- a/main/tests/UserInterfaceTests/LogMessageValidator.cs
+++ b/main/tests/UserInterfaceTests/LogMessageValidator.cs
@@ -38,7 +38,14 @@ namespace UserInterfaceTests
 
 		public static void Validate (string fileName)
 		{
-			var readIdeLog = File.ReadAllText (fileName);
+			string readIdeLog = string.Empty;
+			using (FileStream fileStream = new FileStream (fileName, FileMode.Open, 
+				                               FileAccess.Read, FileShare.ReadWrite)) {
+				using (StreamReader streamReader = new StreamReader (fileStream)) {
+					readIdeLog = streamReader.ReadToEnd ();
+				}
+			}
+
 			foreach (var error in invalidLogStrings) {
 				Assert.IsFalse (readIdeLog.Contains (error),
 					string.Format ("GTK Error detected in Ide.log file:\n\t{0}",error));


### PR DESCRIPTION
…dows

On windows, the IDE holds a lock on the IDE's log file which was causing
unauthorized exception when we try to read it. With this change we can
read it on both windows and mac.