### PR TITLE
[DesignerSupport] Update PropertyGrid on ProjectFile property changes.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
@@ -252,6 +252,10 @@ namespace MonoDevelop.Components.PropertyGrid
 		{
 			if (this.currentObject == obj)
 				return;
+			if (this.propertyProviders != null) {
+				foreach (var old in this.propertyProviders.OfType<IDisposable> ())
+					old.Dispose ();
+			}
 			this.currentObject = obj;
 			this.propertyProviders = propertyProviders;
 			UpdateTabs ();


### PR DESCRIPTION
Refresh the propertygrid on projectfile property changes.

Bug 33629 - Property grid should refresh when build action changed