### PR TITLE
[PropertyPad] Ignore autohide boxes from the command target visitor

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPadVisitor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPadVisitor.cs
@@ -83,6 +83,10 @@ namespace MonoDevelop.DesignerSupport
 			if (ob == ((DefaultWorkbench)IdeApp.Workbench.RootWindow).ActiveWorkbenchWindow)
 				visitedCurrentDoc = true;
 
+			if (ob is MonoDevelop.Components.Docking.AutoHideBox) {
+				found = true;
+				return true;
+			}
 			if (ob is PropertyPad) {
 				// Don't change the property grid selection when the focus is inside the property grid itself
 				found = true;


### PR DESCRIPTION
Bug 33626 - [Regression] Auto-hidden property pad can't be used with
solution tree