### PR TITLE
[AutoTest] handle unauthorized exception in OnCleanUp ()

### DIFF
--- a/main/tests/UserInterfaceTests/UITestBase.cs
+++ b/main/tests/UserInterfaceTests/UITestBase.cs
@@ -173,6 +173,8 @@ namespace UserInterfaceTests
 						Directory.Delete (folder, true);
 				} catch (IOException e) {
 					TestService.Session.DebugObject.Debug ("Cleanup failed\n" +e);
+				} catch (UnauthorizedAccessException e) {
+					TestService.Session.DebugObject.Debug (string.Format ("Unable to clean directory: {0}\n", folder) + e);
 				}
 			}
 		}


### PR DESCRIPTION
When running ui tests on windows via wrench, some git files can't be cleaned up until mdtool exits. Handle the unauthorized exception to avoid test failure. Wrench will clean up the rest