### PR TITLE
Trying to fix error: Cannot copy as the source file doesn't exist.

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
@@ -116,27 +116,13 @@
       <Name>MonoDevelop.Xml</Name>
       <Private>False</Private>
     </ProjectReference>
-    <Reference Include="Microsoft.Web.Infrastructure">
-      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Razor">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.2.2\lib\net45\System.Web.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Helpers">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Deployment">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Razor">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Mvc">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure" />
+    <Reference Include="System.Web.Razor" />
+    <Reference Include="System.Web.Helpers" />
+    <Reference Include="System.Web.WebPages" />
+    <Reference Include="System.Web.WebPages.Deployment" />
+    <Reference Include="System.Web.WebPages.Razor" />
+    <Reference Include="System.Web.Mvc" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This currently breaks the build from tarballs:

```
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.AspNet.Mvc.5.2.2/lib/net45/System.Web.Mvc.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/System.Web.Mvc.dll, as the source file doesn't exist.
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.AspNet.Razor.3.2.2/lib/net45/System.Web.Razor.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/System.Web.Razor.dll, as the source file doesn't exist.
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.AspNet.WebPages.3.2.2/lib/net45/System.Web.Helpers.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/System.Web.Helpers.dll, as the source file doesn't exist.
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.AspNet.WebPages.3.2.2/lib/net45/System.Web.WebPages.Deployment.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/System.Web.WebPages.Deployment.dll, as the source file doesn't exist.
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.AspNet.WebPages.3.2.2/lib/net45/System.Web.WebPages.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/System.Web.WebPages.dll, as the source file doesn't exist.
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.AspNet.WebPages.3.2.2/lib/net45/System.Web.WebPages.Razor.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/System.Web.WebPages.Razor.dll, as the source file doesn't exist.
[  105s]        /usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/packages/Microsoft.Web.Infrastructure.1.0.0.0/lib/net40/Microsoft.Web.Infrastructure.dll to /home/abuild/rpmbuild/BUILD/monodevelop-5.9.6/build/AddIns/AspNet/Microsoft.Web.Infrastructure.dll, as the source file doesn't exist.
```