### PR TITLE
[IDE] Display the main IDE window before the Yes/No addin load error …

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -219,7 +219,13 @@ namespace MonoDevelop.Ide
 				Counters.Initialization.Trace ("Loading Icons");
 				//force initialisation before the workbench so that it can register stock icons for GTK before they get requested
 				ImageService.Initialize ();
-				
+
+				// If we display an error dialog before the main workbench window on OS X then a second application menu is created
+				// which is then replaced with an second empty Apple menu.
+				// XBC #33699
+				Counters.Initialization.Trace ("Initializing IdeApp");
+				IdeApp.Initialize (monitor);
+
 				if (errorsList.Count > 0) {
 					using (AddinLoadErrorDialog dlg = new AddinLoadErrorDialog ((AddinError[]) errorsList.ToArray (typeof(AddinError)), false)) {
 						if (!dlg.Run ())
@@ -233,9 +239,6 @@ namespace MonoDevelop.Ide
 
 				// no alternative for Application.ThreadException?
 				// Application.ThreadException += new ThreadExceptionEventHandler(ShowErrorBox);
-
-				Counters.Initialization.Trace ("Initializing IdeApp");
-				IdeApp.Initialize (monitor);
 
 				// Load requested files
 				Counters.Initialization.Trace ("Opening Files");


### PR DESCRIPTION
…dialog

If we display an error dialog before the main window, then Cocoa creates an extra empty Application menu that turns into a second Apple menu when the IDE starts. This patch moves the IDE main window creation to before the Yes/No addin load error dialog.

Fixes BXC #33699