### PR TITLE
[IDE] Force the solutionpad treeview to update its offsets

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
@@ -46,6 +46,34 @@ namespace MonoDevelop.Components
 		Gtk.TreePath buttonPressPath;
 		bool selectOnRelease;
 
+		// Workaround for Bug 31712 - Solution pad doesn't refresh properly after resizing application window
+		// If the treeview size is modified while the pad is unrealized (autohidden), the treeview
+		// doesn't update its internal vertical offset. This can lead to items becoming offset outside the 
+		// visible area and therefore becoming unreachable. The only way to force the treeview to recalculate
+		// this offset is by setting the Vadjustment.Value, but it ignores values the same as the current value.
+		// Therefore we simply set it to something slightly different then back again.
+
+		// See also MonoDevelop.Ide.Gui.Components.PadTreeView for same fix.
+		bool forceInternalOffsetUpdate;
+
+		protected override void OnUnrealized ()
+		{
+			base.OnUnrealized ();
+			forceInternalOffsetUpdate = true;
+		}
+
+		protected override void OnSizeAllocated (Gdk.Rectangle allocation)
+		{
+			base.OnSizeAllocated (allocation);
+			if (forceInternalOffsetUpdate && IsRealized) {
+				forceInternalOffsetUpdate = false;
+				var v = Vadjustment.Value;
+				int delta = v > 2? 0 : 1;
+				Vadjustment.Value = v + delta;
+				Vadjustment.Value = v;
+			}
+		}
+
 		protected override void OnDragBegin (Gdk.DragContext context)
 		{
 			//If user starts dragging don't do any selection


### PR DESCRIPTION
If the treeview is changed when unrealised (autohidden), the treeview doesn't update its internal vertical offset. This can lead to items being offset outside the visible area and therefore becoming unreachable. The only way to force the treeview is to recalculate this offset by setting the Vadjustment.Value, but it ignores values the same as the current value. Therefore we simply set it to something slightly different then back again.

See also MonoDevelop.Ide.Gui.Components.PadTreeView for the same fix.

Fixes BXC #31712

This sounds like something that might be able to be fixed in Gtk+ itself? @bratsche 
