### PR TITLE
[Components] Only add the Search in Solution category if a solution i…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
@@ -30,7 +30,7 @@ using MonoDevelop.Core;
 using ICSharpCode.NRefactory.TypeSystem;
 using MonoDevelop.Ide.FindInFiles;
 using System.Linq;
-using MonoDevelop.Ide.Gui;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.Components.MainToolbar
 {
@@ -42,9 +42,13 @@ namespace MonoDevelop.Components.MainToolbar
 
 		public override Task<ISearchDataSource> GetResults (SearchPopupSearchPattern searchPattern, int resultsCount, CancellationToken token)
 		{
-			return Task.Factory.StartNew (delegate {
-				return (ISearchDataSource)new SearchInSolutionDataSource (searchPattern);
-			});
+			if (IdeApp.ProjectOperations.CurrentSelectedSolution != null) {
+				return Task.Factory.StartNew (delegate {
+					return (ISearchDataSource)new SearchInSolutionDataSource (searchPattern);
+				});
+			}
+
+			return Task.FromResult<ISearchDataSource> (default(ISearchDataSource));
 		}
 
 		public override bool IsValidTag (string tag)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -120,6 +120,7 @@ namespace MonoDevelop.Components.MainToolbar
 			categories.Add (new ProjectSearchCategory (this));
 			categories.Add (new FileSearchCategory (this));
 			categories.Add (new CommandSearchCategory (this));
+
 			categories.Add (new SearchInSolutionSearchCategory ());
 			categories.AddRange (AddinManager.GetExtensionObjects<SearchCategory> ("/MonoDevelop/Ide/SearchCategories"));
 


### PR DESCRIPTION
…s open.

Don't add the Search in Solution category to the Search popup window if no solution is open.

Fixes BXC #33199