### PR TITLE
[Autotest] Check the object exists before trying to get its properties

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -253,6 +253,8 @@ namespace MonoDevelop.Components.AutoTest
 			
 			if (remaining == null)
 				return res;
+			else if (res == null)
+				return null;
 			else
 				return GetValue (res, res.GetType (), remaining);
 		}


### PR DESCRIPTION
When calling GetGlobalValue check that each object in the name exists before descending further.

Fixes BXC #30853