### PR TITLE
[UITest] Implement test log file and ReproStep method

### DIFF
--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // CreateBuildTemplatesTestBase.cs
 //
 // Author:
@@ -91,7 +91,7 @@ namespace UserInterfaceTests
 					TakeScreenShot ("BeforeBuildActionFailed");
 					Assert.Fail (e.ToString ());
 				}
-
+				ReproStep ("Build solution");
 				OnBuildTemplate ((int)projectDetails.BuildTimeout.TotalSeconds);
 			} catch (Exception e) {
 				TakeScreenShot ("TestFailedWithGenericException");
@@ -105,6 +105,7 @@ namespace UserInterfaceTests
 			ProjectDetails projectDetails, GitOptions gitOptions = null, object miscOptions = null)
 		{
 			PrintToTestRunner (templateOptions, projectDetails, gitOptions, miscOptions);
+			ReproStep ("Create a new project", templateOptions, projectDetails, gitOptions, miscOptions);
 			var newProject = new NewProjectController ();
 
 			if (projectDetails.AddProjectToExistingSolution)

--- a/main/tests/UserInterfaceTests/Util.cs
+++ b/main/tests/UserInterfaceTests/Util.cs
@@ -41,7 +41,7 @@ namespace UserInterfaceTests
 
 		public static string ToPathSafeString (this string str)
 		{
-			return str.Replace (@"\", "").Replace ("/", "");
+			return str.Replace (@"\", "-").Replace ("/", "-");
 		}
 
 		public static FilePath CreateTmpDir (string hint = null)


### PR DESCRIPTION
This creates a log file specific for the current test in the TestResults folder. It is registered with the LoggingService so any log entry will go to the log (usually errors which will be useful). 

The ReproStep method allows entries to the log that we can later parse to create bug report repro steps. The log looks something like this:
```
INFO[2015-09-24 15:09:13Z]: @Repro-Step-01: Create a new project
INFO[2015-09-24 15:09:13Z]: @Repro-Info-01: CategoryRoot=Other, Category=.NET, TemplateKindRoot=General, TemplateKind=Console Project
INFO[2015-09-24 15:09:13Z]: @Repro-Info-01: ProjectName=ConsoleProject, SolutionName=ConsoleProject, SolutionLocation=/Users/kylewhite/Workspace/monodevelop/main/build/tests/wrveibzd.8xy, ProjectInSolution=True, AddProjectToExistingSolution=False
INFO[2015-09-24 15:09:17Z]: @Repro-Step-02: Build solution
```

@manish What do you think? We would need to retroactively go to all the helper methods and add ReproStep calls where necessary, I only did it for `CreateBuildProject`.