### PR TITLE
[UITest] Added WaitForPackageUpdateOrSaved for NuGetAdded or Project Saved

### DIFF
--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -99,6 +99,19 @@ namespace UserInterfaceTests
 			WaitUntil (() => c.TotalTime > tt, timeout);
 		}
 
+
+		public readonly static Action WaitForPackageUpdateOrSaved = delegate {
+			try {
+				WaitForPackageUpdate ();
+			} catch (TimeoutException e1) {
+				try {
+					WaitForSolutionLoaded ();
+				} catch (TimeoutException e2) {
+					throw new TimeoutException (string.Format ("{0}\n{1}", e1.Message, e2.Message), e1);
+				}
+			}
+		};
+
 		public readonly static Action EmptyAction = delegate { };
 
 		static string[] waitForNuGetMessages = {

--- a/main/tests/UserInterfaceTests/UITestBase.cs
+++ b/main/tests/UserInterfaceTests/UITestBase.cs
@@ -89,8 +89,10 @@ namespace UserInterfaceTests
 		public virtual void Teardown ()
 		{
 			try {
-				if (TestContext.CurrentContext.Result.Status != TestStatus.Passed && Session.Query (IdeQuery.XamarinUpdate).Any ()) {
-					Assert.Inconclusive ("Xamarin Update is blocking the application focus");
+				if (TestContext.CurrentContext.Result.Status != TestStatus.Passed) {
+					var updateOpened = Session.Query (IdeQuery.XamarinUpdate);
+					if (updateOpened != null && updateOpened.Any ())
+						Assert.Inconclusive ("Xamarin Update is blocking the application focus");
 				}
 				ValidateIdeLogMessages ();
 			} finally {

--- a/main/tests/UserInterfaceTests/VersionControlTests/Git/GitStashManagerTests.cs
+++ b/main/tests/UserInterfaceTests/VersionControlTests/Git/GitStashManagerTests.cs
@@ -111,7 +111,7 @@ namespace UserInterfaceTests
 			GitCreateAndCommit (templateOptions, "First commit");
 			var changeDescription = MakeSomeChangesAndSaveAll ("Program.cs");
 			TestGitStash (changeDescription);
-			Session.WaitForElement (IdeQuery.TextArea);
+			Session.WaitForElement (IdeQuery.TextArea, 20000);
 			TakeScreenShot ("After-Stash");
 		}
 	}


### PR DESCRIPTION
There are times when we are not sure if "Packages Added" or
"Project Saved" would end up showing on the status bar as there
is no defined order. This method can be used in tests to make
sure that out tests don't fail just because we can't predict
the order of status message

Also check for Xamarin Update open in a different line checking
first if it is not null to avoid NRE

Also update WaitForTextArea in git tests to give it 20 seconds
instead of standard 5 seconds for the project to be opened