### PR TITLE
[UITest] Add BuildTimeout in ProjectDetails as some templates take more time to build than others

### DIFF
--- a/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
+++ b/main/tests/UserInterfaceTests/CreateBuildTemplatesTestBase.cs
@@ -92,7 +92,7 @@ namespace UserInterfaceTests
 					Assert.Fail (e.ToString ());
 				}
 
-				OnBuildTemplate ();
+				OnBuildTemplate ((int)projectDetails.BuildTimeout.TotalSeconds);
 			} catch (Exception e) {
 				TakeScreenShot ("TestFailedWithGenericException");
 				Assert.Fail (e.ToString ());

--- a/main/tests/UserInterfaceTests/TemplateTestOptions.cs
+++ b/main/tests/UserInterfaceTests/TemplateTestOptions.cs
@@ -96,6 +96,7 @@ namespace UserInterfaceTests
 		{
 			ProjectName = CreateBuildTemplatesTestBase.GenerateProjectName (templateData.TemplateKind);
 			SolutionName = ProjectName;
+			BuildTimeout = TimeSpan.FromSeconds (180);
 		}
 
 		public static ProjectDetails ToExistingSolution (string solutionName, string projectName)
@@ -117,6 +118,8 @@ namespace UserInterfaceTests
 		public bool ProjectInSolution { get; set; }
 
 		public bool AddProjectToExistingSolution { get; set; }
+
+		public TimeSpan BuildTimeout { get; set; }
 
 		public override string ToString ()
 		{


### PR DESCRIPTION
Android Wear takes way more time, so hardcoding time for all templates of one Category is not a sensible way to go. The timeout should be associated with each template