### PR TITLE
[UITest] Enhanced ToPathSafeString utility method

### DIFF
--- a/main/tests/UserInterfaceTests/Util.cs
+++ b/main/tests/UserInterfaceTests/Util.cs
@@ -28,6 +28,7 @@ using System;
 using System.IO;
 using MonoDevelop.Core;
 using System.Reflection;
+using System.Linq;
 
 namespace UserInterfaceTests
 {
@@ -39,9 +40,10 @@ namespace UserInterfaceTests
 				TestService.Session.DebugObject.Debug (data.ToString ());
 		}
 
-		public static string ToPathSafeString (this string str)
+		public static string ToPathSafeString (this string str, char replaceWith = '-')
 		{
-			return str.Replace (@"\", "-").Replace ("/", "-");
+			var invalids = Path.GetInvalidFileNameChars ().Concat (Path.GetInvalidPathChars ()).Distinct ().ToArray ();
+			return new string (str.Select (c => invalids.Contains (c) ? replaceWith : c).ToArray ());
 		}
 
 		public static FilePath CreateTmpDir (string hint = null)


### PR DESCRIPTION
It now removes most invalid characters rather than only slashes. 

cc: @Therzok, since you pointed out it should be dashes