### PR TITLE
[UITest] Updated locator for SelectPane

### DIFF
--- a/main/tests/UserInterfaceTests/Controllers/OptionsController.cs
+++ b/main/tests/UserInterfaceTests/Controllers/OptionsController.cs
@@ -96,7 +96,7 @@ namespace UserInterfaceTests
 		{
 			string.Format ("Selected Pane :{0}", name).PrintData ();
 			Session.SelectElement (c => windowQuery (c).Children ().Marked (
-				"__gtksharp_16_MonoDevelop_Components_HeaderBox").Children ().TreeView ().Model ().Children ().Property ("Label", name));
+				"MonoDevelop.Components.HeaderBox").Children ().TreeView ().Model ().Children ().Property ("Label", name));
 		}
 
 		protected void SetEntry (string entryName, string entryValue, string stepName,  Action<string> takeScreenshot)


### PR DESCRIPTION
The locator for SelectPane in the OptionsController only worked on Mac, with this change it will work on both platforms.

CC: @manish 