### PR TITLE
[IDE] Hide the updater with a hidden property key

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateCheckHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateCheckHandler.cs
@@ -26,6 +26,7 @@
 
 
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Updater;
 
 namespace MonoDevelop.Ide.Updater
@@ -48,6 +49,11 @@ namespace MonoDevelop.Ide.Updater
 		protected override void Run ()
 		{
 			UpdateService.CheckForUpdates ();
+		}
+
+		protected override void Update (CommandInfo info)
+		{
+			info.Visible = !PropertyService.Get<bool>("MonoDevelop.Ide.AddinUpdater.HideFromUI");
 		}
 	}
 }


### PR DESCRIPTION
Setting the property MonoDevelop.Ide.AddinUpdater.HideFromUI will hide the Check For Updates menu

Fixes BXC #14627