### PR TITLE
FileLogger: use the testname as the logger, WaitForIdeIdle keeps blocked on certain messages

### DIFF
--- a/main/tests/UserInterfaceTests/DialogTests/NuGetDialogTests.cs
+++ b/main/tests/UserInterfaceTests/DialogTests/NuGetDialogTests.cs
@@ -130,6 +130,7 @@ namespace UserInterfaceTests
 		}
 
 		[Test]
+		[Timeout (90000)]
 		[Description ("When readme.txt from a package has already been opened, adding same package to another project should not open readme.txt")]
 		public void TestDontOpenReadmeOpenedInOther ()
 		{
@@ -153,6 +154,7 @@ namespace UserInterfaceTests
 			var pclProjectDetails = ProjectDetails.ToExistingSolution (projectDetails.SolutionName,
 				GenerateProjectName (pclTemplateOptions.TemplateKind));
 			CreateProject (pclTemplateOptions, pclProjectDetails);
+			Ide.WaitForIdeIdle (30);
 
 			SolutionExplorerController.SelectProject (projectDetails.SolutionName, pclProjectDetails.ProjectName);
 			NuGetController.AddPackage (packageInfo, this);

--- a/main/tests/UserInterfaceTests/UITestBase.cs
+++ b/main/tests/UserInterfaceTests/UITestBase.cs
@@ -156,7 +156,7 @@ namespace UserInterfaceTests
 			reproStepIndex = 0;
 			var currentTestLog = Path.Combine (currentTestResultFolder, string.Format ("{0}.Test.log.txt", TestContext.CurrentContext.Test.Name.ToPathSafeString ()));
 			Logger = new FileLogger (currentTestLog) {
-				Name = "UITestLogger",
+				Name = TestContext.CurrentContext.Test.Name,
 				EnabledLevel = EnabledLoggingLevel.All,
 			};
 			LoggingService.AddLogger (Logger);

--- a/main/tests/UserInterfaceTests/VersionControlTests/Git/GitRepositoryConfigurationTests.cs
+++ b/main/tests/UserInterfaceTests/VersionControlTests/Git/GitRepositoryConfigurationTests.cs
@@ -63,7 +63,7 @@ namespace UserInterfaceTests
 		[Description ("Create a New Branch")]
 		public void CreateNewBranchTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ();
@@ -75,7 +75,7 @@ namespace UserInterfaceTests
 		[Description ("Create a New Branch and switch to it")]
 		public void GitSwitchBranchTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ();
@@ -88,7 +88,7 @@ namespace UserInterfaceTests
 		[Description ("Create a New Branch, select it and edit the name and switch to it")]
 		public void GitEditBranchTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ();
@@ -103,7 +103,7 @@ namespace UserInterfaceTests
 		[Description ("Create a new branch, select it and delete it")]
 		public void GitDeleteBranchTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ();
@@ -193,7 +193,7 @@ namespace UserInterfaceTests
 		[Description ("Clone a repo and select a remote")]
 		public void SelectRemoteTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ("Remote Sources");
@@ -205,7 +205,7 @@ namespace UserInterfaceTests
 		[Description ("Clone a repo, add a new remote and select that added remote")]
 		public void AddGitRemoteTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			const string newRemoteName = "second";
@@ -220,7 +220,7 @@ namespace UserInterfaceTests
 		[Description ("Clone a repo, add a new remote, select it and delete it")]
 		public void DeleteGitRemoteTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			const string newRemoteName = "second";
@@ -236,7 +236,7 @@ namespace UserInterfaceTests
 		[Description ("Edit only Remote Name, don't edit URL or Push URL")]
 		public void EditGitRemoteNameTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ("Remote Sources");
@@ -257,7 +257,7 @@ namespace UserInterfaceTests
 		[Description ("Edit only Remote Name and URL, don't edit Push URL")]
 		public void EditGitRemoteNameAndUrlTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ("Remote Sources");
@@ -278,7 +278,7 @@ namespace UserInterfaceTests
 		[Description ("Edit only Remote Name and Push URL, don't edit URL")]
 		public void EditGitRemoteNameAndPushUrlTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ("Remote Sources");
@@ -299,7 +299,7 @@ namespace UserInterfaceTests
 		[Description ("Edit only Remote URL and Push URL, don't edit Name")]
 		public void EditGitRemoteUrlTest ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			OpenRepositoryConfiguration ("Remote Sources");
@@ -319,7 +319,7 @@ namespace UserInterfaceTests
 		[Description ("Clone a repo, add a new remote and fetch the remote branches for that remote")]
 		public void FetchRemoteBranches ()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			const string newRemoteName = "second";
@@ -334,7 +334,7 @@ namespace UserInterfaceTests
 		[Description ("Clone a repo, add a new remote, fetch the remote branch, chose a branch and track it in local. Select that branch in Branches tab")]
 		public void TrackRemoteBranchInLocalTest()
 		{
-			TestClone ("git@github.com:mono/jurassic.git");
+			TestClone (gtkSharpUrl);
 			Ide.WaitForSolutionCheckedOut ();
 
 			const string newRemoteName = "second";

--- a/main/tests/UserInterfaceTests/VersionControlTests/Git/GitTests.cs
+++ b/main/tests/UserInterfaceTests/VersionControlTests/Git/GitTests.cs
@@ -32,15 +32,16 @@ namespace UserInterfaceTests
 {
 	[TestFixture, Timeout(60000)]
 	[Category ("Git")]
+	[Category ("GitBase")]
 	public class GitTests : VCSBase
 	{
 		[Test, Timeout(90000)]
-		[TestCase ("git@github.com:mono/jurassic.git", TestName = "TestGitSSHClone", Description = "Clone Git repo over SSH")]
-		[TestCase ("https://github.com/mono/jurassic.git", TestName = "TestGitHTTPSClone", Description = "Clone Git repo over HTTPS")]
+		[TestCase ("git@github.com:mono/gtk-sharp.git", TestName = "TestGitSSHClone", Description = "Clone Git repo over SSH")]
+		[TestCase ("https://github.com/mono/gtk-sharp.git", TestName = "TestGitHTTPSClone", Description = "Clone Git repo over HTTPS")]
 		public void TestGitClone (string url)
 		{
 			TestClone (url);
-			Ide.WaitForSolutionCheckedOut ();
+			Ide.WaitForIdeIdle ();
 		}
 
 		[Test]


### PR DESCRIPTION
**[UITest] For UITest FileLogger use the testname as the logger**

This change is required because there are times when the test fails where XS crashes and doesn't get time for the logger to be cleaned up. Having different logger names for different tests would give other tests a chance to continue

---

**[UITest] WaitForIdeIdle does not unblock on specific messages. Extra messages can be added**

There are situations where the operation takes more than poll time and the method unblocks. Examples of such messages as "Solution loading..." or "Updatinng packages in solution..." etc. The method now also takes an optional argument to add more messages to block on if needed

------

**[UITest] Fix NuGet and Git tests by fixing timeouts and using gtk-sharp repo to clone**
