### PR TITLE
[Ide] Fix infinite recursion on progress monitor progress reports

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
@@ -69,7 +69,6 @@ namespace MonoDevelop.Ide.Gui
 				DesktopService.SetGlobalProgress (Progress);
 			} else
 				DesktopService.ShowGlobalProgressIndeterminate ();
-			DispatchService.RunPendingEvents ();
 		}
 		
 		public void UpdateStatusBar ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
@@ -84,7 +84,6 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 			if (dialog != null) {
 				dialog.Message = CurrentTaskName;
 				dialog.Progress = Progress;
-				DispatchService.RunPendingEvents ();
 			}
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MultiTaskDialogProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MultiTaskDialogProgressMonitor.cs
@@ -108,7 +108,6 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 		{
 			if (dialog != null) {
 				dialog.SetProgress (Progress);
-				DispatchService.RunPendingEvents ();
 			}
 		}
 		


### PR DESCRIPTION
Excerpt of stacktrace
  at MonoDevelop.Core.ProgressMonitor.ReportProgressChanged () [0x0000b]
in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:635
  at MonoDevelop.Core.ProgressMonitor/<Step>c__AnonStorey2.<>m__0
(object) [0x00017] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:287
  at
MonoDevelop.Ide.Gui.GtkSynchronizationContext/<Post>c__AnonStorey0.<>m__0
() [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/GtkSynchronizationContext.cs:36
  at MonoDevelop.Ide.DispatchService/<GuiDispatch>c__AnonStorey1.<>m__0
() [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:114
  at MonoDevelop.Ide.GenericMessageContainer.Run () [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:479
  at MonoDevelop.Ide.DispatchService.guiDispatcher () [0x00092] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:319
  at MonoDevelop.Ide.DispatchService.RunPendingEvents () [0x00085] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:194
  at MonoDevelop.Ide.Gui.StatusProgressMonitor.OnProgressChanged ()
[0x00058] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs:72
  at MonoDevelop.Core.ProgressMonitor.<ReportProgressChanged>m__1
(object) [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:635
  at
MonoDevelop.Ide.Gui.GtkSynchronizationContext/<Post>c__AnonStorey0.<>m__0
() [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/GtkSynchronizationContext.cs:36
  at MonoDevelop.Ide.DispatchService.GuiDispatch (System.Action)
[0x00022] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:104
  at MonoDevelop.Ide.Gui.GtkSynchronizationContext.Post
(System.Threading.SendOrPostCallback,object) [0x00014] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/GtkSynchronizationContext.cs:35
  at MonoDevelop.Core.ProgressMonitor.ReportProgressChanged () [0x0000b]
in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:635
  at MonoDevelop.Core.ProgressMonitor/<Step>c__AnonStorey2.<>m__0
(object) [0x00017] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:287
  at
MonoDevelop.Ide.Gui.GtkSynchronizationContext/<Post>c__AnonStorey0.<>m__0
() [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/GtkSynchronizationContext.cs:36
  at MonoDevelop.Ide.DispatchService/<GuiDispatch>c__AnonStorey1.<>m__0
() [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:114
  at MonoDevelop.Ide.GenericMessageContainer.Run () [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:479
  at MonoDevelop.Ide.DispatchService.guiDispatcher () [0x00092] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:319
  at MonoDevelop.Ide.DispatchService.RunPendingEvents () [0x00085] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:194
  at
MonoDevelop.Ide.ProgressMonitoring.MessageDialogProgressMonitor.OnProgressChanged
() [0x0002d] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs:87
  at MonoDevelop.Core.ProgressMonitor.<ReportProgressChanged>m__1
(object) [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:635
  at
MonoDevelop.Ide.Gui.GtkSynchronizationContext/<Post>c__AnonStorey0.<>m__0
() [0x00000] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/GtkSynchronizationContext.cs:36
  at MonoDevelop.Ide.DispatchService.GuiDispatch (System.Action)
[0x00022] in
/Users/builder/data/lanes/1507/4b7bd82d/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:104

cc @slluis 