### PR TITLE
[Mac] Improved monostub and added unit tests!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ obj/
 /main/tests/config
 /main/tests/UnitTests/test-results
 /main/build/MacOSX/monostub
+/main/build/MacOSx/monostub-test
 /main/contrib/bin/
 /main/contrib/*/*/bin/
 /local-libs
@@ -50,6 +51,7 @@ install-sh
 autom4te.cache/
 *.user
 *.tar.gz
+*.dSYM
 tarballs/
 test-results/
 Thumbs.db

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -16,7 +16,7 @@ CLEANFILES = render.exe
 #DISTCLEANFILES =
 EXTRA_DIST = dmg-bg.png DS_Store Info.plist.in make-dmg-bundle.sh render.cs
 
-all: monostub
+all: monostub monostub-test
 
 render.exe: render.cs
 	gmcs -r:System.Drawing render.cs
@@ -29,11 +29,15 @@ monostub: monostub.m $(MONOSTUB_EXTRA_SOURCES)
 #	gcc -Wall -mmacosx-version-min=10.10 -m32 -o $@ $^ -framework AppKit -isysroot $(SDK_PATH)
 	cp monostub ../bin/MonoDevelop
 
+monostub-test: monostub-test.m $(MONOSTUB_EXTRA_SOURCES)
+	gcc -g -Wall -mmacosx-version-min=10.10 -m32 -o $@ $^ -framework AppKit
+	./monostub-test
+
 clean-local:
 	rm -rf MonoDevelop.app
 	rm -f MonoDevelop*.dmg
 
-app: monostub
+app: monostub monostub-test
 	@echo ""
 	@echo "Creating directories in app bundle"
 	@echo ""

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -1,0 +1,187 @@
+#include <stdio.h>
+
+#include "monostub-utils.h"
+
+void fail(void)
+{
+	NSLog(@"%@", [NSThread callStackSymbols]);
+	exit(1);
+}
+
+void check_string_equal(const char *expected, const char *actual)
+{
+	if (strcmp(expected, actual)) {
+		printf("Expected '%s'\nActual   '%s'\n", expected, actual);
+		fail();
+	}
+}
+
+void check_bool_equal(int expected, int actual)
+{
+	if (expected != actual) {
+		printf("Expected '%d'\nActual   '%d'\n", expected, actual);
+		fail();
+	}
+}
+
+void test_mono_lib_path(void)
+{
+	char *expected = "/Library/Frameworks/Mono.framework/Versions/Current/lib/test";
+	char *actual = MONO_LIB_PATH("test");
+
+	check_string_equal(expected, actual);
+}
+
+void test_check_mono_version(void)
+{
+	typedef struct {
+		char *mono_version, *req_mono_version;
+		int expected;
+	} version_check;
+
+	version_check versions[] = {
+		// Lower than requirement
+		{ "3.0", "3.1", FALSE },
+
+		// Higher than requirement
+		{ "3.1", "3.0", TRUE },
+
+		// Release lower than requirement.
+		// FIXME
+		//{ "3.1", "3.1.1", FALSE },
+
+		// Release higher than requirement.
+		{ "3.1.1", "3.1", TRUE },
+
+		// Bogus requirement value.
+		{ "3.1", "BOGUS STRING", FALSE },
+	};
+
+	version_check *version;
+	int i;
+	for (i = 0; i < sizeof(versions) / sizeof(version_check); ++i) {
+		version = &versions[i];
+		check_bool_equal(version->expected, check_mono_version(version->mono_version, version->req_mono_version));
+	}
+}
+
+void test_str_append(void)
+{
+	char *str = "asdf";
+	char *conc = str_append(str, str);
+
+	check_string_equal("asdfasdf", conc);
+}
+
+void test_generate_fallback_path (void)
+{
+	char *actual = generate_fallback_path(".");
+
+	check_string_equal("./Resources/lib:./Resources/lib/monodevelop/bin:/Library/Frameworks/Mono.framework/Versions/Current/lib:/lib:/usr/lib:/Library/Developer/CommandLineTools/usr/lib:/usr/local/lib", actual);
+}
+
+void test_env2bool(void)
+{
+	typedef struct {
+		bool expected, defaultValue;
+		const char *var, *value;
+	} bool_check;
+
+	bool_check bools[] = {
+		// If variable does not exist, return default.
+		{ TRUE, TRUE, "WILL_NOT_EXIST", NULL },
+		{ FALSE, FALSE, "WILL_NOT_EXIST", NULL },
+
+		// Check that truth-y values are true.
+		{ TRUE, FALSE, "WILL_EXIST", "TRUE" },
+		{ TRUE, FALSE, "WILL_EXIST", "YES" },
+		{ TRUE, FALSE, "WILL_EXIST", "1" },
+
+		// Check that false-y values are false.
+		{ FALSE, TRUE, "WILL_EXIST", "BOGUS" },
+		{ FALSE, TRUE, "WILL_EXIST", "0" },
+	};
+
+	bool_check *current;
+	int i;
+	for (i = 0; i < sizeof(bools) / sizeof(bool_check); ++i) {
+		current = &bools[i];
+		if (current->value)
+			setenv(current->var, current->value, 1);
+
+		check_bool_equal(current->expected, env2bool(current->var, current->defaultValue));
+	}
+}
+
+void test_push_env(void)
+{
+	typedef struct {
+		bool expected;
+		const char *var, *initial, *to_find, *updated;
+	} push_env_check;
+
+	const char *three_part = "/usr/lib:/lib:/etc";
+	push_env_check checks[] = {
+		// We don't have an initial value.
+		{ TRUE, "WILL_NOT_EXIST", NULL, "/usr/lib", "/usr/lib" },
+
+		// First component matches.
+		{ FALSE, "WILL_EXIST", three_part, "/usr/lib", three_part },
+
+		// Middle component matches.
+		{ FALSE, "WILL_EXIST", three_part, "/lib", three_part },
+
+		// End component matches.
+		{ FALSE, "WILL_EXIST", three_part, "/etc", three_part },
+
+		// Add a non existing component.
+		{ TRUE, "WILL_EXIST", three_part, "/Library", "/Library:/usr/lib:/lib:/etc" },
+	};
+
+	push_env_check *current;
+	int i;
+	for (i = 0; i < sizeof(checks) / sizeof(push_env_check); ++i) {
+		current = &checks[i];
+		if (current->initial)
+			setenv(current->var, current->initial, 1);
+
+		check_bool_equal(current->expected, push_env(current->var, current->to_find));
+		check_string_equal(current->updated, getenv(current->var));
+	}
+}
+
+void test_update_environment(void)
+{
+	const char *added_path = "/Library/Frameworks/Mono.framework/Commands:./Resources:./MacOS:/Library/Frameworks/Mono.framework/Versions/Current/bin";
+
+	// Check that we only get updates one time, that's how monostub works.
+	check_bool_equal(TRUE, update_environment("."));
+	check_bool_equal(FALSE, update_environment("."));
+
+	check_string_equal("/usr/local/lib:/Library/Developer/CommandLineTools/usr/lib:/usr/lib:/lib:/Library/Frameworks/Mono.framework/Versions/Current/lib:./Resources/lib/monodevelop/bin:./Resources/lib", getenv("DYLD_FALLBACK_LIBRARY_PATH"));
+	check_string_equal("./Resources/lib/pkgconfig:/Library/Frameworks/Mono.framework/External/pkgconfig", getenv("PKG_CONFIG_PATH"));
+	check_string_equal("./Resources", getenv("MONO_GAC_PREFIX"));
+
+	const char *new_path = getenv("PATH");
+
+	// Check we have the new components in the beginning.
+	if (strstr(new_path, added_path) != new_path)
+		fail();
+}
+
+void (*tests[])(void) = {
+	test_mono_lib_path,
+	test_check_mono_version,
+	test_str_append,
+	test_generate_fallback_path,
+	test_env2bool,
+	test_push_env,
+	test_update_environment,
+};
+
+int main(int argc, char **argv)
+{
+	for (int i = 0; i < sizeof(tests) / sizeof(void *); ++i)
+		tests[i]();
+	return 0;
+}

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -121,9 +121,9 @@ push_env (const char *variable, const char *value)
 	BOOL updated = YES;
 	
 	if ((current = getenv (variable)) && *current) {
-		char *token, *copy;
+		char *token, *copy, *tofree;
 
-		copy = strdup (current);
+		tofree = copy = strdup (current);
 		len = strlen (value);
 		while ((token = strsep(&copy, ":"))) {
 			if (!strncmp (token, value, len)) {
@@ -144,7 +144,7 @@ push_env (const char *variable, const char *value)
 		setenv (variable, buf, 1);
 		free (buf);
 done:
-		free (copy);
+		free (tofree);
 	} else {
 		setenv (variable, value, 1);
 	}

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -1,0 +1,214 @@
+#include <stdlib.h>
+#include <string.h>
+
+#import <Cocoa/Cocoa.h>
+
+#define MONO_LIB_PATH(lib) "/Library/Frameworks/Mono.framework/Versions/Current/lib/"lib
+
+static int
+check_mono_version (const char *version, const char *req_version)
+{
+	char *req_end, *end;
+	long req_val, val;
+	
+	while (*req_version) {
+		req_val = strtol (req_version, &req_end, 10);
+		if (req_version == req_end || (*req_end && *req_end != '.')) {
+			fprintf (stderr, "Bad version requirement string '%s'\n", req_end);
+			return FALSE;
+		}
+		
+		req_version = req_end;
+		if (*req_version)
+			req_version++;
+		
+		val = strtol (version, &end, 10);
+		if (version == end || val < req_val)
+			return FALSE;
+		
+		if (val > req_val)
+			return TRUE;
+		
+		if (*req_version == '.' && *end != '.')
+			return FALSE;
+		
+		version = end + 1;
+	}
+	
+	return TRUE;
+}
+
+static char *
+str_append (const char *base, const char *append)
+{
+	size_t baselen = strlen (base);
+	size_t len = strlen (append);
+	char *buf;
+	
+	if (!(buf = malloc (baselen + len + 1)))
+		return NULL;
+	
+	memcpy (buf, base, baselen);
+	strcpy (buf + baselen, append);
+	
+	return buf;
+}
+
+static char *
+generate_fallback_path (const char *contentsDir)
+{
+	char *lib_dir;
+	char *monodevelop_bin_dir;
+	char *value;
+	char *result;
+
+	/* Inject our Resources/lib dir */
+	lib_dir = str_append (contentsDir, "/Resources/lib:");
+
+	/* Inject our Resources/lib/monodevelop/bin dir so we can load libxammac.dylib */
+	monodevelop_bin_dir = str_append (contentsDir, "/Resources/lib/monodevelop/bin:");
+
+	if (lib_dir == NULL || monodevelop_bin_dir == NULL)
+		abort ();
+
+	value = str_append (lib_dir, monodevelop_bin_dir);
+	if (value == NULL)
+		abort ();
+
+	/* Mono's lib dir, and CommandLineTool's lib dir into the DYLD_FALLBACK_LIBRARY_PATH */
+	result = str_append (value, "/Library/Frameworks/Mono.framework/Versions/Current/lib:/lib:/usr/lib:/Library/Developer/CommandLineTools/usr/lib:/usr/local/lib");
+
+	free (lib_dir);
+	free (monodevelop_bin_dir);
+	free (value);
+	return result;
+}
+
+static bool
+env2bool (const char *env, bool defaultValue)
+{
+	const char *value;
+	bool nz = NO;
+	int i;
+	
+	if (!(value = getenv (env)))
+		return defaultValue;
+	
+	if (!strcasecmp (value, "true"))
+		return YES;
+	
+	if (!strcasecmp (value, "yes"))
+		return YES;
+	
+	/* check to see if the value is numeric. All numeric values evaluate to true *except* zero */
+	for (i = 0; value[i]; i++) {
+		if (!isdigit ((int) ((unsigned char) value[i])))
+			return NO;
+		
+		if (value[i] != '0')
+			nz = YES;
+	}
+	
+	return nz;
+}
+
+static bool
+push_env (const char *variable, const char *value)
+{
+	const char *current;
+	size_t len;
+	char *buf;
+	BOOL updated = YES;
+	
+	if ((current = getenv (variable)) && *current) {
+		char *token, *copy;
+
+		copy = strdup (current);
+		len = strlen (value);
+		while ((token = strsep(&copy, ":"))) {
+			if (!strncmp (token, value, len)) {
+				while ((strsep(&copy, ":")))
+					continue;
+
+				updated = NO;
+				goto done;
+			}
+		}
+
+		if (!(buf = malloc (len + strlen (current) + 2)))
+			return NO;
+		
+		memcpy (buf, value, len);
+		buf[len] = ':';
+		strcpy (buf + len + 1, current);
+		setenv (variable, buf, 1);
+		free (buf);
+done:
+		free (copy);
+	} else {
+		setenv (variable, value, 1);
+	}
+
+	//if (updated)
+	//	printf ("Updated the %s environment variable with '%s'.\n", variable, value);
+
+	return updated;
+}
+
+static bool
+update_environment (const char *contentsDir)
+{
+	bool updated = NO;
+	char *value;
+	
+	if ((value = generate_fallback_path (contentsDir))) {
+		char *token;
+
+		while ((token = strsep(&value, ":"))) {
+			if (push_env ("DYLD_FALLBACK_LIBRARY_PATH", token))
+				updated = YES;
+		}
+
+		free (value);
+	}
+	
+	if (push_env ("PKG_CONFIG_PATH", "/Library/Frameworks/Mono.framework/External/pkgconfig"))
+		updated = YES;
+
+	/* Enable the use of stuff bundled into the app bundle and the Mono "External" directory */
+	if ((value = str_append (contentsDir, "/Resources/lib/pkgconfig"))) {
+		if (push_env ("PKG_CONFIG_PATH", value))
+			updated = YES;
+
+		free (value);
+	}
+
+	if ((value = str_append (contentsDir, "/Resources"))) {
+		if (push_env ("MONO_GAC_PREFIX", value))
+			updated = YES;
+		
+		free (value);
+	}
+	
+	if ((value = str_append (contentsDir, "/MacOS"))) {
+		if (push_env ("PATH", value))
+			updated = YES;
+
+		free (value);
+	}
+
+	// Note: older versions of Xamarin Studio incorrectly set the PATH to the Resources dir instead of the MacOS dir
+	// and older versions of mtouch relied on this broken behavior.
+	if ((value = str_append (contentsDir, "/Resources"))) {
+		if (push_env ("PATH", value))
+			updated = YES;
+
+		free (value);
+	}
+
+	if (push_env ("PATH", "/Library/Frameworks/Mono.framework/Commands"))
+		updated = YES;
+
+	return updated;
+}
+

--- a/main/build/MacOSX/monostub.m
+++ b/main/build/MacOSX/monostub.m
@@ -1,7 +1,6 @@
 //gcc -m32 monostub.m -o monostub -framework AppKit
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -11,10 +10,9 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <ctype.h>
+#include <time.h>
 
-#import <Cocoa/Cocoa.h>
-
-#define MONO_LIB_PATH(lib) "/Library/Frameworks/Mono.framework/Versions/Current/lib/"lib
+#include "monostub-utils.h"
 
 typedef int (* mono_main) (int argc, char **argv);
 typedef void (* mono_free) (void *ptr);
@@ -53,38 +51,6 @@ exit_with_message (char *reason, char *argv0)
 	exit (1);
 }
 
-static int
-check_mono_version (const char *version, const char *req_version)
-{
-	char *req_end, *end;
-	long req_val, val;
-	
-	while (*req_version) {
-		req_val = strtol (req_version, &req_end, 10);
-		if (req_version == req_end || (*req_end && *req_end != '.')) {
-			fprintf (stderr, "Bad version requirement string '%s'\n", req_end);
-			return FALSE;
-		}
-		
-		req_version = req_end;
-		if (*req_version)
-			req_version++;
-		
-		val = strtol (version, &end, 10);
-		if (version == end || val < req_val)
-			return FALSE;
-		
-		if (val > req_val)
-			return TRUE;
-		
-		if (*req_version == '.' && *end != '.')
-			return FALSE;
-		
-		version = end + 1;
-	}
-	
-	return TRUE;
-}
 
 typedef struct _ListNode {
 	struct _ListNode *next;
@@ -208,181 +174,9 @@ get_mono_env_options (int *count)
 	return argv;
 }
 
-static bool
-push_env (const char *variable, const char *value)
-{
-	const char *current;
-	size_t len;
-	char *buf;
-	
-	if ((current = getenv (variable)) && *current) {
-		len = strlen (value);
-		
-		if (!strncmp (current, value, len) && (current[len] == ':' || current[len] == '\0'))
-			return NO;
-		
-		if (!(buf = malloc (len + strlen (current) + 2)))
-			return NO;
-		
-		memcpy (buf, value, len);
-		buf[len] = ':';
-		strcpy (buf + len + 1, current);
-		setenv (variable, buf, 1);
-		free (buf);
-	} else {
-		setenv (variable, value, 1);
-	}
-
-	//printf ("Updated the %s environment variable with '%s'.\n", variable, value);
-	
-	return YES;
-}
-
-static char *
-str_append (const char *base, const char *append)
-{
-	size_t baselen = strlen (base);
-	size_t len = strlen (append);
-	char *buf;
-	
-	if (!(buf = malloc (baselen + len + 1)))
-		return NULL;
-	
-	memcpy (buf, base, baselen);
-	strcpy (buf + baselen, append);
-	
-	return buf;
-}
-
-static char *
-generate_fallback_path (const char *contentsDir)
-{
-	char *lib_dir;
-	char *monodevelop_bin_dir;
-	char *value;
-	char *result;
-
-	/* Inject our Resources/lib dir */
-	lib_dir = str_append (contentsDir, "/Resources/lib:");
-
-	/* Inject our Resources/lib/monodevelop/bin dir so we can load libxammac.dylib */
-	monodevelop_bin_dir = str_append (contentsDir, "/Resources/lib/monodevelop/bin:");
-
-	if (lib_dir == NULL || monodevelop_bin_dir == NULL)
-		abort ();
-
-	value = str_append (lib_dir, monodevelop_bin_dir);
-	if (value == NULL)
-		abort ();
-
-	/* Mono's lib dir, and CommandLineTool's lib dir into the DYLD_FALLBACK_LIBRARY_PATH */
-	result = str_append (value, "/Library/Frameworks/Mono.framework/Versions/Current/lib:/lib:/usr/lib:/Library/Developer/CommandLineTools/usr/lib:/usr/local/lib");
-
-	free (lib_dir);
-	free (monodevelop_bin_dir);
-	free (value);
-	return result;
-}
-
-static bool
-update_environment (const char *contentsDir)
-{
-	bool updated = NO;
-	char *value;
-	
-	if ((value = generate_fallback_path (contentsDir))) {
-		if (push_env ("DYLD_FALLBACK_LIBRARY_PATH", value))
-			updated = YES;
-		
-		free (value);
-	}
-	
-	/* Enable the use of stuff bundled into the app bundle and the Mono "External" directory */
-	if ((value = str_append (contentsDir, "/Resources/lib/pkgconfig:/Library/Frameworks/Mono.framework/External/pkgconfig"))) {
-		if (push_env ("PKG_CONFIG_PATH", value))
-			updated = YES;
-		
-		free (value);
-	}
-
-	if ((value = str_append (contentsDir, "/Resources"))) {
-		if (push_env ("MONO_GAC_PREFIX", value))
-			updated = YES;
-		
-		free (value);
-	}
-	
-	if ((value = str_append (contentsDir, "/MacOS"))) {
-		char *compat;
-
-		char *value2 = str_append("/Library/Frameworks/Mono.framework/Commands:", value);
-
-		// Note: older versions of Xamarin Studio incorrectly set the PATH to the Resources dir instead of the MacOS dir
-		// and older versions of mtouch relied on this broken behavior.
-		if ((compat = str_append (contentsDir, "/Resources"))) {
-			size_t compatlen = strlen (compat);
-			size_t valuelen = strlen (value2);
-			char *combined;
-			
-			if ((combined = malloc (compatlen + valuelen + 2))) {
-				memcpy (combined, compat, compatlen);
-				combined[compatlen] = ':';
-				strcpy (combined + compatlen + 1, value2);
-
-				if (push_env ("PATH", combined))
-					updated = YES;
-				
-				free (combined);
-			} else {
-				// if we can't combine them, set the old (incorrect) compat value
-				if (push_env ("PATH", compat))
-					updated = YES;
-			}
-			
-			free (compat);
-		} else {
-			if (push_env ("PATH", value2))
-				updated = YES;
-		}
-
-		free (value);
-		free (value2);
-	}
-
-
-	return updated;
-}
-
-static bool
-env2bool (const char *env, bool defaultValue)
-{
-	const char *value;
-	bool nz = NO;
-	int i;
-	
-	if (!(value = getenv (env)))
-		return defaultValue;
-	
-	if (!strcasecmp (value, "true"))
-		return YES;
-	
-	if (!strcasecmp (value, "yes"))
-		return YES;
-	
-	/* check to see if the value is numeric. All numeric values evaluate to true *except* zero */
-	for (i = 0; value[i]; i++) {
-		if (!isdigit ((int) ((unsigned char) value[i])))
-			return NO;
-		
-		if (value[i] != '0')
-			nz = YES;
-	}
-	
-	return nz;
-}
-
 int main (int argc, char **argv)
 {
+	//clock_t start = clock();
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	NSString *binDir = [[NSString alloc] initWithUTF8String: "Contents/Resources/lib/monodevelop/bin"];
 
@@ -494,5 +288,7 @@ int main (int argc, char **argv)
 	free (extra_argv);
 	[pool drain];
 	
+	//clock_t end = clock();
+	//printf("%f seconds to start\n", (float)(end - start) / CLOCKS_PER_SEC);
 	return _mono_main (argc + extra_argc + injected, new_argv);
 }


### PR DESCRIPTION
Added unit tests that will fail CI builds when these tests fail. If
this fails, you won't be able to run MonoDevelop on Mac anyway. :P

More importantly, I changed `push_env` so it takes into account other
parts that the beginning of the environment variable string. Now it
will check whether the path components are not the first component, the
path variable will no longer be updated.

`push_env` also now takes only a path component, so pieces need to be
added manually, or you need to `strsep(&value, ":")` before appending.