### PR TITLE
[UITest] Copy MonoDevelopProperties.xml to test profile and disable updater

### DIFF
--- a/main/tests/UserInterfaceTests/VersionControlTests/Git/GitBase.cs
+++ b/main/tests/UserInterfaceTests/VersionControlTests/Git/GitBase.cs
@@ -231,6 +231,7 @@ namespace UserInterfaceTests
 			TakeScreenShot (string.Format ("{0}-Branch-Selected", branchName));
 			Session.ClickElement (c => IdeQuery.GitConfigurationDialog(c).Children ().Button ().Text ("Switch to Branch"), false);
 			CheckIfNameEmailNeeded ();
+			CheckIfUserConflict ();
 			Assert.IsTrue (IsBranchSwitched (branchName));
 			TakeScreenShot (string.Format ("Switched-To-{0}", branchName));
 		}

--- a/main/tests/UserInterfaceTests/VersionControlTests/VCSBase.cs
+++ b/main/tests/UserInterfaceTests/VersionControlTests/VCSBase.cs
@@ -92,6 +92,7 @@ namespace UserInterfaceTests
 			TakeScreenShot ("Commit-Msg-Entered");
 			Session.ClickElement (c => c.Window ().Marked ("MonoDevelop.VersionControl.Dialogs.CommitDialog").Children ().Button ().Marked ("buttonCommit"), false);
 			CheckIfNameEmailNeeded ();
+			CheckIfUserConflict ();
 			Ide.WaitForStatusMessage (new[] {"Commit operation completed."});
 			TakeScreenShot ("Commit-Completed");
 		}
@@ -154,6 +155,15 @@ namespace UserInterfaceTests
 				TakeScreenShot ("Git-User-Not-Configured");
 				EnterGitUserConfig ("John Doe", "john.doe@example.com");
 			} catch (TimeoutException e) { }
+		}
+
+		protected void CheckIfUserConflict ()
+		{
+			try {
+				Session.WaitForElement (c => c.Window ().Marked ("User Information Conflict"));
+				Session.ClickElement (c => c.Window ().Marked ("User Information Conflict").Children ().Button ().Text ("OK"));
+			} catch (TimeoutException) {
+			}
 		}
 
 		protected override void OnBuildTemplate (int buildTimeoutInSecs = 180)


### PR DESCRIPTION
In this change, copy the MonoDevelopProperties.xml from default location to test folder, set `MonoDevelop.Ide.AddinUpdater.CheckForUpdates` to `false` and pass this location as `MONODEVELOP_PROFILE`.

Additionally remove the Update Dialog waiting code as it is no longer needed