### PR TITLE
[Mac] Prevent a NRE when no key window is focused.

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
@@ -107,7 +107,7 @@ namespace MonoDevelop.MacIntegration
 			if (!string.IsNullOrEmpty (data.CurrentFolder))
 				panel.DirectoryUrl = new NSUrl (data.CurrentFolder, true);
 			
-			panel.ParentWindow = NSApplication.SharedApplication.KeyWindow;
+			panel.ParentWindow = NSApplication.SharedApplication.KeyWindow ?? NSApplication.SharedApplication.MainWindow;
 
 			var openPanel = panel as NSOpenPanel;
 			if (openPanel != null) {


### PR DESCRIPTION
When no key window is focused, key window is null. Try routing back to
MainWindow is no KeyWindow is present.

Bug 34979 - Crash when uploading DYSM to Insights While Publishing to
App Store via Archive