### PR TITLE
[AutoTest] Allow selecting row based on different models and Allow Toggling of embedded CheckBox in TreeView

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -78,7 +78,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override AppResult Model (string column)
 		{
-			return null;
+			var columnNumber = GetColumnNumber (column, TModel);
+			if (columnNumber == -1)
+				return null;
+			Column = columnNumber;
+			return this;
 		}
 
 		bool CheckForText (TreeModel model, TreeIter iter, bool exact)
@@ -274,6 +278,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override bool Toggle (bool active)
 		{
+			if (resultIter.HasValue) {
+				var modelValue = TModel.GetValue ((TreeIter)resultIter, Column);
+				if (modelValue is bool) {
+					TModel.SetValue ((TreeIter)resultIter, Column, active);
+					return true;
+				}
+			}
 			return false;
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -152,7 +152,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			return null;
 		}
 
-		TreeModel ModelFromWidget (Widget widget)
+		protected TreeModel ModelFromWidget (Widget widget)
 		{
 			TreeView tv = widget as TreeView;
 			if (tv != null) {
@@ -179,25 +179,23 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 
 			// Check if the class has the SemanticModelAttribute
+			var columnNumber = GetColumnNumber (column, model);
+			return columnNumber == -1 ? null : new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery };
+		}
+
+		protected int GetColumnNumber (string column, TreeModel model)
+		{
 			Type modelType = model.GetType ();
 			SemanticModelAttribute attr = modelType.GetCustomAttribute<SemanticModelAttribute> ();
-
 			if (attr == null) {
 				// Check if the instance has the attributes
 				AttributeCollection attrs = TypeDescriptor.GetAttributes (model);
 				attr = (SemanticModelAttribute)attrs [typeof(SemanticModelAttribute)];
-
 				if (attr == null) {
-					return null;
+					return -1;
 				}
 			}
-
-			int columnNumber = Array.IndexOf (attr.ColumnNames, column);
-			if (columnNumber == -1) {
-				return null;
-			}
-
-			return new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery };
+			return Array.IndexOf (attr.ColumnNames, column);
 		}
 
 		public override AppResult Property (string propertyName, object value)


### PR DESCRIPTION
This patch adds two things

* calling `Model ()` many times so that we can select a row based on multiple values

* Use GtkTreeModelResult.Toggle to set true/false for bool entries, this is useful for embedded checkboxes in the TreeView rows.