### PR TITLE
[Mac] Fix context menu position when app is fullscreen

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -72,6 +72,8 @@ namespace MonoDevelop.Components
 				if (toplevel.TypeHint == Gdk.WindowTypeHint.Toolbar && toplevel.Type == Gtk.WindowType.Toplevel && toplevel.Decorated == false) {
 					// Undecorated toplevel toolbars are used for auto-hide pad windows. Don't add a titlebar offset for them.
 					titleBarOffset = 0;
+				} else if (MonoDevelop.Ide.DesktopService.GetIsFullscreen (toplevel)) {
+					titleBarOffset = 0;
 				} else {
 					titleBarOffset = MonoDevelop.Components.Mac.GtkMacInterop.GetTitleBarHeight () + 12;
 				}


### PR DESCRIPTION
Don't factor the titlebar height into the context menu
position when we're in fullscreen mode.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=35172

This is already in `master`, this PR is to merge into `cycle6`