### PR TITLE
[NUnit] Fix duplicate test result text in Test Results status bar.

### DIFF
--- a/main/src/addins/NUnit/Gui/TestResultsPad.cs
+++ b/main/src/addins/NUnit/Gui/TestResultsPad.cs
@@ -250,6 +250,8 @@ namespace MonoDevelop.NUnit
 			
 			progressBar.HeightRequest = infoLabel.SizeRequest ().Height;
 			runPanel.ShowAll ();
+			progressBar.Hide ();
+			infoSep.Hide ();
 			resultSummary = new UnitTestResult ();
 			UpdateCounters ();
 		}
@@ -289,7 +291,9 @@ namespace MonoDevelop.NUnit
 			progressBar.Text = "";
 			testsRun = 0;
 			resultSummary = new UnitTestResult ();
-			resultLabel.Markup = GetResultsMarkup ();
+			resultLabel.Markup = "";
+			resultLabel.Hide ();
+			labels.Show ();
 			UpdateCounters ();
 		}
 		


### PR DESCRIPTION
Fixed bug #35105 - Test Results pad status bar has overlapping views
https://bugzilla.xamarin.com/show_bug.cgi?id=35105

The status bar of the Test Results pad would sometimes show the same
test result information twice. This could cause the text to overlap
itself if the Test Results pad did not have enough room. The simplest
way to reproduce this is to start Xamarin Studio, open a project,
open the Test Results pad and dock it, then close the solution and
re-open it again. The test result text in the status bar is shown
twice and may overlap itself if the width of the Test Result window
is not wide enough.

Now the duplicate text is no longer shown. Also the progress bar is
hidden when the Test Results pad is first created since the progress
bar is shown when running a test and then hidden when the test run
completes so there is no reason to show it when the Test Results pad
is first displayed.