### PR TITLE
[MacPlatform] Fix the modal window detection for El Capitan

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -791,10 +791,12 @@ namespace MonoDevelop.MacIntegration
 			// When we're looking for modal windows that don't belong to GTK, exclude
 			// NSStatusBarWindow (which is visible on Mavericks when we're in fullscreen) and
 			// NSToolbarFullscreenWindow (which is visible on Yosemite in fullscreen).
+			// _NSFullScreenTileDividerWindow (which is visible on El Capitan when two apps share the same fullscreen).
 			return toplevels.Any (t => t.Key.IsVisible && (t.Value == null || t.Value.Modal) &&
 				!(t.Key.DebugDescription.StartsWith("<NSStatusBarWindow", StringComparison.Ordinal) ||
 					t.Key.DebugDescription.StartsWith ("<NSToolbarFullScreenWindow", StringComparison.Ordinal) ||
-					t.Key.DebugDescription.StartsWith ("<NSCarbonMenuWindow", StringComparison.Ordinal)
+					t.Key.DebugDescription.StartsWith ("<NSCarbonMenuWindow", StringComparison.Ordinal) ||
+					t.Key.DebugDescription.StartsWith ("<_NSFullScreenTileDividerWindow", StringComparison.Ordinal)
 				));
 		}
 


### PR DESCRIPTION
When two windows share a fullscreen in El Capitan a special window is added that was causing us to flag it as modal which would disable the windows