### PR TITLE
Bug 35512 - [XS 5.10] The "Locals" pad appends new items each time an…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
@@ -49,6 +49,7 @@ namespace MonoDevelop.Debugger
 			if (frame == null)
 				return;
 
+			tree.ClearAll ();
 			tree.AddValues (frame.GetAllLocals ().Where (l => !string.IsNullOrWhiteSpace (l.Name) && l.Name != "?").ToArray ());
 		}
 	}


### PR DESCRIPTION
… item in the "Call Stack" is double-clicked