### PR TITLE
[Core] Use a default name for imported policies if none given.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyService.cs
@@ -1240,6 +1240,11 @@ namespace MonoDevelop.Projects.Policies
 						if (pset.Id == "Default") {
 							defaultPolicies = pset;
 						} else {
+							// if the policy file does not have a name, use the file name as one
+							if (!string.IsNullOrEmpty (pset.Name)) {
+								pset.Name = file.FileNameWithoutExtension;
+							}
+
 							AddUserPolicySet (pset);
 						}
 						xr.MoveToContent ();


### PR DESCRIPTION
Fixes bug #19275