### PR TITLE
[Ide] Allow sorting by completed column in Task Pad.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
@@ -98,6 +98,7 @@ namespace MonoDevelop.Ide.Tasks
 			cellRendCompleted.Toggled += new ToggledHandler (UserTaskCompletedToggled);
 			cellRendCompleted.Activatable = true;
 			col = view.AppendColumn (String.Empty, cellRendCompleted, "active", Columns.Completed);
+			col.SortColumnId = (int)Columns.Completed;
 
 			cellRendDesc = view.TextRenderer;
 			cellRendDesc.Editable = true;


### PR DESCRIPTION
Fixed [bug #36027](https://bugzilla.xamarin.com/show_bug.cgi?id=36027) - Task Pad can no longer be sorted by the "completed" checkbox column
