### PR TITLE
[MonoDevelop.Refactoring] Use MonoDevelop.Components.ContextMenu

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -40,6 +40,7 @@ using ICSharpCode.NRefactory.Semantics;
 using MonoDevelop.AnalysisCore.Fixes;
 using ICSharpCode.NRefactory.Refactoring;
 using MonoDevelop.Ide.Gui;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.CodeActions
 {
@@ -298,132 +299,50 @@ namespace MonoDevelop.CodeActions
 			ShowFixesMenu (document.Editor.Parent, rect, menu);
 		}
 
-		#if MAC
-		class ClosingMenuDelegate : AppKit.NSMenuDelegate
-		{
-			readonly TextEditorData data;
-
-			public ClosingMenuDelegate (TextEditorData editor_data)
-			{
-				data = editor_data;
-			}
-
-			public override void MenuWillHighlightItem (AppKit.NSMenu menu, AppKit.NSMenuItem item)
-			{
-			}
-
-			public override void MenuDidClose (AppKit.NSMenu menu)
-			{
-				data.SuppressTooltips = false;
-			}
-		}
-		#endif
-
 		bool ShowFixesMenu (Gtk.Widget parent, Gdk.Rectangle evt, FixMenuDescriptor entrySet)
 		{
-			if (parent == null || parent.GdkWindow == null)
+			if (parent == null || parent.GdkWindow == null) {
+				document.Editor.SuppressTooltips = false;
 				return true;
+			}
+
 			try {
-				#if MAC
 				parent.GrabFocus ();
 				int x, y;
 				x = (int)evt.X;
 				y = (int)evt.Y;
+
 				// Explicitly release the grab because the menu is shown on the mouse position, and the widget doesn't get the mouse release event
 				Gdk.Pointer.Ungrab (Gtk.Global.CurrentEventTime);
-				var menu = CreateNSMenu (entrySet);
-				menu.Delegate = new ClosingMenuDelegate (document.Editor);
-				var nsview = MonoDevelop.Components.Mac.GtkMacInterop.GetNSView (parent);
-				var toplevel = parent.Toplevel as Gtk.Window;
-				int trans_x, trans_y;
-				parent.TranslateCoordinates (toplevel, (int)x, (int)y, out trans_x, out trans_y);
 
-				// Window coordinates in gtk are the same for cocoa, with the exception of the Y coordinate, that has to be flipped.
-				var pt = new CoreGraphics.CGPoint ((float)trans_x, (float)trans_y);
-				int w,h;
-				toplevel.GetSize (out w, out h);
-				pt.Y = h - pt.Y;
-
-				var tmp_event = AppKit.NSEvent.MouseEvent (AppKit.NSEventType.LeftMouseDown,
-				pt,
-				0, 0,
-				MonoDevelop.Components.Mac.GtkMacInterop.GetNSWindow (toplevel).WindowNumber,
-				null, 0, 0, 0);
-
-				AppKit.NSMenu.PopUpContextMenu (menu, tmp_event, nsview);
-				#else
-				var menu = CreateGtkMenu (entrySet);
-				menu.Events |= Gdk.EventMask.AllEventsMask;
-				menu.SelectFirst (true);
-
-				menu.Hidden += delegate {
-					document.Editor.SuppressTooltips = false;
-				};
-				menu.ShowAll ();
-				menu.SelectFirst (true);
-				menu.MotionNotifyEvent += (o, args) => {
-					if (args.Event.Window == Editor.Parent.TextArea.GdkWindow) {
-						StartMenuCloseTimer ();
-					} else {
-						CancelMenuCloseTimer ();
-					}
-				};
-
-				GtkWorkarounds.ShowContextMenu (menu, parent, null, evt);
-				#endif
+				var menu = CreateContextMenu (entrySet);
+				menu.Show (parent, x, y, () => document.Editor.SuppressTooltips = false);
 			} catch (Exception ex) {
 				LoggingService.LogError ("Error while context menu popup.", ex);
 			}
 			return true;
 		}
-		#if MAC
 
-		AppKit.NSMenu CreateNSMenu (FixMenuDescriptor entrySet)
+		ContextMenu CreateContextMenu (FixMenuDescriptor entrySet)
 		{
-			var menu = new AppKit.NSMenu ();
+			var menu = new ContextMenu ();
 			foreach (var item in entrySet.Items) {
 				if (item == FixMenuEntry.Separator) {
-					menu.AddItem (AppKit.NSMenuItem.SeparatorItem);
+					menu.Items.Add (new SeparatorContextMenuItem ());
 					continue;
 				}
-				var subMenu = item as FixMenuDescriptor;
-				if (subMenu != null) {
-					var gtkSubMenu = new AppKit.NSMenuItem (item.Label.Replace ("_", ""));
-					gtkSubMenu.Submenu = CreateNSMenu (subMenu);
-					menu.AddItem (gtkSubMenu); 
-					continue;
-				}
-				var menuItem = new AppKit.NSMenuItem (item.Label.Replace ("_", ""));
-				menuItem.Activated += delegate {
-					item.Action ();
-				};
-				menu.AddItem (menuItem); 
-			}
-			return menu;
-		}
-		#endif
 
-		static Menu CreateGtkMenu (FixMenuDescriptor entrySet)
-		{
-			var menu = new Menu ();
-			foreach (var item in entrySet.Items) {
-				if (item == FixMenuEntry.Separator) {
-					menu.Add (new SeparatorMenuItem ()); 
-					continue;
-				}
+				var menuItem = new ContextMenuItem (item.Label);
+				menuItem.Context = item.Action;
 				var subMenu = item as FixMenuDescriptor;
 				if (subMenu != null) {
-					var gtkSubMenu = new Gtk.MenuItem (item.Label);
-					gtkSubMenu.Submenu = CreateGtkMenu (subMenu);
-					menu.Add (gtkSubMenu); 
-					continue;
+					menuItem.SubMenu = CreateContextMenu (subMenu);
+				} else {
+					menuItem.Clicked += (object sender, ContextMenuItemClickedEventArgs e) => ((System.Action)((ContextMenuItem)sender).Context) ();
 				}
-				var menuItem = new Gtk.MenuItem (item.Label);
-				menuItem.Activated += delegate {
-					item.Action ();
-				};
-				menu.Add (menuItem); 
+				menu.Items.Add (menuItem);
 			}
+
 			return menu;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenu.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenu.cs
@@ -62,14 +62,40 @@ namespace MonoDevelop.Components
 
 		public void Show (Gtk.Widget parent, Gdk.EventButton evt)
 		{
+			Show (parent, evt, null);
+		}
+
+		public void Show (Gtk.Widget parent, Gdk.EventButton evt, Action closeHandler)
+		{
 			#if MAC
 			if (Platform.IsMac) {
-				ContextMenuExtensionsMac.ShowContextMenu (parent, evt, this);
+				ContextMenuExtensionsMac.ShowContextMenu (parent, evt, this, closeHandler);
 				return;
 			}
 			#endif
 
-			ContextMenuExtensionsGtk.ShowContextMenu (parent, evt, this);
+			ContextMenuExtensionsGtk.ShowContextMenu (parent, evt, this, closeHandler);
+		}
+
+		public void Show (Gtk.Widget parent, int x, int y, Action closeHandler)
+		{
+			#if MAC
+			if (Platform.IsMac) {
+				int tx, ty;
+
+				// x, y are in gtk coordinates, so they need to be translated for Cocoa.
+				parent.TranslateCoordinates (parent.Toplevel, x, y, out tx, out ty);
+				ContextMenuExtensionsMac.ShowContextMenu (parent, tx, ty, this, closeHandler);
+				return;
+			}
+			#endif
+
+			ContextMenuExtensionsGtk.ShowContextMenu (parent, x, y, this, closeHandler);
+		}
+
+		public void Show (Gtk.Widget parent, int x, int y)
+		{
+			Show (parent, x, y, null);
 		}
 	}
 }


### PR DESCRIPTION
Use the ContextMenu object to share the Mac/Gtk code instead of creating yet another custom popup menu system