### PR TITLE
[roslyn branch] Add Suspend / Resume methods for IViewContent

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BaseView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BaseView.cs
@@ -104,5 +104,11 @@ namespace MonoDevelop.VersionControl
 		event EventHandler IViewContent.ContentChanged { add { } remove { } }
 		event EventHandler IViewContent.ContentNameChanged { add { } remove { } }
 		event EventHandler IViewContent.DirtyChanged { add { } remove { } }
+
+		void IViewContent.Suspend () {
+		}
+
+		void IViewContent.Resume () {
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
@@ -170,13 +170,23 @@ namespace MonoDevelop.Components.DockNotebook
 			set {
 				if (currentTab != value) {
 					currentTab = value;
-					if (contentBox.Child != null)
+					if (contentBox.Child != null) {
+						var window = contentBox.Child as MonoDevelop.Ide.Gui.SdiWorkspaceWindow;
+						if (window != null) {
+							window.ViewContent.Suspend ();
+						}
 						contentBox.Remove (contentBox.Child);
+					}
 
 					if (currentTab != null) {
 						if (currentTab.Content != null) {
 							contentBox.Add (currentTab.Content);
 							contentBox.ChildFocus (DirectionType.Down);
+
+							var window = contentBox.Child as MonoDevelop.Ide.Gui.SdiWorkspaceWindow;
+							if (window != null) {
+								window.ViewContent.Resume ();
+							}
 						}
 						pagesHistory.Remove (currentTab);
 						pagesHistory.Insert (0, currentTab);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -517,6 +517,14 @@ namespace MonoDevelop.Ide.Editor
 			}
 		}
 
+		void IViewContent.Suspend ()
+		{
+		}
+
+		void IViewContent.Resume ()
+		{
+		}
+
 		#endregion
 
 		#region IBaseViewContent implementation

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/AbstractViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/AbstractViewContent.cs
@@ -161,6 +161,14 @@ namespace MonoDevelop.Ide.Gui
 			if (ContentNameChanged != null)
 				ContentNameChanged (this, e);
 		}
+
+		public virtual void Suspend ()
+		{
+		}
+
+		public virtual void Resume ()
+		{
+		}
 	}
 
 	public abstract class AbstractXwtViewContent :AbstractViewContent

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IViewContent.cs
@@ -62,5 +62,8 @@ namespace MonoDevelop.Ide.Gui
         event EventHandler ContentChanged;
         event EventHandler DirtyChanged;
         event EventHandler BeforeSave;
+
+		void Suspend ();
+		void Resume ();
 	}
 }


### PR DESCRIPTION
This adds Suspend and Resume methods for IViewContent.  They are invoked when a tab is switched away from and when a tab is switched to.

For the Protobuild plugin, I embed another window within the tab.  When the tab is switched away from, it destroys the GTK widgets underneath the tab, and thus destroys the window handle.  I need to know when the tab is switched back to so I can reconstruct the window handle and pass it to the other application.