### PR TITLE
[roslyn branch] Allow display bindings to be registered at runtime

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DisplayBindingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DisplayBindingService.cs
@@ -39,12 +39,24 @@ namespace MonoDevelop.Ide.Gui
 {
 	public static class DisplayBindingService
 	{
+		private static List<IDisplayBinding> runtimeBindings = new List<IDisplayBinding>();
+
 		public static IEnumerable<T> GetBindings<T> ()
 		{
-			return AddinManager.GetExtensionObjects ("/MonoDevelop/Ide/DisplayBindings")
-				.OfType<T> ();
+			return runtimeBindings.OfType<T>().Concat(AddinManager.GetExtensionObjects ("/MonoDevelop/Ide/DisplayBindings")
+				.OfType<T> ());
 		}
-		
+
+		public static void RegisterRuntimeDisplayBinding(IDisplayBinding binding)
+		{
+			runtimeBindings.Add(binding);
+		}
+
+		public static void DeregisterRuntimeDisplayBinding(IDisplayBinding binding)
+		{
+			runtimeBindings.Remove(binding);
+		}
+
 		internal static IEnumerable<IDisplayBinding> GetDisplayBindings (FilePath filePath, string mimeType, Project ownerProject)
 		{
 			if (mimeType == null && !filePath.IsNullOrEmpty)


### PR DESCRIPTION
This allows display bindings to be registered at runtime.  This is useful when an extension (like the Protobuild add-in I'm developing) needs to add and remove display bindings as it becomes aware of more supported extensions.

In the Protobuild add-in, we support having projects in the solution provide IDE editors, and we load the compiled assemblies into an AppDomain or GtkPlug/Socket/separate process to allow developers to provide additional editors for the content of their own project.