### PR TITLE
[roslyn branch] Allow derived types in Initialize

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Projects
 
 		internal protected void Initialize<T> (T instance)
 		{
-			if (instance.GetType () != typeof(T))
+			if (!typeof(T).IsAssignableFrom(instance.GetType ()))
 				return;
 			var delayedInitialize = CallContext.LogicalGetData ("MonoDevelop.DelayItemInitialization");
 			if (delayedInitialize != null && (bool)delayedInitialize)


### PR DESCRIPTION
When deriving from a class that calls Initialize in it's constructor
(like Solution), the initialization does not occur because the derived
type does not match the type that calls Initialize.  However, if that
derived class then relies on being initialized later in the constructor,
an exception is thrown.

Instead, permit derived types to initialize in the base constructor (in
the use case this is for, we actually want the derived type in the add-
in to behave as the base type for almost every scenario).