### PR TITLE
[roslyn branch] Unseal Solution class

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
@@ -43,7 +43,7 @@ using MonoDevelop.Projects.Formats.MSBuild;
 namespace MonoDevelop.Projects
 {
 	[ProjectModelDataItem]
-	public sealed class Solution: WorkspaceItem, IConfigurationTarget, IPolicyProvider, IBuildTarget, IMSBuildFileObject
+	public class Solution: WorkspaceItem, IConfigurationTarget, IPolicyProvider, IBuildTarget, IMSBuildFileObject
 	{
 		internal object MemoryProbe = Counters.SolutionsInMemory.CreateMemoryProbe ();
 		SolutionFolder rootFolder;


### PR DESCRIPTION
In the Protobuild add-in that I am writing, I need Protobuild modules to be derived from Solution.  Not only is this because Solution is the hard coded class that is used everywhere, but because Protobuild modules actually directly map to solutions.
    
Protobuild is a cross-platform project generator, and for each Protobuild module, it produces a solution file on disk (for the desired platform).  The add-in reads Protobuild modules directly, invokes the project generation, and then loads the real .NET solutions in the background, passing through all of the relevant calls from the module class through to the loaded solution.  When the user changes the active platform (Windows, Mac, Linux, iOS, Android, etc) in the IDE, Protobuild re-generates the solution and project files for the new platform, and switches out the solution and projects that were loaded in the background.
    
Thus for the Protobuild add-in, our concepts map directly to the MSBuild solution / project model (but we need an additional layer of indirection through deriving the classes), so it is suitable to derive from Solution here.