### PR TITLE
[roslyn branch] Make OnRunTarget public for Project class

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -854,7 +854,8 @@ namespace MonoDevelop.Projects
 		/// build or clean. The default implementation delegates the execution to the more specific OnBuild
 		/// and OnClean methods, or to the item handler for other targets.
 		/// </remarks>
-		internal protected virtual Task<TargetEvaluationResult> OnRunTarget (ProgressMonitor monitor, string target, ConfigurationSelector configuration, TargetEvaluationContext context)
+		// REMARKS: This is marked public because I need to call it on the shadow project.
+		public virtual Task<TargetEvaluationResult> OnRunTarget (ProgressMonitor monitor, string target, ConfigurationSelector configuration, TargetEvaluationContext context)
 		{
 			if (target == ProjectService.BuildTarget)
 				return RunBuildTarget (monitor, configuration, context);


### PR DESCRIPTION
As per #1153, we need to redirect
operations performed on Protobuild objects (modules / definitions) to
the underlying MSBuild solutions and projects.  Although we can override
OnRunTarget in the Protobuild classes, we can't actually call
OnRunTarget on the MSBuild classes (that are being proxied / shadowed)
because it's internal protected.  In order to pass the OnRunTarget
operation through to the actual project, we need this method to be
public.