### PR TITLE
[Ide][Mac] Fix checkbox style

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -288,7 +288,7 @@ style "notebook" = "default"
     }
 }
 
-style "radio-or-check-box"
+style "radio-or-check-box" = "default"
 {
     ythickness = 6
     GtkCheckButton::indicator-size = 14


### PR DESCRIPTION
This fixes a regression caused by https://github.com/mono/xamarin-gtk-theme/commit/33ef875d70716b2a6fc210d9e4a9f6e2177ed6e6, which fixes the way the engine draws the text on buttons (required for https://github.com/mono/monodevelop/tree/dark-skin/ support). Previously the engine did not honor the Gtk state colors and our gtkrc did not declare them for option-/checkboxes.

Patched theme engine only:
![image](https://cloud.githubusercontent.com/assets/951587/11418674/549d3edc-9422-11e5-8672-954fc6880924.png)

Fixed Gtkrc for Mac:
![image](https://cloud.githubusercontent.com/assets/951587/11418630/ec8eb3f2-9421-11e5-8342-f7b4374e7265.png)
