### PR TITLE
[Ide] Fix crash in global search popup window.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -245,6 +245,7 @@ namespace MonoDevelop.Components.MainToolbar
 			if (incompleteResults.Count == categories.Count) {
 				results.Clear ();
 				results.AddRange (incompleteResults);
+				List<Tuple<SearchCategory, ISearchDataSource>> failedResults = null;
 				topItem = null;
 
 				for (int i = 0; i < results.Count; i++) {
@@ -256,10 +257,16 @@ namespace MonoDevelop.Components.MainToolbar
 							topItem = new ItemIdentifier(tuple.Item1, tuple.Item2, 0);
 					} catch (Exception e) {
 						LoggingService.LogError ("Error while showing result " + i, e);
+						if (failedResults == null)
+							failedResults = new List<Tuple<SearchCategory, ISearchDataSource>> ();
+						failedResults.Add (results [i]);
 						continue;
 					}
 				}
 				selectedItem = topItem;
+
+				if (failedResults != null)
+					failedResults.ForEach (failedResult => results.Remove (failedResult));
 
 				ShowTooltip ();
 				isInSearch = false;


### PR DESCRIPTION
Fixed bug #29879 - Crash if I type in search box
https://bugzilla.xamarin.com/show_bug.cgi?id=29879

If a search category throws an exception when its ItemCount is called
then this can cause the IDE to terminate. One way to reproduce this
with Xamarin Studio 5.10 or later is to install an old version of the
NuGet extensions addin, version 0.10 or earlier, then attempt to use
the global search in the top right of the IDE. This was causing an
exception to be thrown in the SearchPopupWindow's OnDrawContent
method when it tried to use the ItemCount property. This then
terminated the IDE.

Now a search category that throws an exception is removed from the
list of results so the OnDrawContent method never uses a badly
behaving search category.