### PR TITLE
[TextEditor] Fix memory leak.

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/TextEditorOptions.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/TextEditorOptions.cs
@@ -95,7 +95,7 @@ namespace Mono.TextEditor
 				}
 			}
 		}
-		public event EventHandler ZoomChanged { add { StaticZoomChanged += value; } remove { StaticZoomChanged -= value; } }
+		public event EventHandler ZoomChanged;
 
 		public bool CanZoomIn {
 			get {
@@ -583,6 +583,7 @@ namespace Mono.TextEditor
 		void HandleStaticZoomChanged (object sender, EventArgs e)
 		{
 			DisposeFont ();
+			ZoomChanged?.Invoke (this, EventArgs.Empty);
 			OnChanged (EventArgs.Empty);
 		}
 


### PR DESCRIPTION
The TextEditorOptions StaticZoomChanged static event handler was
keeping each TextEditor instance alive even after they were closed.
This was also causing the project to be kept alive since the
TextEditor's PolicyBag references the project. The TextEditorFactory
creates a new TextEditor and then adds an anonymous delegate to the
TextEditor's ZoomLevelChanged event. This delegate references the
original TextEditor. The ZoomLevelChanged event maps to the
TextEditorOptions ZoomLevelChanged event which adds the delegate
to the static event. The static event then references the original
TextEditor and keeps it alive until the IDE is closed.

Making the ZoomLevelChanged event not directly reference the static
event fixes the problem since there is only an instance event handler
pointing to the TextEditor instead of a static event handler. The
other static event has to remain static so that changing the zoom in
one text editor is reflected in the other open text editors.