### PR TITLE
Added host.ResolveAssemblyReference() as a fallback for resolving assemblies not found in the directly-referenced assembly list

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/CompiledTemplate.cs
@@ -121,13 +121,17 @@ namespace Mono.TextTemplating
 		
 		Assembly ResolveReferencedAssemblies (object sender, ResolveEventArgs args)
 		{
-			Assembly asm = null;
+			AssemblyName asmName = new AssemblyName (args.Name);
 			foreach (var asmFile in assemblyFiles) {
-				var name = System.IO.Path.GetFileNameWithoutExtension (asmFile);
-				if (args.Name.StartsWith (name, StringComparison.Ordinal))
-					asm = Assembly.LoadFrom (asmFile);
+				if (asmName.Name == System.IO.Path.GetFileNameWithoutExtension (asmFile))
+					return Assembly.LoadFrom (asmFile);
 			}
-			return asm;
+
+			var path = host.ResolveAssemblyReference (asmName.Name + ".dll");
+			if (System.IO.File.Exists (path))
+				return Assembly.LoadFrom (path);
+
+			return null;
 		}
 		
 		public void Dispose ()


### PR DESCRIPTION
This is a continuation of the discussion at #1166.  The problem with the code in master is that it will only find assemblies directly referenced by the template, not assemblies that those assemblies themselves reference.  This change adds `host.ResolveAssemblyReference()` as a fallback step after checking the reference assemblies listed in `assemblyFiles`, so that these 'second-step' dependencies can be found in the same directory as directly-referenced assemblies.

@slluis @mhutch @mrward 