### PR TITLE
[Core] Allow # and % characters in file names.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -69,13 +69,13 @@ namespace MonoDevelop.Core
 
 		const int PATHMAX = 4096 + 1;
 
-		static readonly char[] invalidPathChars = Path.GetInvalidPathChars ().Concat ("#%&").ToArray ();
+		static readonly char[] invalidPathChars = Path.GetInvalidPathChars ();
 		public static char[] GetInvalidPathChars()
 		{
 			return (char[])invalidPathChars.Clone();
 		}
 
-		static readonly char[] invalidFileNameChars = Path.GetInvalidFileNameChars ().Concat ("#%&").ToArray ();
+		static readonly char[] invalidFileNameChars = Path.GetInvalidFileNameChars ();
 		public static char[] GetInvalidFileNameChars ()
 		{
 			return (char[])invalidFileNameChars.Clone ();


### PR DESCRIPTION
Fixed bug #36432 - Cannot create new project c# console
https://bugzilla.xamarin.com/show_bug.cgi?id=36432

From the New Project dialog it was not possible to create a
project inside a directory that contained a '#' or a '%' even though
these are valid.