### PR TITLE
[MacPlatform] Move the Modal window detection from a whitelist to a blacklist

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -788,14 +788,8 @@ namespace MonoDevelop.MacIntegration
 		{
 			var toplevels = GtkQuartz.GetToplevels ();
 
-			// When we're looking for modal windows that don't belong to GTK, exclude
-			// NSStatusBarWindow (which is visible on Mavericks when we're in fullscreen) and
-			// NSToolbarFullscreenWindow (which is visible on Yosemite in fullscreen).
-			return toplevels.Any (t => t.Key.IsVisible && (t.Value == null || t.Value.Modal) &&
-				!(t.Key.DebugDescription.StartsWith("<NSStatusBarWindow", StringComparison.Ordinal) ||
-					t.Key.DebugDescription.StartsWith ("<NSToolbarFullScreenWindow", StringComparison.Ordinal) ||
-					t.Key.DebugDescription.StartsWith ("<NSCarbonMenuWindow", StringComparison.Ordinal)
-				));
+			// Check GtkWindow's Modal flag or for a visible NSPanel
+			return toplevels.Any (t => (t.Value != null && t.Value.Modal && t.Value.Visible) || (t.Key.IsVisible && (t.Key is NSPanel)));
 		}
 
 		public override void AddChildWindow (Gtk.Window parent, Gtk.Window child)


### PR DESCRIPTION

Instead of playing whack-a-mole everytime a new version of OSX adds a new magic window that breaks our modal window detection, this change makes a blacklist of windows we know are modal.

Currently we only need to blacklist NSOpenPanel and NSSavePanel. If other window types are added to the code, they should be added to this list.

Also check that a modal GtkWindow is also visible.

Fixes BXC #35465
Fixes BXC #34250