### PR TITLE
[Ide] Clear metadata reference cache when workspace is closed.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MetadataReferenceCache.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MetadataReferenceCache.cs
@@ -80,6 +80,13 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
+		public static void Clear ()
+		{
+			lock (cache) {
+				cache.Clear ();
+			}
+		}
+
 		//static Timer timer;
 
 		static MetadataReferenceCache ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -964,11 +964,15 @@ namespace MonoDevelop.Ide
 			if (WorkspaceItemClosed != null)
 				WorkspaceItemClosed (this, args);
 
-			if (Items.Count == 0 && !reloading) {
+			bool lastWorkspaceItemClosing = Items.Count == 0 && !reloading;
+			if (lastWorkspaceItemClosing) {
 				if (LastWorkspaceItemClosed != null)
 					LastWorkspaceItemClosed (this, EventArgs.Empty);
 			}
 			MonoDevelop.Ide.TypeSystem.TypeSystemService.Unload (item);
+
+			if (lastWorkspaceItemClosing)
+				MonoDevelop.Ide.TypeSystem.MetadataReferenceCache.Clear ();
 
 			NotifyDescendantItemRemoved (this, args);
 		}


### PR DESCRIPTION
The metadata reference cache is now cleared when the last workspace item is closed. If the workspace is being reloaded, for example if the solution file has changed outside the IDE, then the cache is not cleared since the metadata will be re-used when the projects are loaded again.