### PR TITLE
[WebReferences] Generate events for a web reference.

### DIFF
--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.WS/WebServiceDiscoveryResultWS.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.WS/WebServiceDiscoveryResultWS.cs
@@ -27,6 +27,7 @@
 using System.Web.Services.Discovery;
 using System.Linq;
 using System.Text;
+using System.Xml.Serialization;
 using MonoDevelop.Projects;
 using System.Web.Services.Description;
 using System.IO;
@@ -135,6 +136,7 @@ namespace MonoDevelop.WebReferences.WS
 
 			// Setup the importer and import the service description into the code unit
 			ServiceDescriptionImporter importer = Library.ReadServiceDescriptionImporter (protocol);
+			importer.CodeGenerationOptions = CodeGenerationOptions.GenerateNewAsync;
 			importer.Import (codeNamespace, codeUnit);
 
 			// Add the new Constructor with Url as a paremeter


### PR DESCRIPTION
Fixed bug #36276 - No Event Args or Event Handlers created in Web
References
https://bugzilla.xamarin.com/show_bug.cgi?id=36276

Adding a '.NET 2.0 Web Services' web reference was not generating
Async methods and events with Mono 4.2.1. With Mono 4.2 they were
being generated.

Changed the code generator options to use GenerateNewAsync which will
generate the Async methods and events for a web reference.