### PR TITLE
[Ide] When sorting SearchResultWidget by FileName also take "line" number into account

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs
@@ -422,14 +422,19 @@ namespace MonoDevelop.Ide.FindInFiles
 		{
 			return 0;
 		}
-		
+
 		static int CompareFileNames (TreeModel model, TreeIter first, TreeIter second)
 		{
 			var searchResult1 = (SearchResult)model.GetValue (first, SearchResultColumn);
 			var searchResult2 = (SearchResult)model.GetValue (second, SearchResultColumn);
 			if (searchResult1 == null || searchResult2 == null || searchResult1.FileName == null || searchResult2.FileName == null)
 				return -1;
-			return string.Compare (System.IO.Path.GetFileName (searchResult1.FileName), System.IO.Path.GetFileName (searchResult2.FileName), StringComparison.Ordinal);
+			var strCompare = string.Compare (System.IO.Path.GetFileName (searchResult1.FileName), System.IO.Path.GetFileName (searchResult2.FileName), StringComparison.Ordinal);
+			if (strCompare == 0) {
+				return searchResult1.Offset.CompareTo (searchResult2.Offset);
+			} else {
+				return strCompare;
+			}
 		}
 
 		static int CompareProjectFileNames (TreeModel model, TreeIter first, TreeIter second)


### PR DESCRIPTION
Now it looks all nice and sorted instead of random:
![image](https://cloud.githubusercontent.com/assets/774791/11748987/5b25aef0-a02b-11e5-83d8-711e1127c8b4.png)
