### PR TITLE
[Components] Prevent simultaneous command dispatches

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -333,6 +333,12 @@ namespace MonoDevelop.Components.Commands
 					return null;
 			}
 
+			// If a modal dialog is running then the menus are disabled, even if the commands are not
+			// See MDMenuItem::IsGloballyDisabled
+			if (DesktopService.IsModalDialogRunning ()) {
+				return ev;
+			}
+
 			var gdkev = MonoDevelop.Components.Mac.GtkMacInterop.ConvertKeyEvent (ev);
 			if (gdkev != null) {
 				if (ProcessKeyEvent (gdkev))
@@ -1166,7 +1172,7 @@ namespace MonoDevelop.Components.Commands
 				return false;
 
 			commandId = CommandManager.ToCommandId (commandId);
-			
+
 			List<HandlerCallback> handlers = new List<HandlerCallback> ();
 			ActionCommand cmd = null;
 			try {


### PR DESCRIPTION
Disable command processing on OS X when a modal dialog is running

Fixes BXC #29519 - Multiple copies of the same modal dialog can be made visible at the same time