### PR TITLE
[IDE] Use the unsorted path to edit the model

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
@@ -252,12 +252,14 @@ namespace MonoDevelop.Ide.Tasks
 				}
 			}
 		}
-		
+
 		void UserTaskPriorityEdited (object o, ComboSelectionChangedArgs args)
 		{
-			Gtk.TreeIter iter;
-			if (store.GetIterFromString (out iter,  args.Path)) {
-				TaskListEntry task = (TaskListEntry) store.GetValue (iter, (int)Columns.UserTask);
+			Gtk.TreeIter iter, sortedIter;
+
+			if (sortModel.GetIterFromString (out sortedIter, args.Path)) {
+				iter = sortModel.ConvertIterToChildIter (sortedIter);
+				TaskListEntry task = (TaskListEntry) sortModel.GetValue (sortedIter, (int)Columns.UserTask);
 				if (args.Active == 0)
 				{
 					task.Priority = TaskPriority.High;
@@ -276,10 +278,12 @@ namespace MonoDevelop.Ide.Tasks
 		
 		void UserTaskCompletedToggled (object o, ToggledArgs args)
 		{
-			Gtk.TreeIter iter;
-			if (store.GetIterFromString (out iter, args.Path)) {
-				bool val = (bool)store.GetValue (iter, (int)Columns.Completed);
-				TaskListEntry task = (TaskListEntry) store.GetValue (iter, (int)Columns.UserTask);
+			Gtk.TreeIter iter, sortedIter;
+
+			if (sortModel.GetIterFromString (out sortedIter, args.Path)) {
+				iter = sortModel.ConvertIterToChildIter (sortedIter);
+				bool val = (bool)sortModel.GetValue (sortedIter, (int)Columns.Completed);
+				TaskListEntry task = (TaskListEntry) sortModel.GetValue (sortedIter, (int)Columns.UserTask);
 				task.Completed = !val;
 				store.SetValue (iter, (int)Columns.Completed, !val);
 				store.SetValue (iter, (int)Columns.Bold, task.Completed ? (int)Pango.Weight.Light : (int)Pango.Weight.Bold);
@@ -289,9 +293,11 @@ namespace MonoDevelop.Ide.Tasks
 		
 		void UserTaskDescEdited (object o, EditedArgs args)
 		{
-			Gtk.TreeIter iter;
-			if (store.GetIterFromString (out iter,  args.Path)) {
-				TaskListEntry task = (TaskListEntry) store.GetValue (iter, (int)Columns.UserTask);
+			Gtk.TreeIter iter, sortedIter;
+
+			if (sortModel.GetIterFromString (out sortedIter, args.Path)) {
+				iter = sortModel.ConvertIterToChildIter (sortedIter);
+				TaskListEntry task = (TaskListEntry) sortModel.GetValue (sortedIter, (int)Columns.UserTask);
 				task.Description = args.NewText;
 				store.SetValue (iter, (int)Columns.Description, args.NewText);
 				TaskService.SaveUserTasks (task.WorkspaceObject);


### PR DESCRIPTION
The path from the various editing args is relative to the sorted model, so we need to convert it to the unsorted model before accessing the data

Fixes BXC #36056