### PR TITLE
[SourceEditor] Don't delete the history while changing the test

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SearchAndReplaceWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SearchAndReplaceWidget.cs
@@ -212,8 +212,17 @@ namespace MonoDevelop.SourceEditor
 				if (oldPattern != SearchAndReplaceOptions.SearchPattern)
 					UpdateSearchEntry ();
 				var history = GetHistory (seachHistoryProperty);
+
+				// Don't do anything to the history if we have a blank search
+				if (string.IsNullOrWhiteSpace (SearchPattern)) {
+					return;
+				}
+
 				if (history.Count > 0 && history [0] == oldPattern) {
-					ChangeHistory (seachHistoryProperty, SearchAndReplaceOptions.SearchPattern);
+					// Only update the current history item if we're adding to the search string
+					if (!oldPattern.StartsWith (SearchPattern)) {
+						ChangeHistory (seachHistoryProperty, SearchAndReplaceOptions.SearchPattern);
+					}
 				} else {
 					UpdateSearchHistory (SearchAndReplaceOptions.SearchPattern);
 				}


### PR DESCRIPTION
When changing the history, we would completely delete the old entry, making it almost impossible to get a search term added to the Recent Searches menu

Fixes BXC #35928