### PR TITLE
[mdtool] Fix tools that depend on PlatformService

### DIFF
--- a/main/src/core/MonoDevelop.Ide/AssemblyInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/AssemblyInfo.cs
@@ -32,3 +32,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MonoDevelop.CSharpBinding.AspNet")]
 [assembly: InternalsVisibleTo("MonoDevelop.GtkCore")]
 [assembly: InternalsVisibleTo("MonoDevelop.PackageManagement")]
+[assembly: InternalsVisibleTo("mdtool")]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -52,6 +52,11 @@ namespace MonoDevelop.Ide
 
 		public static void Initialize ()
 		{
+			Initialize (false);
+		}
+
+		internal static void Initialize (bool noGui)
+		{
 			if (platformService != null)
 				return;
 			object[] platforms = AddinManager.GetExtensionObjects ("/MonoDevelop/Core/PlatformService");
@@ -62,6 +67,10 @@ namespace MonoDevelop.Ide
 				LoggingService.LogFatalError ("A platform service implementation has not been found.");
 			}
 			PlatformService.Initialize ();
+
+			if (noGui)
+				return;
+
 			if (PlatformService.CanOpenTerminal)
 				Runtime.ProcessService.SetExternalConsoleHandler (PlatformService.StartConsoleProcess);
 			

--- a/main/src/tools/mdtool/mdtool.csproj
+++ b/main/src/tools/mdtool/mdtool.csproj
@@ -51,6 +51,10 @@
       <Name>Mono.Addins.Setup</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
+      <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
+      <Name>MonoDevelop.Ide</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\AssemblyInfo.cs" />

--- a/main/src/tools/mdtool/src/mdtool.cs
+++ b/main/src/tools/mdtool/src/mdtool.cs
@@ -135,6 +135,9 @@ class MonoDevelopProcessHost
 				return badInput? 1 : 0;
 			}
 
+			//needed for mimetype service etc
+			MonoDevelop.Ide.DesktopService.Initialize (true);
+
 			var task = tool.Run (toolArgs);
 			task.ContinueWith ((t) => sc.ExitLoop ());
 			sc.RunMainLoop ();


### PR DESCRIPTION
e.g. for mimetype lookup

Kinda hacky fix and for some reason we still end up with

    FATAL ERROR [2015-12-15 20:54:24Z]: A platform service implementation has not been found.

but it works well enough for update-po.