### PR TITLE
[Ide] Load projects into Roslyn only if they are C# or VB.net projects

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -192,11 +192,15 @@ namespace MonoDevelop.Ide.TypeSystem
 			foreach (var proj in mdProjects) {
 				if (token.IsCancellationRequested)
 					return null;
-				var tp = LoadProject (proj, token).ContinueWith (t => {
-					if (!t.IsCanceled)
-						projects.Add (t.Result);
-				});
-				allTasks.Add (tp);
+				if (string.Equals (proj.TypeGuid, "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ||
+				    string.Equals (proj.TypeGuid, "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", StringComparison.OrdinalIgnoreCase)) {
+
+					var tp = LoadProject (proj, token).ContinueWith (t => {
+						if (!t.IsCanceled)
+							projects.Add (t.Result);
+					});
+					allTasks.Add (tp);
+				}
 			}
 			await Task.WhenAll (allTasks.ToArray ());
 			if (token.IsCancellationRequested)
@@ -868,11 +872,6 @@ namespace MonoDevelop.Ide.TypeSystem
 				}
 
 			}
-		}
-
-		public async Task AddProject (MonoDevelop.Projects.Project project)
-		{
-			await LoadProject (project, default(CancellationToken)).ConfigureAwait (false);
 		}
 
 		public void RemoveProject (MonoDevelop.Projects.Project project)


### PR DESCRIPTION
Also removed unused method
Fixes Bug 36963 - Error while getting C# recommendations

@slluis is this correct way of checking this, I can't check "project is CSharpProject", because we are inside MD.Ide.csproj project...?
@mkrueger this change makes sense, right?

Problem was, that also shared project was loaded inside Roslyn... which doesn't have references, files weren't updated... All kind of weird stuff...