### PR TITLE
[Projects] Add imported configurations to master project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -682,6 +682,17 @@ namespace MonoDevelop.Projects.MSBuild
 			NotifyChanged ();
 		}
 
+		public void RemovePropertyGroup (MSBuildPropertyGroup group)
+		{
+			AssertCanModify ();
+			if (group.ParentProject != this)
+				throw new InvalidOperationException ("Group belongs to different project");
+
+			ChildNodes = ChildNodes.Remove (group);
+
+			NotifyChanged ();
+		}
+
 		public IEnumerable<MSBuildObject> GetAllObjects ()
 		{
 			return ChildNodes.OfType<MSBuildObject> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
@@ -77,6 +77,14 @@ namespace MonoDevelop.Projects.MSBuild
 			properties [prop.Name] = prop; // If a property is defined more than once, we only care about the last registered value
 		}
 
+		// Only write this element if it is not imported
+		internal override void Write (XmlWriter writer, WriteContext context)
+		{
+			if (!IsImported) {
+				base.Write (writer, context);
+			}
+		}
+
 		internal override string GetElementName ()
 		{
 			return "PropertyGroup";


### PR DESCRIPTION
When dealing with imported projects we use the properties to evaluate the master project and then we discard them. When the imported projects include configuration property groups they need to be added to the master project without being evaluated so the IDE can find them