### PR TITLE
Add GetRealProject() proxy method

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpProjectExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpProjectExtension.cs
@@ -34,7 +34,7 @@ using MonoDevelop.Core.Instrumentation;
 
 namespace MonoDevelop.CSharp.Project
 {
-	class CSharpProject: DotNetProject, ICSharpProject
+	public class CSharpProject: DotNetProject, ICSharpProject
 	{
 		[ItemProperty ("StartupObject", DefaultValue = "")]
 		string mainclass = string.Empty;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectExtension.cs
@@ -47,11 +47,33 @@ namespace MonoDevelop.Projects
 
 		internal protected override bool SupportsObject (WorkspaceObject item)
 		{
-			return base.SupportsObject (item) && (item is DotNetProject);
+			if (base.SupportsObject (item)) {
+				if (item is DotNetProject) {
+					return true;
+				}
+
+				var project = item as Project;
+				if (project != null) {
+					return project.GetRealProject() is DotNetProject;
+				}
+			}
+
+			return false;
 		}
 
 		new public DotNetProject Project {
-			get { return (DotNetProject)base.Item; }
+			get {
+				if (base.Item is DotNetProject) {
+					return (DotNetProject)base.Item;
+				}
+
+				var project = base.Item as Project;
+				if (project.GetRealProject() is DotNetProject) {
+					return (DotNetProject)project.GetRealProject();
+				}
+
+				throw new InvalidOperationException();
+			}
 		}
 
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -211,6 +211,11 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		public virtual Project GetRealProject() {
+			// Normal MSBuild projects just use themselves for the type system and other extensions.
+			return this;
+		}
+
 		public List<string> DefaultImports {
 			get {
 				if (defaultImports == null) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
@@ -540,14 +540,6 @@ namespace MonoDevelop.Projects
 			}
 		}
 
-		public ConfigurationSelector DefaultConfigurationSelector {
-			get {
-				if (defaultConfiguration == null && configurations.Count > 0)
-					DefaultConfigurationId = configurations [0].Id;
-				return new SolutionConfigurationSelector (DefaultConfigurationId);
-			}
-		}
-
 		IItemConfigurationCollection IConfigurationTarget.Configurations {
 			get {
 				return Configurations;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionConfigurationSelector.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionConfigurationSelector.cs
@@ -51,6 +51,11 @@ namespace MonoDevelop.Projects
 			if (target is SolutionItem) {
 				// Get the mapped configuration
 				SolutionItem item = (SolutionItem) target;
+				var project = item as Project;
+				if (project != null) {
+					item = project.GetRealProject();
+				}
+
 				if (item.ParentSolution != null) {
 					SolutionConfiguration config = item.ParentSolution.Configurations [Id];
 					if (config != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -862,6 +862,7 @@ namespace MonoDevelop.Ide.Gui
 			CancelOldParsing ();
 			var token = parseTokenSource.Token;
 			var project = adhocProject ?? Project;
+			project = project.GetRealProject();
 			var projectFile = project?.GetProjectFile (currentParseFile);
 
 			ThreadPool.QueueUserWorkItem (delegate {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -103,7 +103,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				IdeApp.Workspace.ActiveConfigurationChanged -= HandleActiveConfigurationChanged;
 			}
 			if (currentMonoDevelopSolution != null) {
-				foreach (var prj in currentMonoDevelopSolution.GetAllProjects ()) {
+				foreach (var prj in currentMonoDevelopSolution.GetAllProjects ().Select(x => x.GetRealProject())) {
 					UnloadMonoProject (prj);
 				}
 				currentMonoDevelopSolution = null;
@@ -189,7 +189,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		async Task<SolutionInfo> CreateSolutionInfo (MonoDevelop.Projects.Solution solution, CancellationToken token)
 		{
 			var projects = new ConcurrentBag<ProjectInfo> ();
-			var mdProjects = solution.GetAllProjects ();
+			var mdProjects = solution.GetAllProjects ().Select(x => x.GetRealProject()).ToList();
 			projectionList.Clear ();
 			solutionData = new SolutionData ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -248,6 +248,8 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		public static Microsoft.CodeAnalysis.Project GetCodeAnalysisProject (MonoDevelop.Projects.Project project)
 		{
+			project = project.GetRealProject();
+
 			if (project == null)
 				throw new ArgumentNullException ("project");
 			foreach (var w in workspaces) {


### PR DESCRIPTION
Follow up from #1160.

In Protobuild, we want auto-completion and text highlighting to work in C# documents when they're opened.  But the types of projects in the solution are `ProtobuildStandardDefinition`, not `CSharpProject` or `DotNetProject`.

To support this, we need to have a `GetRealProject` method, which the type systems and text highlighters can use to get the actual underlying project.  The value of this method will change whenever the active configuration changes.

This doesn't cover everywhere I need to intercept this value; when I open a Protobuild project in MonoDevelop it still raises errors in text files about System.Object not being loaded.  If someone could point me any other locations I might missing to make this work, that'd be appreciated.