### PR TITLE
Bug 37248 - Roslyn: typing "<" after IEnumerable deletes the text in front of it.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
@@ -102,10 +102,10 @@ namespace MonoDevelop.CSharp.Completion
 			var doc = ext.DocumentContext;
 			using (var undo = ext.Editor.OpenUndoGroup ()) {
 				string text = insertNamespace ? type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat) + "." + type.Name : type.Name;
-				if (text != GetCurrentWord (window)) {
+				if (text != GetCurrentWord (window, descriptor)) {
 					if (window.WasShiftPressed && generateUsing) 
 						text = type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat) + "." + text;
-					window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, GetCurrentWord (window), text);
+					window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, GetCurrentWord (window, descriptor), text);
 				}
 
 				if (!window.WasShiftPressed && generateUsing) {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynCodeCompletionFactory.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynCodeCompletionFactory.cs
@@ -167,7 +167,7 @@ namespace MonoDevelop.CSharp.Completion
 
 			public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
 			{
-				var currentWord = GetCurrentWord (window);
+				var currentWord = GetCurrentWord (window, descriptor);
 				var text = CompletionText;
 				if (descriptor.KeyChar == '>' && text.EndsWith (">", StringComparison.Ordinal))
 					text = text.Substring (0, text.Length - 1);

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
@@ -159,7 +159,7 @@ namespace MonoDevelop.CSharp.Completion
 
 		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
 		{
-			string partialWord = GetCurrentWord (window);
+			string partialWord = GetCurrentWord (window, descriptor);
 			int skipChars = 0;
 			bool runParameterCompletionCommand = false;
 			bool runCompletionCompletionCommand = false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
@@ -119,11 +119,16 @@ namespace MonoDevelop.Ide.CodeCompletion
 			this.Description = description;
 			this.CompletionText = completionText;
 		}
-		
-		public static string GetCurrentWord (CompletionListWindow window)
+
+		public static string GetCurrentWord (CompletionListWindow window, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
 		{
 			int partialWordLength = window.PartialWord != null ? window.PartialWord.Length : 0;
-			int replaceLength = window.CodeCompletionContext.TriggerWordLength + partialWordLength - window.InitialWordLength;
+			int replaceLength;
+			if (descriptor.SpecialKey == SpecialKey.Return || descriptor.SpecialKey == SpecialKey.Tab) {
+				replaceLength = window.CodeCompletionContext.TriggerWordLength + partialWordLength - window.InitialWordLength;
+			} else {
+				replaceLength = partialWordLength;
+			}
 			int endOffset = Math.Min (window.StartOffset + replaceLength, window.CompletionWidget.TextLength);
 			var result = window.CompletionWidget.GetText (window.StartOffset, endOffset);
 			return result;
@@ -131,7 +136,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		public virtual void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
 		{
-			var currentWord = GetCurrentWord (window);
+			var currentWord = GetCurrentWord (window, descriptor);
 			window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, currentWord, CompletionText);
 		}
 		


### PR DESCRIPTION
Fan fact: not roslyn specific bug
Basically fix is to replace text behind cursor only in case of Enter and Tab keys...