### PR TITLE
Add packages restore for mono-addins in winbuild.bat

### DIFF
--- a/main/winbuild.bat
+++ b/main/winbuild.bat
@@ -1,3 +1,4 @@
 ".nuget\NuGet.exe" restore Main.sln
 "external\RefactoringEssentials\.nuget\NuGet.exe" restore external\RefactoringEssentials\RefactoringEssentials.sln
+".nuget\NuGet.exe" restore external\mono-addins\Mono.Addins.sln
 "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Main.sln /m /p:Configuration=ReleaseWin32 /p:Platform="Any CPU"


### PR DESCRIPTION
Without it build on broken with error reference to SharpZipLib.