### PR TITLE
Bug 36857 - [Roslyn] False positive errors referencing PCL project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetRuntime.cs
@@ -41,6 +41,7 @@ using MonoDevelop.Core.Serialization;
 using Mono.Addins;
 using Mono.PkgConfig;
 using MonoDevelop.Core.Instrumentation;
+using System.Linq;
 
 namespace MonoDevelop.Core.Assemblies
 {
@@ -290,6 +291,16 @@ namespace MonoDevelop.Core.Assemblies
 					continue;
 
 				return Directory.GetFiles (facades, "*.dll");
+			}
+
+			//MonoDroid is special case because it's keeping Fascades in v1.0 folder
+			if (tx.Id.Identifier == TargetFrameworkMoniker.ID_MONODROID) {
+				var frameworkFolder = GetFrameworkFolders (tx).FirstOrDefault ();
+				if (frameworkFolder != null) {
+					var facades = Path.Combine (Path.Combine (Path.GetDirectoryName (frameworkFolder), "v1.0"), "Facades");
+					if (Directory.Exists (facades))
+						return Directory.GetFiles (facades, "*.dll");
+				}
 			}
 
 			return new string[0];

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -878,7 +878,7 @@ namespace MonoDevelop.Projects
 				RemoteProjectBuilder builder = await GetProjectBuilder ();
 				var configs = GetConfigurations (configuration, false);
 
-				string[] refs;
+				string [] refs;
 				using (Counters.ResolveMSBuildReferencesTimer.BeginTiming (GetProjectEventMetadata (configuration)))
 					refs = await builder.ResolveAssemblyReferences (configs, CancellationToken.None);
 				foreach (var r in refs)
@@ -913,6 +913,37 @@ namespace MonoDevelop.Projects
 				var sa = AssemblyContext.GetAssemblies (TargetFramework).FirstOrDefault (a => a.Name == "System.Core" && a.Package.IsFrameworkPackage);
 				if (sa != null)
 					result.Add (sa.Location);
+			}
+			var addFacadeAssemblies = false;
+			foreach (var r in GetReferencedAssemblyProjects (configuration)) {
+				if (r.IsPortableLibrary) {
+					addFacadeAssemblies = true;
+					break;
+				}
+			}
+			if (!addFacadeAssemblies) {
+				foreach (var refFilename in result) {
+					string fullPath = null;
+					if (!Path.IsPathRooted (refFilename)) {
+						fullPath = Path.Combine (Path.GetDirectoryName (FileName), refFilename);
+					} else {
+						fullPath = Path.GetFullPath (refFilename);
+					}
+					if (SystemAssemblyService.ContainsReferenceToSystemRuntime (fullPath)) {
+						addFacadeAssemblies = true;
+						break;
+					}
+				}
+			}
+
+			if (addFacadeAssemblies) {
+				var runtime = TargetRuntime ?? MonoDevelop.Core.Runtime.SystemAssemblyService.DefaultRuntime;
+				var facades = runtime.FindFacadeAssembliesForPCL (TargetFramework);
+				foreach (var facade in facades) {
+					if (!File.Exists (facade))
+						continue;
+					result.Add (facade);
+				}
 			}
 			return result;
 		}


### PR DESCRIPTION
Fix is made from two parts...
1st part(TargetRuntime.cs) is fixing method FindFacadeAssembliesForPCL for MonoDroid frameworks since instead of having Facades in every framework folder it only has in v1.0 folder which is hardcoded in [.targets file](https://github.com/xamarin/monodroid/blob/200ed2f87bdc0933338c623aa32b4b868859870f/tools/msbuild/Xamarin.Android.Common.targets#L547)...
2nd part(MonoDevelopWorkspace.cs) is fixing logic to also check if project reference includes Portable projects...