### PR TITLE
[Project] Don't write out imported configurations into the csproj file

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemConfiguration.cs
@@ -41,6 +41,8 @@ namespace MonoDevelop.Projects
 		string name = null;
 		
 		string platform;
+
+		bool isImported = false;
 		
 		[ItemProperty ("CustomCommands", SkipEmpty = true)]
 		[ItemProperty ("Command", Scope="*")]
@@ -108,12 +110,18 @@ namespace MonoDevelop.Projects
 			get { return customCommands; }
 		}
 
+		public bool IsImported {
+			get { return isImported; }
+			set { isImported = value; }
+		}
+
 		public object Clone()
 		{
 			ItemConfiguration conf = (ItemConfiguration) Activator.CreateInstance (GetType ());
 			conf.CopyFrom (this);
 			conf.name = name;
 			conf.platform = platform;
+			conf.isImported = isImported;
 			return conf;
 		}
 		


### PR DESCRIPTION
When a csproj file was being saved extra config lines were being written for imported configurations that didn't need to be there.

For example, with OpenLiveWriter the following would be added to each csproj file

<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   <IntermediateOutputPath>..\obj\Debug\OpenLiveWriter.Api</IntermediateOutputPath>
   <OutputPath>..\bin\Debug\i386\Writer</OutputPath>
</PropertyGroup>

for each configuration that was imported. These extra lines broke xbuild.

This patch prevents imported configurations being written to the csproj file.