### PR TITLE
Bug 36857 - [Roslyn] False positive errors referencing PCL project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -294,12 +294,12 @@ namespace MonoDevelop.Projects.MSBuild
 							// FIXME: This lock should not be necessary, but remoting seems to have problems when doing many concurrent calls.
 							result = builder.Run (
 										configurations, null, MSBuildVerbosity.Normal,
-										new [] { "ResolveAssemblyReferences" }, new [] { "ReferencePath" }, null, null, taskId
+										new [] { "ResolveReferences" }, new [] { "ReferencePath" }, null, null, taskId
 									);
 						}
 					} catch (Exception ex) {
 						CheckDisconnected ();
-						LoggingService.LogError ("ResolveAssemblyReferences failed", ex);
+						LoggingService.LogError ("ResolveReferences failed", ex);
 						return new string [0];
 					} finally {
 						EndOperation ();
@@ -307,7 +307,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 					List<MSBuildEvaluatedItem> items;
 					if (result.Items.TryGetValue ("ReferencePath", out items) && items != null) {
-						refs = items.Select (i => i.ItemSpec).ToArray ();
+						refs = items.Where (i => !i.Metadata.ContainsKey ("Project")).Select (i => i.ItemSpec).ToArray ();
 					} else
 						refs = new string[0];
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -866,7 +866,7 @@ namespace MonoDevelop.Projects
 			if (CheckUseMSBuildEngine (configuration)) {
 				// Get the references list from the msbuild project
 				RemoteProjectBuilder builder = await GetProjectBuilder ();
-				var configs = GetConfigurations (configuration, false);
+				var configs = GetConfigurations (configuration, true);
 
 				string[] refs;
 				using (Counters.ResolveMSBuildReferencesTimer.BeginTiming (GetProjectEventMetadata (configuration)))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -530,8 +530,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			var configurationSelector = IdeApp.Workspace?.ActiveConfiguration ?? MonoDevelop.Projects.ConfigurationSelector.Default;
 			var hashSet = new HashSet<string> (FilePath.PathComparer);
 
-			bool addFacadeAssemblies = false;
-
 			try {
 				foreach (string file in await netProject.GetReferencedAssemblies (configurationSelector, false).ConfigureAwait (false)) {
 					if (token.IsCancellationRequested)
@@ -548,22 +546,9 @@ namespace MonoDevelop.Ide.TypeSystem
 					if (!File.Exists (fileName))
 						continue;
 					result.Add (MetadataReferenceCache.LoadReference (projectId, fileName));
-					addFacadeAssemblies |= MonoDevelop.Core.Assemblies.SystemAssemblyService.ContainsReferenceToSystemRuntime (fileName);
 				}
 			} catch (Exception e) {
 				LoggingService.LogError ("Error while getting referenced assemblies", e);
-			}
-			// HACK: Facade assemblies should be added by the project system. Remove that when the project system can do that.
-			if (addFacadeAssemblies) {
-				if (netProject != null) {
-					var runtime = netProject.TargetRuntime ?? MonoDevelop.Core.Runtime.SystemAssemblyService.DefaultRuntime;
-					var facades = runtime.FindFacadeAssembliesForPCL (netProject.TargetFramework);
-					foreach (var facade in facades) {
-						if (!File.Exists (facade))
-							continue;
-						result.Add (MetadataReferenceCache.LoadReference (projectId, facade));
-					}
-				}
 			}
 
 			foreach (var pr in p.GetReferencedItems (configurationSelector)) {


### PR DESCRIPTION
This is different approach to https://github.com/mono/monodevelop/pull/1206 it uses "ResolveReferences".
Problems with this approach:
* If Portable project is not built(.dll is not in bin/Debug/projectName.dll), Facades are not resolved(Visual Studio has same problem) 
* Had to add `.Where (i => !i.Metadata.ContainsKey ("Project"))` to exclude now included project references.
* Probably slower since it executes more targets...

I would still prefer #1206.