### PR TITLE
[Ide] Improved updating of StatusBar after long status bar changing operation(mostly Rebuild)

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -1740,7 +1740,7 @@ namespace MonoDevelop.Components.Commands
 					}
 				}
 			}
-			
+
 			lastFocused = newFocused;
 			UpdateAppFocusStatus (hasFocus, lastFocusedExists);
 			
@@ -1854,6 +1854,8 @@ namespace MonoDevelop.Components.Commands
 				newWait = 500;
 			else if (secs < 30)
 				newWait = 700;
+			else if (appHasFocus)
+				newWait = 2000;
 			else {
 				// The application seems to be idle. Stop the status updater and
 				// start a pasive wait for user interaction
@@ -1898,8 +1900,10 @@ namespace MonoDevelop.Components.Commands
 			
 			waitingForUserInteraction = true;
 			toolbarUpdaterRunning = false;
-			foreach (var win in topLevelWindows)
+			foreach (var win in topLevelWindows) {
 				win.MotionNotifyEvent += HandleWinMotionNotifyEvent;
+				win.FocusInEvent += HandleFocusInEventHandler;
+			}
 		}
 		
 		void EndWaitingForUserInteraction ()
@@ -1907,8 +1911,10 @@ namespace MonoDevelop.Components.Commands
 			if (!waitingForUserInteraction)
 				return;
 			waitingForUserInteraction = false;
-			foreach (var win in topLevelWindows)
+			foreach (var win in topLevelWindows) {
 				win.MotionNotifyEvent -= HandleWinMotionNotifyEvent;
+				win.FocusInEvent -= HandleFocusInEventHandler;
+			}
 
 			StartStatusUpdater ();
 		}
@@ -1919,6 +1925,11 @@ namespace MonoDevelop.Components.Commands
 				lastUserInteraction = DateTime.Now;
 				EndWaitingForUserInteraction ();
 			}
+		}
+
+		void HandleFocusInEventHandler (object o, Gtk.FocusInEventArgs args)
+		{
+			RegisterUserInteraction ();
 		}
 
 		void HandleWinMotionNotifyEvent (object o, Gtk.MotionNotifyEventArgs args)


### PR DESCRIPTION
So bug was if user started Rebuild/Build or any other long operation(also debugging and if he didn't use IDE and app terminated) that took more then 30sec and didn't interact with IDE UpdateStatus last operation would still be Stop(still building), because we stopped updating status bar after 30sec of no user interaction...

We had HandleWinMotionNotificationEvent which would update on user interaction but for some reason that event triggers few seconds after mouse is moved and only reacts to moves in GTK area(not in Mac StatusBar) plus it forces user to move mouse(if he switched to app with Alt+Tab) and always takes me few moments to realise build actually finished based on status bar and I have to move mouse to update stop/run icon

This is fixed by using win.FocusInEvent so when user switches back it instantly updates

But if user starts building, goes AFK and comes back after 5minutes(and MD is top most app) it would still display Stop icon instead of play(no focus changing happened) to fix this I added "if(appHasFocus) newWait=2000;" which means never stop updating when in front...

There is still problem with case when user has split screen between MD and some other app and is using that app(so MD is visible but not in focus, hence we stop updating but users sees Stop icon after build is finish), this is not so critical problem imo and fix would be to run updates also when MD is in background(maybe every 5 seconds?) proper fix will be when we stop using timer for status bar and switch do everything event based... But as we discussed in Boston it's not going to happen soon...