### PR TITLE
 [source-editor] Set encoding of view to encoding used for writing.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -714,6 +714,7 @@ namespace MonoDevelop.SourceEditor
 						}
 					}
 					await MonoDevelop.Core.Text.TextFileUtility.WriteTextAsync (fileName, writeText, writeEncoding, writeBom);
+					this.encoding = writeEncoding;
 				} catch (InvalidEncodingException) {
 					var result = MessageService.AskQuestion (GettextCatalog.GetString ("Can't save file with current codepage."), 
 						GettextCatalog.GetString ("Some unicode characters in this file could not be saved with the current encoding.\nDo you want to resave this file as Unicode ?\nYou can choose another encoding in the 'save as' dialog."),


### PR DESCRIPTION
Fixes issue with text view showing garbage characters (file loaded with wrong encoding) when using "Save As" and saving to a different encoding than the current view is using.

Repro steps on Windows:
1. Open UTF-8 encoded file.
2. Use "Save As" to save with new filename and select UTF-16 encoding (Default for me)
3. File is reloaded as UTF8 instead of UTF-16.