### PR TITLE
[MacPlatform] Don't zoom when double clicking on the widgets in the toolbar

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -96,7 +96,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public override void MouseDown (NSEvent theEvent)
 		{
 			base.MouseDown (theEvent);
-			if (theEvent.ClickCount == 2) {
+
+			var locationInSV = Superview.ConvertPointFromView (theEvent.LocationInWindow, null);
+			if (theEvent.ClickCount == 2 && HitTest (locationInSV) == this) {
 				Window.Zoom (this);
 			}
 		}


### PR DESCRIPTION
Use HitTest to check that we're double clicking inside the toolbar and not its children