### PR TITLE
[Toolbox] Assume ItemToolboxNode.Name uses Pango markup formatting.

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TemplateToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TemplateToolboxNode.cs
@@ -37,7 +37,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 	{
 		public override string Name {
 			get {
-				return Template.Shortcut;
+				return GLib.Markup.EscapeText (Template.Shortcut);
 			}
 			set {
 				Template.Shortcut = value;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -292,7 +292,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 				if (listMode || !curCategory.CanIconizeItems)  {
 					cr.DrawImage (this, item.Icon, xpos + ItemLeftPadding, ypos + Math.Round ((itemDimension.Height - item.Icon.Height) / 2));
-					layout.SetText (item.Text);
+					layout.SetMarkup (item.Text);
 					int width, height;
 					layout.GetPixelSize (out width, out height);
 					cr.SetSourceColor (Style.Text (item != this.SelectedItem ? StateType.Normal : StateType.Selected).ToCairoColor ());
@@ -835,7 +835,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					int x, y = item.ItemHeight;
 
 					if (y == 0) {
-						layout.SetText (item.Text);
+						layout.SetMarkup (item.Text);
 						layout.GetPixelSize (out x, out y);
 						y = Math.Max (IconSize.Height, y);
 						y += ItemTopBottomPadding * 2;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -2081,6 +2081,7 @@ namespace MonoDevelop.SourceEditor
 				item.Name = text.Length > 16 ? text.Substring (0, 16) + "..." : text;
 				item.Name = item.Name.Replace ("\t", "\\t");
 				item.Name = item.Name.Replace ("\n", "\\n");
+				item.Name = GLib.Markup.EscapeText (item.Name);
 				clipboardRing.Add (item);
 				while (clipboardRing.Count > 12) {
 					clipboardRing.RemoveAt (0);


### PR DESCRIPTION
@slluis I assume this change, even though not technically an API break, is a breach of contract so I would like to know what you think about it.

The rationale for this change is to be able to create toolbox item with a bit of style for conveying more information than simple text. My use case is to inform from which assembly/location a custom control is originating (see http://screencast.com/t/71JK7a21kD).

If you have a better idea on how I could achieve this better I'm open to suggestions.

NB: I noticed that toolbox is already having escaping issue because the tooltip that is created for those items already uses `SetMarkup` instead of `SetText` and that causes some text (e.g. clipboard ring of an XML file) to display incorrectly or not at all.

