### PR TITLE
Add Source property to ItemToolboxNode and render it in ToolboxWidget.

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ItemToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ItemToolboxNode.cs
@@ -59,6 +59,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		
 		[ItemProperty ("description")]
 		string description = "";
+
+		[ItemProperty ("source")]
+		string source = "";
 		
 		List <ToolboxItemFilterAttribute> itemFilters = new List <ToolboxItemFilterAttribute> ();
 		
@@ -95,6 +98,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			get { return description; }
 			set { description = value; }
 		}
+
+		public virtual string Source {
+			get { return source; }
+			set { source = value; }
+		}
 		
 		[Browsable(false)]
 		public virtual IList<ToolboxItemFilterAttribute> ItemFilters {
@@ -113,13 +121,14 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public virtual bool Filter (string keyword)
 		{
 			return ((Name != null) && (Name.IndexOf (keyword, StringComparison.InvariantCultureIgnoreCase) >= 0))
-			    || ((Description != null) && (Description.IndexOf (keyword, StringComparison.InvariantCultureIgnoreCase) >= 0));
+			    || ((Description != null) && (Description.IndexOf (keyword, StringComparison.InvariantCultureIgnoreCase) >= 0))
+			    || ((Source != null) && (Source.IndexOf (keyword, StringComparison.InvariantCultureIgnoreCase) >= 0));
 		}
 		
 		public override bool Equals (object o)
 		{
 			ItemToolboxNode node = o as ItemToolboxNode;
-			return (node != null) && (node.Name == this.Name) && (node.Category == this.Category) && (node.Description == this.Description);
+			return (node != null) && (node.Name == this.Name) && (node.Category == this.Category) && (node.Description == this.Description) && (node.Source == this.Source);
 		}
 		
 		public override int GetHashCode ()
@@ -131,6 +140,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				code ^= Category.GetHashCode ();
 			if (Description != null)
 				code ^= Description.GetHashCode ();
+			if (Source != null)
+				code ^= Source.GetHashCode ();
 			return code;
 		}
 		

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -267,7 +267,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				cr.SetSourceColor (CategoryBorderColor);
 				cr.Stroke ();
 
-				headerLayout.SetText (category.Text);
+				headerLayout.SetMarkup (category.Text);
 				int width, height;
 				cr.SetSourceColor (CategoryLabelColor);
 				layout.GetPixelSize (out width, out height);
@@ -292,7 +292,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 				if (listMode || !curCategory.CanIconizeItems)  {
 					cr.DrawImage (this, item.Icon, xpos + ItemLeftPadding, ypos + Math.Round ((itemDimension.Height - item.Icon.Height) / 2));
-					layout.SetText (item.Text);
+					layout.SetMarkup (item.Text);
 					int width, height;
 					layout.GetPixelSize (out width, out height);
 					cr.SetSourceColor (Style.Text (item != this.SelectedItem ? StateType.Normal : StateType.Selected).ToCairoColor ());
@@ -835,7 +835,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					int x, y = item.ItemHeight;
 
 					if (y == 0) {
-						layout.SetText (item.Text);
+						layout.SetMarkup (item.Text);
 						layout.GetPixelSize (out x, out y);
 						y = Math.Max (IconSize.Height, y);
 						y += ItemTopBottomPadding * 2;
@@ -875,7 +875,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					int x, y = category.ItemHeight;
 
 					if (y == 0) {
-						layout.SetText (category.Text);
+						layout.SetMarkup (category.Text);
 						layout.GetPixelSize (out x, out y);
 						y += CategoryTopBottomPadding * 2;
 						category.ItemHeight = y;
@@ -1134,8 +1134,14 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		
 		public string Text {
 			get {
-				if (node != null)
-					return node.Name;
+				if (node != null) {
+					var t = GLib.Markup.EscapeText (node.Name);
+					if (!string.IsNullOrEmpty (node.Source)) {
+						var c = MonoDevelop.Ide.Gui.Styles.DimTextColor.ToHexString ().Substring (0, 7);
+						t += string.Format (" <span size=\"smaller\" color=\"{1}\">{0}</span>", node.Source, c);
+					}
+					return t;
+				}
 				return text;
 			}
 		}
@@ -1182,7 +1188,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public Item (Xwt.Drawing.Image icon, string text, string tooltip, object tag)
 		{
 			this.icon    = icon;
-			this.text    = text;
+			this.text    = GLib.Markup.EscapeText (text);
 			this.tooltip = tooltip;
 			this.tag     = tag;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -36,6 +36,7 @@ namespace MonoDevelop.Ide.Gui
 		// General
 
 		public static readonly Gdk.Color ThinSplitterColor = new Gdk.Color (166, 166, 166);
+		public static readonly Xwt.Drawing.Color DimTextColor = Xwt.Drawing.Color.FromBytes (170, 170, 170);
 
 		// Document tab bar
 


### PR DESCRIPTION
This property allows one to set the origin of an element in a toolbox (e.g. from which assembly, library, file the item comes from).

Originating from comments in the other PR: https://github.com/mono/monodevelop/pull/1228