### PR TITLE
Async renaming

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFeaturesTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFeaturesTextEditorExtension.cs
@@ -89,9 +89,9 @@ namespace MonoDevelop.CSharp.Refactoring
 		}
 
 		[CommandHandler (EditCommands.Rename)]
-		public void RenameCommand ()
+		public async void RenameCommand ()
 		{
-			new RenameHandler ().Run (Editor, DocumentContext);
+			await new RenameHandler ().Run (Editor, DocumentContext);
 		}
 
 		[CommandUpdateHandler (RefactoryCommands.GotoDeclaration)]

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/ExtractMethodCommandHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/ExtractMethodCommandHandler.cs
@@ -95,7 +95,7 @@ namespace MonoDevelop.CSharp.Refactoring
 				var info = RefactoringSymbolInfo.GetSymbolInfoAsync (doc, extractionResult.InvocationNameToken.Span.Start).Result;
 				var sym = info.DeclaredSymbol ?? info.Symbol;
 				if (sym != null)
-					new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (sym);
+					await new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (sym);
 			}
 			catch (Exception e) {
 				LoggingService.LogError ("Error while extracting method", e);

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.CSharp.Refactoring
 			result.Text = GettextCatalog.GetString ("Fix");
 			foreach (var diagnostic in container.CodeFixActions) {
 				var info = new CommandInfo (diagnostic.CodeAction.Title);
-				result.CommandInfos.Add (info, new Action (new CodeActionEditorExtension.ContextActionRunner (diagnostic.CodeAction, editor, ctx).Run));
+				result.CommandInfos.Add (info, new Action (async () => await new CodeActionEditorExtension.ContextActionRunner (diagnostic.CodeAction, editor, ctx).Run ()));
 			}
 			if (result.CommandInfos.Count == 0)
 				return result;
@@ -188,8 +188,8 @@ namespace MonoDevelop.CSharp.Refactoring
 
 			bool canRename = RenameHandler.CanRename (info.Symbol ?? info.DeclaredSymbol);
 			if (canRename) {
-				ciset.CommandInfos.Add (IdeApp.CommandService.GetCommandInfo (MonoDevelop.Ide.Commands.EditCommands.Rename), new Action (delegate {
-					new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (info.Symbol ?? info.DeclaredSymbol);
+				ciset.CommandInfos.Add (IdeApp.CommandService.GetCommandInfo (MonoDevelop.Ide.Commands.EditCommands.Rename), new Action (async delegate {
+					await new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (info.Symbol ?? info.DeclaredSymbol);
 				}));
 				added = true;
 			}
@@ -199,7 +199,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					if (added & first && ciset.CommandInfos.Count > 0)
 						ciset.CommandInfos.AddSeparator ();
 					var info2 = new CommandInfo (fix.CodeAction.Title);
-					ciset.CommandInfos.Add (info2, new Action (new CodeActionEditorExtension.ContextActionRunner (fix.CodeAction, doc.Editor, doc).Run));
+					ciset.CommandInfos.Add (info2, new Action (async () => await new CodeActionEditorExtension.ContextActionRunner (fix.CodeAction, doc.Editor, doc).Run ()));
 					added = true;
 					first = false;
 				}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
@@ -83,7 +83,10 @@ namespace MonoDevelop.CSharp.Refactoring
 
 		internal async Task Run (TextEditor editor, DocumentContext ctx)
 		{
-			var info = await RefactoringSymbolInfo.GetSymbolInfoAsync (ctx, editor.CaretOffset);
+			var cts = new CancellationTokenSource ();
+			var getSymbolTask = RefactoringSymbolInfo.GetSymbolInfoAsync (ctx, editor.CaretOffset, cts.Token);
+			var message = GettextCatalog.GetString ("Waiting for rename operation to resolve symbol...");
+			var info = await MessageService.ExecuteTaskAndShowWaitDialog (getSymbolTask, message, cts);
 			var sym = info.DeclaredSymbol ?? info.Symbol;
 			if (!CanRename (sym))
 				return;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
@@ -85,7 +85,7 @@ namespace MonoDevelop.CSharp.Refactoring
 		{
 			var cts = new CancellationTokenSource ();
 			var getSymbolTask = RefactoringSymbolInfo.GetSymbolInfoAsync (ctx, editor.CaretOffset, cts.Token);
-			var message = GettextCatalog.GetString ("Waiting for rename operation to resolve symbol...");
+			var message = GettextCatalog.GetString ("Resolving symbol…");
 			var info = await MessageService.ExecuteTaskAndShowWaitDialog (getSymbolTask, message, cts);
 			var sym = info.DeclaredSymbol ?? info.Symbol;
 			if (!CanRename (sym))

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
@@ -37,6 +37,8 @@ using ICSharpCode.NRefactory6.CSharp;
 using MonoDevelop.Refactoring;
 using MonoDevelop.Refactoring.Rename;
 using MonoDevelop.Ide.TypeSystem;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace MonoDevelop.CSharp.Refactoring
 {
@@ -71,21 +73,21 @@ namespace MonoDevelop.CSharp.Refactoring
 			return false;
 		}
 		
-		protected override void Run (object data)
+		protected override async void Run (object data)
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
 			if (doc == null || doc.FileName == FilePath.Null)
 				return;
-			Run (doc.Editor, doc);
+			await Run (doc.Editor, doc);
 		}
 
-		internal void Run (TextEditor editor, DocumentContext ctx)
+		internal async Task Run (TextEditor editor, DocumentContext ctx)
 		{
-			var info = RefactoringSymbolInfo.GetSymbolInfoAsync (ctx, editor.CaretOffset).Result;
+			var info = await RefactoringSymbolInfo.GetSymbolInfoAsync (ctx, editor.CaretOffset);
 			var sym = info.DeclaredSymbol ?? info.Symbol;
 			if (!CanRename (sym))
 				return;
-			new RenameRefactoring ().Rename (sym);
+			await new RenameRefactoring ().Rename (sym);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/ActionGroupView.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/ActionGroupView.cs
@@ -197,9 +197,9 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			codeBinder.BindSignal (a.Signal);
 		}
 		
-		void OnSignalChanged (object s, Stetic.ComponentSignalEventArgs a)
+		async void OnSignalChanged (object s, Stetic.ComponentSignalEventArgs a)
 		{
-			codeBinder.UpdateSignal (a.OldSignal, a.Signal);
+			await codeBinder.UpdateSignal (a.OldSignal, a.Signal);
 		}
 		
 		async void OnBindField (object s, EventArgs args)

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/CodeBinder.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/CodeBinder.cs
@@ -135,7 +135,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			return cls.GetMembers (signal.Handler).OfType<IMethodSymbol> ().FirstOrDefault ();
 		}
 
-		public void UpdateField (Stetic.Component obj, string oldName)
+		public async Task UpdateField (Stetic.Component obj, string oldName)
 		{
 			if (targetObject == null)
 				return;
@@ -152,7 +152,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			if (cls != null) {
 				var f = ClassUtils.FindWidgetField (cls, oldName);
 				if (f != null) {
-					MonoDevelop.Refactoring.Rename.RenameRefactoring.Rename (f, newName);
+					await MonoDevelop.Refactoring.Rename.RenameRefactoring.Rename (f, newName);
 				}
 			}
 		}
@@ -195,7 +195,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			return cls.Locations.First ();
 		}
 
-		public void UpdateSignal (Stetic.Signal oldSignal, Stetic.Signal newSignal)
+		public async Task UpdateSignal (Stetic.Signal oldSignal, Stetic.Signal newSignal)
 		{
 			if (targetObject == null)
 				return;
@@ -209,7 +209,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			var met = FindSignalHandler (cls, oldSignal);
 			if (met == null)
 				return;
-			MonoDevelop.Refactoring.Rename.RenameRefactoring.Rename (met, newSignal.Handler);
+			await MonoDevelop.Refactoring.Rename.RenameRefactoring.Rename (met, newSignal.Handler);
 		}
 
 		/// Adds a field to the class

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderView.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderView.cs
@@ -267,7 +267,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			codeBinder.TargetObject = designer.RootComponent;
 		}
 		
-		void OnComponentNameChanged (object s, Stetic.ComponentNameEventArgs args)
+		async void OnComponentNameChanged (object s, Stetic.ComponentNameEventArgs args)
 		{
 			try {
 				// Make sure the fields in the partial class are up to date.
@@ -278,7 +278,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 				if (gproject.Project.UsePartialTypes)
 					GuiBuilderService.GenerateSteticCodeStructure ((DotNetProject)gproject.Project, designer.RootComponent, args, false, false);
 				
-				codeBinder.UpdateField (args.Component, args.OldName);
+				await codeBinder.UpdateField (args.Component, args.OldName);
 			}
 			catch (Exception ex) {
 				LoggingService.LogInternalError (ex);
@@ -323,9 +323,9 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 		{
 		}
 
-		void OnSignalChanged (object sender, Stetic.ComponentSignalEventArgs args)
+		async void OnSignalChanged (object sender, Stetic.ComponentSignalEventArgs args)
 		{
-			codeBinder.UpdateSignal (args.OldSignal, args.Signal);
+			await codeBinder.UpdateSignal (args.OldSignal, args.Signal);
 		}
 		
 		public override async Task Save (FileSaveInformation fileSaveInformation)

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -464,8 +464,8 @@ namespace MonoDevelop.CodeActions
 
 				var fix = fix_;
 				var label = CreateLabel (fix.CodeAction.Title, ref mnemonic);
-				var thisInstanceMenuItem = new FixMenuEntry (label, delegate {
-					new ContextActionRunner (fix.CodeAction, Editor, DocumentContext).Run (null, EventArgs.Empty);
+				var thisInstanceMenuItem = new FixMenuEntry (label,async delegate {
+					await new ContextActionRunner (fix.CodeAction, Editor, DocumentContext).Run ();
 					ConfirmUsage (fix.CodeAction.EquivalenceKey);
 				});
 				menu.Add (thisInstanceMenuItem);
@@ -481,8 +481,8 @@ namespace MonoDevelop.CodeActions
 				}
 
 				var label = CreateLabel (fix.CodeAction.Title, ref mnemonic);
-				var thisInstanceMenuItem = new FixMenuEntry (label, delegate {
-					new ContextActionRunner (fix.CodeAction, Editor, DocumentContext).Run (null, EventArgs.Empty);
+				var thisInstanceMenuItem = new FixMenuEntry (label, async delegate {
+					await new ContextActionRunner (fix.CodeAction, Editor, DocumentContext).Run ();
 					ConfirmUsage (fix.CodeAction.EquivalenceKey);
 				});
 				menu.Add (thisInstanceMenuItem);
@@ -596,12 +596,7 @@ namespace MonoDevelop.CodeActions
 				this.documentContext = documentContext;
 			}
 
-			public void Run (object sender, EventArgs e)
-			{
-				Run ();
-			}
-
-			internal async void Run ()
+			public async Task Run ()
 			{
 				var token = default (CancellationToken);
 				var insertionAction = act as InsertionAction;
@@ -652,7 +647,7 @@ namespace MonoDevelop.CodeActions
 						operation.Apply (documentContext.RoslynWorkspace, token);
 					}
 				}
-				TryStartRenameSession (documentContext.RoslynWorkspace, oldSolution, updatedSolution, token);
+				await TryStartRenameSession (documentContext.RoslynWorkspace, oldSolution, updatedSolution, token);
 			}
 
 			static IEnumerable<DocumentId> GetChangedDocuments (Solution newSolution, Solution oldSolution)
@@ -667,7 +662,7 @@ namespace MonoDevelop.CodeActions
 				}
 			}
 
-			async void TryStartRenameSession (Workspace workspace, Solution oldSolution, Solution newSolution, CancellationToken cancellationToken)
+			async Task TryStartRenameSession (Workspace workspace, Solution oldSolution, Solution newSolution, CancellationToken cancellationToken)
 			{
 				var changedDocuments = GetChangedDocuments (newSolution, oldSolution);
 				foreach (var documentId in changedDocuments) {
@@ -682,7 +677,7 @@ namespace MonoDevelop.CodeActions
 						var latestDocument = workspace.CurrentSolution.GetDocument (documentId);
 						var latestModel = await latestDocument.GetSemanticModelAsync (cancellationToken).ConfigureAwait (false);
 						var latestRoot = await latestDocument.GetSyntaxRootAsync (cancellationToken).ConfigureAwait (false);
-						Application.Invoke (delegate {
+						await Runtime.RunInMainThread (async delegate {
 							try {
 								var node = latestRoot.FindNode (renameTokenOpt.Value.Parent.Span, false, false);
 								if (node == null)
@@ -690,7 +685,7 @@ namespace MonoDevelop.CodeActions
 								var info = latestModel.GetSymbolInfo (node);
 								var sym = info.Symbol ?? latestModel.GetDeclaredSymbol (node);
 								if (sym != null)
-									new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (sym);
+									await new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (sym);
 							} catch (Exception ex) {
 								LoggingService.LogError ("Error while renaming " + renameTokenOpt.Value.Parent, ex);
 							}

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.Refactoring.Rename
 
 			var currentSolution = ws.CurrentSolution;
 			var cts = new CancellationTokenSource ();
-			var newSolution = await MessageService.ExecuteTaskAndShowWaitDialog (Task.Run (() => Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options, cts.Token)), GettextCatalog.GetString ("Waiting for rename operation to find all references..."), cts);
+			var newSolution = await MessageService.ExecuteTaskAndShowWaitDialog (Task.Run (() => Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options, cts.Token)), GettextCatalog.GetString ("Looking for all references"), cts);
 			var projectChanges = currentSolution.GetChanges (newSolution).GetProjectChanges ().ToList ();
 			var changedDocuments = new HashSet<string> ();
 			foreach (var change in projectChanges) {

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
@@ -41,19 +41,21 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Editor;
 using Microsoft.CodeAnalysis.Rename;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace MonoDevelop.Refactoring.Rename
 {
 	public class RenameRefactoring
 	{
-		public static bool Rename (ISymbol symbol, string newName)
+		public static async Task<bool> Rename (ISymbol symbol, string newName)
 		{
 			if (symbol == null)
 				throw new ArgumentNullException ("symbol");
 			if (newName == null)
 				throw new ArgumentNullException ("newName");
 			try {
-				new RenameRefactoring ().PerformChanges (symbol, new RenameProperties () { NewName = newName });
+				await new RenameRefactoring ().PerformChangesAsync (symbol, new RenameProperties () { NewName = newName });
 				return true;
 			} catch (AggregateException ae) {
 				foreach (var inner in ae.Flatten ().InnerExceptions)
@@ -73,20 +75,21 @@ namespace MonoDevelop.Refactoring.Rename
 			}
 		}
 
-		public void Rename (ISymbol symbol)
+		public async Task Rename (ISymbol symbol)
 		{
-
 			var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
 			var ws = TypeSystemService.GetWorkspace (solution);
 
 			var currentSolution = ws.CurrentSolution;
-			var newSolution = Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options).Result;
+			var newSolution = await Task.Run (() => Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options));
 			var projectChanges = currentSolution.GetChanges (newSolution).GetProjectChanges ().ToList ();
 			var changedDocuments = new HashSet<string> ();
-			foreach (var change in projectChanges)
+			foreach (var change in projectChanges) {
 				foreach (var changedDoc in change.GetChangedDocuments ()) {
 					changedDocuments.Add (ws.CurrentSolution.GetDocument (changedDoc).FilePath);
 				}
+			}
+
 			if (changedDocuments.Count > 1) {
 				using (var dlg = new RenameItemDialog (symbol, this))
 					MessageService.ShowCustomDialog (dlg);
@@ -110,7 +113,7 @@ namespace MonoDevelop.Refactoring.Rename
 			var oldDoc = projectChange.OldProject.GetDocument (cd);
 			var newDoc = projectChange.NewProject.GetDocument (cd);
 			var oldVersion = editor.Version;
-			foreach (var textChange in oldDoc.GetTextChangesAsync (newDoc).Result) {
+			foreach (var textChange in await oldDoc.GetTextChangesAsync (newDoc)) {
 				var segment = new TextSegment (textChange.Span.Start, textChange.Span.Length);
 				if (segment.Offset <= editor.CaretOffset && editor.CaretOffset <= segment.EndOffset) {
 					link.Links.Insert (0, segment); 
@@ -149,12 +152,12 @@ namespace MonoDevelop.Refactoring.Rename
 			}
 		}
 		
-		public void PerformChanges (ISymbol symbol, RenameProperties properties)
+		public async Task PerformChangesAsync (ISymbol symbol, RenameProperties properties)
 		{
 			var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
 			var ws = TypeSystemService.GetWorkspace (solution);
 
-			var newSolution = Renamer.RenameSymbolAsync (ws.CurrentSolution, symbol, properties.NewName, ws.Options).Result;
+			var newSolution = await Renamer.RenameSymbolAsync (ws.CurrentSolution, symbol, properties.NewName, ws.Options);
 
 			ws.TryApplyChanges (newSolution);
 		}

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
@@ -81,7 +81,8 @@ namespace MonoDevelop.Refactoring.Rename
 			var ws = TypeSystemService.GetWorkspace (solution);
 
 			var currentSolution = ws.CurrentSolution;
-			var newSolution = await Task.Run (() => Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options));
+			var cts = new CancellationTokenSource ();
+			var newSolution = await MessageService.ExecuteTaskAndShowWaitDialog (Task.Run (() => Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options, cts.Token)), GettextCatalog.GetString ("Waiting for rename operation to find all references..."), cts);
 			var projectChanges = currentSolution.GetChanges (newSolution).GetProjectChanges ().ToList ();
 			var changedDocuments = new HashSet<string> ();
 			foreach (var change in projectChanges) {


### PR DESCRIPTION
This change should be reviewed by looking at commits separately...

* [Make all Renaming operations use Tasks/async/await instead of .Result](https://github.com/mono/monodevelop/commit/b00fa0bad2cea82dfd8991f17035deae1ed36eed)
 * This one is pretty straight forward, just introduce async Task to Rename method and propagate Task all the way back to events
* [[Refactoring] Changed GetSymbolInfoAsync to run on thread pool](https://github.com/mono/monodevelop/commit/4fea349627a50fc1c6efe98bcc3b602cbe68d6c9)
 * @mkrueger What do you think about this commit? I think this is best way to handle getting symbol info...
* [[Ide] Introduced MessageService.ExecuteTaskAndShowWaitDialog](https://github.com/mono/monodevelop/commit/db3dc0e6edfd56a9653e4690d38dc381bac90c0a)
 * @slluis and anyone else interested, can you review this commit and make comments about this new method, I think it's nice... Would appreciate comments...

Commits need to be merged simultaneously... because otherwise there is awkward delay between using Rename command and rename actually starting...(in past there was beachball instead of nice cancel dialog)

SS of dialog:
![image](https://cloud.githubusercontent.com/assets/774791/12485347/a7c04e3e-c05e-11e5-872f-e2d233922377.png)
