### PR TITLE
[AutoTest] For consitency move MemStats class over to the dto file

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -132,7 +132,7 @@ namespace MonoDevelop.Components.AutoTest
 				}
 		}
 
-		public AutoTestSession.MemoryStats MemoryStats {
+		public MemoryStatsDTO MemoryStats {
 			get {
 				return session.GetMemoryStats ();
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -67,20 +67,11 @@ namespace MonoDevelop.Components.AutoTest
 			return null;
 		}
 
-		[Serializable]
-		public struct MemoryStats {
-			public long PrivateMemory;
-			public long PeakVirtualMemory;
-			public long PagedSystemMemory;
-			public long PagedMemory;
-			public long NonPagedSystemMemory;
-		};
-
-		public MemoryStats GetMemoryStats ()
+		public MemoryStatsDTO GetMemoryStats ()
 		{
-			MemoryStats stats;
+			MemoryStatsDTO stats;
 			using (Process proc = Process.GetCurrentProcess ()) {
-				stats = new MemoryStats {
+				stats = new MemoryStatsDTO {
 					PrivateMemory = proc.PrivateMemorySize64,
 					PeakVirtualMemory = proc.PeakVirtualMemorySize64,
 					PagedSystemMemory = proc.PagedSystemMemorySize64,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/DataTransferObjects.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/DataTransferObjects.cs
@@ -56,5 +56,34 @@ namespace MonoDevelop.Components.AutoTest
 			set;
 		}
 	}
+
+	[Serializable]
+	public class MemoryStatsDTO
+	{
+		public long PrivateMemory {
+			get;
+			set;
+		}
+
+		public long PeakVirtualMemory {
+			get;
+			set;
+		}
+
+		public long PagedSystemMemory {
+			get;
+			set;
+		}
+
+		public long PagedMemory {
+			get;
+			set;
+		}
+
+		public long NonPagedSystemMemory {
+			get;
+			set;
+		}
+	};
 }
 


### PR DESCRIPTION
This is not really a necessity but in the name of consistency/organization