### PR TITLE
[Core] Load global xbuild-frameworks also for other runtimes then currently running

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
@@ -109,13 +109,6 @@ namespace MonoDevelop.Core.Assemblies
 
 		public override IEnumerable<FilePath> GetReferenceFrameworkDirectories ()
 		{
-			//during initializion, only return the global directory once (for the running runtime) so that it doesn't
-			//get scanned multiple times
-			return GetReferenceFrameworkDirectories (IsInitialized || IsRunning);
-		}
-
-		IEnumerable<FilePath> GetReferenceFrameworkDirectories (bool includeGlobalDirectories)
-		{
 			//duplicate xbuild's framework folders path logic
 			//see xbuild man page
 			string env;
@@ -124,7 +117,7 @@ namespace MonoDevelop.Core.Assemblies
 					yield return (FilePath) dir;
 			}
 
-			if (includeGlobalDirectories && Platform.IsMac) {
+			if (Platform.IsMac) {
 				yield return "/Library/Frameworks/Mono.framework/External/xbuild-frameworks";
 			}
 


### PR DESCRIPTION
Reason why this check was added was to speedup boot time of IDE so it doesn't load all custom frameworks... But based on my testing it appears different runtimes are loaded as needed so there is no reason for this check anymore...