### PR TITLE
Fix WPF toolbar for high-dpi displays

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Windows/GtkWPFWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Windows/GtkWPFWidget.cs
@@ -68,15 +68,17 @@ namespace MonoDevelop.Components.Windows
 		void RepositionWpfWindow ()
 		{
 			int x, y;
+			int scale = (int)GtkWorkarounds.GetScaleFactor (this);
+
 			if (TranslateCoordinates (Toplevel, 0, 0, out x, out y)) {
-				wpfWidgetHost.Left = x;
-				wpfWidgetHost.Top = y;
+				wpfWidgetHost.Left = x * scale;
+				wpfWidgetHost.Top = y * scale;
 			} else {
-				wpfWidgetHost.Left = Allocation.Left;
-				wpfWidgetHost.Top = Allocation.Top;
+				wpfWidgetHost.Left = Allocation.Left * scale;
+				wpfWidgetHost.Top = Allocation.Top * scale;
 			}
-			wpfWidgetHost.Width = Allocation.Width + 1;
-			wpfWidgetHost.Height = Allocation.Height + 1;
+			wpfWidgetHost.Width = (Allocation.Width + 1) * scale;
+			wpfWidgetHost.Height = (Allocation.Height + 1) * scale;
 		}
 
 		protected override void OnRealized ()


### PR DESCRIPTION
We need to convert the gtk widget's coordinates into the same units that
WPF is using.

Here's what it currently looks like:

![highdpitest1](https://cloud.githubusercontent.com/assets/2041/12625884/6225d9ec-c4fb-11e5-809a-dcd4a76bdfac.png)

Here's what it looks like when I scale the coordinates:

<img width="1247" alt="screen shot 2016-01-27 at 1 37 43 pm" src="https://cloud.githubusercontent.com/assets/2041/12625848/35372544-c4fb-11e5-8fa6-a5abd4188c3a.png">
