### PR TITLE
Make ProjectOperations setters public.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -119,7 +119,7 @@ namespace MonoDevelop.Ide
 			get {
 				return currentWorkspaceItem;
 			}
-			internal set {
+			set {
 				if (value != currentWorkspaceItem) {
 					WorkspaceItem oldValue = currentWorkspaceItem;
 					currentWorkspaceItem = value;
@@ -135,7 +135,7 @@ namespace MonoDevelop.Ide
 					return CurrentSelectedSolution.RootFolder;
 				return currentSolutionItem;
 			}
-			internal set {
+			set {
 				if (value != currentSolutionItem) {
 					SolutionFolderItem oldValue = currentSolutionItem;
 					currentSolutionItem = value;
@@ -149,7 +149,7 @@ namespace MonoDevelop.Ide
 			get {
 				return currentItem;
 			}
-			internal set {
+			set {
 				currentItem = value;
 			}
 		}


### PR DESCRIPTION
Make setter for CurrentSelectedWorkspaceItem, CurrentSelectedSoutionItem & CurrentSelectedItem public. Allows to set active solution and project without solution pad.

We are at Unity working a on new integration for MonoDevelop and we do not show the solution pad, however we do create an in-memory only solution. In order to be able to debug, build and perform other project operations, the solution must be set on the ProjectOperations. However, it is currently internal and only set when the solution pad is shown and the solution is selected through the solution pad tree view.

This change allows us to set the solution without having to visually show the solution pad first. If there is a better solution this to this problem, I would happily submit a new PR with any suggestions.