### PR TITLE
[NUnit+Core] Debug.WriteLine and tracepoints now work when debugging unit test

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxLoader.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxLoader.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			
 			ExternalLoader eloader;
 			if (!externalLoaders.TryGetValue (runtime, out eloader)) {
-				eloader = (ExternalLoader) Runtime.ProcessService.CreateExternalProcessObject (typeof(ExternalLoader), runtime);
+				eloader = (ExternalLoader) Runtime.ProcessService.CreateExternalProcessObject (typeof(ExternalLoader), runtime.GetExecutionHandler ());
 				externalLoaders [runtime] = eloader;
 				values [counter++] = eloader;
 			} else {

--- a/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
@@ -382,8 +382,8 @@ namespace MonoDevelop.NUnit
 			var runnerExe = GetCustomConsoleRunnerCommand ();
 			if (runnerExe != null)
 				return RunWithConsoleRunner (runnerExe, test, suiteName, pathName, testName, testContext);
-
-			ExternalTestRunner runner = (ExternalTestRunner)Runtime.ProcessService.CreateExternalProcessObject (typeof(ExternalTestRunner), testContext.ExecutionContext, UserAssemblyPaths);
+			var console = IdeApp.Workbench?.ProgressMonitors.ConsoleFactory.CreateConsole ();
+			ExternalTestRunner runner = (ExternalTestRunner)Runtime.ProcessService.CreateExternalProcessObject (typeof(ExternalTestRunner), testContext.ExecutionContext, UserAssemblyPaths, console);
 			LocalTestMonitor localMonitor = new LocalTestMonitor (testContext, test, suiteName, testName != null);
 
 			ITestFilter filter = null;

--- a/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/NUnit/Services/NUnitAssemblyTestSuite.cs
@@ -471,8 +471,14 @@ namespace MonoDevelop.NUnit
 		UnitTestResult RunWithConsoleRunner (ProcessExecutionCommand cmd, UnitTest test, string suiteName, string pathName, string testName, TestContext testContext)
 		{
 			var outFile = Path.GetTempFileName ();
-			LocalConsole cons = new LocalConsole ();
-
+			var xmlOutputConsole = new LocalConsole ();
+			var appDebugOutputConsole = IdeApp.Workbench?.ProgressMonitors.ConsoleFactory.CreateConsole ();
+			OperationConsole cons;
+			if (appDebugOutputConsole != null) {
+				cons = new MultipleOperationConsoles (appDebugOutputConsole, xmlOutputConsole);
+			} else {
+				cons = xmlOutputConsole;
+			}
 			try {
 				MonoDevelop.NUnit.External.TcpTestListener tcpListener = null;
 				LocalTestMonitor localMonitor = new LocalTestMonitor (testContext, test, suiteName, testName != null);
@@ -517,9 +523,9 @@ namespace MonoDevelop.NUnit
 				if (doc.Root != null) {
 					var root = doc.Root.Elements ("test-suite").FirstOrDefault ();
 					if (root != null) {
-						cons.SetDone ();
-						var ot = cons.OutReader.ReadToEnd ();
-						var et = cons.ErrorReader.ReadToEnd ();
+						xmlOutputConsole.SetDone ();
+						var ot = xmlOutputConsole.OutReader.ReadToEnd ();
+						var et = xmlOutputConsole.ErrorReader.ReadToEnd ();
 						testContext.Monitor.WriteGlobalLog (ot);
 						if (!string.IsNullOrEmpty (et)) {
 							testContext.Monitor.WriteGlobalLog ("ERROR:\n");
@@ -535,9 +541,9 @@ namespace MonoDevelop.NUnit
 				}
 				throw new Exception ("Test results could not be parsed.");
 			} catch (Exception ex) {
-				cons.SetDone ();
-				var ot = cons.OutReader.ReadToEnd ();
-				var et = cons.ErrorReader.ReadToEnd ();
+				xmlOutputConsole.SetDone ();
+				var ot = xmlOutputConsole.OutReader.ReadToEnd ();
+				var et = xmlOutputConsole.ErrorReader.ReadToEnd ();
 				testContext.Monitor.WriteGlobalLog (ot);
 				if (!string.IsNullOrEmpty (et)) {
 					testContext.Monitor.WriteGlobalLog ("ERROR:\n");

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/MultipleOperationConsoles.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/MultipleOperationConsoles.cs
@@ -1,0 +1,480 @@
+﻿//
+// MultipleOperationConsoles.cs
+//
+// Author:
+//       David Karlaš <david.karlas@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace MonoDevelop.Core.Execution
+{
+	public class MultipleOperationConsoles : OperationConsole
+	{
+		readonly OperationConsole [] consoles;
+		readonly TextWriter OutWriter;
+		readonly TextWriter ErrorWriter;
+		readonly TextWriter LogWriter;
+
+		public MultipleOperationConsoles (params OperationConsole [] consoles)
+		{
+			if (consoles == null)
+				throw new ArgumentNullException (nameof (consoles));
+			if (consoles.Length == 0)
+				throw new ArgumentOutOfRangeException (nameof (consoles));
+
+			this.consoles = consoles;
+			this.ErrorWriter = new MultipleTextWriters (consoles.Select (c => c.Error).ToArray ());
+			this.OutWriter = new MultipleTextWriters (consoles.Select (c => c.Out).ToArray ());
+			this.LogWriter = new MultipleTextWriters (consoles.Select (c => c.Log).ToArray ());
+		}
+
+		public override void Debug (int level, string category, string message)
+		{
+			foreach (var console in consoles) {
+				console.Debug (level, category, message);
+			}
+		}
+
+		public override TextWriter Error {
+			get {
+				return ErrorWriter;
+			}
+		}
+
+		public override TextReader In {
+			get {
+				return consoles [0].In;
+			}
+		}
+
+		public override TextWriter Log {
+			get {
+				return LogWriter;
+			}
+		}
+
+		public override TextWriter Out {
+			get {
+				return OutWriter;
+			}
+		}
+
+		public override void Dispose ()
+		{
+			foreach (var console in consoles) {
+				console.Dispose ();
+			}
+		}
+
+		class MultipleTextWriters : TextWriter
+		{
+			readonly Encoding encoding;
+			readonly TextWriter [] writers;
+
+			public MultipleTextWriters (params TextWriter [] writers)
+			{
+				if (writers == null)
+					throw new ArgumentNullException (nameof (writers));
+				if (writers.Length == 0)
+					throw new ArgumentOutOfRangeException (nameof (writers));
+
+				this.writers = writers;
+				encoding = writers [0].Encoding;
+
+				foreach (var writer in writers) {
+					if (encoding.GetType () != writer.Encoding.GetType ()) {
+						throw new Exception ("Encodings mismatch between writers.");
+					}
+				}
+			}
+
+			public override Encoding Encoding {
+				get {
+					return encoding;
+				}
+			}
+
+			public override void Close ()
+			{
+				foreach (var writer in writers) {
+					writer.Close ();
+				}
+			}
+
+			protected override void Dispose (bool disposing)
+			{
+				foreach (var writer in writers) {
+					writer.Dispose ();
+				}
+				base.Dispose (disposing);
+			}
+
+			public override void Flush ()
+			{
+				foreach (var writer in writers) {
+					writer.Flush ();
+				}
+			}
+
+			public override Task FlushAsync ()
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.FlushAsync ());
+				}
+				return Task.WhenAll (tasks);
+			}
+
+			public override IFormatProvider FormatProvider {
+				get {
+					return writers [0].FormatProvider;
+				}
+			}
+
+			public override string NewLine {
+				get {
+					return writers [0].NewLine;
+				}
+				set {
+					foreach (var writer in writers) {
+						writer.NewLine = value;
+					}
+				}
+			}
+
+			public override void Write (bool value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (char value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (char [] buffer)
+			{
+				foreach (var writer in writers) {
+					writer.Write (buffer);
+				}
+			}
+
+			public override void Write (char [] buffer, int index, int count)
+			{
+				foreach (var writer in writers) {
+					writer.Write (buffer, index, count);
+				}
+			}
+
+			public override void Write (decimal value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (double value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (float value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (int value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (long value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (object value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (string format, object arg0)
+			{
+				foreach (var writer in writers) {
+					writer.Write (format, arg0);
+				}
+			}
+
+			public override void Write (string format, object arg0, object arg1)
+			{
+				foreach (var writer in writers) {
+					writer.Write (format, arg0, arg1);
+				}
+			}
+
+			public override void Write (string format, object arg0, object arg1, object arg2)
+			{
+				foreach (var writer in writers) {
+					writer.Write (format, arg0, arg1, arg2);
+				}
+			}
+
+			public override void Write (string format, params object [] arg)
+			{
+				foreach (var writer in writers) {
+					writer.Write (format, arg);
+				}
+			}
+
+			public override void Write (string value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (uint value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override void Write (ulong value)
+			{
+				foreach (var writer in writers) {
+					writer.Write (value);
+				}
+			}
+
+			public override Task WriteAsync (char value)
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteAsync (value));
+				}
+				return Task.WhenAll (tasks);
+			}
+
+			public override Task WriteAsync (char [] buffer, int index, int count)
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteAsync (buffer, index, count));
+				}
+				return Task.WhenAll (tasks);
+			}
+
+			public override Task WriteAsync (string value)
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteAsync (value));
+				}
+				return Task.WhenAll (tasks);
+			}
+
+
+			public override Task WriteLineAsync ()
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteLineAsync ());
+				}
+				return Task.WhenAll (tasks);
+			}
+
+			public override void WriteLine ()
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine ();
+				}
+			}
+
+			public override void WriteLine (bool value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (char value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (char [] buffer)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (buffer);
+				}
+			}
+
+			public override void WriteLine (char [] buffer, int index, int count)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (buffer, index, count);
+				}
+			}
+
+			public override void WriteLine (decimal value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (double value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (float value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (int value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (long value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (object value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (string format, object arg0)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (format, arg0);
+				}
+			}
+
+			public override void WriteLine (string format, object arg0, object arg1)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (format, arg0, arg1);
+				}
+			}
+
+			public override void WriteLine (string format, object arg0, object arg1, object arg2)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (format, arg0, arg1, arg2);
+				}
+			}
+
+			public override void WriteLine (string format, params object [] arg)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (format, arg);
+				}
+			}
+
+			public override void WriteLine (string value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (uint value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override void WriteLine (ulong value)
+			{
+				foreach (var writer in writers) {
+					writer.WriteLine (value);
+				}
+			}
+
+			public override Task WriteLineAsync (char [] buffer, int index, int count)
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteLineAsync (buffer, index, count));
+				}
+				return Task.WhenAll (tasks);
+			}
+
+			public override Task WriteLineAsync (char value)
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteLineAsync (value));
+				}
+				return Task.WhenAll (tasks);
+			}
+
+			public override Task WriteLineAsync (string value)
+			{
+				var tasks = new List<Task> (writers.Length);
+				foreach (var writer in writers) {
+					tasks.Add (writer.WriteLineAsync (value));
+				}
+				return Task.WhenAll (tasks);
+			}
+		}
+	}
+}
+

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessHostController.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessHostController.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Core.Execution
 			timer.Elapsed += new System.Timers.ElapsedEventHandler (WaitTimeout);
 		}
 
-		public void Start (IList<string> userAssemblyPaths = null)
+		public void Start (IList<string> userAssemblyPaths = null, OperationConsole console = null)
 		{
 			lock (this) {
 				if (starting)
@@ -129,7 +129,7 @@ namespace MonoDevelop.Core.Execution
 					if (userAssemblyPaths != null)
 						cmd.UserAssemblyPaths = userAssemblyPaths;
 					cmd.DebugMode = isDebugMode;
-					ProcessHostConsole cons = new ProcessHostConsole ();
+					OperationConsole cons = console ?? new ProcessHostConsole ();
 					var p = process = executionHandlerFactory.Execute (cmd, cons);
 					Counters.ExternalHostProcesses++;
 
@@ -182,12 +182,12 @@ namespace MonoDevelop.Core.Execution
 			}
 		}
 
-		public object CreateInstance (Type type, string[] addins, IList<string> userAssemblyPaths = null)
+		public object CreateInstance (Type type, string[] addins, IList<string> userAssemblyPaths = null, OperationConsole console = null)
 		{
 			lock (this) {
 				references++;
 				if (processHost == null)
-					Start (userAssemblyPaths);
+					Start (userAssemblyPaths, console);
 			}
 
 			if (!runningEvent.WaitOne (15000, false)) {
@@ -212,12 +212,12 @@ namespace MonoDevelop.Core.Execution
 			}
 		}
 		
-		public object CreateInstance (string assemblyPath, string typeName, string[] addins, IList<string> userAssemblyPaths = null)
+		public object CreateInstance (string assemblyPath, string typeName, string[] addins, IList<string> userAssemblyPaths = null, OperationConsole console = null)
 		{
 			lock (this) {
 				references++;
 				if (processHost == null)
-					Start (userAssemblyPaths);
+					Start (userAssemblyPaths, console);
 			}
 
 			if (!runningEvent.WaitOne (15000, false)) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs
@@ -305,44 +305,25 @@ namespace MonoDevelop.Core.Execution
 				return externalProcess;
 			}
 		}
-		
-		public IDisposable CreateExternalProcessObject (Type type)
-		{
-			return CreateExternalProcessObject (type, true);
-		}
-		
+
 		void CheckRemoteType (Type type)
 		{
 			if (!typeof(IDisposable).IsAssignableFrom (type))
 				throw new ArgumentException ("The remote object type must implement IDisposable", "type");
 		}
 		
-		public IDisposable CreateExternalProcessObject (Type type, bool shared, IList<string> userAssemblyPaths = null)
+		public IDisposable CreateExternalProcessObject (Type type, bool shared = true, IList<string> userAssemblyPaths = null, OperationConsole console = null)
 		{
 			CheckRemoteType (type);
-			ProcessHostController hc = GetHost (type.ToString(), shared, null);
-			return (IDisposable) hc.CreateInstance (type.Assembly.Location, type.FullName, GetRequiredAddins (type), userAssemblyPaths);
+			var hc = GetHost (type.ToString(), shared, null);
+			return (IDisposable) hc.CreateInstance (type.Assembly.Location, type.FullName, GetRequiredAddins (type), userAssemblyPaths, console);
 		}
 
-		public IDisposable CreateExternalProcessObject (Type type, TargetRuntime runtime)
-		{
-			return CreateExternalProcessObject (type, runtime.GetExecutionHandler ());
-		}
-
-		public IDisposable CreateExternalProcessObject (Type type, IExecutionHandler executionHandler, IList<string> userAssemblyPaths = null)
+		public IDisposable CreateExternalProcessObject (Type type, IExecutionHandler executionHandler, IList<string> userAssemblyPaths = null, OperationConsole console = null)
 		{
 			CheckRemoteType (type);
-			return (IDisposable)GetHost (type.ToString (), false, executionHandler).CreateInstance (type.Assembly.Location, type.FullName, GetRequiredAddins (type), userAssemblyPaths);
-		}
-		
-		public IDisposable CreateExternalProcessObject (string assemblyPath, string typeName, bool shared, params string[] requiredAddins)
-		{
-			return (IDisposable) GetHost (typeName, shared, null).CreateInstance (assemblyPath, typeName, requiredAddins);
-		}
-		
-		public IDisposable CreateExternalProcessObject (string assemblyPath, string typeName, IExecutionHandler executionHandler, params string[] requiredAddins)
-		{
-			return (IDisposable) GetHost (typeName, false, executionHandler).CreateInstance (assemblyPath, typeName, requiredAddins);
+			var hc = GetHost (type.ToString (), false, executionHandler);
+			return (IDisposable)hc.CreateInstance (type.Assembly.Location, type.FullName, GetRequiredAddins (type), userAssemblyPaths, console);
 		}
 		
 		public bool IsValidForRemoteHosting (IExecutionHandler handler)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Logging/AssertLoggingTraceListener.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Logging/AssertLoggingTraceListener.cs
@@ -32,28 +32,8 @@ using System.IO;
 
 namespace MonoDevelop.Core.Logging
 {
-	class AssertLoggingTraceListener : TraceListener
+	class AssertLoggingTraceListener : DefaultTraceListener
 	{
-		public override void Write (string message)
-		{
-			//ignore
-		}
-
-		public override void WriteLine (string message)
-		{
-			//ignore
-		}
-
-		public override void TraceData (TraceEventCache eventCache, string source, TraceEventType eventType, int id, params object[] data)
-		{
-			//ignore
-		}
-
-		public override void TraceData (TraceEventCache eventCache, string source, TraceEventType eventType, int id, object data)
-		{
-			//ignore
-		}
-
 		public override void Fail (string message, string detailMessage)
 		{
 			var frames = new StackTrace (1, true).GetFrames ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -557,6 +557,7 @@
     <Compile Include="MonoDevelop.Core\FileWriteableState.cs" />
     <Compile Include="MonoDevelop.Projects\ConditionedPropertyCollection.cs" />
     <Compile Include="MonoDevelop.Core\AsyncEventHandler.cs" />
+    <Compile Include="MonoDevelop.Core.Execution\MultipleOperationConsoles.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
Also reduced number of CreateExternalProcessObject overloads(removed unused)

Before this change it was impossible(afaik) to use tracepoints or Debug.WriteLine in unit tests...