### PR TITLE
[Ide] Allow other project types to be supported by the type system.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpProjectExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpProjectExtension.cs
@@ -64,6 +64,7 @@ namespace MonoDevelop.CSharp.Project
 		protected override void OnInitialize ()
 		{
 			base.OnInitialize ();
+			SupportsRoslyn = true;
 			StockIcon = "md-csharp-project";
 		}
 

--- a/main/src/addins/VBNetBinding/Project/VBProjectExtension.cs
+++ b/main/src/addins/VBNetBinding/Project/VBProjectExtension.cs
@@ -102,6 +102,7 @@ namespace MonoDevelop.VBNetBinding
 		{
 			base.OnInitialize ();
 			DefaultNamespaceIsImplicit = true;
+			SupportsRoslyn = true;
 			StockIcon = "md-project";
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -258,6 +258,8 @@ namespace MonoDevelop.Projects
 			get { return (flags & DotNetProjectFlags.GeneratesDebugInfoFile) != 0; }
 		}
 
+		public bool SupportsRoslyn { get; protected set; }
+
 		protected virtual DotNetProjectFlags OnGetDotNetProjectFlags ()
 		{
 			return DotNetProjectFlags.GeneratesDebugInfoFile;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2832,6 +2832,11 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		public virtual bool SupportsRoslyn ()
+		{
+			return string.Equals (TypeGuid, "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) || string.Equals (TypeGuid, "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", StringComparison.OrdinalIgnoreCase);
+		}
+
 		/// <summary>
 		/// Occurs when a file is removed from this project.
 		/// </summary>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2832,11 +2832,6 @@ namespace MonoDevelop.Projects
 			}
 		}
 
-		public virtual bool SupportsRoslyn ()
-		{
-			return string.Equals (TypeGuid, "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) || string.Equals (TypeGuid, "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", StringComparison.OrdinalIgnoreCase);
-		}
-
 		/// <summary>
 		/// Occurs when a file is removed from this project.
 		/// </summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -192,7 +192,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			foreach (var proj in mdProjects) {
 				if (token.IsCancellationRequested)
 					return null;
-				if (!proj.SupportsRoslyn ())
+				if (!proj.SupportsRoslyn)
 					continue;
 				var tp = LoadProject (proj, token).ContinueWith (t => {
 					if (!t.IsCanceled)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -180,11 +180,6 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		}
 
-		static bool SupportsRoslyn (MonoDevelop.Projects.Project proj)
-		{
-			return string.Equals (proj.TypeGuid, "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) || string.Equals (proj.TypeGuid, "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", StringComparison.OrdinalIgnoreCase);
-		}
-
 		SolutionData solutionData;
 		async Task<SolutionInfo> CreateSolutionInfo (MonoDevelop.Projects.Solution solution, CancellationToken token)
 		{
@@ -197,7 +192,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			foreach (var proj in mdProjects) {
 				if (token.IsCancellationRequested)
 					return null;
-				if (!SupportsRoslyn (proj))
+				if (!proj.SupportsRoslyn ())
 					continue;
 				var tp = LoadProject (proj, token).ContinueWith (t => {
 					if (!t.IsCanceled)


### PR DESCRIPTION
Currently only projects that have a type guid for C# or VB.NET are added to the type system. This is currently hard coded.

Now a project can indicate that it supports the type system. This allows other projects, such as DNX projects, which have a different type guid, to be supported by the type system and code completion will then work for C# files in these projects.

This is a rework of commit: a49d6220af5f369dcc243dde21c018b20755a846