### PR TITLE
[Ide] Removed 600ms delay from StartReparseThread + few code cleanups

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/TypeSystemProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/TypeSystemProvider.cs
@@ -43,15 +43,8 @@ namespace MonoDevelop.CSharp.Parser
 			var fileName = options.FileName;
 			var project = options.Project;
 			var result = new CSharpParsedDocument (fileName);
+			result.Flags |= ParsedDocumentFlags.NonSerializable;
 
-			if (project != null) {
-				
-				var projectFile = project.Files.GetFile (fileName);
-				if (projectFile != null && !TypeSystemParserNode.IsCompileBuildAction (projectFile.BuildAction))
-					result.Flags |= ParsedDocumentFlags.NonSerializable;
-			}
-
-			var compilerArguments = GetCompilerArguments (project);
 			SyntaxTree unit = null;
 
 			if (project != null) {
@@ -70,29 +63,23 @@ namespace MonoDevelop.CSharp.Parser
 						unit = model.SyntaxTree;
 						result.Ast = model;
 					} catch (AggregateException ae) {
-						ae.Flatten ().Handle (x => x is OperationCanceledException); 
+						ae.Flatten ().Handle (x => x is OperationCanceledException);
 						return result;
 					} catch (OperationCanceledException) {
 						return result;
 					} catch (Exception e) {
-						LoggingService.LogError ("Error while getting the semantic model for " + fileName, e); 
+						LoggingService.LogError ("Error while getting the semantic model for " + fileName, e);
 					}
 				}
 			}
-
-			if (unit == null) {
-				unit = CSharpSyntaxTree.ParseText (SourceText.From (options.Content.Text), compilerArguments, fileName);
-			} 
-
-			result.Unit = unit;
-
-			DateTime time;
 			try {
-				time = System.IO.File.GetLastWriteTimeUtc (fileName);
-			} catch (Exception) {
-				time = DateTime.UtcNow;
+				if (unit == null) {
+					var compilerArguments = GetCompilerArguments (project);
+					unit = CSharpSyntaxTree.ParseText (SourceText.From (options.Content.Text), compilerArguments, fileName, cancellationToken);
+				}
+			} catch (OperationCanceledException) {
 			}
-			result.LastWriteTimeUtc = time;
+			result.Unit = unit;
 			return result;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -68,8 +68,6 @@ namespace MonoDevelop.Ide.Gui
 		ParsedDocument parsedDocument;
 		Microsoft.CodeAnalysis.DocumentId analysisDocument;
 
-		const int ParseDelay = 600;
-
 		public IWorkbenchWindow Window {
 			get { return window; }
 		}
@@ -510,20 +508,10 @@ namespace MonoDevelop.Ide.Gui
 			base.OnSaved (e);
 		}
 
-		public void CancelParseTimeout ()
-		{
-			if (parseTimeout != 0) {
-				GLib.Source.Remove (parseTimeout);
-				parseTimeout = 0;
-			}
-		}
-		
 		bool isClosed;
 		void OnClosed (object s, EventArgs a)
 		{
 			isClosed = true;
-//			TypeSystemService.DomRegistered -= UpdateRegisteredDom;
-			CancelParseTimeout ();
 			ClearTasks ();
 			TypeSystemService.RemoveSkippedfile (FileName);
 
@@ -780,7 +768,6 @@ namespace MonoDevelop.Ide.Gui
 			return this.parsedDocument;
 		}
 			
-		uint parseTimeout = 0;
 		CancellationTokenSource analysisDocumentSrc = new CancellationTokenSource ();
 
 		void CancelEnsureAnalysisDocumentIsOpen ()
@@ -791,17 +778,23 @@ namespace MonoDevelop.Ide.Gui
 
 		Task EnsureAnalysisDocumentIsOpen ()
 		{
-			if (analysisDocument != null)
-				return SpecializedTasks.EmptyTask;
-			if (Editor == null) {
+			var editor = Editor;
+			if (editor == null) {
 				UnsubscibeAnalysisdocument ();
 				return SpecializedTasks.EmptyTask;
 			}
-			if (Project != null && Editor.MimeType == "text/x-csharp" && !IsUnreferencedSharedProject(Project)) {
-				RoslynWorkspace = TypeSystemService.GetWorkspace (this.Project.ParentSolution);
-				analysisDocument = TypeSystemService.GetDocumentId (this.Project, this.FileName);
+
+			if (analysisDocument != null)
+				return SpecializedTasks.EmptyTask;
+
+			if (editor.MimeType != "text/x-csharp")
+				return SpecializedTasks.EmptyTask;
+
+			if (Project != null && !IsUnreferencedSharedProject (Project)) {
+				RoslynWorkspace = TypeSystemService.GetWorkspace (Project.ParentSolution);
+				analysisDocument = TypeSystemService.GetDocumentId (Project, FileName);
 				if (analysisDocument != null) {
-					TypeSystemService.InformDocumentOpen (analysisDocument, Editor);
+					TypeSystemService.InformDocumentOpen (analysisDocument, editor);
 				}
 			} else {
 				CancelEnsureAnalysisDocumentIsOpen ();
@@ -810,35 +803,33 @@ namespace MonoDevelop.Ide.Gui
 					if (adhocProject != null) {
 						return SpecializedTasks.EmptyTask;
 					}
-					if (Editor != null && Editor.MimeType == "text/x-csharp") {
-						var newProject = Services.ProjectService.CreateDotNetProject ("C#");
-						this.adhocProject = newProject;
+					var newProject = Services.ProjectService.CreateDotNetProject ("C#");
+					this.adhocProject = newProject;
 
-						newProject.Name = "InvisibleProject";
-						newProject.References.Add (ProjectReference.CreateAssemblyReference ("mscorlib"));
-						newProject.References.Add (ProjectReference.CreateAssemblyReference ("System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"));
-						newProject.References.Add (ProjectReference.CreateAssemblyReference ("System.Core"));
+					newProject.Name = "InvisibleProject";
+					newProject.References.Add (ProjectReference.CreateAssemblyReference ("mscorlib"));
+					newProject.References.Add (ProjectReference.CreateAssemblyReference ("System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"));
+					newProject.References.Add (ProjectReference.CreateAssemblyReference ("System.Core"));
 
-						newProject.FileName = "test.csproj";
-						if (!Window.ViewContent.IsUntitled) {
-							adHocFile = Editor.FileName;
-						} else {
-							adHocFile = (Platform.IsWindows ? "C:\\" : "/") + Window.ViewContent.UntitledName + ".cs";
-						}
-
-						newProject.Files.Add (new ProjectFile (adHocFile, BuildAction.Compile));
-
-						adhocSolution = new Solution ();
-						adhocSolution.AddConfiguration ("", true);
-						adhocSolution.DefaultSolutionFolder.AddItem (newProject);
-						return TypeSystemService.Load (adhocSolution, new ProgressMonitor (), token).ContinueWith (task => {
-							if (token.IsCancellationRequested)
-								return;
-							RoslynWorkspace = task.Result.FirstOrDefault(); // 1 solution loaded ->1 workspace as result
-							analysisDocument = TypeSystemService.GetDocumentId (RoslynWorkspace, newProject, adHocFile);
-							TypeSystemService.InformDocumentOpen (RoslynWorkspace, analysisDocument, Editor);
-						});
+					newProject.FileName = "test.csproj";
+					if (!Window.ViewContent.IsUntitled) {
+						adHocFile = editor.FileName;
+					} else {
+						adHocFile = (Platform.IsWindows ? "C:\\" : "/") + Window.ViewContent.UntitledName + ".cs";
 					}
+
+					newProject.Files.Add (new ProjectFile (adHocFile, BuildAction.Compile));
+
+					adhocSolution = new Solution ();
+					adhocSolution.AddConfiguration ("", true);
+					adhocSolution.DefaultSolutionFolder.AddItem (newProject);
+					return TypeSystemService.Load (adhocSolution, new ProgressMonitor (), token).ContinueWith (task => {
+						if (token.IsCancellationRequested)
+							return;
+						RoslynWorkspace = task.Result.FirstOrDefault (); // 1 solution loaded ->1 workspace as result
+						analysisDocument = TypeSystemService.GetDocumentId (RoslynWorkspace, newProject, adHocFile);
+						TypeSystemService.InformDocumentOpen (RoslynWorkspace, analysisDocument, editor);
+					});
 				}
 			}
 			return SpecializedTasks.EmptyTask;
@@ -877,75 +868,64 @@ namespace MonoDevelop.Ide.Gui
 			string currentParseFile = adhocProject != null ? adHocFile : FileName;
 			if (string.IsNullOrEmpty (currentParseFile))
 				return;
-			CancelParseTimeout ();
 
-			parseTimeout = GLib.Timeout.Add (ParseDelay, delegate {
-				StartReparseThreadDelayed (currentParseFile);
-				parseTimeout = 0;
-				return false;
-			});
+			CancelOldParsing ();
+			var token = parseTokenSource.Token;
+			Task.Run (() => StartReparseThreadDelayed (currentParseFile, token), token);
 		}
 
-		async void StartReparseThreadDelayed (FilePath currentParseFile)
+		async Task StartReparseThreadDelayed (FilePath currentParseFile, CancellationToken token)
 		{
 			var editor = Editor;
 			if (editor == null)
 				return;
 
-			// Don't directly parse the document because doing it at every key press is
-			// very inefficient. Do it after a small delay instead, so several changes can
-			// be parsed at the same time.
 			await EnsureAnalysisDocumentIsOpen ();
 			var currentParseText = editor.CreateSnapshot ();
 			string mimeType = editor.MimeType;
-			CancelOldParsing ();
-			var token = parseTokenSource.Token;
 			var project = adhocProject ?? Project;
 			var projectFile = project?.GetProjectFile (currentParseFile);
 
-			ThreadPool.QueueUserWorkItem (delegate {
-				TypeSystemService.AddSkippedFile (currentParseFile);
-				var options = new ParseOptions {
-					Project = project,
-					Content = currentParseText,
-					FileName = currentParseFile,
-					OldParsedDocument = parsedDocument,
-					RoslynDocument = AnalysisDocument
-				};
-				if (projectFile != null)
-					options.BuildAction = projectFile.BuildAction;
-				
-				if (project != null && TypeSystemService.CanParseProjections (project, mimeType, currentParseFile)) {
-					TypeSystemService.ParseProjection (options, mimeType, token).ContinueWith (task => {
-						if (token.IsCancellationRequested)
-							return;
-						Application.Invoke (delegate {
-							// this may be called after the document has closed, in that case the OnDocumentParsed event shouldn't be invoked.
-							var taskResult = task.Result;
-							if (isClosed || taskResult == null || token.IsCancellationRequested)
-								return;
-							this.parsedDocument = taskResult.ParsedDocument;
-							var projections = taskResult.Projections;
-							foreach (var p2 in projections)
-								p2.CreateProjectedEditor (this);
-							Editor.SetOrUpdateProjections (this, projections, taskResult.DisabledProjectionFeatures);
-							OnDocumentParsed (EventArgs.Empty);
-						});
-					}, TaskContinuationOptions.OnlyOnRanToCompletion);
-				} else {
-					TypeSystemService.ParseFile (options, mimeType, token).ContinueWith (task => {
-						if (token.IsCancellationRequested)
-							return;
-						Application.Invoke (delegate {
-							// this may be called after the document has closed, in that case the OnDocumentParsed event shouldn't be invoked.
-							if (isClosed || task.Result == null || token.IsCancellationRequested)
-								return;
-							this.parsedDocument = task.Result;
-							OnDocumentParsed (EventArgs.Empty);
-						});
-					}, TaskContinuationOptions.OnlyOnRanToCompletion);
-				}
-			});
+			TypeSystemService.AddSkippedFile (currentParseFile);
+			var options = new ParseOptions {
+				Project = project,
+				Content = currentParseText,
+				FileName = currentParseFile,
+				OldParsedDocument = parsedDocument,
+				RoslynDocument = AnalysisDocument
+			};
+			if (projectFile != null)
+				options.BuildAction = projectFile.BuildAction;
+			if (token.IsCancellationRequested)
+				return;
+			
+			if (project != null && TypeSystemService.CanParseProjections (project, mimeType, currentParseFile)) {
+				var taskResult = await TypeSystemService.ParseProjection (options, mimeType, token);
+				if (taskResult == null || token.IsCancellationRequested)
+					return;
+				Application.Invoke (delegate {
+					// this may be called after the document has closed, in that case the OnDocumentParsed event shouldn't be invoked.
+					if (isClosed || token.IsCancellationRequested)
+						return;
+					this.parsedDocument = taskResult.ParsedDocument;
+					var projections = taskResult.Projections;
+					foreach (var p2 in projections)
+						p2.CreateProjectedEditor (this);
+					Editor.SetOrUpdateProjections (this, projections, taskResult.DisabledProjectionFeatures);
+					OnDocumentParsed (EventArgs.Empty);
+				});
+			} else {
+				var taskResult = await TypeSystemService.ParseFile (options, mimeType, token);
+				if (taskResult == null || token.IsCancellationRequested)
+					return;
+				Application.Invoke (delegate {
+					// this may be called after the document has closed, in that case the OnDocumentParsed event shouldn't be invoked.
+					if (isClosed || token.IsCancellationRequested)
+						return;
+					this.parsedDocument = taskResult;
+					OnDocumentParsed (EventArgs.Empty);
+				});
+			}
 		}
 		
 		/// <summary>


### PR DESCRIPTION
Reasoning here is this, user experience with 600ms delay is suffering mostly noticeable is SemanticHighlighting but also other stuff that is executed based on DocumentChanged with 600ms delay which is not ideal...
Second reasoning why this is acceptable is... It's parser job to cancel parsing based on CancellationToken and not abuse ThreadPool/CPU... If this change is problem... Parser should be reviewed to cancel faster...

@mkrueger Can you review this?
Changes in CSharpBinding/MonoDevelop.CSharp.Parser/TypeSystemProvider.cs:

* It's my understanding C# files are not Serialisable anymore, correct? Hence removed logic excluding them from `ParsedDocumentFlags.NotSerializable` based on IsCompileBuildAction... Instead making them `ParsedDocumentFlags.NotSerializable` always...
* I wrapped `CSharpSyntaxTree.ParseText` into try catch(cancelation) because I added cancellationToken...
* Generating `compilerArguments` only if needed
* I assume `result.LastWriteTimeUtc` was set for serialization reasons?(hence I removed logic)

Changes in Document.cs:

* At begining of `EnsureAnalysisDocumentIsOpen` I swapped
```
if (analysisDocument != null)
    return SpecializedTasks.EmptyTask;
```
and
```
if (editor == null) {
    UnsubscibeAnalysisdocument ();
    return SpecializedTasks.EmptyTask;
}
```
because otherwise UnsubscibeAnalysisdocument had no effect...

Rest of changes are just refactoring
