### PR TITLE
Bug 37958 - XS 6 Preview Toggle Line Comments no longer work in XAML/XML files

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -1690,7 +1690,7 @@ namespace MonoDevelop.Components.Commands
 				cmdTarget = null;
 			
 			if (cmdTarget == null || !visitedTargets.Add (cmdTarget)) {
-				if (delegatorStack.Count > 0) {
+				while (delegatorStack.Count > 0) {
 					var del = delegatorStack.Pop ();
 					if (del is ICommandDelegatorRouter)
 						cmdTarget = ((ICommandDelegatorRouter)del).GetNextCommandTarget ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -503,6 +503,11 @@ namespace MonoDevelop.Ide.Editor
 
 		#region ICommandRouter implementation
 
+		internal object GetTextEditorExtensionChain ()
+		{
+			return textEditor.TextEditorExtensionChain;
+		}
+
 		object ICommandRouter.GetNextCommandTarget ()
 		{
 			return textEditorImpl;


### PR DESCRIPTION
So problem was that I implemented xml comments via command on BaseXmlExtension class but that was considered after more generic implementation inside TextEditorViewContent, with this change extensions are considered before TextEditorViewContent allowing extension to implement more specific implementations then generic ones in TextEditorViewContent

After looking at this problem for some time and at CommandManager.cs...
IMHO, ideally instead of IMultiCastCommandRouter, IMultiCastCommandRouter, ICommandDelegator, ICommandDelegatorRouter, ICommandRouter.
We should just have:
```
interface IAfterCommandTarget
{
object GetAfterCommandTarget();
}
interface IAfterCommandTargets
{
IEnumerable GetAfterCommandTargets();
}
interface IBeforeCommandTarget
{
object GetBeforeCommandTarget();
}
interface IBeforeCommandTargets
{
IEnumerable GetBeforeCommandTargets();
}
```
CommandTarget vs CommandTargets is just for optimizations I guess... but could be merged just under CommandTargets...

This would allow TextEditorViewContent to specify what command targets should be considered before itself... Instead now I had to change SdiWorkspaceWindow to call extensions before TextEditorViewContent...

Maybe we could just change CommandManager.cs so Delegated command target are considered before current cmdTarget and delegated command targets would be BeforeCommandTargets and NextCommadTarget would be AfterComamndTarget in this my new interfaces... But I guess this is kinda late for XS 6.0 to do all this changes and it will be API breakage... So I guess XS 7.0 :(
