### PR TITLE
Moved ConfigurationChanged and UpdatePathText inside ActiveConfiguration.set

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -277,7 +277,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 								ActiveConfiguration = configurationModel.First (c => c.OriginalId == _configuration.OriginalId);
 								if (ConfigurationChanged != null)
 									ConfigurationChanged (o2, e2);
-								UpdatePathText (ConfigurationIdx, _configuration.DisplayString);
 							}) {
 								Enabled = true,
 								IndentationLevel = 1,

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -275,8 +275,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 							var _configuration = configuration;
 							menu.AddItem (new NSMenuItem (configuration.DisplayString, (o2, e2) => {
 								ActiveConfiguration = configurationModel.First (c => c.OriginalId == _configuration.OriginalId);
-								if (ConfigurationChanged != null)
-									ConfigurationChanged (o2, e2);
 							}) {
 								Enabled = true,
 								IndentationLevel = 1,
@@ -360,6 +358,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				set {
 					activeConfiguration = value;
 					state |= CellState.ConfigurationShown;
+					if (ConfigurationChanged != null)
+						ConfigurationChanged (this, EventArgs.Empty);
 					UpdatePathText (ConfigurationIdx, value.DisplayString);
 					OnSizeChanged ();
 				}


### PR DESCRIPTION
Not sure if this the right way to do things, but this is the only way in which UITest can actually set configurations.

Without this patch, only the UI is updated since the UITest was just setting `ActiveConfiguration` property, but this change was not propagated all along.

I used `ConfigurationChanged (this, EventArgs.Empty)` since I noticed that `(object o, EventArgs e)` were not being used anywhere