### PR TITLE
[IDE] Don't let pad label overlap icon

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
@@ -194,7 +194,7 @@ namespace MonoDevelop.Components.Docking
 				alignLabel.BottomPadding = 0;
 				alignLabel.RightPadding = 15;
 				alignLabel.Add (labelWidget);
-				box.PackStart (alignLabel, true, true, 0);
+				box.PackStart (alignLabel, false, false, 0);
 			} else {
 				labelWidget = null;
 			}


### PR DESCRIPTION
Stop the pad label overlapping the icon when there's not enough space allocated for the whole tab.

Returns to the pre-dark skin behaviour of cropping the label.

Fixes BXC#38011