### PR TITLE
[Components] Protect against NaN in the Dock layout file

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockGroup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockGroup.cs
@@ -454,7 +454,8 @@ namespace MonoDevelop.Components.Docking
 			for (int n=0; n<VisibleObjects.Count; n++) {
 				DockObject ob = VisibleObjects [n];
 
-				int ins = (int) Math.Truncate (ob.Size);
+				double obSize = double.IsNaN (ob.Size) ? 10.0 : ob.Size;
+				int ins = (int) Math.Truncate (obSize);
 				
 				if (n == VisibleObjects.Count - 1)
 					ins = realSize - ts;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
@@ -422,6 +422,9 @@ namespace MonoDevelop.Components.Docking
 			
 			rect.X += leftPadding;
 			rect.Width -= leftPadding + rightPadding;
+			if (rect.Width < 1) {
+				rect.Width = 1;
+			}
 
 			if (Child != null) {
 				var bottomPadding = active ? (int)TabActivePadding.Bottom : (int)TabPadding.Bottom;


### PR DESCRIPTION
The EditingLayout.xml in bug 32385 contains NaN for certain widths which caused 1 warning and 1 assertion.
Protect against both by checking for NaN before proceeding, and limiting widths to >= 1

Fixes BXC #32385