### PR TITLE
[IDE] Save layouts when they're changed

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
@@ -52,6 +52,7 @@ namespace MonoDevelop.Components.DockNotebook
 		static List<DockNotebook> allNotebooks = new List<DockNotebook> ();
 
 		public static event EventHandler ActiveNotebookChanged;
+		public static event EventHandler NotebookChanged;
 
 		enum TargetList {
 			UriList = 100
@@ -315,6 +316,8 @@ namespace MonoDevelop.Components.DockNotebook
 			if (PageAdded != null)
 				PageAdded (this, EventArgs.Empty);
 
+			NotebookChanged?.Invoke (this, EventArgs.Empty);
+
 			return tab;
 		}
 
@@ -349,6 +352,8 @@ namespace MonoDevelop.Components.DockNotebook
 
 			if (PageRemoved != null)
 				PageRemoved (this, EventArgs.Empty);
+
+			NotebookChanged?.Invoke (this, EventArgs.Empty);
 		}
 
 		internal void ReorderTab (DockNotebookTab tab, DockNotebookTab targetTab)
@@ -395,6 +400,7 @@ namespace MonoDevelop.Components.DockNotebook
 		protected override void OnDestroyed ()
 		{
 			allNotebooks.Remove (this);
+
 			if (ActiveNotebook == this)
 				ActiveNotebook = null;
 			if (fleurCursor != null) {
@@ -402,6 +408,15 @@ namespace MonoDevelop.Components.DockNotebook
 				fleurCursor = null;
 			}
 			base.OnDestroyed ();
+		}
+	}
+
+	class DockNotebookChangedArgs : EventArgs
+	{
+		public DockNotebook Notebook { get; private set; }
+		public DockNotebookChangedArgs (DockNotebook notebook)
+		{
+			Notebook = notebook;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -42,6 +42,8 @@ namespace MonoDevelop.Components.Docking
 {
 	class DockFrame: HBox, IAnimatable
 	{
+		public event EventHandler<EventArgs> LayoutChanged;
+
 		internal const double ItemDockCenterArea = 0.4;
 		internal const int GroupDockSeparatorSize = 40;
 		
@@ -667,6 +669,7 @@ namespace MonoDevelop.Components.Docking
 			while (reader.NodeType != XmlNodeType.EndElement) {
 				if (reader.NodeType == XmlNodeType.Element) {
 					DockLayout layout = DockLayout.Read (this, reader);
+					layout.AllocationChanged += LayoutAllocationChanged;
 					layouts.Add (layout.Name, layout);
 				}
 				else
@@ -675,6 +678,11 @@ namespace MonoDevelop.Components.Docking
 			}
 			reader.ReadEndElement ();
 			container.RelayoutWidgets ();
+		}
+
+		void LayoutAllocationChanged (object sender, EventArgs e)
+		{
+			LayoutChanged?.Invoke (this, EventArgs.Empty);
 		}
 
 		internal void UpdateTitle (DockItem item)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockGroup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockGroup.cs
@@ -140,11 +140,10 @@ namespace MonoDevelop.Components.Docking
 			gitem.ParentGroup = this;
 			return gitem;
 		}
-		
+
 		DockGroupItem Split (DockGroupType newType, bool addFirst, DockItem obj, int npos)
 		{
 			DockGroupItem item = new DockGroupItem (Frame, obj);
-			
 			if (npos == -1 || type == DockGroupType.Tabbed) {
 				if (ParentGroup != null && ParentGroup.Type == newType) {
 					// No need to split. Just add the new item as a sibling of this one.
@@ -189,7 +188,7 @@ namespace MonoDevelop.Components.Docking
 			}
 			return item;
 		}
-		
+
 		internal DockGroup FindGroupContaining (string id)
 		{
 			DockGroupItem it = FindDockGroupItem (id);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockObject.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockObject.cs
@@ -38,6 +38,8 @@ namespace MonoDevelop.Components.Docking
 {
 	internal abstract class DockObject
 	{
+		public event EventHandler<EventArgs> AllocationChanged;
+
 		DockGroup parentGroup;
 		DockFrame frame;
 		Gdk.Rectangle rect;
@@ -144,7 +146,7 @@ namespace MonoDevelop.Components.Docking
 				return rect;
 			}
 			set {
-				rect = value; 
+				rect = value;
 			}
 		}
 
@@ -154,6 +156,7 @@ namespace MonoDevelop.Components.Docking
 			}
 			set {
 				allocSize = value;
+				OnAllocationChanged ();
 			}
 		}
 		
@@ -281,6 +284,15 @@ namespace MonoDevelop.Components.Docking
 			if (!ParentGroup.IsNextToMargin (margin, visibleOnly))
 				return false;
 			return ParentGroup.IsChildNextToMargin (margin, this, visibleOnly);
+		}
+
+		protected void OnAllocationChanged ()
+		{
+			if (ParentGroup != null) {
+				ParentGroup.OnAllocationChanged ();
+			} else {
+				AllocationChanged?.Invoke (this, EventArgs.Empty);
+			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -101,6 +101,7 @@ namespace MonoDevelop.Ide.Gui
 #endif
 		
 		public event EventHandler ActiveWorkbenchWindowChanged;
+		public event EventHandler WorkbenchTabsChanged;
 		
 		public MonoDevelop.Ide.StatusBar StatusBar {
 			get {
@@ -218,8 +219,14 @@ namespace MonoDevelop.Ide.Gui
 			SetAppIcons ();
 
 			IdeApp.CommandService.SetRootWindow (this);
+			DockNotebook.NotebookChanged += NotebookPagesChanged;
 		}
-		
+
+		void NotebookPagesChanged (object sender, EventArgs e)
+		{
+			WorkbenchTabsChanged?.Invoke (this, EventArgs.Empty);
+		}
+
 		void SetAppIcons ()
 		{
 			//first try to get the icon from the GTK icon theme

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -91,6 +91,7 @@ namespace MonoDevelop.Ide.Gui
 				
 				((Gtk.Window)workbench).Visible = false;
 				workbench.ActiveWorkbenchWindowChanged += OnDocumentChanged;
+				workbench.WorkbenchTabsChanged += WorkbenchTabsChanged;
 				IdeApp.Workspace.StoringUserPreferences += OnStoringWorkspaceUserPreferences;
 				IdeApp.Workspace.LoadingUserPreferences += OnLoadingWorkspaceUserPreferences;
 				
@@ -1302,6 +1303,24 @@ namespace MonoDevelop.Ide.Gui
 				if (doc.ParsedDocument != null)
 					doc.ReparseDocument ();
 			}
+		}
+
+		System.Timers.Timer tabsChangedTimer = null;
+		void WorkbenchTabsChanged (object sender, EventArgs ev)
+		{
+			if (tabsChangedTimer != null) {
+				tabsChangedTimer.Stop ();
+				tabsChangedTimer.Dispose ();
+			}
+
+			tabsChangedTimer = new System.Timers.Timer (10000);
+			tabsChangedTimer.Elapsed += async (s, e) => {
+				await IdeApp.Workspace.SaveAsync ();
+				tabsChangedTimer.Stop ();
+				tabsChangedTimer.Dispose ();
+				tabsChangedTimer = null;
+			};
+			tabsChangedTimer.Start ();
 		}
 	}
 	


### PR DESCRIPTION
Save layouts after a short delay after they've been changed, rather than waiting until the workspace window is closed

Fixes BXC #25609
Fixes BXC #33009