### PR TITLE
[Mac] Use stub mdtool to run tests.

### DIFF
--- a/main/Makefile.include
+++ b/main/Makefile.include
@@ -12,4 +12,8 @@ MD_BIN_PATH=$(abs_top_builddir)/build/bin
 MD_LAUNCH_SETUP= \
 	MONODEVELOP_LOCALE_PATH="$(abs_top_builddir)/build/locale"
 
+if ENABLE_MACPLATFORM
+MDTOOL_RUN=$(MD_LAUNCH_SETUP) "$(MD_BIN_PATH)/mdtool"
+else
 MDTOOL_RUN=$(MD_LAUNCH_SETUP) exec -a "mdtool" $(RUNTIME)$(SGEN_SUFFIX) --debug "$(MD_BIN_PATH)/mdtool.exe"
+endif

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -31,6 +31,7 @@ monostub: monostub.m $(MONOSTUB_EXTRA_SOURCES)
 	gcc -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.m -framework AppKit
 #	gcc -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.m -framework AppKit -isysroot $(SDK_PATH)
 	cp monostub ../bin/MonoDevelop
+	cp monostub ../bin/mdtool
 
 monostub-test: monostub-test.m $(MONOSTUB_EXTRA_SOURCES)
 	gcc -g -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub-test.m -framework AppKit

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=dba061cf4f3a16f5384faabcf42d082c31503975
-DEP_BRANCH_AND_REMOTE[0]="master origin/master"
+DEP_NEEDED_VERSION[0]=0254d8cd02bc23e8124777fc6a31d3b4e6cd807d
+DEP_BRANCH_AND_REMOTE[0]="stub-mac-tests origin/stub-mac-tests"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
This fixes locating native subversion libs provided by apple in 64bit.