### PR TITLE
[NUnit] - allow the tests to run without being in debug mode

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
@@ -506,7 +506,12 @@ namespace MonoDevelop.UnitTesting.NUnit
 				// Note that we always dispose the tcp listener as we don't want it listening
 				// forever if the test runner does not try to connect to it
 				using (tcpListener) {
-					var p = testContext.ExecutionContext.ExecutionHandler.Execute (cmd, cons);
+					var handler = testContext.ExecutionContext.ExecutionHandler;
+
+					if (handler == null)
+						handler = Runtime.ProcessService.DefaultExecutionHandler;
+					
+					var p = handler.Execute (cmd, cons);
 					using (testContext.Monitor.CancellationToken.Register (p.Cancel))
 						p.Task.Wait ();
 


### PR DESCRIPTION
testContext.ExecutionContext.ExecutionHandler was null when not being ran under the debugger.