### PR TITLE
Bug 39075 - XS is now writing empty properties to my debug and release property groups in android projects

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
@@ -400,7 +400,7 @@ namespace MonoDevelop.Projects.MSBuild
 			// Remove properties that have been modified and have the default value. Usually such properties
 			// would be removed when assigning the value, but that won't happen if IgnoreDefaultValues=true
 			foreach (MSBuildProperty prop in GetProperties ()) {
-				if ((prop.Modified && prop.HasDefaultValue && !prop.EvaluatedValueModified) || (!prop.Modified && prop.IsNew))
+				if ((prop.Modified && prop.HasDefaultValue && !prop.EvaluatedValueModified) || (!prop.Modified && prop.IsNew) || (prop.IsNew && prop.HasDefaultValue))
 					RemoveProperty (prop.Name);
 				prop.Modified = false;
 			}


### PR DESCRIPTION
Based on debugging I came to conclusion to add this code which fixes that bug...
Since I don't have enough understanding in this part of XS I can't be certain I didn't introduce new bug, remove some feature or anything like that...
@slluis can you review this?