### PR TITLE
[Core] Do not show warning dialog for known unsupported projects.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -260,7 +260,8 @@ namespace MonoDevelop.Projects.MSBuild
 					loadAsProject = projectInfo.LoadFiles;
 					unsupportedMessage = projectInfo.GetInstructions ();
 					LoggingService.LogWarning (string.Format ("Could not load {0} project '{1}'. {2}", projectInfo.Name, relPath, projectInfo.GetInstructions ()));
-					monitor.ReportWarning (GettextCatalog.GetString ("Could not load {0} project '{1}'. {2}", projectInfo.Name, relPath, projectInfo.GetInstructions ()));
+					if (!loadAsProject)
+						monitor.ReportWarning (GettextCatalog.GetString ("Could not load {0} project '{1}'. {2}", projectInfo.Name, relPath, projectInfo.GetInstructions ()));
 				} else {
 					unsupportedMessage = GettextCatalog.GetString ("Unknown project type: {0}", unknownTypeGuid);
 					LoggingService.LogWarning (string.Format ("Could not load project '{0}' with unknown item type '{1}'", relPath, unknownTypeGuid));


### PR DESCRIPTION
Fixed bug #36960 - Adding/Opening unsupported project shows 'Could
not load...' warning pop up.
https://bugzilla.xamarin.com/show_bug.cgi?id=36960

Do not show a warning dialog when opening a solution containing
unsupported but known project types. A warning dialog is now only
shown for unknown project types or known unsupported project types
that cannot have their files loaded into the solution window.