### PR TITLE
[ide] Show missing GTK# installation error in native dialog on Windows.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -597,6 +597,26 @@ namespace MonoDevelop.Ide
 						"may not be properly installed in the GAC.",
 						BrandingService.ApplicationName
 					), ex);
+
+				if (Platform.IsWindows)
+				{
+					string url = "http://monodevelop.com/Download";
+					string caption = "Fatal Error";
+					string message =
+						"{0} failed to start. Some of the assemblies required to run {0} (for example GTK#) " +
+						"may not be properly installed in the GAC.\n\r\n\r" +
+						"Please click OK to open the download page, where " +
+						"you can download the necessary dependencies for {0} to run.";
+
+					if (DisplayWindowsOkCancelMessage(
+						string.Format(message, BrandingService.ApplicationName, url), caption)
+					)
+					{
+						Process.Start(url);
+					}
+				}
+
+
 			} finally {
 				Runtime.Shutdown ();
 			}


### PR DESCRIPTION
If GTK# is not installed on Windows and you start MonoDevelop, then you get only get an error in the log file and MonoDevelop does not start.

This change shows a native Windows dialog if MonoDevelop fails to start.