### PR TITLE
Fix files open race

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -46,6 +46,7 @@ using MonoDevelop.Components.AutoTest;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Ide.Templates;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide
 {
@@ -323,13 +324,15 @@ namespace MonoDevelop.Ide
 			//open the firsts sln/workspace file, and remove the others from the list
 		 	//FIXME: can we handle multiple slns?
 			bool foundSln = false;
+			Task<bool> openTaskOperation = null;
 			foreach (var file in files) {
 				if (Services.ProjectService.IsWorkspaceItemFile (file.FileName) ||
 				    Services.ProjectService.IsSolutionItemFile (file.FileName)) {
 					if (!foundSln) {
 						try {
-							Workspace.OpenWorkspaceItem (file.FileName);
+							var task = Workspace.OpenWorkspaceItem (file.FileName);
 							foundSln = true;
+							openTaskOperation = task;
 						} catch (Exception ex) {
 							MessageService.ShowError (GettextCatalog.GetString ("Could not load solution: {0}", file.FileName), ex);
 						}
@@ -338,7 +341,14 @@ namespace MonoDevelop.Ide
 					filteredFiles.Add (file);
 				}
 			}
-			
+
+			// Wait for solution and it's open files to load, so we are sure
+			// that the files we open afterwards are actually opened in tabs
+			// after the solution's saved open files and that the last file
+			// in the filteredFiles gets focus, if specified as an option.
+			if (filteredFiles.Count > 0 && openTaskOperation != null)
+				openTaskOperation.Wait ();
+
 			foreach (var file in filteredFiles) {
 				try {
 					Workbench.OpenDocument (file.FileName, null, file.Line, file.Column, file.Options);


### PR DESCRIPTION
Make sure solution is fully loaded before loading other files. Fixes race condition with file opening from launch arguments.
