### PR TITLE
[UnitTesting] Fix UITest failing to connect.

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -407,11 +407,13 @@ namespace MonoDevelop.UnitTesting
 			this.monitor = new TestMonitor (resultsPad, CancellationTokenSource);
 			this.resultsPad = resultsPad;
 			resultsPad.InitializeTestRun (test, cs);
+			Task = new Task ((Action)RunTests);
 		}
 		
 		public Task Start ()
 		{
-			return Task = Task.Run ((Action)RunTests);
+			Task.Start ();
+			return Task;
 		}
 
 		void RunTests ()


### PR DESCRIPTION
Fixed bug #39525 - UITests fail to run connect
https://bugzilla.xamarin.com/show_bug.cgi?id=39525

The UnitTestService fires an TestSessionStarting event just before the
test is started. The event args passed contains a TestSession. In
Xamarin Studio 5 there was a completed event on the TestSession that
could be used to indicate the test had finished. This completed event
has been replaced with a Task. At the time the TestSessionStarting
event is fired the Task is not yet started but the existing Task says
it is completed. Since the TestSession's Task is marked as completed
when the TestSessionStarting event is fired any action that uses the
Task will run straight away since the Task is already completed even
though the test has not been started yet.

To fix this the creation of the Task and the starting of it have been
separated. The TestSession's constructor creates a new unstarted Task
so it is available for any callers using the TestSessionStarting event.
After this event is fired the Task is started by the Start method,
which runs the tests.