### PR TITLE
Bug 39557 - [XS 6.0] "Could not load assembly Perhaps it doesn't exist in the Mono for Android profile?"

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -229,7 +229,7 @@ namespace MonoDevelop.Projects
 			else if (buildItem.Name == "ProjectReference")
 				ReadProjectReference (project, buildItem);
 
-			LocalCopy = buildItem.Metadata.GetValue ("Private", DefaultLocalCopy);
+			localCopy = buildItem.Metadata.GetValue<bool?> ("Private", null);
 			ReferenceOutputAssembly = buildItem.Metadata.GetValue ("ReferenceOutputAssembly", true);
 		}
 


### PR DESCRIPTION
When attempting to build immediately after restoring NuGet packages.

@slluis This makes sense, right?
Problem was that DefaultLocalCopy returned False, because File.Exists("..\Packages\NLua.Android\file.dll") returned false. Which resulted in localCopy field being set and even after NuGets were restored it didn't change to True... DefaultLocalCopy did change but localCopy was already set, hence not copying .dlls and bug... With this change we set localCopy only if it's actually written in .csproj file otherwise LocalCopy property returns DefaultLocalCopy...