### PR TITLE
Use the correct mono executable for the target architecture of the as…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/SoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/SoftDebuggerEngine.cs
@@ -92,7 +92,11 @@ namespace MonoDevelop.Debugger.Soft
 					ExternalConsoleFactory.Instance.CreateConsole (dsi.CloseExternalConsoleOnExit), varsCopy);
 				return new ProcessAdapter (oper, Path.GetFileName (info.FileName));
 			};
-			startArgs.MonoExecutableFileName = runtime.MonoRuntimeInfo.Force64or32bit.HasValue ? runtime.MonoRuntimeInfo.Force64or32bit.Value ? "mono64" : "mono32" : "mono";
+			if (runtime.MonoRuntimeInfo.Force64or32bit.HasValue)
+				startArgs.MonoExecutableFileName = runtime.MonoRuntimeInfo.Force64or32bit.Value ? "mono64" : "mono32";
+			else {
+				startArgs.MonoExecutableFileName = SystemAssemblyService.GetAssemblyArchitecture (cmd.Command) == AssemblyArchitecture.x86_64 ? "mono64" : "mono";
+			}
 			return dsi;
 		}
 		

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -449,6 +449,15 @@ namespace MonoDevelop.Core.Assemblies
 			}
 		}
 
+		public static AssemblyArchitecture GetAssemblyArchitecture (string path)
+		{
+			var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly (path);
+			if (asm.Modules.Any (m => m.Architecture == Mono.Cecil.TargetArchitecture.AMD64 || m.Architecture == Mono.Cecil.TargetArchitecture.IA64))
+				return AssemblyArchitecture.x86_64;
+			else
+				return AssemblyArchitecture.x86;
+		}
+
 		public class ManifestResource
 		{
 			public string Name {
@@ -487,5 +496,11 @@ namespace MonoDevelop.Core.Assemblies
 			}
 		}
 
+	}
+
+	public enum AssemblyArchitecture
+	{
+		x86,
+		x86_64
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/MonoPlatformExecutionHandler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/MonoPlatformExecutionHandler.cs
@@ -29,6 +29,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using MonoDevelop.Core.Assemblies;
+using System.IO;
 
 namespace MonoDevelop.Core.Execution
 {
@@ -50,9 +52,16 @@ namespace MonoDevelop.Core.Execution
 			DotNetExecutionCommand dotcmd = (DotNetExecutionCommand) command;
 			
 			string runtimeArgs = string.IsNullOrEmpty (dotcmd.RuntimeArguments) ? "--debug" : dotcmd.RuntimeArguments;
+
+			var monoRunner = monoPath;
+			if (System.IO.Path.GetFileName (monoPath) == "mono") {
+				// If the assembly was compiled as 64bit, use the 64bit runner
+				if (SystemAssemblyService.GetAssemblyArchitecture (dotcmd.Command) == AssemblyArchitecture.x86_64)
+					monoRunner = monoRunner += "64";
+			}
 			
 			string args = string.Format ("{2} \"{0}\" {1}", dotcmd.Command, dotcmd.Arguments, runtimeArgs);
-			NativeExecutionCommand cmd = new NativeExecutionCommand (monoPath, args, dotcmd.WorkingDirectory, dotcmd.EnvironmentVariables);
+			NativeExecutionCommand cmd = new NativeExecutionCommand (monoRunner, args, dotcmd.WorkingDirectory, dotcmd.EnvironmentVariables);
 			
 			return base.Execute (cmd, console);
 		}


### PR DESCRIPTION
…sembly being executed

Fixes bug #39313 - 32/64bit execution on Mac should use assembly flags