### PR TITLE
Bug 39709 - XS reformats empty tags in project files

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
@@ -106,7 +106,6 @@ namespace MonoDevelop.Projects.MSBuild
 					properties [cp.Name] = cp;
 					cp.ParentNode = PropertiesParent;
 					cp.Owner = this;
-					cp.ResetIndent (false);
 				} else
 					ChildNodes = ChildNodes.Add (node);
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildValueType.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildValueType.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (base.Equals (ob1, ob2))
 				return true;
 			if (ob1 == null || ob2 == null)
-				return false;
+				return string.IsNullOrEmpty (ob1) && string.IsNullOrEmpty (ob2);//Empty or null path is same thing
 			return ob1.TrimEnd ('\\') == ob2.TrimEnd ('\\');
 		}
 	}


### PR DESCRIPTION
@slluis can you review this?

PathValueType.Equals change is so https://github.com/mono/monodevelop/blob/cycle7/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProperty.cs#L370 doesn't happen, I think comment make sense...

CopyFrom method is called from https://github.com/mono/monodevelop/blob/cycle7/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/MultiConfigItemOptionsDialog.cs#L163 so every time dialog is opened and user pressed OK, reseting indent happened so white spaces were lost... Idea is... there is no harm in keeping indent... Afaik reseting indent was introduced in Roslyn lane: https://github.com/mono/monodevelop/commit/edbb3523daad196a740cec57549bd382e98398bc and modifed here: https://github.com/mono/monodevelop/commit/2554428f444ef9216f0aec9f5d552791e0932d2d#diff-f0ab5aae796ac27507a96d9b17c20b00L110

All unit tests pass