### PR TITLE
[NuGet] insert .props at top of project file

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeDotNetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeDotNetProject.cs
@@ -105,11 +105,9 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			return buildAction;
 		}
 
-		public List<ImportAndCondition> ImportsAdded = new List<ImportAndCondition> ();
-
 		public void AddImportIfMissing (string name, string condition)
 		{
-			ImportsAdded.Add (new ImportAndCondition (name, condition));
+			throw new ApplicationException ("Obsolete should not be called.");
 		}
 
 		public List<string> ImportsRemoved = new List <string> ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageNewImportsHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageNewImportsHandler.cs
@@ -1,10 +1,10 @@
 ﻿//
-// ImportAndCondition.cs
+// FakeNuGetPackageNewImportsHandler.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2014 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using NuGet;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
-	public class ImportAndCondition
+	public class FakeNuGetPackageNewImportsHandler : INuGetPackageNewImportsHandler
 	{
-		public ImportAndCondition (string name, string condition)
-			: this (name, condition, ProjectImportLocation.Bottom)
+		public bool IsDisposed;
+		public List<ImportAndCondition> ImportsAdded = new List<ImportAndCondition> ();
+
+		public void AddImportIfMissing (string name, string condition, ProjectImportLocation location)
 		{
+			ImportsAdded.Add (new ImportAndCondition (name, condition, location));
 		}
 
-		public ImportAndCondition (string name, string condition, ProjectImportLocation location)
+		public void Dispose ()
 		{
-			Name = name;
-			Condition = condition;
-			Location = location;
+			IsDisposed = true;
 		}
-
-		public string Name { get; set; }
-		public string Condition { get; set; }
-		public ProjectImportLocation Location { get; set; }
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableMonoDevelopProjectSystem.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableMonoDevelopProjectSystem.cs
@@ -47,6 +47,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public ReferenceAndProjectName ReferenceAndProjectNamePassedToLogAddedReferenceToProject;
 		public ReferenceAndProjectName ReferenceAndProjectNamePassedToLogRemovedReferenceFromProject;
 		public FileNameAndProjectName FileNameAndProjectNamePassedToLogAddedFileToProject;
+		public FakeNuGetPackageNewImportsHandler NewImportsHandler;
 
 		public static Action<Action> GuiSyncDispatcher = handler => handler.Invoke ();
 		public static Func<Func<Task>,Task> GuiSyncDispatcherFunc = handler => handler.Invoke();
@@ -118,6 +119,12 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		{
 			FileNameAndProjectNamePassedToLogAddedFileToProject =
 				new FileNameAndProjectName (fileName, projectName);
+		}
+
+		protected override INuGetPackageNewImportsHandler CreateNewImportsHandler ()
+		{
+			NewImportsHandler = new FakeNuGetPackageNewImportsHandler ();
+			return NewImportsHandler;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableCheckForUpdatesTaskRunner.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\MinClientVersionTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeLicenseAcceptanceService.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeNuGetPackageNewImportsHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/MonoDevelopProjectSystemTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/MonoDevelopProjectSystemTests.cs
@@ -87,26 +87,38 @@ namespace MonoDevelop.PackageManagement.Tests
 
 		void AssertLastMSBuildChildElementHasProjectAttributeValue (string expectedImport)
 		{
-			ImportAndCondition import = project.ImportsAdded.Last ();
+			ImportAndCondition import = projectSystem.NewImportsHandler.ImportsAdded.Last ();
 			Assert.AreEqual (expectedImport, import.Name);
 		}
 
 		void AssertLastImportHasCondition (string expectedCondition)
 		{
-			ImportAndCondition import = project.ImportsAdded.Last ();
+			ImportAndCondition import = projectSystem.NewImportsHandler.ImportsAdded.Last ();
 			Assert.AreEqual (expectedCondition, import.Condition);
+		}
+
+		void AssertLastImportHasImportLocation (ProjectImportLocation expectedLocation)
+		{
+			ImportAndCondition import = projectSystem.NewImportsHandler.ImportsAdded.Last ();
+			Assert.AreEqual (expectedLocation, import.Location);
 		}
 
 		void AssertFirstMSBuildChildElementHasProjectAttributeValue (string expectedImport)
 		{
-			ImportAndCondition import = project.ImportsAdded.First ();
+			ImportAndCondition import = projectSystem.NewImportsHandler.ImportsAdded.First ();
 			Assert.AreEqual (expectedImport, import.Name);
 		}
 
 		void AssertFirstImportHasCondition (string expectedCondition)
 		{
-			ImportAndCondition import = project.ImportsAdded.First ();
+			ImportAndCondition import = projectSystem.NewImportsHandler.ImportsAdded.First ();
 			Assert.AreEqual (expectedCondition, import.Condition);
+		}
+
+		void AssertFirstImportHasImportLocation (ProjectImportLocation expectedLocation)
+		{
+			ImportAndCondition import = projectSystem.NewImportsHandler.ImportsAdded.First ();
+			Assert.AreEqual (expectedLocation, import.Location);
 		}
 
 		void AssertImportRemoved (string expectedImportRemoved)
@@ -899,6 +911,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
 
 			AssertLastMSBuildChildElementHasProjectAttributeValue (@"..\packages\Foo.0.1\build\Foo.targets");
+			AssertLastImportHasImportLocation (ProjectImportLocation.Bottom);
 		}
 
 		[Test]
@@ -911,6 +924,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
 
 			AssertLastMSBuildChildElementHasProjectAttributeValue (@"packages\Foo.0.1\build\Foo.targets");
+			AssertLastImportHasImportLocation (ProjectImportLocation.Bottom);
 		}
 
 		[Test]
@@ -923,6 +937,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
 
 			AssertLastImportHasCondition ("Exists('..\\packages\\Foo.0.1\\build\\Foo.targets')");
+			AssertLastImportHasImportLocation (ProjectImportLocation.Bottom);
 		}
 
 		[Test]
@@ -931,11 +946,12 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreateTestProject (@"d:\projects\MyProject\MyProject\MyProject.csproj");
 			CreateProjectSystem (project);
 			string targetPath = @"d:\projects\MyProject\packages\Foo.0.1\build\Foo.targets".ToNativePath ();
-			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
 
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 
-			Assert.AreEqual (2, project.ImportsAdded.Count);
+			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 		}
 
 		[Test]
@@ -945,11 +961,12 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreateProjectSystem (project);
 			string targetPath1 = @"d:\projects\MyProject\packages\Foo.0.1\build\Foo.targets".ToNativePath ();
 			string targetPath2 = @"d:\projects\MyProject\packages\Foo.0.1\BUILD\FOO.TARGETS".ToNativePath ();
+
 			projectSystem.AddImport (targetPath1, ProjectImportLocation.Bottom);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 
 			projectSystem.AddImport (targetPath2, ProjectImportLocation.Bottom);
-
-			Assert.AreEqual (2, project.ImportsAdded.Count);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 		}
 
 		[Test]
@@ -988,7 +1005,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			projectSystem.RemoveImport (targetPath2);
 
-			Assert.AreEqual (1, project.ImportsAdded.Count);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 			Assert.AreEqual (2, project.ImportsRemoved.Count);
 		}
 
@@ -1013,6 +1030,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Top);
 
 			AssertFirstMSBuildChildElementHasProjectAttributeValue (@"..\packages\Foo.0.1\build\Foo.targets");
+			AssertFirstImportHasImportLocation (ProjectImportLocation.Top);
 		}
 
 		[Test]
@@ -1025,6 +1043,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Top);
 
 			AssertFirstImportHasCondition ("Exists('..\\packages\\Foo.0.1\\build\\Foo.targets')");
+			AssertFirstImportHasImportLocation (ProjectImportLocation.Top);
 		}
 
 		[Test]
@@ -1033,11 +1052,13 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreateTestProject (@"d:\projects\MyProject\MyProject\MyProject.csproj");
 			CreateProjectSystem (project);
 			string targetPath = @"d:\projects\MyProject\packages\Foo.0.1\build\Foo.targets".ToNativePath ();
+
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Top);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 
 			projectSystem.AddImport (targetPath, ProjectImportLocation.Top);
 
-			Assert.AreEqual (2, project.ImportsAdded.Count);
+			Assert.AreEqual (1, projectSystem.NewImportsHandler.ImportsAdded.Count);
 		}
 
 		[Test]
@@ -1217,6 +1238,18 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (fileName, referenceBeingRemoved.HintPath.ToString ());
 			Assert.IsFalse (projectIsSaved);
+		}
+
+		[Test]
+		public void AddImport_FullImportFilePathAndBottomOfProject_ImportHandlerIsDisposed ()
+		{
+			CreateTestProject (@"d:\projects\MyProject\MyProject\MyProject.csproj");
+			CreateProjectSystem (project);
+			string targetPath = @"d:\projects\MyProject\packages\Foo.0.1\build\Foo.targets".ToNativePath ();
+
+			projectSystem.AddImport (targetPath, ProjectImportLocation.Bottom);
+
+			Assert.IsTrue (projectSystem.NewImportsHandler.IsDisposed);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -377,6 +377,8 @@
     <Compile Include="MonoDevelop.PackageManagement\MonoDevelopProjectSystemFactory.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementBackgroundDispatcher.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementSolutionProjectService.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\NuGetPackageNewImportsHandler.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\INuGetPackageNewImportsHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/INuGetPackageNewImportsHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/INuGetPackageNewImportsHandler.cs
@@ -1,10 +1,10 @@
 ﻿//
-// ImportAndCondition.cs
+// INuGetPackageNewImportsHandler.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2014 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using NuGet;
 
-namespace MonoDevelop.PackageManagement.Tests.Helpers
+namespace MonoDevelop.PackageManagement
 {
-	public class ImportAndCondition
+	public interface INuGetPackageNewImportsHandler : IDisposable
 	{
-		public ImportAndCondition (string name, string condition)
-			: this (name, condition, ProjectImportLocation.Bottom)
-		{
-		}
-
-		public ImportAndCondition (string name, string condition, ProjectImportLocation location)
-		{
-			Name = name;
-			Condition = condition;
-			Location = location;
-		}
-
-		public string Name { get; set; }
-		public string Condition { get; set; }
-		public ProjectImportLocation Location { get; set; }
+		void AddImportIfMissing (string name, string condition, ProjectImportLocation location);
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopProjectSystem.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopProjectSystem.cs
@@ -407,9 +407,16 @@ namespace MonoDevelop.PackageManagement
 			GuiSyncDispatch (async () => {
 				string relativeTargetPath = GetRelativePath (targetPath);
 				string condition = GetCondition (relativeTargetPath);
-				project.AddImportIfMissing (relativeTargetPath, condition);
-				await project.SaveAsync ();
+				using (var handler = CreateNewImportsHandler ()) {
+					handler.AddImportIfMissing (relativeTargetPath, condition, location);
+					await project.SaveAsync ();
+				}
 			});
+		}
+
+		protected virtual INuGetPackageNewImportsHandler CreateNewImportsHandler ()
+		{
+			return new NuGetPackageNewImportsHandler ();
 		}
 
 		static string GetCondition (string targetPath)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageNewImportsHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageNewImportsHandler.cs
@@ -1,10 +1,10 @@
 ﻿//
-// ImportAndCondition.cs
+// NuGetPackageNewImportsHandler.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2014 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,42 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
+using MonoDevelop.Projects.MSBuild;
 using NuGet;
 
-namespace MonoDevelop.PackageManagement.Tests.Helpers
+namespace MonoDevelop.PackageManagement
 {
-	public class ImportAndCondition
+	public class NuGetPackageNewImportsHandler : INuGetPackageNewImportsHandler
 	{
-		public ImportAndCondition (string name, string condition)
-			: this (name, condition, ProjectImportLocation.Bottom)
+		string name;
+		string condition;
+		ProjectImportLocation location;
+
+		public NuGetPackageNewImportsHandler ()
 		{
+			PackageManagementMSBuildExtension.NewImportsHandler = this;
 		}
 
-		public ImportAndCondition (string name, string condition, ProjectImportLocation location)
+		public void Dispose ()
 		{
-			Name = name;
-			Condition = condition;
-			Location = location;
+			PackageManagementMSBuildExtension.NewImportsHandler = null;
 		}
 
-		public string Name { get; set; }
-		public string Condition { get; set; }
-		public ProjectImportLocation Location { get; set; }
+		public void AddImportIfMissing (string name, string condition, ProjectImportLocation location)
+		{
+			this.name = name;
+			this.condition = condition;
+			this.location = location;
+		}
+
+		public void UpdateProject (MSBuildProject project)
+		{
+			if (String.IsNullOrEmpty (name))
+				return;
+
+			project.AddImportIfMissing (name, location, condition);
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementMSBuildExtension.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementMSBuildExtension.cs
@@ -34,6 +34,7 @@ namespace MonoDevelop.PackageManagement
 	public class PackageManagementMSBuildExtension : ProjectExtension
 	{
 		public static EnsureNuGetPackageBuildImportsTargetUpdater Updater;
+		public static NuGetPackageNewImportsHandler NewImportsHandler;
 
 		protected override void OnWriteProject (ProgressMonitor monitor, MSBuildProject msproject)
 		{
@@ -46,6 +47,11 @@ namespace MonoDevelop.PackageManagement
 			EnsureNuGetPackageBuildImportsTargetUpdater currentUpdater = Updater;
 			if (currentUpdater != null) {
 				currentUpdater.UpdateProject (msproject);
+			}
+
+			NuGetPackageNewImportsHandler importsHandler = NewImportsHandler;
+			if (importsHandler != null) {
+				importsHandler.UpdateProject (msproject);
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
@@ -379,7 +379,8 @@ namespace MonoDevelop.Projects.MSBuild
 					parent.StartInnerWhitespace = project.TextFormat.NewLine;
 					parent.EndInnerWhitespace = parent.StartWhitespace;
 				}
-				StartWhitespace = parent.StartWhitespace + "  ";
+				object parentStartWhitespace = (parent != project) ? parent.StartWhitespace : "";
+				StartWhitespace = parentStartWhitespace + "  ";
 				if (closeInNewLine)
 					EndInnerWhitespace = StartWhitespace;
 			}

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -331,6 +331,39 @@ namespace MonoDevelop.Projects
 				new ValueSet (new [] { "cond1", "cond2" }, new [] { "val14_5", "val14_6" }),
 			}, Is.EquivalentTo (p.ConditionedProperties.GetCombinedPropertyValues ("cond1", "cond2").ToArray ()));
 		}
+
+		[Test]
+		public void StartWhitespaceForImportInsertedAsLastImport ()
+		{
+			string projectFile = Util.GetSampleProject ("ConsoleApp-VS2013", "ConsoleApplication.csproj");
+			var p = new MSBuildProject ();
+			p.Load (projectFile);
+			p.Evaluate ();
+
+			MSBuildImport import = p.AddNewImport ("MyImport.targets", beforeObject: null);
+
+			Assert.AreEqual (p.TextFormat.NewLine, p.StartWhitespace);
+			Assert.AreEqual ("  ", import.StartWhitespace);
+		}
+
+		/// <summary>
+		/// Inserting an import at the start as the first child was inserting an extra
+		/// new line between the Project start element and the Import element.
+		/// </summary>
+		[Test]
+		public void StartWhitespaceForImportInsertedAsFirstChild ()
+		{
+			string projectFile = Util.GetSampleProject ("ConsoleApp-VS2013", "ConsoleApplication.csproj");
+			var p = new MSBuildProject ();
+			p.Load (projectFile);
+			p.Evaluate ();
+			var firstChild = p.GetAllObjects ().First ();
+
+			MSBuildImport import = p.AddNewImport ("MyImport.targets", beforeObject: firstChild);
+
+			Assert.AreEqual (p.TextFormat.NewLine, p.StartWhitespace);
+			Assert.AreEqual ("  ", import.StartWhitespace);
+		}
 	}
 }
 


### PR DESCRIPTION
Adds support to insert an Import for .props in a NuGet package at the start of the project.

Added a fix for an extra newline being inserted when MSBuildProject's AddNewImport is called passing a beforeObject which is the first item in the project. This particular [commit](https://github.com/mono/monodevelop/commit/e834096c420d5c3938402f3333d0608932ee4123) could do with being reviewed.