### PR TITLE
[IDE] Disable minimize/maximise for dialogs on OS X

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -35,6 +35,11 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor.Highlighting;
 using System.Text.RegularExpressions;
 
+#if MAC
+using AppKit;
+using MonoDevelop.Components.Mac;
+#endif
+
 namespace MonoDevelop.Components
 {
 	public static class GtkWorkarounds
@@ -1278,6 +1283,42 @@ namespace MonoDevelop.Components
 		public static void SetTransparentBgHint (this Widget widget, bool enable)
 		{
 			SetData (widget, "transparent-bg-hint", enable);
+		}
+
+		static void OnMappedDisableButtons (object sender, EventArgs args)
+		{
+			var window = sender as Gtk.Window;
+
+			if (window == null) {
+				return;
+			}
+
+			DisableButtonsInternal (window);
+
+			window.Mapped -= OnMappedDisableButtons;
+		}
+
+		static void DisableButtonsInternal (Gtk.Window window)
+		{
+			// GtkQuartz appears to ignore any attempts to set the window's type hint or window functions to disable
+			// minimize/maximize buttons. This may be because on Cocoa these are set at window creation and can only
+			// be changed afterwards by directly accessing the window button and disabling it like so.
+			NSWindow nsWindow = GtkMacInterop.GetNSWindow (window);
+
+			nsWindow.StandardWindowButton (NSWindowButton.MiniaturizeButton).Enabled = false;
+			nsWindow.StandardWindowButton (NSWindowButton.ZoomButton).Enabled = false;
+		}
+
+		public static void DisableMinimizeMaximizeButtons (Gtk.Window window)
+		{
+#if MAC
+			if (window.IsMapped) {
+				DisableButtonsInternal (window);
+				return;
+			}
+
+			window.Mapped += OnMappedDisableButtons;
+#endif
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeDialog.cs
@@ -34,6 +34,7 @@ namespace MonoDevelop.Components
 		public IdeDialog ()
 		{
 			IdeTheme.ApplyTheme (this);
+			GtkWorkarounds.DisableMinimizeMaximizeButtons (this);
 		}
 
 		public IdeDialog (string title, Gtk.Window parentWindow, DialogFlags flags): base (title, parentWindow, flags)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
@@ -34,11 +34,6 @@ using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Ide.Gui.Components;
 using MonoDevelop.Components;
 
-#if MAC
-using AppKit;
-using MonoDevelop.Components.Mac;
-#endif
-
 namespace MonoDevelop.Ide.Gui.Dialogs
 {
 	
@@ -206,21 +201,6 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 
 			DefaultWidth = 960;
 			DefaultHeight = 680;
-		}
-
-		protected override void OnMapped ()
-		{
-			base.OnMapped ();
-
-#if MAC
-			// GtkQuartz appears to ignore any attempts to set the window's type hint or window functions to disable
-			// minimize/maximize buttons. This may be because on Cocoa these are set at window creation and can only
-			// be changed afterwards by directly accessing the window button and disabling it like so.
-			NSWindow nsWindow = GtkMacInterop.GetNSWindow (this);
-
-			nsWindow.StandardWindowButton (NSWindowButton.MiniaturizeButton).Enabled = false;
-			nsWindow.StandardWindowButton (NSWindowButton.ZoomButton).Enabled = false;
-#endif
 		}
 
 		void PixbufCellDataFunc (TreeViewColumn col, CellRenderer cell, TreeModel model, TreeIter iter)


### PR DESCRIPTION
Improved the method of disabling minimise/maximise for dialogs, and apply it to all IdeDialog derived classes