### PR TITLE
Treeview speedups

### DIFF
--- a/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.NodeBuilders/PackagingProjectNodeBuilder.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.NodeBuilders/PackagingProjectNodeBuilder.cs
@@ -65,9 +65,7 @@ namespace MonoDevelop.Deployment.NodeBuilders
 		public override void BuildChildNodes (ITreeBuilder builder, object dataObject)
 		{
 			PackagingProject project = dataObject as PackagingProject;
-				
-			foreach (Package p in project.Packages)
-				builder.AddChild (p);
+			builder.AddChildren (project.Packages);
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyNodeBuilder.cs
@@ -89,12 +89,8 @@ namespace MonoDevelop.AssemblyBrowser
 				var ns = namespaces [namespaceName];
 				ns.Types.Add (type);
 			}
-			
-			foreach (var ns in namespaces.Values) {
-				if (publicOnly && !ns.Types.Any (t => t.IsPublic))
-					continue;
-				treeBuilder.AddChild (ns);
-			}
+
+			treeBuilder.AddChildren (namespaces.Values.Where (ns => !publicOnly || ns.Types.Any (t => t.IsPublic)));
 		}
 		
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyReferenceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyReferenceFolderNodeBuilder.cs
@@ -72,10 +72,8 @@ namespace MonoDevelop.AssemblyBrowser
 					//	ctx.AddChild (new Error (MonoDevelop.Core.GettextCatalog.GetString ("Error while loading:") + assemblyNameReference.FullName + "/" + e.Message));
 				}
 			}
-			
-			foreach (ModuleReference moduleRef in referenceFolder.ModuleReferences) {
-				ctx.AddChild (moduleRef);
-			}
+
+			ctx.AddChildren (referenceFolder.ModuleReferences);
 		}
 		
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyResourceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyResourceFolderNodeBuilder.cs
@@ -54,9 +54,7 @@ namespace MonoDevelop.AssemblyBrowser
 		public override void BuildChildNodes (ITreeBuilder ctx, object dataObject)
 		{
 			var resourceFolder = (AssemblyResourceFolder)dataObject;
-			foreach (object resource in resourceFolder.Resources) {
-				ctx.AddChild (resource);
-			}
+			ctx.AddChildren (resourceFolder.Resources);
 		}
 		
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/BaseTypeFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/BaseTypeFolderNodeBuilder.cs
@@ -100,9 +100,7 @@ namespace MonoDevelop.AssemblyBrowser
 		public override void BuildChildNodes (ITreeBuilder builder, object dataObject)
 		{
 			var baseTypeFolder = (BaseTypeFolder)dataObject;
-			foreach (var type in baseTypeFolder.Type.BaseTypes) {
-				builder.AddChild (type);
-			}
+			builder.AddChildren (baseTypeFolder.Type.BaseTypes);
 		}
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)
 		{

--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.NodeBuilders/TranslationProjectNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.NodeBuilders/TranslationProjectNodeBuilder.cs
@@ -93,9 +93,8 @@ namespace MonoDevelop.Gettext.NodeBuilders
 			TranslationProject project = dataObject as TranslationProject;
 			if (project == null)
 				return;
-				
-			foreach (Translation translation in project.Translations)
-				builder.AddChild (translation);
+
+			builder.AddChildren (project.Translations);
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/WidgetNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/WidgetNodeBuilder.cs
@@ -81,9 +81,7 @@ namespace MonoDevelop.GtkCore.NodeBuilders
 		public override void BuildChildNodes (ITreeBuilder builder, object dataObject)
 		{
 			GuiBuilderWindow win = (GuiBuilderWindow) dataObject;
-			foreach (Stetic.ActionGroupInfo agroup in win.RootWidget.ActionGroups) {
-				builder.AddChild (agroup);
-			}
+			builder.AddChildren (win.RootWidget.ActionGroups);
 		}
 		
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/WindowsFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/WindowsFolderNodeBuilder.cs
@@ -75,10 +75,8 @@ namespace MonoDevelop.GtkCore.NodeBuilders
 			GtkDesignInfo info = GtkDesignInfo.FromProject (p);
 			if (!info.GuiBuilderProject.HasError) {
 				builder.AddChild (new StockIconsNode (p));
-				foreach (GuiBuilderWindow fi in info.GuiBuilderProject.Windows)
-					builder.AddChild (fi);
-				foreach (Stetic.ActionGroupInfo group in info.GuiBuilderProject.SteticProject.ActionGroups)
-					builder.AddChild (group);
+				builder.AddChildren (info.GuiBuilderProject.Windows);
+				builder.AddChildren (info.GuiBuilderProject.SteticProject.ActionGroups);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
@@ -107,9 +107,7 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 
 		public override void BuildChildNodes (ITreeBuilder treeBuilder, object dataObject)
 		{
-			foreach (PackageReferenceNode packageReference in GetPackageReferencesNodes (dataObject)) {
-				treeBuilder.AddChild (packageReference);
-			}
+			treeBuilder.AddChildren (GetPackageReferencesNodes (dataObject));
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectReferencesFromPackagesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectReferencesFromPackagesFolderNodeBuilder.cs
@@ -65,9 +65,7 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 
 		public override void BuildChildNodes (ITreeBuilder treeBuilder, object dataObject)
 		{
-			foreach (ProjectReference projectReference in GetReferencesFromPackages (dataObject)) {
-				treeBuilder.AddChild (projectReference);
-			}
+			treeBuilder.AddChildren (GetReferencesFromPackages (dataObject));
 		}
 
 		IEnumerable<ProjectReference> GetReferencesFromPackages (object dataObject)

--- a/main/src/addins/MonoDevelop.UnitTesting/Gui/TestNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Gui/TestNodeBuilder.cs
@@ -99,9 +99,8 @@ namespace MonoDevelop.UnitTesting
 			UnitTestGroup test = dataObject as UnitTestGroup;
 			if (test == null)
 				return;
-				
-			foreach (UnitTest t in test.Tests)
-				builder.AddChild (t);
+
+			builder.AddChildren (test.Tests);
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.NodeBuilders/WebReferenceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.NodeBuilders/WebReferenceFolderNodeBuilder.cs
@@ -65,11 +65,9 @@ namespace MonoDevelop.WebReferences.NodeBuilders
 		{
 			var folder = (WebReferenceFolder) dataObject;
 			if (folder.IsWCF)
-				foreach (WebReferenceItem item in WebReferencesService.GetWebReferenceItemsWCF (folder.Project))
-					treeBuilder.AddChild(item);
+				treeBuilder.AddChildren (WebReferencesService.GetWebReferenceItemsWCF (folder.Project));
 			else
-				foreach (WebReferenceItem item in WebReferencesService.GetWebReferenceItemsWS (folder.Project))
-					treeBuilder.AddChild(item);
+				treeBuilder.AddChildren (WebReferencesService.GetWebReferenceItemsWS (folder.Project));
 		}
 		
 		/// <summary>Compare two object with one another and returns a number based on their sort order.</summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassNodeBuilder.cs
@@ -94,36 +94,31 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 			if (classData.Class.TypeKind == TypeKind.Delegate)
 				return;
 
-			foreach (var innerClass in classData.Class.GetTypeMembers ())
-				if (innerClass.DeclaredAccessibility == Accessibility.Public
-					|| (innerClass.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly)
-					|| !publicOnly)
-					builder.AddChild (new ClassData (classData.Project, innerClass));
+			builder.AddChildren (classData.Class.GetTypeMembers ()
+								 .Where (innerClass => innerClass.DeclaredAccessibility == Accessibility.Public ||
+													   (innerClass.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly) ||
+													   !publicOnly)
+								 .Select (innerClass => new ClassData (classData.Project, innerClass)));
 
-			foreach (var method in classData.Class.GetMembers ().OfType<IMethodSymbol> ().Where (m => m.MethodKind != MethodKind.PropertyGet && m.MethodKind != MethodKind.PropertySet)) {
-				if (method.DeclaredAccessibility == Accessibility.Public
-					|| (method.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly)
-					|| !publicOnly)
-					builder.AddChild (method);
-			}
+			builder.AddChildren (classData.Class.GetMembers ().OfType<IMethodSymbol> ().Where (m => m.MethodKind != MethodKind.PropertyGet && m.MethodKind != MethodKind.PropertySet)
+								 .Where (method => method.DeclaredAccessibility == Accessibility.Public ||
+												   (method.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly) ||
+												   !publicOnly));
 
-			foreach (var property in classData.Class.GetMembers ().OfType<IPropertySymbol> ())
-				if (property.DeclaredAccessibility == Accessibility.Public
-					|| (property.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly)
-					|| !publicOnly)
-					builder.AddChild (property);
+			builder.AddChildren (classData.Class.GetMembers ().OfType<IPropertySymbol> ()
+								 .Where (property => property.DeclaredAccessibility == Accessibility.Public ||
+										 (property.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly) ||
+			                             !publicOnly));
 
-			foreach (var field in classData.Class.GetMembers ().OfType<IFieldSymbol> ())
-				if (field.DeclaredAccessibility == Accessibility.Public
-					|| (field.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly)
-					|| !publicOnly)
-					builder.AddChild (field);
+			builder.AddChildren (classData.Class.GetMembers ().OfType<IFieldSymbol> ()
+								 .Where (field => field.DeclaredAccessibility == Accessibility.Public ||
+										 (field.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly) ||
+										 !publicOnly));
 
-			foreach (var e in classData.Class.GetMembers ().OfType<IEventSymbol> ())
-				if (e.DeclaredAccessibility == Accessibility.Public
-					|| (e.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly)
-					|| !publicOnly)
-					builder.AddChild (e);
+			builder.AddChildren (classData.Class.GetMembers ().OfType<IEventSymbol> ()
+								 .Where (e => e.DeclaredAccessibility == Accessibility.Public ||
+										 (e.DeclaredAccessibility == Accessibility.Protected && publicProtectedOnly) ||
+										 !publicOnly));
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/CombineNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/CombineNodeBuilder.cs
@@ -62,8 +62,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		{
 			SolutionFolder combine = (SolutionFolder) dataObject;
 			if (builder.Options ["ShowProjects"]) {
-				foreach (SolutionFolderItem entry in combine.Items)
-					builder.AddChild (entry);
+				builder.AddChildren (combine.Items);
 			} else {
 				AddClasses (builder, combine);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/NamespaceData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/NamespaceData.cs
@@ -105,17 +105,15 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 
 		void AddProjectContent (ITreeBuilder builder, Project p)
 		{
-			foreach (var ns in namesp.GetNamespaceMembers ()) {
-				if (!builder.HasChild (ns.Name, typeof (NamespaceData)))
-					builder.AddChild (new ProjectNamespaceData (project, ns));
-			}
+			builder.AddChildren (namesp.GetNamespaceMembers ()
+								 .Where (ns => !builder.HasChild (ns.Name, typeof (NamespaceData)))
+								 .Select (ns => new ProjectNamespaceData (project, ns)));
 			//			bool nestedNs = builder.Options ["NestedNamespaces"];
 			bool publicOnly = builder.Options ["PublicApiOnly"];
 
-			foreach (var type in namesp.GetAllTypes ()) {
-				if (!publicOnly || type.DeclaredAccessibility == Accessibility.Public)
-					builder.AddChild (new ClassData (project, type));
-			}
+			builder.AddChildren (namesp.GetAllTypes ()
+								 .Where (type => !publicOnly || type.DeclaredAccessibility == Accessibility.Public)
+								 .Select (type => new ClassData (project, type)));
 		}
 
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ProjectNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ProjectNodeBuilder.cs
@@ -113,10 +113,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 					FillNamespaces (builder, project, ns);
 				}
 			}
-			foreach (var type in dom.Assembly.GlobalNamespace.GetTypeMembers ()) {
-				if (!publicOnly || type.DeclaredAccessibility == Microsoft.CodeAnalysis.Accessibility.Public)
-					builder.AddChild (new ClassData (project, type));
-			}
+			builder.AddChildren (dom.Assembly.GlobalNamespace.GetTypeMembers ()
+								 .Where (type => !publicOnly || type.DeclaredAccessibility == Accessibility.Public)
+								 .Select (type => new ClassData (project, type)));
 		}
 
 		public static void FillNamespaces (ITreeBuilder builder, Project project, INamespaceSymbol ns)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/SolutionNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/SolutionNodeBuilder.cs
@@ -98,8 +98,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		public override void BuildChildNodes (ITreeBuilder ctx, object dataObject)
 		{
 			Solution solution = (Solution) dataObject;
-			foreach (SolutionFolderItem entry in solution.RootFolder.Items)
-				ctx.AddChild (entry);
+			ctx.AddChildren (solution.RootFolder.Items);
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -71,12 +71,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			List<string> folders;
 
 			GetFolderContent (project, path, out files, out folders);
-			
-			foreach (ProjectFile file in files)
-				builder.AddChild (file);
-			
-			foreach (string folder in folders)
-				builder.AddChild (new ProjectFolder (folder, project, dataObject));
+
+			builder.AddChildren (files);
+			builder.AddChildren (folders.Select (f => new ProjectFolder (f, project, dataObject)));
 		}
 				
 		void GetFolderContent (Project project, string folder, out ProjectFileCollection files, out List<string> folders)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/PortableFrameworkSubsetNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/PortableFrameworkSubsetNodeBuilder.cs
@@ -29,6 +29,7 @@ using MonoDevelop.Core.Assemblies;
 using MonoDevelop.Projects;
 using MonoDevelop.Core;
 using Gdk;
+using System.Linq;
 
 namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 {
@@ -79,9 +80,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				treeBuilder.AddChild (new TreeViewItem (msg, Stock.Warning));
 			}
 
-			foreach (var asm in project.TargetRuntime.AssemblyContext.GetAssemblies (project.TargetFramework))
-				if (asm.Package.IsFrameworkPackage && asm.Name != "mscorlib")
-					treeBuilder.AddChild (new ImplicitFrameworkAssemblyReference (asm));
+			treeBuilder.AddChildren (project.TargetRuntime.AssemblyContext.GetAssemblies (project.TargetFramework)
+									 .Where (asm => asm.Package.IsFrameworkPackage && asm.Name != "mscorlib")
+									 .Select (asm => new ImplicitFrameworkAssemblyReference (asm)));
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
@@ -143,8 +143,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			base.BuildChildNodes (treeBuilder, dataObject);
 			ProjectFile file = (ProjectFile) dataObject;
 			if (file.HasChildren)
-				foreach (ProjectFile pf in file.DependentChildren)
-					treeBuilder.AddChild (pf);
+				treeBuilder.AddChildren (file.DependentChildren);
 		}
 	}
 	

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectReferenceFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectReferenceFolderNodeBuilder.cs
@@ -75,8 +75,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		public override void BuildChildNodes (ITreeBuilder ctx, object dataObject)
 		{
 			ProjectReferenceCollection refs = (ProjectReferenceCollection) dataObject;
-			foreach (ProjectReference pref in refs)
-				ctx.AddChild (pref);
+			ctx.AddChildren (refs);
 
 			// For portable libraries, add node that represents all framework assemblies
 			var project = (DotNetProject) ctx.GetParentDataItem (typeof(DotNetProject), false);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Projects;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Gui.Components;
+using System.Linq;
 
 namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 {
@@ -135,15 +136,14 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 					folderFiles = ((Solution)dataObject).RootFolder.Files;
 				else if (dataObject is SolutionFolder)
 					folderFiles = ((SolutionFolder)dataObject).Files;
-				
-				foreach (string file in Directory.GetFiles (path)) {
-					if ((project == null || project.Files.GetFile (file) == null) && (folderFiles == null || !folderFiles.Contains (file)))
-						builder.AddChild (new SystemFile (file, project));
-				}
-				
-				foreach (string folder in Directory.GetDirectories (path))
-					if (!builder.HasChild (Path.GetFileName (folder), typeof(ProjectFolder)))
-						builder.AddChild (new ProjectFolder (folder, project));
+
+				builder.AddChildren (Directory.EnumerateFiles (path)
+									 .Where (file => (project == null || project.Files.GetFile (file) == null) && (folderFiles == null || !folderFiles.Contains (file)))
+									 .Select (file => new SystemFile (file, project)));
+
+				builder.AddChildren (Directory.EnumerateDirectories (path)
+									 .Where (folder => !builder.HasChild (Path.GetFileName (folder), typeof (ProjectFolder)))
+									 .Select (folder => new ProjectFolder (folder, project)));
 			}
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderNodeBuilder.cs
@@ -27,6 +27,7 @@
 //
 
 using System;
+using System.Linq;
 
 using MonoDevelop.Projects;
 using MonoDevelop.Core;
@@ -68,10 +69,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		public override void BuildChildNodes (ITreeBuilder ctx, object dataObject)
 		{
 			SolutionFolder folder = (SolutionFolder) dataObject;
-			foreach (SolutionFolderItem entry in folder.Items)
-				ctx.AddChild (entry);
-			foreach (FilePath file in folder.Files)
-				ctx.AddChild (new SolutionFolderFileNode (file, folder));
+			ctx.AddChildren (folder.Items);
+			ctx.AddChildren (folder.Files.Select (file => new SolutionFolderFileNode (file, folder)));
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionNodeBuilder.cs
@@ -85,10 +85,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		public override void BuildChildNodes (ITreeBuilder ctx, object dataObject)
 		{
 			Solution solution = (Solution) dataObject;
-			foreach (SolutionFolderItem entry in solution.RootFolder.Items)
-				ctx.AddChild (entry);
-			foreach (FilePath file in solution.RootFolder.Files)
-				ctx.AddChild (new SolutionFolderFileNode (file, solution.RootFolder));
+			ctx.AddChildren (solution.RootFolder.Items);
+			ctx.AddChildren (solution.RootFolder.Files.Select (f => new SolutionFolderFileNode (f, solution.RootFolder)));
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/WorkspaceNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/WorkspaceNodeBuilder.cs
@@ -69,8 +69,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		public override void BuildChildNodes (ITreeBuilder ctx, object dataObject)
 		{
 			Workspace ws = (Workspace) dataObject;
-			foreach (WorkspaceItem entry in ws.Items)
-				ctx.AddChild (entry);
+			ctx.AddChildren (ws.Items);
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)


### PR DESCRIPTION
To be taken with a grain of salt for now. It's orthogonal with https://github.com/mono/gtk-sharp/commit/f4d4443e4eb4ee130bbf786bd1718fafab44a524 and https://github.com/mono/gtk-sharp/commit/decbc5ac25d389d474f06e57dbaa1e99ef96d26c, but combined they improve the situation a lot.

I have no idea if this causes a slowdown with the current gtk-sharp, but it shouldn't do so.

Those patches above brought down building the TreeBuilder of libgit2sharp with one open file from 2 seconds down to 1.2s. Combined with https://github.com/mono/monodevelop/commit/18bb88f6c827e470837f239cd695d6af9ec769c8, it  _further_ optimized it down to 300ms.

That said, I thought it would be a good idea to replace occurrences of AddChild with AddChildren, as AddChildren is guarded against multiple resorting. This should reduce a few cycles on sorting, after the above commits in gtk-sharp are merged.

Might be a good idea to look at tweaking that a bit more.