### PR TITLE
[Ide] Asynchronize OnTheFly formatting.

### DIFF
--- a/main/src/addins/AspNet/Html/DocTypeCompletionData.cs
+++ b/main/src/addins/AspNet/Html/DocTypeCompletionData.cs
@@ -27,6 +27,7 @@
 //
 
 using System;
+using System.Threading.Tasks;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.Ide.Editor.Extension;
@@ -62,7 +63,7 @@ namespace MonoDevelop.AspNet.Html
 			get { return name; }
 		}
 		
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var buf = window.CompletionWidget;
 			if (buf != null) {
@@ -78,6 +79,7 @@ namespace MonoDevelop.AspNet.Html
 				
 				buf.Replace (deleteStartOffset, buf.CaretOffset - deleteStartOffset, text);
 			}
+			return Task.FromResult (ka);
 		}
 	}
 }

--- a/main/src/addins/AspNet/Html/HtmlPathCompletion.cs
+++ b/main/src/addins/AspNet/Html/HtmlPathCompletion.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Core;
 using System.Text.RegularExpressions;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AspNet.Html
 {
@@ -117,13 +118,13 @@ namespace MonoDevelop.AspNet.Html
 				get { throw new InvalidOperationException (); }
 			}
 			
-			public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+			public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 			{
 				string text;
 				var dialog = new MonoDevelop.Ide.Projects.ProjectFileSelectorDialog (proj, "", pattern);
 				try {
 					if (MessageService.RunCustomDialog (dialog) != (int)Gtk.ResponseType.Ok || dialog.SelectedFile == null)
-						return;
+						return Task.FromResult (ka);
 					text = pathFunc (dialog.SelectedFile);
 				}
 				finally {
@@ -131,6 +132,7 @@ namespace MonoDevelop.AspNet.Html
 					dialog.Dispose ();
 				}
 				window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, "", text);
+				return Task.FromResult (ka);
 			}
 		}
 	}

--- a/main/src/addins/AspNet/Razor/RazorCSharpEditorExtension.cs
+++ b/main/src/addins/AspNet/Razor/RazorCSharpEditorExtension.cs
@@ -242,11 +242,11 @@ namespace MonoDevelop.AspNet.Razor
 		XObject prevNode;
 		bool updateNeeded;
 
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			Tracker.UpdateEngine ();
 			if (razorDocument == null)
-				return NonCSharpCompletion (descriptor);
+				return await NonCSharpCompletion (descriptor);
 
 			var n = Tracker.Engine.Nodes.Peek ();
 			if (prevNode is RazorExpression && !(n is RazorExpression))
@@ -263,20 +263,20 @@ namespace MonoDevelop.AspNet.Razor
 			// Rule out Razor comments, html, transition sign (@) and e-mail addresses
 			if (state is RazorCommentState || (previousChar != '@' && !(state is RazorState))  || descriptor.KeyChar == '@'
 				|| (previousChar == '@' && Char.IsLetterOrDigit (beforePrevious)))
-				return NonCSharpCompletion (descriptor);
+				return await NonCSharpCompletion (descriptor);
 
 			// Determine if we are inside generics
 			if (previousChar == '<') {
 				var codeState = state as RazorCodeFragmentState;
 				if (codeState == null || !codeState.IsInsideGenerics)
-					return NonCSharpCompletion (descriptor);
+					return await NonCSharpCompletion (descriptor);
 			}
 			// Determine whether we begin an html tag or generics
 			else if (descriptor.KeyChar == '<' && (n is XElement || !Char.IsLetterOrDigit (previousChar)))
-				return NonCSharpCompletion (descriptor);
+				return await NonCSharpCompletion (descriptor);
 			// Determine whether we are inside html text or in code
 			else if (previousChar != '@' && n is XElement && !(state is RazorSpeculativeState) && !(state is RazorExpressionState))
-				return NonCSharpCompletion (descriptor);
+				return await NonCSharpCompletion (descriptor);
 
 			// We're in C# context
 			InitializeCodeCompletion ();
@@ -284,7 +284,7 @@ namespace MonoDevelop.AspNet.Razor
 
 			bool result;
 			try {
-				result = base.KeyPress (descriptor);
+				result = await base.KeyPress (descriptor);
 				if (/*EnableParameterInsight &&*/ (descriptor.KeyChar == ',' || descriptor.KeyChar == ')') && CanRunParameterCompletionCommand ())
 				    base.RunParameterCompletionCommand ();
 			} finally {
@@ -310,7 +310,7 @@ namespace MonoDevelop.AspNet.Razor
 			CompletionWidget = defaultCompletionWidget;
 		}
 
-		bool NonCSharpCompletion (KeyDescriptor descriptor)
+		Task<bool> NonCSharpCompletion (KeyDescriptor descriptor)
 		{
 			isInCSharpContext = false;
 			return base.KeyPress (descriptor);

--- a/main/src/addins/AspNet/WebForms/SuggestedHandlerCompletionData.cs
+++ b/main/src/addins/AspNet/WebForms/SuggestedHandlerCompletionData.cs
@@ -35,6 +35,7 @@ using MonoDevelop.DesignerSupport;
 using System.Linq;
 using MonoDevelop.Ide.Editor.Extension;
 using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AspNet.WebForms
 {
@@ -75,14 +76,14 @@ namespace MonoDevelop.AspNet.WebForms
 			}
 		}
 		
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			//insert the method name
 			var buf = window.CompletionWidget;
 			if (buf != null) {
 				buf.Replace (window.CodeCompletionContext.TriggerOffset, buf.CaretOffset - window.CodeCompletionContext.TriggerOffset, methodInfo.Name);
 			}
-			
+
 			//generate the codebehind method
 
 			// TODO: Roslyn port.
@@ -90,6 +91,7 @@ namespace MonoDevelop.AspNet.WebForms
 //				BindingService.AddMemberToClass (project, codeBehindClass, codeBehindClassLocation, methodInfo, false);
 //			else
 //				BindingService.AddMemberToClass (project, codeBehindClass, codeBehindClass.Locations.First (), methodInfo, false);
+			return Task.FromResult (ka);
 		}
 	}
 }

--- a/main/src/addins/AspNet/WebForms/WebFormsEditorExtension.cs
+++ b/main/src/addins/AspNet/WebForms/WebFormsEditorExtension.cs
@@ -297,19 +297,19 @@ namespace MonoDevelop.AspNet.WebForms
 //			return documentBuilder.HandleCompletion (defaultEditor, defaultDocumentContext, completionContext, documentInfo, localDocumentInfo, completionChar, ref triggerWordLength);
 //		}
 
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			Tracker.UpdateEngine ();
 			bool isAspExprState = Tracker.Engine.CurrentState is WebFormsExpressionState;
 			if (documentBuilder == null || !isAspExprState)
-				return base.KeyPress (descriptor);
+				return await base.KeyPress (descriptor);
 			InitializeCodeCompletion ('\0');
 //			DocumentContext = localDocumentInfo.HiddenDocument;
 //			Editor = localDocumentInfo.HiddenDocument.Editor;
 //			CompletionWidget = documentBuilder.CreateCompletionWidget (localDocumentInfo.HiddenDocument.Editor, localDocumentInfo.HiddenDocument, localDocumentInfo);
 			bool result;
 			try {
-				result = base.KeyPress (descriptor);
+				result = await base.KeyPress (descriptor);
 				if (PropertyService.Get ("EnableParameterInsight", true) && (descriptor.KeyChar == ',' || descriptor.KeyChar == ')') && CanRunParameterCompletionCommand ()) {
 					RunParameterCompletionCommand ();
 				}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/AnonymousMethodCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/AnonymousMethodCompletionData.cs
@@ -26,6 +26,7 @@
 using System;
 using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.CSharp.Formatting;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharp.Completion
 {
@@ -49,14 +50,16 @@ namespace MonoDevelop.CSharp.Completion
 			return DisplayText.CompareTo(anonymousMethodCompletionData.DisplayText);
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, Ide.Editor.Extension.KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, Ide.Editor.Extension.KeyDescriptor descriptor)
 		{
-			base.InsertCompletionText (window, ref ka, descriptor);
+			ka = await base.InsertCompletionText (window, ka, descriptor);
+
 			factory.Ext.Editor.GetContent<CSharpTextEditorIndentation> ().DoReSmartIndent ();
 			if (this.CompletionText.Contains ("\n")) {
-				
+
 				factory.Ext.Editor.GetContent<CSharpTextEditorIndentation> ().DoReSmartIndent (factory.Ext.Editor.GetLine (factory.Ext.Editor.CaretLine).NextLine.Offset);
 			}
+			return ka;
 		}
 
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -278,9 +278,9 @@ namespace MonoDevelop.CSharp.Completion
 			HandleDocumentParsed (null, null);
 		}
 		
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
-			bool result = base.KeyPress (descriptor);
+			var result = await base.KeyPress (descriptor);
 			
 			if (/*EnableParameterInsight &&*/ (descriptor.KeyChar == ',' || descriptor.KeyChar == ')') && CanRunParameterCompletionCommand ())
 				base.RunParameterCompletionCommand ();

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CastCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CastCompletionData.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharp.Completion
 {
@@ -56,16 +57,18 @@ namespace MonoDevelop.CSharp.Completion
 			return "<span foreground=\"darkgray\">" + description + "</span>";
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var editor = factory.Ext.Editor;
 			var offset = window.CodeCompletionContext.TriggerOffset;
 			using (var undo = editor.OpenUndoGroup ()) {
-				base.InsertCompletionText (window, ref ka, descriptor);
+				ka = await base.InsertCompletionText (window, ka, descriptor);
+
 				var span = nodeToCast.Span;
 				var type = SafeMinimalDisplayString (targetType, semanticModel, nodeToCast.SpanStart, Ambience.LabelFormat);
 				editor.ReplaceText (span.Start, span.Length, "((" + type + ")" + nodeToCast + ")");
 			}
+			return ka;
 		}
 
 		public override bool IsOverload (CompletionData other)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CreateOverrideCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CreateOverrideCompletionData.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Ide.Editor.Extension;
 using MonoDevelop.CSharp.Refactoring;
 using MonoDevelop.CSharp.Formatting;
 using System;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharp.Completion
 {
@@ -93,7 +94,7 @@ namespace MonoDevelop.CSharp.Completion
 			this.GenerateBody = true;
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var editor = ext.Editor;
 			bool isExplicit = false;
@@ -142,7 +143,8 @@ namespace MonoDevelop.CSharp.Completion
 				editor.CaretOffset = targetCaretPosition;
 			}
 
-			OnTheFlyFormatter.Format (editor, ext.DocumentContext, declarationBegin, declarationBegin + sb.Length);
+			await OnTheFlyFormatter.Format (editor, ext.DocumentContext, declarationBegin, declarationBegin + sb.Length);
+			return ka;
 		}
 
 		public override bool IsOverload (CompletionData other)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CreatePartialCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CreatePartialCompletionData.cs
@@ -32,6 +32,7 @@ using MonoDevelop.CSharp.Refactoring;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Ide.Editor.Extension;
 using System;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharp.Completion
 {
@@ -89,7 +90,7 @@ namespace MonoDevelop.CSharp.Completion
 			this.GenerateBody = true;
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var editor = ext.Editor;
 			bool isExplicit = false;
@@ -131,8 +132,9 @@ namespace MonoDevelop.CSharp.Completion
 				editor.CaretOffset = targetCaretPosition;
 			}
 
-			OnTheFlyFormatter.Format (editor, ext.DocumentContext, declarationBegin, declarationBegin + sb.Length);
+			await OnTheFlyFormatter.Format (editor, ext.DocumentContext, declarationBegin, declarationBegin + sb.Length);
 			editor.CaretLine--;
+			return ka;
 		}
 
 		public override bool IsOverload (CompletionData other)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/EventCreationCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/EventCreationCompletionData.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.CSharp.Completion
 			this.Icon = "md-newmethod";
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			// insert add/remove event handler code after +=/-=
 			var editor = factory.Ext.Editor;
@@ -80,7 +80,7 @@ namespace MonoDevelop.CSharp.Completion
 
 
 			var document = IdeApp.Workbench.ActiveDocument;
-			var parsedDocument = document.UpdateParseDocument ().Result;
+			var parsedDocument = await document.UpdateParseDocument ();
 			var semanticModel = parsedDocument.GetAst<SemanticModel> ();
 
 			var declaringType = semanticModel.GetEnclosingSymbol<INamedTypeSymbol> (position, default(CancellationToken));
@@ -140,7 +140,7 @@ namespace MonoDevelop.CSharp.Completion
 			);
 
 			editor.StartInsertionMode (options);
-
+			return ka;
 		}
 
 		public override bool IsOverload (CompletionData other)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Components.PropertyGrid.PropertyEditors;
 using MonoDevelop.Ide.Editor;
 using System.Text;
 using ICSharpCode.NRefactory.MonoCSharp;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharp.Completion
 {
@@ -97,19 +98,19 @@ namespace MonoDevelop.CSharp.Completion
 
 		#region IActionCompletionData implementation
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
 		{
 			Initialize ();
 			var doc = completionExt.DocumentContext;
 
-			base.InsertCompletionText (window, ref ka, descriptor);
-
+			ka = await base.InsertCompletionText (window, ka, descriptor);
 			using (var undo = completionExt.Editor.OpenUndoGroup ()) {
 				if (!window.WasShiftPressed && generateUsing) {
-					AddGlobalNamespaceImport (completionExt.Editor, doc, type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+					AddGlobalNamespaceImport (completionExt.Editor, doc, type.ContainingNamespace.ToDisplayString (SymbolDisplayFormat.CSharpErrorMessageFormat));
 				}
 			}
 			ka |= KeyActions.Ignore;
+			return ka;
 		}
 
 		static void AddGlobalNamespaceImport (MonoDevelop.Ide.Editor.TextEditor editor, DocumentContext context, string nsName)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ProtocolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ProtocolCompletionData.cs
@@ -33,6 +33,7 @@ using Microsoft.CodeAnalysis;
 using MonoDevelop.CSharp.Refactoring;
 using System.Linq;
 using MonoDevelop.CSharp.Formatting;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharp.Completion
 {
@@ -130,7 +131,7 @@ namespace MonoDevelop.CSharp.Completion
 			this.GenerateBody = true;
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var editor = ext.Editor;
 			bool isExplicit = false;
@@ -179,7 +180,8 @@ namespace MonoDevelop.CSharp.Completion
 				editor.CaretOffset = targetCaretPosition;
 			}
 
-			OnTheFlyFormatter.Format (editor, ext.DocumentContext, declarationBegin, declarationBegin + sb.Length);
+			await OnTheFlyFormatter.Format (editor, ext.DocumentContext, declarationBegin, declarationBegin + sb.Length);
+			return ka;
 		}
 	}
 }

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynCodeCompletionFactory.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynCodeCompletionFactory.cs
@@ -194,7 +194,7 @@ namespace MonoDevelop.CSharp.Completion
 //				return sig.GetKeywordTooltip (title, null);
 //			}
 
-			public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
+			public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
 			{
 				var currentWord = GetCurrentWord (window, descriptor);
 				var text = CompletionText;
@@ -204,6 +204,7 @@ namespace MonoDevelop.CSharp.Completion
 					text = text.Substring (1);
 				
 				window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, currentWord, text);
+				return Task.FromResult (ka);
 			}
 		}
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
@@ -175,7 +175,7 @@ namespace MonoDevelop.CSharp.Completion
 			});
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
+		public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, MonoDevelop.Ide.Editor.Extension.KeyDescriptor descriptor)
 		{
 			string partialWord = GetCurrentWord (window, descriptor);
 			int skipChars = 0;
@@ -311,6 +311,7 @@ namespace MonoDevelop.CSharp.Completion
 					ext.RunCompletionCommand ();
 				});
 			}
+			return Task.FromResult (ka);
 		}
 
 		static bool IsBracketAlreadyInserted (CSharpCompletionTextEditorExtension ext, IMethodSymbol method)

--- a/main/src/addins/CSharpBinding/MonoDevelop.JSon/JSonTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.JSon/JSonTextEditorExtension.cs
@@ -30,6 +30,7 @@ using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.Ide.Editor.Extension;
 using ICSharpCode.NRefactory6.CSharp;
 using MonoDevelop.Ide.Editor;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.JSon
 {
@@ -46,9 +47,9 @@ namespace MonoDevelop.JSon
 			stateTracker = new CacheIndentEngine (indentEngine);
 			Editor.SetIndentationTracker (new JSonIndentationTracker (Editor, stateTracker));
 		}
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
-			var result = base.KeyPress (descriptor);
+			var result = await base.KeyPress (descriptor);
 
 			if (descriptor.SpecialKey == SpecialKey.Return) {
 				if (Editor.Options.IndentStyle == MonoDevelop.Ide.Editor.IndentStyle.Virtual) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerConsoleView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerConsoleView.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Ide;
 using MonoDevelop.Components;
 using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Debugger
 {
@@ -268,18 +269,18 @@ namespace MonoDevelop.Debugger
 			Buffer.MoveMark (tokenBeginMark, iter);
 		}
 
-		void OnEditKeyRelease (object sender, Gtk.KeyReleaseEventArgs args)
+		async void OnEditKeyRelease (object sender, Gtk.KeyReleaseEventArgs args)
 		{
 			UpdateTokenBeginMarker ();
 
 			if (keyHandled)
 				return;
 
-			CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
+			await CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
 			PopupCompletion ();
 		}
 
-		protected override bool ProcessKeyPressEvent (Gtk.KeyPressEventArgs args)
+		protected override async Task<bool> ProcessKeyPressEvent (Gtk.KeyPressEventArgs args)
 		{
 			keyHandled = false;
 
@@ -293,11 +294,11 @@ namespace MonoDevelop.Debugger
 			}
 
 			if (currentCompletionData != null) {
-				if ((keyHandled = CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier))))
+				if ((keyHandled = await CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier))))
 					return true;
 			}
 
-			return base.ProcessKeyPressEvent (args);
+			return await base.ProcessKeyPressEvent (args);
 		}
 
 		protected override void UpdateInputLineBegin ()

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -40,6 +40,7 @@ using MonoDevelop.Ide.TextEditing;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.Editor.Extension;
 using MonoDevelop.Ide.Fonts;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Debugger
 {
@@ -771,14 +772,14 @@ namespace MonoDevelop.Debugger
 
 	class ExceptionCaughtTextEditorExtension: TextEditorExtension
 	{
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			if (descriptor.SpecialKey == SpecialKey.Escape && DebuggingService.ExceptionCaughtMessage != null &&
 			    !DebuggingService.ExceptionCaughtMessage.IsMinimized &&
 				DebuggingService.ExceptionCaughtMessage.File.CanonicalPath == new FilePath(DocumentContext.Name).CanonicalPath) {
 
 				DebuggingService.ExceptionCaughtMessage.ShowMiniButton ();
-				return true;
+				return Task.FromResult (true);
 			}
 
 			return base.KeyPress (descriptor);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExpressionEvaluatorDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExpressionEvaluatorDialog.cs
@@ -108,17 +108,17 @@ namespace MonoDevelop.Debugger
 			}
 		}
 
-		void OnEditKeyRelease (object sender, EventArgs e)
+		async void OnEditKeyRelease (object sender, EventArgs e)
 		{
 			if (keyHandled)
 				return;
 
-			CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
+			await CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
 			PopupCompletion ((Entry) sender);
 		}
 
 		[GLib.ConnectBeforeAttribute]
-		void OnEditKeyPress (object sender, KeyPressEventArgs args)
+		async void OnEditKeyPress (object sender, KeyPressEventArgs args)
 		{
 			keyHandled = false;
 
@@ -132,7 +132,7 @@ namespace MonoDevelop.Debugger
 			}
 
 			if (currentCompletionData != null)
-				args.RetVal = keyHandled = CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
+				args.RetVal = keyHandled = await CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
 		}
 
 		void OnEditFocusOut (object sender, FocusOutEventArgs args)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1515,10 +1515,10 @@ namespace MonoDevelop.Debugger
 				EndEditing (this, EventArgs.Empty);
 		}
 
-		void OnEditKeyRelease (object sender, EventArgs e)
+		async void OnEditKeyRelease (object sender, EventArgs e)
 		{
 			if (!wasHandled) {
-				CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifierState));
+				await CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifierState));
 				PopupCompletion ((Entry) sender);
 			}
 		}
@@ -1531,7 +1531,7 @@ namespace MonoDevelop.Debugger
 		uint keyValue;
 
 		[GLib.ConnectBeforeAttribute]
-		void OnEditKeyPress (object s, KeyPressEventArgs args)
+		async void OnEditKeyPress (object s, KeyPressEventArgs args)
 		{
 			wasHandled = false;
 			key = args.Event.Key;
@@ -1540,7 +1540,7 @@ namespace MonoDevelop.Debugger
 			keyValue = args.Event.KeyValue;
 
 			if (currentCompletionData != null) {
-				wasHandled  = CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifierState));
+				wasHandled  = await CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifierState));
 				args.RetVal = wasHandled;
 			}
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/TextEntryWithCodeCompletion.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/TextEntryWithCodeCompletion.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.Debugger
 		}
 
 		[GLib.ConnectBeforeAttribute]
-		void HandleKeyPressEvent (object o, Gtk.KeyPressEventArgs args)
+		async void HandleKeyPressEvent (object o, Gtk.KeyPressEventArgs args)
 		{
 			keyHandled = false;
 
@@ -80,17 +80,17 @@ namespace MonoDevelop.Debugger
 			}
 
 			if (list != null)
-				args.RetVal = keyHandled = CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
+				args.RetVal = keyHandled = await CompletionWindowManager.PreProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
 		}
 
-		void HandleKeyReleaseEvent (object o, Gtk.KeyReleaseEventArgs args)
+		async void HandleKeyReleaseEvent (object o, Gtk.KeyReleaseEventArgs args)
 		{
 			if (keyHandled)
 				return;
 
 			string text = ctx == null ? Text : Text.Substring (Math.Max (0, Math.Min (ctx.TriggerOffset, Text.Length)));
 			CompletionWindowManager.UpdateWordSelection (text);
-			CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
+			await CompletionWindowManager.PostProcessKeyEvent (KeyDescriptor.FromGtk (key, keyChar, modifier));
 			PopupCompletion ();
 		}
 

--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/DocFoodTextEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood/DocFoodTextEditorExtension.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -48,7 +49,7 @@ namespace MonoDevelop.DocFood
 			return doc.Substring (trimStart).TrimEnd ('\n', '\r');
 		}
 
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			if (descriptor.KeyChar != '/')
 				return base.KeyPress (descriptor);
@@ -103,7 +104,7 @@ namespace MonoDevelop.DocFood
 				if (SelectSummary (offset, insertedLength, documentation) == false)
 					Editor.CaretOffset = offset + insertedLength;
 			}
-			return false;
+			return Task.FromResult (false);
 		}
 
 		/// <summary>

--- a/main/src/addins/Xml/Completion/XmlCompletionData.cs
+++ b/main/src/addins/Xml/Completion/XmlCompletionData.cs
@@ -36,6 +36,7 @@ using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Xml.Editor;
 using MonoDevelop.Ide.Editor.Extension;
 using MonoDevelop.Ide.Editor;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Xml.Completion
 {
@@ -109,13 +110,13 @@ namespace MonoDevelop.Xml.Completion
 			}
 		}
 
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override async Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			if (XmlEditorOptions.AutoInsertFragments && dataType == DataType.XmlAttribute) {
 				//This temporary variable is needed because
 				//base.InsertCompletionText sets window.CompletionWidget to null
 				var completionWidget = window.CompletionWidget;
-				base.InsertCompletionText (window, ref ka, descriptor);
+				ka = await base.InsertCompletionText (window, ka, descriptor);
 				if (completionWidget is ITextEditorImpl) {
 					((ITextEditorImpl)completionWidget).EditorExtension.Editor.StartSession (new SkipCharSession ('"'));
 				}
@@ -124,8 +125,9 @@ namespace MonoDevelop.Xml.Completion
 				//otherwise code calling InsertCompletionText will close completion window created by this command
 				Application.Invoke ((s,e) => IdeApp.CommandService.DispatchCommand (TextEditorCommands.ShowCompletionWindow));
 				ka &= ~KeyActions.CloseWindow;
+				return ka;
 			} else {
-				base.InsertCompletionText (window, ref ka, descriptor);
+				return await base.InsertCompletionText (window, ka, descriptor);
 			}
 		}
 		

--- a/main/src/addins/Xml/Completion/XmlTagCompletionData.cs
+++ b/main/src/addins/Xml/Completion/XmlTagCompletionData.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Xml.Completion
 {
@@ -67,7 +68,7 @@ namespace MonoDevelop.Xml.Completion
 			get { return element; }
 		}
 		
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var buf = window.CompletionWidget;
 			if (buf != null) {
@@ -79,6 +80,7 @@ namespace MonoDevelop.Xml.Completion
 				// Move caret into the middle of the tags
 				buf.CaretOffset = codeCompletionContext.TriggerOffset + cursorOffset;
 			}
+			return Task.FromResult (ka);
 		}
 	}
 }

--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -234,11 +234,11 @@ namespace MonoDevelop.Xml.Editor
 		{
 		}
 		
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			if (Editor.Options.IndentStyle == IndentStyle.Smart) {
 				var newLine = Editor.CaretLine + 1;
-				var ret = base.KeyPress (descriptor);
+				var ret = await base.KeyPress (descriptor);
 				if (descriptor.SpecialKey == SpecialKey.Return && Editor.CaretLine == newLine) {
 					string indent = GetLineIndent (newLine);
 					var oldIndent = Editor.GetLineIndent (newLine);
@@ -251,7 +251,7 @@ namespace MonoDevelop.Xml.Editor
 				}
 				return ret;
 			}
-			return base.KeyPress (descriptor);
+			return await base.KeyPress (descriptor);
 		}
 		
 		#region Code completion

--- a/main/src/addins/Xml/Editor/XmlTextEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/XmlTextEditorExtension.cs
@@ -611,17 +611,16 @@ namespace MonoDevelop.Xml.Editor
 		
 		#region Smart indent
 		
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			bool result;
-			
 
 			if (Editor.Options.IndentStyle == IndentStyle.Smart && descriptor.SpecialKey == SpecialKey.Return) {
-				result = base.KeyPress (descriptor);
+				result = await base.KeyPress (descriptor);
 				SmartIndentLine (Editor.CaretLine);
 				return result;
 			}
-			return base.KeyPress (descriptor);
+			return await base.KeyPress (descriptor);
 		}
 		
 		void SmartIndentLine (int line)

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -36,6 +36,7 @@ using Mono.TextEditor.Theatrics;
 
 using Gdk;
 using Gtk;
+using System.Threading.Tasks;
 
 namespace Mono.TextEditor
 {
@@ -876,10 +877,10 @@ namespace Mono.TextEditor
 		/// <remarks>
 		/// The Key may be null if it has been handled by the IMContext. In such cases, the char is the value.
 		/// </remarks>
-		protected internal virtual bool OnIMProcessedKeyPressEvent (Gdk.Key key, uint ch, Gdk.ModifierType state)
+		protected internal virtual Task<bool> OnIMProcessedKeyPressEvent (Gdk.Key key, uint ch, Gdk.ModifierType state)
 		{
 			SimulateKeyPress (key, ch, state);
-			return true;
+			return Task.FromResult (true);
 		}
 
 		public void SimulateKeyPress (Gdk.Key key, uint unicodeChar, ModifierType modifier)

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
@@ -1062,7 +1062,7 @@ namespace Mono.TextEditor
 			//FIXME: OnIMProcessedKeyPressEvent should return false when it didn't handle the event
 			if (await editor.OnIMProcessedKeyPressEvent (key, unicodeChar, mod))
 				return;
-			args.RetVal = false;
+			args.RetVal = base.OnKeyPressEvent (evt);
 		}
 
 		protected override bool OnKeyReleaseEvent (EventKey evnt)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ConsoleView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ConsoleView.cs
@@ -28,7 +28,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Threading.Tasks;
 using Gtk;
 
 using MonoDevelop.Core;
@@ -105,9 +105,9 @@ namespace MonoDevelop.Components
 		public string PromptMultiLineString { get; set; }
 		
 		[GLib.ConnectBeforeAttribute]
-		void TextViewKeyPressEvent (object o, KeyPressEventArgs args)
+		async void TextViewKeyPressEvent (object o, KeyPressEventArgs args)
 		{
-			if (ProcessKeyPressEvent (args))
+			if (await ProcessKeyPressEvent (args))
 				args.RetVal = true;
 		}
 
@@ -198,12 +198,12 @@ namespace MonoDevelop.Components
 			return true;
 		}
 		
-		protected virtual bool ProcessKeyPressEvent (KeyPressEventArgs args)
+		protected virtual Task<bool> ProcessKeyPressEvent (KeyPressEventArgs args)
 		{
 			// Short circuit to avoid getting moved back to the input line
 			// when paging up and down in the shell output
 			if (args.Event.Key == Gdk.Key.Page_Up || args.Event.Key == Gdk.Key.Page_Down)
-				return false;
+				return Task.FromResult (false);
 			
 			// Needed so people can copy and paste, but always end up
 			// typing in the prompt.
@@ -213,7 +213,7 @@ namespace MonoDevelop.Components
 			}
 
 			if (!TextView.Editable) {
-				return false;
+				return Task.FromResult (false);
 			}
 
 //			if (ev.State == Gdk.ModifierType.ControlMask && ev.Key == Gdk.Key.space)
@@ -222,13 +222,13 @@ namespace MonoDevelop.Components
 			switch (args.Event.Key) {
 			case Gdk.Key.KP_Enter:
 			case Gdk.Key.Return:
-				return ProcessReturn ();
+				return Task.FromResult (ProcessReturn ());
 			case Gdk.Key.KP_Up:
 			case Gdk.Key.Up:
-				return ProcessCommandHistoryUp ();
+				return Task.FromResult (ProcessCommandHistoryUp ());
 			case Gdk.Key.KP_Down:
 			case Gdk.Key.Down:
-				return ProcessCommandHistoryDown ();
+				return Task.FromResult (ProcessCommandHistoryDown ());
 			case Gdk.Key.KP_Left:
 			case Gdk.Key.Left:
 				// On Mac, when using a small keyboard, Home is Command+Left
@@ -239,12 +239,12 @@ namespace MonoDevelop.Components
 					if (!args.Event.State.HasFlag (Gdk.ModifierType.ShiftMask))
 						Buffer.MoveMark (Buffer.SelectionBound, InputLineBegin);
 
-					return true;
+					return Task.FromResult (true);
 				}
 
 				// Keep our cursor inside the prompt area
 				if (Cursor.Compare (InputLineBegin) <= 0)
-					return true;
+					return Task.FromResult (true);
 
 				break;
 			case Gdk.Key.KP_Home:
@@ -255,7 +255,7 @@ namespace MonoDevelop.Components
 				if (!args.Event.State.HasFlag (Gdk.ModifierType.ShiftMask))
 					Buffer.MoveMark (Buffer.SelectionBound, InputLineBegin);
 
-				return true;
+				return Task.FromResult (true);
 			case Gdk.Key.a:
 				if (args.Event.State.HasFlag (Gdk.ModifierType.ControlMask)) {
 					Buffer.MoveMark (Buffer.InsertMark, InputLineBegin);
@@ -264,16 +264,16 @@ namespace MonoDevelop.Components
 					if (!args.Event.State.HasFlag (Gdk.ModifierType.ShiftMask))
 						Buffer.MoveMark (Buffer.SelectionBound, InputLineBegin);
 
-					return true;
+					return Task.FromResult (true);
 				}
 				break;
 			case Gdk.Key.period:
-				return false;
+				return Task.FromResult (false);
 			default:
-				return false;
+				return Task.FromResult (false);
 			}
 			
-			return false;
+			return Task.FromResult (false);
 		}
 
 		public TextIter InputLineBegin {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
@@ -135,10 +135,11 @@ namespace MonoDevelop.Ide.CodeCompletion
 			return result;
 		}
 
-		public virtual void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public virtual Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			var currentWord = GetCurrentWord (window, descriptor);
 			window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, currentWord, CompletionText);
+			return Task.FromResult (ka);
 		}
 		
 		public override string ToString ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionWindowManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionWindowManager.cs
@@ -28,6 +28,7 @@ using System;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.CodeCompletion
 {
@@ -158,10 +159,10 @@ namespace MonoDevelop.Ide.CodeCompletion
 			OnWindowClosed (EventArgs.Empty);
 		}
 		
-		public static bool PreProcessKeyEvent (KeyDescriptor descriptor)
+		public static Task<bool> PreProcessKeyEvent (KeyDescriptor descriptor)
 		{
 			if (!IsVisible)
-				return false;
+				return Task.FromResult (false);
 			if (descriptor.KeyChar != '\0') {
 				wnd.EndOffset = wnd.StartOffset + wnd.CurrentPartialWord.Length + 1;
 			}
@@ -188,11 +189,11 @@ namespace MonoDevelop.Ide.CodeCompletion
 			}
 		}
 
-		public static void PostProcessKeyEvent (KeyDescriptor descriptor)
+		public static Task PostProcessKeyEvent (KeyDescriptor descriptor)
 		{
 			if (!IsVisible)
-				return;
-			wnd.PostProcessKeyEvent (descriptor);
+				return TaskUtil.Default<object> ();
+			return wnd.PostProcessKeyEvent (descriptor);
 		}
 
 		public static void RepositionWindow ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateCompletionData.cs
@@ -30,6 +30,7 @@ using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor.Extension;
 using MonoDevelop.Ide.Editor;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.CodeTemplates
 {
@@ -53,9 +54,10 @@ namespace MonoDevelop.Ide.CodeTemplates
 			this.Description = template.Shortcut + Environment.NewLine + GettextCatalog.GetString (template.Description);
 		}
 		
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
+		public override Task<KeyActions> InsertCompletionText (CompletionListWindow window, KeyActions ka, KeyDescriptor descriptor)
 		{
 			template.Insert (doc.Editor, doc.DocumentContext);
+			return Task.FromResult (ka);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/AutoInsertBracketTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/AutoInsertBracketTextEditorExtension.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Mono.Addins;
 
 namespace MonoDevelop.Ide.Editor.Extension
@@ -56,9 +57,9 @@ namespace MonoDevelop.Ide.Editor.Extension
 			});
 		}
 
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
-			var result = base.KeyPress (descriptor);
+			var result = await base.KeyPress (descriptor);
 
 			if (DefaultSourceEditorOptions.Instance.AutoInsertMatchingBracket && !Editor.IsSomethingSelected) {
 				var handler = allHandlers.FirstOrDefault(h => h.CanHandle (Editor));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TextEditorExtension.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.TypeSystem;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.Editor.Extension
 {
@@ -78,9 +79,9 @@ namespace MonoDevelop.Ide.Editor.Extension
 		/// Return true if the key press should be processed by the editor.
 		/// When a key is pressed, and before the key is processed by the editor, this method will be invoked.
 		/// </summary>
-		public virtual bool KeyPress (KeyDescriptor descriptor)
+		public virtual async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
-			return Next == null || Next.KeyPress (descriptor);
+			return Next == null || await Next.KeyPress (descriptor);
 		}
 
 		public virtual void Dispose ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/ProjectedCompletionExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/ProjectedCompletionExtension.cs
@@ -319,16 +319,16 @@ namespace MonoDevelop.Ide.Editor.Projection
 			return projectedExtension.HandleParameterCompletionAsync (ConvertContext (completionContext), completionChar, token);
 		}
 
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			var task = ctx.GetPartialProjectionsAsync ();
 			if (task != null)
-				projections = task.Result;
+				projections = await task;
 			var projectedExtension = GetCurrentExtension();
 			if (projectedExtension != null) {
-				return projectedExtension.KeyPress (descriptor);
+				return await projectedExtension.KeyPress (descriptor);
 			}
-			return base.KeyPress (descriptor);
+			return await base.KeyPress (descriptor);
 		}
 
 		public override Task<ParameterHintingResult> ParameterCompletionCommand (MonoDevelop.Ide.CodeCompletion.CodeCompletionContext completionContext)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/ProjectedFilterCompletionTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/ProjectedFilterCompletionTextEditorExtension.cs
@@ -67,11 +67,11 @@ namespace MonoDevelop.Ide.Editor.Projection
 			return false;
 		}
 
-		public override bool KeyPress (KeyDescriptor descriptor)
+		public override async Task<bool> KeyPress (KeyDescriptor descriptor)
 		{
 			if (!IsActiveExtension())
-				return Next == null || Next.KeyPress (descriptor);
-			return completionTextEditorExtension.KeyPress (descriptor);
+				return Next == null || await Next.KeyPress (descriptor);
+			return await completionTextEditorExtension.KeyPress (descriptor);
 		}
 
 		public override bool IsValidInContext (DocumentContext context)

--- a/main/tests/UnitTests/MonoDevelop.CSharpBinding/AutomaticBracketInsertionTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.CSharpBinding/AutomaticBracketInsertionTests.cs
@@ -216,7 +216,7 @@ namespace MonoDevelop.CSharpBinding
 			var data = new RoslynSymbolCompletionData (null, factory, method);
 			data.IsDelegateExpected = isDelegateExpected;
 			KeyActions ka = KeyActions.Process;
-			data.InsertCompletionText (listWindow, ref ka, KeyDescriptor.FromGtk (key, (char)key, Gdk.ModifierType.None)); 
+			ka = await data.InsertCompletionText (listWindow, ka, KeyDescriptor.FromGtk (key, (char)key, Gdk.ModifierType.None)); 
 
 			return widget.CompletedWord;
 		}

--- a/main/tests/UnitTests/MonoDevelop.CSharpBinding/NamedArgumentCompletionTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.CSharpBinding/NamedArgumentCompletionTests.cs
@@ -213,7 +213,7 @@ namespace MonoDevelop.CSharpBinding
 			var data = new RoslynSymbolCompletionData (null, factory, foundMember);
 			data.DisplayFlags |= DisplayFlags.NamedArgument;
 			KeyActions ka = KeyActions.Process;
-			data.InsertCompletionText (listWindow, ref ka, KeyDescriptor.FromGtk (key, (char)key, Gdk.ModifierType.None)); 
+			ka = await data.InsertCompletionText (listWindow, ka, KeyDescriptor.FromGtk (key, (char)key, Gdk.ModifierType.None)); 
 
 			return widget.CompletedWord;
 		}

--- a/main/tests/UnitTests/MonoDevelop.CSharpBinding/OnTheFlyFormatterTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.CSharpBinding/OnTheFlyFormatterTests.cs
@@ -136,8 +136,8 @@ namespace MonoDevelop.CSharpBinding
 	{
 		Console.WriteLine ()      ;$
 	}
-}", (content, ext) => {
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.semicolon, ';', Gdk.ModifierType.None));
+}", async (content, ext) => {
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.semicolon, ';', Gdk.ModifierType.None));
 			
 				var newText = content.Text;
 				Assert.AreEqual (@"class Foo
@@ -159,8 +159,8 @@ namespace MonoDevelop.CSharpBinding
 	{
 		Console.WriteLine()                   ;
 	}$
-}", (content, ext) => {
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.braceright, '}', Gdk.ModifierType.None));
+}", async (content, ext) => {
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.braceright, '}', Gdk.ModifierType.None));
 
 				var newText = content.Text;
 				Console.WriteLine (newText);
@@ -188,8 +188,8 @@ namespace MonoDevelop.CSharpBinding
 		Console.WriteLine()                   ;
 	}$
 	}
-}", (content, ext) => {
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.braceright, '}', Gdk.ModifierType.None));
+}", async (content, ext) => {
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.braceright, '}', Gdk.ModifierType.None));
 			
 				var newText = content.Text;
 				Console.WriteLine (newText);
@@ -221,8 +221,8 @@ namespace MonoDevelop.CSharpBinding
 	}catch(Exception e){
 	}$
 	}
-}", (content, ext) => {
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.braceright, '}', Gdk.ModifierType.None));
+}", async (content, ext) => {
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.braceright, '}', Gdk.ModifierType.None));
 			
 				var newText = content.Text;
 				Console.WriteLine (newText);
@@ -272,9 +272,9 @@ namespace MonoDevelop.CSharpBinding
 		[Test]
 		public async Task TestNonVerbatimToVerbatimConversion ()
 		{
-			await Simulate ("$\"\\t\"", (content, ext) => {
+			await Simulate ("$\"\\t\"", async (content, ext) => {
 				content.Data.InsertText (0, "@");
-				ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
 				var newText = content.Text;
 				Assert.AreEqual ("@\"\t\"", newText);
 			});
@@ -286,9 +286,9 @@ namespace MonoDevelop.CSharpBinding
 		[Test]
 		public async Task TestBug14686 ()
 		{
-			await Simulate ("$\"\\\\\"", (content, ext) => {
+			await Simulate ("$\"\\\\\"", async (content, ext) => {
 				content.Data.InsertText (0, "@");
-				ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
 				var newText = content.Text;
 				Assert.AreEqual ("@\"\\\"", newText);
 			});
@@ -297,16 +297,16 @@ namespace MonoDevelop.CSharpBinding
 		[Test]
 		public async Task TestBug14686Case2 ()
 		{
-			await Simulate ("$\"\\\"", (content, ext) => {
+			await Simulate ("$\"\\\"", async (content, ext) => {
 				content.Data.InsertText (0, "@");
-				ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
 				var newText = content.Text;
 				Assert.AreEqual ("@\"\\\"", newText);
 			});
 
-			await Simulate ("$\"\\\"a", (content, ext) => {
+			await Simulate ("$\"\\\"a", async (content, ext) => {
 				content.Data.InsertText (0, "@");
-				ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
 				var newText = content.Text;
 				Assert.AreEqual ("@\"\\\"a", newText);
 			});
@@ -324,10 +324,10 @@ class Foo
 		} catch (Exception e) {$}
 	}
 }
-", (content, ext) => {
+", async (content, ext) => {
 				ext.ReindentOnTab ();
 				EditActions.NewLine (ext.Editor);
-				ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'\n', '\n', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'\n', '\n', Gdk.ModifierType.None));
 
 				var newText = content.Text;
 
@@ -354,12 +354,12 @@ class Foo
 		[Test]
 		public async Task TestBug16174_AutoIndent ()
 		{
-			await Simulate ("namespace Foo\n{\n\tpublic class Bar\n\t{\n$\t\tvoid Test()\n\t\t{\n\t\t}\n\t}\n}\n", (content, ext) => {
+			await Simulate ("namespace Foo\n{\n\tpublic class Bar\n\t{\n$\t\tvoid Test()\n\t\t{\n\t\t}\n\t}\n}\n", async (content, ext) => {
 				var options = DefaultSourceEditorOptions.Instance;
 				options.IndentStyle = IndentStyle.Auto;
 				ext.Editor.Options = options;
 				EditActions.NewLine (ext.Editor);
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
 
 				var newText = content.Text;
 
@@ -373,12 +373,12 @@ class Foo
 		[Test]
 		public async Task TestBug16174_VirtualIndent ()
 		{
-			await Simulate ("namespace Foo\n{\n\tpublic class Bar\n\t{\n$\t\tvoid Test()\n\t\t{\n\t\t}\n\t}\n}\n", (content, ext) => {
+			await Simulate ("namespace Foo\n{\n\tpublic class Bar\n\t{\n$\t\tvoid Test()\n\t\t{\n\t\t}\n\t}\n}\n", async (content, ext) => {
 				var options = DefaultSourceEditorOptions.Instance;
 				options.IndentStyle = IndentStyle.Virtual;
 				ext.Editor.Options = options;
 				EditActions.NewLine (ext.Editor);
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
 
 				var newText = content.Text;
 
@@ -396,9 +396,9 @@ class Foo
 		[Test]
 		public async Task TestBug16283 ()
 		{
-			await Simulate ("$\"\\dev\\null {0}\"", (content, ext) => {
+			await Simulate ("$\"\\dev\\null {0}\"", async (content, ext) => {
 				content.Data.InsertText (0, "@");
-				ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk ((Gdk.Key)'@', '@', Gdk.ModifierType.None));
 				var newText = content.Text;
 				Assert.AreEqual ("@\"\\dev\null {0}\"", newText);
 			});
@@ -447,11 +447,11 @@ namespace FormatSelectionTest
 		//random comment
 		Console.WriteLine ()      ;$
 	}
-}", (content, ext) => {
+}", async (content, ext) => {
 				content.Data.Options = new CustomEditorOptions {
 					IndentStyle = IndentStyle.Virtual
 				};
-				ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.semicolon, ';', Gdk.ModifierType.None));
+				await ext.KeyPress (KeyDescriptor.FromGtk (Gdk.Key.semicolon, ';', Gdk.ModifierType.None));
 			
 				var newText = content.Text;
 				Assert.AreEqual (@"class Foo

--- a/main/tests/UnitTests/MonoDevelop.Ide.Gui/CompletionListWindowTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Gui/CompletionListWindowTests.cs
@@ -33,6 +33,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.CodeCompletion;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.Gui
 {
@@ -134,7 +135,7 @@ namespace MonoDevelop.Ide.Gui
 			StringBuilder sb = new StringBuilder ();
 		}
 		
-		static void SimulateInput (CompletionListWindow listWindow, string input)
+		static async Task SimulateInput (CompletionListWindow listWindow, string input)
 		{
 			var testCompletionWidget = ((TestCompletionWidget)listWindow.CompletionWidget);
 			bool isClosed = false;
@@ -144,38 +145,38 @@ namespace MonoDevelop.Ide.Gui
 			foreach (char ch in input) {
 				switch (ch) {
 				case '8':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Up, '\0', Gdk.ModifierType.None));
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Up, '\0', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Up, '\0', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Up, '\0', Gdk.ModifierType.None));
 					break;
 				case '2':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Down, '\0', Gdk.ModifierType.None));
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Down, '\0', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Down, '\0', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Down, '\0', Gdk.ModifierType.None));
 					break;
 				case '4':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Left, '\0', Gdk.ModifierType.None));
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Left, '\0', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Left, '\0', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Left, '\0', Gdk.ModifierType.None));
 					break;
 				case '6':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Right, '\0', Gdk.ModifierType.None));
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Right, '\0', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Right, '\0', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Right, '\0', Gdk.ModifierType.None));
 					break;
 				case '\t':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Tab, '\t', Gdk.ModifierType.None));
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Tab, '\t', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Tab, '\t', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Tab, '\t', Gdk.ModifierType.None));
 					break;
 				case '\b':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.BackSpace, '\b', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.BackSpace, '\b', Gdk.ModifierType.None));
 					testCompletionWidget.Backspace ();
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.BackSpace, '\b', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.BackSpace, '\b', Gdk.ModifierType.None));
 					break;
 				case '\n':
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk (Gdk.Key.Return, '\n', Gdk.ModifierType.None));
 					break;
 				default:
-					listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk ((Gdk.Key)ch, ch, Gdk.ModifierType.None));
+					await listWindow.PreProcessKeyEvent (KeyDescriptor.FromGtk ((Gdk.Key)ch, ch, Gdk.ModifierType.None));
 					testCompletionWidget.AddChar (ch);
-					listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk ((Gdk.Key)ch, ch, Gdk.ModifierType.None));
+					await listWindow.PostProcessKeyEvent (KeyDescriptor.FromGtk ((Gdk.Key)ch, ch, Gdk.ModifierType.None));
 					break;
 				}
 				// window closed.
@@ -194,12 +195,12 @@ namespace MonoDevelop.Ide.Gui
 			public string[] CompletionData { get; set; }
 		}
 		
-		static string RunSimulation (string partialWord, string simulatedInput, bool autoSelect, bool completeWithSpaceOrPunctuation, params string[] completionData)
+		static Task<string> RunSimulation (string partialWord, string simulatedInput, bool autoSelect, bool completeWithSpaceOrPunctuation, params string[] completionData)
 		{
 			return RunSimulation (partialWord, simulatedInput, autoSelect, completeWithSpaceOrPunctuation, true, completionData);
 		}
 		
-		static string RunSimulation (string partialWord, string simulatedInput, bool autoSelect, bool completeWithSpaceOrPunctuation, bool autoCompleteEmptyMatch, params string[] completionData)
+		static Task<string> RunSimulation (string partialWord, string simulatedInput, bool autoSelect, bool completeWithSpaceOrPunctuation, bool autoCompleteEmptyMatch, params string[] completionData)
 		{
 			return RunSimulation (new SimulationSettings () {
 				SimulatedInput = simulatedInput,
@@ -210,11 +211,11 @@ namespace MonoDevelop.Ide.Gui
 			});
 		}
 		
-		static string RunSimulation (SimulationSettings settings)
+		static async Task<string> RunSimulation (SimulationSettings settings)
 		{
 			CompletionListWindow listWindow = CreateListWindow (settings);
 			var testCompletionWidget = (TestCompletionWidget)listWindow.CompletionWidget;
-			SimulateInput (listWindow, settings.SimulatedInput);
+			await SimulateInput (listWindow, settings.SimulatedInput);
 			return testCompletionWidget.CompletedWord;
 		}
 
@@ -240,23 +241,23 @@ namespace MonoDevelop.Ide.Gui
 
 		
 		[Test()]
-		public void TestPunctuationCompletion ()
+		public async Task TestPunctuationCompletion ()
 		{
-			string output = RunSimulation ("", "aaa ", true, true, 
+			string output = await RunSimulation ("", "aaa ", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual ("AbAbAb", output);
 			
-			output = RunSimulation ("", "aa.", true, true, 
+			output = await RunSimulation ("", "aa.", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual ("AbAb", output);
 			
-			output = RunSimulation ("", "AbAbA.", true, true, 
+			output = await RunSimulation ("", "AbAbA.", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -265,9 +266,9 @@ namespace MonoDevelop.Ide.Gui
 		}
 
 		[Test()]
-		public void TestTabCompletion ()
+		public async Task TestTabCompletion ()
 		{
-			string output = RunSimulation ("", "aaa\t", true, false, 
+			string output = await RunSimulation ("", "aaa\t", true, false, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -276,9 +277,9 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestTabCompletionWithAutoSelectOff ()
+		public async Task TestTabCompletionWithAutoSelectOff ()
 		{
-			string output = RunSimulation ("", "aaa\t", false, false, 
+			string output = await RunSimulation ("", "aaa\t", false, false, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -287,9 +288,9 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestReturnCompletion ()
+		public async Task TestReturnCompletion ()
 		{
-			string output = RunSimulation ("", "aaa\n", true, false, 
+			string output = await RunSimulation ("", "aaa\n", true, false, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -299,9 +300,9 @@ namespace MonoDevelop.Ide.Gui
 
 		[Ignore("\n now always commits")]
 		[Test()]
-		public void TestReturnCompletionWithAutoSelectOff ()
+		public async Task TestReturnCompletionWithAutoSelectOff ()
 		{
-			string output = RunSimulation ("", "aaa\n", false, false, 
+			string output = await RunSimulation ("", "aaa\n", false, false, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -310,10 +311,10 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestAutoSelectionOn ()
+		public async Task TestAutoSelectionOn ()
 		{
 			// shouldn't select anything since auto select is disabled.
-			string output = RunSimulation ("", "aaa ", true, true, 
+			string output = await RunSimulation ("", "aaa ", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -321,7 +322,7 @@ namespace MonoDevelop.Ide.Gui
 			Assert.AreEqual ("AbAbAb", output);
 			
 			// now with cursor down
-			output = RunSimulation ("", "aaa2 ", true, true, 
+			output = await RunSimulation ("", "aaa2 ", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -330,10 +331,10 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestAutoSelectionOff ()
+		public async Task TestAutoSelectionOff ()
 		{
 			// shouldn't select anything since auto select is disabled.
-			string output = RunSimulation ("", "aaa ", false, true, 
+			string output = await RunSimulation ("", "aaa ", false, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -341,7 +342,7 @@ namespace MonoDevelop.Ide.Gui
 			Assert.IsNull (output);
 			
 			// now with cursor down (shouldn't change selection)
-			output = RunSimulation ("", "aaa2 ", false, true, 
+			output = await RunSimulation ("", "aaa2 ", false, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -349,7 +350,7 @@ namespace MonoDevelop.Ide.Gui
 			Assert.AreEqual ("AbAbAb", output);
 			
 			// now with 2x cursor down - shold select next item.
-			output = RunSimulation ("", "aaa22 ", false, true, 
+			output = await RunSimulation ("", "aaa22 ", false, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb",
@@ -359,23 +360,23 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestBackspace ()
+		public async Task TestBackspace ()
 		{
-			string output = RunSimulation ("", "aaaa\b\t", true, true, 
+			string output = await RunSimulation ("", "aaaa\b\t", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual ("AbAbAb", output);
 			
-			output = RunSimulation ("", "aaaa\b\b\b\t", true, true, 
+			output = await RunSimulation ("", "aaaa\b\b\b\t", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual ("AbAb", output);
 			
-			output = RunSimulation ("", "aaaa\b\b\baaa\t", true, true, 
+			output = await RunSimulation ("", "aaaa\b\b\baaa\t", true, true, 
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -384,9 +385,9 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestBackspacePreserveAutoSelect ()
+		public async Task TestBackspacePreserveAutoSelect ()
 		{
-			string output = RunSimulation ("", "c\bc ", false, true, 
+			string output = await RunSimulation ("", "c\bc ", false, true, 
 				"a",
 				"b", 
 				"c");
@@ -395,16 +396,16 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestAutoCompleteEmptyMatchOn ()
+		public async Task TestAutoCompleteEmptyMatchOn ()
 		{
-			string output = RunSimulation ("", " ", true, true, true,
+			string output = await RunSimulation ("", " ", true, true, true,
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual ("AbAb", output);
 			
-			output = RunSimulation ("", "\t", true, true, true,
+			output = await RunSimulation ("", "\t", true, true, true,
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -414,13 +415,13 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestAutoCompleteFileNames ()
+		public async Task TestAutoCompleteFileNames ()
 		{
-			string output = RunSimulation ("", "Doc.cs ", true, true, true, "Document.cs");
+			string output = await RunSimulation ("", "Doc.cs ", true, true, true, "Document.cs");
 
 			Assert.AreEqual ("Document.cs", output);
 			
-			output = RunSimulation ("", "cwid.cs ", true, true, true,
+			output = await RunSimulation ("", "cwid.cs ", true, true, true,
 				"Test.txt",
 				"CompletionWidget.cs", 
 				"CommandWindow.cs");
@@ -429,23 +430,23 @@ namespace MonoDevelop.Ide.Gui
 		}
 		
 		[Test()]
-		public void TestAutoCompleteEmptyMatchOff ()
+		public async Task TestAutoCompleteEmptyMatchOff ()
 		{
-			string output = RunSimulation ("", " ", true, true, false,
+			string output = await RunSimulation ("", " ", true, true, false,
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual (null, output);
 			
-			output = RunSimulation ("", "\t", true, true, false,
+			output = await RunSimulation ("", "\t", true, true, false,
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
 			
 			Assert.AreEqual ("AbAb", output);
 			
-			output = RunSimulation ("", "a ", true, true, false,
+			output = await RunSimulation ("", "a ", true, true, false,
 				"AbAb",
 				"AbAbAb", 
 				"AbAbAbAb");
@@ -465,66 +466,66 @@ namespace MonoDevelop.Ide.Gui
 		};
 
 		[Test]
-		public void TestMatchPunctuation ()
+		public async Task TestMatchPunctuation ()
 		{
-			string output = RunSimulation ("", "/\n", true, false, false, punctuationData);
+			string output = await RunSimulation ("", "/\n", true, false, false, punctuationData);
 			Assert.AreEqual ("/AbAb", output);
 		}
 
 		[Test]
-		public void TestMatchPunctuationCase2 ()
+		public async Task TestMatchPunctuationCase2 ()
 		{
-			string output = RunSimulation ("", "A\n", true, false, false, punctuationData);
+			string output = await RunSimulation ("", "A\n", true, false, false, punctuationData);
 			Assert.AreEqual ("AbAb", output);
 		}
 
 		[Test]
-		public void TestMatchPunctuationCase3 ()
+		public async Task TestMatchPunctuationCase3 ()
 		{
-			string output = RunSimulation ("", ",A..\n", true, false, false, punctuationData);
+			string output = await RunSimulation ("", ",A..\n", true, false, false, punctuationData);
 			Assert.AreEqual (",A..bAb", output);
 		}
 		
 		[Test]
-		public void TestMatchPunctuationCommitOnSpaceAndPunctuation ()
+		public async Task TestMatchPunctuationCommitOnSpaceAndPunctuation ()
 		{
-			string output = RunSimulation ("", "Ac ", true, true, false, punctuationData);
+			string output = await RunSimulation ("", "Ac ", true, true, false, punctuationData);
 			Assert.AreEqual ("Accc", output);
 		}
 
 		[Test]
-		public void TestMatchPunctuationCommitOnSpaceAndPunctuation2 ()
+		public async Task TestMatchPunctuationCommitOnSpaceAndPunctuation2 ()
 		{
-			var output = RunSimulation ("", "/ ", true, true, false, punctuationData);
+			var output = await RunSimulation ("", "/ ", true, true, false, punctuationData);
 			Assert.AreEqual ("/AbAb", output);
 		}
 
 		[Ignore]
 		[Test]
-		public void TestMatchPunctuationCommitOnSpaceAndPunctuation3 ()
+		public async Task TestMatchPunctuationCommitOnSpaceAndPunctuation3 ()
 		{
-			var output = RunSimulation ("", ".", true, true, false, punctuationData);
+			var output = await RunSimulation ("", ".", true, true, false, punctuationData);
 			Assert.AreEqual (null, output);
 		}
 
 		[Test]
-		public void TestMatchPunctuationCommitOnSpaceAndPunctuation4 ()
+		public async Task TestMatchPunctuationCommitOnSpaceAndPunctuation4 ()
 		{
-			var output = RunSimulation ("", "A ", true, true, false, punctuationData);
+			var output = await RunSimulation ("", "A ", true, true, false, punctuationData);
 			Assert.AreEqual ("AbAb", output);
 		}
 
 		[Test]
-		public void TestMatchPunctuationCommitOnSpaceAndPunctuation5 ()
+		public async Task TestMatchPunctuationCommitOnSpaceAndPunctuation5 ()
 		{
-			var output = RunSimulation ("", ",A.b ", true, true, false, punctuationData);
+			var output = await RunSimulation ("", ",A.b ", true, true, false, punctuationData);
 			Assert.AreEqual (",A.bAb", output);
 		}
 		
 		[Test]
-		public void TestDefaultCompletionString ()
+		public async Task TestDefaultCompletionString ()
 		{
-			string output = RunSimulation (new SimulationSettings {
+			string output = await RunSimulation (new SimulationSettings {
 				SimulatedInput = "\t",
 				AutoSelect = true,
 				CompleteWithSpaceOrPunctuation = true,
@@ -539,7 +540,7 @@ namespace MonoDevelop.Ide.Gui
 			
 			Assert.AreEqual ("C", output);
 			
-			output = RunSimulation (new SimulationSettings {
+			output = await RunSimulation (new SimulationSettings {
 				SimulatedInput = " ",
 				AutoSelect = true,
 				CompleteWithSpaceOrPunctuation = true,
@@ -577,9 +578,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 543923 - Completion window should deselect when word is deleted
 		/// </summary>
 		[Test]
-		public void TestBug543923 ()
+		public async Task TestBug543923 ()
 		{
-			string output = RunSimulation (new SimulationSettings {
+			string output = await RunSimulation (new SimulationSettings {
 				SimulatedInput = "i\b ",
 				AutoSelect = true,
 				CompleteWithSpaceOrPunctuation = true,
@@ -594,13 +595,13 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 543938 - Completion list up/down broken with single entry
 		/// </summary>
 		[Test]
-		public void TestBug543938 ()
+		public async Task TestBug543938 ()
 		{
-			string output = RunSimulation ("", "2 ", true, true, false, "singleEntry");
+			string output = await RunSimulation ("", "2 ", true, true, false, "singleEntry");
 			
 			Assert.AreEqual ("singleEntry", output);
 			
-			output = RunSimulation ("", " ", true, true, false, "singleEntry");
+			output = await RunSimulation ("", " ", true, true, false, "singleEntry");
 			Assert.IsTrue (string.IsNullOrEmpty (output));
 		}
 		
@@ -608,30 +609,30 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 543984 – Completion window should only accept punctuation when it's an exact match
 		/// </summary>
 		[Test]
-		public void TestBug543984 ()
+		public async Task TestBug543984 ()
 		{
-			string output = RunSimulation ("", "foo#b\n", true, true, false, "foo#bar", "foo#bar#baz");
+			string output = await RunSimulation ("", "foo#b\n", true, true, false, "foo#bar", "foo#bar#baz");
 			Assert.AreEqual ("foo#bar", output);
 		}
 		
 		[Test]
-		public void TestBug595240 ()
+		public async Task TestBug595240 ()
 		{
-			string output = RunSimulation ("", "A\t", true, true, false, "AbCdEf");
+			string output = await RunSimulation ("", "A\t", true, true, false, "AbCdEf");
 			Assert.AreEqual ("AbCdEf", output);
 		}
 
 		[Test]
-		public void TestBug595240Case2 ()
+		public async Task TestBug595240Case2 ()
 		{
-			var output = RunSimulation ("", "Cd\t", true, true, false, "AbCdEf");
+			var output = await RunSimulation ("", "Cd\t", true, true, false, "AbCdEf");
 			Assert.AreEqual ("AbCdEf", output);
 		}
 
 		[Test]
-		public void TestBug595240Case3 ()
+		public async Task TestBug595240Case3 ()
 		{
-			var output = RunSimulation ("", "bC\t", true, true, false, "AbCdEf");
+			var output = await RunSimulation ("", "bC\t", true, true, false, "AbCdEf");
 			Assert.AreNotEqual ("AbCdEf", output);
 		}
 		
@@ -639,9 +640,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 613539 - DOBa does not complete to DynamicObjectBase
 		/// </summary>
 		[Test]
-		public void TestBug613539 ()
+		public async Task TestBug613539 ()
 		{
-			string output = RunSimulation ("", "DOB ", true, true, false, "DynamicObject", "DynamicObjectBase");
+			string output = await RunSimulation ("", "DOB ", true, true, false, "DynamicObject", "DynamicObjectBase");
 			Assert.AreEqual ("DynamicObjectBase", output);
 		}
 		
@@ -649,9 +650,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 629361 - Exact completion matches should take account of case
 		/// </summary>
 		[Test]
-		public void TestBug629361 ()
+		public async Task TestBug629361 ()
 		{
-			string output = RunSimulation ("", "unit\t", true, true, false, "Unit", "unit");
+			string output = await RunSimulation ("", "unit\t", true, true, false, "Unit", "unit");
 			Assert.IsTrue (output == null || "unit" == output);
 		}
 		
@@ -659,64 +660,64 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 668136 - Subword matching in completion does not work well for xml
 		/// </summary>
 		[Test]
-		public void TestBug668136 ()
+		public async Task TestBug668136 ()
 		{
-			string output = RunSimulation ("", "bar\t", true, true, false, "foo:test", "foo:bar", "foo:foo");
+			string output = await RunSimulation ("", "bar\t", true, true, false, "foo:test", "foo:bar", "foo:foo");
 			Assert.AreEqual ("foo:bar", output);
 		}
 		
 		[Test]
-		public void TestSubstringMatch ()
+		public async Task TestSubstringMatch ()
 		{
-			string output = RunSimulation ("", "comcoll\n", true, true, false, "CustomCommandCollection");
+			string output = await RunSimulation ("", "comcoll\n", true, true, false, "CustomCommandCollection");
 			Assert.AreEqual ("CustomCommandCollection", output);
 			
-			output = RunSimulation ("", "cuscoll\n", true, true, false, "CustomCommandCollection");
+			output = await RunSimulation ("", "cuscoll\n", true, true, false, "CustomCommandCollection");
 			Assert.AreEqual ("CustomCommandCollection", output);
 			
-			output = RunSimulation ("", "commandcollection\n", true, true, false, "CustomCommandCollection");
+			output = await RunSimulation ("", "commandcollection\n", true, true, false, "CustomCommandCollection");
 			Assert.AreEqual ("CustomCommandCollection", output);
 		}
 		
 		[Test]
-		public void TestUpperCase1 ()
+		public async Task TestUpperCase1 ()
 		{
-			string output = RunSimulation ("", "WR\t", true, true, false, "WriteLine");
+			string output = await RunSimulation ("", "WR\t", true, true, false, "WriteLine");
 			Assert.AreEqual ("WriteLine", output);
 		}
 		
 		[Test]
-		public void TestUpperCase2 ()
+		public async Task TestUpperCase2 ()
 		{
-			string output = RunSimulation ("", "WR\t", true, true, false, "WriteLine", "WriteRaw");
+			string output = await RunSimulation ("", "WR\t", true, true, false, "WriteLine", "WriteRaw");
 			Assert.AreEqual ("WriteRaw", output);
 		}
 		
 		[Test]
-		public void TestDigitSelection ()
+		public async Task TestDigitSelection ()
 		{
-			string output = RunSimulation ("", "v1\t", true, true, false, "var", "var1");
+			string output = await RunSimulation ("", "v1\t", true, true, false, "var", "var1");
 			Assert.AreEqual ("var1", output);
 		}
 
 		[Test]
-		public void TestSelectFirst ()
+		public async Task TestSelectFirst ()
 		{
-			string output = RunSimulation ("", "Are\t", true, true, false, "AreDifferent", "Differenx", "AreDiffereny");
+			string output = await RunSimulation ("", "Are\t", true, true, false, "AreDifferent", "Differenx", "AreDiffereny");
 			Assert.AreEqual ("AreDifferent", output);
 		}
 
 		[Test]
-		public void TestPreferStart ()
+		public async Task TestPreferStart ()
 		{
-			string output = RunSimulation ("", "InC\t", true, true, false, "Equals", "InvariantCultureIfo", "GetInvariantCulture");
+			string output = await RunSimulation ("", "InC\t", true, true, false, "Equals", "InvariantCultureIfo", "GetInvariantCulture");
 			Assert.AreEqual ("InvariantCultureIfo", output);
 		}
 
 		[Test]
-		public void TestPreProcessorDirective ()
+		public async Task TestPreProcessorDirective ()
 		{
-			string output = RunSimulation ("", "if\t", true, true, false, "#if", "if");
+			string output = await RunSimulation ("", "if\t", true, true, false, "#if", "if");
 			Assert.AreEqual ("if", output);
 		}
 
@@ -724,24 +725,24 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 4732 - [Regression] Broken intellisense again 
 		/// </summary>
 		[Test]
-		public void TestBug4732 ()
+		public async Task TestBug4732 ()
 		{
-			string output = RunSimulation ("", "a\t", true, true, false, "_AppDomain", "A");
+			string output = await RunSimulation ("", "a\t", true, true, false, "_AppDomain", "A");
 			Assert.AreEqual ("A", output);
 		}
 
 
 		[Test]
-		public void TestFavorFirstSubword ()
+		public async Task TestFavorFirstSubword ()
 		{
-			string output = RunSimulation ("", "button\t", true, true, false, "AnotherTestButton", "Button");
+			string output = await RunSimulation ("", "button\t", true, true, false, "AnotherTestButton", "Button");
 			Assert.AreEqual ("Button", output);
 		}
 
 		[Test]
-		public void TestFavorExactMatch ()
+		public async Task TestFavorExactMatch ()
 		{
-			string output = RunSimulation ("", "View\t", true, true, false, "view", "View");
+			string output = await RunSimulation ("", "View\t", true, true, false, "view", "View");
 			Assert.AreEqual ("View", output);
 		}
 
@@ -749,16 +750,16 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 6897 - Case insensitive matching issues
 		/// </summary>
 		[Test]
-		public void TestBug6897 ()
+		public async Task TestBug6897 ()
 		{
-			string output = RunSimulation ("", "io\t", true, true, false, "InvalidOperationException", "IO");
+			string output = await RunSimulation ("", "io\t", true, true, false, "InvalidOperationException", "IO");
 			Assert.AreEqual ("IO", output);
 		}
 
 		[Test]
-		public void TestBug6897Case2 ()
+		public async Task TestBug6897Case2 ()
 		{
-			string output = RunSimulation ("", "io\t", true, true, false, "InvalidOperationException", "IOException");
+			string output = await RunSimulation ("", "io\t", true, true, false, "InvalidOperationException", "IOException");
 			Assert.AreEqual ("IOException", output);
 		}
 
@@ -766,9 +767,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 7288 - Completion not selecting the correct entry
 		/// </summary>
 		[Test]
-		public void TestBug7288 ()
+		public async Task TestBug7288 ()
 		{
-			string output = RunSimulation ("", "pages\t", true, true, false, "pages", "PageSystem");
+			string output = await RunSimulation ("", "pages\t", true, true, false, "pages", "PageSystem");
 			Assert.AreEqual ("pages", output);
 		}
 
@@ -776,12 +777,12 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 7420 - Prefer properties over named parameters
 		/// </summary>
 		[Test]
-		public void TestBug7420 ()
+		public async Task TestBug7420 ()
 		{
-			string output = RunSimulation ("", "val\t", true, true, false, "Value", "value:");
+			string output = await RunSimulation ("", "val\t", true, true, false, "Value", "value:");
 			Assert.AreEqual ("Value", output);
 
-			output = RunSimulation ("", "val\t", true, true, false, "Value", "value", "value:");
+			output = await RunSimulation ("", "val\t", true, true, false, "Value", "value", "value:");
 			Assert.AreEqual ("value", output);
 		}
 
@@ -789,9 +790,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 7522 - Code completion list should give preference to shorter words
 		/// </summary>
 		[Test]
-		public void TestBug7522 ()
+		public async Task TestBug7522 ()
 		{
-			string output = RunSimulation ("", "vis\t", true, true, false, "VisibilityNotifyEvent", "Visible");
+			string output = await RunSimulation ("", "vis\t", true, true, false, "VisibilityNotifyEvent", "Visible");
 			Assert.AreEqual ("Visible", output);
 		}
 
@@ -799,9 +800,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 8257 - Incorrect entry selected in code completion list
 		/// </summary>
 		[Test]
-		public void TestBug8257 ()
+		public async Task TestBug8257 ()
 		{
-			string output = RunSimulation ("", "childr\t", true, true, false, "children", "ChildRequest");
+			string output = await RunSimulation ("", "childr\t", true, true, false, "children", "ChildRequest");
 			Assert.AreEqual ("children", output);
 		}
 
@@ -810,9 +811,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 9114 - Code completion fumbles named parameters 
 		/// </summary>
 		[Test]
-		public void TestBug9114 ()
+		public async Task TestBug9114 ()
 		{
-			string output = RunSimulation ("", "act\t", true, true, false, "act:", "Action");
+			string output = await RunSimulation ("", "act\t", true, true, false, "act:", "Action");
 			Assert.AreEqual ("act:", output);
 		}
 
@@ -820,9 +821,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 36451 - Text input is weird.
 		/// </summary>
 		[Test]
-		public void TestBug36451 ()
+		public async Task TestBug36451 ()
 		{
-			string output = RunSimulation ("", "x\"", true, true, false, "X");
+			string output = await RunSimulation ("", "x\"", true, true, false, "X");
 			Assert.AreEqual ("X", output);
 		}
 
@@ -830,9 +831,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 17779 - Symbol names with multiple successive letters are filtered out too early
 		/// </summary>
 		[Test]
-		public void TestBug17779 ()
+		public async Task TestBug17779 ()
 		{
-			string output = RunSimulation ("", "ID11\t", true, true, false, "ID11Tag");
+			string output = await RunSimulation ("", "ID11\t", true, true, false, "ID11Tag");
 			Assert.AreEqual ("ID11Tag", output);
 		}
 
@@ -840,16 +841,16 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 21121 - Aggressive completion for delegates
 		/// </summary>
 		[Test]
-		public void TestBug21121 ()
+		public async Task TestBug21121 ()
 		{
-			string output = RunSimulation ("", "d)", true, true, false, "d", "delegate ()");
+			string output = await RunSimulation ("", "d)", true, true, false, "d", "delegate ()");
 			Assert.AreEqual ("d", output);
 		}
 
 		[Test]
-		public void TestSpaceCommits ()
+		public async Task TestSpaceCommits ()
 		{
-			string output = RunSimulation ("", "over ", true, true, 
+			string output = await RunSimulation ("", "over ", true, true, 
 				"override",
 				"override foo");
 
@@ -859,14 +860,15 @@ namespace MonoDevelop.Ide.Gui
 
 
 		[Test]
-		public void TestNumberInput ()
+		public async Task TestNumberInput ()
 		{
-			string output = RunSimulation ("", "1.", true, true, false, "foo1");
+			string output = await RunSimulation ("", "1.", true, true, false, "foo1");
 			Assert.IsTrue (string.IsNullOrEmpty (output), "output was " + output);
 		}
 
-		static void ContinueSimulation (CompletionListWindow listWindow, ICompletionDataList list, ref TestCompletionWidget testCompletionWidget, string simulatedInput)
+		static async Task<TestCompletionWidget> ContinueSimulation (CompletionListWindow listWindow, ICompletionDataList list, string simulatedInput)
 		{
+			TestCompletionWidget testCompletionWidget;
 			listWindow.ResetState ();
 			listWindow.CodeCompletionContext = new CodeCompletionContext ();
 			listWindow.CompletionDataList = list;
@@ -874,12 +876,13 @@ namespace MonoDevelop.Ide.Gui
 			listWindow.List.FilterWords ();
 			listWindow.ResetSizes ();
 			listWindow.UpdateWordSelection ();
-			SimulateInput (listWindow, simulatedInput);
-			listWindow.CompleteWord ();
+			await SimulateInput (listWindow, simulatedInput);
+			await listWindow.CompleteWord ();
+			return testCompletionWidget;
 		}
 
 		[Test]
-		public void TestMruSimpleLastItem ()
+		public async Task TestMruSimpleLastItem ()
 		{
 			var settings = new SimulationSettings () {
 				AutoSelect = true,
@@ -892,18 +895,18 @@ namespace MonoDevelop.Ide.Gui
 			var list = listWindow.CompletionDataList;
 			var testCompletionWidget = (TestCompletionWidget)listWindow.CompletionWidget;
 
-			SimulateInput (listWindow, "FooBar\t");
+			await SimulateInput (listWindow, "FooBar\t");
 			Assert.AreEqual ("FooBar1", testCompletionWidget.CompletedWord);
 
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "FooFoo\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "FooFoo\t");
 			Assert.AreEqual ("FooFoo2", testCompletionWidget.CompletedWord);
 
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "F\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "F\t");
 			Assert.AreEqual ("FooFoo2", testCompletionWidget.CompletedWord);
 		}
 
 		[Test]
-		public void TestMruEmptyMatch ()
+		public async Task TestMruEmptyMatch ()
 		{
 			var settings = new SimulationSettings () {
 				AutoSelect = true,
@@ -915,28 +918,28 @@ namespace MonoDevelop.Ide.Gui
 			var listWindow = CreateListWindow (settings);
 			var list = listWindow.CompletionDataList;
 			var testCompletionWidget = (TestCompletionWidget)listWindow.CompletionWidget;
-			SimulateInput (listWindow, "Foo\t");
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "F\t");
+			await SimulateInput (listWindow, "Foo\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "F\t");
 			Assert.AreEqual ("Foo", testCompletionWidget.CompletedWord);
 
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "Bar\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "Bar\t");
 			Assert.AreEqual ("Bar", testCompletionWidget.CompletedWord);
 
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "\t");
 			Assert.AreEqual ("Bar", testCompletionWidget.CompletedWord);
 		}
 
 		[Test]
-		public void TestCloseWithPunctiation ()
+		public async Task TestCloseWithPunctiation ()
 		{
-			var output = RunSimulation ("", "\"\t", true, true, false, punctuationData);
+			var output = await RunSimulation ("", "\"\t", true, true, false, punctuationData);
 			Assert.AreEqual (null, output);
 		}
 
 		[Test]
-		public void TestPreference ()
+		public async Task TestPreference ()
 		{
-			string output = RunSimulation ("", "expr\t", true, true, false, "expression", "PostfixExpressionStatementSyntax");
+			string output = await RunSimulation ("", "expr\t", true, true, false, "expression", "PostfixExpressionStatementSyntax");
 			Assert.AreEqual ("expression", output);
 		}
 
@@ -944,9 +947,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 30591 - [Roslyn] Enum code-completion doesn't generate type on "."(dot)
 		/// </summary>
 		[Test]
-		public void TestBug30591 ()
+		public async Task TestBug0591 ()
 		{
-			var output = RunSimulation ("", ".", false, false, false, new [] { "foo" } );
+			var output = await RunSimulation ("", ".", false, false, false, new [] { "foo" } );
 			Assert.AreEqual ("foo", output);
 		}
 
@@ -954,9 +957,9 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 37985 - Code completion is selecting 'int32' instead of letting me type '2' 
 		/// </summary>
 		[Test]
-		public void TestBug37985 ()
+		public async Task TestBug37985 ()
 		{
-			var output = RunSimulation ("", "3\t", false, false, false, new [] { "Int32" } );
+			var output = await RunSimulation ("", "3\t", false, false, false, new [] { "Int32" } );
 			Assert.AreEqual (null, output);
 		}
 
@@ -964,7 +967,7 @@ namespace MonoDevelop.Ide.Gui
 		/// Bug 38180 - Code completion should be case sensitive 
 		/// </summary>
 		[Test]
-		public void TestBug38180 ()
+		public async Task TestBug38180 ()
 		{
 			var settings = new SimulationSettings () {
 				AutoSelect = true,
@@ -977,13 +980,13 @@ namespace MonoDevelop.Ide.Gui
 			var list = listWindow.CompletionDataList;
 			var testCompletionWidget = (TestCompletionWidget)listWindow.CompletionWidget;
 
-			SimulateInput (listWindow, "test\t");
+			await SimulateInput (listWindow, "test\t");
 			Assert.AreEqual ("test", testCompletionWidget.CompletedWord);
 
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "t\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "t\t");
 			Assert.AreEqual ("test", testCompletionWidget.CompletedWord);
 
-			ContinueSimulation (listWindow, list, ref testCompletionWidget, "T\t");
+			testCompletionWidget = await ContinueSimulation (listWindow, list, "T\t");
 			Assert.AreEqual ("Test", testCompletionWidget.CompletedWord);
 		}
 


### PR DESCRIPTION
This patch asynchronizes all the way up for `OnTheFlyFormatter`'s `Format` and `FormatStatmentAt` methods.

The reason for this patch is to fix editor choking on formatting a block and keypresses.