### PR TITLE
[MacPlatform] Use the OS X theme colour to decide the dock icon colour

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -416,12 +416,14 @@ namespace MonoDevelop.MacIntegration
 			NSObject initialBundleIconFileValue;
 			string iconFile = null;
 
+			string appleTheme = NSUserDefaults.StandardUserDefaults.StringForKey ("AppleInterfaceStyle");
+
 			// Try setting a dark variant of the application dock icon if one exists in the app bundle.
 			if (NSBundle.MainBundle.InfoDictionary.TryGetValue (new NSString ("CFBundleIconFile"), out initialBundleIconFileValue)) {
 				FilePath bundleIconRoot = GetAppBundleRoot (exePath).Combine ("Contents", "Resources");
 				NSString initialBundleIconFile = (NSString)initialBundleIconFileValue;
 
-				if (IdeApp.Preferences.UserInterfaceSkin == Skin.Dark) {
+				if (appleTheme == "Dark") {
 					iconFile = bundleIconRoot.Combine (Path.GetFileNameWithoutExtension (initialBundleIconFile) + "~dark" + Path.GetExtension (initialBundleIconFile));
 				}
 
@@ -433,12 +435,12 @@ namespace MonoDevelop.MacIntegration
 				// Setup without bundle.
 				string iconName = BrandingService.GetString ("ApplicationIcon");
 				if (iconName != null) {
-					if (IdeApp.Preferences.UserInterfaceSkin == Skin.Dark) {
+					if (appleTheme == "Dark") {
 						string darkIconName = Path.GetFileNameWithoutExtension (iconName) + "~dark" + Path.GetExtension (iconName);
 						iconFile = BrandingService.GetFile (darkIconName);
 					}
 
-					if (IdeApp.Preferences.UserInterfaceSkin == Skin.Light || iconFile == null) {
+					if (appleTheme == "Light" || iconFile == null) {
 						iconFile = BrandingService.GetFile (iconName);
 					}
 				} else {


### PR DESCRIPTION
Use the OS X theme to decide the colour of the icon in the dark, not the XS theme

@vancura, in case you think this is better suited?