### PR TITLE
Branding service improvements

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -65,6 +65,17 @@ namespace MonoDevelop.MacIntegration
 
 		Lazy<Dictionary<string, string>> mimemap;
 
+		static string applicationMenuName;
+
+		public static string ApplicationMenuName {
+			get {
+				return applicationMenuName ?? BrandingService.ApplicationName;
+			}
+			set {
+				applicationMenuName = value;
+			}
+		}
+
 		public MacPlatformService ()
 		{
 			if (initedGlobal)
@@ -253,13 +264,12 @@ namespace MonoDevelop.MacIntegration
 			//mac-ify these command names
 			commandManager.GetCommand (EditCommands.MonodevelopPreferences).Text = GettextCatalog.GetString ("Preferences...");
 			commandManager.GetCommand (EditCommands.DefaultPolicies).Text = GettextCatalog.GetString ("Custom Policies...");
-			commandManager.GetCommand (HelpCommands.About).Text = GettextCatalog.GetString ("About {0}", BrandingService.ApplicationName);
-			commandManager.GetCommand (MacIntegrationCommands.HideWindow).Text = GettextCatalog.GetString ("Hide {0}", BrandingService.ApplicationName);
 			commandManager.GetCommand (ToolCommands.AddinManager).Text = GettextCatalog.GetString ("Add-ins...");
 
 			initedApp = true;
 
 			IdeApp.Workbench.RootWindow.DeleteEvent += HandleDeleteEvent;
+			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
 
 			if (MacSystemInformation.OsVersion >= MacSystemInformation.Lion) {
 				IdeApp.Workbench.RootWindow.Realized += (sender, args) => {
@@ -277,6 +287,29 @@ namespace MonoDevelop.MacIntegration
 			
 			// FIXME: Immediate theme switching disabled, until NSAppearance issues are fixed 
 			//IdeApp.Preferences.UserInterfaceTheme.Changed += (s,a) => PatchGtkTheme ();
+		}
+
+		static string GetAboutCommandText ()
+		{
+			return GettextCatalog.GetString ("About {0}", ApplicationMenuName);
+		}
+
+		static string GetHideWindowCommandText ()
+		{
+			return GettextCatalog.GetString ("Hide {0}", ApplicationMenuName);
+		}
+
+		static void ApplicationNameChanged (object sender, EventArgs e)
+		{
+			Command aboutCommand = IdeApp.CommandService.GetCommand (HelpCommands.About);
+			if (aboutCommand != null)
+				aboutCommand.Text = GetAboutCommandText ();
+
+			Command hideCommand = IdeApp.CommandService.GetCommand (MacIntegrationCommands.HideWindow);
+			if (hideCommand != null)
+				hideCommand.Text = GetHideWindowCommandText ();
+
+			Carbon.SetProcessName (ApplicationMenuName);
 		}
 
 		// VV/VK: Disable tint based color generation

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -398,7 +398,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			textField.Cell = new VerticallyCenteredTextFieldCell (0f);
 			textField.Cell.StringValue = "";
-			textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationName, ColorForType (MessageType.Ready));
+			UpdateApplicationNamePlaceholderText ();
 
 			// The rect is empty because we use InVisibleRect to track the whole of the view.
 			textFieldArea = new NSTrackingArea (CGRect.Empty, NSTrackingAreaOptions.MouseEnteredAndExited | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.InVisibleRect, this, null);
@@ -437,6 +437,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			TaskService.Errors.TasksAdded += updateHandler;
 			TaskService.Errors.TasksRemoved += updateHandler;
+			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
 
 			AddSubview (buildResults);
 			AddSubview (imageView);
@@ -444,6 +445,16 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			progressView = new ProgressView ();
 			AddSubview (progressView);
+		}
+
+		void UpdateApplicationNamePlaceholderText ()
+		{
+			textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationName, ColorForType (MessageType.Ready));
+		}
+
+		void ApplicationNameChanged (object sender, EventArgs e)
+		{
+			UpdateApplicationNamePlaceholderText ();
 		}
 
 		public override void DidChangeBackingProperties ()
@@ -471,6 +482,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			TaskService.Errors.TasksAdded -= updateHandler;
 			TaskService.Errors.TasksRemoved -= updateHandler;
 			Ide.Gui.Styles.Changed -= LoadStyles;
+			BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
 			base.Dispose (disposing);
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BrandingService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BrandingService.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Core
 		static XDocument brandingDocument;
 		static XDocument localizedBrandingDocument;
 		
-		public static readonly string ApplicationName;
+		public static string ApplicationName;
 		public static readonly string SuiteName;
 		public static readonly string ProfileDirectoryName;
 		public static readonly string StatusSteadyIconId;
@@ -183,6 +183,22 @@ namespace MonoDevelop.Core
 		public static string BrandApplicationName (string s)
 		{
 			return s.Replace ("MonoDevelop", ApplicationName);
+		}
+
+		public static event EventHandler ApplicationNameChanged;
+
+		public static void UpdateApplicationName (string name)
+		{
+			if (string.IsNullOrEmpty (name))
+				name = "MonoDevelop";
+
+			if (ApplicationName != name) {
+				ApplicationName = name;
+
+				var handler = ApplicationNameChanged;
+				if (handler != null)
+					handler (null, new EventArgs ());
+			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
@@ -105,6 +105,8 @@ namespace MonoDevelop.Components.MainToolbar
 		StatusBarContextHandler ctxHandler;
 		bool progressBarVisible;
 
+		string currentApplicationName = String.Empty;
+
 		Queue<Message> messageQueue;
 
 		public StatusBar MainContext {
@@ -345,9 +347,13 @@ namespace MonoDevelop.Components.MainToolbar
 			TaskService.Errors.TasksAdded += updateHandler;
 			TaskService.Errors.TasksRemoved += updateHandler;
 
+			currentApplicationName = BrandingService.ApplicationName;
+			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
+			
 			box.Destroyed += delegate {
 				TaskService.Errors.TasksAdded -= updateHandler;
 				TaskService.Errors.TasksRemoved -= updateHandler;
+				BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
 			};
 
 			ebox.VisibleWindow = false;
@@ -364,6 +370,16 @@ namespace MonoDevelop.Components.MainToolbar
 			warningImage.Visible = false;
 
 			return ebox;
+		}
+
+		void ApplicationNameChanged (object sender, EventArgs e)
+		{
+			if (renderArg.CurrentText == currentApplicationName) {
+				LoadText (BrandingService.ApplicationName, false);
+				LoadPixbuf (null);
+				QueueDraw ();
+			}
+			currentApplicationName = BrandingService.ApplicationName;
 		}
 
 		protected override void OnRealized ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/AboutMonoDevelopTabPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/AboutMonoDevelopTabPage.cs
@@ -43,11 +43,11 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		{
 			BorderWidth = 0;
 
-			var aboutFile = BrandingService.GetFile ("AboutImage.png");
+			var aboutFile = BrandingService.GetFile (AboutDialogImage.Name);
 			if (aboutFile != null)
 				imageSep = Xwt.Drawing.Image.FromFile (aboutFile);
 			else
-				imageSep = Xwt.Drawing.Image.FromResource ("AboutImage.png");
+				imageSep = Xwt.Drawing.Image.FromResource (AboutDialogImage.Name);
 
 			PackStart (new ImageView (imageSep), false, false, 0);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/CommonAboutDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/CommonAboutDialog.cs
@@ -48,6 +48,11 @@ using MonoDevelop.Components;
 
 namespace MonoDevelop.Ide.Gui.Dialogs
 {
+	public static class AboutDialogImage
+	{
+		public static string Name =  "AboutImage.png";
+	}
+
 	internal class CommonAboutDialog : IdeDialog
 	{
 		public CommonAboutDialog ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -211,6 +211,7 @@ namespace MonoDevelop.Ide.Gui
 			HeightRequest = normalBounds.Height;
 
 			DeleteEvent += new Gtk.DeleteEventHandler (OnClosing);
+			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
 			
 			SetAppIcons ();
 
@@ -556,6 +557,11 @@ namespace MonoDevelop.Ide.Gui
 				return IdeApp.ProjectOperations.CurrentSelectedProject.Name + " - " + BrandingService.ApplicationName;
 			return BrandingService.ApplicationName;
 		}
+
+		void ApplicationNameChanged (object sender, EventArgs e)
+		{
+			SetWorkbenchTitle ();
+		}
 		
 		public Properties GetStoredMemento (ViewContent content)
 		{
@@ -730,6 +736,8 @@ namespace MonoDevelop.Ide.Gui
 				return false;
 			
 			CloseAllViews ();
+
+			BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
 			
 			PropertyService.Set ("SharpDevelop.Workbench.WorkbenchMemento", this.Memento);
 			IdeApp.OnExited ();


### PR DESCRIPTION
The BrandingService's ApplicationName is no longer readonly. If the
UpdateApplicationName method is used to update the name then the
ApplicationNameChanged event will fire. This can be used to update
any part of the UI that is showing the old application name.

Moved the default name of the dialog image to a class so it can
be updated at runtime.