### PR TITLE
[Core] Remove RemoteProjectBuilder finalizer

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -374,12 +374,6 @@ namespace MonoDevelop.Projects.MSBuild
 				builder = null;
 			}
 		}
-		
-		~RemoteProjectBuilder ()
-		{
-			// Using the logging service when shutting down MD can cause exceptions
-			Console.WriteLine ("RemoteProjectBuilder not disposed");
-		}
 
 		void BeginOperation ()
 		{


### PR DESCRIPTION
Fix for [#39972](https://bugzilla.xamarin.com/show_bug.cgi?id=39972)(review bug description for more details)

With `Console.WriteLine` in `RemoteProjectBuilder`'s finalizer headless builds failed with:
```
System.NotSupportedException: Stream does not support writing
  at System.IO.FileStream.Write (System.Byte[] array, Int32 offset, Int32 count) [0x000a5] in /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.IO/FileStream.cs:632
...
```

Before finalizer method was used to call `Dispose` method and it's not actual anymore since reference counter [was implemented](https://github.com/mono/monodevelop/commit/7c5dfe52cb698c4c71acf597ff9598f8104b04fe) in `RemoteProjectBuilder`.