### PR TITLE
[Ide] Fix editor traversal in command target chain

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -327,7 +327,7 @@ namespace MonoDevelop.Ide.Editor
 
 		object ICommandRouter.GetNextCommandTarget ()
 		{
-			return textEditorImpl;
+			return textEditor;
 		}
 
 		#endregion


### PR DESCRIPTION
This commit fixes the traversal of the editor in the command target
chain, to take into account the traversal of the editor extensions too.

The SourceEditorView does not route into the TextEditor, which is in
fact the real iterator of the text editor extensions in the chain.

Bug 39660 - Upon changing "Build Action" property grid gets reset