### PR TITLE
[Debugger] Set the debug layout after executing the process.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -574,8 +574,8 @@ namespace MonoDevelop.Debugger
 			session.TargetExited += delegate {
 				monitor.Dispose ();
 			};
-			SetDebugLayout ();
 			session.AttachToProcess (proc, GetUserOptions ());
+			SetDebugLayout ();
 			return currentDebugOperation;
 		}
 		
@@ -649,10 +649,9 @@ namespace MonoDevelop.Debugger
 			
 			SetupSession ();
 			
-			SetDebugLayout ();
-			
 			try {
 				session.Run (startInfo, GetUserOptions ());
+				SetDebugLayout ();
 			} catch {
 				Cleanup ();
 				throw;


### PR DESCRIPTION
Bug 3770 - Application output open while editing execution parameters