### PR TITLE
[Ide] Make mimetypes ignore case when checking supported files.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/MimeTypeNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/MimeTypeNode.cs
@@ -109,7 +109,7 @@ namespace MonoDevelop.Ide.Extensions
 						globalPattern.Append ('|');
 					globalPattern.Append (pattern);
 				}
-				return new Regex (globalPattern.ToString ());
+				return new Regex (globalPattern.ToString (), RegexOptions.IgnoreCase);
 			}
 			public bool SupportsFile (string fileName)
 			{
@@ -140,7 +140,7 @@ namespace MonoDevelop.Ide.Extensions
 			public bool SupportsFile (string fileName)
 			{
 				foreach (var ending in endings)
-					if (fileName.EndsWith (ending, StringComparison.Ordinal))
+					if (fileName.EndsWith (ending, StringComparison.OrdinalIgnoreCase))
 						return true;
 				return false;
 			}


### PR DESCRIPTION
This fixes files such as file.XML being considered as XML files.
Bug 4752 - Mimetype system does not recognize files with uppercased extensions

cc @mkrueger 