### PR TITLE
[Ide] Fix cell foreground after tree tooltip has been shown

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Gui/TestResultsPad.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Gui/TestResultsPad.cs
@@ -127,8 +127,6 @@ namespace MonoDevelop.UnitTesting
 			col.AddAttribute (tr, "markup", 1);
 			failuresTreeView.AppendColumn (col);
 			failuresTreeView.Model = failuresStore;
-			failuresTreeView.StyleSet += (o, args) => 
-				tr.Foreground = Styles.BaseForegroundColor.ToHexString (false);
 		
 			var sw = new MonoDevelop.Components.CompactScrolledWindow ();
 			sw.ShadowType = ShadowType.None;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -354,6 +354,21 @@ namespace MonoDevelop.Components
 			}
 		}
 
+		public static bool GetCellForegroundSet (this Gtk.CellRendererText cell)
+		{
+			GLib.Value property = cell.GetProperty ("foreground-set");
+			bool result = (bool)property;
+			property.Dispose ();
+			return result;
+		}
+
+		public static void SetCellForegroundSet (this Gtk.CellRendererText cell, bool value)
+		{
+			GLib.Value val = new GLib.Value (value);
+			cell.SetProperty ("foreground-set", val);
+			val.Dispose ();
+		}
+
 		public static Gdk.Rectangle ToScreenCoordinates (Gtk.Widget widget, Gdk.Window w, Gdk.Rectangle rect)
 		{
 			return new Gdk.Rectangle (ToScreenCoordinates (widget, w, rect.X, rect.Y), rect.Size);
@@ -837,6 +852,7 @@ namespace MonoDevelop.Components
 
 			Gdk.Rectangle expose = Allocation;
 			Gdk.Color save = Gdk.Color.Zero;
+			bool hasFgColor = false;
 			int x = 1;
 
 			col.CellSetCellData (tree.Model, iter, false, false);
@@ -846,6 +862,7 @@ namespace MonoDevelop.Components
 					continue;
 
 				if (cr is CellRendererText) {
+					hasFgColor = ((CellRendererText)cr).GetCellForegroundSet ();
 					save = ((CellRendererText)cr).ForegroundGdk;
 					((CellRendererText)cr).ForegroundGdk = Style.Foreground (State);
 				}
@@ -862,6 +879,7 @@ namespace MonoDevelop.Components
 
 				if (cr is CellRendererText) {
 					((CellRendererText)cr).ForegroundGdk = save;
+					((CellRendererText)cr).SetCellForegroundSet (hasFgColor);
 				}
 			}
 


### PR DESCRIPTION
Cell Foreground color rendering needs to be disabled
using the “foreground-set” property if the cell had
no foreground color before it has been modified
by the tooltip. Otherwise the cell will render its foreground
with the default Gdk.Color.Zero which is actually black.