### PR TITLE
[Ide] Don't remove projects from recent projects if they can't be found

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentOpen.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentOpen.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Ide.Desktop
 		public FdoRecentFiles (string storageFile)
 		{
 			recentFiles = new RecentFileStorage (storageFile);
-			recentFiles.RemoveMissingFiles (projGroup, fileGroup);
+			recentFiles.RemoveMissingFiles (fileGroup);
 		}
 		
 		public override event EventHandler Changed {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageRecentProjectsList.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageRecentProjectsList.cs
@@ -95,8 +95,6 @@ namespace MonoDevelop.Ide.WelcomePage
 			//TODO: pinned files
 			foreach (var recent in DesktopService.RecentFiles.GetProjects ().Take (itemCount)) {
 				var filename = recent.FileName;
-				if (!System.IO.File.Exists (filename))
-					continue;
 
 				var accessed = recent.TimeStamp;
 				var pixbuf = ImageService.GetIcon (GetIcon (filename), IconSize.Dnd);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageSection.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageSection.cs
@@ -150,8 +150,12 @@ namespace MonoDevelop.Ide.WelcomePage
 					// Possible other solution would be to check the recent projects list on focus in
 					// and update them accordingly.
 					if (!System.IO.File.Exists (file)) {
-						MessageService.ShowError (GettextCatalog.GetString ("File not found {0}", file));
-						FileService.NotifyFileRemoved (file);
+						var res = MessageService.AskQuestion (
+							GettextCatalog.GetString ("{0} could not be opened", file),
+							GettextCatalog.GetString ("Do you want to remove the reference to it from the Recent list?"),
+							AlertButton.No, AlertButton.Yes);
+						if (res == AlertButton.Yes)
+							FileService.NotifyFileRemoved (file);
 						return;
 					}
 


### PR DESCRIPTION
The file is inacessible if it is on a network drive that's not
connected.

Git checkout also removes the file and writes a new one causing the
project to be removed.

Bug 37122 - XS deletes solution from "recently opened" list if it is
unavailable