### PR TITLE
[Components] Use the native context menus for SearchEntry

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -564,8 +564,15 @@ namespace MonoDevelop.Components
 			#if MAC
 			var entries = window.FindAllChildWidgets ().OfType<Gtk.Entry> ();
 			foreach (var entry in entries) {
-				entry.ButtonPressEvent += EntryButtonPressHandler;
+				entry.UseNativeContextMenus ();
 			}
+			#endif
+		}
+
+		public static void UseNativeContextMenus (this Gtk.Entry entry)
+		{
+			#if MAC
+			entry.ButtonPressEvent += EntryButtonPressHandler;
 			#endif
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
@@ -161,6 +161,8 @@ namespace MonoDevelop.Components
 
 			box = new HBox ();
 			entry = new FramelessEntry (this);
+			entry.UseNativeContextMenus ();
+
 			filter_button = new HoverImageButton (IconSize.Menu, "md-searchbox-search");
 			clear_button = new HoverImageButton (IconSize.Menu, "md-searchbox-clear");
 


### PR DESCRIPTION
On the Mac use the native context menus for SearchEntry