### PR TITLE
[IDE] Allow Cmd+A to work as standard Gtk keybinding when in floating pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/EditCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/EditCommands.cs
@@ -376,6 +376,7 @@ namespace MonoDevelop.Ide.Commands
 		{
 			object focus = IdeApp.Workbench.RootWindow.HasToplevelFocus ? IdeApp.Workbench.RootWindow.Focus : null;
 			info.Enabled = (focus is Gtk.Editable || focus is Gtk.TextView);
+			info.Bypass = !IdeApp.Workbench.RootWindow.HasToplevelFocus;
 
 #if MAC
 			var macfocus = AppKit.NSApplication.SharedApplication?.KeyWindow?.FirstResponder;


### PR DESCRIPTION

Fixes BXC #39596