### PR TITLE
[NuGet] Fix license dialog closing with auto-hide parent window.

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
@@ -51,7 +51,8 @@ namespace MonoDevelop.PackageManagement
 		bool ShowLicenseAcceptanceDialog (IEnumerable<IPackage> packages)
 		{
 			using (LicenseAcceptanceDialog dialog = CreateLicenseAcceptanceDialog (packages)) {
-				int result = MessageService.ShowCustomDialog (dialog);
+				dialog.Modal = false;
+				int result = MessageService.ShowCustomDialog (dialog, IdeApp.Workbench.RootWindow);
 				return result == (int)Gtk.ResponseType.Ok;
 			}
 		}


### PR DESCRIPTION
Fixed bug #40119 - When trying to add multiple Google Play Packages
in Xamarin Studio Android Project, the dialog automatically selects
Decline

https://bugzilla.xamarin.com/show_bug.cgi?id=40119

If the license dialog was displayed when the top most window was an
auto-hide window, such as the Package Console window, then when the
auto-hide window closed the license dialog also closed without any
user input. This would cancel the install of the NuGet package since
the license was declined.

Note that the dialog's Modal property has to be set to false so the
parent window can be set. If the dialog is modal then the parent
window specified in the call to MessageService.RunCustomDialog is
ignored. The dialog is still treated as modal on the Mac and on
Windows with the Modal property set to false.