### PR TITLE
[Cycle 7] Restrict where the edition name is used. 

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -72,7 +72,10 @@ namespace MonoDevelop.MacIntegration
 				return applicationMenuName ?? BrandingService.ApplicationName;
 			}
 			set {
-				applicationMenuName = value;
+				if (applicationMenuName != value) {
+					applicationMenuName = value;
+					OnApplicationMenuNameChanged ();
+				}
 			}
 		}
 
@@ -269,7 +272,6 @@ namespace MonoDevelop.MacIntegration
 			initedApp = true;
 
 			IdeApp.Workbench.RootWindow.DeleteEvent += HandleDeleteEvent;
-			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
 
 			if (MacSystemInformation.OsVersion >= MacSystemInformation.Lion) {
 				IdeApp.Workbench.RootWindow.Realized += (sender, args) => {
@@ -299,7 +301,7 @@ namespace MonoDevelop.MacIntegration
 			return GettextCatalog.GetString ("Hide {0}", ApplicationMenuName);
 		}
 
-		static void ApplicationNameChanged (object sender, EventArgs e)
+		static void OnApplicationMenuNameChanged ()
 		{
 			Command aboutCommand = IdeApp.CommandService.GetCommand (HelpCommands.About);
 			if (aboutCommand != null)

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -449,7 +449,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		void UpdateApplicationNamePlaceholderText ()
 		{
-			textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationName, ColorForType (MessageType.Ready));
+			textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationLongName, ColorForType (MessageType.Ready));
 		}
 
 		void ApplicationNameChanged (object sender, EventArgs e)
@@ -472,7 +472,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				Appearance = NSAppearance.GetAppearance (NSAppearance.NameAqua);
 			}
 
-			textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationName, ColorForType (MessageType.Ready));
+			UpdateApplicationNamePlaceholderText ();
 			textColor = ColorForType (messageType);
 			ReconstructString ();
 		}
@@ -515,7 +515,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			if (string.IsNullOrEmpty (text)) {
 				textField.AttributedStringValue = new NSAttributedString ("");
-				textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationName, ColorForType (MessageType.Ready));
+				UpdateApplicationNamePlaceholderText ();
 				imageView.Image = ImageService.GetIcon (Stock.StatusSteady).ToNSImage ();
 			} else {
 				textField.AttributedStringValue = GetStatusString (text, textColor);

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/StatusBar.xaml.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/StatusBar.xaml.cs
@@ -223,7 +223,7 @@ namespace WindowsPlatform.MainToolbar
 		public void ShowReady ()
 		{
 			Status = StatusBarStatus.Ready;
-			ShowMessage (BrandingService.StatusSteadyIconId, BrandingService.ApplicationName);
+			ShowMessage (BrandingService.StatusSteadyIconId, BrandingService.ApplicationLongName);
 		}
 
 		public StatusBarIcon ShowStatusIcon (Xwt.Drawing.Image pixbuf)

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/StatusBar.xaml.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/StatusBar.xaml.cs
@@ -74,6 +74,7 @@ namespace WindowsPlatform.MainToolbar
 			};
 			TaskService.Errors.TasksAdded += updateHandler;
 			TaskService.Errors.TasksRemoved += updateHandler;
+			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
 
 			StatusText.ToolTipOpening += (o, e) => {
 				e.Handled = !TextTrimmed ();
@@ -119,6 +120,7 @@ namespace WindowsPlatform.MainToolbar
 		{
 			TaskService.Errors.TasksAdded -= updateHandler;
 			TaskService.Errors.TasksRemoved -= updateHandler;
+			BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
 		}
 
 		public void EndProgress ()
@@ -224,6 +226,12 @@ namespace WindowsPlatform.MainToolbar
 		{
 			Status = StatusBarStatus.Ready;
 			ShowMessage (BrandingService.StatusSteadyIconId, BrandingService.ApplicationLongName);
+		}
+
+		void ApplicationNameChanged (object sender, EventArgs e)
+		{
+			if (Status == StatusBarStatus.Ready)
+				ShowReady ();
 		}
 
 		public StatusBarIcon ShowStatusIcon (Xwt.Drawing.Image pixbuf)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BrandingService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BrandingService.cs
@@ -42,12 +42,44 @@ namespace MonoDevelop.Core
 		static XDocument brandingDocument;
 		static XDocument localizedBrandingDocument;
 		
-		public static string ApplicationName;
+		static string applicationName;
+		static string applicationLongName;
+
 		public static readonly string SuiteName;
 		public static readonly string ProfileDirectoryName;
 		public static readonly string StatusSteadyIconId;
 		public static readonly string HelpAboutIconId;
-		
+
+		public static string ApplicationName {
+			get {
+				return applicationName;
+			}
+			set {
+				if (string.IsNullOrEmpty (value))
+					value = "MonoDevelop";
+
+				if (applicationName != value) {
+					applicationName = value;
+					OnApplicationNameChanged ();
+				}
+			}
+		}
+
+		public static string ApplicationLongName {
+			get {
+				return applicationLongName;
+			}
+			set {
+				if (string.IsNullOrEmpty (value))
+					value = "MonoDevelop";
+
+				if (applicationLongName != value) {
+					applicationLongName = value;
+					OnApplicationNameChanged ();
+				}
+			}
+		}
+
 		static BrandingService ()
 		{
 			try {
@@ -77,6 +109,7 @@ namespace MonoDevelop.Core
 					}
 				}
 				ApplicationName = GetString ("ApplicationName");
+				ApplicationLongName = GetString ("ApplicationLongName") ?? ApplicationName;
 				SuiteName = GetString ("SuiteName");
 				ProfileDirectoryName = GetString ("ProfileDirectoryName");
 				StatusSteadyIconId = GetString ("StatusAreaSteadyIcon");
@@ -84,9 +117,6 @@ namespace MonoDevelop.Core
 			} catch (Exception ex) {
 				LoggingService.LogError ("Could not read branding document", ex);
 			}
-			
-			if (string.IsNullOrEmpty (ApplicationName))
-				ApplicationName = "MonoDevelop";
 
 			if (string.IsNullOrEmpty (SuiteName))
 				SuiteName = ApplicationName;
@@ -187,18 +217,11 @@ namespace MonoDevelop.Core
 
 		public static event EventHandler ApplicationNameChanged;
 
-		public static void UpdateApplicationName (string name)
+		static void OnApplicationNameChanged ()
 		{
-			if (string.IsNullOrEmpty (name))
-				name = "MonoDevelop";
-
-			if (ApplicationName != name) {
-				ApplicationName = name;
-
-				var handler = ApplicationNameChanged;
-				if (handler != null)
-					handler (null, new EventArgs ());
-			}
+			var handler = ApplicationNameChanged;
+			if (handler != null)
+				handler (null, new EventArgs ());
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
@@ -347,7 +347,7 @@ namespace MonoDevelop.Components.MainToolbar
 			TaskService.Errors.TasksAdded += updateHandler;
 			TaskService.Errors.TasksRemoved += updateHandler;
 
-			currentApplicationName = BrandingService.ApplicationName;
+			currentApplicationName = BrandingService.ApplicationLongName;
 			BrandingService.ApplicationNameChanged += ApplicationNameChanged;
 			
 			box.Destroyed += delegate {
@@ -375,11 +375,11 @@ namespace MonoDevelop.Components.MainToolbar
 		void ApplicationNameChanged (object sender, EventArgs e)
 		{
 			if (renderArg.CurrentText == currentApplicationName) {
-				LoadText (BrandingService.ApplicationName, false);
+				LoadText (BrandingService.ApplicationLongName, false);
 				LoadPixbuf (null);
 				QueueDraw ();
 			}
-			currentApplicationName = BrandingService.ApplicationName;
+			currentApplicationName = BrandingService.ApplicationLongName;
 		}
 
 		protected override void OnRealized ()
@@ -721,7 +721,7 @@ namespace MonoDevelop.Components.MainToolbar
 		void LoadText (string message, bool isMarkup)
 		{
 			if (string.IsNullOrEmpty(message))
-				message = BrandingService.ApplicationName;
+				message = BrandingService.ApplicationLongName;
 			message = message ?? "";
 
 			renderArg.LastText = renderArg.CurrentText;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/CommonAboutDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/CommonAboutDialog.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		public CommonAboutDialog ()
 		{
 			Name = "wizard_dialog";
-			Title = string.Format (GettextCatalog.GetString ("About {0}"), BrandingService.ApplicationName);
+			Title = string.Format (GettextCatalog.GetString ("About {0}"), BrandingService.ApplicationLongName);
 			TransientFor = IdeApp.Workbench.RootWindow;
 			AllowGrow = false;
 			HasSeparator = false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -529,7 +529,7 @@ namespace MonoDevelop.Ide.Gui
 				post = "*";
 			}
 			if (window.ViewContent.Project != null) {
-				return window.ViewContent.Project.Name + " - " + window.ViewContent.PathRelativeToProject + post + " - " + BrandingService.ApplicationName;
+				return window.ViewContent.Project.Name + " - " + window.ViewContent.PathRelativeToProject + post + " - " + BrandingService.ApplicationLongName;
 			}
 			return window.ViewContent.ContentName + post + " - " + BrandingService.ApplicationLongName;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -204,7 +204,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public DefaultWorkbench()
 		{
-			Title = BrandingService.ApplicationName;
+			Title = BrandingService.ApplicationLongName;
 			LoggingService.LogInfo ("Creating DefaultWorkbench");
 			
 			WidthRequest = normalBounds.Width;
@@ -531,7 +531,7 @@ namespace MonoDevelop.Ide.Gui
 			if (window.ViewContent.Project != null) {
 				return window.ViewContent.Project.Name + " - " + window.ViewContent.PathRelativeToProject + post + " - " + BrandingService.ApplicationName;
 			}
-			return window.ViewContent.ContentName + post + " - " + BrandingService.ApplicationName;
+			return window.ViewContent.ContentName + post + " - " + BrandingService.ApplicationLongName;
 		}
 		
 		void SetWorkbenchTitle ()
@@ -554,8 +554,8 @@ namespace MonoDevelop.Ide.Gui
 		static string GetDefaultTitle ()
 		{
 			if (IdeApp.ProjectOperations.CurrentSelectedProject != null)
-				return IdeApp.ProjectOperations.CurrentSelectedProject.Name + " - " + BrandingService.ApplicationName;
-			return BrandingService.ApplicationName;
+				return IdeApp.ProjectOperations.CurrentSelectedProject.Name + " - " + BrandingService.ApplicationLongName;
+			return BrandingService.ApplicationLongName;
 		}
 
 		void ApplicationNameChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
@@ -108,7 +108,7 @@ namespace MonoDevelop.Ide
 		}
 		
 		string ISystemInformationProvider.Title {
-			get { return BrandingService.ApplicationName; }
+			get { return BrandingService.ApplicationLongName; }
 		}
 
 		string ISystemInformationProvider.Description {


### PR DESCRIPTION
Fixed bug #40133 - Edition shown in places it shouldn't be
https://bugzilla.xamarin.com/show_bug.cgi?id=40133

The edition was added to the application name globally so it affected
all parts of the IDE. Now the application's edition is only shown in
the About dialog, the status area and the main window title on
Windows.

The BrandingService now has two application names - a short IDE name
(ApplicationName) and one that includes the edition
(ApplicationLongName).

The BrandingService has also been changed so that these two
application names are properties that can be set instead of fields so
the separate setter method can be removed.

Also needs an md-addins change.
