### PR TITLE
[Cycle 7] Fix wrong NuGet package version being installed.

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementSolutionExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementSolutionExtensions.cs
@@ -24,8 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using MonoDevelop.PackageManagement;
 using MonoDevelop.Projects;
 
 namespace MonoDevelop.PackageManagement
@@ -35,8 +33,7 @@ namespace MonoDevelop.PackageManagement
 		public static IPackageManagementProject GetProject (this IPackageManagementSolution solution, DotNetProject project)
 		{
 			var projectProxy = new DotNetProjectProxy (project);
-			var repository = PackageManagementServices.PackageRepositoryCache.CreateAggregateWithPriorityMachineCacheRepository ();
-			return solution.GetProject (repository, projectProxy);
+			return solution.GetProject (projectProxy);
 		}
 	}
 }


### PR DESCRIPTION
If a package version is not specified then using the aggregate
repository with the machine cache as the priority repository will
use the highest version found in the local machine cache instead
of the aggregate repository. This can result in a lower version being
installed than what is available on a remote package source.

One example of this problem is when the Google Play Services dialog
is used. This installs a Google Play Service NuGet package but does
not specify a version. If the NuGet package being installed is
found in the local machine cache then it will be used instead of
the latest from nuget.org.