### PR TITLE
[Test/Templates] Fix gtk-critical errors

### DIFF
--- a/main/tests/Ide.Tests/ProjectTemplateTests.cs
+++ b/main/tests/Ide.Tests/ProjectTemplateTests.cs
@@ -1,10 +1,10 @@
 //
-// MyClass.cs
+// ProjectTemplateTests.cs
 //
 // Author:
-//       alan <>
+//       Alan McGovern <alan@xamarin.com>
 //
-// Copyright (c) 2013 alan
+// Copyright (c) 2016 Xamarin Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
 using System.Collections.Generic;
 using MonoDevelop.Ide.Templates;
 using MonoDevelop.Projects;
 using NUnit.Framework;
-using System.Text;
 using UnitTests;
 using System.Linq;
 
@@ -37,19 +35,14 @@ namespace MonoDevelop.Ide
 	[TestFixture]
 	public class ProjectTemplateTests : TestBase
 	{
-		[Test]
-		[Ignore]
-		public void CreateGtkSharpProjectTemplate ()
+		public ProjectTemplateTests ()
 		{
-			// This test is a placeholder to remind us that Gtk# project creation is untested.
-			//
-			// The GTK# template uses stetic which depends on the IdeApp being initialized, but we cannot
-			// reliably start/shutdown XS as part of the test suite.
+			Simulate ();
 		}
 
-		static IEnumerable<string> Templates {
+		IEnumerable<string> Templates {
 			get {
-				return ProjectTemplate.ProjectTemplates.Select (t => t.Category + t.Name + t.LanguageName);
+				return ProjectTemplate.ProjectTemplates.Select (t => t.Id);
 			}
 		}
 
@@ -57,41 +50,24 @@ namespace MonoDevelop.Ide
 		[TestCaseSource ("Templates")]
 		public void CreateEveryProjectTemplate (string tt)
 		{
-//			var builder = new StringBuilder ();
-//			foreach (var template in ProjectTemplate.ProjectTemplates) {
-			var template = ProjectTemplate.ProjectTemplates.FirstOrDefault (t => t.Category + t.Name + t.LanguageName == tt);
-				if (template.Name.Contains ("Gtk#"))
-					return;
-//				try {
-					var dir = Util.CreateTmpDir (template.Id);
-					var cinfo = new ProjectCreateInformation {
-						ProjectBasePath = dir,
-						ProjectName = "ProjectName",
-						SolutionName = "SolutionName",
-						SolutionPath = dir
-					};
-					cinfo.Parameters ["CreateSharedAssetsProject"] = "False";
-					cinfo.Parameters ["UseUniversal"] = "True";
-					cinfo.Parameters ["UseIPad"] = "False";
-					cinfo.Parameters ["UseIPhone"] = "False";
-					cinfo.Parameters ["CreateiOSUITest"] = "False";
-					cinfo.Parameters ["CreateAndroidUITest"] = "False";
+			var template = ProjectTemplate.ProjectTemplates.FirstOrDefault (t => t.Id == tt);
+			if (template.Name.Contains ("Gtk#"))
+				return;
+			var dir = Util.CreateTmpDir (template.Id);
+			var cinfo = new ProjectCreateInformation {
+				ProjectBasePath = dir,
+				ProjectName = "ProjectName",
+				SolutionName = "SolutionName",
+				SolutionPath = dir
+			};
+			cinfo.Parameters ["CreateSharedAssetsProject"] = "False";
+			cinfo.Parameters ["UseUniversal"] = "True";
+			cinfo.Parameters ["UseIPad"] = "False";
+			cinfo.Parameters ["UseIPhone"] = "False";
+			cinfo.Parameters ["CreateiOSUITest"] = "False";
+			cinfo.Parameters ["CreateAndroidUITest"] = "False";
 
-					template.CreateWorkspaceItem (cinfo);
-/*				} catch (Exception ex) {
-					builder.AppendFormat (
-						"Could not create a project from the template '{0} / {1} ({2})': {3}",
-						template.Category, template.Name, template.LanguageName, ex
-					);
-					builder.AppendLine ();
-					builder.AppendLine ();
-					builder.AppendLine (ex.ToString ());
-					builder.AppendLine ();
-				}*/
-			//}
-
-//			if (builder.Length > 0)
-//				Assert.Fail (builder.ToString ());
+			template.CreateWorkspaceItem (cinfo);
 		}
 	}
 }

--- a/main/tests/UnitTests/TestBase.cs
+++ b/main/tests/UnitTests/TestBase.cs
@@ -81,7 +81,7 @@ namespace UnitTests
 			Environment.SetEnvironmentVariable ("MONO_ADDINS_REGISTRY", rootDir);
 			Environment.SetEnvironmentVariable ("XDG_CONFIG_HOME", rootDir);
 			Runtime.Initialize (true);
-			Xwt.Application.Initialize ();
+			Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
 			Gtk.Application.Init ();
 			DesktopService.Initialize ();
 			global::MonoDevelop.Projects.Services.ProjectService.DefaultTargetFramework

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -212,6 +212,11 @@
       <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>
       <Name>MonoDevelop.UnitTesting</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\external\xwt\Xwt.Gtk\Xwt.Gtk.csproj">
+      <Project>{C3887A93-B2BD-4097-8E2F-3A063EFF32FD}</Project>
+      <Name>Xwt.Gtk</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Util.cs" />


### PR DESCRIPTION
- Fixes monodevelop hang on debian 7 (according to @akoeplinger).
- Fixes templates tests (using IDs).
- Fixes test tree pad.