### PR TITLE
Fixed 'Bug 39397 - F# Addin Breaks Find References in C#'.

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -45,13 +45,14 @@ using Microsoft.CodeAnalysis.Options;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
 
 namespace MonoDevelop.Refactoring
 { 
 	public static class RefactoringService
 	{
 		internal static Func<TextEditor, DocumentContext, OptionSet> OptionSetCreation;
-		static List<FindReferencesProvider> findReferencesProvider = new List<FindReferencesProvider> ();
+		static ImmutableList<FindReferencesProvider> findReferencesProvider = ImmutableList<FindReferencesProvider>.Empty;
 		static List<JumpToDeclarationHandler> jumpToDeclarationHandler = new List<JumpToDeclarationHandler> ();
 
 		static RefactoringService ()
@@ -248,20 +249,20 @@ namespace MonoDevelop.Refactoring
 			if (hintProject == null)
 				hintProject = IdeApp.Workbench.ActiveDocument?.Project;
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
-			try {
-				foreach (var provider in findReferencesProvider) {
+			foreach (var provider in findReferencesProvider) {
+				try {
 					foreach (var result in await provider.FindReferences (documentIdString, hintProject, monitor.CancellationToken)) {
 						monitor.ReportResult (result);
 					}
-				}
-			} catch (Exception ex) {
-				if (monitor != null)
-					monitor.ReportError ("Error finding references", ex);
-				else
+				} catch (Exception ex) {
+					if (monitor != null)
+						monitor.ReportError ("Error finding references", ex);
 					LoggingService.LogError ("Error finding references", ex);
-			} finally {
-				if (monitor != null)
-					monitor.Dispose ();
+					findReferencesProvider = findReferencesProvider.Remove (provider);
+				} finally {
+					if (monitor != null)
+						monitor.Dispose ();
+				}
 			}
 		}
 
@@ -270,38 +271,40 @@ namespace MonoDevelop.Refactoring
 			if (hintProject == null)
 				hintProject = IdeApp.Workbench.ActiveDocument?.Project;
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
-			try {
-				foreach (var provider in findReferencesProvider) {
+			foreach (var provider in findReferencesProvider) {
+				try {
 					foreach (var result in await provider.FindAllReferences (documentIdString, hintProject, monitor.CancellationToken)) {
 						monitor.ReportResult (result);
 					}
-				}
-			} catch (OperationCanceledException) {
+				} catch (OperationCanceledException) {
 
-			} catch (Exception ex) {
-				if (monitor != null)
-					monitor.ReportError ("Error finding references", ex);
-				else
+				} catch (Exception ex) {
+					if (monitor != null)
+						monitor.ReportError ("Error finding references", ex);
 					LoggingService.LogError ("Error finding references", ex);
-			} finally {
-				if (monitor != null)
-					monitor.Dispose ();
+					findReferencesProvider = findReferencesProvider.Remove (provider);
+				} finally {
+					if (monitor != null)
+						monitor.Dispose ();
+				}
 			}
 		}
 
 		public static async Task<bool> TryJumpToDeclarationAsync (string documentIdString, Projects.Project hintProject = null, CancellationToken token = default(CancellationToken))
 		{
-			try {
 				if (hintProject == null)
 					hintProject = IdeApp.Workbench.ActiveDocument?.Project;
-				foreach (var handler in jumpToDeclarationHandler) {
+			for (int i = 0; i < jumpToDeclarationHandler.Count; i++) {
+				var handler = jumpToDeclarationHandler [i];
+				try {
 					if (await handler.TryJumpToDeclarationAsync (documentIdString, hintProject, token))
 						return true;
+				} catch (OperationCanceledException) {
+				} catch (Exception ex) {
+					LoggingService.LogError ("Error jumping to declaration", ex);
 				}
-			} catch (OperationCanceledException) {
-			} catch (Exception ex) {
-				LoggingService.LogError ("Error finding references", ex);
 			}
+
 			return false;
 		}
 	}

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -198,33 +198,33 @@ namespace MonoDevelop.Refactoring
 			}
 		}
 
-//		public static void QueueQuickFixAnalysis (Document doc, TextLocation loc, CancellationToken token, Action<List<CodeAction>> callback)
-//		{
-//			var ext = doc.GetContent<MonoDevelop.AnalysisCore.Gui.ResultsEditorExtension> ();
-//			var issues = ext != null ? ext.GetResultsAtOffset (doc.Editor.LocationToOffset (loc), token).OrderBy (r => r.Level).ToList () : new List<Result> ();
-//
-//			ThreadPool.QueueUserWorkItem (delegate {
-//				try {
-//					var result = new List<CodeAction> ();
-//					foreach (var r in issues) {
-//						if (token.IsCancellationRequested)
-//							return;
-//						var fresult = r as FixableResult;
-//						if (fresult == null)
-//							continue;
-////						foreach (var action in FixOperationsHandler.GetActions (doc, fresult)) {
-////							result.Add (new AnalysisContextActionProvider.AnalysisCodeAction (action, r) {
-////								DocumentRegion = action.DocumentRegion
-////							});
-////						}
-//					}
-//					result.AddRange (GetValidActions (doc, loc).Result);
-//					callback (result);
-//				} catch (Exception ex) {
-//					LoggingService.LogError ("Error in analysis service", ex);
-//				}
-//			});
-//		}	
+		//		public static void QueueQuickFixAnalysis (Document doc, TextLocation loc, CancellationToken token, Action<List<CodeAction>> callback)
+		//		{
+		//			var ext = doc.GetContent<MonoDevelop.AnalysisCore.Gui.ResultsEditorExtension> ();
+		//			var issues = ext != null ? ext.GetResultsAtOffset (doc.Editor.LocationToOffset (loc), token).OrderBy (r => r.Level).ToList () : new List<Result> ();
+		//
+		//			ThreadPool.QueueUserWorkItem (delegate {
+		//				try {
+		//					var result = new List<CodeAction> ();
+		//					foreach (var r in issues) {
+		//						if (token.IsCancellationRequested)
+		//							return;
+		//						var fresult = r as FixableResult;
+		//						if (fresult == null)
+		//							continue;
+		////						foreach (var action in FixOperationsHandler.GetActions (doc, fresult)) {
+		////							result.Add (new AnalysisContextActionProvider.AnalysisCodeAction (action, r) {
+		////								DocumentRegion = action.DocumentRegion
+		////							});
+		////						}
+		//					}
+		//					result.AddRange (GetValidActions (doc, loc).Result);
+		//					callback (result);
+		//				} catch (Exception ex) {
+		//					LoggingService.LogError ("Error in analysis service", ex);
+		//				}
+		//			});
+		//		}	
 
 		public static MonoDevelop.Ide.Editor.DocumentLocation GetCorrectResolveLocation (IReadonlyTextDocument editor, MonoDevelop.Ide.Editor.DocumentLocation location)
 		{
@@ -249,20 +249,22 @@ namespace MonoDevelop.Refactoring
 			if (hintProject == null)
 				hintProject = IdeApp.Workbench.ActiveDocument?.Project;
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
-			foreach (var provider in findReferencesProvider) {
-				try {
-					foreach (var result in await provider.FindReferences (documentIdString, hintProject, monitor.CancellationToken)) {
-						monitor.ReportResult (result);
+			try {
+				foreach (var provider in findReferencesProvider) {
+					try {
+						foreach (var result in await provider.FindReferences (documentIdString, hintProject, monitor.CancellationToken)) {
+							monitor.ReportResult (result);
+						}
+					} catch (Exception ex) {
+						if (monitor != null)
+							monitor.ReportError ("Error finding references", ex);
+						LoggingService.LogError ("Error finding references", ex);
+						findReferencesProvider = findReferencesProvider.Remove (provider);
 					}
-				} catch (Exception ex) {
-					if (monitor != null)
-						monitor.ReportError ("Error finding references", ex);
-					LoggingService.LogError ("Error finding references", ex);
-					findReferencesProvider = findReferencesProvider.Remove (provider);
-				} finally {
-					if (monitor != null)
-						monitor.Dispose ();
 				}
+			} finally {
+				if (monitor != null)
+					monitor.Dispose ();
 			}
 		}
 
@@ -271,22 +273,24 @@ namespace MonoDevelop.Refactoring
 			if (hintProject == null)
 				hintProject = IdeApp.Workbench.ActiveDocument?.Project;
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
-			foreach (var provider in findReferencesProvider) {
-				try {
-					foreach (var result in await provider.FindAllReferences (documentIdString, hintProject, monitor.CancellationToken)) {
-						monitor.ReportResult (result);
-					}
-				} catch (OperationCanceledException) {
+			try {
+				foreach (var provider in findReferencesProvider) {
+					try {
+						foreach (var result in await provider.FindAllReferences (documentIdString, hintProject, monitor.CancellationToken)) {
+							monitor.ReportResult (result);
+						}
+					} catch (OperationCanceledException) {
 
-				} catch (Exception ex) {
-					if (monitor != null)
-						monitor.ReportError ("Error finding references", ex);
-					LoggingService.LogError ("Error finding references", ex);
-					findReferencesProvider = findReferencesProvider.Remove (provider);
-				} finally {
-					if (monitor != null)
-						monitor.Dispose ();
+					} catch (Exception ex) {
+						if (monitor != null)
+							monitor.ReportError ("Error finding references", ex);
+						LoggingService.LogError ("Error finding references", ex);
+						findReferencesProvider = findReferencesProvider.Remove (provider);
+					}
 				}
+			} finally {
+				if (monitor != null)
+					monitor.Dispose ();
 			}
 		}
 


### PR DESCRIPTION
A breaking provider no longer breaks working ones.
If a provider breaks it's removed from the provider list to prevent
flooding of the IDE log.