### PR TITLE
[Mac] SelectorView should only do popup when enabled.

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -307,6 +307,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			public override void MouseDown (NSEvent theEvent)
 			{
+				if (!Enabled)
+					return;
+
 				var locationInView = ConvertPointFromView (theEvent.LocationInWindow, null);
 
 				var cellIdx = IndexOfCellAtX (locationInView.X);
@@ -315,7 +318,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				}
 
 				var item = PathComponentCells [cellIdx];
-				if (item == null)
+				if (item == null || !item.Enabled)
 					return;
 
 				var componentRect = ((NSPathCell)Cell).GetRect (item, Frame, this);


### PR DESCRIPTION
Bug 40293 - User should not able to change Active Configuration of running application in XS.