### PR TITLE
[C7][Bug 37577/40150] Focus Search result pad on search dialog closed

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
@@ -90,7 +90,7 @@ namespace MonoDevelop.Components.MainToolbar
 				var options = new FilterOptions ();
 				if (PropertyService.Get ("AutoSetPatternCasing", true))
 					options.CaseSensitive = pattern.Pattern.Any (c => char.IsUpper (c));
-				FindInFilesDialog.SearchReplace (pattern.Pattern, null, new WholeSolutionScope (), options, null);
+				FindInFilesDialog.SearchReplace (pattern.Pattern, null, new WholeSolutionScope (), options, null, null);
 			}
 
 			public override string GetMarkupText (bool selected)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
@@ -39,6 +39,12 @@ namespace MonoDevelop.Ide.FindInFiles
 	{
 		SearchResultPad outputPad;
 
+		internal SearchResultPad ResultPad {
+			get {
+				return outputPad;
+			}
+		}
+
 		internal SearchProgressMonitor (Pad pad, CancellationTokenSource cancellationTokenSource = null): base (Runtime.MainSynchronizationContext, cancellationTokenSource)
 		{
 			AddFollowerMonitor (IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (GettextCatalog.GetString ("Searching..."), Stock.StatusSearch, false, true, false, pad));


### PR DESCRIPTION
From #1359: When the "Find in Files" dialog is being closed, the Search Result Pad disappears (if it is not docked).
Fix: Search dialog retrieves the result pad from the monitor and focuses it when the Close button has been activated.

(fixes bug #37577)
(cherry picked from commit 0b9da61c9e836de36a703423d46f3c5ccfbf8cc7)