### PR TITLE
[Core] Fixed restored assembly not reflected in text editor.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2744,7 +2744,7 @@ namespace MonoDevelop.Projects
 			var include = GetPrefixedInclude (pathPrefix, item.UnevaluatedInclude ?? item.Include);
 
 			MSBuildItem buildItem;
-			if (item.BackingItem != null && item.BackingItem.Name == item.ItemName) {
+			if (item.BackingItem?.ParentObject != null && item.BackingItem.Name == item.ItemName) {
 				buildItem = item.BackingItem;
 			} else {
 				buildItem = msproject.AddNewItem (item.ItemName, include);


### PR DESCRIPTION
Fixed bug #39094 - Restoring NuGet packages does not update the type
system
https://bugzilla.xamarin.com/show_bug.cgi?id=39094

After a NuGet package restore sometimes on Windows the text editor
would still show errors for types that are now available due to the
restored assemblies.

When the NuGet addin refreshes the references by calling
DotNetProject.RefreshReferenceStatus the reference is removed and
added back again to the project. The changes to the references
fires events which cause the TypeSystem to ask the project for the
updated assembly information. This may cause the project to update
its MSBuildProject information in memory. If the MSBuildProject
informationis updated after the reference is removed but before the
refreshed reference is added back again the MSBuildProject removes the
the MSBuildItem associated with this reference. The MSBuildProject
then does not add this MSBuildItem back again after the reference is
added back to the DotNetProject.

The problem was that the refreshed reference has a copy of the
original MSBuildItem in its BackingItem property. However this
MSBuildItem is no longer part of the MSBuildProject. So when the
MSBuildProject is updated in memory the project reference's
MSBuildItem is not added to it since the Project's SaveProjectItem
believes it is already added.

The fix in this commit checks the project item's BackingItem has a
non-null ParentObject instead of just checking the BackingItem is
not null and will add a new MSBuildItem to the MSBuildProject if
the ParentObject is null. The ParentObject is set to null if the
MSBuildItem is removed from the MSBuildProject.

Another alternative way of fixing this would be to set the
project reference's BackingItem to null when the ProjectReference's
GetRefreshedReference method is called.