### PR TITLE
[MacToolbar] Hack to work around possible Cocoa bug in El Capitan

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -46,6 +46,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		internal NSToolbar widget;
 		internal Gtk.Window gtkWindow;
 
+		public static bool IsFullscreen { get; private set; }
 		AwesomeBar awesomeBar;
 
 		RunButton runButton {
@@ -150,6 +151,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			NSWindow nswin = GtkMacInterop.GetNSWindow (window);
 			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidResizeNotification, resizeAction, nswin);
 			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidEndLiveResizeNotification, resizeAction, nswin);
+
+			nswin.WillEnterFullScreen += (sender, e) => IsFullscreen = true;
+			nswin.WillExitFullScreen += (sender, e) => IsFullscreen = false;
 		}
 
 		internal void Initialize ()

--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -131,7 +131,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				//
 				// However after switching theme this filter is removed and the colour set here is the actual colour
 				// displayed onscreen.
-				Styles.DarkBorderBrokenColor.ToNSColor ().SetStroke ();
+
+				// This also seems to happen in fullscreen mode
+				if (MainToolbar.IsFullscreen) {
+					Styles.DarkBorderColor.ToNSColor ().SetStroke ();
+				} else {
+					Styles.DarkBorderBrokenColor.ToNSColor ().SetStroke ();
+				}
+
 				path.Stroke ();
 			} else {
 				if (controlView.Window?.Screen?.BackingScaleFactor == 2) {
@@ -144,7 +151,18 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public override void DrawInteriorWithFrame (CGRect cellFrame, NSView inView)
 		{
 			cellFrame = new CGRect (cellFrame.X, cellFrame.Y + 0.5f, cellFrame.Width, cellFrame.Height);
+
+			var old = Enabled;
+
+			// In fullscreen mode with dark skin on El Capitan, the disabled icon picked is for the
+			// normal appearance so it is too dark. Hack this so it comes up lighter.
+			// For further information see the comment in AwesomeBar.cs
+			if (IdeApp.Preferences.UserInterfaceSkin == Skin.Dark && MainToolbar.IsFullscreen) {
+				Enabled = true;
+			}
 			base.DrawInteriorWithFrame (cellFrame, inView);
+			Enabled = old;
+
 		}
 	}
 }

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -58,7 +58,13 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 						var path = NSBezierPath.FromRoundedRect (inset, 3, 3);
 						path.LineWidth = 0.5f;
 
-						Styles.DarkBorderColor.ToNSColor ().SetStroke ();
+						// Hack to make the border be the correct colour in fullscreen mode
+						// See comment in AwesomeBar.cs for more details
+						if (MainToolbar.IsFullscreen) {
+							Styles.DarkBorderBrokenColor.ToNSColor ().SetStroke ();
+						} else {
+							Styles.DarkBorderColor.ToNSColor ().SetStroke ();
+						}
 						path.Stroke ();
 					}
 


### PR DESCRIPTION
In El Capitan, the fullscreen toolbar does not respect the VibrantDark appearance if the user has the Graphite appearance selected instead of the default Blue. These hacks colour the fullscreen toolbar the correct grey we wanted in the first place.

Fixes BXC #40160