### PR TITLE
[MacToolbar] Hack to work around possible Cocoa bug in El Capitan

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -30,7 +30,7 @@ using CoreGraphics;
 using Foundation;
 using MonoDevelop.Core;
 
-using MonoDevelop.Core;
+using Xwt.Mac;
 using MonoDevelop.Ide;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
@@ -74,6 +74,57 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public static float ToolbarWidgetHeight {
 			get {
 				return MacSystemInformation.OsVersion >= MacSystemInformation.ElCapitan ? 24.0f : 22.0f;
+			}
+		}
+
+		public override void ViewDidMoveToWindow ()
+		{
+			base.ViewDidMoveToWindow ();
+
+			if (IdeApp.Preferences.UserInterfaceSkin == Skin.Light) {
+				return;
+			}
+
+			// I'm sorry. I'm so so sorry.
+			// When the user has Graphite appearance set in System Preferences on El Capitan
+			// and they enter fullscreen mode, Cocoa doesn't respect the VibrantDark appearance
+			// making the toolbar background white instead of black, however the toolbar items do still respect
+			// the dark appearance, making them white on white.
+			//
+			// So, an absolute hack is to go through the toolbar hierarchy and make all the views background colours
+			// be the dark grey we wanted them to be in the first place.
+			//
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=40160
+			//
+			if (Window == null || Window == MacInterop.GtkQuartz.GetWindow (IdeApp.Workbench.RootWindow)) {
+				if (Superview != null) {
+					Superview.WantsLayer = false;
+
+					if (Superview.Superview != null) {
+						Superview.Superview.WantsLayer = false;
+					}
+				}
+				return;
+			}
+
+			var bgColor = Styles.DarkToolbarBackgroundColor.ToNSColor ().CGColor;
+
+			// NSToolbarItemViewer
+			if (Superview != null) {
+				Superview.WantsLayer = true;
+				Superview.Layer.BackgroundColor = bgColor;
+
+				if (Superview.Superview != null) {
+					// _NSToolbarViewClipView
+					Superview.Superview.WantsLayer = true;
+					Superview.Superview.Layer.BackgroundColor = bgColor;
+
+					if (Superview.Superview.Superview != null && Superview.Superview.Superview.Superview != null) {
+						// NSTitlebarView
+						Superview.Superview.Superview.Superview.WantsLayer = true;
+						Superview.Superview.Superview.Superview.Layer.BackgroundColor = bgColor;
+					}
+				}
 			}
 		}
 

--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -46,6 +46,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		internal NSToolbar widget;
 		internal Gtk.Window gtkWindow;
 
+		public static bool IsFullscreen { get; private set; }
 		AwesomeBar awesomeBar;
 
 		RunButton runButton {
@@ -147,9 +148,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				item.MaxSize = size;
 			});
 
+			// We can't use the events that Xamarin.Mac adds for delegate methods as they will overwrite
+			// the delegate that Gtk has added
 			NSWindow nswin = GtkMacInterop.GetNSWindow (window);
 			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidResizeNotification, resizeAction, nswin);
 			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidEndLiveResizeNotification, resizeAction, nswin);
+
+			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.WillEnterFullScreenNotification, (note) => IsFullscreen = true, nswin);
+			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.WillExitFullScreenNotification, (note) => IsFullscreen = false, nswin);
 		}
 
 		internal void Initialize ()

--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -131,7 +131,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				//
 				// However after switching theme this filter is removed and the colour set here is the actual colour
 				// displayed onscreen.
-				Styles.DarkBorderBrokenColor.ToNSColor ().SetStroke ();
+
+				// This also seems to happen in fullscreen mode
+				if (MainToolbar.IsFullscreen) {
+					Styles.DarkBorderColor.ToNSColor ().SetStroke ();
+				} else {
+					Styles.DarkBorderBrokenColor.ToNSColor ().SetStroke ();
+				}
+
 				path.Stroke ();
 			} else {
 				if (controlView.Window?.Screen?.BackingScaleFactor == 2) {
@@ -144,7 +151,17 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public override void DrawInteriorWithFrame (CGRect cellFrame, NSView inView)
 		{
 			cellFrame = new CGRect (cellFrame.X, cellFrame.Y + 0.5f, cellFrame.Width, cellFrame.Height);
+
+			var old = Enabled;
+
+			// In fullscreen mode with dark skin on El Capitan, the disabled icon picked is for the
+			// normal appearance so it is too dark. Hack this so it comes up lighter.
+			// For further information see the comment in AwesomeBar.cs
+			if (IdeApp.Preferences.UserInterfaceSkin == Skin.Dark && MainToolbar.IsFullscreen) {
+				Enabled = true;
+			}
 			base.DrawInteriorWithFrame (cellFrame, inView);
+			Enabled = old;
 		}
 	}
 }

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -58,7 +58,13 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 						var path = NSBezierPath.FromRoundedRect (inset, 3, 3);
 						path.LineWidth = 0.5f;
 
-						Styles.DarkBorderColor.ToNSColor ().SetStroke ();
+						// Hack to make the border be the correct colour in fullscreen mode
+						// See comment in AwesomeBar.cs for more details
+						if (MainToolbar.IsFullscreen) {
+							Styles.DarkBorderBrokenColor.ToNSColor ().SetStroke ();
+						} else {
+							Styles.DarkBorderColor.ToNSColor ().SetStroke ();
+						}
 						path.Stroke ();
 					}
 

--- a/main/src/addins/MacPlatform/MainToolbar/Styles.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/Styles.cs
@@ -41,6 +41,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		// Dark workaround colors
 		public static Color DarkBorderColor { get; private set; }
 		public static Color DarkBorderBrokenColor { get; private set; }
+		public static Color DarkToolbarBackgroundColor { get; private set; }
 
 		static Styles ()
 		{
@@ -72,6 +73,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				// To get the DarkBorderColor we need to use a workaround.
 				// See comment in ColoredButtonCell.DrawBezelWithFrame (RunButton.cs)
 				DarkBorderBrokenColor = Color.FromName ("#3e3e3e");
+
+				DarkToolbarBackgroundColor = Color.FromName ("#4e4e4e");
 			}
 		}
 	}


### PR DESCRIPTION
In El Capitan, the fullscreen toolbar does not respect the VibrantDark appearance if the user has the Graphite appearance selected instead of the default Blue. These hacks colour the fullscreen toolbar the correct grey we wanted in the first place.

Fixes BXC #40160