### PR TITLE
[Ide][Bug 28451] Fix disabled state colors in Solution Pad [c7]

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -65,7 +65,10 @@ namespace MonoDevelop.Components
 
 		public static string GetHex (this Gdk.Color color)
 		{
-			return String.Format("#{0:x2}{1:x2}{2:x2}", (byte)(color.Red), (byte)(color.Green), (byte)(color.Blue));
+			return String.Format("#{0:x2}{1:x2}{2:x2}",
+			                     (byte)(((double)color.Red / ushort.MaxValue) * 255),
+			                     (byte)(((double)color.Green / ushort.MaxValue) * 255),
+			                     (byte)(((double)color.Blue / ushort.MaxValue) * 255));
 		}
 
 		public static Gdk.Color ToGdkColor (this Cairo.Color color)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -325,10 +325,8 @@ namespace MonoDevelop.Ide.Gui.Components
 			var info = (NodeInfo)model.GetValue (it, NodeInfoColumn);
 			var cell = (CustomCellRendererText)renderer;
 
-			if (info.DisabledStyle)
-				cell.TextMarkup = "<span foreground='gray'>" + info.Label + "</span>";
-			else
-				cell.TextMarkup = info.Label;
+			cell.DisabledStyle = info.DisabledStyle;
+			cell.TextMarkup = info.Label;
 
 			cell.StatusIcon = info.StatusIconInternal;
 		}
@@ -2387,6 +2385,8 @@ namespace MonoDevelop.Ide.Gui.Components
 				set { Markup = markup = value; }
 			}
 
+			public bool DisabledStyle { get; set; }
+
 			[GLib.Property ("status-icon")]
 			public Xwt.Drawing.Image StatusIcon { get; set; }
 
@@ -2420,8 +2420,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				return icon.WithSize (size);
 			}
 
-
-			void SetupLayout (Gtk.Widget widget)
+			void SetupLayout (Gtk.Widget widget, Gtk.CellRendererState flags = 0)
 			{
 				if (scaledFont == null) {
 					if (scaledFont != null)
@@ -2439,7 +2438,15 @@ namespace MonoDevelop.Ide.Gui.Components
 					layout.FontDescription = scaledFont;
 				}
 
-				layout.SetMarkup (TextMarkup);
+				if (DisabledStyle) {
+					Gdk.Color fgColor;
+					if (Platform.IsMac && flags.HasFlag (Gtk.CellRendererState.Selected)) 
+						fgColor = widget.Style.Text (IdeTheme.UserInterfaceSkin == Skin.Light ? Gtk.StateType.Selected : Gtk.StateType.Normal);
+					else
+						fgColor = widget.Style.Text (Gtk.StateType.Insensitive);
+					layout.SetMarkup ("<span foreground='" + fgColor.GetHex () + "'>" + TextMarkup + "</span>");
+				} else
+					layout.SetMarkup (TextMarkup);
 			}
 
 			protected override void Render (Gdk.Drawable window, Gtk.Widget widget, Gdk.Rectangle background_area, Gdk.Rectangle cell_area, Gdk.Rectangle expose_area, Gtk.CellRendererState flags)
@@ -2454,7 +2461,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				if ((flags & Gtk.CellRendererState.Selected) != 0)
 					st = widget.HasFocus ? Gtk.StateType.Selected : Gtk.StateType.Active;
 
-				SetupLayout (widget);
+				SetupLayout (widget, flags);
 
 				int w, h;
 				layout.GetPixelSize (out w, out h);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/UnknownEntryNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/UnknownEntryNodeBuilder.cs
@@ -62,13 +62,15 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 					Context.CacheComposedIcon (nodeInfo.Icon, "fade", gicon);
 				}
 				nodeInfo.Icon = gicon;
-				nodeInfo.Label = GettextCatalog.GetString ("<span foreground='grey'>{0} <span size='small'>(Unavailable)</span></span>", GLib.Markup.EscapeText (entry.Name));
+				nodeInfo.Label = GettextCatalog.GetString ("{0} <span size='small'>(Unavailable)</span>", GLib.Markup.EscapeText (entry.Name));
+				nodeInfo.DisabledStyle = true;
 			}
 			else if (entry.LoadError.Length > 0) {
 				nodeInfo.Icon = Context.GetIcon (MonoDevelop.Ide.Gui.Stock.Project).WithAlpha (0.5);
 				nodeInfo.Label = entry.Name;
 				nodeInfo.StatusSeverity = TaskSeverity.Error;
 				nodeInfo.StatusMessage = GettextCatalog.GetString ("Load failed: ") + entry.LoadError;
+				nodeInfo.DisabledStyle = true;
 			} else {
 				nodeInfo.Icon = Context.GetIcon (MonoDevelop.Ide.Gui.Stock.Project);
 				var gicon = Context.GetComposedIcon (nodeInfo.Icon, "fade");


### PR DESCRIPTION
Fix disabled state colors in Solution Pad

* Load cell foreground colors from GtkTreeView style
* Different selected state colors on Mac
* Fix Gdk.Color to Hex string conversion

(fixes bug #28451)