### PR TITLE
[Core] Fix ProcessWrapper

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessWrapper.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessWrapper.cs
@@ -96,10 +96,10 @@ namespace MonoDevelop.Core.Execution
 				if (endEventErr != null)
 					endEventErr.WaitOne ();
 
-				if (HasExited)
-					operation.ExitCode = ExitCode;
-
 				try {
+					if (HasExited)
+						operation.ExitCode = ExitCode;
+
 					OnExited (this, EventArgs.Empty);
 				} catch {
 					// Ignore


### PR DESCRIPTION
Fixed bug #40379.

Avoid "System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'handle'" when calling HasExited.