### PR TITLE
Fixed 'Bug 40413 - Incorrect number of method overloads'.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/DelegateCreationContextHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/DelegateCreationContextHandler.cs
@@ -86,14 +86,12 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 			var enclosingType = model.GetEnclosingNamedType (position, cancellationToken);
 			if (enclosingType == null)
 				return Task.FromResult (Enumerable.Empty<CompletionData> ());
-			var memberMethods = enclosingType.GetMembers ().OfType<IMethodSymbol> ().Where (m => m.MethodKind == MethodKind.Ordinary).ToArray ();
 
 			var list = new List<CompletionData> ();
 			foreach (var type in ctx.InferredTypes) {
 				if (type.TypeKind != TypeKind.Delegate)
 					continue;
 
-				AddCompatibleMethods (engine, list, type, memberMethods, cancellationToken);
 
 				string delegateName = null;
 
@@ -107,16 +105,6 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 				result.AutoSelect = false;
 			}
 			return Task.FromResult ((IEnumerable<CompletionData>)list);
-		}
-
-		void AddCompatibleMethods (CompletionEngine engine, List<CompletionData> list, ITypeSymbol delegateType, IMethodSymbol [] memberMethods, CancellationToken cancellationToken)
-		{
-			var delegateMethod = delegateType.GetDelegateInvokeMethod ();
-			foreach (var method in memberMethods) {
-				if (method.ReturnType.Equals (delegateMethod.ReturnType) && SignatureComparer.HaveSameSignature (delegateMethod.Parameters, method.Parameters, false, false)) {
-					list.Add (engine.Factory.CreateExistingMethodDelegate (this, method));
-				}
-			}
 		}
 
 		static string GuessEventHandlerBaseName (SyntaxNode node, TypeDeclarationSyntax containingTypeDeclaration)

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/Features/CodeCompletion/NR6/MiscTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/Features/CodeCompletion/NR6/MiscTests.cs
@@ -183,5 +183,32 @@ using System.Reflection;
 [assembly: AssemblyTitle(S$$)]
 ", "System");
 		}
+
+		/// <summary>
+		/// Bug 40413 - Incorrect number of method overloads
+		/// </summary>
+		[Test]
+		public void TestBug40413 ()
+		{
+			var provider = CreateProvider (
+				@"
+using System;
+
+class Test
+{
+    static object Foo(int arg, int arg2) { return null; }
+    static object Foo(object arg, object arg2) { return null; }
+
+    public static void Main(string[] args)
+    {
+        Func<int, int, object> o = $F$
+    }
+}", usePreviousCharAsTrigger: true);
+			Assert.IsNotNull (provider, "provider was not created.");
+			var data = provider.Find ("Foo");
+			Assert.IsNotNull (data);
+			Assert.AreEqual (2, data.OverloadedData.Count);
+		}
+
 	}
 }


### PR DESCRIPTION
No need to add methods in the delegate context handler - the roslyn
recommender already does that for us. Must be a left over from the NR5
engine.