### PR TITLE
[Ide] Error list pad not taking into account a sorted model.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -915,8 +915,9 @@ namespace MonoDevelop.Ide.Gui.Pads
 		private void ItemToggled (object o, ToggledArgs args)
 		{
 			Gtk.TreeIter iter;
-			if (store.GetIterFromString (out iter, args.Path)) {
-				TaskListEntry task = (TaskListEntry)store.GetValue (iter, DataColumns.Task);
+
+			if (view.Model.GetIterFromString (out iter, args.Path)) {
+				TaskListEntry task = (TaskListEntry)view.Model.GetValue (iter, DataColumns.Task);
 				task.Completed = !task.Completed;
 				TaskService.FireTaskToggleEvent (this, new TaskEventArgs (task));
 			}


### PR DESCRIPTION
When getting an iter from a sorted model, the store is not guaranteed to have the same iter paths.
Use the view's treemodel to get the element to ensure same elements are being used.
Bug 40157 - [Error Pad] Inverted click when errors/warnings are sorted descending