### PR TITLE
[Ide] Fixes to miscellaneous reusages of iter/paths from model/store …

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
@@ -472,7 +472,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 				do {
 					Command command = (Command) keyStore.GetValue (citer, commandCol);
 					if (command == cmd) {
-						TreePath path = keyStore.GetPath (citer);
+						TreePath path = filterModel.ConvertChildPathToPath (keyStore.GetPath (citer));
 						keyTreeView.ExpandToPath (path);
 						keyTreeView.Selection.SelectPath (path);
 						keyTreeView.ScrollToCell (path, keyTreeView.Columns[0], true, 0.5f, 0f);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -562,10 +562,10 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 		void OnTaskJumpto (object o, EventArgs args)
 		{
-			TreeIter iter;
+			TreeIter iter, sortedIter;
 			TreeModel model;
-			if (view.Selection.GetSelected (out model, out iter)) {
-				iter = filter.ConvertIterToChildIter (sort.ConvertIterToChildIter (iter));
+			if (view.Selection.GetSelected (out model, out sortedIter)) {
+				iter = filter.ConvertIterToChildIter (sort.ConvertIterToChildIter (sortedIter));
 				store.SetValue (iter, DataColumns.Read, true);
 				TaskListEntry task = store.GetValue (iter, DataColumns.Task) as TaskListEntry;
 				if (task != null) {
@@ -781,11 +781,13 @@ namespace MonoDevelop.Ide.Gui.Pads
 			filter.Refilter ();
 		}
 
-		bool FilterTasks (TreeModel model, TreeIter iter)
+		bool FilterTasks (TreeModel model, TreeIter sortedIter)
 		{
+			Gtk.TreeIter iter;
 			bool canShow = false;
 
 			try {
+				iter = filter.ConvertIterToChildIter (sort.ConvertIterToChildIter (sortedIter));
 				TaskListEntry task = store.GetValue (iter, DataColumns.Task) as TaskListEntry;
 				if (task == null)
 					return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
@@ -210,10 +210,10 @@ namespace MonoDevelop.Ide.Tasks
 			TaskService.UserTasks.Add (task);
 			updating = false;
 			TreeIter iter = store.AppendValues (GettextCatalog.GetString (Enum.GetName (typeof (TaskPriority), task.Priority)), task.Completed, task.Description, task, GetColorByPriority (task.Priority), task.Completed ? (int)Pango.Weight.Light : (int)Pango.Weight.Bold);
-			view.Selection.SelectIter (iter);
-			TreePath path = store.GetPath (iter);
-			view.ScrollToCell (path, view.Columns[(int)Columns.Description], true, 0, 0);
-			view.SetCursorOnCell (path, view.Columns[(int)Columns.Description], cellRendDesc, true);
+			view.Selection.SelectIter (sortModel.ConvertChildIterToIter (iter));
+			TreePath sortedPath = sortModel.ConvertChildPathToPath (store.GetPath (iter));
+			view.ScrollToCell (sortedPath, view.Columns[(int)Columns.Description], true, 0, 0);
+			view.SetCursorOnCell (sortedPath, view.Columns[(int)Columns.Description], cellRendDesc, true);
 			TaskService.SaveUserTasks (task.WorkspaceObject);
 		}
 
@@ -241,7 +241,8 @@ namespace MonoDevelop.Ide.Tasks
 			if (view.Selection.CountSelectedRows () > 0)
 			{
 				TreeIter iter;
-				if (store.GetIter (out iter, view.Selection.GetSelectedRows ()[0]))
+				Gtk.TreePath path = sortModel.ConvertPathToChildPath (view.Selection.GetSelectedRows () [0]);
+				if (store.GetIter (out iter, path))
 				{
 					TaskListEntry task = (TaskListEntry) store.GetValue (iter, (int)Columns.UserTask);
 					updating = true;


### PR DESCRIPTION
…when sorts/filters are in place.

We probably need to do a full pass through all the store/treemodel usages to ensure they are correct, I just went for wherever filter/sorts were in place.

That means making them future-proof for sorting/filtering.