### PR TITLE
[Cycle 7][Core] Fix null reference when getting missing property as path.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyCore.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyCore.cs
@@ -97,7 +97,7 @@ namespace MonoDevelop.Projects.MSBuild
 			var res = MSBuildProjectService.FromMSBuildPath (baseDir, val, out path);
 
 			// Remove the trailing slash
-			if (path.Length > 0 && path[path.Length - 1] == System.IO.Path.DirectorySeparatorChar && path != "." + System.IO.Path.DirectorySeparatorChar)
+			if (path != null && path.Length > 0 && path[path.Length - 1] == System.IO.Path.DirectorySeparatorChar && path != "." + System.IO.Path.DirectorySeparatorChar)
 				path = path.TrimEnd (System.IO.Path.DirectorySeparatorChar);
 			
 			value = path;

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1354,6 +1354,24 @@ namespace MonoDevelop.Projects
         }
 
 		[Test]
+		public async Task TargetEvaluationResultTryGetPathValueForNullPropertyValue ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			Solution sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (Project) sol.Items [0];
+
+			var ctx = new TargetEvaluationContext ();
+			ctx.PropertiesToEvaluate.Add ("MissingProperty");
+			var res = await p.RunTarget (Util.GetMonitor (), "Build", p.Configurations [0].Selector, ctx);
+
+			Assert.IsNull (res.Properties.GetValue ("MissingProperty"));
+
+			FilePath path = null;
+			bool foundProperty = res.Properties.TryGetPathValue ("MissingProperty", out path);
+			Assert.IsFalse (foundProperty);
+		}
+
+		[Test]
 		public async Task BuildWithCustomProps ()
 		{
 			string projFile = Util.GetSampleProject ("msbuild-tests", "project-with-custom-build-target.csproj");


### PR DESCRIPTION
If after an MSBuild target is run with a set of properties to
evaluate and a property is missing when converting that property to
a FilePath the TryGetPathValue method would throw a null reference
exception if the property was not set by the MSBuild target.