### PR TITLE
[Core] Fix ProcessWrapper

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessWrapper.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessWrapper.cs
@@ -96,8 +96,12 @@ namespace MonoDevelop.Core.Execution
 				if (endEventErr != null)
 					endEventErr.WaitOne ();
 
-				if (HasExited)
-					operation.ExitCode = ExitCode;
+				try {
+					if (HasExited)
+						operation.ExitCode = ExitCode;
+				} catch {
+					// Ignore
+				}
 
 				try {
 					OnExited (this, EventArgs.Empty);


### PR DESCRIPTION
Fixed bug [#40379](https://bugzilla.xamarin.com/show_bug.cgi?id=40379).

Avoid "System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'handle'" when calling HasExited.