### PR TITLE
[Windows] Send the text changed event when encountering an empty string.

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/WPFToolbar.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/WPFToolbar.cs
@@ -68,7 +68,7 @@ namespace WindowsPlatform.MainToolbar
 			};
 
 			toolbar.SearchBar.SearchBar.TextChanged += (o, e) => {
-				if (string.IsNullOrEmpty (SearchText) || SearchText == SearchPlaceholderMessage)
+				if (SearchText == SearchPlaceholderMessage)
 					return;
 
 				if (SearchEntryChanged != null)


### PR DESCRIPTION
Bug 40339 - [Cycle 7] Search list is not getting close after removing the search text in search box.