### PR TITLE
[Refactoring] Fixed extract method bug.

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/InsertionPointService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/InsertionPointService.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Refactoring
 			if (result.Count > 1) {
 				result.RemoveAt (result.Count - 1); 
 				NewLineInsertion insertLine;
-				var typeSyntaxReference = type.DeclaringSyntaxReferences.FirstOrDefault (r => r.Span.Contains (sourceSpan));
+				var typeSyntaxReference = type.DeclaringSyntaxReferences.FirstOrDefault (r => r.SyntaxTree.FilePath == data.FileName && r.Span.Contains (sourceSpan));
 
 				var lineBefore = data.GetLineByOffset (typeSyntaxReference.Span.End).PreviousLine;
 				if (lineBefore != null && lineBefore.Length == lineBefore.GetIndentation (data).Length) {


### PR DESCRIPTION
Declaring references need to be checked for the filename not just for
the position -> partial classes could span accross multiple files.