### PR TITLE
[Win32] Use native full screening APIs instead of Gtk ones.

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/Win32.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/Win32.cs
@@ -32,7 +32,19 @@ namespace CustomControls.OS
 
         [DllImport (Win32.SHLWAPI, SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern int AssocQueryStringW (AssociationFlags flags, AssociationString str, string assoc, string extra, StringBuilder outBuffer, ref int outBufferSize);
-    }
+
+		[DllImport (Win32.USER32)]
+		[return: MarshalAs (UnmanagedType.Bool)]
+		public static extern bool GetWindowPlacement (IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+
+		[DllImport (Win32.USER32)]
+		[return: MarshalAs (UnmanagedType.Bool)]
+		public static extern bool SetWindowPlacement (IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+
+		public const int SW_SHOWNORMAL = 1;
+		public const int SW_SHOWMINIMIZED = 2;
+		public const int SW_SHOWMAXIMIZED = 3;
+	}
 
 	[Flags]
 	public enum AssociationFlags {
@@ -74,5 +86,15 @@ namespace CustomControls.OS
 		DelegateExecute,
 		SupportedUriProtocols,
 		MaxString
+	}
+
+	public struct WINDOWPLACEMENT
+	{
+		public int length;
+		public int flags;
+		public int showCmd;
+		public System.Drawing.Point ptMinPosition;
+		public System.Drawing.Point ptMaxPosition;
+		public System.Drawing.Rectangle rcNormalPosition;
 	}
 }

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/WindowsPlatform.cs
@@ -134,6 +134,29 @@ namespace MonoDevelop.Platform
 		}
 		#endregion
 
+		public override bool GetIsFullscreen (Components.Window window)
+		{
+			WINDOWPLACEMENT lpwndpl = new WINDOWPLACEMENT ();
+			lpwndpl.length = Marshal.SizeOf (lpwndpl);
+
+			Gtk.Window controlWindow = window;
+			IntPtr handle = GdkWin32.HgdiobjGet (controlWindow.GdkWindow);
+			Win32.GetWindowPlacement (handle, ref lpwndpl);
+			return lpwndpl.showCmd == Win32.SW_SHOWMAXIMIZED;
+		}
+
+		public override void SetIsFullscreen (Components.Window window, bool isFullscreen)
+		{
+			WINDOWPLACEMENT lpwndpl = new WINDOWPLACEMENT ();
+			lpwndpl.length = Marshal.SizeOf (lpwndpl);
+
+			Gtk.Window controlWindow = window;
+			IntPtr handle = GdkWin32.HgdiobjGet (controlWindow.GdkWindow);
+			Win32.GetWindowPlacement (handle, ref lpwndpl);
+			lpwndpl.showCmd = isFullscreen ? Win32.SW_SHOWMAXIMIZED : Win32.SW_SHOWNORMAL;
+			Win32.SetWindowPlacement (handle, ref lpwndpl);
+		}
+
 		internal static Xwt.Toolkit WPFToolkit;
 
 		public override void Initialize ()


### PR DESCRIPTION
Bug 40487 - [Cycle 7] Unable to exit in "Full Screen" mode on Windows XS .