### PR TITLE
[Cycle 7][Core] Fix invalid configuration mapping for new generic projects.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/GenericProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/GenericProject.cs
@@ -29,6 +29,7 @@
 using System.Xml;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Projects
 {
@@ -59,6 +60,12 @@ namespace MonoDevelop.Projects
 		{
 			base.OnGetTypeTags (types);
 			types.Add ("GenericProject");
+		}
+
+		protected override void OnWriteConfiguration (ProgressMonitor monitor, ProjectConfiguration config, IPropertySet pset)
+		{
+			base.OnWriteConfiguration (monitor, config, pset);
+			pset.SetValue ("OutputPath", config.OutputDirectory);
 		}
 	}
 	


### PR DESCRIPTION
Fixed bug #40507 - On creating Generic project, it is showing error
in Solution pad.
https://bugzilla.xamarin.com/show_bug.cgi?id=40507

Creating a new generic project would show an error icon next to the
project in the Solution pad. The error message was 'Invalid
configuration mapping'. The generic project was created without any
configuration property group since the properties inside this group
had the default values so the entire group is removed when the project
was saved.

  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Default|AnyCPU' ">

Now the OutputPath uses a different default value so the configuration
property group is saved in the generic project. The generic project
file created now matches what is created with Xamarin Studio 5.10.