### PR TITLE
[Ide] Reset the message source pad on showing a ready statusbar.

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -611,6 +611,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public void ShowReady ()
 		{
 			ShowMessage (null, "", false, MessageType.Ready);
+			SetMessageSourcePad (null);
 		}
 
 		static Pad sourcePad;

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/StatusBar.xaml.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/StatusBar.xaml.cs
@@ -226,6 +226,7 @@ namespace WindowsPlatform.MainToolbar
 		{
 			Status = StatusBarStatus.Ready;
 			ShowMessage (BrandingService.StatusSteadyIconId, BrandingService.ApplicationLongName);
+			SetMessageSourcePad (null);
 		}
 
 		void ApplicationNameChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
@@ -436,6 +436,7 @@ namespace MonoDevelop.Components.MainToolbar
 		public void ShowReady ()
 		{
 			ShowMessage ("");
+			SetMessageSourcePad (null);
 		}
 
 		public void SetMessageSourcePad (Pad pad)


### PR DESCRIPTION
Bug 24598 - Blank solution pane and text editor is displayed on clicking 'Xamarin Studio Status' bar after close Solution.