### PR TITLE
[Ide] Signal that the last task was removed to progressmonitor users.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
@@ -237,8 +237,13 @@ namespace MonoDevelop.Core
 				openStepWork = -1;
 				var t = currentTask;
 				currentTask = t.ParentTask;
-				if (currentTask == null)
+				if (currentTask == null) {
 					rootTask = null;
+					if (context != null)
+						context.Post ((o) => OnLastTaskRemoved (), null);
+					else
+						OnLastTaskRemoved ();
+				}
 				t.SetComplete ();
 		//		if (t.Name != null) {
 					if (context != null)
@@ -552,6 +557,10 @@ namespace MonoDevelop.Core
 		}
 
 		protected virtual void OnEndTask (string name, int totalWork, int stepWork)
+		{
+		}
+
+		protected virtual void OnLastTaskRemoved ()
 		{
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
@@ -82,6 +82,11 @@ namespace MonoDevelop.Ide.Gui
 			else
 				statusBar.SetProgressFraction (0);
 		}
+
+		protected override void OnLastTaskRemoved ()
+		{
+			statusBar.EndProgress ();
+		}
 		
 		protected override void OnCompleted ()
 		{


### PR DESCRIPTION
This adds a LastTaskRemoved entrypoint where subscribers can decide
whether to end animations relating to the current progress of a monitor.

The current ProgressMonitor behaviour is to replace the rootTask if none
exists.

In the case of the Rebuild command, a Clean Task would be attached, then
finished, afterwards a Build Task would be attached, then finished.

The Clean Task would end up with a Progress > 0, so the animation would
progress in the statusbar.

The newly placed Build Task would end up with a Progress = 0, in a context
where a progress is started, but never ended. Therefore the progressbar
would animate backwards to 0 and continue forward with the Build Task's
result.

Bug 39314 - Progress bar goes backwards when building solution