### PR TITLE
[Ide] Make the build log the default focus in the Errors pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -271,7 +271,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				AddTask (t);
 			}
 
-			control.FocusChain = new Gtk.Widget [] { sw };
+			control.FocusChain = new Gtk.Widget [] { outputView };
 		}
 
 		public override void Dispose ()


### PR DESCRIPTION
Fixes BXC #5170