### PR TITLE
[Ide] Don't trigger the Completed event on assignment.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageLoader.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageLoader.cs
@@ -184,8 +184,9 @@ namespace MonoDevelop.Components
 				lock (mutex) {
 					if (Downloading)
 						completed += value;
+					else
+						value (this, EventArgs.Empty);
 				}
-				value (this, EventArgs.Empty);
 			}
 			remove {
 				lock (mutex) {


### PR DESCRIPTION
If a download is not yet completed, we should not trigger a completed
event when assinging the event handler.