### PR TITLE
Fixed 'Bug 40770 - Search Result links don't display properly if code

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Document/TextDocument.cs
@@ -35,7 +35,6 @@ using System.ComponentModel;
 using ICSharpCode.NRefactory.Editor;
 using System.Threading.Tasks;
 using System.Threading;
-using Gtk;
 
 namespace Mono.TextEditor
 {
@@ -1311,7 +1310,7 @@ namespace Mono.TextEditor
 			lock (foldSegmentTaskLock) {
 				if (foldSegmentTask != null) {
 					foldSegmentTask.ContinueWith (delegate {
-						Application.Invoke (delegate {
+						Gtk.Application.Invoke (delegate {
 							InternalInformFoldChanged (args);	
 						});
 					});


### PR DESCRIPTION
is in a collapsed region in XS 6.1'

It's caused by a race - we made the loading async this seems to be a
side effect of that.