### PR TITLE
Search cancellation

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindBaseSymbolsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindBaseSymbolsHandler.cs
@@ -48,8 +48,12 @@ namespace MonoDevelop.CSharp.Navigation
 				using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)) {
 					var foundSymbol = sym.OverriddenMember ();
 					while (foundSymbol != null) {
-						foreach (var loc in foundSymbol.Locations)
+						foreach (var loc in foundSymbol.Locations) {
+							if (monitor.CancellationToken.IsCancellationRequested)
+								return;
+							
 							monitor.ReportResult (new MemberReference (foundSymbol, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
+						}
 						foundSymbol = foundSymbol.OverriddenMember ();
 					}
 				}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindBaseSymbolsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindBaseSymbolsHandler.cs
@@ -51,6 +51,9 @@ namespace MonoDevelop.CSharp.Navigation
 						foreach (var loc in foundSymbol.Locations) {
 							if (monitor.CancellationToken.IsCancellationRequested)
 								return;
+
+							if (loc.SourceTree == null)
+								continue;
 							
 							monitor.ReportResult (new MemberReference (foundSymbol, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
 						}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindDerivedSymbolsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindDerivedSymbolsHandler.cs
@@ -87,8 +87,7 @@ namespace MonoDevelop.CSharp.Refactoring
 						}
 						foreach (var foundSymbol in result) {
 							foreach (var loc in foundSymbol.Locations) {
-								if (monitor.CancellationToken.IsCancellationRequested)
-									monitor.CancellationToken.ThrowIfCancellationRequested ();
+								monitor.CancellationToken.ThrowIfCancellationRequested ();
 								monitor.ReportResult (new MemberReference (foundSymbol, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
 							}
 						}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindDerivedSymbolsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindDerivedSymbolsHandler.cs
@@ -69,24 +69,30 @@ namespace MonoDevelop.CSharp.Refactoring
 			Task.Run (async delegate {
 				using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)) {
 					IEnumerable<ISymbol> result;
-					if (symbol.ContainingType != null && symbol.ContainingType.TypeKind == TypeKind.Interface) {
-						result = await SymbolFinder.FindImplementationsAsync (symbol, TypeSystemService.Workspace.CurrentSolution).ConfigureAwait (false); 
-					} else if (symbol.Kind == SymbolKind.NamedType) {
-						var type = (INamedTypeSymbol)symbol;
-						if (type.TypeKind == TypeKind.Interface) {
-							
-							result = (await SymbolFinder.FindImplementationsAsync (type, TypeSystemService.Workspace.CurrentSolution).ConfigureAwait (false)).Cast<ISymbol> ().Concat (
-								await FindInterfaceImplementaitonsAsync (type, TypeSystemService.Workspace.CurrentSolution).ConfigureAwait (false) 
-							);
+					try {
+						if (symbol.ContainingType != null && symbol.ContainingType.TypeKind == TypeKind.Interface) {
+							result = await SymbolFinder.FindImplementationsAsync (symbol, TypeSystemService.Workspace.CurrentSolution, cancellationToken: monitor.CancellationToken).ConfigureAwait (false);
+						} else if (symbol.Kind == SymbolKind.NamedType) {
+							var type = (INamedTypeSymbol)symbol;
+							if (type.TypeKind == TypeKind.Interface) {
+
+								result = (await SymbolFinder.FindImplementationsAsync (type, TypeSystemService.Workspace.CurrentSolution, cancellationToken: monitor.CancellationToken).ConfigureAwait (false)).Cast<ISymbol> ().Concat (
+									await FindInterfaceImplementaitonsAsync (type, TypeSystemService.Workspace.CurrentSolution, monitor.CancellationToken).ConfigureAwait (false)
+								);
+							} else {
+								result = (await SymbolFinder.FindDerivedClassesAsync (type, TypeSystemService.Workspace.CurrentSolution, cancellationToken: monitor.CancellationToken).ConfigureAwait (false)).Cast<ISymbol> ();
+							}
 						} else {
-							result = (await SymbolFinder.FindDerivedClassesAsync (type, TypeSystemService.Workspace.CurrentSolution).ConfigureAwait (false)).Cast<ISymbol> ();
+							result = await SymbolFinder.FindOverridesAsync (symbol, TypeSystemService.Workspace.CurrentSolution, cancellationToken: monitor.CancellationToken).ConfigureAwait (false);
 						}
-					} else {
-						result = await SymbolFinder.FindOverridesAsync (symbol, TypeSystemService.Workspace.CurrentSolution).ConfigureAwait (false);
-					}
-					foreach (var foundSymbol in result) {
-						foreach (var loc in foundSymbol.Locations)
-							monitor.ReportResult (new MemberReference (foundSymbol, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
+						foreach (var foundSymbol in result) {
+							foreach (var loc in foundSymbol.Locations) {
+								if (monitor.CancellationToken.IsCancellationRequested)
+									monitor.CancellationToken.ThrowIfCancellationRequested ();
+								monitor.ReportResult (new MemberReference (foundSymbol, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
+							}
+						}
+					} catch (OperationCanceledException) {
 					}
 				}
 			});

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindExtensionMethodsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindExtensionMethodsHandler.cs
@@ -72,11 +72,14 @@ namespace MonoDevelop.CSharp.Navigation
 			if (symType == null)
 				return;
 			using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)) {
-				foreach (var type in compilation.Assembly.GlobalNamespace.GetAllTypes ()) {
+				foreach (var type in compilation.Assembly.GlobalNamespace.GetAllTypes (monitor.CancellationToken)) {
 					if (!type.MightContainExtensionMethods)
 						continue;
 
 					foreach (var extMethod in type.GetMembers ().OfType<IMethodSymbol> ().Where (method => method.IsExtensionMethod)) {
+						if (monitor.CancellationToken.IsCancellationRequested)
+							break;
+
 						var reducedMethod = extMethod.ReduceExtensionMethod (symType);
 						if (reducedMethod != null) {
 							var loc = extMethod.Locations.First ();

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindImplementingMembersHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindImplementingMembersHandler.cs
@@ -80,6 +80,8 @@ namespace MonoDevelop.CSharp.Navigation
 					if (implementingType == null)
 						return;
 					foreach (var interfaceMember in interfaceType.GetMembers ()) {
+						if (monitor.CancellationToken.IsCancellationRequested)
+							return;
 						var impl = implementingType.FindImplementationForInterfaceMember (interfaceMember);
 						if (impl == null)
 							continue;
@@ -89,6 +91,9 @@ namespace MonoDevelop.CSharp.Navigation
 					foreach (var iFace in interfaceType.AllInterfaces) {
 					
 						foreach (var interfaceMember in iFace.GetMembers ()) {
+							if (monitor.CancellationToken.IsCancellationRequested)
+								return;
+
 							var impl = implementingType.FindImplementationForInterfaceMember (interfaceMember);
 							if (impl == null)
 								continue;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindMemberOverloadsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindMemberOverloadsHandler.cs
@@ -58,14 +58,22 @@ namespace MonoDevelop.CSharp.Navigation
 				switch (symbol.Kind) {
 				case SymbolKind.Method:
 					foreach (var method in symbol.ContainingType.GetMembers (symbol.Name).OfType<IMethodSymbol> ()) {
-						foreach (var loc in method.Locations)
+						foreach (var loc in method.Locations) {
+							if (monitor.CancellationToken.IsCancellationRequested)
+								return;
+							
 							monitor.ReportResult (new MemberReference (method, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
+						}
 					}
 					break;
 				case SymbolKind.Property:
 					foreach (var property in symbol.ContainingType.GetMembers ().OfType<IPropertySymbol> () .Where (p => p.IsIndexer)) {
-						foreach (var loc in property.Locations)
+						foreach (var loc in property.Locations) {
+							if (monitor.CancellationToken.IsCancellationRequested)
+								return;
+							
 							monitor.ReportResult (new MemberReference (property, loc.SourceTree.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length));
+						}
 					}
 					break;
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFeaturesTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFeaturesTextEditorExtension.cs
@@ -70,8 +70,12 @@ namespace MonoDevelop.CSharp.Refactoring
 
 			GoToDefinitionService.DisplayMultiple = delegate (IEnumerable<Tuple<Solution, ISymbol, Location>> list) {
 				using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)) {
-					foreach (var part in list)
+					foreach (var part in list) {
+						if (monitor.CancellationToken.IsCancellationRequested)
+							return;
+
 						monitor.ReportResult (GotoDeclarationHandler.GetJumpTypePartSearchResult (part.Item2, part.Item3));
+					}
 				}
 			};
 		}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
@@ -206,6 +206,9 @@ namespace MonoDevelop.CSharp.Refactoring
 					}
 
 					foreach (var loc in lookup.Symbol.Locations) {
+						if (token.IsCancellationRequested)
+							break;
+						
 						if (!loc.IsInSource)
 							continue;
 						var fileName = loc.SourceTree.FilePath;
@@ -223,6 +226,8 @@ namespace MonoDevelop.CSharp.Refactoring
 
 					foreach (var mref in await SymbolFinder.FindReferencesAsync (lookup.Symbol, lookup.Solution).ConfigureAwait (false)) {
 						foreach (var loc in mref.Locations) {
+							if (token.IsCancellationRequested)
+								break;
 							var fileName = loc.Document.FilePath;
 							var offset = loc.Location.SourceSpan.Start;
 							string projectedName;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -249,6 +249,8 @@ namespace MonoDevelop.Refactoring
 						foreach (var result in await provider.FindReferences (documentIdString, hintProject, monitor.CancellationToken)) {
 							monitor.ReportResult (result);
 						}
+					} catch (OperationCanceledException) {
+						return;
 					} catch (Exception ex) {
 						if (monitor != null)
 							monitor.ReportError ("Error finding references", ex);
@@ -274,7 +276,7 @@ namespace MonoDevelop.Refactoring
 							monitor.ReportResult (result);
 						}
 					} catch (OperationCanceledException) {
-
+						return;
 					} catch (Exception ex) {
 						if (monitor != null)
 							monitor.ReportError ("Error finding references", ex);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -869,20 +869,18 @@ namespace MonoDevelop.Ide.FindInFiles
 						LoggingService.LogError ("Error while search", ex);
 					}
 						
-					string message;
+					string message = null;
 					if (errorMessage != null) {
 						message = GettextCatalog.GetString ("The search could not be finished: {0}", errorMessage);
 						searchMonitor.ReportError (message, null);
-					} else if (searchMonitor.CancellationToken.IsCancellationRequested) {
-						message = GettextCatalog.GetString ("Search cancelled.");
-						searchMonitor.ReportWarning (message);
-					} else {
+					} else if (!searchMonitor.CancellationToken.IsCancellationRequested) {
 						string matches = string.Format (GettextCatalog.GetPluralString ("{0} match found", "{0} matches found", find.FoundMatchesCount), find.FoundMatchesCount);
 						string files = string.Format (GettextCatalog.GetPluralString ("in {0} file.", "in {0} files.", find.SearchedFilesCount), find.SearchedFilesCount);
 						message = GettextCatalog.GetString ("Search completed.") + Environment.NewLine + matches + " " + files;
 						searchMonitor.ReportSuccess (message);
 					}
-					searchMonitor.ReportStatus (message);
+					if (message != null)
+						searchMonitor.ReportStatus (message);
 					searchMonitor.Log.WriteLine (GettextCatalog.GetString ("Search time: {0} seconds."), (DateTime.Now - timer).TotalSeconds);
 				}
 				if (UpdateStopButton != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -836,7 +836,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			searchTokenSource = cancelSource;
 			var token = cancelSource.Token;
 			currentTask = Task.Run (delegate {
-				using (SearchProgressMonitor searchMonitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, cancellationTokenSource:cancelSource)) {
+				using (SearchProgressMonitor searchMonitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true)) {
 
 					searchMonitor.PathMode = scope.PathMode;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
@@ -99,14 +99,18 @@ namespace MonoDevelop.Ide.FindInFiles
 		protected override void OnCompleted ()
 		{
 			if (outputPad == null) throw GetDisposedException ();
+
 			outputPad.WriteText ("\n");
 			
 			foreach (string msg in SuccessMessages)
 				outputPad.WriteText (msg + "\n");
 			
+			if (CancellationToken.IsCancellationRequested)
+				ReportWarning (GettextCatalog.GetString ("Search operation canceled"));
+
 			foreach (string msg in Warnings)
 				outputPad.WriteText (msg + "\n");
-			
+
 			foreach (var msg in Errors)
 				outputPad.WriteText (msg.Message + "\n");
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultPad.cs
@@ -126,8 +126,12 @@ namespace MonoDevelop.Ide.FindInFiles
 		public void EndProgress ()
 		{
 			Window.IsWorking = false;
-			widget.ShowStatus (" " + GettextCatalog.GetString("Search completed") + " - " + 
-				string.Format (GettextCatalog.GetPluralString("{0} match.", "{0} matches.", widget.ResultCount), widget.ResultCount));
+			if (CancellationTokenSource.Token.IsCancellationRequested) {
+				widget.ShowStatus (" " + GettextCatalog.GetString ("Search cancelled"));
+			} else {
+				widget.ShowStatus (" " + GettextCatalog.GetString ("Search completed") + " - " +
+				string.Format (GettextCatalog.GetPluralString ("{0} match.", "{0} matches.", widget.ResultCount), widget.ResultCount));
+			}
 			widget.EndProgress ();
 			if (FocusPad) 
 				widget.FocusPad ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -311,8 +311,11 @@ namespace MonoDevelop.Ide
 			
 			if (askIfMultipleLocations && locations.Length > 1) {
 				using (var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)) {
-					foreach (var part in locations)
+					foreach (var part in locations) {
+						if (monitor.CancellationToken.IsCancellationRequested)
+							return;
 						monitor.ReportResult (GetJumpTypePartSearchResult (symbol, part));
+					}
 				}
 				return;
 			}


### PR DESCRIPTION
cc @mkrueger @slluis 

This is pretty annoying as we can do Find references of methods like Dispose or ToString and the task takes a _LOT_ of CPU and Memory to finish.

This way, we can cancel an active search and get rid of wait times / having to close XS.

Unified cancellation reporting for searchprogressmonitor and fixed an exception that happened in Go to base command.