### PR TITLE
[Ide] Add support for IPropertyEditors which change ReadOnly state.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/BooleanEditorCell.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/BooleanEditorCell.cs
@@ -90,18 +90,22 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 		}
 	}
 	
-	public class BooleanEditor : Gtk.CheckButton, IPropertyEditor 
+	public class BooleanEditor : Gtk.CheckButton, IPropertyEditorWithReadOnly 
 	{
 		public void Initialize (EditSession session)
 		{
 			if (session.Property.PropertyType != typeof(bool))
 				throw new ApplicationException ("Boolean editor does not support editing values of type " + session.Property.PropertyType);
-			Sensitive = !session.Property.IsReadOnly;
 		}
 		
 		public object Value { 
 			get { return Active; } 
 			set { Active = (bool) value; }
+		}
+
+		public bool IsReadOnly {
+			get { return Sensitive; }
+			set { Sensitive = value; }
 		}
 		
 		protected override void OnToggled ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/PropertyTextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/PropertyTextEditor.cs
@@ -36,7 +36,7 @@ using Gdk;
 namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 {
 	[PropertyEditorType (typeof (string))]
-	public class PropertyTextEditor: Gtk.HBox, IPropertyEditor
+	public class PropertyTextEditor: Gtk.HBox, IPropertyEditorWithReadOnly
 	{
 		EditSession session;
 		bool disposed;
@@ -231,6 +231,14 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 					entry.Text = val ?? string.Empty;
 					initialText = entry.Text;
 				}
+			}
+		}
+
+		public bool IsReadOnly {
+			get { return entry != null && !entry.IsEditable; }
+			set {
+				if (entry != null)
+					entry.IsEditable = !value;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyEditorCell.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyEditorCell.cs
@@ -235,6 +235,10 @@ namespace MonoDevelop.Components.PropertyGrid
 				currentEditor.Value = context.PropertyDescriptor.GetValue (Instance);
 			
 			currentEditor.ValueChanged += OnValueChanged;
+
+			var readOnlyEditor = currentEditor as IPropertyEditorWithReadOnly;
+			if (readOnlyEditor != null)
+				readOnlyEditor.IsReadOnly = context.PropertyDescriptor.IsReadOnly;
 		}
 		
 		public void Dispose ()
@@ -295,7 +299,13 @@ namespace MonoDevelop.Components.PropertyGrid
 		{
 			if (!syncing) {
 				syncing = true;
+
 				currentEditor.Value = context.PropertyDescriptor.GetValue (context.Instance);
+
+				var readOnlyPropertyEditor = currentEditor as IPropertyEditorWithReadOnly;
+				if (readOnlyPropertyEditor != null)
+					readOnlyPropertyEditor.IsReadOnly = context.PropertyDescriptor.IsReadOnly;
+
 				syncing = false;
 			}
 		}
@@ -399,5 +409,10 @@ namespace MonoDevelop.Components.PropertyGrid
 
 		// To be fired when the edited value changes.
 		event EventHandler ValueChanged;
+	}
+
+	public interface IPropertyEditorWithReadOnly : IPropertyEditor
+	{
+		bool IsReadOnly { get; set; }
 	}
 }


### PR DESCRIPTION
Since the base interface for IPropertyEditor does not have a ReadOnly
tag we can use, a new interface IPropertyEditorWithReadOnly has been
added to support this case.

Trigger IsReadOnly update on editor updates. This is currently done for
the widgets which had IsReadOnly support - BooleanEditorCell and
PropertyTextEditor.

Bug 40753 - On Demand Resource changes doesn't get reflected after
changing the Build action, until property window not get reopened.