### PR TITLE
[SourceEditor] Removed UnderlineError option.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/MarkerPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/MarkerPanel.cs
@@ -38,8 +38,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 
 		bool showLineNumbers;
 
-		bool underlineErrors;
-
 		bool highlightMatchingBracket;
 
 		bool highlightCurrentLine;
@@ -62,7 +60,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 		{
 			this.Build();
 			showLineNumbers = DefaultSourceEditorOptions.Instance.ShowLineNumberMargin;
-			underlineErrors = DefaultSourceEditorOptions.Instance.UnderlineErrors;
 			highlightMatchingBracket = DefaultSourceEditorOptions.Instance.HighlightMatchingBracket;
 			highlightCurrentLine = DefaultSourceEditorOptions.Instance.HighlightCaretLine;
 			showRuler = DefaultSourceEditorOptions.Instance.ShowRuler;
@@ -79,14 +76,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.showLineNumbersCheckbutton.Active = showLineNumbers = DefaultSourceEditorOptions.Instance.ShowLineNumberMargin;
 			this.showLineNumbersCheckbutton.Toggled += delegate {
 				DefaultSourceEditorOptions.Instance.ShowLineNumberMargin = this.showLineNumbersCheckbutton.Active;
-			};
-
-			this.underlineErrorsCheckbutton.Active = underlineErrors = DefaultSourceEditorOptions.Instance.UnderlineErrors;
-			this.underlineErrorsCheckbutton.Toggled += delegate {
-				DefaultSourceEditorOptions.Instance.UnderlineErrors = this.underlineErrorsCheckbutton.Active;
-				foreach (var doc in IdeApp.Workbench.Documents)
-					doc.StartReparseThread ();
-
 			};
 
 			this.highlightMatchingBracketCheckbutton.Active = highlightMatchingBracket = DefaultSourceEditorOptions.Instance.HighlightMatchingBracket;
@@ -157,7 +146,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 		public virtual void ApplyChanges ()
 		{
 			showLineNumbers = this.showLineNumbersCheckbutton.Active;
-			underlineErrors = this.underlineErrorsCheckbutton.Active;
 			highlightMatchingBracket = this.highlightMatchingBracketCheckbutton.Active;
 			highlightCurrentLine = this.highlightCurrentLineCheckbutton.Active;
 			showRuler = this.showRulerCheckbutton.Active;
@@ -180,7 +168,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 		protected override void OnDestroyed ()
 		{
 			DefaultSourceEditorOptions.Instance.ShowLineNumberMargin = showLineNumbers;
-			DefaultSourceEditorOptions.Instance.UnderlineErrors = underlineErrors;
 			DefaultSourceEditorOptions.Instance.HighlightMatchingBracket = highlightMatchingBracket;
 			DefaultSourceEditorOptions.Instance.HighlightCaretLine = highlightCurrentLine;
 			DefaultSourceEditorOptions.Instance.ShowRuler = showRuler;

--- a/main/src/addins/MonoDevelop.SourceEditor2/gtk-gui/MonoDevelop.SourceEditor.OptionPanels.MarkerPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/gtk-gui/MonoDevelop.SourceEditor.OptionPanels.MarkerPanel.cs
@@ -14,8 +14,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 
 		private global::Gtk.CheckButton showLineNumbersCheckbutton;
 
-		private global::Gtk.CheckButton underlineErrorsCheckbutton;
-
 		private global::Gtk.CheckButton highlightMatchingBracketCheckbutton;
 
 		private global::Gtk.CheckButton highlightCurrentLineCheckbutton;
@@ -84,18 +82,6 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			w2.Expand = false;
 			w2.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
-			this.underlineErrorsCheckbutton = new global::Gtk.CheckButton();
-			this.underlineErrorsCheckbutton.CanFocus = true;
-			this.underlineErrorsCheckbutton.Name = "underlineErrorsCheckbutton";
-			this.underlineErrorsCheckbutton.Label = global::Mono.Unix.Catalog.GetString("_Underline errors");
-			this.underlineErrorsCheckbutton.DrawIndicator = true;
-			this.underlineErrorsCheckbutton.UseUnderline = true;
-			this.vbox3.Add(this.underlineErrorsCheckbutton);
-			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.underlineErrorsCheckbutton]));
-			w3.Position = 1;
-			w3.Expand = false;
-			w3.Fill = false;
-			// Container child vbox3.Gtk.Box+BoxChild
 			this.highlightMatchingBracketCheckbutton = new global::Gtk.CheckButton();
 			this.highlightMatchingBracketCheckbutton.CanFocus = true;
 			this.highlightMatchingBracketCheckbutton.Name = "highlightMatchingBracketCheckbutton";
@@ -103,10 +89,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.highlightMatchingBracketCheckbutton.DrawIndicator = true;
 			this.highlightMatchingBracketCheckbutton.UseUnderline = true;
 			this.vbox3.Add(this.highlightMatchingBracketCheckbutton);
-			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.highlightMatchingBracketCheckbutton]));
-			w4.Position = 2;
-			w4.Expand = false;
-			w4.Fill = false;
+			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.highlightMatchingBracketCheckbutton]));
+			w3.Position = 1;
+			w3.Expand = false;
+			w3.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.highlightCurrentLineCheckbutton = new global::Gtk.CheckButton();
 			this.highlightCurrentLineCheckbutton.CanFocus = true;
@@ -115,10 +101,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.highlightCurrentLineCheckbutton.DrawIndicator = true;
 			this.highlightCurrentLineCheckbutton.UseUnderline = true;
 			this.vbox3.Add(this.highlightCurrentLineCheckbutton);
-			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.highlightCurrentLineCheckbutton]));
-			w5.Position = 3;
-			w5.Expand = false;
-			w5.Fill = false;
+			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.highlightCurrentLineCheckbutton]));
+			w4.Position = 2;
+			w4.Expand = false;
+			w4.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.showRulerCheckbutton = new global::Gtk.CheckButton();
 			this.showRulerCheckbutton.CanFocus = true;
@@ -127,10 +113,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.showRulerCheckbutton.DrawIndicator = true;
 			this.showRulerCheckbutton.UseUnderline = true;
 			this.vbox3.Add(this.showRulerCheckbutton);
-			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.showRulerCheckbutton]));
-			w6.Position = 4;
-			w6.Expand = false;
-			w6.Fill = false;
+			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.showRulerCheckbutton]));
+			w5.Position = 3;
+			w5.Expand = false;
+			w5.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.enableAnimationCheckbutton1 = new global::Gtk.CheckButton();
 			this.enableAnimationCheckbutton1.CanFocus = true;
@@ -139,10 +125,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.enableAnimationCheckbutton1.DrawIndicator = true;
 			this.enableAnimationCheckbutton1.UseUnderline = true;
 			this.vbox3.Add(this.enableAnimationCheckbutton1);
-			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.enableAnimationCheckbutton1]));
-			w7.Position = 5;
-			w7.Expand = false;
-			w7.Fill = false;
+			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.enableAnimationCheckbutton1]));
+			w6.Position = 4;
+			w6.Expand = false;
+			w6.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.enableHighlightUsagesCheckbutton = new global::Gtk.CheckButton();
 			this.enableHighlightUsagesCheckbutton.CanFocus = true;
@@ -151,10 +137,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.enableHighlightUsagesCheckbutton.DrawIndicator = true;
 			this.enableHighlightUsagesCheckbutton.UseUnderline = true;
 			this.vbox3.Add(this.enableHighlightUsagesCheckbutton);
-			global::Gtk.Box.BoxChild w8 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.enableHighlightUsagesCheckbutton]));
-			w8.Position = 6;
-			w8.Expand = false;
-			w8.Fill = false;
+			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.enableHighlightUsagesCheckbutton]));
+			w7.Position = 5;
+			w7.Expand = false;
+			w7.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.drawIndentMarkersCheckbutton = new global::Gtk.CheckButton();
 			this.drawIndentMarkersCheckbutton.CanFocus = true;
@@ -163,10 +149,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.drawIndentMarkersCheckbutton.DrawIndicator = true;
 			this.drawIndentMarkersCheckbutton.UseUnderline = true;
 			this.vbox3.Add(this.drawIndentMarkersCheckbutton);
-			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.drawIndentMarkersCheckbutton]));
-			w9.Position = 7;
-			w9.Expand = false;
-			w9.Fill = false;
+			global::Gtk.Box.BoxChild w8 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.drawIndentMarkersCheckbutton]));
+			w8.Position = 6;
+			w8.Expand = false;
+			w8.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.enableQuickDiffCheckbutton = new global::Gtk.CheckButton();
 			this.enableQuickDiffCheckbutton.CanFocus = true;
@@ -175,10 +161,10 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.enableQuickDiffCheckbutton.DrawIndicator = true;
 			this.enableQuickDiffCheckbutton.UseUnderline = true;
 			this.vbox3.Add(this.enableQuickDiffCheckbutton);
-			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.enableQuickDiffCheckbutton]));
-			w10.Position = 8;
-			w10.Expand = false;
-			w10.Fill = false;
+			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.enableQuickDiffCheckbutton]));
+			w9.Position = 7;
+			w9.Expand = false;
+			w9.Fill = false;
 			// Container child vbox3.Gtk.Box+BoxChild
 			this.table1 = new global::Gtk.Table(((uint)(4)), ((uint)(4)), false);
 			this.table1.Name = "table1";
@@ -192,13 +178,13 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.checkbuttonLineEndings.DrawIndicator = true;
 			this.checkbuttonLineEndings.UseUnderline = true;
 			this.table1.Add(this.checkbuttonLineEndings);
-			global::Gtk.Table.TableChild w11 = ((global::Gtk.Table.TableChild)(this.table1[this.checkbuttonLineEndings]));
-			w11.TopAttach = ((uint)(3));
-			w11.BottomAttach = ((uint)(4));
-			w11.LeftAttach = ((uint)(1));
-			w11.RightAttach = ((uint)(4));
-			w11.XOptions = ((global::Gtk.AttachOptions)(4));
-			w11.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w10 = ((global::Gtk.Table.TableChild)(this.table1[this.checkbuttonLineEndings]));
+			w10.TopAttach = ((uint)(3));
+			w10.BottomAttach = ((uint)(4));
+			w10.LeftAttach = ((uint)(1));
+			w10.RightAttach = ((uint)(4));
+			w10.XOptions = ((global::Gtk.AttachOptions)(4));
+			w10.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
 			this.checkbuttonSpaces = new global::Gtk.CheckButton();
 			this.checkbuttonSpaces.CanFocus = true;
@@ -207,13 +193,13 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.checkbuttonSpaces.DrawIndicator = true;
 			this.checkbuttonSpaces.UseUnderline = true;
 			this.table1.Add(this.checkbuttonSpaces);
-			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table1[this.checkbuttonSpaces]));
-			w12.TopAttach = ((uint)(1));
-			w12.BottomAttach = ((uint)(2));
-			w12.LeftAttach = ((uint)(1));
-			w12.RightAttach = ((uint)(4));
-			w12.XOptions = ((global::Gtk.AttachOptions)(4));
-			w12.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w11 = ((global::Gtk.Table.TableChild)(this.table1[this.checkbuttonSpaces]));
+			w11.TopAttach = ((uint)(1));
+			w11.BottomAttach = ((uint)(2));
+			w11.LeftAttach = ((uint)(1));
+			w11.RightAttach = ((uint)(4));
+			w11.XOptions = ((global::Gtk.AttachOptions)(4));
+			w11.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
 			this.checkbuttonTabs = new global::Gtk.CheckButton();
 			this.checkbuttonTabs.CanFocus = true;
@@ -222,41 +208,41 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.checkbuttonTabs.DrawIndicator = true;
 			this.checkbuttonTabs.UseUnderline = true;
 			this.table1.Add(this.checkbuttonTabs);
-			global::Gtk.Table.TableChild w13 = ((global::Gtk.Table.TableChild)(this.table1[this.checkbuttonTabs]));
-			w13.TopAttach = ((uint)(2));
-			w13.BottomAttach = ((uint)(3));
-			w13.LeftAttach = ((uint)(1));
-			w13.RightAttach = ((uint)(4));
-			w13.XOptions = ((global::Gtk.AttachOptions)(4));
-			w13.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w12 = ((global::Gtk.Table.TableChild)(this.table1[this.checkbuttonTabs]));
+			w12.TopAttach = ((uint)(2));
+			w12.BottomAttach = ((uint)(3));
+			w12.LeftAttach = ((uint)(1));
+			w12.RightAttach = ((uint)(4));
+			w12.XOptions = ((global::Gtk.AttachOptions)(4));
+			w12.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
 			this.label1 = new global::Gtk.Label();
 			this.label1.Name = "label1";
 			this.label1.LabelProp = global::Mono.Unix.Catalog.GetString("_Show invisible characters:");
 			this.label1.UseUnderline = true;
 			this.table1.Add(this.label1);
-			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table1[this.label1]));
-			w14.XOptions = ((global::Gtk.AttachOptions)(4));
-			w14.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w13 = ((global::Gtk.Table.TableChild)(this.table1[this.label1]));
+			w13.XOptions = ((global::Gtk.AttachOptions)(4));
+			w13.YOptions = ((global::Gtk.AttachOptions)(4));
 			// Container child table1.Gtk.Table+TableChild
 			this.showWhitespacesCombobox = global::Gtk.ComboBox.NewText();
 			this.showWhitespacesCombobox.Name = "showWhitespacesCombobox";
 			this.table1.Add(this.showWhitespacesCombobox);
-			global::Gtk.Table.TableChild w15 = ((global::Gtk.Table.TableChild)(this.table1[this.showWhitespacesCombobox]));
-			w15.LeftAttach = ((uint)(1));
-			w15.RightAttach = ((uint)(4));
-			w15.XOptions = ((global::Gtk.AttachOptions)(4));
-			w15.YOptions = ((global::Gtk.AttachOptions)(4));
+			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table1[this.showWhitespacesCombobox]));
+			w14.LeftAttach = ((uint)(1));
+			w14.RightAttach = ((uint)(4));
+			w14.XOptions = ((global::Gtk.AttachOptions)(4));
+			w14.YOptions = ((global::Gtk.AttachOptions)(4));
 			this.vbox3.Add(this.table1);
-			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.table1]));
-			w16.Position = 9;
-			w16.Fill = false;
+			global::Gtk.Box.BoxChild w15 = ((global::Gtk.Box.BoxChild)(this.vbox3[this.table1]));
+			w15.Position = 8;
+			w15.Fill = false;
 			this.alignment1.Add(this.vbox3);
 			this.vbox1.Add(this.alignment1);
-			global::Gtk.Box.BoxChild w18 = ((global::Gtk.Box.BoxChild)(this.vbox1[this.alignment1]));
-			w18.Position = 1;
-			w18.Expand = false;
-			w18.Fill = false;
+			global::Gtk.Box.BoxChild w17 = ((global::Gtk.Box.BoxChild)(this.vbox1[this.alignment1]));
+			w17.Position = 1;
+			w17.Expand = false;
+			w17.Fill = false;
 			this.Add(this.vbox1);
 			if ((this.Child != null))
 			{

--- a/main/src/addins/MonoDevelop.SourceEditor2/gtk-gui/gui.stetic
+++ b/main/src/addins/MonoDevelop.SourceEditor2/gtk-gui/gui.stetic
@@ -263,7 +263,7 @@
       </widget>
     </child>
   </widget>
-  <widget class="Gtk.Bin" id="MonoDevelop.SourceEditor.OptionPanels.MarkerPanel" design-size="383 418">
+  <widget class="Gtk.Bin" id="MonoDevelop.SourceEditor.OptionPanels.MarkerPanel" design-size="416 434">
     <property name="MemberName" />
     <child>
       <widget class="Gtk.VBox" id="vbox1">
@@ -308,22 +308,6 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="Gtk.CheckButton" id="underlineErrorsCheckbutton">
-                    <property name="MemberName" />
-                    <property name="CanFocus">True</property>
-                    <property name="Label" translatable="yes">_Underline errors</property>
-                    <property name="DrawIndicator">True</property>
-                    <property name="HasLabel">True</property>
-                    <property name="UseUnderline">True</property>
-                  </widget>
-                  <packing>
-                    <property name="Position">1</property>
-                    <property name="AutoSize">True</property>
-                    <property name="Expand">False</property>
-                    <property name="Fill">False</property>
-                  </packing>
-                </child>
-                <child>
                   <widget class="Gtk.CheckButton" id="highlightMatchingBracketCheckbutton">
                     <property name="MemberName" />
                     <property name="CanFocus">True</property>
@@ -333,7 +317,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">2</property>
+                    <property name="Position">1</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -349,7 +333,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">3</property>
+                    <property name="Position">2</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -365,7 +349,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">4</property>
+                    <property name="Position">3</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -381,7 +365,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">5</property>
+                    <property name="Position">4</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -397,7 +381,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">6</property>
+                    <property name="Position">5</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -413,7 +397,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">7</property>
+                    <property name="Position">6</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -429,7 +413,7 @@
                     <property name="UseUnderline">True</property>
                   </widget>
                   <packing>
-                    <property name="Position">8</property>
+                    <property name="Position">7</property>
                     <property name="AutoSize">True</property>
                     <property name="Expand">False</property>
                     <property name="Fill">False</property>
@@ -566,7 +550,7 @@
                     </child>
                   </widget>
                   <packing>
-                    <property name="Position">9</property>
+                    <property name="Position">8</property>
                     <property name="AutoSize">False</property>
                     <property name="Fill">False</property>
                   </packing>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/CommonTextEditorOptions.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/CommonTextEditorOptions.cs
@@ -160,14 +160,6 @@ namespace MonoDevelop.VersionControl.Views
 			}
 		}
 
-		public bool UnderlineErrors {
-			get {
-				return MonoDevelop.Ide.Editor.DefaultSourceEditorOptions.Instance.UnderlineErrors; 
-			}
-			set {
-			}
-		}
-
 		public override IndentStyle IndentStyle {
 			get {
 				return (IndentStyle)MonoDevelop.Ide.Editor.DefaultSourceEditorOptions.Instance.IndentStyle;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/ErrorHandlerTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/ErrorHandlerTextEditorExtension.cs
@@ -141,7 +141,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 
 		async Task UpdateErrorUndelines (DocumentContext ctx, ParsedDocument parsedDocument, CancellationToken token)
 		{
-			if (!DefaultSourceEditorOptions.Instance.UnderlineErrors || parsedDocument == null || isDisposed)
+			if (parsedDocument == null || isDisposed)
 				return;
 			try {
 				var errors = await parsedDocument.GetErrorsAsync(token).ConfigureAwait (false);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
@@ -359,17 +359,6 @@ namespace MonoDevelop.Ide.Editor
 					OnChanged (EventArgs.Empty);
 			}
 		}
-		
-		ConfigurationProperty<bool> underlineErrors = ConfigurationProperty.Create ("UnderlineErrors", true);
-		public bool UnderlineErrors {
-			get {
-				return underlineErrors; 
-			}
-			set {
-				if (underlineErrors.Set (value))
-					OnChanged (EventArgs.Empty);
-			}
-		}
 
 		ConfigurationProperty<IndentStyle> indentStyle = ConfigurationProperty.Create ("IndentStyle", IndentStyle.Smart);
 		public IndentStyle IndentStyle {


### PR DESCRIPTION
This option doesn't really make any sense anymore and causes unwanted
side effects. It was used for disabeling compiler errors in older
versions.
The compiler errors are now shown as message bubbles which can be
disabled separately.
This here was now used for the on the fly errors and if that's
disabled the fix system wouldn't be usable anymore.