### PR TITLE
Reset the tree selection func when a node is activated.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -2075,6 +2075,14 @@ namespace MonoDevelop.Ide.Gui.Components
 
 		void OnNodeActivated (object sender, Gtk.RowActivatedArgs args)
 		{
+			// This is to work around an issue in ContextMenuTreeView, when we set the
+			// SelectFunction to block selection then it doesn't seem to always get
+			// properly unset.
+			//   https://bugzilla.xamarin.com/show_bug.cgi?id=40469
+			tree.Selection.SelectFunction = (s, m, p, b) => {
+				return true;
+			};
+
 			ActivateCurrentItem ();
 		}
 


### PR DESCRIPTION
When we double-click a project we're getting a sequence of button
events ['press', 'release', 'press'] but we're not getting the
second release event that we're expecting. ContextMenuTreeView is
expecting this in order to reset the selection func, so instead
this works around it by resetting it in the activation event.

https://bugzilla.xamarin.com/show_bug.cgi?id=40469