### PR TITLE
Bug 40543 - I renamed an AXML, and it updated everywhere but the csproj

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -889,9 +889,13 @@ namespace MonoDevelop.Core
 				}
 			}
 			if (del != null) {
-				Runtime.MainSynchronizationContext.Post (delegate {
+				if (Runtime.IsMainThread) {
 					del.DynamicInvoke (thisObj, args);
-				}, null);
+				} else {
+					Runtime.MainSynchronizationContext.Post (delegate {
+						del.DynamicInvoke (thisObj, args);
+					}, null);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Bug occurred(rename not applied to .csproj) because rename operations was executed after saving operation, that happened because rename operation was posted to UI thread to be executed later while code flow continued and started saving, most of the time rename executed before save operation because that operation is executed on thread pool via Task.Run... With avoiding Posting on UI thread if we are already on UI thread we ensure rename is always executed before we even call Task.Run for saving.