### PR TITLE
[C7][Ide] Don't save the edit session when modifying the buildaction from…

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Projects/ProjectFileDescriptor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Projects/ProjectFileDescriptor.cs
@@ -57,7 +57,7 @@ namespace MonoDevelop.DesignerSupport
 
 			var grid = ((PropertyPad)pad.Content).PropertyGrid;
 			if (args.Any (arg => arg.ProjectFile == file))
-				grid.Populate (saveEditSession: true);
+				grid.Populate (saveEditSession: false);
 		}
 
 		void IDisposable.Dispose ()


### PR DESCRIPTION
… a menu

Bug 40753 - On Demand Resource changes doesn't get reflected after changing the Build action, until property window not get reopened.

Please view the commit with ?w=1.