### PR TITLE
[AutoTest] Make sure ToString() value is also saved as property

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -152,6 +152,7 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			var propertiesObject = new ObjectProperties ();
 			if (resultObject != null) {
+				propertiesObject.Add ("ToString", new ObjectResult (resultObject.ToString ()), null);
 				var properties = resultObject.GetType ().GetProperties (
 					BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
 				foreach (var property in properties) {


### PR DESCRIPTION
There is no way to fetch the actual value of the object fetched.
This comes handy when trying to fetch a value of TreeIter