### PR TITLE
Fixed 'Bug 40893 - Ctor generator doesn’t recognize C#6 get-only

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/CreateConstructorGenerator.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/CreateConstructorGenerator.cs
@@ -36,6 +36,7 @@ using Microsoft.CodeAnalysis.Simplification;
 using ICSharpCode.NRefactory6.CSharp;
 using Gtk;
 using MonoDevelop.Ide.TypeSystem;
+using ICSharpCode.NRefactory6.CSharp.ExtractMethod;
 
 namespace MonoDevelop.CodeGeneration
 {
@@ -115,8 +116,16 @@ namespace MonoDevelop.CodeGeneration
 				foreach (IPropertySymbol property in Options.EnclosingType.GetMembers ().OfType<IPropertySymbol> ()) {
 					if (property.IsImplicitlyDeclared)
 						continue;
-					if (property.SetMethod == null)
-						continue;
+					if (property.SetMethod == null) {
+						if (property.GetMethod == null)
+							continue;
+						var r = property.GetMethod.DeclaringSyntaxReferences.FirstOrDefault ();
+						if (r == null)
+							continue;
+						var node = r.SyntaxTree.GetRoot ().FindNode (r.Span) as AccessorDeclarationSyntax;
+						if (node == null || node.GetBlockBody () != null)
+							continue;
+					}
 					yield return property;
 				}
 			}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/WriteLineGenerator.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/WriteLineGenerator.cs
@@ -126,17 +126,18 @@ namespace MonoDevelop.CodeGeneration
 			{
 				var format = new StringBuilder ();
 				int i = 0;
+				format.Append ("$\"");
 				foreach (var member in includedMembers) {
 					if (i > 0)
 						format.Append (", ");
 					format.Append (GetName (member));
 					format.Append ("={");
-					format.Append (i++);
+					format.Append (member.ToString ());
 					format.Append ("}");
 				}
-
+				format.Append ("\"");
 				var arguments = new List<ArgumentSyntax> ();
-				arguments.Add (SyntaxFactory.Argument (SyntaxFactory.LiteralExpression (SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal (format.ToString ()))));
+				arguments.Add (SyntaxFactory.Argument (SyntaxFactory.ParseExpression (format.ToString ())));
 				var node = 
 					SyntaxFactory.ExpressionStatement (
 						SyntaxFactory.InvocationExpression (


### PR DESCRIPTION
properties'