### PR TITLE
[Ide] Don't trigger edit session mangling if we have one in progress

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Projects/ProjectFileDescriptor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Projects/ProjectFileDescriptor.cs
@@ -56,6 +56,9 @@ namespace MonoDevelop.DesignerSupport
 				return;
 
 			var grid = ((PropertyPad)pad.Content).PropertyGrid;
+			if (grid.IsEditing)
+				return;
+
 			if (args.Any (arg => arg.ProjectFile == file))
 				grid.Populate (saveEditSession: false);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
@@ -286,6 +286,10 @@ namespace MonoDevelop.Components.PropertyGrid
 			Update (); 
 			QueueDraw ();
 		}
+
+		internal bool IsEditing {
+			get { return tree.IsEditing; } 
+		}
 		
 		internal void Populate (bool saveEditSession)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
@@ -237,9 +237,15 @@ namespace MonoDevelop.Components.PropertyGrid
 			QueueResize ();
 		}
 
+		internal bool IsEditing {
+			get {
+				return editSession != null;
+			}
+		}
+
 		internal void SaveEditSession ()
 		{
-			if (editSession == null)
+			if (!IsEditing)
 				return;
 
 			lastEditedProperty = editSession.Property;
@@ -837,6 +843,7 @@ namespace MonoDevelop.Components.PropertyGrid
 				editSession.Dispose ();
 				editSession = null;
 				currentEditorRow = null;
+				parentGrid.Populate (saveEditSession: false);
 				QueueDraw ();
 			}
 		}


### PR DESCRIPTION
This makes the PropertyGrid more reliable when properties updates are
also triggered from outside the property grid.

We now have 3 scenarios of updates:
* ProjectFileDescriptor, which will update the value and trigger a
 refresh if no edit session is in progress.
* PropertyGridEditor internal updates through the editor.
* While having a propertygrideditor session up and someone modifies
* the
 value through external means, we will now trigger a grid population on
  edit session end to ensure we have the right values inside each
  element.

Bug 41135 - Properties window gets blank, on changing the Build
Action from Properties window.