### PR TITLE
Bug 40784 - BaseXmlEditorExtension causes an infinite loop with shared asset projects

### DIFF
--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -52,6 +52,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Ide.Commands;
+using MonoDevelop.Ide.Gui;
 
 namespace MonoDevelop.Xml.Editor
 {
@@ -120,6 +121,9 @@ namespace MonoDevelop.Xml.Editor
 			if (DocumentContext == null) {
 				return;//This can happen if this object is disposed
 			}
+			var view = DocumentContext.GetContent<BaseViewContent> ();
+			if (view != null && view.ProjectReloadCapability == ProjectReloadCapability.None)
+				return;
 			var projects = new HashSet<DotNetProject> (IdeApp.Workspace.GetAllItems<DotNetProject> ().Where (p => p.IsFileInProject (DocumentContext.Name)));
 			if (ownerProjects == null || !projects.SetEquals (ownerProjects)) {
 				ownerProjects = projects.OrderBy (p => p.Name).ToList ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -698,14 +698,12 @@ namespace MonoDevelop.Ide.Gui
 			if (Window == null || Window.ViewContent == null || Window.ViewContent.Project == project)
 				return;
 			UnloadAdhocProject ();
-			if (adhocProject == null) 
+			if (adhocProject == null)
 				UnsubscibeAnalysisdocument ();
-			if (Window.ViewContent.ProjectReloadCapability != ProjectReloadCapability.None) {
-				// Unsubscribe project events
-				if (Window.ViewContent.Project != null)
-					Window.ViewContent.Project.Modified -= HandleProjectModified;
-				Window.ViewContent.Project = project;
-			}
+			// Unsubscribe project events
+			if (Window.ViewContent.Project != null)
+				Window.ViewContent.Project.Modified -= HandleProjectModified;
+			Window.ViewContent.Project = project;
 			if (project != null)
 				project.Modified += HandleProjectModified;
 			InitializeExtensionChain ();


### PR DESCRIPTION
Change in Document.cs fixes loop, since loop was caused by setting project not actually setting it
Changed in BaseXmlEditorExtension.cs is just respecting ProjectReloadCapability.None and not showing shared project switching option or calls AttachToProject method.