### PR TITLE
Add documentation extension point

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -200,6 +200,11 @@
 		<ExtensionNode name="Class"/>
 	</ExtensionPoint>
 
+	<ExtensionPoint path = "/MonoDevelop/Ide/IErrorDocumentationProvider" name = "Link to documentation">
+		<Description>Send users to the appropriate documentation for errors in the error pad.</Description>
+		<ExtensionNode name = "Class" objectType = "MonoDevelop.Ide.Extensions.IErrorDocumentationProvider" />
+	</ExtensionPoint>
+
 	<!-- Extensions -->
 	
 	<Extension path = "/MonoDevelop/Core/Applications">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/IErrorDocumentationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/IErrorDocumentationProvider.cs
@@ -1,0 +1,34 @@
+﻿//
+// IErrorDocumentationProvider.cs
+//
+// Author:
+//       Vincent Dondain <vincent.dondain@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace MonoDevelop.Ide.Extensions
+{
+	public interface IErrorDocumentationProvider
+	{
+		string GetDocumentationLink (string errorDescription);
+	}
+}
+

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -539,21 +539,24 @@ namespace MonoDevelop.Ide.Gui.Pads
 		void OnShowReference (object o, EventArgs args)
 		{
 			string reference = null;
-			if (GetSelectedErrorReference (out reference)) {
-				Process.Start ("http://google.com/search?q=" + System.Web.HttpUtility.UrlEncode (reference));
-				return;
-			}
+			if (GetSelectedErrorReference (out reference) && reference != null)
+				DesktopService.ShowUrl (reference);
 		}
 
 		bool GetSelectedErrorReference (out string reference)
 		{
+			string webRequest = "http://google.com/search?q=";
 			TaskListEntry task = SelectedTask;
-			if (task != null && !String.IsNullOrEmpty (task.HelpKeyword)) {
-				reference = task.HelpKeyword;
+			if (task != null && task.HasDocumentationLink ()) {
+				reference = task.DocumentationLink;
 				return true;
 			}
-			if (task != null && !String.IsNullOrEmpty (task.Code)) {
-				reference = task.Code;
+			if (task != null && !string.IsNullOrEmpty (task.HelpKeyword)) {
+				reference = webRequest + System.Web.HttpUtility.UrlEncode (task.HelpKeyword);
+				return true;
+			}
+			if (task != null && !string.IsNullOrEmpty (task.Code)) {
+				reference = webRequest + System.Web.HttpUtility.UrlEncode (task.Code);
 				return true;
 			}
 			reference = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
@@ -235,6 +235,23 @@ namespace MonoDevelop.Ide.Tasks
 			}
 		}
 
+		public string DocumentationLink {
+			get; set;
+		}
+
+		public bool HasDocumentationLink ()
+		{
+			var extensions = Mono.Addins.AddinManager.GetExtensionObjects<Extensions.IErrorDocumentationProvider> ("/MonoDevelop/Ide/IErrorDocumentationProvider", false);
+			foreach (var ext in extensions) {
+				var link = ext.GetDocumentationLink (description);
+				if (!string.IsNullOrEmpty (link)) {
+					DocumentationLink = link;
+					return true;
+				}
+			}
+			return false;
+		}
+
 		public virtual void JumpToPosition()
 		{
 			if (!file.IsNullOrEmpty) {
@@ -242,8 +259,12 @@ namespace MonoDevelop.Ide.Tasks
 					var project = WorkspaceObject as Project;
 					IdeApp.Workbench.OpenDocument (file, project, Math.Max (1, line), Math.Max (1, column));
 				} else {
-					var pad = IdeApp.Workbench.GetPad<ErrorListPad> ()?.Content as ErrorListPad;
-					pad?.FocusOutputView ();
+					if (HasDocumentationLink ()) {
+						DesktopService.ShowUrl (DocumentationLink);
+					} else {
+						var pad = IdeApp.Workbench.GetPad<ErrorListPad> ()?.Content as ErrorListPad;
+						pad?.FocusOutputView ();
+					}
 				}
 			} else if (parentObject != null) {
 				Pad pad = IdeApp.Workbench.GetPad<ProjectSolutionPad> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -8242,6 +8242,7 @@
     <Compile Include="MonoDevelop.Ide.Editor.Extension\DefaultCommandTextEditorExtension.cs" />
     <Compile Include="MonoDevelop.Ide.Editor\EditSession.cs" />
     <Compile Include="MonoDevelop.Ide.Editor.Extension\AutoInsertBracketTextEditorExtension.cs" />
+    <Compile Include="MonoDevelop.Ide.Extensions\IErrorDocumentationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
`IErrorDocumentationProvider` has one method: `GetDocumentationLink` which gives the address of the documentation for a given error code within the error's description.

Related to https://github.com/xamarin/md-addins/pull/1080.