### PR TITLE
Improve the speed of Find in files

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FileProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FileProvider.cs
@@ -95,20 +95,25 @@ namespace MonoDevelop.Ide.FindInFiles
 				if (doc != null && doc.Editor != null) {
 					return doc.Editor.CreateReader ();
 				} else {
-					try {
-						if (!File.Exists (FileName))
-							return null;
-						if (!readBinaryFiles && TextFileUtility.IsBinary (FileName))
-							return null;
-						return TextFileUtility.OpenStream (FileName);
-					} catch (Exception e) {
-						LoggingService.LogError ("Error while opening " + FileName, e);
-						return null;
-					}
+					return GetReaderForFileName (readBinaryFiles);
 				}
 			}
 		}
-		
+
+		internal TextReader GetReaderForFileName (bool readBinaryFiles = false)
+		{
+			try {
+				if (!File.Exists (FileName))
+					return null;
+				if (!readBinaryFiles && TextFileUtility.IsBinary (FileName))
+					return null;
+				return TextFileUtility.OpenStream (FileName);
+			} catch (Exception e) {
+				LoggingService.LogError ("Error while opening " + FileName, e);
+				return null;
+			}
+		}
+
 		async Task<Document> SearchDocument ()
 		{
 			string fullPath = Path.GetFullPath (FileName);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindReplace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindReplace.cs
@@ -106,6 +106,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			IsRunning = true;
 			FoundMatchesCount = SearchedFilesCount = 0;
 			monitor.BeginTask (scope.GetDescription (filter, pattern, replacePattern), 150);
+
 			try {
 				int totalWork = scope.GetTotalWork (filter);
 				int step = Math.Max (1, totalWork / 50);
@@ -128,10 +129,7 @@ namespace MonoDevelop.Ide.FindInFiles
 					}
 				}
 
-				TextReader [] readers = null;
-				var task = GetSearchDocumentsReaders (filenames);
-				if (task.Wait (1000))
-					readers = task.Result;
+				var readers = IdeApp.Workbench.GetDocumentReaders (filenames);
 
 				int idx = 0;
 				if (readers != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindReplace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindReplace.cs
@@ -110,7 +110,6 @@ namespace MonoDevelop.Ide.FindInFiles
 				int totalWork = scope.GetTotalWork (filter);
 				int step = Math.Max (1, totalWork / 50);
 
-
 				var contents = new List<FileSearchResult>();
 				var filenames = new List<string> ();
 				foreach (var provider in scope.GetFiles (monitor, filter)) {
@@ -118,7 +117,7 @@ namespace MonoDevelop.Ide.FindInFiles
 						return Enumerable.Empty<SearchResult> ();
 					try {
 						searchedFilesCount++;
-						contents.Add(new FileSearchResult (provider, /*provider.ReadString ()*/null, new List<SearchResult> ()));
+						contents.Add(new FileSearchResult (provider, null, new List<SearchResult> ()));
 
 						filenames.Add (Path.GetFullPath (provider.FileName));
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindReplace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindReplace.cs
@@ -209,11 +209,6 @@ namespace MonoDevelop.Ide.FindInFiles
 			}
 		}
 
-		async Task<TextReader[]> GetSearchDocumentsReaders (List<string> filenames)
-		{
-			return await Runtime.RunInMainThread (() => IdeApp.Workbench.GetDocumentReaders (filenames));
-		}
-
 		// Took: 17743
 
 		IEnumerable<SearchResult> FindAll (ProgressMonitor monitor, FileProvider provider, TextReader content, string pattern, string replacePattern, FilterOptions filter)


### PR DESCRIPTION
A couple of patches to improve the Find In Files speed. tl;dr these patches cut about 10seconds from the time taken to search through files in Main.sln.

Some speed results from runs of 10 goes on Main.sln (18,000 files)

Average time to search every file for the word "Updater"
Master branch: 21.85 seconds (Range 20.36 -> 23.3)
With this patch applied: 11.63 seconds (Range 9.54 -> 14.34)

We can look closer at this because there are two phases to the search, generating the list of files and readers for them, and doing the search on those files.

Master (average over 10 runs):
 - List files: 18.98 seconds (range: 17.5 -> 20.43)
 - Search files: 2.85 seconds

With patch applied:
 - List files: 8.81 seconds (range: 6.75 -> 11.46)
 - Search files: 2.85 seconds

Which makes sense as we haven't touch the searching code.
With the patch attached, we can split the List files section into another two phases: getting a list of the files to search, and creating readers for those files, and the times for that are

 - creating list of files: 3.23 seconds (range 3.04 -> 3.39)
 - creating readers for the files: 5.5 seconds (range 3.57 -> 8.07)

it's clear that the creating readers section is pretty time consuming, ~~and I'm wondering if the wild fluctuation in the range is maybe because of the context switch that occurs.~~ [edit: no, checked, the context switch only takes .2seconds] 

Creating the readers for each file involves loading the whole file into memory, then checking the BOM on it, before creating a StreamReader. I tried porting this to use a memory mapped file, but it was slower for some reason. This is certainly an area for further investigation