### PR TITLE
[Ide] Fixup rebuild progress monitor behaviour

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1180,7 +1180,11 @@ namespace MonoDevelop.Ide
 			try {
 				OnStartClean (monitor, tt);
 
+				monitor.BeginTask (GettextCatalog.GetString ("Rebuilding..."), 2);
+				monitor.BeginStep (GettextCatalog.GetString ("Rebuilding... (Clean)"));
+
 				var res = await CleanAsync (entry, monitor, tt, true, operationContext);
+				monitor.EndStep ();
 				if (res.HasErrors) {
 					tt.End ();
 					monitor.Dispose ();
@@ -1189,6 +1193,7 @@ namespace MonoDevelop.Ide
 				if (StartBuild != null) {
 					BeginBuild (monitor, tt, true);
 				}
+				monitor.BeginStep (GettextCatalog.GetString ("Rebuilding... (Build)"));
 				return await BuildSolutionItemAsync (entry, monitor, tt, operationContext:operationContext);
 			} finally {
 				tt.End ();


### PR DESCRIPTION
We need to have one statusbar progress per action we're doing, so we
will have to attach the same error pad to a different status bar for
build and clean.

The idea of the code is to have one statusbar monitor alive at a time,
while the error one is alive for the whole operation, and the
aggregated monitors are disposed at the end just so they're not
marked as finalized but not Disposed by profiler tools.