### PR TITLE
[NUnit] Guard against null execution context on running tests.

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -402,7 +402,8 @@ namespace MonoDevelop.UnitTesting
 		public TestSession (UnitTest test, MonoDevelop.Projects.ExecutionContext context, TestResultsPad resultsPad, CancellationTokenSource cs)
 		{
 			this.test = test;
-			this.context = new Projects.ExecutionContext (context.ExecutionHandler, new CustomConsoleFactory (context.ConsoleFactory, cs), context.ExecutionTarget);
+			if (context != null)
+				this.context = new Projects.ExecutionContext (context.ExecutionHandler, new CustomConsoleFactory (context.ConsoleFactory, cs), context.ExecutionTarget);
 			CancellationTokenSource = cs;
 			this.monitor = new TestMonitor (resultsPad, CancellationTokenSource);
 			this.resultsPad = resultsPad;


### PR DESCRIPTION
As per 14872cd219d96421caee9a69935c474488fcf94b, we were no longer
checking whether the passed context was null.

The context we are not assigning as per this change will be fixed up by
TestContext in the constructor and assigned a fallback value.

Bug 41320 - Run Unit Tests from Run Menu isn't working. Shows NRE in log