### PR TITLE
Make ErrorDocumentationProvider a custom extension point

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -200,9 +200,9 @@
 		<ExtensionNode name="Class"/>
 	</ExtensionPoint>
 
-	<ExtensionPoint path = "/MonoDevelop/Ide/IErrorDocumentationProvider" name = "Link to documentation">
+	<ExtensionPoint path = "/MonoDevelop/Ide/ErrorDocumentationProvider" name = "Link to documentation">
 		<Description>Send users to the appropriate documentation for errors in the error pad.</Description>
-		<ExtensionNode name = "Class" objectType = "MonoDevelop.Ide.Extensions.IErrorDocumentationProvider" />
+		<ExtensionNode name = "ErrorDocumentationProvider" type = "MonoDevelop.Ide.Extensions.ErrorDocumentationProvider" />
 	</ExtensionPoint>
 
 	<!-- Extensions -->

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/ErrorDocumentationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/ErrorDocumentationProvider.cs
@@ -1,5 +1,5 @@
 ﻿//
-// IErrorDocumentationProvider.cs
+// ErrorDocumentationProvider.cs
 //
 // Author:
 //       Vincent Dondain <vincent.dondain@xamarin.com>
@@ -24,11 +24,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using Mono.Addins;
+using MonoDevelop.Core;
+
 namespace MonoDevelop.Ide.Extensions
 {
-	public interface IErrorDocumentationProvider
+	[ExtensionNode (Description = "A link to the error's documentation to be used in the error pad.")]
+	class ErrorDocumentationProvider : TypeExtensionNode
 	{
-		string GetDocumentationLink (string errorDescription);
+		[NodeAttribute ("regex", true, "Regex to get the error code.")]
+		string regex = null;
+
+		[NodeAttribute ("url", true, "URL to the error's documentation with a placeholder for the error code.")]
+		string url = null;
+
+		/// <summary>
+		/// Provides a link to the documentation using the extension's regex and url template.
+		/// </summary>
+		/// <returns>The documentation link or null.</returns>
+		/// <param name="errorDescription">The error message with the error code to parse.</param>
+		public string GetDocumentationLink (string errorDescription) {
+			string address = null;
+			if (!string.IsNullOrEmpty (errorDescription) && !string.IsNullOrEmpty (regex)) {
+				var mtError = System.Text.RegularExpressions.Regex.Match (errorDescription, regex);
+				if (!string.IsNullOrEmpty (mtError.Value) && !string.IsNullOrEmpty (url))
+					address = string.Format (url, mtError.Value);
+			}
+			return address;
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
@@ -241,8 +241,7 @@ namespace MonoDevelop.Ide.Tasks
 
 		public bool HasDocumentationLink ()
 		{
-			var extensions = Mono.Addins.AddinManager.GetExtensionObjects<Extensions.IErrorDocumentationProvider> ("/MonoDevelop/Ide/IErrorDocumentationProvider", false);
-			foreach (var ext in extensions) {
+			foreach (Extensions.ErrorDocumentationProvider ext in Mono.Addins.AddinManager.GetExtensionNodes ("/MonoDevelop/Ide/ErrorDocumentationProvider")) {
 				var link = ext.GetDocumentationLink (description);
 				if (!string.IsNullOrEmpty (link)) {
 					DocumentationLink = link;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -8266,7 +8266,7 @@
     <Compile Include="MonoDevelop.Ide.Editor.Extension\DefaultCommandTextEditorExtension.cs" />
     <Compile Include="MonoDevelop.Ide.Editor\EditSession.cs" />
     <Compile Include="MonoDevelop.Ide.Editor.Extension\AutoInsertBracketTextEditorExtension.cs" />
-    <Compile Include="MonoDevelop.Ide.Extensions\IErrorDocumentationProvider.cs" />
+    <Compile Include="MonoDevelop.Ide.Extensions\ErrorDocumentationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
It's now easier for add-ins to implement link to the documentation for specific error codes thanks to the custom extension point logic.

Here's an exemple of the only thing add-ins need to do:

```
<Extension path = "/MonoDevelop/Ide/ErrorDocumentationProvider">
        <ErrorDocumentationProvider id = "MTErrorDocumentation"
                                    regex = "MT\d{4}"
                                    url = "https://developer.xamarin.com/guides/ios/troubleshooting/mtouch-errors/#{0}"/>
</Extension>
```