### PR TITLE
[C7][Bug 40898] Fix unreadable node status in soultion pad

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNode.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNode.cs
@@ -99,25 +99,30 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 
 		public string GetLabel ()
 		{
+			return Id;
+		}
+
+		public string GetSecondaryLabel ()
+		{
 			if (UpdatedVersion != null) {
-				return Id + GetUpdatedVersionLabelText ();
+				return GetUpdatedVersionLabelText ();
 			}
 			if (IsInstallPending) {
-				return Id + GetInstallingLabelText ();
+				return GetInstallingLabelText ();
 			}
-			return Id;
+			return string.Empty;
 		}
 
 		string GetUpdatedVersionLabelText ()
 		{
-			return String.Format (" <span color='grey'>({0} {1})</span>",
+			return String.Format ("({0} {1})",
 				UpdatedVersion,
 				GettextCatalog.GetString ("available"));
 		}
 
 		string GetInstallingLabelText ()
 		{
-			return String.Format (" ({0})", GettextCatalog.GetString ("installing"));
+			return String.Format ("({0})", GettextCatalog.GetString ("installing"));
 		}
 
 		public IconId GetIconId ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNodeBuilder.cs
@@ -57,6 +57,7 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 		{
 			var packageReferenceNode = (PackageReferenceNode)dataObject;
 			nodeInfo.Label = packageReferenceNode.GetLabel ();
+			nodeInfo.SecondaryLabel = packageReferenceNode.GetSecondaryLabel ();
 			nodeInfo.Icon = Context.GetIcon (packageReferenceNode.GetIconId ());
 			nodeInfo.StatusSeverity = packageReferenceNode.GetStatusSeverity ();
 			nodeInfo.StatusMessage = packageReferenceNode.GetStatusMessage ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNode.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNode.cs
@@ -71,17 +71,17 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 
 		public string GetLabel ()
 		{
-			return GettextCatalog.GetString ("Packages") + GetUpdatedPackagesCountLabel ();
+			return GettextCatalog.GetString ("Packages");
 		}
 
-		string GetUpdatedPackagesCountLabel ()
+		public string GetSecondaryLabel ()
 		{
 			int count = GetUpdatedPackagesCount ();
 			if (count == 0) {
 				return String.Empty;
 			}
 
-			return " <span color='grey'>" + GetUpdatedPackagesCountLabel (count) + "</span>";
+			return GetUpdatedPackagesCountLabel (count);
 		}
 
 		string GetUpdatedPackagesCountLabel (int count)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
@@ -57,6 +57,7 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 		{
 			var node = (ProjectPackagesFolderNode)dataObject;
 			nodeInfo.Label = node.GetLabel ();
+			nodeInfo.SecondaryLabel = node.GetSecondaryLabel ();
 			nodeInfo.Icon = Context.GetIcon (node.Icon);
 			nodeInfo.ClosedIcon = Context.GetIcon (node.ClosedIcon);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -327,6 +327,7 @@ namespace MonoDevelop.Ide.Gui.Components
 
 			cell.DisabledStyle = info.DisabledStyle;
 			cell.TextMarkup = info.Label;
+			cell.SecondaryTextMarkup = info.SecondaryLabel;
 
 			cell.StatusIcon = info.StatusIconInternal;
 		}
@@ -2356,6 +2357,7 @@ namespace MonoDevelop.Ide.Gui.Components
 			Gdk.Rectangle buttonScreenRect;
 			Gdk.Rectangle buttonAllocation;
 			string markup;
+			string secondarymarkup;
 
 			const int StatusIconSpacing = 4;
 
@@ -2382,7 +2384,25 @@ namespace MonoDevelop.Ide.Gui.Components
 			[GLib.Property ("text-markup")]
 			public string TextMarkup {
 				get { return markup; }
-				set { Markup = markup = value; }
+				set {
+					markup = value;
+					if (!string.IsNullOrEmpty (secondarymarkup))
+						Markup = markup + " " + secondarymarkup;
+					else
+						Markup = markup;
+				}
+			}
+
+			[GLib.Property ("secondary-text-markup")]
+			public string SecondaryTextMarkup {
+				get { return secondarymarkup; }
+				set {
+					secondarymarkup = value;
+					if (!string.IsNullOrEmpty (secondarymarkup))
+						Markup = markup + " " + secondarymarkup;
+					else
+						Markup = markup;
+				}
 			}
 
 			public bool DisabledStyle { get; set; }
@@ -2438,15 +2458,24 @@ namespace MonoDevelop.Ide.Gui.Components
 					layout.FontDescription = scaledFont;
 				}
 
+				string newmarkup = TextMarkup;
 				if (DisabledStyle) {
 					Gdk.Color fgColor;
-					if (Platform.IsMac && flags.HasFlag (Gtk.CellRendererState.Selected)) 
+					if (Platform.IsMac && flags.HasFlag (Gtk.CellRendererState.Selected))
 						fgColor = widget.Style.Text (IdeTheme.UserInterfaceTheme == Theme.Light ? Gtk.StateType.Selected : Gtk.StateType.Normal);
 					else
 						fgColor = widget.Style.Text (Gtk.StateType.Insensitive);
-					layout.SetMarkup ("<span foreground='" + fgColor.GetHex () + "'>" + TextMarkup + "</span>");
-				} else
-					layout.SetMarkup (TextMarkup);
+					newmarkup = "<span foreground='" + fgColor.GetHex () + "'>" + TextMarkup + "</span>";
+				}
+
+				if (!string.IsNullOrEmpty (SecondaryTextMarkup)) {
+					if (Platform.IsMac && flags.HasFlag (Gtk.CellRendererState.Selected))
+						newmarkup += " <span foreground='" + Styles.SecondarySelectionTextColor.ToHexString (false) + "'>" + SecondaryTextMarkup + "</span>";
+					else
+						newmarkup += " <span foreground='" + Styles.SecondaryTextColor.ToHexString (false) + "'>" + SecondaryTextMarkup + "</span>";
+				}
+
+				layout.SetMarkup (newmarkup);
 			}
 
 			protected override void Render (Gdk.Drawable window, Gtk.Widget widget, Gdk.Rectangle background_area, Gdk.Rectangle cell_area, Gdk.Rectangle expose_area, Gtk.CellRendererState flags)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/NodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/NodeBuilder.cs
@@ -161,6 +161,7 @@ namespace MonoDevelop.Ide.Gui.Components
 		public void Reset ()
 		{
 			Label = string.Empty;
+			SecondaryLabel = string.Empty;
 			Icon = CellRendererImage.NullImage;
 			ClosedIcon = CellRendererImage.NullImage;
 			OverlayBottomLeft = CellRendererImage.NullImage;
@@ -180,6 +181,7 @@ namespace MonoDevelop.Ide.Gui.Components
 		}
 
 		public string Label { get; set; }
+		public string SecondaryLabel { get; set; }
 		public Xwt.Drawing.Image Icon { get; set; }
 		public Xwt.Drawing.Image ClosedIcon { get; set; }
 		public Xwt.Drawing.Image OverlayBottomLeft { get; set; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -45,6 +45,8 @@ namespace MonoDevelop.Ide.Gui
 		public static Color BaseSelectionTextColor { get; internal set; }
 		public static Color BaseIconColor { get; internal set; }
 		public static Color LinkForegroundColor { get; internal set; }
+		public static Color SecondaryTextColor { get; internal set; }
+		public static Color SecondarySelectionTextColor { get; internal set; }
 
 		public static Color ErrorForegroundColor { get; internal set; }
 		public static Color WarningForegroundColor { get; internal set; }
@@ -328,6 +330,8 @@ namespace MonoDevelop.Ide.Gui
 			SubTabBarActiveTextColor = BaseSelectionTextColor;
 			SubTabBarSeparatorColor = SubTabBarTextColor;
 			InactiveBrowserPadBackground = InactivePadBackground;
+			SecondaryTextColor = Color.FromName ("#808080");
+			SecondarySelectionTextColor = Color.FromName ("#d3d3d3");
 
 			// Tabs
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -331,7 +331,7 @@ namespace MonoDevelop.Ide.Gui
 			SubTabBarSeparatorColor = SubTabBarTextColor;
 			InactiveBrowserPadBackground = InactivePadBackground;
 			SecondaryTextColor = Color.FromName ("#808080");
-			SecondarySelectionTextColor = Color.FromName ("#d3d3d3");
+			SecondarySelectionTextColor = Color.FromName ("#93cbff");
 
 			// Tabs
 


### PR DESCRIPTION
Fixes the color of the NuGet status message in solution pad nodes.