### PR TITLE
[Ide][Mac] Fix unfocused selected tree row background

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -241,9 +241,7 @@ style "tooltip"
 
 style "treeview" = "default"
 {
-    base[SELECTED] = @selected_bg_color
-    base[ACTIVE] = @selected_bg_color
-    text[SELECTED] = @selected_fg_color
+    base[ACTIVE] = "#a0a0a0"
     text[ACTIVE] = @selected_fg_color
 
     engine "xamarin" {

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -244,9 +244,7 @@ style "tooltip"
 
 style "treeview" = "default"
 {
-    base[SELECTED] = @selected_bg_color
-    base[ACTIVE] = @selected_bg_color
-    text[SELECTED] = @selected_fg_color
+    base[ACTIVE] = "#a0a0a0"
     text[ACTIVE] = @selected_fg_color
 
     engine "xamarin" {


### PR DESCRIPTION
This fix depends on mono/xamarin-gtk-theme@c202097fba9982925fff4d5e67d0ca0feadd8ecb and requires an updated mono build.

The problem with this is, that without the updated mono build the trees will always have the inactive selection color on Mac:
![pasted image at 2016_05_31 14_59](https://cloud.githubusercontent.com/assets/951587/15701102/860d49cc-27d8-11e6-9861-ca4614b1a735.png)

~~**Please don't merge now**, I'll update the status as soon as the new mono builds include the patch.~~
(fixes bug #40877)