### PR TITLE
Explicitly add Name to ExtensibleTreeView

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Gui/TestPad.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Gui/TestPad.cs
@@ -348,6 +348,8 @@ namespace MonoDevelop.UnitTesting
 			
 			foreach (UnitTest t in UnitTestService.RootTests)
 				TreeView.AddChild (t);
+			
+			base.TreeView.Tree.Name = "unitTestBrowserTree";
 		}
 		
 		void OnTestSuiteChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -43,6 +43,9 @@ using MonoDevelop.Ide.Gui.Pads;
 using MonoDevelop.Projects.Extensions;
 using System.Linq;
 using MonoDevelop.Ide.Tasks;
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("MonoDevelop.UnitTesting")]
 
 namespace MonoDevelop.Ide.Gui.Components
 {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassBrowserPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassBrowserPad.cs
@@ -50,6 +50,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassBrowser
 		{
 			base.Initialize (container);
 			this.widget = new ClassBrowserPadWidget (base.TreeView, container); 
+			base.TreeView.Tree.Name = "classBrowserTree";
 		}
 
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/SolutionPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/SolutionPad.cs
@@ -46,6 +46,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			base.Initialize (builders, options, contextMenuPath);
 			foreach (WorkspaceItem it in IdeApp.Workspace.Items)
 				treeView.AddChild (it);
+			base.TreeView.Tree.Name = "solutionBrowserTree";
 		}
 		
 		protected virtual void OnOpenWorkspace (object sender, WorkspaceItemEventArgs e)


### PR DESCRIPTION
It's needed for automation of Xamarin Studio to avoid clash between multiple instances