### PR TITLE
[VersionControl] Fix solution pad overlay icons [C7][Bug41580]

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
@@ -95,7 +95,9 @@ namespace MonoDevelop.VersionControl
 			
 			VersionInfo vi = repo.GetVersionInfo (file);
 
-			nodeInfo.OverlayBottomRight = VersionControlService.LoadOverlayIconForStatus (vi.Status);
+			var overlay = VersionControlService.LoadOverlayIconForStatus (vi.Status);
+			if (overlay != null)
+				nodeInfo.OverlayBottomRight = overlay;
 		}
 
 /*		public override void PrepareChildNodes (object dataObject)
@@ -128,7 +130,8 @@ namespace MonoDevelop.VersionControl
 			} else {
 				overlay = VersionControlService.LoadOverlayIconForStatus (vinfo.Status);
 			}
-			nodeInfo.OverlayBottomRight = overlay;
+			if (overlay != null)
+				nodeInfo.OverlayBottomRight = overlay;
 		}
 		
 		void Monitor (object sender, FileUpdateEventArgs args)


### PR DESCRIPTION
Set solution pad overlay icons only if the status
of the node has been changed. Otherwise keep
the original overlay.

(cherry picked from commit e5e9798a9952601ca128fa223c724e8511904b13)
(fixes bug #41580)