### PR TITLE
Bug 41572 - InitializeComponent() The Call is Ambiguous between

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -485,6 +485,8 @@ namespace MonoDevelop.Ide.TypeSystem
 					yield return CreateDocumentInfo (solutionData, p.Name, projectData, f);
 				} else {
 					foreach (var projectedDocument in GenerateProjections (f, projectData, p)) {
+						if (!duplicates.Add (projectData.GetOrCreateDocumentId (projectedDocument.FilePath)))
+							continue;
 						yield return projectedDocument;
 					}
 				}


### PR DESCRIPTION
'ClassName.InitializeComponent()' and 'ClassName.InitializeComponent()'

This is same fix as https://github.com/mono/monodevelop/pull/1489 but for C7SR1