### PR TITLE
Bug 41604 - File not found exception logged every second into IDE log when not project not compiled

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -341,6 +341,8 @@ namespace MonoDevelop.Core.Assemblies
 		//FIXME: the fallback is broken since multiple frameworks can have the same corlib
 		public TargetFrameworkMoniker GetTargetFrameworkForAssembly (TargetRuntime tr, string file)
 		{
+			if (!File.Exists (file))
+				return TargetFrameworkMoniker.UNKNOWN;
 			var universe = CreateClosedUniverse ();
 			try {
 				IKVM.Reflection.Assembly assembly = universe.LoadFile (file);


### PR DESCRIPTION
Reason this appeared only now and only to Matt is because he installed my adding which caused this here: https://github.com/DavidKarlas/VSCodeDebugger/blob/master/VSCodeDebugger/VSCodeDebuggerEngine.cs#L23

Since I will fix this in AddIn this weekend, maybe we can reject this commit for C7SR1(I already committed this check to master...)
I opened this PR against C7SR1 because bug is specified as such...