### PR TITLE
Shared asset files need to be added first for F#

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -370,11 +370,11 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 		{
 			pref.Flags = ProjectItemFlags.DontPersist;
 			pref.SetItemsProjectPath (ProjItemsPath);
-			foreach (var f in Files) {
+			foreach (var f in Files.Reverse()) {
 				if (pref.OwnerProject.Files.GetFile (f.FilePath) == null && f.Subtype != Subtype.Directory) {
 					var cf = (ProjectFile)f.Clone ();
 					cf.Flags |= ProjectItemFlags.DontPersist | ProjectItemFlags.Hidden;
-					pref.OwnerProject.Files.Add (cf);
+					pref.OwnerProject.Files.Insert (0, cf);
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -402,7 +402,7 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 					if (f.ProjectFile.Subtype != Subtype.Directory && p.Files.GetFile (f.ProjectFile.FilePath) == null) {
 						var pf = (ProjectFile)f.ProjectFile.Clone ();
 						pf.Flags |= ProjectItemFlags.DontPersist | ProjectItemFlags.Hidden;
-						p.Files.Add (pf);
+						p.Files.Insert (0, pf);
 					}
 				}
 			}
@@ -429,7 +429,7 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 					var pf = (ProjectFile) f.ProjectFile.Clone ();
 					p.Files.Remove (f.OldName);
 					pf.Flags |= ProjectItemFlags.DontPersist | ProjectItemFlags.Hidden;
-					p.Files.Add (pf);
+					p.Files.Insert (0, pf);
 				}
 			}
 		}

--- a/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
@@ -318,6 +318,26 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void SharedFilesShouldBeAddedFirst ()
+		{
+			var sol = new Solution ();
+			var shared = new SharedAssetsProject ("F#");
+			shared.AddFile ("Shared1.fs");
+			shared.AddFile ("Shared2.fs");
+			sol.RootFolder.AddItem (shared);
+
+			// Reference to shared is added before adding project to solution
+			var main = Services.ProjectService.CreateDotNetProject ("F#");
+			main.AddFile ("File1.fs");
+			main.References.Add (ProjectReference.CreateProjectReference (shared));
+			sol.RootFolder.AddItem (main);
+
+			var files = main.Files.Select (f => f.FilePath.FileName);
+
+			Assert.AreEqual (new [] { "Shared1.fs", "Shared2.fs", "File1.fs" }, files);
+		}
+
+		[Test]
 		public void SharedProjectAddedAfterIncluder ()
 		{
 			var sol = new Solution ();


### PR DESCRIPTION
If the shared asset files aren't included first, then the consuming project won't compile. 

I'm working on the assumption that it won't make any difference for C# projects, so can treat them the same.
/cc @slluis 