### PR TITLE
[Cycle7][NuGet] Fix delay for packages to appear in Add Packages dialog.

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.cs
@@ -447,18 +447,8 @@ namespace MonoDevelop.PackageManagement
 		void LoadPackageImage (int row, PackageViewModel packageViewModel)
 		{
 			if (packageViewModel.HasIconUrl) {
-				// Workaround: Image loading is incorrectly being done on GUI thread
-				// since the wrong synchronization context seems to be used. So
-				// here we switch to a background thread and then back to the GUI thread.
-				Task.Run (() => LoadImage (packageViewModel.IconUrl, row));
+				imageLoader.LoadFrom (packageViewModel.IconUrl, row);
 			}
-		}
-
-		void LoadImage (Uri iconUrl, int row)
-		{
-			// Put it back on the GUI thread so the correct synchronization context
-			// is used. The image loading will be done on a background thread.
-			Runtime.RunInMainThread (() => imageLoader.LoadFrom (iconUrl, row));
 		}
 
 		bool IsOddRow (int row)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -379,6 +379,7 @@
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementSolutionProjectService.cs" />
     <Compile Include="MonoDevelop.PackageManagement\NuGetPackageNewImportsHandler.cs" />
     <Compile Include="MonoDevelop.PackageManagement\INuGetPackageNewImportsHandler.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\BackgroundDispatcher.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundDispatcher.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundDispatcher.cs
@@ -1,0 +1,100 @@
+﻿//
+// BackgroundDispatcher.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.PackageManagement
+{
+	class BackgroundDispatcher
+	{
+		Queue<Action> backgroundQueue = new Queue<Action> ();
+		ManualResetEvent backgroundThreadWait = new ManualResetEvent (false);
+		Thread backgroundThread;
+		bool stopped;
+
+		public void Start (string name)
+		{
+			backgroundThread = new Thread (new ThreadStart (RunDispatcher)) {
+				Name = name,
+				IsBackground = true,
+				Priority = ThreadPriority.Lowest,
+			};
+			backgroundThread.Start ();
+		}
+
+		void RunDispatcher ()
+		{
+			while (!stopped) {
+				Action action = null;
+				bool wait = false;
+				lock (backgroundQueue) {
+					if (backgroundQueue.Count == 0) {
+						backgroundThreadWait.Reset ();
+						wait = true;
+					} else
+						action = backgroundQueue.Dequeue ();
+				}
+
+				if (wait) {
+					backgroundThreadWait.WaitOne ();
+					continue;
+				}
+
+				if (action != null) {
+					try {
+						action ();
+					} catch (Exception ex) {
+						LoggingService.LogError ("BackgroundDispatcher error.", ex);
+					}
+				}
+			}
+		}
+
+		public void Dispatch (Action action)
+		{
+			QueueBackground (action);
+		}
+
+		void QueueBackground (Action action)
+		{
+			lock (backgroundQueue) {
+				backgroundQueue.Enqueue (action);
+				if (backgroundQueue.Count == 1)
+					backgroundThreadWait.Set ();
+			}
+		}
+
+		public void Stop ()
+		{
+			stopped = true;
+			backgroundThreadWait.Set ();
+		}
+	}
+}
+


### PR DESCRIPTION
Fixed bug #41499 - Searching for a NuGet package takes five to ten
minutes to populate the results.
https://bugzilla.xamarin.com/show_bug.cgi?id=41499

When opening the Add Packages dialog sometimes it could take a while
(1 to 2 minutes) to display the list of NuGet packages. The problem
was that the images displayed in the Add Packages dialog for the
NuGet packages were loaded individually each using their own Task
which could use up many thread pool threads. The search itself uses a
Task and if this is run whilst the images are being loaded the task
can take a long time before a thread pool thread is made available to
start the search.

To fix this the image loading no longer uses tasks and instead uses
a single low priority background thread to load the images one at a
time.