### PR TITLE
[Cycle7][NuGet] Fixed failing unit tests due to api change.

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNodeTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNodeTests.cs
@@ -81,8 +81,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreatePackageReferenceNode ();
 
 			string label = node.GetLabel ();
+			string secondaryLabel = node.GetSecondaryLabel ();
 
 			Assert.AreEqual ("MyPackage", label);
+			Assert.AreEqual (String.Empty, secondaryLabel);
 		}
 
 		[Test]
@@ -92,8 +94,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreatePackageReferenceNode (installed: false);
 
 			string label = node.GetLabel ();
+			string secondaryLabel = node.GetSecondaryLabel ();
 
 			Assert.AreEqual ("MyPackage", label);
+			Assert.AreEqual (String.Empty, secondaryLabel);
 		}
 
 		[Test]
@@ -103,8 +107,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreatePackageReferenceNode (installed: true);
 
 			string label = node.GetLabel ();
+			string secondaryLabel = node.GetSecondaryLabel ();
 
 			Assert.AreEqual ("MyPackage", label);
+			Assert.AreEqual (String.Empty, secondaryLabel);
 		}
 
 		[Test]
@@ -114,8 +120,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreatePackageReferenceNode (installed: false, installPending: true);
 
 			string label = node.GetLabel ();
+			string secondaryLabel = node.GetSecondaryLabel ();
 
-			Assert.AreEqual ("MyPackage (installing)", label);
+			Assert.AreEqual ("MyPackage", label);
+			Assert.AreEqual ("(installing)", secondaryLabel);
 		}
 
 		[Test]
@@ -162,8 +170,10 @@ namespace MonoDevelop.PackageManagement.Tests
 				updatedPackage: new PackageName ("MyPackage", new SemanticVersion ("1.2.3.4")));
 
 			string label = node.GetLabel ();
+			string secondaryLabel = node.GetSecondaryLabel ();
 
-			Assert.AreEqual ("MyPackage <span color='grey'>(1.2.3.4 available)</span>", label);
+			Assert.AreEqual ("MyPackage", label);
+			Assert.AreEqual ("(1.2.3.4 available)", secondaryLabel);
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackagesFolderNodeTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackagesFolderNodeTests.cs
@@ -90,8 +90,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			NoUpdatedPackages ();
 
 			string label = packagesFolderNode.GetLabel ();
+			string secondaryLabel = packagesFolderNode.GetSecondaryLabel ();
 
 			Assert.AreEqual ("Packages", label);
+			Assert.AreEqual (String.Empty, secondaryLabel);
 		}
 
 		[Test]
@@ -124,8 +126,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			AddUpdatedPackageForProject ("MyPackage", "1.1");
 
 			string label = packagesFolderNode.GetLabel ();
+			string secondaryLabel = packagesFolderNode.GetSecondaryLabel ();
 
-			Assert.AreEqual ("Packages <span color='grey'>(1 update)</span>", label);
+			Assert.AreEqual ("Packages", label);
+			Assert.AreEqual ("(1 update)", secondaryLabel);
 		}
 
 		[Test]
@@ -137,8 +141,10 @@ namespace MonoDevelop.PackageManagement.Tests
 			AddUpdatedPackagesForProject ("One", "1.1", "Two", "1.3");
 
 			string label = packagesFolderNode.GetLabel ();
+			string secondaryLabel = packagesFolderNode.GetSecondaryLabel ();
 
-			Assert.AreEqual ("Packages <span color='grey'>(2 updates)</span>", label);
+			Assert.AreEqual ("Packages", label);
+			Assert.AreEqual ("(2 updates)", secondaryLabel);
 		}
 
 		[Test]
@@ -155,6 +161,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual (1, nodes.Count);
 			Assert.IsTrue (referenceNode.Installed);
 			Assert.AreEqual ("MyPackage", referenceNode.GetLabel ());
+			Assert.AreEqual (String.Empty, packagesFolderNode.GetSecondaryLabel ());
 		}
 
 		[Test]
@@ -170,6 +177,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual (1, nodes.Count);
 			Assert.IsFalse (referenceNode.Installed);
 			Assert.AreEqual ("MyPackage", referenceNode.GetLabel ());
+			Assert.AreEqual (String.Empty, referenceNode.GetSecondaryLabel ());
 		}
 
 		[Test]
@@ -185,7 +193,8 @@ namespace MonoDevelop.PackageManagement.Tests
 			PackageReferenceNode referenceNode = nodes.FirstOrDefault ();
 			Assert.AreEqual (1, nodes.Count);
 			Assert.AreEqual ("1.2", referenceNode.UpdatedVersion.ToString ());
-			Assert.AreEqual ("MyPackage <span color='grey'>(1.2 available)</span>", referenceNode.GetLabel ());
+			Assert.AreEqual ("MyPackage", referenceNode.GetLabel ());
+			Assert.AreEqual ("(1.2 available)", referenceNode.GetSecondaryLabel ());
 		}
 
 		[Test]
@@ -200,7 +209,8 @@ namespace MonoDevelop.PackageManagement.Tests
 			PackageReferenceNode referenceNode = nodes.FirstOrDefault ();
 			Assert.AreEqual (1, nodes.Count);
 			Assert.AreEqual ("1.2", referenceNode.UpdatedVersion.ToString ());
-			Assert.AreEqual ("MyPackage <span color='grey'>(1.2 available)</span>", referenceNode.GetLabel ());
+			Assert.AreEqual ("MyPackage", referenceNode.GetLabel ());
+			Assert.AreEqual ("(1.2 available)", referenceNode.GetSecondaryLabel ());
 			Assert.AreEqual (Stock.Reference, referenceNode.GetIconId ());
 			Assert.IsTrue (referenceNode.IsDisabled ());
 		}


### PR DESCRIPTION
How the solution pad nodes display labels was changed in commit:

9197e1153e424ac964f50e6b444a7d393e459834

So instead of having one _label_ there is a primary and a secondary
label. The secondary label is displayed in a different colour text.
This broke the unit tests since they were based on the original
api where there was no secondary label and the code in the NuGet
addin has been changed to use a secondary label.
