### PR TITLE
Fix App Config is not read in Unit Tests

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitTestRunner.cs
@@ -96,6 +96,7 @@ namespace MonoDevelop.UnitTesting.NUnit.External
 				tr = new RemoteTestRunner ();
 
 			TestPackage package = new TestPackage (path);
+			package.Settings ["ShadowCopyFiles"] = false;
 			if (!string.IsNullOrEmpty (suiteName))
 				package.TestName = suiteName;
 			tr.Load (package);


### PR DESCRIPTION
Set ShadowCopyFiles to false in order to fix a bug that prevents app.config settings from being loaded when running tests.

https://bugzilla.xamarin.com/show_bug.cgi?id=41541