### PR TITLE
[NUnit] Fix 41541 - App Config is not read in Unit Tests

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/ExternalTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/ExternalTestRunner.cs
@@ -101,7 +101,7 @@ namespace MonoDevelop.UnitTesting.NUnit.External
 
 			TestPackage package = new TestPackage (assemblyPath);
 			package.Settings ["ShadowCopyFiles"] = false;
-			package.BasePath = basePath;
+			package.BasePath = Path.GetDirectoryName(assemblyPath);
 			
 			AppDomain domain = Services.DomainManager.CreateDomain (package);
 			string asm = Path.Combine (basePath, "NUnitRunner.exe");


### PR DESCRIPTION
The BasePath property on the created TestPackage was being set to the directory that contains the NUnitRunner.exe binary. It is supposed to be set to the directory that contains the test assembly.