### PR TITLE
[Ide]Stop tooltip from appearing after completion list has closed 

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionListWindow.cs
@@ -440,21 +440,12 @@ namespace MonoDevelop.Ide.CodeCompletion
 			WindowTransparencyDecorator.Attach (this);
 			DataProvider = facade;
 			HideDeclarationView ();
-			VisibilityNotifyEvent += (object sender, VisibilityNotifyEventArgs e) => {
-				if (!Visible)
-					HideDeclarationView ();
-			};
 			List.ListScrolled += (object sender, EventArgs e) => {
 				HideDeclarationView ();
 				UpdateDeclarationView ();
 			};
 			List.WordsFiltered += delegate {
-				HideDeclarationView ();
-				UpdateDeclarationView ();
-			};
-			List.VisibilityNotifyEvent += (object sender, VisibilityNotifyEventArgs e) => {
-				if (!List.Visible)
-					HideDeclarationView ();
+				RepositionDeclarationViewWindow ();
 			};
 		}
 
@@ -956,15 +947,8 @@ namespace MonoDevelop.Ide.CodeCompletion
 			base.GdkWindow.GetOrigin (out ox, out oy);
 			declarationviewwindow.MaximumYTopBound = oy;
 			int y = rect.Y + Theme.Padding - (int)List.vadj.Value;
-			if (!declarationViewHidden && Visible && List.Visible && completionDataList != null &&
-				List.SelectionFilterIndex < completionDataList.Count && List.SelectionFilterIndex != -1)
-				declarationviewwindow.ShowPopup (
-					this,
-					new Gdk.Rectangle (0, Math.Min (Allocation.Height, Math.Max (0, y)), Allocation.Width, rect.Height),
-					PopupPosition.Left);
-			if (declarationViewHidden || !Visible || !List.Visible || completionDataList == null ||
-				List.SelectionFilterIndex >= completionDataList.Count || List.SelectionFilterIndex == -1)
-				HideDeclarationView();
+			declarationviewwindow.ShowPopup (this, new Gdk.Rectangle (0, Math.Min (Allocation.Height, Math.Max (0, y)), Allocation.Width, rect.Height), PopupPosition.Left);
+			declarationViewHidden = false;
 		}
 
 		bool DelayedTooltipShow ()
@@ -1025,7 +1009,6 @@ namespace MonoDevelop.Ide.CodeCompletion
 			}
 
 			if (declarationViewHidden && Visible) {
-				declarationViewHidden = false;
 				RepositionDeclarationViewWindow ();
 			}
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/TooltipInformationWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/TooltipInformationWindow.cs
@@ -308,13 +308,14 @@ namespace MonoDevelop.Ide.CodeCompletion
 			IdeApp.Preferences.ColorScheme.Changed += HandleThemeChanged;
 		}
 
-		public override void RepositionWindow(Gdk.Rectangle? newCaret = null)
+		public override void RepositionWindow (Gdk.Rectangle? newCaret = null)
 		{
 			// Setting the opicity delayed to 1 is a hack to ensure smooth animation popup see "Bug 32046 - Janky animations on tooltips"
 			Opacity = 0;
 			base.RepositionWindow(newCaret);
 			GLib.Timeout.Add (50, delegate {
-				Opacity = 1;
+				if (Visible)
+					Opacity = 1;
 				return false;
 			});
 		}


### PR DESCRIPTION
I believe I've found the cause of the bug I tried to fix in pull request #1353 

Commit 176ab0480dd24fa2e3623ea5b85c228dd4036ab1 added a hack that uses a timeout to change the opacity of the tooltip window.

This timeout adds a small timing window where the opacity on the tooltip window could get updated after the tooltip window has been hidden.

After adding a check for if the tooltip window is set to visible before changing the opacity inside the timeout handler, I am no longer able to reproduce the bug.

The extra checks to the completion list window in my last pull request do not appear to be necessary after this fix and can be reverted.