### PR TITLE
[c7][Ide][Mac] Fix property pad checkbox design

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -342,15 +342,22 @@ style "radio-or-check-box" = "default"
     }
 }
 
-style "propertygrid-radio-or-check-box" = "radio-or-check-box"
+style "propertygrid-radio-or-check-box" = "button"
 {
-    base[ACTIVE] = @base_color
-    base[SELECTED] = @base_color
-    base[PRELIGHT] = @base_color
-    text[SELECTED] = @fg_color
+    base[ACTIVE] = "#419bf9"
+    base[SELECTED] = "#419bf9"
+    base[PRELIGHT] = "#419bf9"
+    text[ACTIVE] = @base_color
+    text[SELECTED] = @base_color
+    text[PRELIGHT] = @base_color
+    text[NORMAL] = @base_color
     GtkCheckButton::indicator-spacing = 0
+    GtkCheckButton::indicator-size = 15
 
     engine "xamarin" {
+        focusstyle = 0
+        border_shades = { 1.0, 1.0 }
+        border_colors = { @fg_color, @fg_color }
     }
 }
 

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -319,18 +319,22 @@ style "quartz-radio-or-check-box" = "default"
     }
 }
 
-style "propertygrid-radio-or-check-box" = "default"
+style "propertygrid-radio-or-check-box" = "button"
 {
-    GtkCheckButton::indicator-spacing = 0
-
-    base[NORMAL] = "#fff"
-    base[ACTIVE] = "#fff"
+    base[ACTIVE] = "#99999e"
     base[SELECTED] = "#fff"
-    base[PRELIGHT] = "#fff"
-    text[SELECTED] = @base_color
+    base[PRELIGHT] = "#99999e"
+    text[ACTIVE] = @selected_fg_color
+    text[SELECTED] = @selected_fg_color
+    text[PRELIGHT] = @selected_fg_color
+    text[NORMAL] = @selected_fg_color
+    GtkCheckButton::indicator-spacing = 0
+    GtkCheckButton::indicator-size = 15
 
     engine "xamarin" {
-        border_shades = { 1.33, 1.33 }
+        focusstyle = 0
+        border_shades = { 1.0, 1.0 }
+        border_colors = { @fg_color, @fg_color }
     }
 }
 


### PR DESCRIPTION
This PR changes/fixes the Chack-/OptionButton design inside the Property Pad.
Current:

<img width="212" alt="original gtkrc" src="https://cloud.githubusercontent.com/assets/951587/16080280/4e97653c-3308-11e6-9d3b-f0a3303d9ef1.png">

Patched Gtkrc (this PR):

<img width="212" alt="patched gtkrc" src="https://cloud.githubusercontent.com/assets/951587/16080292/5cd2c240-3308-11e6-94ae-ff322bc20d60.png">

With this change and the patched xamarin-gtk-theme (https://github.com/mono/xamarin-gtk-theme/pull/28) they will look even more native (will be automatically effective with an updated MDK):

<img width="212" alt="patched xamarin-gtk-theme" src="https://cloud.githubusercontent.com/assets/951587/16080325/8982b4ee-3308-11e6-878e-cd9e10ec7ba6.png">
