### PR TITLE
[Cycle7][Core] Fixed build failure when using custom commands.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CustomCommand.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CustomCommand.cs
@@ -276,7 +276,7 @@ namespace MonoDevelop.Projects
 					oper = context.ExecutionHandler.Execute (cmd, console);
 				} else {
 					if (externalConsole) {
-						console = context.ExternalConsoleFactory.CreateConsole (!pauseExternalConsole, monitor.CancellationToken);
+						console = ExternalConsoleFactory.Instance.CreateConsole (!pauseExternalConsole, monitor.CancellationToken);
 						oper = Runtime.ProcessService.StartConsoleProcess (cmd.Command, cmd.Arguments,
 							cmd.WorkingDirectory, console, null);
 					} else {


### PR DESCRIPTION
Fixed bug #41722 - Build Failed
https://bugzilla.xamarin.com/show_bug.cgi?id=41722

When a custom command is created that runs before the build and is
configured to run on the external console then a null reference
exception is thrown when building. This is because the execution
context is null and it was being referenced when trying to create
an external console.

Command execution failed
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Projects.CustomCommand+<Execute>c__async0.MoveNext () [0x0016d] in /Users/builder/data/lanes/3342/694a75f0/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CustomCommand.cs:279

To repro:

1) Create a new C# console project.
2) Open project options and select Build - Custom Commands.
3) Create a 'Before Build' command and check Run on external
console.
4) Click OK to save the changes.
5) Build the project.