### PR TITLE
Bug 41738 - The 'TextTemplatingFileGenerator' code generator crashed

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/DummyTemplateGenerator.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/DummyTemplateGenerator.cs
@@ -1,0 +1,44 @@
+﻿//
+// DummyTemplateGenerator.cs
+//
+// Author:
+//       David Karlaš <david.karlas@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Reflection;
+
+namespace Mono.TextTemplating.Tests
+{
+	public class DummyTemplateGenerator : TemplateGenerator
+	{
+		protected override string ResolveAssemblyReference (string assemblyReference)
+		{
+			var assemblyName = new AssemblyName (assemblyReference).Name;
+			if (assemblyName == typeof (Uri).Assembly.GetName ().Name)
+				return typeof (Uri).Assembly.Location;//System.dll
+			else if (assemblyName == typeof (System.Linq.Enumerable).Assembly.GetName ().Name)
+				return typeof (System.Linq.Enumerable).Assembly.Location;//System.Core.dll
+			return base.ResolveAssemblyReference (assemblyReference);
+		}
+	}
+}
+

--- a/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/GenerationTests.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/GenerationTests.cs
@@ -40,10 +40,19 @@ namespace Mono.TextTemplating.Tests
 		[Test]
 		public void TemplateGeneratorTest ()
 		{
-			var gen = new TemplateGenerator ();
+			var gen = new DummyTemplateGenerator ();
 			string tmp = null;
 			gen.ProcessTemplate (null, "<#@ template language=\"C#\" #>", ref tmp, out tmp);
 			Assert.AreEqual (0, gen.Errors.Count, "ProcessTemplate");
+		}
+
+		[Test]
+		public void ImportReferencesTest ()
+		{
+			var gen = new DummyTemplateGenerator ();
+			string tmp = null;
+			gen.ProcessTemplate (null, "<#@ assembly name=\"System.dll\" #>\n<#@ assembly name=\"System.Core.dll\" #>", ref tmp, out tmp);
+			Assert.AreEqual (0, gen.Errors.Count, "ImportReferencesTest");
 		}
 
 		[Test]

--- a/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating.Tests/Mono.TextTemplating.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="GenerateIndentedClassCodeTests.cs" />
     <Compile Include="TextTemplatingSessionTests.cs" />
     <Compile Include="EngineTests.cs" />
+    <Compile Include="DummyTemplateGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mono.TextTemplating\Mono.TextTemplating.csproj">

--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -62,7 +62,7 @@ namespace Mono.TextTemplating
 		public TemplateGenerator ()
 		{
 			Refs.Add (typeof (TextTransformation).Assembly.Location);
-			Refs.Add (typeof(Uri).Assembly.Location);
+			Refs.Add (typeof(Uri).Assembly.FullName);
 			Imports.Add ("System");
 		}
 		

--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -167,7 +167,10 @@ namespace Mono.TextTemplating
 			
 			if (settings.Debug)
 				pars.TempFiles.KeepFiles = true;
-			
+			if (string.IsNullOrWhiteSpace (pars.CompilerOptions))
+				pars.CompilerOptions = "/noconfig";
+			else if (!pars.CompilerOptions.Contains ("/noconfig"))
+				pars.CompilerOptions = "/noconfig " + pars.CompilerOptions;
 			return settings.Provider.CompileAssemblyFromDom (pars, ccu);
 		}
 		

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelopTemplatingHost.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelopTemplatingHost.cs
@@ -70,8 +70,12 @@ namespace MonoDevelop.TextTemplating
 			var fx = Runtime.SystemAssemblyService.GetTargetFramework (TargetFrameworkMoniker.NET_4_5);
 			var ctx = Runtime.SystemAssemblyService.CurrentRuntime.AssemblyContext;
 
-			var fullname = ctx.FindInstalledAssembly (assemblyReference, null, fx);
+			if (assemblyReference.EndsWith (".dll", StringComparison.OrdinalIgnoreCase))
+				assemblyReference = assemblyReference.Remove (assemblyReference.Length - 4);
 
+			var fullname = ctx.FindInstalledAssembly (assemblyReference, null, fx);
+			if (fullname == null)
+				return null;
 			var asm = ctx.GetAssemblyFromFullName (fullname, null, fx);
 			if (asm != null)
 				return asm.Location;

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/ProjectFileTemplatingHost.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/ProjectFileTemplatingHost.cs
@@ -27,6 +27,7 @@
 using MonoDevelop.Core;
 using MonoDevelop.Core.StringParsing;
 using MonoDevelop.Projects;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.TextTemplating
 {
@@ -45,6 +46,12 @@ namespace MonoDevelop.TextTemplating
 		{
 			var model = file.Project.GetStringTagModel (activeConfiguration);
 			return StringParserService.Parse (s, model);
+		}
+
+		protected override string ResolveAssemblyReference (string assemblyReference)
+		{
+			assemblyReference = StringParserService.Parse (assemblyReference, IdeApp.Workbench.GetStringTagModel ());
+			return base.ResolveAssemblyReference (assemblyReference);
 		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=41738

Changes by files:
ProjectFileTemplatingHost.cs:
Replacing properties like $(SolutionDir) with correct value when resolving assembly path(https://msdn.microsoft.com/en-us/library/bb126478.aspx#Anchor_3)
MonoDevelopTemplatingHost.cs:
Apperently it's legal to say "System.dll" in T4, which GAC lookup doesn't like
TemplatingEngine.cs:
/noconfig is needed so mcs.exe(or csc.exe) doesn't report error CS1703(An assembly `System' with the same identity has already been imported. Consider removing one of the references) for System.dll
TemplateGenerator.cs:
By adding reference by FullName we let framework resolve full path, which allows deduplication of System.dll reference in case when user also specifies <#@ assembly name="System.dll" #>

@mhutch can you review this?