### PR TITLE
[Cycle7][Ide] Fixed fatal error when running custom command.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -418,10 +418,10 @@ namespace MonoDevelop.Ide.Commands
 			ProgressMonitor monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor ();
 			
 			Thread t = new Thread (
-				delegate () {
+				async delegate () {
 					using (monitor) {
 						try {
-							cmd.Execute (monitor, ce, IdeApp.Workspace.ActiveConfiguration);
+							await cmd.Execute (monitor, ce, IdeApp.Workspace.ActiveConfiguration);
 						} catch (Exception ex) {
 							monitor.ReportError (GettextCatalog.GetString ("Command execution failed"), ex);
 						}


### PR DESCRIPTION
Fixed bug #41790 - Xamarin Studio fatal error when running project
build custom commands
https://bugzilla.xamarin.com/show_bug.cgi?id=41790

Running a custom command would cause a unhandled exception and
terminate the IDE. To reproduce:

1) In project options select Build - Custom Commands.
2) Select Custom Command in the drop down, enter a name and a
valid command. Press OK to save the changes.
3) Right click the project and run the custom command just created.

An unhandled exception has occured. Terminating Xamarin Studio? True
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Ide.Gui.Components.LogViewProgressMonitor.OnWriteLog (System.String message)
  in monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs:723
  at MonoDevelop.Core.ProgressMonitor.DoWriteLog (System.String message)
  in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs:614
  at MonoDevelop.Core.ProgressMonitoring.LogTextWriter.Write (System.String value)
  in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/LogTextWriter.cs:93
  at MonoDevelop.Core.Execution.OutWriter.WriteOut (System.Object sender, System.String s)
  in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs:435
  at MonoDevelop.Core.Execution.ProcessWrapper.CaptureOutput ()
  in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessWrapper.cs:87

The problem was the progress monitor was being disposed before the
custom command had finished executing.

Conflicts:
	main/external/fsharpbinding