### PR TITLE
[NUnit] Fixed load failure for Android and iOS unit test projects.

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
@@ -95,7 +95,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 
 		public static NUnitVersion? GetNUnitVersion (ProjectReference p)
 		{
-			if (p.Reference.IndexOf ("GuiUnit", StringComparison.OrdinalIgnoreCase) != -1 || p.Reference.IndexOf ("nunitlite", StringComparison.OrdinalIgnoreCase) != -1)
+			if (p.Reference.IndexOf ("GuiUnit", StringComparison.OrdinalIgnoreCase) != -1 || p.Reference.StartsWith ("nunitlite", StringComparison.OrdinalIgnoreCase))
 				return NUnitVersion.NUnit2;
 			if (p.Reference.IndexOf ("nunit.framework", StringComparison.OrdinalIgnoreCase) != -1) {
 				var selector = p.Project?.DefaultConfiguration.Selector;


### PR DESCRIPTION
Fixed bug #41715 - Unit Tests pad shows "Load failed" for unit test
projects (both iOS and Android)
https://bugzilla.xamarin.com/show_bug.cgi?id=41715

Android and iOS unit test projects are not supported by the NUnit
addin and cause a load failure to be displayed in the Unit Tests
window. In older versions (5.0) of the NUnit addin the Android and iOS
unit test projects were not displayed in the Unit Tests window
since they were filtered out since the references did not match
any of the supported assembly names. The reference name check was
changed in 6.0 to match any nunitlite assembly reference ignoring
the case which meant XamarinAndroid.NUnitLite and
MonoTouch.NUnitLite were being loaded into the Unit Tests window.

Now the nunitlite reference name check has been made more strict so
projects that use the Android and iOS NUnitLite assemblies are not
displayed in the Unit Tests window.