### PR TITLE
Initial work to make the Mac toolbar accessible

### DIFF
--- a/dependency_checker.rb
+++ b/dependency_checker.rb
@@ -2,7 +2,7 @@ require 'pp'
 
 NOT_INSTALLED_VERSION="-1"
 
-XAMARIN_MAC_MIN_VERSION="2.3"
+XAMARIN_MAC_MIN_VERSION="2.9"
 XAMARIN_MAC_VERSION=lambda { product_version ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/bin/mmp") }
 XAMARIN_MAC_URL="http://www.xamarin.com"
 

--- a/main/src/addins/MacPlatform/MacMenu/MDMenu.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenu.cs
@@ -95,6 +95,9 @@ namespace MonoDevelop.MacIntegration.MacMenu
 			}
 		}
 
+		[Export ("accessibilityTitle")]
+		string AccessibilityTitle { get { return Title; } }
+
 		// http://lists.apple.com/archives/cocoa-dev/2008/Apr/msg01696.html
 		void FlashMenu ()
 		{

--- a/main/src/addins/MacPlatform/MacMenu/MDMenu.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenu.cs
@@ -95,8 +95,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 			}
 		}
 
-		[Export ("accessibilityTitle")]
-		string AccessibilityTitle { get { return Title; } }
+		public override string AccessibilityTitle { get { return Title; } }
 
 		// http://lists.apple.com/archives/cocoa-dev/2008/Apr/msg01696.html
 		void FlashMenu ()

--- a/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
@@ -163,8 +163,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 		{
 			public CommandInfo Info;
 
-			[Export ("accessibilityTitle")]
-			string AccessibilityTitle { get { return Title; } }
+			public override string AccessibilityTitle { get { return Title; } }
 		}
 
 		void SetItemValues (NSMenuItem item, CommandInfo info, bool disabledVisible, string overrideLabel = null)
@@ -229,8 +228,7 @@ namespace MonoDevelop.MacIntegration.MacMenu
 			}
 		}
 
-		[Export ("accessibilityTitle")]
-		string AccessibilityTitle { get { return Title; } }
+		public override string AccessibilityTitle { get { return Title; } }
 
 		static void SetAccel (NSMenuItem item, string accelKey)
 		{

--- a/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDMenuItem.cs
@@ -162,6 +162,9 @@ namespace MonoDevelop.MacIntegration.MacMenu
 		class MDExpandedArrayItem : NSMenuItem
 		{
 			public CommandInfo Info;
+
+			[Export ("accessibilityTitle")]
+			string AccessibilityTitle { get { return Title; } }
 		}
 
 		void SetItemValues (NSMenuItem item, CommandInfo info, bool disabledVisible, string overrideLabel = null)
@@ -225,6 +228,9 @@ namespace MonoDevelop.MacIntegration.MacMenu
 				item.State = NSCellStateValue.Off;
 			}
 		}
+
+		[Export ("accessibilityTitle")]
+		string AccessibilityTitle { get { return Title; } }
 
 		static void SetAccel (NSMenuItem item, string accelKey)
 		{

--- a/main/src/addins/MacPlatform/MacMenu/MDSubMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDSubMenuItem.cs
@@ -27,6 +27,7 @@
 using AppKit;
 using MonoDevelop.Components.Commands;
 using System.Linq;
+using Foundation;
 
 namespace MonoDevelop.MacIntegration.MacMenu
 {
@@ -53,5 +54,8 @@ namespace MonoDevelop.MacIntegration.MacMenu
 				MDMenu.ShowLastSeparator (ref lastSeparator);
 			}
 		}
+
+		[Export ("accessibilityTitle")]
+		string AccessibilityTitle { get { return Title; } }
 	}
 }

--- a/main/src/addins/MacPlatform/MacMenu/MDSubMenuItem.cs
+++ b/main/src/addins/MacPlatform/MacMenu/MDSubMenuItem.cs
@@ -55,7 +55,6 @@ namespace MonoDevelop.MacIntegration.MacMenu
 			}
 		}
 
-		[Export ("accessibilityTitle")]
-		string AccessibilityTitle { get { return Title; } }
+		public override string AccessibilityTitle { get { return Title; } }
 	}
 }

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -231,11 +231,24 @@ namespace MonoDevelop.MacIntegration
 				}
 
 				CommandEntrySet appCes = commandManager.CreateCommandEntrySet (appMenuAddinPath);
-				rootMenu.AddItem (new MDSubMenuItem (commandManager, appCes));
+				var submenuitem = new MDSubMenuItem (commandManager, appCes);
+				int index = 0;
+				NSMenuItem lastSeparator = null;
+
+				// Need to update the menus when they're created rather than just when they're opened
+				// so that they'll have correct values for accessibility purposes
+				submenuitem.Update (null, ref lastSeparator, ref index);
+				rootMenu.AddItem (submenuitem);
 
 				CommandEntrySet ces = commandManager.CreateCommandEntrySet (commandMenuAddinPath);
 				foreach (CommandEntry ce in ces) {
-					rootMenu.AddItem (new MDSubMenuItem (commandManager, (CommandEntrySet) ce));
+					index++;
+					lastSeparator = null;
+
+					submenuitem = new MDSubMenuItem (commandManager, (CommandEntrySet)ce);
+					submenuitem.Update (null, ref lastSeparator, ref index);
+
+					rootMenu.AddItem (submenuitem);
 				}
 			} catch (Exception ex) {
 				try {
@@ -249,6 +262,7 @@ namespace MonoDevelop.MacIntegration
 				setupFail = true;
 				return false;
 			}
+
 			return true;
 		}
 

--- a/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
@@ -84,7 +84,13 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		readonly Dictionary<IButtonBarButton, int> indexMap = new Dictionary<IButtonBarButton, int> ();
 		readonly IReadOnlyList<IButtonBarButton> buttons;
 
-		public string Title { get; set; }
+		public string Title {
+			set {
+				AccessibilityLabel = value;
+				AccessibilityTitle = value;
+			}
+		}
+
 		public ButtonBar (IEnumerable<IButtonBarButton> buttons)
 		{
 			Cell = new DarkThemeSegmentedCell ();

--- a/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
@@ -84,6 +84,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		readonly Dictionary<IButtonBarButton, int> indexMap = new Dictionary<IButtonBarButton, int> ();
 		readonly IReadOnlyList<IButtonBarButton> buttons;
 
+		public string Title { get; set; }
 		public ButtonBar (IEnumerable<IButtonBarButton> buttons)
 		{
 			Cell = new DarkThemeSegmentedCell ();

--- a/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
@@ -118,6 +118,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 						return;
 					Cell.SetToolTip (_button.Tooltip, indexMap [_button]);
 				};
+				button.TitleChanged += (o, e) => {
+					if (!indexMap.ContainsKey (_button))
+						return;
+					SetLabel (_button.Title, indexMap [_button]);
+				};
 			}
 			Activated += (sender, e) => indexMap.First (b => b.Value == SelectedSegment).Key.NotifyPushed ();
 
@@ -136,6 +141,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			else
 				img = ImageService.GetIcon (button.Image, Gtk.IconSize.Menu).WithStyles ("disabled").ToNSImage ();
 			SetImage (img, indexMap [button]);
+
+			// We need to set the width because if there is an image and a title set, then Cocoa uses the
+			// title to set the width, even if the title isn't shown. We need to set the title for accessibility.
+			SetWidth (ButtonBarContainer.SegmentWidth - 1, indexMap [button]);
 		}
 
 		public override nint SegmentCount {
@@ -178,6 +187,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				SetEnabled (button.Enabled, idx);
 			if (button.Tooltip != Cell.GetToolTip (idx))
 				Cell.SetToolTip (button.Tooltip, idx);
+			if (button.Title != GetLabel (idx))
+				SetLabel (button.Title, idx);
 			SetNeedsDisplay ();
 		}
 

--- a/main/src/addins/MacPlatform/MainToolbar/ButtonBarContainer.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/ButtonBarContainer.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			Ide.Gui.Styles.Changed += (o, e) => LayoutButtonBars ();
 		}
 
-		const float segmentWidth = 33.0f;
+		internal const float SegmentWidth = 33.0f;
 		const float buttonBarSpacing = 8.0f;
 		const float extraPadding = 6.0f;
 
@@ -88,7 +88,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 
 			foreach (ButtonBar bar in buttonBars) {
-				var frame = new CGRect (nextX, y, extraPadding + (bar.SegmentCount * segmentWidth), height);
+				var frame = new CGRect (nextX, y, extraPadding + (bar.SegmentCount * SegmentWidth), height);
 				bar.Frame = frame;
 
 				nextX = frame.GetMaxX () + buttonBarSpacing;

--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -190,20 +190,38 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 		}
 
+		[Obsolete ("Use RebuildToolbar (IEnumerable<IButtonBarGroup> groups) instead")]
 		public void RebuildToolbar (IEnumerable<IButtonBarButton> buttons)
 		{
-			List<IButtonBarButton> barItems = new List<IButtonBarButton> ();
-			List<ButtonBar> buttonBars = new List<ButtonBar> ();
+			var groups = new List<ButtonBarGroup> ();
+			int gCount = 1;
 
-			foreach (var item in buttons) {
-				if (item.IsSeparator) {
-					var bar = new ButtonBar (barItems);
-					buttonBars.Add (bar);
+			// We can't set a good title here.
+			var group = new ButtonBarGroup (GettextCatalog.GetString ("Group {0}", gCount));
+			gCount++;
 
-					barItems.Clear ();
+			foreach (var b in buttons) {
+				if (b.IsSeparator) {
+					groups.Add (group);
+
+					group = new ButtonBarGroup (GettextCatalog.GetString ("Group {0}", gCount));
+					gCount++;
 				} else {
-					barItems.Add (item);
+					group.Buttons.Add (b);
 				}
+			}
+
+			RebuildToolbar (groups);
+		}
+
+		public void RebuildToolbar (IEnumerable<ButtonBarGroup> groups)
+		{
+			var buttonBars = new List<ButtonBar> ();
+			foreach (var g in groups) {
+				var bar = new ButtonBar (g.Buttons) {
+					Title = g.Title
+				};
+				buttonBars.Add (bar);
 			}
 
 			awesomeBar.ButtonBarContainer.ButtonBars = buttonBars;

--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -28,18 +28,16 @@ using AppKit;
 using Foundation;
 using CoreGraphics;
 using MonoDevelop.Components.MainToolbar;
+using MonoDevelop.Core;
 using MonoDevelop.Ide;
-using MonoDevelop.Components;
 using Xwt.Mac;
-using CoreImage;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
-	[Register]
-	class RunButton : NSButton
+	[Register ("RunButton")]
+	class RunButton : NSButton, INSAccessibilityButton, INSAccessibility
 	{
 		NSImage stopIcon, continueIcon, buildIcon;
-
 
 		public RunButton ()
 		{
@@ -53,7 +51,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			ImagePosition = NSCellImagePosition.ImageOnly;
 			BezelStyle = NSBezelStyle.TexturedRounded;
 
-			Enabled = false;
+			UpdateAccessibilityValues ();
 		}
 
 		void UpdateIcons (object sender = null, EventArgs e = null)
@@ -86,6 +84,27 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			throw new InvalidOperationException ();
 		}
 
+		void GetTitleAndHelpForIcon (out string title, out string help)
+		{
+			title = "";
+			help = "";
+
+			switch (icon) {
+			case OperationIcon.Stop:
+				title = GettextCatalog.GetString ("Stop");
+				help = GettextCatalog.GetString ("Stop the executing solution");
+				break;
+			case OperationIcon.Run:
+				title = GettextCatalog.GetString ("Run");
+				help = GettextCatalog.GetString ("Build and run the current solution");
+				break;
+			case OperationIcon.Build:
+				title = GettextCatalog.GetString ("Build");
+				help = GettextCatalog.GetString ("Build the current solution");
+				break;
+			}
+		}
+
 		public override bool Enabled {
 			get {
 				return base.Enabled;
@@ -93,6 +112,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			set {
 				base.Enabled = value;
 				Image = GetIcon ();
+
+				UpdateAccessibilityValues ();
 			}
 		}
 
@@ -104,7 +125,43 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					return;
 				icon = value;
 				Image = GetIcon ();
+
+				UpdateAccessibilityValues ();
 			}
+		}
+
+		void UpdateAccessibilityValues ()
+		{
+			var nsa = (INSAccessibility) this;
+			nsa.AccessibilityIdentifier = "MainToolbar.RunButton";
+
+			string help, title;
+			GetTitleAndHelpForIcon (out title, out help);
+
+			AccessibilityHelp = help;
+			AccessibilityTitle = title;
+			AccessibilityEnabled = Enabled;
+			AccessibilitySubrole = NSAccessibilitySubroles.ToolbarButtonSubrole;
+
+			// FIXME: Setting this doesn't appear to change anything.
+			// Nor does overriding the INSAccessibilityButton.AccessibilityLabel getter
+			nsa.AccessibilityLabel = title;
+		}
+
+		/*
+		string INSAccessibility.AccessibilityLabel {
+			get {
+				return "test";
+			}
+
+			set {
+				Console.WriteLine ($"{value}");
+			}
+		}
+*/
+		public override bool AccessibilityPerformPress ()
+		{
+			return base.AccessibilityPerformPress ();
 		}
 
 		public override CGSize IntrinsicContentSize {

--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -148,17 +148,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			nsa.AccessibilityLabel = title;
 		}
 
-		/*
-		string INSAccessibility.AccessibilityLabel {
-			get {
-				return "test";
-			}
-
-			set {
-				Console.WriteLine ($"{value}");
-			}
-		}
-*/
 		public override bool AccessibilityPerformPress ()
 		{
 			return base.AccessibilityPerformPress ();

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -181,10 +181,30 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			Cell = new DarkThemeSearchFieldCell ();
 
+			var nsa = (INSAccessibility)this;
+
+			AccessibilitySubrole = NSAccessibilitySubroles.SearchFieldSubrole;
+			nsa.AccessibilityIdentifier = "MainToolbar.SearchField";
+			AccessibilityHelp = GettextCatalog.GetString ("Search");
+			// Hide this from the A11y system because we actually care about the inner search field
+			// and not this one according to Cocoa?
+			AccessibilityElement = false;
+
 			Initialize ();
 
 			Ide.Gui.Styles.Changed +=  (o, e) => UpdateLayout ();
 			UpdateLayout ();
+		}
+
+		public override bool AccessibilityPerformShowMenu ()
+		{
+			Cell.SearchButtonCell.PerformClick (this);
+			return true;
+		}
+
+		public override bool AccessibilityPerformConfirm ()
+		{
+			return true;
 		}
 
 		NSAttributedString MakePlaceholderString (string t)

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -74,6 +74,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			RealSelectorView = new PathSelectorView (new CGRect (6, 0, 1, 1));
 			RealSelectorView.UnregisterDraggedTypes ();
 			AddSubview (RealSelectorView);
+
+			// Disguise this NSButton as a group
+			AccessibilityRole = NSAccessibilityRoles.GroupRole;
 		}
 
 		public override CGSize SizeThatFits (CGSize size)

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -157,6 +157,19 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				return iconSize;
 			}
 
+			int IndexFromIdentifier (string identifier)
+			{
+				int i = 0;
+				foreach (var cell in Cells) {
+					if (cell.Identifier == identifier) {
+						return i;
+					}
+					i++;
+				}
+
+				throw new Exception ($"No cell with {identifier} found");
+			}
+
 			public override CGSize SizeThatFits (CGSize size)
 			{
 				int n = 0;
@@ -167,7 +180,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				totalWidth += AddCellSize (LastSelectedCell, totalWidth, size.Width, allIconsWidth);
 
 				for (;n < VisibleCells.Length; n++) {
-					int cellId = VisibleCellIds [n];
+					var cellId = VisibleCellIds [n];
 					if (cellId == LastSelectedCell)
 						continue;
 					
@@ -482,7 +495,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				} else
 					throw new NotSupportedException ();
 				
-				LastSelectedCell = cellIdx;
+				LastSelectedCell = IndexFromIdentifier (item.Identifier);
 				if (menu.Count > 1) {
 					var offs = new CGPoint (componentRect.Left + 3, componentRect.Top + 3);
 

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -142,7 +142,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			static readonly string RunConfigurationIdentifier = "RunConfiguration";
 			static readonly string ConfigurationIdentifier = "Configuration";
 			static readonly string RuntimeIdentifier = "Runtime";
-			CellState state = CellState.AllShown;
 
 			static nfloat iconSize = 28;
 			nfloat AddCellSize (int cellId, nfloat totalWidth, nfloat layoutWidth, nfloat allIconsWidth)

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -51,6 +51,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public StatusIcon (StatusBar bar) : base (CGRect.Empty)
 		{
 			imageView = new NSImageView (CGRect.Empty);
+			// Hide this image from the accessibility tree
+			imageView.AccessibilityElement = false;
 			AddSubview (imageView);
 
 			var trackingArea = new NSTrackingArea (CGRect.Empty, NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.InVisibleRect | NSTrackingAreaOptions.MouseEnteredAndExited, this, null);
@@ -81,14 +83,35 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			base.Dispose ();
 		}
 
+		string tooltip;
 		public new string ToolTip {
-			get;
-			set;
+			get {
+				return tooltip;
+			}
+
+			set {
+				tooltip = value;
+				AccessibilityTitle = tooltip;
+				AccessibilityValue = new NSString (tooltip);
+			}
 		}
 
+		string help;
+		public string Help {
+			get {
+				return help;
+			}
+
+			set {
+				help = value;
+				AccessibilityHelp = value;
+			}
+		}
+
+		public string Title { get; set; }
 		string INSAccessibilityButton.AccessibilityLabel {
 			get {
-				return ToolTip;
+				return Title;
 			}
 		}
 
@@ -399,7 +422,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		}
 	}
 
-	class CancelButton : NSButton
+	class CancelButton : NSButton, INSAccessibilityButton
 	{
 		readonly NSImage stopIcon = MultiResImage.CreateMultiResImage ("status-stop-16", string.Empty);
 		readonly NSImage stopIconHover = MultiResImage.CreateMultiResImage ("status-stop-16", "hover");
@@ -412,6 +435,12 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			ImagePosition = NSCellImagePosition.ImageOnly;
 			SetButtonType (NSButtonType.MomentaryChange);
 			AddTrackingArea (new NSTrackingArea (CGRect.Empty, NSTrackingAreaOptions.MouseEnteredAndExited | NSTrackingAreaOptions.ActiveAlways | NSTrackingAreaOptions.InVisibleRect, this, null));
+
+			AccessibilityHelp = GettextCatalog.GetString ("Cancel the current operation");
+			AccessibilityTitle = GettextCatalog.GetString ("Cancel");
+
+			var nsa = (INSAccessibility) this;
+			nsa.AccessibilityIdentifier = "MainToolbar.StatusDisplay.Cancel";
 		}
 
 		public override void MouseEntered (NSEvent theEvent)
@@ -424,6 +453,12 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			Image = stopIcon;
 			base.MouseExited (theEvent);
+		}
+
+		string INSAccessibilityButton.AccessibilityLabel {
+			get {
+				return GettextCatalog.GetString ("Cancel");
+			}
 		}
 	}
 

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -43,7 +43,7 @@ using System.Threading;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
-	class StatusIcon : NSView, StatusBarIcon
+	class StatusIcon : NSView, StatusBarIcon, INSAccessibilityButton
 	{
 		StatusBar bar;
 		NSImageView imageView;
@@ -86,6 +86,12 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			set;
 		}
 
+		string INSAccessibilityButton.AccessibilityLabel {
+			get {
+				return ToolTip;
+			}
+		}
+
 		Xwt.Drawing.Image image;
 		public Xwt.Drawing.Image Image {
 			get { return image; }
@@ -123,13 +129,30 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				});
 		}
 
+		public override bool AccessibilityPerformPress ()
+		{
+			Clicked?.Invoke (this, new StatusBarIconClickedEventArgs {
+				Button = Xwt.PointerButton.Left
+			});
+
+			return true;
+		}
+
 		public event EventHandler<StatusBarIconClickedEventArgs> Clicked;
 		public event EventHandler<EventArgs> Entered;
 		public event EventHandler<EventArgs> Exited;
 	}
 
-	class BuildResultsView : NSView
+	class BuildResultsView : NSView, INSAccessibilityStaticText
 	{
+		public enum ResultsType
+		{
+			Warning,
+			Error
+		};
+
+		public ResultsType Type { get; set; }
+
 		NSAttributedString resultString;
 		int resultCount;
 		public int ResultCount { 
@@ -157,6 +180,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public BuildResultsView () : base (new CGRect (0, 0, 0, 0))
 		{
+			AccessibilityIdentifier = "MainToolbar.StatusDisplay.BuildResults";
+			AccessibilityHelp = "Number of errors or warnings in the current project";
 		}
 
 		public override void DrawRect (CGRect dirtyRect)
@@ -184,11 +209,21 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			IdeApp.Workbench.GetPad<MonoDevelop.Ide.Gui.Pads.ErrorListPad> ().BringToFront ();
 		}
+
+		string INSAccessibilityStaticText.AccessibilityValue {
+			get {
+				if (Type == ResultsType.Warning) {
+					return GettextCatalog.GetPluralString ("{0} warning", "%d warnings", resultCount, resultCount);
+				} else {
+					return GettextCatalog.GetPluralString ("{0} error", "%d errors", resultCount, resultCount);
+				}
+			}
+		}
 	}
 
 	// We need a separate layer backed view to put over the NSTextFields because the NSTextField draws itself differently
 	// if it is layer backed so we can't make it or its superview layer backed.
-	class ProgressView : NSView
+	class ProgressView : NSView, INSAccessibilityProgressIndicator
 	{
 		const string ProgressLayerFadingId = "ProgressLayerFading";
 		const string growthAnimationKey = "bounds";
@@ -215,16 +250,37 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			progressLayer.FillMode = CAFillMode.Forwards;
 			progressLayer.Frame = new CGRect (0, 0, 0, barHeight);
 			progressLayer.AnchorPoint = new CGPoint (0, 0);
+
+			AccessibilityIdentifier = "MainToolbar.StatusDisplay.Progress";
+			AccessibilityHelp = "The progress of the current action";
+			AccessibilityHidden = true;
+		}
+
+		NSNumber INSAccessibilityProgressIndicator.AccessibilityValue {
+			get {
+				// Convert the number to a percentage
+				var percent = (int)(oldFraction * 100.0f);
+				return new NSNumber (percent);
+			}
+		}
+
+		void SetProgressValue (double p)
+		{
+			oldFraction = p;
+			var percent = (int)(oldFraction * 100.0f);
+			((INSAccessibility)this).AccessibilityValue = new NSNumber (percent);
 		}
 
 		public void BeginProgress ()
 		{
-			oldFraction = 0.0;
+			SetProgressValue (0.0);
 			progressLayer.RemoveAllAnimations ();
 
 			progressLayer.Hidden = false;
 			progressLayer.Opacity = 1;
 			progressLayer.Frame = new CGRect (0, 0, 0, barHeight);
+
+			AccessibilityHidden = false;
 		}
 
 		public void SetProgressFraction (double work)
@@ -245,6 +301,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			if (progressLayer != null) {
 				progressLayer.RemoveAnimation (growthAnimationKey);
 				progressLayer.Hidden = true;
+				AccessibilityHidden = true;
+
+				// We don't set the progress to 0 here, because EndProgress can be called many times
+				// for a single task, and if we do then the progress bar pulses from 0 every time
 			}
 			inProgress = false;
 		}
@@ -300,7 +360,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					progress.Opacity = 1;
 					progress.Frame = new CGRect (0, 0, 0, barHeight);
 					progress.RemoveAllAnimations ();
-					oldFraction = 0.0;
+					SetProgressValue (0.0);
 
 					progress.Hidden = false;
 				};
@@ -314,7 +374,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			progressMarks.Clear ();
 			var grp = CreateMoveAndGrowAnimation (progressLayer, newFraction);
-			oldFraction = newFraction;
+
+			SetProgressValue (newFraction);
 
 			AttachFadeoutAnimation (progressLayer, grp, () => {
 				if (oldFraction < 1 && inProgress) {
@@ -330,6 +391,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		}
 
 		const double frameAutoPulseWidth = 100;
+
 		public void StartProgressAutoPulse ()
 		{
 			var move = CreateAutoPulseAnimation ();
@@ -427,6 +489,12 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		TaskEventHandler updateHandler;
 		public StatusBar ()
 		{
+			var nsa = (INSAccessibility)this;
+
+			// Pretend that this button is a Group
+			AccessibilityRole = NSAccessibilityRoles.GroupRole;
+			nsa.AccessibilityIdentifier = "MainToolbar.StatusDisplay";
+
 			Cell = new ColoredButtonCell ();
 			BezelStyle = NSBezelStyle.TexturedRounded;
 			Title = "";
@@ -439,6 +507,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			textField.Cell = new VerticallyCenteredTextFieldCell (0f);
 			textField.Cell.StringValue = "";
+
+			textField.AccessibilityRole = NSAccessibilityRoles.StaticTextRole;
+			textField.AccessibilityEnabled = true;
+			textField.AccessibilityHelp = GettextCatalog.GetString ("Status of the current operation");
+
+			var tfNSA = (INSAccessibility)textField;
+			tfNSA.AccessibilityIdentifier = "MainToolbar.StatusDisplay.Status";
+
 			UpdateApplicationNamePlaceholderText ();
 
 			// The rect is empty because we use InVisibleRect to track the whole of the view.
@@ -447,6 +523,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			imageView.Frame = new CGRect (0.5, 0, 0, 0);
 			imageView.Image = ImageService.GetIcon (Stock.StatusSteady).ToNSImage ();
+
+			// Hide this image from accessibility
+			imageView.AccessibilityElement = false;
 
 			buildResults = new BuildResultsView ();
 			buildResults.Hidden = true;
@@ -471,6 +550,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				Runtime.RunInMainThread (delegate {
 					buildResults.Hidden = (ec == 0 && wc == 0);
 					buildResults.ResultCount = ec > 0 ? ec : wc;
+					buildResults.Type = ec > 0 ? BuildResultsView.ResultsType.Error : BuildResultsView.ResultsType.Warning;
 
 					buildImageId = ec > 0 ? "md-status-error-count" : "md-status-warning-count";
 					buildResults.IconImage = ImageService.GetIcon (buildImageId, Gtk.IconSize.Menu).ToNSImage ();
@@ -492,11 +572,19 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			progressView = new ProgressView ();
 			AddSubview (progressView);
+
+			var newChildren = new NSObject [] {
+				textField, buildResults, progressView
+			};
+			AccessibilityChildren = newChildren;
 		}
 
 		void UpdateApplicationNamePlaceholderText ()
 		{
 			textField.Cell.PlaceholderAttributedString = GetStatusString (BrandingService.ApplicationLongName, ColorForType (MessageType.Ready));
+
+			var nsa = (INSAccessibility)textField;
+			nsa.AccessibilityValue = new NSString (BrandingService.ApplicationLongName);
 		}
 
 		void ApplicationNameChanged (object sender, EventArgs e)
@@ -759,6 +847,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			messageType = statusType;
 			textColor = ColorForType (statusType);
 
+			var nsa = (INSAccessibility)textField;
+			nsa.AccessibilityValue = new NSString (message);
+
 			return true;
 		}
 
@@ -1014,7 +1105,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			cancelButton.Frame = new CGRect (cancelButton.Frame.X, cancelButton.Frame.Y, 16, Frame.Height);
 			RepositionStatusIcons ();
 
-			progressView.Frame = new CGRect (0.5f, MacSystemInformation.OsVersion >= MacSystemInformation.ElCapitan ? 1f : 2f, Frame.Width - 2, Frame.Height - 2);
+			progressView.Frame = new CGRect (0.5f, Frame.Height - (MacSystemInformation.OsVersion >= MacSystemInformation.ElCapitan ? 1f : 2f), Frame.Width - 2, 2);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
@@ -253,7 +253,7 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/CommandBar">
-		<ItemSet id = "Debug">
+		<ItemSet id = "Debug" _label="Debugger">
 			<CommandItem id = "MonoDevelop.Debugger.DebugCommands.Continue" />
 			<CommandItem id = "MonoDevelop.Debugger.DebugCommands.Pause" />
 			<CommandItem id = "MonoDevelop.Debugger.DebugCommands.StepOver" />

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -712,7 +712,9 @@ namespace MonoDevelop.Debugger
 					if (busyStatusIcon == null) {
 						busyStatusIcon = IdeApp.Workbench.StatusBar.ShowStatusIcon (ImageService.GetIcon ("md-bug", Gtk.IconSize.Menu));
 						busyStatusIcon.SetAlertMode (100);
+						busyStatusIcon.Title = GettextCatalog.GetString ("Debugger");
 						busyStatusIcon.ToolTip = GettextCatalog.GetString ("The debugger runtime is not responding. You can wait for it to recover, or stop debugging.");
+						busyStatusIcon.Help = GettextCatalog.GetString ("Debugger information");
 						busyStatusIcon.Clicked += OnBusyStatusIconClicked;
 					}
 				} else {

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -143,6 +143,12 @@ namespace MonoDevelop.SourceEditor
 		public override string TabPageLabel {
 			get { return GettextCatalog.GetString ("Source"); }
 		}
+
+		public override string TabAccessibilityDescription {
+			get {
+				return GettextCatalog.GetString ("The main source editor");
+			}
+		}
 		
 
 		uint removeMarkerTimeout;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
@@ -233,8 +233,10 @@ namespace MonoDevelop.SourceEditor
 				this.strip = new QuickTaskStrip ();
 
 				scrolledBackground = new EventBox ();
+				scrolledBackground.Accessible.SetAccessibilityShouldIgnore (true);
 				scrolledWindow = new CompactScrolledWindow ();
 				scrolledWindow.ButtonPressEvent += PrepareEvent;
+				scrolledWindow.Accessible.SetAccessibilityShouldIgnore (true);
 				scrolledBackground.Add (scrolledWindow);
 				PackStart (scrolledBackground, true, true, 0);
 				strip.VAdjustment = scrolledWindow.Vadjustment;
@@ -390,6 +392,8 @@ namespace MonoDevelop.SourceEditor
 		{
 			this.view = view;
 			vbox.SetSizeRequest (32, 32);
+			vbox.Accessible.SetAccessibilityShouldIgnore (true);
+
 			this.lastActiveEditor = this.textEditor = new MonoDevelop.SourceEditor.ExtensibleTextEditor (view);
 			this.textEditor.TextArea.FocusInEvent += (o, s) => {
 				lastActiveEditor = (ExtensibleTextEditor)((TextArea)o).GetTextEditorData ().Parent;
@@ -402,6 +406,7 @@ namespace MonoDevelop.SourceEditor
 			if (IdeApp.CommandService != null)
 				IdeApp.FocusOut += IdeApp_FocusOut;
 			mainsw = new DecoratedScrolledWindow (this);
+			mainsw.Accessible.SetAccessibilityShouldIgnore (true);
 			mainsw.SetTextEditor (textEditor);
 			
 			vbox.PackStart (mainsw, true, true, 0);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BaseView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BaseView.cs
@@ -5,14 +5,22 @@ namespace MonoDevelop.VersionControl
 	public abstract class BaseView : ViewContent
 	{
 		readonly string name;
+		readonly string accessibilityDescription;
 
-		protected BaseView (string name)
+		protected BaseView (string name, string description = "")
 		{
 			ContentName = this.name = name;
+			accessibilityDescription = description;
 		}
 
 		public override string TabPageLabel {
 			get { return name; }
+		}
+
+		public override string TabAccessibilityDescription {
+			get {
+				return accessibilityDescription;
+			}
 		}
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BaseView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BaseView.cs
@@ -7,7 +7,11 @@ namespace MonoDevelop.VersionControl
 		readonly string name;
 		readonly string accessibilityDescription;
 
-		protected BaseView (string name, string description = "")
+		protected BaseView (string name) :this (name, "")
+		{
+		}
+
+		protected BaseView (string name, string description)
 		{
 			ContentName = this.name = name;
 			accessibilityDescription = description;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
@@ -47,7 +47,7 @@ namespace MonoDevelop.VersionControl.Views
 			}
 		}
 		
-		public BlameView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Blame"))
+		public BlameView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Blame"), GettextCatalog.GetString ("Shows the blame for the current file"))
 		{
 			this.info = info;
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.VersionControl.Views
 		}
 
 		VersionControlDocumentInfo info;
-		public DiffView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Changes"))
+		public DiffView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Changes"), GettextCatalog.GetString ("Shows the differences in the code between the current code and the version in the repository"))
 		{
 			this.info = info;
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogView.cs
@@ -30,7 +30,7 @@ namespace MonoDevelop.VersionControl.Views
 		}
 		
 		VersionControlDocumentInfo info;
-		public LogView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Log"))
+		public LogView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Log"), GettextCatalog.GetString ("Shows the source control log for the current file"))
 		{
 			this.info = info;
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeView.cs
@@ -48,7 +48,7 @@ namespace MonoDevelop.VersionControl.Views
 			}
 		}
 
-		public MergeView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Merge"))
+		public MergeView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Merge"), GettextCatalog.GetString ("Shows the merge view for the current file"))
 		{
 			this.info = info;
 		}

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.csproj
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.csproj
@@ -78,6 +78,9 @@
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.Mac">
+      <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mono.TextEditor.Highlighting\Rule.cs" />
@@ -382,6 +385,14 @@
     <ProjectReference Include="..\..\..\external\xwt\Xwt\Xwt.csproj">
       <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>
       <Name>Xwt</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.Core\MonoDevelop.Core.csproj">
+      <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
+      <Name>MonoDevelop.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
+      <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
+      <Name>MonoDevelop.Ide</Name>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/Margin.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/Margin.cs
@@ -28,6 +28,8 @@
 using System;
 using System.Collections.Generic;
 
+using MonoDevelop.Components;
+
 namespace Mono.TextEditor
 {
 	public abstract class Margin : IDisposable
@@ -35,8 +37,18 @@ namespace Mono.TextEditor
 		public abstract double Width {
 			get;
 		}
-		
-		public bool IsVisible { get; set; }
+
+		bool isVisible;
+		public bool IsVisible {
+			get {
+				return isVisible;
+			}
+			set {
+				isVisible = value;
+
+				Accessible.AccessibilityHidden = !value;
+			}
+		}
 		
 		// set by the text editor
 		public virtual double XOffset {
@@ -64,8 +76,40 @@ namespace Mono.TextEditor
 			set;
 		}
 
+		AtkCocoaHelper.AccessibilityElementProxy accessible;
+		public virtual AtkCocoaHelper.AccessibilityElementProxy Accessible {
+			get {
+				if (accessible == null) {
+					accessible = new AtkCocoaHelper.AccessibilityElementProxy ();
+				}
+				return accessible;
+			}
+		}
+
+		Gdk.Rectangle rectInParent;
+		public Gdk.Rectangle RectInParent {
+			get {
+				return rectInParent;
+			}
+
+			set {
+				rectInParent = value;
+
+				if (Accessible == null) {
+					Console.WriteLine ("No accessible");
+					return;
+				}
+
+				Accessible.SetFrameInRealParent (rectInParent);
+				// SetFrameInParent is in Cocoa coords, but because margins take up the whole vertical height
+				// we don't need to switch anything around and can just pass in the rectInParent
+				Accessible.SetFrameInParent (rectInParent);
+			}
+		}
+
 		protected Margin ()
 		{
+			Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXRuler);
 			IsVisible = true;
 		}
 		

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -210,6 +210,10 @@ namespace Mono.TextEditor
 			info.Y = y;
 			containerChildren.Add (info);
 			SetAdjustments ();
+
+			// Emit the add signal so that the A11y system will pick up that a widget has been added to the box
+			// but the box won't handle it because widget.Parent has already been set.
+			GLib.Signal.Emit (this, "add", widget);
 		}
 		
 		public void MoveTopLevelWidget (Gtk.Widget widget, int x, int y)
@@ -255,6 +259,11 @@ namespace Mono.TextEditor
 		
 		protected override void OnAdded (Widget widget)
 		{
+			// Break the add signal cycle
+			if (widget.Parent == this) {
+				return;
+			}
+
 			AddTopLevelWidget (widget, 0, 0);
 		}
 		

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/TextArea.cs
@@ -39,6 +39,8 @@ using Mono.TextEditor.Highlighting;
 using Mono.TextEditor.PopupWindow;
 using Mono.TextEditor.Theatrics;
 
+using MonoDevelop.Components;
+
 using Gdk;
 using Gtk;
 using GLib;
@@ -341,10 +343,30 @@ namespace Mono.TextEditor
 			textEditorData.Parent = editor;
 
 			iconMargin = new IconMargin (editor);
+			iconMargin.Accessible.SetAccessibilityLabel ("Icon margin");
+			iconMargin.Accessible.SetAccessibilityIdentifier ("TextArea.IconMargin");
+			iconMargin.Accessible.SetRealParent (this);
+			Accessible.AddAccessibleElement (iconMargin.Accessible);
+
 			gutterMargin = new GutterMargin (editor);
+			gutterMargin.Accessible.SetAccessibilityIdentifier ("TextArea.GutterMargin");
+			gutterMargin.Accessible.SetRealParent (this);
+			Accessible.AddAccessibleElement (gutterMargin.Accessible);
+
 			actionMargin = new ActionMargin (editor);
+			actionMargin.Accessible.SetAccessibilityIdentifier ("TextArea.ActionMargin");
+			actionMargin.Accessible.SetRealParent (this);
+			Accessible.AddAccessibleElement (actionMargin.Accessible);
+
 			foldMarkerMargin = new FoldMarkerMargin (editor);
+			foldMarkerMargin.Accessible.SetAccessibilityIdentifier ("TextArea.FoldMarkerMargin");
+			foldMarkerMargin.Accessible.SetRealParent (this);
+			Accessible.AddAccessibleElement (foldMarkerMargin.Accessible);
+
 			textViewMargin = new TextViewMargin (editor);
+			textViewMargin.Accessible.SetAccessibilityIdentifier ("TextArea.TextViewMargin");
+			textViewMargin.Accessible.SetRealParent (this);
+			Accessible.AddAccessibleElement (textViewMargin.Accessible);
 
 			margins.Add (iconMargin);
 			margins.Add (gutterMargin);
@@ -1706,6 +1728,37 @@ namespace Mono.TextEditor
 			if (Options.WrapLines)
 				textViewMargin.PurgeLayoutCache ();
 			SetChildrenPositions (allocation);
+
+			UpdateMarginRects (allocation);
+		}
+
+		void UpdateMarginRects (Gdk.Rectangle allocation)
+		{
+			double curX = 0;
+
+			if (margins == null) {
+				return;
+			}
+
+			foreach (var margin in margins) {
+				Gdk.Rectangle marginRect;
+
+				if (!margin.IsVisible)
+					continue;
+
+				marginRect.X = (int)curX;
+				marginRect.Y = 0;
+				if ((int)margin.Width == -1) {
+					marginRect.Width = (int)(allocation.Width - curX);
+				} else {
+					marginRect.Width = (int)margin.Width;
+				}
+				marginRect.Height = allocation.Height;
+
+				curX += margin.Width;
+
+				margin.RectInParent = marginRect;
+			}
 		}
 
 		uint lastScrollTime;

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -825,6 +825,9 @@
 	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTree"
 			 defaultHandler = "MonoDevelop.Ide.Commands.DumpA11yTreeHandler"
 			 _label = "Dump Accessibility Tree" />
+	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTreeDelayed"
+			 defaultHandler = "MonoDevelop.Ide.Commands.DumpA11yTreeDelayedHandler"
+			 _label = "Dump Accessibility Tree (10s)" />
 	</Category>
 
 	<!-- SearchCommands -->

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -819,6 +819,12 @@
 			_label = "Send Feedback"
 			icon = "md-feedback"
 			_description = "Send feedback to the MonoDevelop development team" />
+	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.DumpUITree"
+			 defaultHandler = "MonoDevelop.Ide.Commands.DumpUITreeHandler"
+			 _label = "Dump UI Tree" />
+	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTree"
+			 defaultHandler = "MonoDevelop.Ide.Commands.DumpA11yTreeHandler"
+			 _label = "Dump Accessibility Tree" />
 	</Category>
 
 	<!-- SearchCommands -->

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -284,6 +284,7 @@
 		<CommandItem id = "MonoDevelop.Ide.Commands.ToolCommands.InstrumentationViewer" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpUITree" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTree" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTreeDelayed" />
 		<Condition id = "Platform" value = "!mac">
 			<SeparatorItem id = "SeparatorAbout" />
 			<CommandItem id = "MonoDevelop.Ide.Updater.UpdateCommands.CheckForUpdates" />

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -282,6 +282,8 @@
 		<SeparatorItem id = "DiagnosticToolsSeparator" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.OpenLogDirectory" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.ToolCommands.InstrumentationViewer" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpUITree" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTree" />
 		<Condition id = "Platform" value = "!mac">
 			<SeparatorItem id = "SeparatorAbout" />
 			<CommandItem id = "MonoDevelop.Ide.Updater.UpdateCommands.CheckForUpdates" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands.ExtensionNodes/ItemSetCodon.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands.ExtensionNodes/ItemSetCodon.cs
@@ -43,7 +43,16 @@ namespace MonoDevelop.Components.Commands.ExtensionNodes
 	{
 		[NodeAttribute ("_label", "Label of the submenu", Localizable=true)]
 		string label;
-		
+		public string Label {
+			get {
+				return label ?? Id;
+			}
+
+			private set {
+				label = value;
+			}
+		}
+
 		[NodeAttribute("icon", "Icon of the submenu. The provided value must be a registered stock icon. A resource icon can also be specified using 'res:' as prefix for the name, for example: 'res:customIcon.png'")]
 		string icon;
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandRouterContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandRouterContainer.cs
@@ -50,6 +50,7 @@ namespace MonoDevelop.Components.Commands
 
 		public CommandRouterContainer (Control child, object target, bool continueToParent) : this (continueToParent)
 		{
+			Accessible.SetAccessibilityShouldIgnore (true);
 			if (child != null) {
 				PackStart (child, true, true, 0);
 				child = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebook.cs
@@ -72,6 +72,7 @@ namespace MonoDevelop.Components.DockNotebook
 			PackStart (tabStrip, false, false, 0);
 
 			contentBox = new EventBox ();
+			contentBox.Accessible.SetAccessibilityShouldIgnore (true);
 			PackStart (contentBox, true, true, 0);
 
 			ShowAll ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/TabStrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/TabStrip.cs
@@ -319,18 +319,6 @@ namespace MonoDevelop.Components.DockNotebook
 				});
 		}
 
-		protected override void ForAll (bool include_internals, Callback callback)
-		{
-			base.ForAll (include_internals, callback);
-			for (int i = 0; i < children.Count; ++i)
-				callback (children [i]);
-		}
-
-		protected override void OnRemoved (Widget widget)
-		{
-			children.Remove (widget);
-		}
-
 		protected override void OnSizeAllocated (Gdk.Rectangle allocation)
 		{
 			if (NavigationButtonsVisible) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/TabStrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/TabStrip.cs
@@ -51,7 +51,6 @@ namespace MonoDevelop.Components.DockNotebook
 
 		HBox innerBox;
 
-		List<Widget> children = new List<Widget> ();
 		readonly DockNotebook notebook;
 		DockNotebookTab highlightedTab;
 		bool overCloseButton;
@@ -111,21 +110,15 @@ namespace MonoDevelop.Components.DockNotebook
 		}
 
 		public bool  NavigationButtonsVisible {
-			get { return children.Contains (PreviousButton); }
+			get { return NextButton.Visible; }
 			set {
 				if (value == NavigationButtonsVisible)
 					return;
-				if (value) {
-					children.Add (NextButton);
-					children.Add (PreviousButton);
-					OnSizeAllocated (Allocation);
-					PreviousButton.ShowAll ();
-					NextButton.ShowAll ();
-				} else {
-					children.Remove (PreviousButton);
-					children.Remove (NextButton);
-					OnSizeAllocated (Allocation);
-				}
+
+				NextButton.Visible = value;
+				PreviousButton.Visible = value;
+
+				OnSizeAllocated (Allocation);
 			}
 		}
 
@@ -204,7 +197,9 @@ namespace MonoDevelop.Components.DockNotebook
 			DropDownButton.Accessible.Description = Core.GettextCatalog.GetString ("Display the document list menu");
 
 			PreviousButton.ShowAll ();
+			PreviousButton.NoShowAll = true;
 			NextButton.ShowAll ();
+			NextButton.NoShowAll = true;
 			DropDownButton.ShowAll ();
 
 			PreviousButton.Name = "MonoDevelop.DockNotebook.BarButton";
@@ -214,10 +209,6 @@ namespace MonoDevelop.Components.DockNotebook
 			innerBox.PackStart (PreviousButton, false, false, 0);
 			innerBox.PackStart (NextButton, false, false, 0);
 			innerBox.PackEnd (DropDownButton, false, false, 0);
-
-			children.Add (PreviousButton);
-			children.Add (NextButton);
-			children.Add (DropDownButton);
 
 			tracker.HoveredChanged += (sender, e) => {
 				if (!tracker.Hovered) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/AutoHideBox.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/AutoHideBox.cs
@@ -131,6 +131,8 @@ namespace MonoDevelop.Components.Docking
 			itemBox.Show ();
 			item.TitleTab.Active = true;
 			itemBox.PackStart (item.TitleTab, false, false, 0);
+
+			item.Widget.Accessible.SetAccessibilityShouldIgnore (true);
 			itemBox.PackStart (item.Widget, true, true, 0);
 
 			item.Widget.Show ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/AutoHideBox.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/AutoHideBox.cs
@@ -32,6 +32,7 @@
 
 using Gtk;
 using Gdk;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.Docking
 {
@@ -70,6 +71,8 @@ namespace MonoDevelop.Components.Docking
 			
 			Box fr;
 			CustomFrame cframe = new CustomFrame ();
+			cframe.Accessible.SetAccessibilityShouldIgnore (true);
+
 			switch (pos) {
 			case PositionType.Left: cframe.SetMargins (0, 0, 1, 1); break;
 			case PositionType.Right: cframe.SetMargins (0, 0, 1, 1); break;
@@ -88,6 +91,11 @@ namespace MonoDevelop.Components.Docking
 			}
 
 			EventBox sepBox = new EventBox ();
+
+			// FIXME How to actually resize this?
+			sepBox.Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXSplitter, GettextCatalog.GetString ("Pad resize handle"));
+			sepBox.Accessible.SetAccessibilityLabel (GettextCatalog.GetString ("Pad resize handle"));
+
 			cframe.Add (sepBox);
 			
 			if (horiz) {
@@ -99,7 +107,8 @@ namespace MonoDevelop.Components.Docking
 				sepBox.Realized += delegate { sepBox.GdkWindow.Cursor = resizeCursorH; };
 				sepBox.HeightRequest = gripSize;
 			}
-			
+			fr.Accessible.SetAccessibilityShouldIgnore (true);
+
 			sepBox.Events = EventMask.AllEventsMask;
 			
 			if (pos == PositionType.Left || pos == PositionType.Top)
@@ -117,6 +126,8 @@ namespace MonoDevelop.Components.Docking
 			scrollable.Show ();
 #endif
 			VBox itemBox = new VBox ();
+			itemBox.Accessible.SetAccessibilityShouldIgnore (true);
+
 			itemBox.Show ();
 			item.TitleTab.Active = true;
 			itemBox.PackStart (item.TitleTab, false, false, 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBarItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBarItem.cs
@@ -334,6 +334,9 @@ namespace MonoDevelop.Components.Docking
 				if (hiddenFrame != null)
 					bar.Frame.AutoHide (it, hiddenFrame, false);
 				autoShowFrame = bar.Frame.AutoShow (it, bar, size);
+				if (!string.IsNullOrEmpty (it.Label)) {
+					autoShowFrame.Title = it.Label;
+				}
 				autoShowFrame.EnterNotifyEvent += OnFrameEnter;
 				autoShowFrame.LeaveNotifyEvent += OnFrameLeave;
 				autoShowFrame.KeyPressEvent += OnFrameKeyPress;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -258,6 +258,8 @@ namespace MonoDevelop.Components.Docking
 					ts.Show ();
 					notebooks.Add (ts);
 					ts.Parent = this;
+
+					GLib.Signal.Emit (this, "add", ts);
 				}
 				frame.UpdateRegionStyle (grp);
 				ts.VisualStyle = grp.VisualStyle;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -57,6 +57,8 @@ namespace MonoDevelop.Components.Docking
 		public DockContainer (DockFrame frame)
 		{
 			GtkWorkarounds.FixContainerLeak (this);
+
+			Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXSplitGroup);
 			
 			this.Events = EventMask.ButtonPressMask | EventMask.ButtonReleaseMask | EventMask.PointerMotionMask | EventMask.LeaveNotifyMask;
 			this.frame = frame;
@@ -485,6 +487,8 @@ namespace MonoDevelop.Components.Docking
 	
 			public SplitterWidget ()
 			{
+				Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXSplitter);
+
 				this.VisibleWindow = false;
 				this.AboveChild = true;
 			}
@@ -497,6 +501,7 @@ namespace MonoDevelop.Components.Docking
 
 			protected override void OnSizeAllocated (Rectangle allocation)
 			{
+				Accessible.SetAccessibilityOrientation (allocation.Height > allocation.Width ? Orientation.Vertical : Orientation.Horizontal);
 				base.OnSizeAllocated (allocation);
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -37,6 +37,7 @@ using Gtk;
 using Gdk;
 using Xwt.Motion;
 using MonoDevelop.Core;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.Components.Docking
 {
@@ -72,17 +73,32 @@ namespace MonoDevelop.Components.Docking
 		{
 			GtkWorkarounds.FixContainerLeak (this);
 
+			Accessible.Name = "DockFrame";
+
 			dockBarTop = new DockBar (this, Gtk.PositionType.Top);
+			dockBarTop.Accessible.Name = "DockFrame.TopBar";
+
 			dockBarBottom = new DockBar (this, Gtk.PositionType.Bottom);
+			dockBarBottom.Accessible.Name = "DockFrame.BottomBar";
+
 			dockBarLeft = new DockBar (this, Gtk.PositionType.Left);
+			dockBarLeft.Accessible.Name = "DockFrame.LeftBar";
+
 			dockBarRight = new DockBar (this, Gtk.PositionType.Right);
-			
+			dockBarRight.Accessible.Name = "DockFrame.RightBar";
+
 			container = new DockContainer (this);
+			container.Accessible.Name = "DockFrame.Main";
+
 			HBox hbox = new HBox ();
+			hbox.Accessible.SetAccessibilityShouldIgnore (true);
+
 			hbox.PackStart (dockBarLeft, false, false, 0);
 			hbox.PackStart (container, true, true, 0);
 			hbox.PackStart (dockBarRight, false, false, 0);
 			mainBox = new VBox ();
+			mainBox.Accessible.SetAccessibilityShouldIgnore (true);
+
 			mainBox.PackStart (dockBarTop, false, false, 0);
 			mainBox.PackStart (hbox, true, true, 0);
 			mainBox.PackStart (dockBarBottom, false, false, 0);
@@ -143,6 +159,11 @@ namespace MonoDevelop.Components.Docking
 
 			this.overlayWidget = widget;
 			widget.Parent = this;
+
+			// Emit the add signal so that the A11y system will pick up that a widget has been added to the box
+			// but the box won't handle it because widget.Parent has already been set.
+			GLib.Signal.Emit (this, "add", widget);
+
 			OverlayWidgetVisible = true;
 			MinimizeAllAutohidden ();
 			if (animate) {
@@ -150,9 +171,13 @@ namespace MonoDevelop.Components.Docking
 				this.Animate (
 					"ShowOverlayWidget", 
 					ShowOverlayWidgetAnimation,
+					finished: (a, b) => {
+						mainBox.Hide ();
+					},
 					easing: Easing.CubicOut);
 			} else {
 				currentOverlayPosition = Math.Max (0, Allocation.Y);
+				mainBox.Hide ();
 				QueueResize ();
 			}
 
@@ -165,21 +190,29 @@ namespace MonoDevelop.Components.Docking
 			this.AbortAnimation ("HideOverlayWidget");
 			OverlayWidgetVisible = false;
 
+			mainBox.Show ();
+
 			if (overlayWidget != null) {
 				if (animate) {
 					currentOverlayPosition = Allocation.Y;
 					this.Animate (
 						"HideOverlayWidget", 
 						HideOverlayWidgetAnimation,
-						finished: (a,b) => { 
+						finished: (a,b) => {
 							if (overlayWidget != null) {
 								overlayWidget.Unparent ();
+
+								// After we've unparented the widget, we call remove so the A11y system can clean up as well.
+								GLib.Signal.Emit (this, "remove", overlayWidget);
 								overlayWidget = null;
 							}
 						},
 						easing: Easing.SinOut);
 				} else {
 					overlayWidget.Unparent ();
+					// After we've unparented the widget, we call remove so the A11y system can clean up as well.
+					GLib.Signal.Emit (this, "remove", overlayWidget);
+
 					overlayWidget = null;
 					QueueResize ();
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrameTopLevel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrameTopLevel.cs
@@ -139,6 +139,11 @@ namespace MonoDevelop.Components.Docking
 		}
 
 		internal Gtk.Window ContainerWindow { get; set; }
-	}
 
+		internal string Title {
+			set {
+				ContainerWindow.Title = value;
+			}
+		}
+	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
@@ -544,6 +544,11 @@ namespace MonoDevelop.Components.Docking
 
 		internal void ShowDockPopupMenu (Gtk.Widget parent, Gdk.EventButton evt)
 		{
+			ShowDockPopupMenu (parent, evt.X, evt.Y);
+		}
+
+		internal void ShowDockPopupMenu (Gtk.Widget parent, double x, double y)
+		{
 			var menu = new ContextMenu ();
 			ContextMenuItem citem;
 
@@ -580,7 +585,7 @@ namespace MonoDevelop.Components.Docking
 			}
 
 			ShowingContextMenu = true;
-			menu.Show (parent, evt, () => { ShowingContextMenu = true; });
+			menu.Show (parent, (int)x,  (int)y, () => { ShowingContextMenu = true; });
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemContainer.cs
@@ -31,6 +31,8 @@
 using System;
 using Gtk;
 
+using MonoDevelop.Components;
+
 namespace MonoDevelop.Components.Docking
 {
 	class DockItemContainer: EventBox
@@ -46,6 +48,7 @@ namespace MonoDevelop.Components.Docking
 			this.item = item;
 
 			mainBox = new VBox ();
+			mainBox.Accessible.SetAccessibilityShouldIgnore (true);
 			Add (mainBox);
 
 			mainBox.ResizeMode = Gtk.ResizeMode.Queue;
@@ -56,10 +59,12 @@ namespace MonoDevelop.Components.Docking
 			mainBox.PackStart (item.GetToolbar (DockPositionType.Top).Container, false, false, 0);
 			
 			HBox hbox = new HBox ();
+			hbox.Accessible.SetAccessibilityShouldIgnore (true);
 			hbox.Show ();
 			hbox.PackStart (item.GetToolbar (DockPositionType.Left).Container, false, false, 0);
 			
 			contentBox = new HBox ();
+			contentBox.Accessible.SetAccessibilityShouldIgnore (true);
 			contentBox.Show ();
 			hbox.PackStart (contentBox, true, true, 0);
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemToolbar.cs
@@ -83,6 +83,12 @@ namespace MonoDevelop.Components.Docking
 			topFrame.BackgroundColor = style.PadBackgroundColor.Value.ToGdkColor ();
 		}
 
+		internal Atk.Object Accessible {
+			get {
+				return box.Accessible;
+			}
+		}
+
 		public DockItem DockItem {
 			get { return parentItem; }
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/TabStrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/TabStrip.cs
@@ -47,8 +47,12 @@ namespace MonoDevelop.Components.Docking
 
 		public TabStrip (DockFrame frame)
 		{
+			Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXTabGroup);
+
 			VBox vbox = new VBox ();
+			vbox.Accessible.SetAccessibilityShouldIgnore (true);
 			box = new TabStripBox () { TabStrip = this };
+			box.Accessible.SetAccessibilityShouldIgnore (true);
 			vbox.PackStart (box, false, false, 0);
 		//	vbox.PackStart (bottomFiller, false, false, 0);
 			Add (vbox);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/ButtonBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/ButtonBar.cs
@@ -54,6 +54,18 @@ namespace MonoDevelop.Components.MainToolbar
 				QueueResize ();
 			}
 		}
+
+		public IEnumerable<ButtonBarGroup> Groups {
+			set {
+				var buttonList = new List<IButtonBarButton> ();
+				foreach (var g in value) {
+					buttonList.AddRange (g.Buttons);
+				}
+
+				Buttons = buttonList;
+			}
+		}
+
 		Dictionary<IButtonBarButton, Gdk.Rectangle> allocations = new Dictionary<IButtonBarButton, Gdk.Rectangle> ();
 		IButtonBarButton[] visibleButtons;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IButtonBarButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IButtonBarButton.cs
@@ -77,6 +77,12 @@ namespace MonoDevelop.Components.MainToolbar
 		string Tooltip { get; }
 
 		/// <summary>
+		/// Gets the button title
+		/// </summary>
+		/// <value>The title.</value>
+		string Title { get; }
+
+		/// <summary>
 		/// Use this when the button is clicked.
 		/// </summary>
 		void NotifyPushed ();
@@ -100,6 +106,9 @@ namespace MonoDevelop.Components.MainToolbar
 		/// Occurs when the tooltip changed.
 		/// </summary>
 		event EventHandler TooltipChanged;
+
+		/// Occurs when the title is changed
+		event EventHandler TitleChanged;
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IButtonBarButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IButtonBarButton.cs
@@ -24,10 +24,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Collections.Generic;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.MainToolbar
 {
+	public class ButtonBarGroup
+	{
+		// The title of the button group. Used for accessibility
+		public string Title { get; private set; }
+
+		// The buttons in this group
+		public List<IButtonBarButton> Buttons { get; }
+
+		public ButtonBarGroup (string title)
+		{
+			Title = title;
+			Buttons = new List<IButtonBarButton> ();
+		}
+	}
+
 	public interface IButtonBarButton
 	{
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IMainToolbarView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IMainToolbarView.cs
@@ -242,7 +242,9 @@ namespace MonoDevelop.Components.MainToolbar
 		/// Rebuilds the toolbar.
 		/// </summary>
 		/// <param name="buttons">A list of buttons.</param>
+		[Obsolete ("Use RebuildToolbar(IEnumerable<ButtonBarGroup> groups) instead")]
 		void RebuildToolbar (IEnumerable<IButtonBarButton> buttons);
+		void RebuildToolbar (IEnumerable<ButtonBarGroup> groups);
 
 		/// <summary>
 		/// Sets a value indicating whether the button bar is interactible.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
@@ -593,6 +593,18 @@ namespace MonoDevelop.Components.MainToolbar
 			buttonBar.Buttons = buttons;
 		}
 
+		public void RebuildToolbar (IEnumerable<ButtonBarGroup> groups)
+		{
+			if (!groups.Any ()) {
+				buttonBarBox.Hide ();
+				return;
+			}
+
+			buttonBarBox.Show ();
+			buttonBar.ShowAll ();
+			buttonBar.Groups = groups;
+		}
+
 		public bool ButtonBarSensitivity {
 			set { buttonBar.Sensitive = value; }
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -796,6 +796,7 @@ namespace MonoDevelop.Components.MainToolbar
 			public bool Enabled { get; set; }
 			public bool Visible { get; set; }
 			public string Tooltip { get; set; }
+			public string Title { get; set; }
 			public bool IsSeparator {
 				get { return CommandId == null; }
 			}
@@ -834,12 +835,17 @@ namespace MonoDevelop.Components.MainToolbar
 					if (VisibleChanged != null)
 						VisibleChanged (this, null);
 				}
+				if (ci.Text != Title) {
+					Title = ci.Text;
+					TitleChanged?.Invoke (this, null);
+				}
 			}
 
 			public event EventHandler EnabledChanged;
 			public event EventHandler ImageChanged;
 			public event EventHandler VisibleChanged;
 			public event EventHandler TooltipChanged;
+			public event EventHandler TitleChanged;
 		}
 
 		class RuntimeModel : IRuntimeModel

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -694,16 +694,22 @@ namespace MonoDevelop.Components.MainToolbar
 		{
 			var bars = AddinManager.GetExtensionNodes<ItemSetCodon> (ToolbarExtensionPath)
 				.Where (n => visibleBars.Contains (n.Id))
-				.Select (b => b.ChildNodes.OfType<CommandItemCodon> ().Select (n => n.Id));
+                .Select (b => new { Label = b.Label, Buttons = b.ChildNodes.OfType<CommandItemCodon> ().Select (n => n.Id) });
 
+			var buttonGroups = new List<ButtonBarGroup> ();
 			buttonBarButtons.Clear ();
 			foreach (var bar in bars) {
-				foreach (string commandId in bar)
-					buttonBarButtons.Add (new ButtonBarButton (this, commandId));
-				buttonBarButtons.Add (new ButtonBarButton (this));
+				var group = new ButtonBarGroup (bar.Label);
+
+				buttonGroups.Add (group);
+				foreach (string commandId in bar.Buttons) {
+					var button = new ButtonBarButton (this, commandId);
+					group.Buttons.Add (button);
+					buttonBarButtons.Add (button);
+				}
 			}
 
-			ToolbarView.RebuildToolbar (buttonBarButtons);
+			ToolbarView.RebuildToolbar (buttonGroups);
 		}
 
 		static void HandleStartButtonClicked (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
@@ -584,6 +584,16 @@ namespace MonoDevelop.Components.MainToolbar
 				}
 			}
 
+			public string Title {
+				get;
+				set;
+			}
+
+			public string Help {
+				get;
+				set;
+			}
+
 			public EventBox EventBox {
 				get { return box; }
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -501,15 +501,7 @@ namespace MonoDevelop.Components
 #if MAC
 			protected void GetCoordsInWindow (Gtk.Widget widget, out int x, out int y)
 			{
-				x = widget.Allocation.X;
-				y = widget.Allocation.Y;
-
-				while ((widget = widget.Parent) != null) {
-					if (!(widget is Gtk.Container) || widget is Gtk.EventBox) {
-						x += widget.Allocation.X;
-						y += widget.Allocation.Y;
-					}
-				}
+				widget.TranslateCoordinates (widget.Toplevel, 0, 0, out x, out y);
 			}
 
 			protected void GetCoordsInScreen (Gtk.Widget widget, int windowX, int windowY, out int screenX, out int screenY)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.Components
 			AXButton,
 			AXGroup,
 			AXImage,
+			AXMenuButton,
 			AXRadioButton,
 			AXRuler,
 			AXSplitGroup,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -58,10 +58,12 @@ namespace MonoDevelop.Components
 		{
 			AXButton,
 			AXGroup,
+			AXImage,
 			AXRadioButton,
 			AXRuler,
 			AXSplitGroup,
 			AXSplitter,
+			AXStaticText,
 			AXTabGroup,
 			AXTextArea
 		};
@@ -72,11 +74,17 @@ namespace MonoDevelop.Components
 		};
 
 #if MAC
+		const string XamarinPrivateAtkCocoaNSAccessibilityKey = "xamarin-private-atkcocoa-nsaccessibility";
 		internal static NSAccessibilityElement GetNSAccessibilityElement (Atk.Object o)
 		{
-			IntPtr handle = GtkWorkarounds.GetData (o, "xamarin-private-atkcocoa-nsaccessibility");
+			IntPtr handle = GtkWorkarounds.GetData (o, XamarinPrivateAtkCocoaNSAccessibilityKey);
 
 			return Runtime.GetNSObject<NSAccessibilityElement> (handle, false);
+		}
+
+		internal static void SetNSAccessibilityElement (Atk.Object o, INativeObject native)
+		{
+			GtkWorkarounds.SetData (o, XamarinPrivateAtkCocoaNSAccessibilityKey, native.Handle);
 		}
 #endif
 
@@ -872,6 +880,18 @@ namespace MonoDevelop.Components
 			protected abstract Range GetRangeForIndex (int index);
 			protected abstract Range GetStyleRangeForIndex (int index);
 			protected abstract Range GetRangeForPosition (Gdk.Point position);
+		}
+
+		public abstract class AtkCellRendererProxy : Atk.Object
+		{
+			public AccessibilityElementProxy Accessible { get; private set; }
+			protected AtkCellRendererProxy ()
+			{
+				Accessible = new AccessibilityElementProxy ();
+
+				// Set the element as secret data on the Atk.Object so AtkCocoa can do something with it
+				AtkCocoaHelper.SetNSAccessibilityElement (this, Accessible);
+			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -1,0 +1,330 @@
+﻿//
+// AtkCocoaHelper.cs
+//
+// Author:
+//       Iain Holmes <iain@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+#if MAC
+using AppKit;
+using Foundation;
+using ObjCRuntime;
+#endif
+
+namespace MonoDevelop.Components
+{
+	// AtkCocoaHelper wraps NSAccessibilityElement to set NSAccessibility properties that aren't supported by Atk
+	public static class AtkCocoaHelper
+	{
+		public enum Actions
+		{
+			AXCancel,
+			AXConfirm,
+			AXDecrement,
+			AXDelete,
+			AXIncrement,
+			AXPick,
+			AXPress,
+			AXRelease,
+			AXShowAlternateUI,
+			AXShowDefaultUI,
+			AXShowMenu
+		};
+
+#if MAC
+		static NSAccessibilityElement GetNSAccessibilityElement (Atk.Object o)
+		{
+			IntPtr handle = GtkWorkarounds.GetData (o, "xamarin-private-atkcocoa-nsaccessibility");
+
+			return Runtime.GetNSObject<NSAccessibilityElement> (handle, false);
+		}
+#endif
+
+		public static void SetAccessibilityLabel (this Atk.Object o, string label)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityLabel = label;
+#endif
+		}
+
+		public static void SetAccessibilityShouldIgnore (this Atk.Object o, bool ignore)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityElement = !ignore;
+#endif
+		}
+
+		public static void SetAccessibilityTitle (this Atk.Object o, string title)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityTitle = title;
+#endif
+		}
+
+		public static void SetAccessibilityValue (this Atk.Object o, string stringValue)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityValue = new NSString (stringValue);
+#endif
+		}
+
+		public static void SetAccessibilityURL (this Atk.Object o, string url)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityUrl = new NSUrl (url);
+#endif
+		}
+
+		public static void SetAccessibilityRole (this Atk.Object o, string role, string description = null)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityRole = role;
+
+			if (!string.IsNullOrEmpty (description)) {
+				nsa.AccessibilityRoleDescription = description;
+			}
+#endif
+		}
+
+		public static void SetAccessibilitySubRole (this Atk.Object o, string subrole)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilitySubrole = subrole;
+#endif
+		}
+
+		public static void SetAccessibilityTitleUIElement (this Atk.Object o, Atk.Object title)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			var titleNsa = GetNSAccessibilityElement (title);
+
+			nsa.AccessibilityTitleUIElement = titleNsa;
+#endif
+		}
+
+		public static void SetAccessibilityAlternateUIVisible (this Atk.Object o, bool visible)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			nsa.AccessibilityAlternateUIVisible = visible;
+#endif
+		}
+
+		public static void SetAccessibilityTitleFor (this Atk.Object o, params Atk.Object [] objects)
+		{
+#if MAC
+			var nsa = GetNSAccessibilityElement (o);
+			NSObject [] titleElements = new NSObject [objects.Length];
+			int idx = 0;
+
+			foreach (var obj in objects) {
+				var nsao = GetNSAccessibilityElement (obj);
+				titleElements [idx] = nsao;
+				idx++;
+			}
+
+			nsa.AccessibilityServesAsTitleForUIElements = titleElements;
+#endif
+		}
+
+		public static void AccessibilityAddElementToTitle (this Atk.Object title, Atk.Object o)
+		{
+#if MAC
+			var titleNsa = GetNSAccessibilityElement (title);
+			var nsa = GetNSAccessibilityElement (o);
+
+			NSObject [] oldElements = titleNsa.AccessibilityServesAsTitleForUIElements;
+			int length = oldElements != null ? oldElements.Length : 0;
+
+			if (oldElements != null && oldElements.IndexOf (nsa) != -1) {
+				return;
+			}
+
+			NSObject [] titleElements = new NSObject [length + 1];
+			if (oldElements != null) {
+				oldElements.CopyTo (titleElements, 0);
+			}
+			titleElements [length] = nsa;
+#endif
+		}
+
+		public static void AccessibilityRemoveElementFromTitle (this Atk.Object title, Atk.Object o)
+		{
+#if MAC
+			var titleNsa = GetNSAccessibilityElement (title);
+			var nsa = GetNSAccessibilityElement (o);
+
+			if (titleNsa.AccessibilityServesAsTitleForUIElements == null) {
+				return;
+			}
+
+			List<NSObject> oldElements = new List<NSObject> (titleNsa.AccessibilityServesAsTitleForUIElements);
+			oldElements.Remove (nsa);
+
+			titleNsa.AccessibilityServesAsTitleForUIElements = oldElements.ToArray ();
+#endif
+		}
+
+		public class ActionDelegate
+		{
+			public Actions [] Actions { get; set; }
+
+			Atk.Object owner;
+			internal Atk.Object Owner {
+				set {
+					owner = value;
+
+					var signal = GLib.Signal.Lookup (owner, "request-actions", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (RequestActionsHandler));
+
+					signal = GLib.Signal.Lookup (owner, "perform-cancel", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformCancelHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-confirm", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformConfirmHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-decrement", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformDecrementHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-delete", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformDeleteHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-increment", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformIncrementHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-pick", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformPickHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-press", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformPressHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-raise", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformRaiseHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-show-alternate-ui", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformShowAlternateUIHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-show-default-ui", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformShowDefaultUIHandler));
+					signal = GLib.Signal.Lookup (owner, "perform-show-menu", typeof (GLib.SignalArgs));
+					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (PerformShowMenuHandler));
+				}
+			}
+
+			void RequestActionsHandler (object sender, GLib.SignalArgs args)
+			{
+				// +1 so we can add a NULL to terminate the array
+				int actionCount = Actions.Length + 1;
+				IntPtr intPtr = Marshal.AllocHGlobal (actionCount * Marshal.SizeOf<IntPtr> ());
+				IntPtr [] actions = new IntPtr [actionCount];
+
+				int i = 0;
+				foreach (var action in Actions) {
+					actions [i] = Marshal.StringToHGlobalAnsi (action.ToString ());
+					i++;
+				}
+
+				// Terminator
+				actions [i] = IntPtr.Zero;
+
+				Marshal.Copy (actions, 0, intPtr, actionCount);
+
+				args.RetVal = intPtr;
+			}
+
+			void PerformCancelHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformCancel?.Invoke (this, args);
+			}
+
+			void PerformConfirmHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformConfirm?.Invoke (this, args);
+			}
+
+			void PerformDecrementHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformDecrement?.Invoke (this, args);
+			}
+
+			void PerformDeleteHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformDelete?.Invoke (this, args);
+			}
+
+			void PerformIncrementHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformIncrement?.Invoke (this, args);
+			}
+
+			void PerformPickHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformPick?.Invoke (this, args);
+			}
+
+			void PerformPressHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformPress?.Invoke (this, args);
+			}
+
+			void PerformRaiseHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformRaise?.Invoke (this, args);
+			}
+
+			void PerformShowAlternateUIHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformShowAlternateUI?.Invoke (this, args);
+			}
+
+			void PerformShowDefaultUIHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformShowDefaultUI?.Invoke (this, args);
+			}
+
+			void PerformShowMenuHandler (object sender, GLib.SignalArgs args)
+			{
+				PerformShowMenu?.Invoke (this, args);
+			}
+
+			public event EventHandler PerformCancel;
+			public event EventHandler PerformConfirm;
+			public event EventHandler PerformDecrement;
+			public event EventHandler PerformDelete;
+			public event EventHandler PerformIncrement;
+			public event EventHandler PerformPick;
+			public event EventHandler PerformPress;
+			public event EventHandler PerformRaise;
+			public event EventHandler PerformShowAlternateUI;
+			public event EventHandler PerformShowDefaultUI;
+			public event EventHandler PerformShowMenu;
+		}
+
+		public static void SetActionDelegate (this Atk.Object o, ActionDelegate ad)
+		{
+			ad.Owner = o;
+		}
+	}
+}
+

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -92,6 +92,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityLabel = label;
 #endif
 		}
@@ -100,6 +104,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityElement = !ignore;
 #endif
 		}
@@ -108,6 +116,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityTitle = title;
 #endif
 		}
@@ -116,6 +128,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityValue = new NSString (stringValue);
 #endif
 		}
@@ -124,6 +140,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityUrl = new NSUrl (url);
 #endif
 		}
@@ -132,6 +152,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityRole = role;
 
 			if (!string.IsNullOrEmpty (description)) {
@@ -149,6 +173,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilitySubrole = subrole;
 #endif
 		}
@@ -159,6 +187,10 @@ namespace MonoDevelop.Components
 			var nsa = GetNSAccessibilityElement (o);
 			var titleNsa = GetNSAccessibilityElement (title);
 
+			if (nsa == null || titleNsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityTitleUIElement = titleNsa;
 #endif
 		}
@@ -167,6 +199,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityAlternateUIVisible = visible;
 #endif
 		}
@@ -175,6 +211,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityOrientation = orientation == Gtk.Orientation.Vertical ? NSAccessibilityOrientation.Vertical : NSAccessibilityOrientation.Horizontal;
 #endif
 
@@ -184,11 +224,19 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			NSObject [] titleElements = new NSObject [objects.Length];
 			int idx = 0;
 
 			foreach (var obj in objects) {
 				var nsao = GetNSAccessibilityElement (obj);
+				if (nsao == null) {
+					return;
+				}
+
 				titleElements [idx] = nsao;
 				idx++;
 			}
@@ -202,6 +250,10 @@ namespace MonoDevelop.Components
 #if MAC
 			var titleNsa = GetNSAccessibilityElement (title);
 			var nsa = GetNSAccessibilityElement (o);
+
+			if (nsa == null || titleNsa == null) {
+				return;
+			}
 
 			NSObject [] oldElements = titleNsa.AccessibilityServesAsTitleForUIElements;
 			int length = oldElements != null ? oldElements.Length : 0;
@@ -224,6 +276,10 @@ namespace MonoDevelop.Components
 			var titleNsa = GetNSAccessibilityElement (title);
 			var nsa = GetNSAccessibilityElement (o);
 
+			if (nsa == null || titleNsa == null) {
+				return;
+			}
+
 			if (titleNsa.AccessibilityServesAsTitleForUIElements == null) {
 				return;
 			}
@@ -243,6 +299,10 @@ namespace MonoDevelop.Components
 			internal Atk.Object Owner {
 				set {
 					owner = value;
+
+					if (owner.GetType () == typeof (Atk.NoOpObject)) {
+						return;
+					}
 
 					var signal = GLib.Signal.Lookup (owner, "request-actions", typeof (GLib.SignalArgs));
 					signal.AddDelegate (new EventHandler<GLib.SignalArgs> (RequestActionsHandler));
@@ -370,6 +430,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			nsa.AccessibilityAddChildElement (child);
 #endif
 		}
@@ -378,6 +442,10 @@ namespace MonoDevelop.Components
 		{
 #if MAC
 			var nsa = GetNSAccessibilityElement (o);
+			if (nsa == null) {
+				return;
+			}
+
 			var children = nsa.AccessibilityChildren;
 
 			if (children == null || children.Length == 0) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -666,6 +666,15 @@ namespace MonoDevelop.Components
 				}
 			}
 
+			public override bool AccessibilityFocused {
+				get {
+					return parent.HasFocus;
+				}
+				set {
+					parent.HasFocus = value;
+				}
+			}
+
 			protected bool OnPerformCancel ()
 			{
 				PerformCancel?.Invoke (this, EventArgs.Empty);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/AtkCocoaHelper.cs
@@ -89,6 +89,33 @@ namespace MonoDevelop.Components
 		}
 #endif
 
+#if MAC
+		internal static void DumpAccessibilityTree (NSObject obj = null, int indentLevel = 0)
+		{
+			if (obj == null) {
+				obj = NSApplication.SharedApplication;
+			}
+
+			string desc = obj.Description;
+			desc = desc.PadLeft (desc.Length + indentLevel, ' ');
+			Console.WriteLine ($"{desc}");
+
+			if (!obj.RespondsToSelector (new Selector ("accessibilityChildren"))) {
+				string notAccessible = "Not accessible";
+				Console.WriteLine ($"{notAccessible.PadLeft (notAccessible.Length + indentLevel + 2, ' ')}");
+				return;
+			}
+
+			NSArray children = (NSArray) obj.PerformSelector (new Selector ("accessibilityChildren"));
+			if (children == null) {
+				return;
+			}
+
+			for (nuint i = 0; i < children.Count; i++) {
+				DumpAccessibilityTree (children.GetItem<NSObject> (i), indentLevel + 2);
+			}
+		}
+#endif
 		public static void SetAccessibilityLabel (this Atk.Object o, string label)
 		{
 #if MAC

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/CellRendererImage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/CellRendererImage.cs
@@ -27,11 +27,81 @@ using System;
 using Xwt.Drawing;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
+using System.Runtime.InteropServices;
 
 namespace MonoDevelop.Components
 {
 	public class CellRendererImage: Gtk.CellRenderer
 	{
+		/*
+		static GLib.GType myType = GLib.GType.None;
+		public static new GLib.GType GType {
+			get {
+				if (myType == GLib.GType.None) {
+					myType = GLib.Object.RegisterGType (typeof (CellRendererImage));
+				}
+				return myType;
+			}
+		}
+
+		class CellRendererImageAccessible : AtkCocoaHelper.AtkCellRendererProxy
+		{
+			static GLib.GType myType = GLib.GType.None;
+			public static new GLib.GType GType {
+				get {
+					if (myType == GLib.GType.None) {
+						myType = GLib.Object.RegisterGType (typeof (CellRendererImageAccessible));
+					}
+					return myType;
+				}
+			}
+
+			public CellRendererImageAccessible ()
+			{
+				Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXImage);
+			}
+		}
+
+		class CellRendererImageAccessibleFactory : Atk.ObjectFactory
+		{
+			static GLib.GType myType = GLib.GType.None;
+			public static new GLib.GType GType {
+				get {
+					if (myType == GLib.GType.None) {
+						myType = GLib.Object.RegisterGType (typeof (CellRendererImageAccessibleFactory));
+					}
+					return myType;
+				}
+			}
+
+			public CellRendererImageAccessibleFactory ()
+			{
+			}
+
+			public CellRendererImageAccessibleFactory (IntPtr handle) : base (handle)
+			{
+				Console.WriteLine ("Created CellRendererImageAccessibleFactory");
+			}
+
+			protected override Atk.Object OnCreateAccessible (GLib.Object obj)
+			{
+				Console.WriteLine ("OnCreateAccessible");
+				return new CellRendererImageAccessible ();
+			}
+
+			protected override GLib.GType OnGetAccessibleType ()
+			{
+				Console.WriteLine ("OnGetAccessibleType");
+				return CellRendererImageAccessible.GType;
+			}
+
+			protected override void OnInvalidate ()
+			{
+				Console.WriteLine ("OnInvalidate");
+			}
+		}
+		*/
+
 		Image image;
 		Image imageOpen;
 		Image imageClosed;
@@ -43,6 +113,16 @@ namespace MonoDevelop.Components
 		/// null values for object that are not of subclasses of GLib.Object
 		/// </summary>
 		public static readonly Xwt.Drawing.Image NullImage = ImageService.GetIcon ("md-empty", Gtk.IconSize.Menu);
+
+		/*
+		static CellRendererImage ()
+		{
+			Atk.Registry registry = Atk.Global.DefaultRegistry;
+			var fakeFactory = new CellRendererImageAccessibleFactory ();
+
+			registry.SetFactoryType (GType, CellRendererImageAccessibleFactory.GType);
+		}
+*/
 
 		public CellRendererImage ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
@@ -32,8 +32,14 @@ namespace MonoDevelop.Components
 	/// </summary>
 	public class ContextMenuTreeView : Gtk.TreeView
 	{
+		internal AtkCocoaHelper.ActionDelegate ActionHandler { get; private set; }
 		public ContextMenuTreeView ()
 		{
+			ActionHandler = new AtkCocoaHelper.ActionDelegate ();
+			ActionHandler.PerformShowMenu += PerformShowMenu;
+			ActionHandler.Actions = new AtkCocoaHelper.Actions [] { AtkCocoaHelper.Actions.AXShowMenu };
+
+			Accessible.SetActionDelegate (ActionHandler);
 		}
 
 		public ContextMenuTreeView (Gtk.TreeModel model) : base (model)
@@ -145,6 +151,11 @@ namespace MonoDevelop.Components
 			}
 			
 			return res;
+		}
+
+		void PerformShowMenu (object sender, EventArgs args)
+		{
+			OnPopupMenu ();
 		}
 
 		protected override bool OnPopupMenu ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1158,12 +1158,20 @@ namespace MonoDevelop.Components
 		[DllImport (PangoUtil.LIBGOBJECT, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_object_get_data (IntPtr source, string name);
 
+		[DllImport (PangoUtil.LIBGOBJECT, CallingConvention = CallingConvention.Cdecl)]
+		static extern void g_object_set_data (IntPtr source, string name, IntPtr dataHandle);
+
 		[DllImport (PangoUtil.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr gtk_icon_set_render_icon_scaled (IntPtr handle, IntPtr style, int direction, int state, int size, IntPtr widget, IntPtr intPtr, ref double scale);
 
 		public static IntPtr GetData (GLib.Object o, string name)
 		{
 			return g_object_get_data (o.Handle, name);
+		}
+
+		public static void SetData (GLib.Object o, string name, IntPtr dataHandle)
+		{
+			g_object_set_data (o.Handle, name, dataHandle);
 		}
 
 		public static bool SetSourceScale (Gtk.IconSource source, double scale)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1161,6 +1161,11 @@ namespace MonoDevelop.Components
 		[DllImport (PangoUtil.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr gtk_icon_set_render_icon_scaled (IntPtr handle, IntPtr style, int direction, int state, int size, IntPtr widget, IntPtr intPtr, ref double scale);
 
+		public static IntPtr GetData (GLib.Object o, string name)
+		{
+			return g_object_get_data (o.Handle, name);
+		}
+
 		public static bool SetSourceScale (Gtk.IconSource source, double scale)
 		{
 			if (!supportsHiResIcons)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HoverImageButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HoverImageButton.cs
@@ -55,11 +55,20 @@ namespace MonoDevelop.Components
 
         public HoverImageButton()
         {
+			var actionHandler = new AtkCocoaHelper.ActionDelegate ();
+			Accessible.SetActionDelegate (actionHandler);
+			actionHandler.Actions = new [] { AtkCocoaHelper.Actions.AXPress };
+			actionHandler.PerformPress += OnPerformPress;
+
+			Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXButton);
+
 			Gtk.Alignment al = new Alignment (0.5f, 0.5f, 0f, 0f);
+			al.Accessible.SetAccessibilityShouldIgnore (true);
 			al.Show ();
             CanFocus = true;
 			VisibleWindow = false;
 			image = new ImageView();
+			image.Accessible.SetAccessibilityShouldIgnore (true);
             image.Show();
 			al.Add (image);
             Add(al);
@@ -82,6 +91,11 @@ namespace MonoDevelop.Components
                 handler(this, EventArgs.Empty);
             }
         }
+
+		void OnPerformPress (object sender, EventArgs args)
+		{
+			Activate ();
+		}
 
         private bool changing_style = false;
         protected override void OnStyleSet(Style previous_style)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.Components
 		internal static string DefaultTheme;
 		internal static string DefaultGtkDataFolder;
 		internal static string DefaultGtk2RcFiles;
+		internal static string DefaultGtkPath;
 
 		public static Theme UserInterfaceTheme { get; private set; }
 
@@ -51,6 +52,7 @@ namespace MonoDevelop.Components
 		{
 			DefaultGtkDataFolder = Environment.GetEnvironmentVariable ("GTK_DATA_PREFIX");
 			DefaultGtk2RcFiles = Environment.GetEnvironmentVariable ("GTK2_RC_FILES");
+			DefaultGtkPath = Environment.GetEnvironmentVariable ("GTK_PATH");
 			// FIXME: Immediate theme switching disabled, until:
 			//        MAC: NSAppearance issues are fixed
 			//        WIN: spradic Gtk crashes on theme realoding are fixed
@@ -67,14 +69,22 @@ namespace MonoDevelop.Components
 			if (!Platform.IsLinux)
 				UpdateGtkTheme ();
 
-			if (Platform.IsMac)
+			if (Platform.IsMac) {
+				// Load a private version of AtkCocoa stored in the XS app directory
+				var gtkPath = $"{AppDomain.CurrentDomain.BaseDirectory}/libs/gtk-2.0:{DefaultGtkPath}";
+
+				LoggingService.LogInfo ($"Loading modules from {gtkPath}");
+				Environment.SetEnvironmentVariable ("GTK_PATH", gtkPath);
 				Environment.SetEnvironmentVariable ("GTK_MODULES", "atkcocoa");
+			}
 
 			Gtk.Application.Init (BrandingService.ApplicationName, ref args);
 
 			// Reset our environment after initialization on Mac
-			if (Platform.IsMac)
+			if (Platform.IsMac) {
 				Environment.SetEnvironmentVariable ("GTK2_RC_FILES", DefaultGtk2RcFiles);
+				Environment.SetEnvironmentVariable ("GTK_PATH", DefaultGtkPath);
+			}
 		}
 
 		internal static void SetupXwtTheme ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
@@ -67,6 +67,9 @@ namespace MonoDevelop.Components
 			if (!Platform.IsLinux)
 				UpdateGtkTheme ();
 
+			if (Platform.IsMac)
+				Environment.SetEnvironmentVariable ("GTK_MODULES", "atkcocoa");
+
 			Gtk.Application.Init (BrandingService.ApplicationName, ref args);
 
 			// Reset our environment after initialization on Mac

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
@@ -44,7 +44,6 @@ namespace MonoDevelop.Components
 		internal static string DefaultTheme;
 		internal static string DefaultGtkDataFolder;
 		internal static string DefaultGtk2RcFiles;
-		internal static string DefaultGtkPath;
 
 		public static Theme UserInterfaceTheme { get; private set; }
 
@@ -52,7 +51,6 @@ namespace MonoDevelop.Components
 		{
 			DefaultGtkDataFolder = Environment.GetEnvironmentVariable ("GTK_DATA_PREFIX");
 			DefaultGtk2RcFiles = Environment.GetEnvironmentVariable ("GTK2_RC_FILES");
-			DefaultGtkPath = Environment.GetEnvironmentVariable ("GTK_PATH");
 			// FIXME: Immediate theme switching disabled, until:
 			//        MAC: NSAppearance issues are fixed
 			//        WIN: spradic Gtk crashes on theme realoding are fixed
@@ -71,11 +69,11 @@ namespace MonoDevelop.Components
 
 			if (Platform.IsMac) {
 				// Load a private version of AtkCocoa stored in the XS app directory
-				var gtkPath = $"{AppDomain.CurrentDomain.BaseDirectory}/libs/gtk-2.0:{DefaultGtkPath}";
+				var appDir = Directory.GetParent (AppDomain.CurrentDomain.BaseDirectory);
+				var gtkPath = $"{appDir.Parent.FullName}/lib/gtk-2.0";
 
 				LoggingService.LogInfo ($"Loading modules from {gtkPath}");
-				Environment.SetEnvironmentVariable ("GTK_PATH", gtkPath);
-				Environment.SetEnvironmentVariable ("GTK_MODULES", "atkcocoa");
+				Environment.SetEnvironmentVariable ("GTK_MODULES", $"{gtkPath}/libatkcocoa.so");
 			}
 
 			Gtk.Application.Init (BrandingService.ApplicationName, ref args);
@@ -83,7 +81,6 @@ namespace MonoDevelop.Components
 			// Reset our environment after initialization on Mac
 			if (Platform.IsMac) {
 				Environment.SetEnvironmentVariable ("GTK2_RC_FILES", DefaultGtk2RcFiles);
-				Environment.SetEnvironmentVariable ("GTK_PATH", DefaultGtkPath);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageButton.cs
@@ -39,9 +39,17 @@ namespace MonoDevelop.Components
 
 		public ImageButton ()
 		{
+			var actionHandler = new AtkCocoaHelper.ActionDelegate ();
+			actionHandler.Actions = new AtkCocoaHelper.Actions [] { AtkCocoaHelper.Actions.AXPress };
+			actionHandler.PerformPress += HandlePress;
+
+			Accessible.SetActionDelegate (actionHandler);
+			Accessible.Role = Atk.Role.PushButton;
+
 			Events |= Gdk.EventMask.EnterNotifyMask | Gdk.EventMask.LeaveNotifyMask | Gdk.EventMask.ButtonReleaseMask;
 			VisibleWindow = false;
 			imageWidget = new ImageView ();
+			imageWidget.Accessible.SetAccessibilityShouldIgnore (true);
 			imageWidget.Show ();
 			Add (imageWidget);
 		}
@@ -121,6 +129,11 @@ namespace MonoDevelop.Components
 				return true;
 			}
 			return base.OnButtonReleaseEvent (evnt);
+		}
+
+		void HandlePress (object o, EventArgs args)
+		{
+			Clicked?.Invoke (this, EventArgs.Empty);
 		}
 
 		public event EventHandler Clicked;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.Components
 
 		public ImageView ()
 		{
+			Accessible.Role = Atk.Role.Image;
 			WidgetFlags |= Gtk.WidgetFlags.AppPaintable | Gtk.WidgetFlags.NoWindow;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
@@ -73,6 +73,7 @@ namespace MonoDevelop.Components
 		
 		public Tabstrip ()
 		{
+			Accessible.SetAccessibilityRole (AtkCocoaHelper.Roles.AXTabGroup);
 			Events |= Gdk.EventMask.ButtonPressMask | Gdk.EventMask.PointerMotionMask | Gdk.EventMask.LeaveNotifyMask;
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
@@ -117,7 +117,15 @@ namespace MonoDevelop.Ide.Commands
 		void DumpGtkWidget (Gtk.Widget widget, int indent = 0)
 		{
 			string spacer = new string (' ', indent);
-			Console.WriteLine ($"{spacer}{widget.Name} - {widget.GetType ()}");
+			Console.WriteLine ($"{spacer} {widget.Accessible.Name} - {widget.GetType ()}");
+			if (widget.GetType () == typeof (Gtk.Label)) {
+				var label = (Gtk.Label)widget;
+				Console.WriteLine ($"{spacer}   {label.Text}");
+			} else if (widget.GetType () == typeof (Gtk.Button)) {
+				var button = (Gtk.Button)widget;
+				Console.WriteLine ($"{spacer}   {button.Label}");
+			}
+
 			var container = widget as Gtk.Container;
 			if (container != null) {
 				var children = container.Children;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
@@ -36,7 +36,8 @@ namespace MonoDevelop.Ide.Commands
 	/// <summary>
 	/// Copied from MonoDevelop.Ide.addin.xml
 	/// </summary>
-	public enum HelpCommands {
+	public enum HelpCommands
+	{
 		Help,
 		TipOfTheDay,
 		OpenLogDirectory,
@@ -44,13 +45,13 @@ namespace MonoDevelop.Ide.Commands
 	}
 
 	// MonoDevelop.Ide.Commands.HelpCommands.Help
-	public class HelpHandler: CommandHandler 
+	public class HelpHandler : CommandHandler
 	{
 		protected override void Run ()
 		{
 			IdeApp.HelpOperations.ShowHelp ("root:");
 		}
-		
+
 		protected override void Update (CommandInfo info)
 		{
 			if (!IdeApp.HelpOperations.CanShowHelp ("root:"))
@@ -97,7 +98,7 @@ namespace MonoDevelop.Ide.Commands
 			info.Icon = MonoDevelop.Core.BrandingService.HelpAboutIconId;
 		}
 	}
-	
+
 	class SendFeedbackHandler : CommandHandler
 	{
 		protected override void Run ()
@@ -108,6 +109,42 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			info.Visible = FeedbackService.Enabled;
+		}
+	}
+
+	class DumpUITreeHandler : CommandHandler
+	{
+		void DumpGtkWidget (Gtk.Widget widget, int indent = 0)
+		{
+			string spacer = new string (' ', indent);
+			Console.WriteLine ($"{spacer}{widget.Name} - {widget.GetType ()}");
+			var container = widget as Gtk.Container;
+			if (container != null) {
+				var children = container.Children;
+				Console.WriteLine ($"{spacer}   Number of children: {children.Length}");
+
+				foreach (var child in children) {
+					DumpGtkWidget (child, indent + 3);
+				}
+			}
+		}
+
+		protected override void Run ()
+		{
+			var windows = Gtk.Window.ListToplevels ();
+			Console.WriteLine ($"---------\nNumber of windows: {windows}");
+			foreach (var window in windows) {
+				Console.WriteLine ($"Window: {window.Title} - {window.GetType ()}");
+				DumpGtkWidget (window);
+			}
+		}
+	}
+
+	class DumpA11yTreeHandler : CommandHandler
+	{
+		protected override void Run ()
+		{
+			Components.AtkCocoaHelper.DumpAccessibilityTree ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
@@ -27,6 +27,8 @@
 
 
 using System;
+using System.Timers;
+
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Components.Commands;
@@ -153,6 +155,21 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Run ()
 		{
 			Components.AtkCocoaHelper.DumpAccessibilityTree ();
+		}
+	}
+
+	class DumpA11yTreeDelayedHandler : CommandHandler
+	{
+		Timer t;
+		protected override void Run ()
+		{
+			t = new Timer (10000);
+			t.Elapsed += (sender, e) => {
+				Components.AtkCocoaHelper.DumpAccessibilityTree ();
+				t.Dispose ();
+				t = null;
+			};
+			t.Start ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -300,6 +300,12 @@ namespace MonoDevelop.Ide.Editor
 			}
 		}
 
+		public override string TabAccessibilityDescription {
+			get {
+				return textEditorImpl.ViewContent.TabAccessibilityDescription;
+			}
+		}
+
 		public override bool IsDirty {
 			get { return textEditorImpl.ViewContent.IsDirty; }
 			set {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -44,6 +44,7 @@ using MonoDevelop.Projects.Extensions;
 using System.Linq;
 using MonoDevelop.Ide.Tasks;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 [assembly:InternalsVisibleTo("MonoDevelop.UnitTesting")]
 
@@ -2644,6 +2645,10 @@ namespace MonoDevelop.Ide.Gui.Components
 		Xwt.Drawing.Image overlayBottomRight;
 		Xwt.Drawing.Image overlayTopLeft;
 		Xwt.Drawing.Image overlayTopRight;
+
+		public ZoomableCellRendererPixbuf () : base ()
+		{
+		}
 
 		public double Zoom {
 			get { return zoom; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -242,6 +242,16 @@ namespace MonoDevelop.Ide.Gui.Components
 			tree.TestExpandRow += OnTestExpandRow;
 			tree.RowActivated += OnNodeActivated;
 			tree.DoPopupMenu += ShowPopup;
+
+			// Add an extra action handler to the tree to handle Press actions
+			var actionHandler = tree.ActionHandler;
+			var actions = new AtkCocoaHelper.Actions [actionHandler.Actions.Length + 1];
+			Array.Copy (actionHandler.Actions, actions, actionHandler.Actions.Length);
+			actions [actionHandler.Actions.Length] = AtkCocoaHelper.Actions.AXPress;
+			actionHandler.Actions = actions;
+
+			actionHandler.PerformPress += OnPerformPress;
+
 			workNode = new TreeNodeNavigator (this);
 			compareNode1 = new TreeNodeNavigator (this);
 			compareNode2 = new TreeNodeNavigator (this);
@@ -2079,6 +2089,11 @@ namespace MonoDevelop.Ide.Gui.Components
 		}
 
 		void OnNodeActivated (object sender, Gtk.RowActivatedArgs args)
+		{
+			ActivateCurrentItem ();
+		}
+
+		void OnPerformPress (object sender, EventArgs args)
 		{
 			ActivateCurrentItem ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/DirtyFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/DirtyFilesDialog.cs
@@ -28,11 +28,24 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		public DirtyFilesDialog (IReadOnlyList<Document> docs, bool closeWorkspace, bool groupByProject) :
 			base (GettextCatalog.GetString ("Save Files"), IdeApp.Workbench.RootWindow, DialogFlags.Modal)
 		{
+			Accessible.Name = "Dialog.DirtyFiles";
+
+			string description;
+			if (closeWorkspace) {
+				description = GettextCatalog.GetString ("Select which files should be saved before closing the workspace");
+			} else {
+				description = GettextCatalog.GetString ("Select which files should be saved before quitting the application");
+			}
+			Accessible.Description = description;
+
 			tsFiles = new TreeStore (typeof(string), typeof(bool), typeof(SdiWorkspaceWindow), typeof(bool));
 			tvFiles = new TreeView (tsFiles);
 			TreeIter topCombineIter = TreeIter.Zero;
 			Hashtable projectIters = new Hashtable ();
-			
+
+			tvFiles.Accessible.Name = "Dialog.DirtyFiles.FileList";
+			tvFiles.Accessible.SetAccessibilityLabel (GettextCatalog.GetString ("Dirty Files"));
+			tvFiles.Accessible.Description = GettextCatalog.GetString ("The list of files which have changes and need saving");
 			foreach (Document doc in docs) {
 				if (!doc.IsDirty)
 					continue;
@@ -81,6 +94,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			tvFiles.ExpandAll ();
 
 			ScrolledWindow sc = new ScrolledWindow ();
+			sc.Accessible.SetAccessibilityShouldIgnore (true);
 			sc.Add (tvFiles);
 			sc.ShadowType = ShadowType.In;
 
@@ -88,8 +102,32 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			this.VBox.PackStart (sc, true, true, 6);
 
 			btnSaveAndQuit = new Button (closeWorkspace ? GettextCatalog.GetString ("_Save and Quit") : GettextCatalog.GetString ("_Save and Close"));
+			btnSaveAndQuit.Accessible.Name = "Dialog.DirtyFiles.SaveAndQuit";
+
+			if (closeWorkspace) {
+				description = GettextCatalog.GetString ("Save the selected files and close the workspace");
+			} else {
+				description = GettextCatalog.GetString ("Save the selected files and quit the application");
+			}
+			btnSaveAndQuit.Accessible.Description = description;
+
 			btnQuit = new Button (closeWorkspace ? Gtk.Stock.Quit : Gtk.Stock.Close);
+			btnQuit.Accessible.Name = "Dialog.DirtyFiles.Quit";
+			if (closeWorkspace) {
+				description = GettextCatalog.GetString ("Close the workspace");
+			} else {
+				description = GettextCatalog.GetString ("Quit the application");
+			}
+			btnQuit.Accessible.Description = description;
+
 			btnCancel = new Button (Gtk.Stock.Cancel);
+			btnCancel.Accessible.Name = "Dialog.DirtyFiles.Cancel";
+			if (closeWorkspace) {
+				description = GettextCatalog.GetString ("Cancel closing the workspace");
+			} else {
+				description = GettextCatalog.GetString ("Cancel quitting the application");
+			}
+			btnCancel.Accessible.Description = description;
 
 			btnSaveAndQuit.Clicked += SaveAndQuit;
 			btnQuit.Clicked += Quit;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
@@ -87,21 +87,32 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		public OptionsDialog (MonoDevelop.Components.Window parentWindow, object dataObject, string extensionPath, bool removeEmptySections)
 		{
 			buttonCancel = new Gtk.Button (Gtk.Stock.Cancel);
+			buttonCancel.Accessible.Name = "Dialogs.Options.Cancel";
+			buttonCancel.Accessible.Description = GettextCatalog.GetString ("Close the options dialog and discard any changes");
 			AddActionWidget (this.buttonCancel, ResponseType.Cancel);
 
 			buttonOk = new Gtk.Button (Gtk.Stock.Ok);
+			buttonOk.Accessible.Name = "Dialogs.Options.Ok";
+			buttonOk.Accessible.Description = GettextCatalog.GetString ("Close the options dialog and keep the changes");
 			this.ActionArea.PackStart (buttonOk);
 			buttonOk.Clicked += OnButtonOkClicked;
 
 			mainHBox = new HBox ();
+			mainHBox.Accessible.SetAccessibilityShouldIgnore (true);
 			tree = new TreeView ();
+			tree.Accessible.Name = "Dialogs.Options.Categories";
+			tree.Accessible.Description = GettextCatalog.GetString ("The categories of options that are available in this dialog");
+
 			var sw = new ScrolledWindow ();
+			sw.Accessible.SetAccessibilityShouldIgnore (true);
 			sw.Add (tree);
 			sw.HscrollbarPolicy = PolicyType.Never;
 			sw.VscrollbarPolicy = PolicyType.Automatic;
 			sw.ShadowType = ShadowType.None;
 
 			var fboxTree = new HeaderBox ();
+			fboxTree.Accessible.SetAccessibilityShouldIgnore (true);
+
 			fboxTree.SetMargins (0, 1, 0, 1);
 			fboxTree.SetPadding (0, 0, 0, 0);
 			fboxTree.BackgroundColor = new Gdk.Color (255, 255, 255);
@@ -113,21 +124,28 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			};
 
 			var vbox = new VBox ();
+			vbox.Accessible.SetAccessibilityShouldIgnore (true);
 			mainHBox.PackStart (vbox, true, true, 0);
 			var headerBox = new HBox (false, 6);
+			headerBox.Accessible.SetAccessibilityShouldIgnore (true);
 
 			labelTitle = new Label ();
+			labelTitle.Accessible.Name = "Dialogs.Options.PageTitle";
 			labelTitle.Xalign = 0;
 			textHeader = new Alignment (0, 0, 1, 1);
+			textHeader.Accessible.SetAccessibilityShouldIgnore (true);
 			textHeader.Add (labelTitle);
 			textHeader.BorderWidth = 12;
 			headerBox.PackStart (textHeader, true, true, 0);
 
 			imageHeader = new OptionsDialogHeader ();
 			imageHeader.Hide ();
-			headerBox.PackStart (imageHeader.ToGtkWidget ());
+			var imageHeaderWidget = imageHeader.ToGtkWidget ();
+			imageHeaderWidget.Accessible.SetAccessibilityShouldIgnore (true);
+			headerBox.PackStart (imageHeaderWidget);
 
 			var fboxHeader = new HeaderBox ();
+			fboxHeader.Accessible.SetAccessibilityShouldIgnore (true);
 			fboxHeader.SetMargins (0, 1, 0, 0);
 			fboxHeader.Add (headerBox);
 //			fbox.GradientBackround = true;
@@ -147,7 +165,9 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			vbox.PackStart (fboxHeader, false, false, 0);
 
 			pageFrame = new HBox ();
+			pageFrame.Accessible.SetAccessibilityShouldIgnore (true);
 			var fbox = new HeaderBox ();
+			fbox.Accessible.SetAccessibilityShouldIgnore (true);
 			fbox.SetMargins (0, 1, 0, 0);
 			fbox.ShowTopShadow = true;
 			fbox.Add (pageFrame);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -121,68 +121,84 @@ namespace MonoDevelop.Ide.Gui.Pads
 			get { return "MonoDevelop.Ide.Gui.Pads.ErrorListPad"; }
 		}
 
+		ToggleButton MakeButton (string image, string name, bool active, out Label label)
+		{
+			var btnBox = new HBox (false, 2);
+			btnBox.Accessible.SetAccessibilityShouldIgnore (true);
+			var imageView = new ImageView (image, Gtk.IconSize.Menu);
+			imageView.Accessible.SetAccessibilityShouldIgnore (true);
+			btnBox.PackStart (imageView);
+
+			label = new Label ();
+			label.Accessible.SetAccessibilityShouldIgnore (true);
+			btnBox.PackStart (label);
+
+			var btn = new ToggleButton { Name = name };
+			btn.Active = active;
+			btn.Child = btnBox;
+
+			return btn;
+		}
+
 		protected override void Initialize (IPadWindow window)
 		{
 			window.Title = GettextCatalog.GetString ("Errors");
 
 			DockItemToolbar toolbar = window.GetToolbar (DockPositionType.Top);
+			toolbar.Accessible.Name = "ErrorPad.Toolbar";
+			toolbar.Accessible.SetAccessibilityLabel ("Error Pad Toolbar");
+			toolbar.Accessible.SetAccessibilityRole ("AXToolbar", "Pad toolbar");
+			toolbar.Accessible.Description = GettextCatalog.GetString ("The Error pad toolbar");
 
-			var btnBox = new HBox (false, 2);
-			btnBox.PackStart (new ImageView (Stock.Error, Gtk.IconSize.Menu));
-			errorBtnLbl = new Label ();
-			btnBox.PackStart (errorBtnLbl);
+			errorBtn = MakeButton (Stock.Error, "toggleErrors", ShowErrors, out errorBtnLbl);
+			errorBtn.Accessible.Name = "ErrorPad.ErrorButton";
 
-			errorBtn = new ToggleButton { Name = "toggleErrors" };
-			errorBtn.Active = ShowErrors;
-			errorBtn.Child = btnBox;
 			errorBtn.Toggled += new EventHandler (FilterChanged);
 			errorBtn.TooltipText = GettextCatalog.GetString ("Show Errors");
+			errorBtn.Accessible.Description = GettextCatalog.GetString ("Show Errors");
 			UpdateErrorsNum();
 			toolbar.Add (errorBtn);
 
-			btnBox = new HBox (false, 2);
-			btnBox.PackStart (new ImageView (Stock.Warning, Gtk.IconSize.Menu));
-			warnBtnLbl = new Label ();
-			btnBox.PackStart (warnBtnLbl);
-
-			warnBtn = new ToggleButton  { Name = "toggleWarnings" };
-			warnBtn.Active = ShowWarnings;
-			warnBtn.Child = btnBox;
+			warnBtn = MakeButton (Stock.Warning, "toggleWarnings", ShowWarnings, out warnBtnLbl);
+			warnBtn.Accessible.Name = "ErrorPad.WarningButton";
 			warnBtn.Toggled += new EventHandler (FilterChanged);
 			warnBtn.TooltipText = GettextCatalog.GetString ("Show Warnings");
+			warnBtn.Accessible.Description = GettextCatalog.GetString ("Show Warnings");
 			UpdateWarningsNum();
 			toolbar.Add (warnBtn);
 
-			btnBox = new HBox (false, 2);
-			btnBox.PackStart (new ImageView (Stock.Information, Gtk.IconSize.Menu));
-			msgBtnLbl = new Label ();
-			btnBox.PackStart (msgBtnLbl);
-
-			msgBtn = new ToggleButton  { Name = "toggleMessages" };
-			msgBtn.Active = ShowMessages;
-			msgBtn.Child = btnBox;
+			msgBtn = MakeButton (Stock.Information, "toggleMessages", ShowMessages, out msgBtnLbl);
+			msgBtn.Accessible.Name = "ErrorPad.MessageButton";
 			msgBtn.Toggled += new EventHandler (FilterChanged);
 			msgBtn.TooltipText = GettextCatalog.GetString ("Show Messages");
+			msgBtn.Accessible.Description = GettextCatalog.GetString ("Show Messages");
 			UpdateMessagesNum();
 			toolbar.Add (msgBtn);
-			
-			toolbar.Add (new SeparatorToolItem ());
 
-			btnBox = new HBox (false, 2);
-			btnBox.PackStart (new ImageView ("md-message-log", Gtk.IconSize.Menu));
-			logBtnLbl = new Label (GettextCatalog.GetString ("Build Output"));
-			btnBox.PackStart (logBtnLbl);
+			var sep = new SeparatorToolItem ();
+			sep.Accessible.SetAccessibilityShouldIgnore (true);
+			toolbar.Add (sep);
 
-			logBtn = new ToggleButton { Name = "toggleBuildOutput" };
-			logBtn.Child = btnBox;
+			logBtn = MakeButton ("md-message-log", "toggleBuildOutput", false, out logBtnLbl);
+			logBtn.Accessible.Name = "ErrorPad.LogButton";
 			logBtn.TooltipText = GettextCatalog.GetString ("Show build output");
+			logBtn.Accessible.Description = GettextCatalog.GetString ("Show build output");
+
+			logBtnLbl.Text = GettextCatalog.GetString ("Build Output");
+			logBtn.Accessible.SetAccessibilityTitle (logBtnLbl.Text);
+
 			logBtn.Toggled += HandleLogBtnToggled;
 			toolbar.Add (logBtn);
 
 			//Dummy widget to take all space between "Build Output" button and SearchEntry
-			toolbar.Add (new HBox (), true);
+			var spacer = new HBox ();
+			spacer.Accessible.SetAccessibilityShouldIgnore (true);
+			toolbar.Add (spacer, true);
 
 			searchEntry = new SearchEntry ();
+			searchEntry.Accessible.SetAccessibilityLabel (GettextCatalog.GetString ("Search"));
+			searchEntry.Accessible.Name = "ErrorPad.Search";
+			searchEntry.Accessible.Description = GettextCatalog.GetString ("Search the error data");
 			searchEntry.Entry.Changed += searchPatternChanged;
 			searchEntry.WidthRequest = 200;
 			searchEntry.Visible = true;
@@ -911,16 +927,19 @@ namespace MonoDevelop.Ide.Gui.Pads
 		void UpdateErrorsNum () 
 		{
 			errorBtnLbl.Text = " " + string.Format(GettextCatalog.GetPluralString("{0} Error", "{0} Errors", errorCount), errorCount);
+			errorBtn.Accessible.SetAccessibilityTitle (errorBtnLbl.Text);
 		}
 
 		void UpdateWarningsNum ()
 		{
 			warnBtnLbl.Text = " " + string.Format(GettextCatalog.GetPluralString("{0} Warning", "{0} Warnings", warningCount), warningCount);
+			warnBtn.Accessible.SetAccessibilityTitle (warnBtnLbl.Text);
 		}
 
 		void UpdateMessagesNum ()
 		{
 			msgBtnLbl.Text = " " + string.Format(GettextCatalog.GetPluralString("{0} Message", "{0} Messages", infoCount), infoCount);
+			msgBtn.Accessible.SetAccessibilityTitle (msgBtnLbl.Text);
 		}
 
 		void UpdatePadIcon ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BackgroundProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BackgroundProgressMonitor.cs
@@ -45,6 +45,8 @@ namespace MonoDevelop.Ide.Gui
 				Application.Invoke (delegate {
 					var img = ImageService.GetIcon (iconName, IconSize.Menu);
 					icon = IdeApp.Workbench.StatusBar.ShowStatusIcon (img);
+					icon.Title = GettextCatalog.GetString ("Background Progress");
+					icon.Help = GettextCatalog.GetString ("An operation is occuring in the background");
 					if (icon == null)
 						LoggingService.LogError ("Icon '" + iconName + "' not found.");
 				});

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BaseViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BaseViewContent.cs
@@ -59,6 +59,12 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
+		public virtual string TabAccessibilityDescription {
+			get {
+				return string.Empty;
+			}
+		}
+
 		public virtual bool CanReuseView (string fileName)
 		{
 			return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -845,7 +845,13 @@ namespace MonoDevelop.Ide.Gui
 
 		void CreateComponents ()
 		{
+			Accessible.Name = "MainWindow";
+
 			fullViewVBox = new VBox (false, 0);
+			fullViewVBox.Accessible.Name = "MainWindow.Root";
+			fullViewVBox.Accessible.SetAccessibilityLabel ("Label");
+			fullViewVBox.Accessible.SetAccessibilityShouldIgnore (true);
+
 			rootWidget = fullViewVBox;
 			
 			InstallMenuBar ();
@@ -854,6 +860,8 @@ namespace MonoDevelop.Ide.Gui
 			DesktopService.SetMainWindowDecorations (this);
 			DesktopService.AttachMainToolbar (fullViewVBox, toolbar);
 			toolbarFrame = new CommandFrame (IdeApp.CommandService);
+			toolbarFrame.Accessible.Name = "MainWindow.Root.ToolbarFrame";
+			toolbarFrame.Accessible.SetAccessibilityShouldIgnore (true);
 
 			fullViewVBox.PackStart (toolbarFrame, true, true, 0);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -100,6 +100,7 @@ namespace MonoDevelop.Ide.Gui
 			extensionContext.RegisterCondition ("FileType", fileTypeCondition);
 			
 			box = new VBox ();
+			box.Accessible.SetAccessibilityShouldIgnore (true);
 
 			viewContents.Add (content);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -621,6 +621,7 @@ namespace MonoDevelop.Ide.Gui
 			var tab = new Tab (subViewToolbar, label) {
 				Tag = viewContent
 			};
+			tab.Accessible.SetAccessibilityHelp (viewContent.TabAccessibilityDescription);
 			
 			// If this is the current displayed document we need to add the control immediately as the tab is already active.
 			if (addedContent) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusBarIcon.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusBarIcon.cs
@@ -57,9 +57,21 @@ namespace MonoDevelop.Ide
 	public interface StatusBarIcon : IDisposable
 	{
 		/// <summary>
+		/// The title of the status icon. Used for accessibility
+		/// </summary>
+		/// <value>The title.</value>
+		string Title { get; set; }
+
+		/// <summary>
 		/// Tooltip of the status icon
 		/// </summary>
 		string ToolTip { get; set; }
+
+		/// <summary>
+		/// The accessibility help message for the button
+		/// </summary>
+		/// <value>The help.</value>
+		string Help { get; set; }
 
 		/// <summary>
 		/// The clicked event to subscribe mouse clicks on the icon.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/AddinsUpdateHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/AddinsUpdateHandler.cs
@@ -88,6 +88,8 @@ namespace MonoDevelop.Ide.Updater
 				s += "\n...";
 
 			updateIcon.ToolTip = s;
+			updateIcon.Title = GettextCatalog.GetString ("Updates");
+			updateIcon.Help = GettextCatalog.GetString ("Indicates that there are updates available to be installed");
 			updateIcon.SetAlertMode (20);
 			updateIcon.Clicked += OnUpdateClicked;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/DefaultWelcomePage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/DefaultWelcomePage.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using MonoDevelop.Core;
+using MonoDevelop.Components;
 using Gtk;
 
 namespace MonoDevelop.Ide.WelcomePage
@@ -37,8 +38,10 @@ namespace MonoDevelop.Ide.WelcomePage
 			TopBorderImage = Xwt.Drawing.Image.FromResource ("welcome-tile.png");
 
 			var mainAlignment = new Gtk.Alignment (0.5f, 0.5f, 0f, 1f);
+			mainAlignment.Accessible.SetAccessibilityShouldIgnore (true);
 
 			var mainCol = new WelcomePageColumn ();
+			mainCol.Accessible.SetAccessibilityShouldIgnore (true);
 			mainAlignment.Add (mainCol);
 
 			var row1 = new WelcomePageRow ();
@@ -49,6 +52,7 @@ namespace MonoDevelop.Ide.WelcomePage
 				new WelcomePageBarButton (GettextCatalog.GetString ("Q&A"), "http://stackoverflow.com/questions/tagged/monodevelop", "welcome-link-chat-16.png")
 				)
 			);
+			row1.Accessible.SetAccessibilityShouldIgnore (true);
 			mainCol.PackStart (row1, false, false, 0);
 
 			var row2 = new WelcomePageRow (
@@ -62,6 +66,7 @@ namespace MonoDevelop.Ide.WelcomePage
 					new WelcomePageTipOfTheDaySection ()
 				)
 			);
+			row2.Accessible.SetAccessibilityShouldIgnore (true);
 			mainCol.PackStart (row2, false, false, 0);
 
 			parent.Add (mainAlignment);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageBarButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageBarButton.cs
@@ -82,7 +82,9 @@ namespace MonoDevelop.Ide.WelcomePage
 			Accessible.Role = Atk.Role.Link;
 
 			Accessible.SetAccessibilityTitle (title);
-			Accessible.SetAccessibilityURL (href);
+			if (!string.IsNullOrEmpty (href)) {
+				Accessible.SetAccessibilityURL (href);
+			}
 			Accessible.Description = "Opens the link in a web browser";
 
 			UpdateStyle ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageBarButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageBarButton.cs
@@ -74,6 +74,17 @@ namespace MonoDevelop.Ide.WelcomePage
 
 		public WelcomePageBarButton (string title, string href, string iconResource = null)
 		{
+			var actionHandler = new AtkCocoaHelper.ActionDelegate ();
+			actionHandler.Actions = new AtkCocoaHelper.Actions [] { AtkCocoaHelper.Actions.AXPress };
+			actionHandler.PerformPress += HandlePress;
+
+			Accessible.SetActionDelegate (actionHandler);
+			Accessible.Role = Atk.Role.Link;
+
+			Accessible.SetAccessibilityTitle (title);
+			Accessible.SetAccessibilityURL (href);
+			Accessible.Description = "Opens the link in a web browser";
+
 			UpdateStyle ();
 
 			VisibleWindow = false;
@@ -84,10 +95,16 @@ namespace MonoDevelop.Ide.WelcomePage
 				imageNormal = imageHover.WithAlpha (0.7);
 			}
 
+			box.Accessible.SetAccessibilityShouldIgnore (true);
+
 			IconTextSpacing = Styles.WelcomeScreen.Links.IconTextSpacing;
 			image = new Xwt.ImageView ();
 			label = CreateLabel ();
 			imageWidget = image.ToGtkWidget ();
+
+			label.Accessible.SetAccessibilityShouldIgnore (true);
+			imageWidget.Accessible.SetAccessibilityShouldIgnore (true);
+
 			box.PackStart (imageWidget, false, false, 0);
 			if (imageNormal == null)
 				imageWidget.NoShowAll = true;
@@ -166,6 +183,11 @@ namespace MonoDevelop.Ide.WelcomePage
 				return true;
 			}
 			return base.OnButtonReleaseEvent (evnt);
+		}
+
+		void HandlePress (object sender, EventArgs args)
+		{
+			OnClicked ();
 		}
 
 		protected virtual void OnClicked ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageButtonBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageButtonBar.cs
@@ -37,9 +37,15 @@ namespace MonoDevelop.Ide.WelcomePage
 	{
 		public WelcomePageButtonBar (params WelcomePageBarButton[] buttons)
 		{
+			Accessible.Name = "WelcomePage.ButtonBar";
+
 			Spacing = Styles.WelcomeScreen.Links.LinkSeparation;
 
+			int idx = 1;
 			foreach (var button in buttons) {
+				button.Accessible.Name = string.Format ("WelcomePage.ButtonBar.Button{0}", idx);
+				idx++;
+
 				if (!button.IsVisible)
 					continue;
 				PackStart (button, false, false, 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageColumn.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageColumn.cs
@@ -26,12 +26,16 @@
 using System;
 using Gtk;
 
+using MonoDevelop.Components;
+
 namespace MonoDevelop.Ide.WelcomePage
 {
 	public class WelcomePageColumn: Gtk.VBox
 	{
 		public WelcomePageColumn ()
 		{
+			Accessible.SetAccessibilityShouldIgnore (true);
+
 			Spacing = Styles.WelcomeScreen.Spacing;
 			MinWidth = -1;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageFrame.cs
@@ -47,7 +47,11 @@ namespace MonoDevelop.Ide.WelcomePage
 
 		public WelcomePageFrame (Gtk.Widget w)
 		{
+			Accessible.Name = "WelcomePageFrame";
+
 			VBox box = new VBox ();
+			box.Accessible.SetAccessibilityShouldIgnore (true);
+
 			box.Show ();
 			projectBar = new WelcomePageProjectBar ();
 			box.PackStart (projectBar, false, false, 0);
@@ -128,14 +132,17 @@ namespace MonoDevelop.Ide.WelcomePage
 
 		public WelcomePageProjectBar ()
 		{
+			Accessible.Name = "WelcomePageProjectBar";
 			SetPadding (3, 3, 12, 12);
 			GradientBackground = true;
 
 			HBox box = new HBox (false, 6);
 			box.PackStart (messageLabel = new Gtk.Label () { Xalign = 0 }, true, true, 0);
 			backButton = new Gtk.Button ();
+			backButton.Accessible.Name = "WelcomePageProjectBar.BackButton";
 			box.PackEnd (backButton, false, false, 0);
 			closeButton = new Gtk.Button ();
+			closeButton.Accessible.Name = "WelcomePageProjectBar.CloseButton";
 			box.PackEnd (closeButton, false, false, 0);
 
 			closeButton.Clicked += delegate {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageLinkButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageLinkButton.cs
@@ -1,21 +1,21 @@
-// 
+//
 // WelcomePageLinkButton.cs
-//  
+//
 // Author:
 //       Michael Hutchinson <mhutch@xamarin.com>
-// 
+//
 // Copyright (c) 2011 Xamarin Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageNewsFeed.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageNewsFeed.cs
@@ -27,6 +27,7 @@
 using Gtk;
 using System;
 using MonoDevelop.Core;
+using MonoDevelop.Components;
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Linq;
@@ -46,7 +47,12 @@ namespace MonoDevelop.Ide.WelcomePage
 		
 		public WelcomePageNewsFeed (string title, string newsUrl, string id, int limit = 5, int spacing = Styles.WelcomeScreen.Pad.News.Item.MarginBottom): base (title)
 		{
+			Accessible.Name = "WelcomePage.NewsFeed";
+			Accessible.Description = "A list of new items";
+
 			box = new VBox (false, spacing);
+			box.Accessible.SetAccessibilityShouldIgnore (true);
+
 			if (string.IsNullOrEmpty (newsUrl))
 				throw new Exception ("News feed is missing src attribute");
 			if (string.IsNullOrEmpty (id))
@@ -81,6 +87,8 @@ namespace MonoDevelop.Ide.WelcomePage
 		protected virtual void AddNewsItem (VBox box, Gtk.Widget newsItem)
 		{
 			box.PackStart (newsItem, true, false, 0);
+
+			SetAccessibilityTitledWidget (newsItem);
 		}
 
 		void LoadNews ()
@@ -90,6 +98,7 @@ namespace MonoDevelop.Ide.WelcomePage
 				return;
 
 			foreach (var c in box.Children) {
+				RemoveAccessibiltyTitledWidget (c);
 				box.Remove (c);
 				c.Destroy ();
 			}
@@ -98,13 +107,21 @@ namespace MonoDevelop.Ide.WelcomePage
 				var news = GetNewsXml ();
 				if (news.FirstNode == null) {
 					var label = new Label (GettextCatalog.GetString ("No news found.")) { Xalign = 0, Xpad = 6 };
+					label.Accessible.Name = "WelcomePage.NewsFeed.NoNews";
 
 					box.PackStart (label, true, false, 0);
 				} else {
-					foreach (var child in OnLoadNews (news).Take (limit))
+					int idx = 1;
+					foreach (var child in OnLoadNews (news).Take (limit)) {
+						child.Accessible.Name = string.Format ("WelcomePage.NewsFeed.NewsItem-{0}", idx);
 						AddNewsItem (box, child);
+						idx++;
+					}
 				}
-				box.PackStart (new Label(), true, false, 4);
+
+				var spacerLabel = new Label ();
+				spacerLabel.Accessible.SetAccessibilityShouldIgnore (true);
+				box.PackStart (spacerLabel, true, false, 4);
 
 			} catch (Exception ex) {
 				LoggingService.LogWarning ("Error loading news feed.", ex);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageRecentProjectsList.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageRecentProjectsList.cs
@@ -32,6 +32,8 @@ using System.Collections.Generic;
 using MonoDevelop.Ide.Desktop;
 using System.Xml.Linq;
 
+using MonoDevelop.Components;
+
 namespace MonoDevelop.Ide.WelcomePage
 {
 	public class WelcomePageRecentProjectsList : WelcomePageSection
@@ -51,9 +53,10 @@ namespace MonoDevelop.Ide.WelcomePage
 			itemCount = count;
 			
 			DesktopService.RecentFiles.Changed += RecentFilesChanged;
-			RecentFilesChanged (null, null);
 
 			SetContent (box);
+			RecentFilesChanged (null, null);
+
 			TitleAlignment.BottomPadding = Styles.WelcomeScreen.Pad.Solutions.LargeTitleMarginBottom;
 			ContentAlignment.LeftPadding = 0;
 			ContentAlignment.RightPadding = 0;
@@ -73,32 +76,49 @@ namespace MonoDevelop.Ide.WelcomePage
 				return;
 			
 			foreach (var c in box.Children) {
+				RemoveAccessibiltyTitledWidget (c);
 				box.Remove (c);
 				c.Destroy ();
 			}
 
 			Gtk.HBox hbox = new HBox ();
+			hbox.Accessible.SetAccessibilityShouldIgnore (true);
+
 			var btn = new WelcomePageListButton (GettextCatalog.GetString ("New..."), null, newProjectIcon, "monodevelop://MonoDevelop.Ide.Commands.FileCommands.NewProject");
+			btn.Accessible.Description = "Create a new solution";
+			btn.Accessible.Name = "WelcomePage.RecentSolutions.NewButton";
 			btn.WidthRequest = (int) (Styles.WelcomeScreen.Pad.Solutions.SolutionTile.Width / 2.3);
 			btn.BorderPadding = 6;
 			btn.LeftTextPadding = 24;
 			hbox.PackStart (btn, false, false, 0);
+
+			SetAccessibilityTitledWidget (btn);
 
 			btn = new WelcomePageListButton (GettextCatalog.GetString ("Open..."), null, openProjectIcon, "monodevelop://MonoDevelop.Ide.Commands.FileCommands.OpenFile");
+			btn.Accessible.Description = "Open an existing solution";
+			btn.Accessible.Name = "WelcomePage.RecentSolutions.OpenButton";
 			btn.WidthRequest = (int) (Styles.WelcomeScreen.Pad.Solutions.SolutionTile.Width / 2.3);
 			btn.BorderPadding = 6;
 			btn.LeftTextPadding = 24;
 			hbox.PackStart (btn, false, false, 0);
 
+			SetAccessibilityTitledWidget (btn);
+
 			box.PackStart (hbox, false, false, 0);
-			
+
 			//TODO: pinned files
+			int idx = 1;
 			foreach (var recent in DesktopService.RecentFiles.GetProjects ().Take (itemCount)) {
 				var filename = recent.FileName;
 
 				var accessed = recent.TimeStamp;
 				var pixbuf = ImageService.GetIcon (GetIcon (filename), IconSize.Dnd);
 				var button = new WelcomePageListButton (recent.DisplayName, System.IO.Path.GetDirectoryName (filename), pixbuf, "project://" + filename);
+
+				button.Accessible.SetAccessibilityURL ("file://" + filename);
+				button.Accessible.Name = string.Format ("WelcomePage.RecentSolutions.RecentFile{0}", idx);
+				idx++;
+
 				button.BorderPadding = 2;
 				button.AllowPinning = true;
 				button.Pinned = recent.IsFavorite;
@@ -112,6 +132,8 @@ namespace MonoDevelop.Ide.WelcomePage
 				box.PackStart (button, false, false, 0);
 				var pinClickHandler = new PinClickHandler (filename);
 				pinClickHandler.Register (button);
+
+				SetAccessibilityTitledWidget (button);
 			}
 
 			this.ShowAll ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageSection.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageSection.cs
@@ -56,19 +56,28 @@ namespace MonoDevelop.Ide.WelcomePage
 
 		public WelcomePageSection (string title = null)
 		{
+			if (!string.IsNullOrEmpty (title)) {
+				Accessible.SetAccessibilityTitle (title);
+			}
+
 			this.title = title;
 			VisibleWindow = false;
+			root.Accessible.SetAccessibilityShouldIgnore (true);
 			Add (root);
+
 			root.Show ();
 
 			uint p = Styles.WelcomeScreen.Pad.ShadowSize * 2;
 			root.SetPadding (p, p, p, p);
 
 			TitleAlignment = new Alignment (0f, 0f, 1f, 1f);
+			TitleAlignment.Accessible.SetAccessibilityShouldIgnore (true);
 			p = Styles.WelcomeScreen.Pad.Padding;
 			TitleAlignment.SetPadding (p, Styles.WelcomeScreen.Pad.LargeTitleMarginBottom, p, p);
+
 			ContentAlignment = new Alignment (0f, 0f, 1f, 1f);
 			ContentAlignment.SetPadding (0, p, p, p);
+			ContentAlignment.Accessible.SetAccessibilityShouldIgnore (true);
 
 			Gui.Styles.Changed += UpdateStyle;
 		}
@@ -91,6 +100,8 @@ namespace MonoDevelop.Ide.WelcomePage
 			}
 
 			var box = new VBox ();
+			box.Accessible.SetAccessibilityShouldIgnore (true);
+
 			label = new Label () { Markup = string.Format (headerFormat, title), Xalign = (uint) 0 };
 			TitleAlignment.Add (label);
 			box.PackStart (TitleAlignment, false, false, 0);
@@ -169,6 +180,32 @@ namespace MonoDevelop.Ide.WelcomePage
 			} catch (Exception ex) {
 				LoggingService.LogInternalError (GettextCatalog.GetString ("Could not open the url '{0}'", uri), ex);
 			}
+		}
+
+		// Accessible widgets can say what other widget acts as their title
+		// so use this to set the Section title to be that title
+		//
+		// The content cannot automatically be set because it might be ignored
+		// by accessibility
+		//
+		// This must be called after setContent, otherwise label will be null
+		protected void SetAccessibilityTitledWidget (Widget widget)
+		{
+			if (label == null) {
+				return;
+			}
+
+			widget.Accessible.SetAccessibilityTitleUIElement (label.Accessible);
+			label.Accessible.AccessibilityAddElementToTitle (widget.Accessible);
+		}
+
+		protected void RemoveAccessibiltyTitledWidget (Widget widget)
+		{
+			if (label == null) {
+				return;
+			}
+
+			label.Accessible.AccessibilityRemoveElementFromTitle (widget.Accessible);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageTipOfTheDaySection.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageTipOfTheDaySection.cs
@@ -29,6 +29,8 @@ using System.Xml;
 using System.Collections.Generic;
 using MonoDevelop.Ide.Fonts;
 
+using MonoDevelop.Components;
+
 namespace MonoDevelop.Ide.WelcomePage
 {
 	public class WelcomePageTipOfTheDaySection: WelcomePageSection
@@ -52,8 +54,13 @@ namespace MonoDevelop.Ide.WelcomePage
 				currentTip = -1;
 
 			Gtk.VBox box = new Gtk.VBox (false, 12);
+			box.Accessible.SetAccessibilityShouldIgnore (true);
 
 			label = new Gtk.Label ();
+
+			label.Accessible.Name = "WelcomePage.TipOfTheDay.TipLabel";
+			label.Accessible.Description = "A tip for using MonoDevelop";
+
 			label.Xalign = 0;
 			label.Wrap = true;
 			label.WidthRequest = 200;
@@ -64,6 +71,9 @@ namespace MonoDevelop.Ide.WelcomePage
 			box.PackStart (label, true, true, 0);
 
 			var next = new Gtk.Button (GettextCatalog.GetString ("Next Tip"));
+			next.Accessible.Name = "WelcomePage.TipOfTheDay.NextButton";
+			next.Accessible.Description = "Show the next tip";
+
 			next.Relief = Gtk.ReliefStyle.Normal;
 			next.Clicked += delegate {
 				if (tips.Count == 0)
@@ -75,9 +85,13 @@ namespace MonoDevelop.Ide.WelcomePage
 			};
 
 			var al = new Gtk.Alignment (0, 0, 0, 0);
+			al.Accessible.SetAccessibilityShouldIgnore (true);
 			al.Add (next);
 			box.PackStart (al, false, false, 0);
 			SetContent (box);
+
+			SetAccessibilityTitledWidget (label);
+			SetAccessibilityTitledWidget (next);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageWidget.cs
@@ -77,17 +77,22 @@ namespace MonoDevelop.Ide.WelcomePage
 			LogoHeight = 90;
 
 			var background = new WelcomePageWidgetBackground ();
+			background.Accessible.SetAccessibilityShouldIgnore (true);
 			Background = background;
 			background.Owner = this;
 			var mainAlignment = new Gtk.Alignment (0f, 0f, 1f, 1f);
+			mainAlignment.Accessible.SetAccessibilityShouldIgnore (true);
 			background.Add (mainAlignment);
 
 			BuildContent (mainAlignment);
 
 			if (ShowScrollbars) {
 				var scroller = new ScrolledWindow ();
+				scroller.Accessible.SetAccessibilityShouldIgnore (true);
 				scroller.AddWithViewport (background);
 				((Gtk.Viewport)scroller.Child).ShadowType = ShadowType.None;
+				scroller.Child.Accessible.SetAccessibilityShouldIgnore (true);
+
 				scroller.ShadowType = ShadowType.None;
 				scroller.FocusChain = new Widget[] { background };
 				scroller.Show ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -8956,6 +8956,7 @@
     <Compile Include="MonoDevelop.Components\XwtBoxTooltip.cs" />
     <Compile Include="MonoDevelop.Components\MDSpinner.cs" />
     <Compile Include="MonoDevelop.Components\RoundedFrameBox.cs" />
+    <Compile Include="MonoDevelop.Components\AtkCocoaHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -486,7 +486,9 @@ namespace MonoDevelop.Ide
 			if (IdeApp.Preferences.EnableInstrumentation) {
 				if (instrumentationStatusIcon == null) {
 					instrumentationStatusIcon = IdeApp.Workbench.StatusBar.ShowStatusIcon (ImageService.GetIcon (MonoDevelop.Ide.Gui.Stock.StatusInstrumentation));
-					instrumentationStatusIcon.ToolTip = "Instrumentation service enabled";
+					instrumentationStatusIcon.Title = GettextCatalog.GetString ("Instrumentation");
+					instrumentationStatusIcon.ToolTip = GettextCatalog.GetString ("Instrumentation service enabled");
+					instrumentationStatusIcon.Help = GettextCatalog.GetString ("Information about the Instrumentation Service");
 					instrumentationStatusIcon.Clicked += delegate {
 						InstrumentationService.StartMonitor ();
 					};

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=22b588e355661c6dbc3bd72474dbd3e5ab1ca60e
+DEP_NEEDED_VERSION[0]=8b32ba3e00379616a7482280fccf8ab75d8aaa54
 DEP_BRANCH_AND_REMOTE[0]="a11y origin/a11y"
 
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=d039cfb31005da4496e2811dd6813b89b906bf54
-DEP_BRANCH_AND_REMOTE[0]="master origin/master"
+DEP_NEEDED_VERSION[0]=dd453516f45c27cb831fc33c787cc13fd4d47d24
+DEP_BRANCH_AND_REMOTE[0]="a11y origin/a11y"
 
 # heap-shot
 DEP[1]=heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=dd453516f45c27cb831fc33c787cc13fd4d47d24
+DEP_NEEDED_VERSION[0]=22b588e355661c6dbc3bd72474dbd3e5ab1ca60e
 DEP_BRANCH_AND_REMOTE[0]="a11y origin/a11y"
 
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=8b32ba3e00379616a7482280fccf8ab75d8aaa54
+DEP_NEEDED_VERSION[0]=7a9611f8d811f31f415420670da1fcd6bd7ccc82
 DEP_BRANCH_AND_REMOTE[0]="a11y origin/a11y"
 
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=7a9611f8d811f31f415420670da1fcd6bd7ccc82
+DEP_NEEDED_VERSION[0]=2b963db5ab8ecc458106abe54b4ea15924300b5a
 DEP_BRANCH_AND_REMOTE[0]="a11y origin/a11y"
 
 # heap-shot


### PR DESCRIPTION
Requires Xamarin.Mac 2.9.2+ (master)

Adds initial work to make the Cocoa parts of the toolbar accessible.
- Run button
- Status bar
- Search bar
- The Debug button bar is partly accessible, and the runtime/configuration selector is not. I need to investigate some more about how accessibility works with them.
- The Button bar needed some new API to make it nicer for accessibility, but I've left in the old API so it won't break. If people use the old API then it just won't be accessible.
