### PR TITLE
[Refactoring] Fix analysis tasks not cleared on solution being closed

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/AnalyzeCurrentProjectHandler.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/AnalyzeCurrentProjectHandler.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.Refactoring
 					}).ConfigureAwait (false);
 
 					await Runtime.RunInMainThread (delegate {
-						AnalyzeWholeSolutionHandler.Report (monitor, allDiagnostics);
+						AnalyzeWholeSolutionHandler.Report (monitor, allDiagnostics, project);
 					}).ConfigureAwait (false);
 				}
 			} catch (OperationCanceledException) {


### PR DESCRIPTION
After analyzing the source the diagnostic errors and warnings are
added to TaskService and displayed in the Errors window. On closing
the solution and then opening another solution the status bar would
still show the warning and error icons for these diagnostics tasks.

The tasks created for the analysis errors and warnings are now
associated with the project or solution so they are removed when
the solution is closed.