### PR TITLE
[Ide] Fix welcome page items not always being displayed

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
@@ -86,6 +86,7 @@ namespace MonoDevelop.Ide.Desktop
 					cachedItemList = ReadStore (stream);
 					cachedItemList.Sort ();
 				}
+				OnRecentFilesChanged (cachedItemList);
 			});
 		}
 		


### PR DESCRIPTION
Fixed bug #42187 - Welcome page items randomly disappear/reappear
https://bugzilla.xamarin.com/show_bug.cgi?id=42187

Sometimes the welcome page can load before the recently used items
are loaded. This results in only the pinned/favourited projects being
displayed on the welcome page and other recently used projects are
not shown.