### PR TITLE
[Ide] Optimize RecentFiles updates.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
@@ -347,21 +347,46 @@ namespace MonoDevelop.Ide.Desktop
 		{
 			return fileName.StartsWith ("file://") ? fileName : "file://" + fileName;
 		}
-		
+
+		RecentItemUnionComparer comparer = new RecentItemUnionComparer ();
 		void OnRecentFilesChanged (List<RecentItem> list)
 		{
+			string[] union;
 			lock (cacheLock) {
+				union = cachedItemList
+					// Filter what changed only.
+					.Except (list, comparer)
+					.Concat (list.Except (cachedItemList, comparer))
+					// Get the distinct groups
+					.SelectMany (it => it.Groups)
+					.Distinct ()
+					.ToArray ();
 				cachedItemList = list;
 			}
 
-			Runtime.RunInMainThread (() => {
-				if (changed != null)
-					changed (this, EventArgs.Empty);
-			});
+			if (union.Length > 0) {
+				Runtime.RunInMainThread (() => {
+					if (changed != null)
+						changed (this, new RecentItemsChangedEventArgs (union));
+				});
+			}
 		}
-		
-		EventHandler changed;
-		public event EventHandler RecentFilesChanged {
+
+		class RecentItemUnionComparer : IEqualityComparer<RecentItem>
+		{
+			public bool Equals (RecentItem x, RecentItem y)
+			{
+				return x.Uri.Equals (y.Uri) && x.Timestamp.Equals (y.Timestamp);
+			}
+
+			public int GetHashCode (RecentItem obj)
+			{
+				return obj.Uri.GetHashCode () ^ obj.Timestamp.GetHashCode ();
+			}
+		}
+
+		EventHandler<RecentItemsChangedEventArgs> changed;
+		public event EventHandler<RecentItemsChangedEventArgs> RecentFilesChanged {
 			add {
 				lock (this) {
 					if (changed == null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentItemsChangedEventArgs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentItemsChangedEventArgs.cs
@@ -1,0 +1,40 @@
+﻿//
+// RecentItemsChangedEventArgs.cs
+//
+// Author:
+//       therzok <marius.ungureanu@xamarin.com>
+//
+// Copyright (c) 2016 (c) Marius Ungureanu
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+
+namespace MonoDevelop.Ide.Desktop
+{
+	class RecentItemsChangedEventArgs : EventArgs
+	{
+		public IEnumerable<string> Groups { get; }
+
+		public RecentItemsChangedEventArgs (IEnumerable<string> groups)
+		{
+			Groups = groups;
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageRecentProjectsList.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageRecentProjectsList.cs
@@ -50,7 +50,7 @@ namespace MonoDevelop.Ide.WelcomePage
 
 			itemCount = count;
 			
-			DesktopService.RecentFiles.Changed += RecentFilesChanged;
+			DesktopService.RecentFiles.ProjectsChanged += RecentFilesChanged;
 			RecentFilesChanged (null, null);
 
 			SetContent (box);
@@ -63,7 +63,7 @@ namespace MonoDevelop.Ide.WelcomePage
 		{
 			destroyed = true;
 			base.OnDestroyed ();
-			DesktopService.RecentFiles.Changed -= RecentFilesChanged;
+			DesktopService.RecentFiles.ProjectsChanged -= RecentFilesChanged;
 		}
 
 		void RecentFilesChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -8555,6 +8555,7 @@
     <Compile Include="MonoDevelop.Ide.Editor.Extension\AutoInsertBracketTextEditorExtension.cs" />
     <Compile Include="MonoDevelop.Ide.Extensions\ErrorDocumentationProvider.cs" />
     <Compile Include="MonoDevelop.Ide\LocalizationService.cs" />
+    <Compile Include="MonoDevelop.Ide.Desktop\RecentItemsChangedEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
This modifies RecentFiles updates so that we do the following:
* Split Projects/Files into different events. This way we can guarantee
that for the WelcomePage, for example, we can subscribe only to project
changes that will cause a refresh of the items in the list.

* Don't trigger updates of recent items if nothing has changed
between the old and the new version.