### PR TITLE
[Ide] Allow existing project files to be overwritten when adding files

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1641,6 +1641,15 @@ namespace MonoDevelop.Ide
 			bool applyToAll = true;
 			bool dialogShown = false;
 			bool supportsLinking = !(project is MonoDevelop.Projects.SharedAssetsProjects.SharedAssetsProject);
+
+			var confirmReplaceFileMessage = new QuestionMessage ();
+			if (files.Length > 1) {
+				confirmReplaceFileMessage.AllowApplyToAll = true;
+				confirmReplaceFileMessage.Buttons.Add (new AlertButton (GettextCatalog.GetString ("Skip")));
+			}
+			confirmReplaceFileMessage.Buttons.Add (AlertButton.Cancel);
+			confirmReplaceFileMessage.Buttons.Add (AlertButton.OverwriteFile);
+			confirmReplaceFileMessage.DefaultButton = confirmReplaceFileMessage.Buttons.Count - 1;
 			
 			ProgressMonitor monitor = null;
 			
@@ -1766,16 +1775,19 @@ namespace MonoDevelop.Ide
 						try {
 							if (!Directory.Exists (targetPath.ParentDirectory))
 								FileService.CreateDirectory (targetPath.ParentDirectory);
-							
-							if (MoveCopyFile (file, targetPath, action == AddAction.Move)) {
+
+							bool? result = MoveCopyFile (file, targetPath, action == AddAction.Move, confirmReplaceFileMessage);
+							if (result == true) {
 								if (vfile == null) {
 									var pf = new ProjectFile (targetPath, fileBuildAction);
 									vpathsInProject [pf.ProjectVirtualPath] = pf;
 									filesInProject [pf.FilePath] = pf;
 									newFileList.Add (pf);
 								}
-							}
-							else {
+							} else if (result == null) {
+								project.Files.AddRange (newFileList.Where (f => f != null));
+								return newFileList;
+							} else {
 								newFileList.Add (null);
 							}
 						}
@@ -1818,12 +1830,16 @@ namespace MonoDevelop.Ide
 			newFileList.Add (pf);
 		}
 		
-		bool MoveCopyFile (string filename, string targetFilename, bool move)
+		bool? MoveCopyFile (string filename, string targetFilename, bool move, QuestionMessage confirm)
 		{
 			if (filename != targetFilename) {
 				if (File.Exists (targetFilename)) {
-					if (!MessageService.Confirm (GettextCatalog.GetString ("The file '{0}' already exists. Do you want to replace it?",
-					                                                       targetFilename), AlertButton.OverwriteFile))
+					confirm.Text = GettextCatalog.GetString ("The file '{0}' already exists. Do you want to replace it?",
+						targetFilename);
+					AlertButton result = MessageService.AskQuestion (confirm);
+					if (result == AlertButton.Cancel)
+						return null;
+					else if (result != AlertButton.OverwriteFile)
 						return false;
 				}
 				FileService.CopyFile (filename, targetFilename);


### PR DESCRIPTION
Fixed bug #20204 - Adding existing items to a folder does not offer
overwrite option
https://bugzilla.xamarin.com/show_bug.cgi?id=20204

Adding existing files to a folder in a project would not allow the
existing files to be overwritten. The existing project files would
need to be deleted first. Now when adding an existing file to a folder
in a project where they already exist the user is prompted to
overwrite the existing file.