### PR TITLE
Revert "Disable MD_CLIPBOARD_FORMAT as a paste target on Windows"

### DIFF
--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Actions/ClipboardActions.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Actions/ClipboardActions.cs
@@ -179,13 +179,7 @@ namespace Mono.TextEditor
 				newTargets.Add (new TargetEntry ("UTF8_STRING", TargetFlags.App, TextType));
 
 				newTargets.Add (new TargetEntry (RTF_ATOM.Name, TargetFlags.OtherApp, RichTextType));
-
-				if (!Platform.IsWindows) {
-					// This seems to randomly break pasting on Windows. We'll disable it
-					// for now until we find a better solution
-					// https://bugzilla.xamarin.com/show_bug.cgi?id=23036
-					newTargets.Add (new TargetEntry (MD_ATOM.Name, TargetFlags.App, MonoTextType));
-				}
+				newTargets.Add (new TargetEntry (MD_ATOM.Name, TargetFlags.App, MonoTextType));
 
 				newTargets.Add (new TargetEntry ("text/plain;charset=utf-8", TargetFlags.App, TextType));
 				newTargets.Add (new TargetEntry ("text/plain", TargetFlags.App, TextType));


### PR DESCRIPTION
This reverts commit 1a4ae771f502e19e914d1111d8c0d8912863ee7b.

This revert is on `master`, but it needs to be on `cycle7` as well in order to fix https://bugzilla.xamarin.com/show_bug.cgi?id=39328