### PR TITLE
Fixed 'Bug 41727 - Documentoutline Pad - When an item on document

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
@@ -228,8 +228,12 @@ namespace MonoDevelop.CSharp.ClassOutline
 				Editor.CaretOffset = ((SyntaxTrivia)o).SpanStart;
 			}
 
-			if (focusEditor)
-				Editor.GrabFocus ();
+			if (focusEditor) {
+				GLib.Timeout.Add (10, delegate {
+					Editor.GrabFocus ();
+					return false;
+				});
+			}
 		}
 
 		static void OutlineTreeIconFunc (TreeViewColumn column, CellRenderer cell, TreeModel model, TreeIter iter)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -3497,5 +3497,11 @@ namespace MonoDevelop.SourceEditor
 		{
 			FocusLost?.Invoke (this, EventArgs.Empty);
 		}
+
+		void ITextEditorImpl.GrabFocus ()
+		{
+			this.TextEditor.GrabFocus ();
+		}
+
 	}
 } 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
@@ -213,7 +213,10 @@ namespace MonoDevelop.Ide.Editor
 
 		IEnumerable<IDocumentLine> VisibleLines { get; }
 
+		void GrabFocus ();
+
 		event EventHandler<LineEventArgs> LineShown;
 		event EventHandler FocusLost;
-	}
+
+}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1416,5 +1416,10 @@ namespace MonoDevelop.Ide.Editor
 		internal ITextEditorImpl Implementation { get { return this.textEditorImpl; } }
 
 		public event EventHandler FocusLost { add { textEditorImpl.FocusLost += value; } remove { textEditorImpl.FocusLost -= value; } }
+
+		public new void GrabFocus ()
+		{
+			this.textEditorImpl.GrabFocus ();
+		}
 	}
 }


### PR DESCRIPTION
outline is clicked the caret is not moved to item on text editor'