### PR TITLE
[Core] Fix MSBuild evaluation issue

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -569,8 +569,16 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 				if (args.Length != argInfo.Length)
 					continue;
-				
-				return m;
+
+				bool isValid = true;
+				for (int n = 0; n < args.Length; n++) {
+					if (!CanConvertArg (m, n, args [n], argInfo [n].ParameterType)) {
+						isValid = false;
+						break;
+					}
+				}
+				if (isValid)
+					return m;
 			}
 			return methodWithParams;
 		}
@@ -580,13 +588,25 @@ namespace MonoDevelop.Projects.MSBuild
 			return pi.ParameterType.IsArray && pi.IsDefined (typeof (ParamArrayAttribute));
 		}
 
+		bool CanConvertArg (MethodBase method, int argNum, object value, Type parameterType)
+		{
+			var sval = value as string;
+			if (sval == "null" || value == null)
+				return !parameterType.IsValueType || typeof(Nullable).IsInstanceOfType (parameterType);
+
+			if (sval != null && parameterType == typeof (char []))
+				return true;
+
+			if (parameterType == typeof (char) && sval != null && sval.Length != 1)
+				return false;
+
+			return true;
+		}
+
 		object ConvertArg (MethodBase method, int argNum, object value, Type parameterType)
 		{
 			var sval = value as string;
-			if (sval == "null")
-				return null;
-
-			if (value == null)
+			if (sval == "null" || value == null)
 				return null;
 
 			if (sval != null && parameterType == typeof (char[]))

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -278,6 +278,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("a", p.EvaluatedProperties.GetValue ("CharTrim"));
 			Assert.AreEqual ("2", p.EvaluatedProperties.GetValue ("SplitLength"));
 			Assert.AreEqual ("abcdefg", p.EvaluatedProperties.GetValue ("NewString"));
+			Assert.AreEqual ("100", p.EvaluatedProperties.GetValue ("CharConvert"));
 
 			var dir = System.IO.Path.GetFullPath (System.IO.Path.Combine (System.IO.Path.GetDirectoryName (projectFile), "foo"));
 			Assert.AreEqual (dir, p.EvaluatedProperties.GetValue ("FullPath"));

--- a/main/tests/test-projects/msbuild-tests/functions.csproj
+++ b/main/tests/test-projects/msbuild-tests/functions.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
   <PropertyGroup>
 	<Prop>abcdefgh</Prop>
+	<SomeChars>1.0</SomeChars>
 	<TestFile>files\test.txt</TestFile>
 	<Substring>$(Prop.Substring(1,3))</Substring>
 	<MethodWithParams1>$([System.String]::Format("ab"))</MethodWithParams1>
@@ -28,6 +29,7 @@
 	<MSBuildValueOrDefault2>$([MSBuild]::ValueOrDefault($(NoProp), "empty"))</MSBuildValueOrDefault2>
 	<SplitLength>$(Prop.Split('d').Length)</SplitLength>
 	<NewString>$([System.String]::new('$(Prop)').TrimEnd('h'))</NewString>
+	<CharConvert>$(SomeChars.Replace(".", "").PadRight(3,"0"))</CharConvert>
 	<Path>\a\b\</Path>
 	<CharTrim>$(Path.Trim (\b))</CharTrim>
 	<OutDir>foo</OutDir>


### PR DESCRIPTION
Fixes bug #41912 - [System.FormatException] MSBuild property evaluation
failed: FrameworkVersion.Replace(".", "").PadRight(3,"0")