### PR TITLE
[Cycle8][Ide] Fix failure to drag and drop file

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
@@ -89,6 +89,10 @@ namespace MonoDevelop.Components
 						//from doing any changes to selectiong we will do changes in OnButtonReleaseEvent
 						return false;
 					};
+				} else {
+					this.Selection.SelectFunction = (s, m, p, b) => {
+						return true;
+					};
 				}
 				return base.OnButtonPressEvent (evnt);
 			}


### PR DESCRIPTION
Fixed bug #38073 - Failure when dragging file from Project A to
Project B then back to Project A
https://bugzilla.xamarin.com/show_bug.cgi?id=38073

After adding a file to a project and then trying to drag that file
to another folder the file would not be dragged. The problem was that
selection was disabled by the ContextMenuTreeView and not reset
since the button release event is sometimes not fired.