### PR TITLE
[Ide] Use the project that is passed from Workspace FileXXX events instead of the ProjectFile.Project

### DIFF
--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/GenerateCommandHandler.cs
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/GenerateCommandHandler.cs
@@ -41,13 +41,13 @@ namespace MonoDevelop.TextTemplating
 
 	class GenerateCommandHandler : CommandHandler
 	{
-		protected override void Run ()
+		protected async override void Run ()
 		{
 			var wob = IdeApp.ProjectOperations.CurrentSelectedItem;
 
 			var pf = wob as ProjectFile;
 			if (pf != null) {
-				CustomToolService.Update (pf, true);
+				CustomToolService.Update (pf, pf.Project, true);
 				return;
 			}
 
@@ -62,7 +62,7 @@ namespace MonoDevelop.TextTemplating
 				return;
 			}
 
-			CustomToolService.Update (files, true);
+			await CustomToolService.Update (files, true);
 		}
 
 		static IEnumerable<ProjectFile> GetFilesToUpdate (Project project)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
@@ -71,19 +71,19 @@ namespace MonoDevelop.Ide.CustomTools
 			});
 			IdeApp.Workspace.FileChangedInProject += delegate (object sender, ProjectFileEventArgs args) {
 				foreach (ProjectFileEventInfo e in args)
-					Update (e.ProjectFile, false);
+					Update (e.ProjectFile, e.Project, false);
 			};
 			IdeApp.Workspace.FilePropertyChangedInProject += delegate (object sender, ProjectFileEventArgs args) {
 				foreach (ProjectFileEventInfo e in args)
-					Update (e.ProjectFile, false);
+					Update (e.ProjectFile, e.Project, false);
 			};
 			IdeApp.Workspace.FileRemovedFromProject += delegate (object sender, ProjectFileEventArgs args) {
 				foreach (ProjectFileEventInfo e in args)
-					Update (e.ProjectFile, false);
+					Update (e.ProjectFile, e.Project, false);
 			};
 			IdeApp.Workspace.FileAddedToProject += delegate (object sender, ProjectFileEventArgs args) {
 				foreach (ProjectFileEventInfo e in args)
-					Update (e.ProjectFile, false);
+					Update (e.ProjectFile, e.Project, false);
 			};
 			//FIXME: handle the rename
 			//MonoDevelop.Ide.Gui.IdeApp.Workspace.FileRenamedInProject
@@ -94,7 +94,7 @@ namespace MonoDevelop.Ide.CustomTools
 			//forces static ctor to run
 		}
 		
-		static ISingleFileCustomTool GetGenerator (string name)
+		static SingleProjectFileCustomTool GetGenerator (string name)
 		{
 			if (string.IsNullOrEmpty (name))
 				return null;
@@ -109,7 +109,7 @@ namespace MonoDevelop.Ide.CustomTools
 			CustomToolExtensionNode node;
 			if (nodes.TryGetValue (name, out node)) {
 				try {
-					return node.Tool;
+					return new SingleFileCustomToolWrapper (node.Tool);
 				} catch (Exception ex) {
 					LoggingService.LogError ("Error loading generator '" + name + "'", ex);
 					nodes.Remove (name);
@@ -136,7 +136,7 @@ namespace MonoDevelop.Ide.CustomTools
 			}
 		}
 
-		static bool ShouldRunGenerator (ProjectFile file, bool force, out ISingleFileCustomTool tool, out ProjectFile genFile)
+		static bool ShouldRunGenerator (ProjectFile file, Project project, bool force, out SingleProjectFileCustomTool tool, out ProjectFile genFile)
 		{
 			tool = null;
 			genFile = null;
@@ -151,23 +151,29 @@ namespace MonoDevelop.Ide.CustomTools
 				return false;
 			}
 
+			if (project == null) {
+				// this might happen if the file is being removed from the project. Ideally we wouldn't hit this path
+				// because if we use the overload with the project param then we can pass the appropriate project
+				return false;
+			}
+
 			//ignore MSBuild tool for projects that aren't MSBuild or can't build
 			//we could emit a warning but this would get very annoying for Xamarin Forms + SAP
 			//in future we could consider running the MSBuild generator in context of every referencing project
 			if (tool is MSBuildCustomTool) {
-				if (!file.Project.SupportsBuild ()) {
+				if (!project.SupportsBuild ()) {
 					return false;
 				}
 				bool byDefault, require;
-				MonoDevelop.Projects.MSBuild.MSBuildProjectService.CheckHandlerUsesMSBuildEngine (file.Project, out byDefault, out require);
-				var usesMSBuild = require || (file.Project.UseMSBuildEngine ?? byDefault);
+				MonoDevelop.Projects.MSBuild.MSBuildProjectService.CheckHandlerUsesMSBuildEngine (project, out byDefault, out require);
+				var usesMSBuild = require || (project.UseMSBuildEngine ?? byDefault);
 				if (!usesMSBuild) {
 					return false;
 				}
 			}
 
 			if (!string.IsNullOrEmpty (file.LastGenOutput)) {
-				genFile = file.Project.Files.GetFile (file.FilePath.ParentDirectory.Combine (file.LastGenOutput));
+				genFile = project.Files.GetFile (file.FilePath.ParentDirectory.Combine (file.LastGenOutput));
 			}
 
 			return force
@@ -179,11 +185,11 @@ namespace MonoDevelop.Ide.CustomTools
 		static async Task Update (ProgressMonitor monitor, IEnumerator<ProjectFile> fileEnumerator, bool force, int succeeded, int warnings, int errors)
 		{
 			ProjectFile file = fileEnumerator.Current;
-			ISingleFileCustomTool tool;
+			SingleProjectFileCustomTool tool;
 			ProjectFile genFile;
 
 			bool shouldRun;
-			while (!(shouldRun = ShouldRunGenerator (file, force, out tool, out genFile)) && fileEnumerator.MoveNext ())
+			while (!(shouldRun = ShouldRunGenerator (file, file.Project, force, out tool, out genFile)) && fileEnumerator.MoveNext ())
 				continue;
 
 			//no files which can be generated in remaining elements of the collection, nothing to do
@@ -198,7 +204,7 @@ namespace MonoDevelop.Ide.CustomTools
 			monitor.BeginTask (GettextCatalog.GetString ("Running generator '{0}' on file '{1}'...", file.Generator, file.Name), 1);
 
 			try {
-				await tool.Generate (monitor, file, result);
+				await tool.Generate (monitor, file.Project, file, result);
 				if (!monitor.HasErrors && !monitor.HasWarnings) {
 					monitor.Log.WriteLine (GettextCatalog.GetString ("File '{0}' was generated successfully.", result.GeneratedFilePath));
 					succeeded++;
@@ -249,11 +255,17 @@ namespace MonoDevelop.Ide.CustomTools
 			monitor.Dispose ();
 		}
 
-		public static async void Update (ProjectFile file, bool force)
+		[Obsolete("Use the overload that specifies the project explicitly")]
+		public static void Update (ProjectFile file, bool force)
 		{
-			ISingleFileCustomTool tool;
+			Update (file, file.Project, force);
+		}
+
+		public static async void Update (ProjectFile file, Project project, bool force)
+		{
+			SingleProjectFileCustomTool tool;
 			ProjectFile genFile;
-			if (!ShouldRunGenerator (file, force, out tool, out genFile)) {
+			if (!ShouldRunGenerator (file, project, force, out tool, out genFile)) {
 				return;
 			}
 			
@@ -305,7 +317,7 @@ namespace MonoDevelop.Ide.CustomTools
 				monitor.BeginTask (GettextCatalog.GetString ("Running generator '{0}' on file '{1}'...", file.Generator, file.Name), 1);
 
 				try {
-					await tool.Generate (monitor, file, result);
+					await tool.Generate (monitor, project, file, result);
 				} catch (Exception ex) {
 					error = ex;
 					result.UnhandledException = ex;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/MSBuildCustomTool.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/MSBuildCustomTool.cs
@@ -34,7 +34,7 @@ using System.Linq;
 
 namespace MonoDevelop.Ide.CustomTools
 {
-	class MSBuildCustomTool : ISingleFileCustomTool
+	class MSBuildCustomTool : SingleProjectFileCustomTool
 	{
 		readonly string targetName;
 
@@ -43,9 +43,13 @@ namespace MonoDevelop.Ide.CustomTools
 			this.targetName = targetName;
 		}
 
-		public async Task Generate (ProgressMonitor monitor, ProjectFile file, SingleFileCustomToolResult result)
+		public override async Task Generate (ProgressMonitor monitor, Project project, ProjectFile file, SingleFileCustomToolResult result)
 		{
-			var buildResult = await file.Project.PerformGeneratorAsync (monitor, IdeApp.Workspace.ActiveConfiguration, this.targetName);
+			if (project == null) {
+				return;
+			}
+
+			var buildResult = await project.PerformGeneratorAsync (monitor, IdeApp.Workspace.ActiveConfiguration, this.targetName);
 
 			foreach (var err in buildResult.BuildResult.Errors) {
 				result.Errors.Add (new CompilerError (err.FileName, err.Line, err.Column, err.ErrorNumber, err.ErrorText) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/SingleProjectFileCustomTool.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/SingleProjectFileCustomTool.cs
@@ -1,0 +1,60 @@
+//
+// SingleProjectFileCustomTool.cs
+//
+// Author:
+//       Greg Munn <greg@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using MonoDevelop.Projects;
+using System.CodeDom.Compiler;
+using MonoDevelop.Core;
+using System.Threading.Tasks;
+
+namespace MonoDevelop.Ide.CustomTools
+{
+	/// <summary>
+	/// Abstract class for processing a file in a project for a custom tool
+	/// </summary>
+	public abstract class SingleProjectFileCustomTool
+	{
+		public abstract Task Generate (ProgressMonitor monitor, Project project, ProjectFile file, SingleFileCustomToolResult result);
+	}
+
+	/// <summary>
+	/// Wraps a ISingleFileCustomTool and delegates execution to customTool's Generate method
+	/// </summary>
+	sealed class SingleFileCustomToolWrapper : SingleProjectFileCustomTool
+	{
+		ISingleFileCustomTool customTool;
+
+		public SingleFileCustomToolWrapper (ISingleFileCustomTool customTool)
+		{
+			this.customTool = customTool;
+		}
+
+		public override Task Generate (ProgressMonitor monitor, Project project, ProjectFile file, SingleFileCustomToolResult result)
+		{
+			return this.customTool.Generate (monitor, file, result);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -8555,6 +8555,7 @@
     <Compile Include="MonoDevelop.Ide.Editor.Extension\AutoInsertBracketTextEditorExtension.cs" />
     <Compile Include="MonoDevelop.Ide.Extensions\ErrorDocumentationProvider.cs" />
     <Compile Include="MonoDevelop.Ide\LocalizationService.cs" />
+    <Compile Include="MonoDevelop.Ide.CustomTools\SingleProjectFileCustomTool.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
When files are removed from a project, ProjectFile.Project is null. We
can use the value of project from the event args instead.

Fixes bug #42345