### PR TITLE
MSBuild(oss): Fix the msbuild assemblies' HintPaths for 14.1 builder

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v14.1.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v14.1.csproj
@@ -39,7 +39,7 @@
   <!-- TODO: Linux -->
   <PropertyGroup>
     <MSBuild_14_1_BinDir Condition="'$(OS)' == 'Windows_NT'">$(MSBuildToolsPath)\</MSBuild_14_1_BinDir>
-    <MSBuild_14_1_BinDir Condition="'$(OS)' == 'Unix'">\Library\Frameworks\Mono.framework\Versions\Current\lib\mono\msbuild\14.1\bin\</MSBuild_14_1_BinDir>
+    <MSBuild_14_1_BinDir Condition="'$(OS)' == 'Unix'">$(MSBuildToolsPath)\..\msbuild\14.1\bin\</MSBuild_14_1_BinDir>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Don't hard code
`/Library/Frameworks/Mono.frameworks/Versions/Current/...`, instead
construct the path from `$(MSBuildToolsPath)`