### PR TITLE
[Ide] Optimize initial Add File location [Bug 8506][Bug 18568]

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -153,6 +153,11 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			get; set;
 		}
 
+		static FolderCommandHandler ()
+		{
+			IdeApp.Workspace.LastWorkspaceItemClosed += (sender, e) => PreviousFolderPath = null;
+		}
+
 		public abstract string GetFolderPath (object dataObject);
 
 		public override bool CanDropNode (object dataObject, DragOperation operation)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -386,7 +386,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			var targetRoot = ((FilePath) GetFolderPath (CurrentNode.DataItem)).CanonicalPath;
 
 			AddFileDialog fdiag  = new AddFileDialog (GettextCatalog.GetString ("Add files"));
-			fdiag.CurrentFolder = !PreviousFolderPath.IsNullOrEmpty ? PreviousFolderPath : targetRoot;
+			fdiag.CurrentFolder = !PreviousFolderPath.IsNullOrEmpty && !PreviousFolderPath.IsChildPathOf (project.ParentSolution.BaseDirectory) ? PreviousFolderPath : targetRoot;
 			fdiag.SelectMultiple = true;
 			fdiag.TransientFor = IdeApp.Workbench.RootWindow;
 			fdiag.BuildActions = project.GetBuildActions ();	


### PR DESCRIPTION
This PR tries to fix the issues with the initial directory in the "Add File ..." and "Add Files from Folder ..." dialogs.

The current behaviour is to navigate to the folder where the previously added file was located, or the selected solution folder, if the command is used for the first time. This seems to be confusing since different users expect different things to happen:
 1. always open the selected folder (in order to i.e. add files which are alredy physically there but not part of the project, like described in https://bugzilla.xamarin.com/show_bug.cgi?id=18568#c0) 
 2. always open the previously used folder in order to add files from outside to different locations inside the solution/project (opposite to 1. described in https://bugzilla.xamarin.com/show_bug.cgi?id=8506, aka current behaviour)

This patch takes both scenarios into account, if the last file added was located inside the solution folder, its path won't be restored the next time the user adds an other file. Only if the user adds a file from somewhere else (not located in the current solution directory), the previous directory will be restored. The new bahaviour does not apply to the "Add Files from Folder ..." dialog, since it doesn't feel common to use it in the first scenario (**?**)

Additionally a84ad97 fixes the issue described in https://bugzilla.xamarin.com/show_bug.cgi?id=8506#c3. The initial location will default to the selected solution folder each time the user closes and opens a solution.