### PR TITLE
[Core][Win] Fix translations in async operations

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
@@ -131,6 +131,10 @@ namespace MonoDevelop.Core
 
 		static string GetStringInternal (string phrase)
 		{
+			if (Platform.IsWindows && Thread.CurrentThread.CurrentUICulture != UICulture) {
+				Thread.CurrentThread.CurrentUICulture = UICulture;
+				SetThreadUILanguage (UICulture.LCID);
+			}
 			try {
 				return Catalog.GetString (phrase);
 			} catch (Exception e) {
@@ -170,6 +174,10 @@ namespace MonoDevelop.Core
 
 		static string GetPluralStringInternal (string singular, string plural, int number)
 		{
+			if (Platform.IsWindows && Thread.CurrentThread.CurrentUICulture != UICulture) {
+				Thread.CurrentThread.CurrentUICulture = UICulture;
+				SetThreadUILanguage (UICulture.LCID);
+			}
 			try {
 				return Catalog.GetPluralString (singular, plural, number);
 			} catch (Exception e) {


### PR DESCRIPTION
On Windows SetThreadUILanguage must be
called for each thread. Setting CurrentThread.CurrentUICulture
or CultureInfo.DefaultThreadCurrentUICulture is
not enough.

(fixes bug #28033)
(cherry picked from commit bb3d385137a4e19905ac29e90a22c26435eac8e9)