### PR TITLE
Optimized document switcher

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -772,6 +772,18 @@
 			macShortcut = "Control|Shift|Tab"
 			_label = "Switch to previous document"
 			_description = "Switch to previous document" />
+	<Command id = "MonoDevelop.Ide.Commands.WindowCommands.SwitchNextPad"
+			defaultHandler = "MonoDevelop.Ide.Commands.SwitchNextPad"
+			shortcut = "Control+Alt+Tab"
+			macShortcut = "Control+Alt+Tab"
+			_label = "Switch to next pad"
+			_description = "Switch to next pad" />
+	<Command id = "MonoDevelop.Ide.Commands.WindowCommands.SwitchPreviousPad"
+			defaultHandler = "MonoDevelop.Ide.Commands.SwitchPreviousPad"
+			shortcut = "Control+Shift+Alt+Tab"
+			macShortcut = "Control+Shift+Alt+Tab"
+			_label = "Switch to previous pad"
+			_description = "Switch to previous pad" />
 	</Category>
 
 	<!-- HelpCommands -->

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -774,13 +774,13 @@
 			_description = "Switch to previous document" />
 	<Command id = "MonoDevelop.Ide.Commands.WindowCommands.SwitchNextPad"
 			defaultHandler = "MonoDevelop.Ide.Commands.SwitchNextPad"
-			shortcut = "Control+Alt+Tab"
+			shortcut = "Alt+F6"
 			macShortcut = "Control+Alt+Tab"
 			_label = "Switch to next pad"
 			_description = "Switch to next pad" />
 	<Command id = "MonoDevelop.Ide.Commands.WindowCommands.SwitchPreviousPad"
 			defaultHandler = "MonoDevelop.Ide.Commands.SwitchPreviousPad"
-			shortcut = "Control+Shift+Alt+Tab"
+			shortcut = "Shift+Alt+F6"
 			macShortcut = "Control+Shift+Alt+Tab"
 			_label = "Switch to previous pad"
 			_description = "Switch to previous pad" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
@@ -338,6 +338,21 @@ namespace MonoDevelop.Components.Docking
 			frame.SetDockLocation (this, location);
 		}
 
+		internal bool HasFocus {
+			get {
+				if (gtkContent.HasFocus || widget.HasFocus)
+					return true;
+				
+				Gtk.Window win = gtkContent.Toplevel as Gtk.Window;
+				if (win != null) {
+					if (Status == DockItemStatus.AutoHide)
+						return win.HasToplevelFocus;
+					return (win.HasToplevelFocus && win.Focus?.IsChildOf (widget) == true);
+				}
+				return false;
+			}
+		}
+
 		internal void SetFocus ()
 		{
 			SetFocus (gtkContent);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1409,6 +1409,17 @@ namespace MonoDevelop.Components
 			}
 		}
 
+		public static bool IsChildOf (this Gtk.Widget child, Gtk.Widget widget)
+		{
+			var parent = child.Parent;
+			while (parent != null) {
+				if (parent == widget)
+					return true;
+				parent = parent.Parent;
+			};
+			return false;
+		}
+
 #if MAC
 		static void OnMappedDisableButtons (object sender, EventArgs args)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -759,6 +759,21 @@ namespace MonoDevelop.Components
 			return mod;
 		}
 
+		public static Gdk.Key[] KeysForMod (Gdk.ModifierType mod)
+		{
+			switch (mod) {
+			case Gdk.ModifierType.ControlMask:
+				return new Gdk.Key [] { Gdk.Key.Control_R, Gdk.Key.Control_L };
+			case Gdk.ModifierType.Mod1Mask:
+				return new Gdk.Key [] { Gdk.Key.Alt_R, Gdk.Key.Alt_L };
+			case Gdk.ModifierType.ShiftMask:
+				return new Gdk.Key [] { Gdk.Key.Shift_R, Gdk.Key.Shift_L };
+			case Gdk.ModifierType.MetaMask:
+				return new Gdk.Key [] { Gdk.Key.Meta_R, Gdk.Key.Meta_L };
+			}
+			return new Gdk.Key [0];
+		}
+
 		static void AddIfNotDuplicate<T> (List<T> list, T item) where T : IEquatable<T>
 		{
 			for (int i = 0; i < list.Count; i++) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
@@ -277,4 +277,31 @@ namespace MonoDevelop.Ide.Commands
 			Switch (false);
 		}
 	}
+
+	internal class SwitchNextPad : CommandHandler
+	{
+		protected static void Switch (bool next)
+		{
+			if (!IdeApp.Preferences.EnableDocumentSwitchDialog)
+				return;
+
+			var toplevel = Window.ListToplevels ().FirstOrDefault (w => w.HasToplevelFocus)
+				?? IdeApp.Workbench.RootWindow;
+			var sw = new DocumentSwitcher (toplevel, GettextCatalog.GetString ("Pads"), next);
+			sw.Present ();
+		}
+
+		protected override void Run ()
+		{
+			Switch (true);
+		}
+	}
+
+	internal class SwitchPreviousPad : SwitchNextPad
+	{
+		protected override void Run ()
+		{
+			Switch (false);
+		}
+	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
@@ -265,6 +265,10 @@ namespace MonoDevelop.Ide
 			GtkWorkarounds.MapKeys (evnt, out key, out mod, out accels);
 			
 			switch (accels [0].Key) {
+			case Gdk.Key.space:
+			case Gdk.Key.KP_Space:
+				RightItem (true);
+				break;
 			case Gdk.Key.Left:
 			case Gdk.Key.KP_Left:
 				LeftItem ();
@@ -332,7 +336,7 @@ namespace MonoDevelop.Ide
 
 		public event EventHandler<RequestActionEventArgs> RequestClose;
 		
-		void LeftItem ()
+		void LeftItem (bool wrap = false)
 		{
 			for (int i = 0; i < categories.Count; i++) {
 				var cat = categories[i];
@@ -340,6 +344,10 @@ namespace MonoDevelop.Ide
 				if (idx < 0)
 					continue;
 				int relIndex = idx - cat.FirstVisibleItem;
+				if (wrap && i == 0) {
+					LastCategory (relIndex);
+					return;
+				}
 				if (relIndex / maxItems == 0) {
 					Category prevCat = GetPrevCat (i);
 					if (prevCat == cat)
@@ -353,7 +361,7 @@ namespace MonoDevelop.Ide
 			}
 		}
 		
-		void RightItem ()
+		void RightItem (bool wrap = false)
 		{
 			for (int i = 0; i < categories.Count; i++) {
 				var cat = categories[i];
@@ -368,9 +376,37 @@ namespace MonoDevelop.Ide
 					if (i + 1 < categories.Count) {
 						int newIndex = Math.Min (nextCat.Items.Count - 1, nextCat.FirstVisibleItem + relIndex);
 						ActiveItem = nextCat.Items [newIndex];
-					}
+					} else if (wrap)
+						FirstCategory (relIndex);
 				} else {
 					ActiveItem = cat.Items [relIndex + maxItems];
+				}
+				return;
+			}
+		}
+
+		public void LastCategory (int selIndex = 0)
+		{
+			for (int i = categories.Count - 1; i >= 0; i--) {
+				var cat = categories [i];
+
+				if (cat.Items.Count > 0) {
+					int newIndex = Math.Min (cat.Items.Count - 1, cat.FirstVisibleItem + selIndex);
+					ActiveItem = cat.Items [newIndex];
+					return;
+				}
+			}
+		}
+
+		public void FirstCategory (int selIndex = 0)
+		{
+			for (int i = 0; i < categories.Count; i++) {
+				var cat = categories [i];
+
+				if (cat.Items.Count > 0) {
+					int newIndex = Math.Min (cat.Items.Count - 1, cat.FirstVisibleItem + selIndex);
+					ActiveItem = cat.Items [newIndex];
+					return;
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
@@ -593,9 +593,16 @@ namespace MonoDevelop.Ide
 		Label labelType     = new Label ();
 		Label labelTitle    = new Label ();
 		DocumentList documentList = new DocumentList ();
-		
-		public DocumentSwitcher (Gtk.Window parent, bool startWithNext) : base(Gtk.WindowType.Toplevel)
+
+		public DocumentSwitcher (Gtk.Window parent, bool startWithNext) : this (parent, null, startWithNext)
 		{
+		}
+
+		public DocumentSwitcher (Gtk.Window parent, string category, bool startWithNext) : base(Gtk.WindowType.Toplevel)
+		{
+			if (string.IsNullOrEmpty (category))
+				category = GettextCatalog.GetString ("Documents");
+			
 			IdeApp.CommandService.IsEnabled = false;
 			this.documents = new List<MonoDevelop.Ide.Gui.Document> (
 				IdeApp.Workbench.Documents.OrderByDescending (d => d.LastTimeActive));
@@ -652,8 +659,10 @@ namespace MonoDevelop.Ide
 					Title = pad.Title,
 					Tag = pad
 				};
-				if (pad.InternalContent.Initialized && pad.Window.HasFocus)
-					activeItem = item;
+				if (category == padCategory.Title) {
+					if (activeItem == null || (pad.InternalContent.Initialized && pad.Window.HasFocus))
+						activeItem = item;
+				}
 				padCategory.AddItem (item);
 			}
 			documentList.AddCategory (padCategory);
@@ -668,8 +677,10 @@ namespace MonoDevelop.Ide
 					Path = doc.Name,
 					Tag = doc
 				};
-				if (doc.Window.ActiveViewContent.Control.HasFocus)
-					activeItem = item;
+				if (category == padCategory.Title) {
+					if (activeItem == null || doc.Window.ActiveViewContent.Control.HasFocus)
+						activeItem = item;
+				}
 				documentCategory.AddItem (item);
 			}
 			documentList.AddCategory (documentCategory);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
@@ -652,7 +652,7 @@ namespace MonoDevelop.Ide
 					Title = pad.Title,
 					Tag = pad
 				};
-				if (pad.InternalContent.Initialized && pad.Window.Content.Control.HasFocus)
+				if (pad.InternalContent.Initialized && pad.Window.HasFocus)
 					activeItem = item;
 				padCategory.AddItem (item);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IPadContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IPadContainer.cs
@@ -88,6 +88,8 @@ namespace MonoDevelop.Ide.Gui
 		/// will be automatically reset when the pad is made visible.
 		/// </summary>
 		bool HasNewData { get; set; }
+
+		bool HasFocus { get; }
 		
 		/// <summary>
 		/// Interface providing the content widget
@@ -226,6 +228,10 @@ namespace MonoDevelop.Ide.Gui
 			set {
 				Item.Visible = value;
 			}
+		}
+
+		public bool HasFocus {
+			get { return Item.HasFocus; }
 		}
 		
 		public bool AutoHide {

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
@@ -139,6 +139,8 @@
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.ZoomReset" shortcut="" />
     <binding command="MonoDevelop.Ide.Commands.WindowCommands.NextDocument" shortcut="Meta+F6" />
     <binding command="MonoDevelop.Ide.Commands.WindowCommands.PrevDocument" shortcut="Meta+Shift+F6" />
+    <binding command="MonoDevelop.Ide.Commands.WindowCommands.SwitchNextPad" shortcut="Alt+F6" />
+    <binding command="MonoDevelop.Ide.Commands.WindowCommands.SwitchPreviousPad" shortcut="Alt+Shift+F6" />
     <binding command="MonoDevelop.MacIntegration.MacIntegrationCommands.HideOthers" shortcut="" />
     <binding command="MonoDevelop.MacIntegration.MacIntegrationCommands.HideWindow" shortcut="" />
     <binding command="MonoDevelop.MacIntegration.MacIntegrationCommands.MinimizeWindow" shortcut="" />

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
@@ -139,6 +139,8 @@
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.ZoomReset" shortcut="" />
     <binding command="MonoDevelop.Ide.Commands.WindowCommands.NextDocument" shortcut="Control+F6" />
     <binding command="MonoDevelop.Ide.Commands.WindowCommands.PrevDocument" shortcut="Control+Shift+F6" />
+    <binding command="MonoDevelop.Ide.Commands.WindowCommands.SwitchNextPad" shortcut="Alt+F6" />
+    <binding command="MonoDevelop.Ide.Commands.WindowCommands.SwitchPreviousPad" shortcut="Alt+Shift+F6" />
     <binding command="MonoDevelop.MacIntegration.MacIntegrationCommands.HideOthers" shortcut="" />
     <binding command="MonoDevelop.MacIntegration.MacIntegrationCommands.HideWindow" shortcut="" />
     <binding command="MonoDevelop.MacIntegration.MacIntegrationCommands.MinimizeWindow" shortcut="" />


### PR DESCRIPTION
This PR adds following features to the document switcher:
* Space key cycles through categories (pads/documents)
* Better Pad Focus detection (the content/top level widget focus does not indicate whether the pad really has the focus, the top level window keeps track of the current focus widget and the patch veriefies whether that widget is a child of the pad or not, in order to detect the focus state of a pad correctly)
* Special separate commands to switch pads (Alt+F6 by default like in VS in Windows)