### PR TITLE
[NuGet] Load package images on the UI thread

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ImageLoader.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ImageLoader.cs
@@ -99,9 +99,8 @@ namespace MonoDevelop.PackageManagement
 		{
 			try {
 				Stream stream = GetResponseStream (uri);
-				Image image = Image.FromStream (stream);
-
-				return new ImageLoadedEventArgs (image, uri, state);
+				var loader = Runtime.RunInMainThread (() => Image.FromStream (stream));
+				return new ImageLoadedEventArgs (loader.Result, uri, state);
 			} catch (Exception ex) {
 				return new ImageLoadedEventArgs (ex, uri, state);
 			}
@@ -109,13 +108,20 @@ namespace MonoDevelop.PackageManagement
 
 		static Stream GetResponseStream (Uri uri)
 		{
+			WebResponse response = null;
 			if (uri.IsFile) {
 				var request = WebRequest.Create (uri);
+				response = request.GetResponse ();
 				return request.GetResponse ().GetResponseStream ();
+			} else {
+				var httpClient = new HttpClient (uri);
+				response = httpClient.GetResponse ();
 			}
 
-			var httpClient = new HttpClient (uri);
-			return httpClient.GetResponse ().GetResponseStream ();
+			var stream = new MemoryStream ();
+			response.GetResponseStream ().CopyTo (stream); // force the download to complete
+			stream.Position = 0;
+			return stream;
 		}
 
 		void OnLoaded (ImageLoadedEventArgs eventArgs)


### PR DESCRIPTION
This is not really a bug, but Xwt images should always be loaded in the UI thread. It didn't break anything in the NuGet dialog, but has the potential to cause failures in the Xwt backend code (i.e. if the current Xwt toolkit is not Gtk for some reason).