### PR TITLE
[Cycle8][NuGet] Handle install error when NuGet package already installed

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
@@ -114,6 +114,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public IEnumerable<SourceRepository> PreviewInstallSecondarySources;
 		public CancellationToken PreviewInstallCancellationToken;
 
+		public Action BeforePreviewInstallPackageAsyncAction = () => { };
+
 		public Task<IEnumerable<NuGetProjectAction>> PreviewInstallPackageAsync (
 			NuGetProject nuGetProject,
 			PackageIdentity packageIdentity,
@@ -129,6 +131,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			PreviewInstallPrimarySources = primarySources.ToList ();
 			PreviewInstallSecondarySources = secondarySources;
 			PreviewInstallCancellationToken = token;
+
+			BeforePreviewInstallPackageAsyncAction ();
 
 			IEnumerable<NuGetProjectAction> actions = InstallActions.ToArray ();
 			return Task.FromResult (actions);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/InstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/InstallNuGetPackageAction.cs
@@ -118,8 +118,17 @@ namespace MonoDevelop.PackageManagement
 
 		public void Execute (CancellationToken cancellationToken)
 		{
-			using (var monitor = new NuGetPackageEventsMonitor (dotNetProject, packageManagementEvents)) {
-				ExecuteAsync (cancellationToken).Wait ();
+			try {
+				using (var monitor = new NuGetPackageEventsMonitor (dotNetProject, packageManagementEvents)) {
+					ExecuteAsync (cancellationToken).Wait ();
+				}
+			} catch (AggregateException ex) {
+				Exception baseException = ex.GetBaseException ();
+				if (baseException.InnerException is PackageAlreadyInstalledException) {
+					context.Log (MessageLevel.Info, baseException.Message);
+				} else {
+					throw;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed bug #42807 - Adding all the Google Play Services packages to an
Android app throws an error as some dependents packages already exist
https://bugzilla.xamarin.com/show_bug.cgi?id=42807

NuGet v3 has different behaviour to NuGet v2. If a NuGet package is
already installed then an attempt is made to install the same
package version again then NuGet v3 will throw a
PackageAlreadyInstalledException. NuGet v2 would log a message and
not throw an error.

The PackageAlreadyInstalledException is now caught and a message is
logged instead of having the exception thrown. This makes the
behaviour consistent with previous versions of the IDE.