### PR TITLE
Fixed 'Bug 41727 - Document Outline Pad - When document outline pad is

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -3543,6 +3543,9 @@ namespace MonoDevelop.SourceEditor
 
 		void ITextEditorImpl.GrabFocus ()
 		{
+			var topLevelWindow = this.TextEditor.Toplevel as Gtk.Window;
+			if (topLevelWindow != null)
+				topLevelWindow.Present ();
 			this.TextEditor.GrabFocus ();
 		}
 


### PR DESCRIPTION
floating and and item is clicked the caret is not moved to item on
text editor'