### PR TITLE
[CSharpBinding] Removed specific logic on KeyPress in completion exte…

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -278,18 +278,6 @@ namespace MonoDevelop.CSharp.Completion
 			HandleDocumentParsed (null, null);
 		}
 		
-		public override bool KeyPress (KeyDescriptor descriptor)
-		{
-			bool result = base.KeyPress (descriptor);
-			
-			if (/*EnableParameterInsight &&*/ (descriptor.KeyChar == ',' || descriptor.KeyChar == ')') && CanRunParameterCompletionCommand ())
-				base.RunParameterCompletionCommand ();
-			
-//			if (IsInsideComment ())
-//				ParameterInformationWindowManager.HideWindow (CompletionWidget);
-			return result;
-		}
-		
 		public override Task<ICompletionDataList> HandleCodeCompletionAsync (CodeCompletionContext completionContext, char completionChar, CancellationToken token = default(CancellationToken))
 		{
 //			if (!EnableCodeCompletion)


### PR DESCRIPTION
…nsion that was invoking parameter info window

Because this is all handled again via general parameter info window logic and this is just duplicate

/cc: @mkrueger 