### PR TITLE
[Cycle8] Allow overwrite project files to be overwritten when adding files

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1722,10 +1722,14 @@ namespace MonoDevelop.Ide
 					ProjectFile vfile;
 					var vpath = targetPath.ToRelative (project.BaseDirectory);
 					if (vpathsInProject.TryGetValue (vpath, out vfile)) {
-						if (vfile.FilePath != file)
+						if (vfile.IsLink) {
 							MessageService.ShowWarning (GettextCatalog.GetString (
-								"There is a already a file or link in the project with the name '{0}'", vpath));
-						continue;
+								"There is already a link in the project with the name '{0}'", vpath));
+							continue;
+						} else if (vfile.FilePath == file) {
+							// File already exists in project.
+							continue;
+						}
 					}
 					
 					string fileBuildAction = buildAction;
@@ -1734,7 +1738,10 @@ namespace MonoDevelop.Ide
 					
 					//files in the target directory get added directly in their current location without moving/copying
 					if (file.CanonicalPath == targetPath) {
-						AddFileToFolder (newFileList, vpathsInProject, filesInProject, file, fileBuildAction);
+						if (vfile != null)
+							ShowFileExistsInProjectMessage (vpath);
+						else
+							AddFileToFolder (newFileList, vpathsInProject, filesInProject, file, fileBuildAction);
 						continue;
 					}
 					
@@ -1773,11 +1780,18 @@ namespace MonoDevelop.Ide
 						}
 						
 						if (action == AddAction.Keep) {
-							AddFileToFolder (newFileList, vpathsInProject, filesInProject, file, fileBuildAction);
+							if (vfile != null)
+								ShowFileExistsInProjectMessage (vpath);
+							else
+								AddFileToFolder (newFileList, vpathsInProject, filesInProject, file, fileBuildAction);
 							continue;
 						}
 						
 						if (action == AddAction.Link) {
+							if (vfile != null) {
+								ShowFileExistsInProjectMessage (vpath);
+								continue;
+							}
 							ProjectFile pf = new ProjectFile (file, fileBuildAction) {
 								Link = vpath
 							};
@@ -1792,10 +1806,12 @@ namespace MonoDevelop.Ide
 								FileService.CreateDirectory (targetPath.ParentDirectory);
 							
 							if (MoveCopyFile (file, targetPath, action == AddAction.Move)) {
-								var pf = new ProjectFile (targetPath, fileBuildAction);
-								vpathsInProject [pf.ProjectVirtualPath] = pf;
-								filesInProject [pf.FilePath] = pf;
-								newFileList.Add (pf);
+								if (vfile == null) {
+									var pf = new ProjectFile (targetPath, fileBuildAction);
+									vpathsInProject [pf.ProjectVirtualPath] = pf;
+									filesInProject [pf.FilePath] = pf;
+									newFileList.Add (pf);
+								}
 							}
 							else {
 								newFileList.Add (null);
@@ -1816,6 +1832,12 @@ namespace MonoDevelop.Ide
 			}
 			project.Files.AddRange (newFileList.Where (f => f != null));
 			return newFileList;
+		}
+
+		static void ShowFileExistsInProjectMessage (FilePath path)
+		{
+			MessageService.ShowWarning (GettextCatalog.GetString (
+				"There is already a file in the project with the name '{0}'", path));
 		}
 		
 		void AddFileToFolder (List<ProjectFile> newFileList, Dictionary<FilePath, ProjectFile> vpathsInProject, Dictionary<FilePath, ProjectFile> filesInProject, FilePath file, string fileBuildAction)


### PR DESCRIPTION
Fixed bug #20204 - Adding existing items to a folder does not offer
overwrite option
https://bugzilla.xamarin.com/show_bug.cgi?id=20204

Adding existing files to a folder in a project would not allow the
existing files to be overwritten. The existing project files would
need to be deleted first. Now when adding an existing file to a folder
in a project where they already exist the user is prompted to
overwrite the existing file.

Add apply all check box to dialog when overwriting project files  …
When adding or moving multiple files into a project, and the files
already exist, the user will be shown a dialog asking if they want
to overwrite each file. The dialog has a Cancel, Skip and Overwrite
File button and an Apply to all check box when multiple files are
being added. If a single file is being added then the Skip and
Apply to all check box is not displayed.

Previously there was no way to cancel multiple files being added
or moved. The cancel button would only cancel the file currently
being added. Also there was no way apply the same action, skip or
overwrite, to all files without having to repeatedly click a button
on the dialog.