### PR TITLE
Opt-into long path support on Windows

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v12.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v12.0.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<runtime>
+		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<generatePublisherEvidence enabled="false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v14.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v14.0.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<runtime>
+		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<generatePublisherEvidence enabled="false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v14.1.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v14.1.config
@@ -5,6 +5,7 @@
 		<section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=14.1.0.0, Culture=neutral" />
 	</configSections>
 	<runtime>
+		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<generatePublisherEvidence enabled="false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v4.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v4.0.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<runtime>
+		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<generatePublisherEvidence enabled="false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<runtime>
+		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />


### PR DESCRIPTION
Will only take effect on .NET 4.6.2+