### PR TITLE
[Cycle8][Core] Fix no debug execution modes being found

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs
@@ -277,8 +277,12 @@ namespace MonoDevelop.Core.Execution
 		public IExecutionModeSet GetDebugExecutionMode ()
 		{
 			foreach (ExtensionNode node in AddinManager.GetExtensionNodes (ExecutionModesExtensionPath)) {
-				if (node.Id == "MonoDevelop.Debugger")
-					return (IExecutionModeSet) ((TypeExtensionNode)node).GetInstance (typeof (IExecutionModeSet));
+				if (node.Id == "Debug") {
+					foreach (ExtensionNode childNode in node.ChildNodes) {
+						if (childNode.Id == "MonoDevelop.Debugger")
+							return (IExecutionModeSet) ((TypeExtensionNode)childNode).GetInstance (typeof (IExecutionModeSet));
+					}
+				}
 			}
 			return null;
 		}


### PR DESCRIPTION
Fixed bug #43194 - "Debug Test" is not showing up context menu when
right clicking test in Unit Test Pad
https://bugzilla.xamarin.com/show_bug.cgi?id=43194

The debug execution modes were not being found since there is now an
extra level of execution modes and the wrong level was being checked.