### PR TITLE
[Mac] Try using a temporary keychain for the credentials tests.

### DIFF
--- a/main/tests/MacPlatform.Tests/CredentialsProviderTests.cs
+++ b/main/tests/MacPlatform.Tests/CredentialsProviderTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using MonoDevelop.MacInterop;
 using NUnit.Framework;
 
 namespace MacPlatform.Tests
@@ -31,6 +32,22 @@ namespace MacPlatform.Tests
 	[TestFixture]
 	public class CredentialsProviderTests : MonoDevelop.Core.BaseCredentialsProviderTests
 	{
+		static string TestKeyChain = "ThisIsMonoDevelopsPrivateKeyChainForTests";
+
+		[TestFixtureSetUp]
+		public void FixtureSetup ()
+		{
+			Keychain.TryDeleteKeychain (TestKeyChain);
+			Keychain.CurrentKeychain = Keychain.CreateKeychain (TestKeyChain, "mypassword");
+		}
+
+		[TestFixtureTearDown]
+		public void FixtureTeardown ()
+		{
+			Keychain.DeleteKeychain (Keychain.CurrentKeychain);
+			Keychain.CurrentKeychain = IntPtr.Zero;
+		}
+
 		protected override MonoDevelop.Core.IPasswordProvider GetPasswordProvider ()
 		{
 			return new MonoDevelop.MacIntegration.MacKeychainPasswordProvider ();


### PR DESCRIPTION
cc @sgmunn 