### PR TITLE
[Cycle8][Core] Fix C# formatting policy not saved for solution

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Serialization/DataItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Serialization/DataItem.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MonoDevelop.Core.Serialization
 {
@@ -87,6 +88,16 @@ namespace MonoDevelop.Core.Serialization
 					}
 				} else if (!d.IsDefaultValue && !(d is DataDeletedNode)) {
 					ItemData.Add (d);
+				}
+			}
+
+			// Remove items that are missing from the passed DataItem.
+			foreach (var d in ItemData.ToArray ()) {
+				var current = item.ItemData[d.Name];
+				if (current == null) {
+					if (d is DataItem)
+						removedItems.Add ((DataItem)d);
+					ItemData.Remove (d);
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Serialization/DataItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Serialization/DataItem.cs
@@ -87,17 +87,17 @@ namespace MonoDevelop.Core.Serialization
 						((DataItem)current).UpdateFromItem ((DataItem)d, removedItems);
 					}
 				} else if (!d.IsDefaultValue && !(d is DataDeletedNode)) {
-					ItemData.Add (d);
-				}
-			}
-
-			// Remove items that are missing from the passed DataItem.
-			foreach (var d in ItemData.ToArray ()) {
-				var current = item.ItemData[d.Name];
-				if (current == null) {
-					if (d is DataItem)
-						removedItems.Add ((DataItem)d);
-					ItemData.Remove (d);
+					var dataItem = d as DataItem;
+					if (dataItem != null) {
+						var newDataItem = new DataItem () {
+							Name = d.Name,
+							UniqueNames = dataItem.UniqueNames
+						};
+						newDataItem.UpdateFromItem (dataItem, removedItems);
+						ItemData.Add (newDataItem);
+					} else {
+						ItemData.Add (d);
+					}
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyBag.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyBag.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.Projects.Policies
 			
 			DataCollection dc = new DataCollection ();
 			foreach (KeyValuePair<PolicyKey,object> p in policies)
-				dc.Add (PolicyService.DiffSerialize (p.Key.PolicyType, p.Value, p.Key.Scope));
+				dc.Add (PolicyService.DiffSerialize (p.Key.PolicyType, p.Value, p.Key.Scope, keepDeletedNodes: true));
 			return dc;
 		}
 


### PR DESCRIPTION
Fixed bug #43246 - Custom code formatting (Indentation) settings are
not stored and reset after the solution restart.
https://bugzilla.xamarin.com/show_bug.cgi?id=43246

When a single C# formatting option was changed so it matched the
inherited policy then the solution was not saved since the policy
information in the solution was not being updated correctly.
When a setting  matches the inherited policy it is removed from the
properties that are to be saved with the solution file. However if
that property was originally stored in the solution file it would not
be removed when the solution was saved. A simple way to reproduce this
is to create a new solution, open the Solution Options dialog, select
Source Code - Code Formatting - C# source code, C# format, Edit,
then change Indent case sections in the Indentation category, close
and re-open the solution. If this repeated a few times then eventually
the option will not have the correct value. At this point changing
the option will not update the solution file at all.