### PR TITLE
Fix Konsole command line options

### DIFF
--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -264,7 +264,7 @@ namespace MonoDevelop.Platform
 				? BashPause.Replace ("'", "\"")
 					: String.Empty;
 
-			return String.Format (@" --nofork --caption ""{4}"" --workdir=""{3}"" -e ""bash"" -c '{0} {1} ; {2}'",
+			return String.Format (@" -p tabtitle=""{4}"" --workdir=""{3}"" -e ""bash"" -c '{0} {1} ; {2}'",
 			                      command,
 			                      args,
 			                      extra_commands,


### PR DESCRIPTION
This line uses several options (`--nofork --caption`) which are removed in KDE Konsole as of version 16.04.2 (released 2016-06-14). This causes any attempt to 'run on external console' under KDE to fail with the error 'Could not connect to the debugger'. Change these options so that running a project on the external console in KDE does not fail.

[This commit](https://quickgit.kde.org/?p=konsole.git&a=commit&h=27dec8d02f705c77eef45a2533bed203eec9454f) removed the `--nofork `option in Konsole. [This commit](https://quickgit.kde.org/?p=konsole.git&a=commitdiff&h=a9a8db2cf4b7a9c063445d1505b8ee410f9949a8) removed the documentation for the `--nofork` option. There does not seem to be a replacement, so perhaps it is no longer necessary..?

I can't find the particular commit where the `--caption` command line option was removed, but Konsole version 16.08.0 thinks it's an 'unknown option'. Equivalent functionality seems to be available with `konsole -p tabtitle="title"` <sup>[[1]](http://stackoverflow.com/a/34068203)</sup> .

[1] http://stackoverflow.com/a/34068203