### PR TITLE
Use a higher limit for max threads

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -580,7 +580,7 @@ namespace MonoDevelop.Ide
 
 			if (!Platform.IsWindows) {
 				// Limit maximum threads when running on mono
-				int threadCount = 8 * Environment.ProcessorCount;
+				int threadCount = 125;
 				ThreadPool.SetMaxThreads (threadCount, threadCount);
 			}
 


### PR DESCRIPTION
XS uses a lot of tasks/threads. To avoid deadlocking the IDE we should not
use such a low number. Mono's default is 400/400 at the time of writing. If
we actually want to limit it then lets go for a max of 125 threads. That gives
us plenty to work with, even if we do kick off 16 parallel nuget restores.

https://bugzilla.xamarin.com/show_bug.cgi?id=42342