### PR TITLE
Fix crash when calculating absolute path

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -454,7 +454,7 @@ namespace MonoDevelop.Core
 				// handle case a: some/path b: some/path/deeper...
 				if (a >= aEnd) {
 					if (IsSeparator (*b)) {
-						lastStartA = a + 1;
+						lastStartA = aEnd;
 						lastStartB = b;
 					}
 				}
@@ -466,7 +466,16 @@ namespace MonoDevelop.Core
 						goUpCount++;
 					lastStartB++;
 				}
-				var size = goUpCount * 2 + goUpCount + aEnd - lastStartA;
+				int remainingPathLength = (int)(aEnd - lastStartA);
+				int size = 0;
+				if (goUpCount > 0)
+					size = goUpCount * 2 + goUpCount - 1;
+				if (remainingPathLength > 0) {
+					if (goUpCount > 0)
+						size++;
+					size += remainingPathLength;
+				}
+				
 				var result = new char [size];
 				fixed (char* rPtr = result) {
 					// go paths up
@@ -474,7 +483,8 @@ namespace MonoDevelop.Core
 					for (int i = 0; i < goUpCount; i++) {
 						*(r++) = '.';
 						*(r++) = '.';
-						*(r++) = Path.DirectorySeparatorChar;
+						if (i != goUpCount - 1 || remainingPathLength > 0) // If there is no remaining path, there is no need for a trailing slash
+							*(r++) = Path.DirectorySeparatorChar;
 					}
 					// copy the remaining absulute path
 					while (lastStartA < aEnd)


### PR DESCRIPTION
Calculation of the size of the resulting string was wrong.
Fixes bug #42376 - Xamarin Studio 6.0 introduced crash while loading
our solution.