### PR TITLE
[msbuild] Add support for building with msbuild 15.0 instead of 14.1

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
@@ -175,7 +175,7 @@ namespace MonoDevelop.Core.Assemblies
 		public override string GetMSBuildBinPath (string toolsVersion)
 		{
 			bool monoUseMSBuild = Runtime.Preferences.BuildWithMSBuild
-						&& System.Version.Parse (toolsVersion) >= new System.Version(14, 1);
+						&& System.Version.Parse (toolsVersion) >= new System.Version(15, 0);
 
 			if (monoUseMSBuild) {
 				var path = Path.Combine (monoDir, "msbuild", toolsVersion, "bin");
@@ -183,7 +183,7 @@ namespace MonoDevelop.Core.Assemblies
 					return path;
 				}
 
-				// ToolsVersion >= 14.1 is supported only by msbuild, so, just
+				// ToolsVersion >= 15.0 is supported only by msbuild, so, just
 				// return null here
 				return null;
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -873,7 +873,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		static string GetNewestInstalledToolsVersion (TargetRuntime runtime, out string binDir)
 		{
-			var supportedToolsVersions = new [] { "14.1", "14.0", "12.0", "4.0" };
+			var supportedToolsVersions = new [] { "15.0", "14.0", "12.0", "4.0" };
 
 			foreach (var toolsVersion in supportedToolsVersions) {
 				binDir = runtime.GetMSBuildBinPath (toolsVersion);
@@ -1034,18 +1034,18 @@ namespace MonoDevelop.Projects.MSBuild
 
 			var version = Version.Parse (toolsVersion);
 			bool useMicrosoftBuild =
-				((version >= new Version (14, 1)) && Runtime.Preferences.BuildWithMSBuild) ||
+				((version >= new Version (15, 0)) && Runtime.Preferences.BuildWithMSBuild) ||
 				(version >= new Version (4, 0) && runtime is MsNetTargetRuntime);
 
 			if (useMicrosoftBuild) {
-				toolsVersion = "dotnet." + toolsVersion;
+				toolsVersion = "dotnet." + (version >= new Version (15, 0) ? "14.1" : toolsVersion);
 			}
 
 			var exe = builderDir.Combine (toolsVersion, "MonoDevelop.Projects.Formats.MSBuild.exe");
 			if (File.Exists (exe))
 				return exe;
 			
-			throw new InvalidOperationException ("Unsupported MSBuild ToolsVersion '" + toolsVersion + "'");
+			throw new InvalidOperationException ("Unsupported MSBuild ToolsVersion '" + version + "'");
 		}
 
 		internal static async void ReleaseProjectBuilder (RemoteBuildEngine engine)

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/AssemblyInfo.v14.1.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/AssemblyInfo.v14.1.cs
@@ -4,6 +4,6 @@ namespace MonoDevelop.Projects.MSBuild
 {
 	static class MSBuildConsts
 	{
-		public const string Version = "14.1";
+		public const string Version = "15.0";
 	}
 }

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/Main.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/Main.cs
@@ -48,6 +48,7 @@ namespace MonoDevelop.Projects.MSBuild
 			try {
 				msbuildBinDir = Console.ReadLine ().Trim ();
 				AppDomain.CurrentDomain.AssemblyResolve += MSBuildAssemblyResolver;
+
 				Start ();
 			} catch (Exception ex) {
 				Console.WriteLine (ex);

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v14.1.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v14.1.csproj
@@ -36,28 +36,34 @@
   </PropertyGroup>
   <!-- TODO: Linux -->
   <PropertyGroup>
-    <MSBuild_14_1_BinDir Condition="'$(OS)' == 'Windows_NT'">$(MSBuildToolsPath)\..\..\14.1\Bin</MSBuild_14_1_BinDir>
-    <MSBuild_14_1_BinDir Condition="'$(OS)' == 'Unix'">$(MSBuildToolsPath)\..\..\..\msbuild\14.1\bin\</MSBuild_14_1_BinDir>
+    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Windows_NT'">$(MSBuildToolsPath)\</MSBuild_OSS_BinDir>
+
+    <!-- when building with xbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/xbuild/*/bin`
+	 when building with msbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/msbuild/*/bin`
+	 Prefer referencing msbuild 15.* assemblies over 14.1 . At runtime, we use correct one anyway
+	 -->
+    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Unix' and '$(MSBuild_OSS_BinDir)' == '' and Exists('$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\MSBuild.exe')">$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\</MSBuild_OSS_BinDir>
+    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Unix' and '$(MSBuild_OSS_BinDir)' == '' and Exists('$(MSBuildToolsPath)\..\..\..\msbuild\14.1\bin\MSBuild.exe')">$(MSBuildToolsPath)\..\..\..\msbuild\14.1\bin\</MSBuild_OSS_BinDir>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.Build">
-      <HintPath>$(MSBuild_14_1_BinDir)Microsoft.Build.dll</HintPath>
+      <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework">
-      <HintPath>$(MSBuild_14_1_BinDir)Microsoft.Build.Framework.dll</HintPath>
+      <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.Framework.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Utilities.Core">
-      <HintPath>$(MSBuild_14_1_BinDir)Microsoft.Build.Utilities.Core.dll</HintPath>
+      <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.Utilities.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.v14.1.config">
+    <None Include="app.v15.0.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
     </None>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
@@ -9,38 +9,38 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="14.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-	<msbuildToolsets default="14.1">
-		<toolset toolsVersion="14.1">
-			<property name="MSBuildBinPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/14.1/bin" />
-			<property name="MSBuildToolsPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/14.1/bin" />
+	<msbuildToolsets default="15.0">
+		<toolset toolsVersion="15.0">
+			<property name="MSBuildBinPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" />
+			<property name="MSBuildToolsPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" />
 			<property name="TargetFrameworkRootPathSearchPathsOSX" value="/Library/Frameworks/Mono.framework/External/xbuild-frameworks/" />
-			<msbuildExtensionsPathSearchPaths>
+			<projectImportSearchPaths>
 				<searchPaths os="osx">
 					<property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
 					<property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
 					<property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
 				</searchPaths>
-			</msbuildExtensionsPathSearchPaths>
+			</projectImportSearchPaths>
 		</toolset>
 	</msbuildToolsets>
 


### PR DESCRIPTION
OSS MSBuild bundled with the mono OSX installer is being updated from
14.1 to 15.0 (toolsVersion), and this updates our support for it.

Any new XS builds installed on OSX with this code will have 15.0
installed and not 14.1 . So, we just disable support for building
projects with 14.1 .

The app.config needs to be updated though because in our earlier build
the element name for extension paths was
`msbuildExtensionsPathSearchPaths`, but that was changed when it was
merged upstream to `projectImportSearchPaths`.

Also, the references in the project file are updated such that the
project can build if either 14.1 or 15.0 msbuild is available. And
at runtime, it will switch to 15.0 assemblies. The check for 14.1 can be
removed with the next release.