### PR TITLE
[build] Keep suggested OS X build doc URL OS-specific.

### DIFF
--- a/configure
+++ b/configure
@@ -143,7 +143,7 @@ handle_config_error ()
 {
 	if test `uname` = "Darwin"; then
 		echo ""
-		echo "Have you followed http://monodevelop.com/Developers/Mac_Support/Building_MonoDevelop_on_OS_X ?"
+		echo "Have you followed http://www.monodevelop.com/developers/building-monodevelop/#macosx ?"
 		echo ""
 	fi
 	exit 1


### PR DESCRIPTION
The OS X-centric URL suggested by `./configure --profile=core` for OS X failures redirects to a generic Building Monodevelop page. Since it is already redirecting, I updated the URL to the OS X anchor on that destination page to both cut out the extra bounce and put people in the right section immediately.