### PR TITLE
[MSBuild] Don't bother adding an evaluated item with an empty include

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -198,10 +198,6 @@ namespace MonoDevelop.Projects.MSBuild
 			EvaluateObjects (pi, context, objects, false);
 			EvaluateObjects (pi, context, objects, true);
 
-			// Remove from the result all items that have an empty include. MSBuild never returns those.
-
-			pi.EvaluatedItems.RemoveAll (it => it.Include.Length == 0);
-
 			// Once items have been evaluated, we need to re-evaluate properties that contain item transformations
 			// (or that contain references to properties that have transformations).
 
@@ -283,6 +279,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 		static void AddItem (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item, MSBuildItemEvaluated it, string include, Regex excludeRegex, bool trueCond)
 		{
+			// Don't add the result from any item that has an empty include. MSBuild never returns those.
+			if (include == string.Empty)
+				return;
+			
 			if (include.Length > 3 && include [0] == '@' && include [1] == '(' && include [include.Length - 1] == ')') {
 				// This is a transform
 				List<MSBuildItemEvaluated> evalItems;


### PR DESCRIPTION
This step was being done too late, therefore some property evaluation in the stack was already trying to use an empty string include. The most common failure path is Path.GetFullPath in GetMetadataValue