### PR TITLE
[Core] FilePath no longer creates extra strings on IsChildPathof.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -173,10 +173,14 @@ namespace MonoDevelop.Core
 
 		public bool IsChildPathOf (FilePath basePath)
 		{
-			if (basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar)
-				return fileName.StartsWith (basePath.fileName + Path.DirectorySeparatorChar, PathComparison);
-			else
-				return fileName.StartsWith (basePath.fileName, PathComparison);
+			bool startsWith = fileName.StartsWith (basePath.fileName, PathComparison);
+			if (startsWith && basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar) {
+				// If the last character isn't a path separator character, check whether the string we're searching in
+				// has more characters than the string we're looking for then check the character.
+				if (fileName.Length > basePath.fileName.Length)
+					startsWith &= fileName [basePath.fileName.Length] == Path.DirectorySeparatorChar;
+			}
+			return startsWith;
 		}
 
 		public FilePath ChangeExtension (string ext)


### PR DESCRIPTION
Rewrote the algorithm so it creates fewer strings. The only do the check when we get a match on the first path, so it shouldn't slow down the code a lot.

On 10,000,000 iterations, the benchmark results are as given:

New with slash: 1331ms
Old with slash: 1311ms

New without slash: 1397ms
Old without slash: 3088ms

This fixes memory pressure, slightly makes the slash variant slower, but
greatly improved the variant without slash.