### PR TITLE
[7.0][Perf] Improve enumerators in custom collections.

### DIFF
--- a/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.csproj
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.csproj
@@ -90,6 +90,10 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\external\roslyn\Binaries\Release\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.Autotools/MonoDevelop.Autotools.csproj
+++ b/main/src/addins/MonoDevelop.Autotools/MonoDevelop.Autotools.csproj
@@ -86,6 +86,10 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\external\roslyn\Binaries\Release\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -100,6 +100,10 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\external\roslyn\Binaries\Release\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -162,6 +162,10 @@
     <Reference Include="NuGet.Credentials">
       <HintPath>..\..\..\external\nuget-binary\NuGet.Credentials.dll</HintPath>
     </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\external\roslyn\Binaries\Release\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit.csproj
@@ -43,6 +43,10 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\external\roslyn\Binaries\Release\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.csproj
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.csproj
@@ -65,6 +65,10 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\external\roslyn\Binaries\Release\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/CloneableStack.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor.Highlighting/CloneableStack.cs
@@ -40,8 +40,12 @@ namespace Mono.TextEditor.Highlighting
 		int count;
 		StackItem top;
 
+		public StackItemEnumerator GetEnumerator ()
+		{
+			return new StackItemEnumerator (top);
+		}
 		#region IEnumerable[T] implementation
-		public IEnumerator<T> GetEnumerator ()
+		IEnumerator<T> IEnumerable<T>.GetEnumerator ()
 		{
 			return new StackItemEnumerator (top);
 		}
@@ -140,7 +144,7 @@ namespace Mono.TextEditor.Highlighting
 		}
 		#endregion
 
-		class StackItem
+		internal class StackItem
 		{
 			public readonly StackItem Parent;
 			public readonly T Item;
@@ -152,24 +156,24 @@ namespace Mono.TextEditor.Highlighting
 			}
 		}
 
-		class StackItemEnumerator : IEnumerator<T>
+		public struct StackItemEnumerator : IEnumerator<T>
 		{
 			StackItem cur, first;
 
-			public StackItemEnumerator (StackItem cur)
+			internal StackItemEnumerator (StackItem cur)
 			{
-				this.cur = first = new StackItem (cur, default(T));
+				this.cur = first = new StackItem (cur, default (T));
 			}
 
 			#region IDisposable implementation
-			void IDisposable.Dispose ()
+			public void Dispose ()
 			{
 				cur = first = null;
 			}
 			#endregion
 
 			#region IEnumerator implementation
-			bool IEnumerator.MoveNext ()
+			public bool MoveNext ()
 			{
 				if (cur == null)
 					return false;
@@ -177,7 +181,7 @@ namespace Mono.TextEditor.Highlighting
 				return cur != null;
 			}
 
-			void IEnumerator.Reset ()
+			public void Reset ()
 			{
 				cur = first;
 			}
@@ -190,7 +194,7 @@ namespace Mono.TextEditor.Highlighting
 			#endregion
 
 			#region IEnumerator[T] implementation
-			T IEnumerator<T>.Current {
+			public T Current {
 				get {
 					return cur.Item;
 				}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Collections/Set.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Collections/Set.cs
@@ -34,8 +34,13 @@ namespace MonoDevelop.Core.Collections
 	public class Set<T>: ICollection<T>
 	{
 		Dictionary<T,Set<T>> dict = new Dictionary<T,Set<T>> ();
-		
-		public IEnumerator GetEnumerator ()
+
+		public Dictionary<T, Set<T>>.KeyCollection.Enumerator GetEnumerator ()
+		{
+			return dict.Keys.GetEnumerator ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
 		{
 			return ((IEnumerable)dict.Keys).GetEnumerator ();
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ExecutionTarget.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ExecutionTarget.cs
@@ -185,9 +185,14 @@ namespace MonoDevelop.Core.Execution
 
 		#endregion
 
+		public List<ExecutionTarget>.Enumerator GetEnumerator ()
+		{
+			return targets.GetEnumerator ();
+		}
+
 		#region IEnumerable implementation
 
-		public IEnumerator<ExecutionTarget> GetEnumerator ()
+		IEnumerator<ExecutionTarget> IEnumerable<ExecutionTarget>.GetEnumerator ()
 		{
 			return targets.GetEnumerator ();
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/EventArgsChain.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/EventArgsChain.cs
@@ -101,6 +101,11 @@ namespace MonoDevelop.Core
 		}
 		#endregion
 
+		public List<T>.Enumerator GetEnumerator ()
+		{
+			return events.GetEnumerator ();
+		}
+
 		#region IEnumerable implementation
 		System.Collections.IEnumerator IEnumerable.GetEnumerator ()
 		{
@@ -109,7 +114,7 @@ namespace MonoDevelop.Core
 		#endregion
 
 		#region IEnumerable[T] implementation
-		public IEnumerator<T> GetEnumerator ()
+		IEnumerator<T> IEnumerable<T>.GetEnumerator ()
 		{
 			return events.GetEnumerator ();
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/EnvironmentVariableCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/EnvironmentVariableCollection.cs
@@ -141,6 +141,11 @@ namespace MonoDevelop.Projects
 			((ICollection<KeyValuePair<string, string>>)dict).CopyTo (array, arrayIndex);
 		}
 
+		public List<KeyValuePair<string, string>>.Enumerator GetEnumerator ()
+		{
+			return dict.GetEnumerator ();
+		}
+
 		IEnumerator IEnumerable.GetEnumerator ()
 		{
 			return ((IEnumerable)dict).GetEnumerator ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileCopySet.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileCopySet.cs
@@ -108,6 +108,11 @@ namespace MonoDevelop.Projects
 				return null;
 			}
 		}
+
+		public Dictionary<FilePath, Item>.ValueCollection.Enumerator GetEnumerator ()
+		{
+			return files.Values.GetEnumerator ();
+		}
 		
 		IEnumerator<Item> IEnumerable<Item>.GetEnumerator ()
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
@@ -148,9 +148,14 @@ namespace MonoDevelop.Projects
 		{
 		}
 
+		public ImmutableList<T>.Enumerator GetEnumerator ()
+		{
+			return list.GetEnumerator ();
+		}
+
 		#region IEnumerable implementation
 
-		public IEnumerator<T> GetEnumerator ()
+		IEnumerator<T> IEnumerable<T>.GetEnumerator ()
 		{
 			return list.GetEnumerator ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandArrayInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandArrayInfo.cs
@@ -129,7 +129,12 @@ namespace MonoDevelop.Components.Commands
 			get { return defaultInfo; }
 		}
 
-		public IEnumerator<CommandInfo> GetEnumerator ()
+		public List<CommandInfo>.Enumerator GetEnumerator ()
+		{
+			return list.GetEnumerator ();
+		}
+
+		IEnumerator<CommandInfo> IEnumerable<CommandInfo>.GetEnumerator ()
 		{
 			return list.GetEnumerator ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandEntrySet.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandEntrySet.cs
@@ -97,8 +97,13 @@ namespace MonoDevelop.Components.Commands
 			cmds.Add (cmdset);
 			return cmdset;
 		}
+
+		public List<CommandEntry>.Enumerator GetEnumerator ()
+		{
+			return cmds.GetEnumerator ();
+		}
 		
-		public System.Collections.IEnumerator GetEnumerator ()
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
 		{
 			return cmds.GetEnumerator ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskStore.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskStore.cs
@@ -183,8 +183,13 @@ namespace MonoDevelop.Ide.Tasks
 		public int Count {
 			get { return tasks.Count; }
 		}
+
+		public List<TaskListEntry>.Enumerator GetEnumerator ()
+		{
+			return tasks.GetEnumerator ();
+		}
 		
-		public IEnumerator<TaskListEntry> GetEnumerator ()
+		IEnumerator<TaskListEntry> IEnumerable<TaskListEntry>.GetEnumerator ()
 		{
 			return tasks.GetEnumerator ();
 		}


### PR DESCRIPTION
This makes it so there is no Enumerator created, as the compiler is smart enough to detect that if there is a strongly typed GetEnumerator() method with a return value that structurally matches IEnumerator, it'll prefer that.
In this case, we're talking about structs. This will save us IEnumerator allocations all over the place.
