### PR TITLE
[Perf] Improve enumerators in internal custom collections

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/CompletionResult.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/CompletionResult.cs
@@ -67,15 +67,20 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 
 		public readonly List<IMethodSymbol> PossibleDelegates = new List<IMethodSymbol>();
 
-		#region IReadOnlyList<ICompletionData> implemenation
-		public IEnumerator<CompletionData> GetEnumerator()
+		public List<CompletionData>.Enumerator GetEnumerator ()
 		{
-			return data.GetEnumerator();
+			return data.GetEnumerator ();
+		}
+
+		#region IReadOnlyList<ICompletionData> implemenation
+		IEnumerator<CompletionData> IEnumerable<CompletionData>.GetEnumerator ()
+		{
+			return data.GetEnumerator ();
 		}
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return ((System.Collections.IEnumerable)data).GetEnumerator();
+			return data.GetEnumerator();
 		}
 		
 		public CompletionData this[int index] {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/ParameterHinting/ParameterHintingResult.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/ParameterHinting/ParameterHintingResult.cs
@@ -42,11 +42,16 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 			private set;
 		}
 
-		#region IReadOnlyList<IParameterHintingData> implementation
-		
-		public IEnumerator<IParameterHintingData> GetEnumerator()
+		public List<IParameterHintingData>.Enumerator GetEnumerator ()
 		{
-			return data.GetEnumerator();
+			return data.GetEnumerator ();
+		}
+
+		#region IReadOnlyList<IParameterHintingData> implementation
+
+		IEnumerator<IParameterHintingData> IEnumerable<IParameterHintingData>.GetEnumerator ()
+		{
+			return data.GetEnumerator ();
 		}
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/main/src/addins/CSharpBinding/Util/CloneableStack.cs
+++ b/main/src/addins/CSharpBinding/Util/CloneableStack.cs
@@ -34,8 +34,12 @@ namespace ICSharpCode.NRefactory6.CSharp
 		int count;
 		StackItem top;
 
+		public StackItemEnumerator GetEnumerator ()
+		{
+			return new StackItemEnumerator (top);
+		}
 		#region IEnumerable[T] implementation
-		public IEnumerator<T> GetEnumerator ()
+		IEnumerator<T> IEnumerable<T>.GetEnumerator ()
 		{
 			return new StackItemEnumerator (top);
 		}
@@ -140,7 +144,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 		}
 		#endregion
 
-		class StackItem
+		internal class StackItem
 		{
 			public readonly StackItem Parent;
 			public readonly T Item;
@@ -152,24 +156,24 @@ namespace ICSharpCode.NRefactory6.CSharp
 			}
 		}
 
-		class StackItemEnumerator : IEnumerator<T>
+		public struct StackItemEnumerator : IEnumerator<T>
 		{
 			StackItem cur, first;
 
-			public StackItemEnumerator (StackItem cur)
+			internal StackItemEnumerator (StackItem cur)
 			{
 				this.cur = first = new StackItem (cur, default(T));
 			}
 
 			#region IDisposable implementation
-			void IDisposable.Dispose ()
+			public void Dispose ()
 			{
 				cur = first = null;
 			}
 			#endregion
 
 			#region IEnumerator implementation
-			bool IEnumerator.MoveNext ()
+			public bool MoveNext ()
 			{
 				if (cur == null)
 					return false;
@@ -177,7 +181,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 				return cur != null;
 			}
 
-			void IEnumerator.Reset ()
+			public void Reset ()
 			{
 				cur = first;
 			}
@@ -190,7 +194,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 			#endregion
 
 			#region IEnumerator[T] implementation
-			T IEnumerator<T>.Current {
+			public T Current {
 				get {
 					return cur.Item;
 				}

--- a/main/src/addins/CSharpBinding/Util/NameSyntaxExtensions.cs
+++ b/main/src/addins/CSharpBinding/Util/NameSyntaxExtensions.cs
@@ -88,27 +88,28 @@ namespace ICSharpCode.NRefactory6.CSharp
 			_name = name;
 		}
 
-		public IEnumerator<NameSyntax> GetEnumerator()
+		public LinkedList<NameSyntax>.Enumerator GetEnumerator ()
 		{
-			var nodes = new LinkedList<NameSyntax>();
+			var nodes = new LinkedList<NameSyntax> ();
 
 			var currentNode = _name;
-			while (true)
-			{
-				if (currentNode.Kind() == SyntaxKind.QualifiedName)
-				{
+			while (true) {
+				if (currentNode.Kind () == SyntaxKind.QualifiedName) {
 					var qualifiedName = currentNode as QualifiedNameSyntax;
-					nodes.AddFirst(qualifiedName.Right);
+					nodes.AddFirst (qualifiedName.Right);
 					currentNode = qualifiedName.Left;
-				}
-				else
-				{
-					nodes.AddFirst(currentNode);
+				} else {
+					nodes.AddFirst (currentNode);
 					break;
 				}
 			}
 
-			return nodes.GetEnumerator();
+			return nodes.GetEnumerator ();
+		}
+
+		IEnumerator<NameSyntax> IEnumerable<NameSyntax>.GetEnumerator()
+		{
+			return GetEnumerator ();
 		}
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()


### PR DESCRIPTION
This makes it so there is no Enumerator created, as the compiler is smart
enough to detect that if there is a strongly typed GetEnumerator() method
with a return value that structurally matches IEnumerator, it'll prefer
that.
In this case, we're talking about structs. This will save us IEnumerator
allocations all over the place.

Split of #1637 by only changing what's internal API.