### PR TITLE
[Mac] OSX style checkboxes with pure Gtk theme

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -348,7 +348,6 @@ style "radio-or-check-box" = "button"
     engine "xamarin" {
         focusstyle = 0
         border_shades = { 1.0, 1.0 }
-        border_colors = { @fg_color, @fg_color }
     }
 }
 

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -334,24 +334,28 @@ style "notebook" = "default"
     }
 }
 
-style "radio-or-check-box" = "default"
+style "radio-or-check-box" = "button"
 {
-    ythickness = 6
+    GtkCheckButton::indicator-size = 17
+    base[ACTIVE] = "#419bf9"
+    base[SELECTED] = "#419bf9"
+    base[PRELIGHT] = @base_color
+    text[ACTIVE] = @base_color
+    text[SELECTED] = @base_color
+    text[PRELIGHT] = @base_color
+    text[NORMAL] = @base_color
 
-    engine "quartz" {
+    engine "xamarin" {
+        focusstyle = 0
+        border_shades = { 1.0, 1.0 }
+        border_colors = { @fg_color, @fg_color }
     }
 }
 
 style "propertygrid-radio-or-check-box" = "radio-or-check-box"
 {
-    base[ACTIVE] = @base_color
-    base[SELECTED] = @base_color
-    base[PRELIGHT] = @base_color
-    text[SELECTED] = @fg_color
     GtkCheckButton::indicator-spacing = 0
-
-    engine "xamarin" {
-    }
+    GtkCheckButton::indicator-size = 15
 }
 
 style "entry" = "default"

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -311,27 +311,28 @@ style "notebook" = "default"
     }
 }
 
-style "quartz-radio-or-check-box" = "default"
+style "quartz-radio-or-check-box" = "button"
 {
-    ythickness = 6
+    GtkCheckButton::indicator-size = 17
+    base[ACTIVE] = "#99999e"
+    base[SELECTED] = "#fff"
+    base[PRELIGHT] = @base_color
+    text[ACTIVE] = @selected_fg_color
+    text[SELECTED] = @selected_fg_color
+    text[PRELIGHT] = @selected_fg_color
+    text[NORMAL] = @selected_fg_color
 
-    engine "quartz" {
+    engine "xamarin" {
+        focusstyle = 0
+        border_shades = { 1.0, 1.0 }
+        border_colors = { @fg_color, @fg_color }
     }
 }
 
-style "propertygrid-radio-or-check-box" = "default"
+style "propertygrid-radio-or-check-box" = "quartz-radio-or-check-box"
 {
     GtkCheckButton::indicator-spacing = 0
-
-    base[NORMAL] = "#fff"
-    base[ACTIVE] = "#fff"
-    base[SELECTED] = "#fff"
-    base[PRELIGHT] = "#fff"
-    text[SELECTED] = @base_color
-
-    engine "xamarin" {
-        border_shades = { 1.33, 1.33 }
-    }
+    GtkCheckButton::indicator-size = 15
 }
 
 style "entry" = "default"

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -158,7 +158,6 @@ style "button" = "default" {
         contrast = 1.0
         focus_color = shade(1.4, @bg_color)
         focusstyle = 3
-        border_colors = { @bg_color, @bg_color }
         textstyle = 0
         highlight_shade = 1.0
         lightborder_shade = 1.0
@@ -325,7 +324,6 @@ style "quartz-radio-or-check-box" = "button"
     engine "xamarin" {
         focusstyle = 0
         border_shades = { 1.0, 1.0 }
-        border_colors = { @fg_color, @fg_color }
     }
 }
 


### PR DESCRIPTION
This PR makes Gtk checks/radios look like native OSX ones and fully replaces the quartz Gtk engine:

<img width="370" alt="bildschirmfoto 2016-10-04 um 17 21 47" src="https://cloud.githubusercontent.com/assets/951587/19080370/21c655a8-8a57-11e6-8e4e-b3e0360796f6.png">

This works with mono 4.6+ and is compatible with `cycle8`, @slluis let me know if we want to backport this.