### PR TITLE
[build] Use nuget.exe from nuget-binary's submodule if nuget not found

### DIFF
--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -24,11 +24,13 @@ clean-local: sln_clean
 NUGET_FOUND = $$(echo $$(which nuget))
 NUGET_RESTORE = \
 	if [ "x$(NUGET_FOUND)" = "x" ]; then \
-		echo "nuget not found; please install it first"; \
-		exit 1; \
-	fi; \
-	nuget restore
+		mono external/nuget-binary/nuget.exe restore; \
+	else \
+		nuget restore; \
+	fi;
 
+#FIXME: move the restore logic into MSBuild (Before.sln.targets),
+#       see: https://github.com/kzu/NuGet.Restore
 restore-packages:
 	@$(NUGET_RESTORE)
 

--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -21,8 +21,16 @@ clean-local: sln_clean
 	cd external && $(MAKE) clean
 	cd build && $(MAKE) clean
 
-restore-packages:
+NUGET_FOUND = $$(echo $$(which nuget))
+NUGET_RESTORE = \
+	if [ "x$(NUGET_FOUND)" = "x" ]; then \
+		echo "nuget not found; please install it first"; \
+		exit 1; \
+	fi; \
 	nuget restore
+
+restore-packages:
+	@$(NUGET_RESTORE)
 
 vcrevision:
 	touch vcrevision


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44889