### PR TITLE
Fixed 'Bug 44537 - XS 6.x branches are not reading XML documentation

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MetadataReferenceCache.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MetadataReferenceCache.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using System.IO;
 using MonoDevelop.Core;
 using System.Threading;
+using System.Reflection;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
@@ -158,6 +159,8 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			readonly static DateTime NonExistentFile = new DateTime (1601, 1, 1);
 
+			static Type docProviderType;
+
 			void CreateNewReference ()
 			{
 				timeStamp = File.GetLastWriteTimeUtc (path);
@@ -166,7 +169,18 @@ namespace MonoDevelop.Ide.TypeSystem
 					LoggingService.LogError ("Error while loading reference " + path + ": File doesn't exist"); 
 				} else {
 					try {
-						Reference = MetadataReference.CreateFromFile (path, MetadataReferenceProperties.Assembly);
+						DocumentationProvider provider = null;
+						try {
+							string xmlName = Path.ChangeExtension (path, ".xml");
+							if (File.Exists (xmlName)) {
+								if (docProviderType == null)
+									docProviderType = Assembly.Load ("Microsoft.CodeAnalysis.Workspaces.Desktop").GetType ("Microsoft.CodeAnalysis.FileBasedXmlDocumentationProvider");
+								provider = (DocumentationProvider)Activator.CreateInstance (docProviderType, xmlName);
+							}
+						} catch (Exception e) {
+							LoggingService.LogError ("Error while creating xml documentation provider for: " + path, e);
+						}
+						Reference = MetadataReference.CreateFromFile (path, MetadataReferenceProperties.Assembly, provider);
 					} catch (Exception e) {
 						LoggingService.LogError ("Error while loading reference " + path + ": " + e.Message, e); 
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -160,6 +160,9 @@
     <Reference Include="System.Composition.Runtime">
       <HintPath>..\..\..\external\roslyn\Binaries\Release\System.Composition.Runtime.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
+      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoDevelop.Core\MonoDevelop.Core.csproj">


### PR DESCRIPTION
from 3rd party libraries'