### PR TITLE
[MSBuild, Perf] Move Token to be a struct

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionParser.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionParser.cs
@@ -209,14 +209,15 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			
 			while (true) {
 				tokenizer.GetNextToken ();
-				if (tokenizer.Token.Type == TokenType.RightParen) {
+				var token = tokenizer.Token;
+				if (token.Type == TokenType.RightParen) {
 					tokenizer.GetNextToken ();
 					break;
 				}
-				if (tokenizer.Token.Type == TokenType.Comma)
+				if (token.Type == TokenType.Comma)
 					continue;
 					
-				tokenizer.Putback (tokenizer.Token);
+				tokenizer.Putback (token);
 				e = (ConditionFactorExpression) ParseFactorExpression ();
 				list.Add (e);
 			}
@@ -227,9 +228,10 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 		//@prefix: @ or $
 		ConditionExpression ParseReferenceExpression (char prefix)
 		{
-			int token_pos = tokenizer.Token.Position;
+			var token = tokenizer.Token;
+			int token_pos = token.Position;
 			string ref_type = prefix == '$' ? "a property" : "an item list";
-			if (!IsAtToken (TokenType.LeftParen))
+			if (token.Type != TokenType.LeftParen)
 				ThrowParseException (TokenType.LeftParen, "Expected {0} at position {1} in condition \"{2}\". Missing opening parantheses after the '{3}'.",
 						ref_type, token_pos, conditionStr, prefix);
 
@@ -263,7 +265,7 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 				}
 			}
 
-			if (!IsAtToken (TokenType.RightParen))
+			if (tokenizer.Token.Type != TokenType.RightParen)
 				ThrowParseException (TokenType.RightParen, "Missing closing parenthesis in condition {0}", conditionStr);
 			tokenizer.GetNextToken ();
 
@@ -271,12 +273,6 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 
 			//FIXME: HACKY!
 			return new ConditionFactorExpression (new Token (sb.ToString (), TokenType.String, token_pos));
-		}
-
-		// used to check current token type
-		bool IsAtToken (TokenType type)
-		{
-			return tokenizer.Token.Type == type;
 		}
 
 		void ThrowParseException(TokenType type, string error_fmt, params object[] args)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionTokenizer.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionTokenizer.cs
@@ -44,7 +44,8 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 		int nextChar = -1;
 		
 		Token	token;
-		Token	putback = null;
+		bool	hasPutback;
+		Token	putback;
 		
 //		bool	ignoreWhiteSpace = true;
 		
@@ -142,14 +143,15 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 		// FIXME test this
 		public void Putback (Token token)
 		{
+			hasPutback = true;
 			putback = token;
 		}
 
 		public void GetNextToken ()
 		{
-			if (putback != null) {
+			if (hasPutback) {
 				token = putback;
-				putback = null;
+				hasPutback = false;
 				return;
 			}
 		

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/Token.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/Token.cs
@@ -31,16 +31,17 @@ using System;
 
 namespace MonoDevelop.Projects.MSBuild.Conditions {
 
-	internal class Token {
+	internal struct Token {
 	
 		string		tokenValue;
 		TokenType	tokenType;
+		int position;
 	
 		public Token (string tokenValue, TokenType tokenType, int position)
 		{
 			this.tokenValue = tokenValue;
 			this.tokenType = tokenType;
-			this.Position = position + 1;
+			this.position = position + 1;
 		}
 		
 		public string Value {
@@ -53,7 +54,7 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 
 		// this is 1-based
 		public int Position {
-			get; private set;
+			get { return position; }
 		}
 
 		public static string TypeAsString (TokenType tokenType)


### PR DESCRIPTION
This commit is pretty much self-explanatory. this reduces allocations for
the Token struct, making the code behave better.

Tokens are short-lived, usually not lasting more than two stackframes. The
idea is that a Token is at most 16bytes in size (on 64bit), it is
immutable and it represents a single value.

This change overall causes a huge change in allocations:
* MonoDevelop.Projects.MSBuild.Conditions allocations go down by 120MB on Main.sln
* 144MB of Tokens are no longer created on the heap (7 million obj)
* ConditionTokenizer allocates 12MB more now, as it has two token members.
* ConditionFactoryExpression allocates 12MB more now as it has a token member.

This should also increase performance.