### PR TITLE
Fixes F# project references from C#

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -563,7 +563,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			var hashSet = new HashSet<string> (FilePath.PathComparer);
 
 			try {
-				foreach (var file in await netProject.GetReferencedAssemblies (configurationSelector, false).ConfigureAwait (false)) {
+				foreach (var file in await netProject.GetReferencedAssemblies (configurationSelector).ConfigureAwait (false)) {
 					if (token.IsCancellationRequested)
 						return result;
 					string fileName;


### PR DESCRIPTION
Not sure of the ramifications of this change, but this makes F# project references work from C# projects.