### PR TITLE
[CSharpBinding] Remove the timeout when we release the outline view

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
@@ -266,6 +266,7 @@ namespace MonoDevelop.CSharp.ClassOutline
 			var w = (ScrolledWindow)outlineTreeView.Parent;
 			w.Destroy ();
 			outlineTreeView = null;
+			RemoveRefillOutlineStoreTimeout ();
 			settings = null;
 			foreach (var tw in toolbarWidgets)
 				tw.Destroy ();


### PR DESCRIPTION
We're null reffing because the callback is being invokde after we
null out the `outlineTreeView`. I think it makes sense to remove
the callback when this is nulled out as we don't want it to be
refilled at that point.

Fixes this spew from my logs:

System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.CSharp.ClassOutline.CSharpOutlineTextEditorExtension.RefillOutlineStore () [0x00023] in /Users/alan/Projects/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs:303
  at GLib.Timeout+TimeoutProxy.Handler (System.IntPtr data) [0x0003f] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-None/glib/Timeout.cs:73