### PR TITLE
Use portable flavor for F#

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
@@ -77,6 +77,7 @@ type ``Template tests``() =
         let name = "FSharpPortableLibrary"
         let projectTemplate = ProjectTemplate.ProjectTemplates |> Seq.find (fun t -> t.Id = name)
         let dir = FilePath (templatesDir/"fsportable")
+        dir.Delete()
         let cinfo = new ProjectCreateInformation (ProjectBasePath = dir, ProjectName = name, SolutionName = name, SolutionPath = dir)
         let sln = projectTemplate.CreateWorkspaceItem (cinfo) :?> Solution
         let proj = sln.Items.[0] :?> FSharpProject

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -42,6 +42,12 @@
     <DotNetProjectType language="F#" extension="fsproj" guid="{f2a71f9b-5d33-465a-a702-920d77279786}" type="MonoDevelop.FSharp.FSharpProject"/>
   </Extension>
 
+  <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
+    <Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.Portable.FSharp.Targets">
+      <ProjectFlavor guid="{786c830f-07a1-408b-bd7f-6ee04809d6db}" type="MonoDevelop.FSharp.PortableFSharpProjectFlavor" language="F#" alias="F#PortableLibrary"/>
+    </Condition>
+  </Extension>
+
   <Extension path="/MonoDevelop/Ide/GlobalOptionsDialog/Other">
     <Section id="FSharpSettings" _label="F# Settings" class = "MonoDevelop.FSharp.FSharpSettingsPanel" icon="md-prefs-source" />
   </Extension>

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="FSharpInteractivePad.fs" />
     <Compile Include="FSharpOptionsPanels.fs" />
     <Compile Include="FSharpProject.fs" />
+    <Compile Include="PortableFSharpProjectFlavor.fs" />
     <Compile Include="FSharpFoldingParser.fs" />
     <Compile Include="FSharpParser.fs" />
     <Compile Include="FSharpOutlineTextEditorExtension.fs" />

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/PortableFSharpProjectFlavor.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/PortableFSharpProjectFlavor.fs
@@ -1,0 +1,14 @@
+﻿namespace MonoDevelop.FSharp
+
+open System
+open MonoDevelop.Projects
+
+type PortableFSharpProjectFlavor() =
+    inherit PortableDotNetProjectFlavor()
+
+    override x.Initialize () =
+        base.Initialize ()
+        base.Project.UseMSBuildEngine <- Nullable(true)
+
+    override x.OnGetDefaultImports imports =
+        imports.Add @"$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets"

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Templates/PortableLibrary.xpt.xml
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Templates/PortableLibrary.xpt.xml
@@ -26,7 +26,7 @@
 			<StartupProject>${ProjectName}</StartupProject>
 		</Options>
 		
-		<Project name = "${ProjectName}" directory = "." >
+		<Project name = "${ProjectName}" directory = "." type="F#PortableLibrary">
 			<Options Target = "Library"
 					 TargetFrameworkVersion = ".NETFramework,Version=v4.5,Profile=Profile78"
 					 FSharpPortable = "true"

--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -93,7 +93,7 @@
 
 	<Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
 		<Condition id="MSBuildTargetIsAvailable" target="$(MSBuildExtensionsPath)\Microsoft\Portable\v4.0\Microsoft.Portable.CSharp.targets">
-			<ProjectFlavor guid="{786C830F-07A1-408B-BD7F-6EE04809D6DB}" type="MonoDevelop.CSharp.Project.PortableCSharpProjectFlavor" alias="C#PortableLibrary"/>
+			<ProjectFlavor guid="{786C830F-07A1-408B-BD7F-6EE04809D6DB}" type="MonoDevelop.CSharp.Project.PortableCSharpProjectFlavor" language="C#" alias="C#PortableLibrary"/>
 		</Condition>
 	</Extension>
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/SolutionItemExtensionNode.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/SolutionItemExtensionNode.cs
@@ -55,6 +55,9 @@ namespace MonoDevelop.Projects.Extensions
 		[NodeAttribute ("alias", Description = "Friendly id of the extension")]
 		public string TypeAlias { get; set; }
 
+		[NodeAttribute ("language", Description = "Language of the extension")]
+		public string LanguageName { get; set; }
+
 		public SolutionItemExtensionNode ()
 		{
 			MSBuildSupport = MSBuildSupport.Supported;
@@ -98,6 +101,7 @@ namespace MonoDevelop.Projects.Extensions
 			var ext = (SolutionItemExtension) CreateInstance (typeof(SolutionItemExtension));
 			ext.FlavorGuid = Guid;
 			ext.TypeAlias = TypeAlias;
+			ext.LanguageName = LanguageName;
 			return ext;
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
@@ -43,6 +43,7 @@ namespace MonoDevelop.Projects
 
 		internal string FlavorGuid { get; set; }
 		internal string TypeAlias { get; set; }
+		internal string LanguageName { get; set; }
 
 		internal protected override void InitializeChain (ChainedExtension next)
 		{
@@ -52,11 +53,23 @@ namespace MonoDevelop.Projects
 
 		internal protected override bool SupportsObject (WorkspaceObject item)
 		{
-			var p = item as SolutionItem;
+			var s = item as SolutionItem;
+			if (s == null)
+				return false;
+
+			var res = FlavorGuid == null || s.GetItemTypeGuids ().Any (id => id.Equals (FlavorGuid, StringComparison.OrdinalIgnoreCase));
+
+			if (!res)
+				return false;
+
+			var p = item as DotNetProject;
 			if (p == null)
 				return false;
 
-			return FlavorGuid == null || p.GetItemTypeGuids ().Any (id => id.Equals (FlavorGuid, StringComparison.OrdinalIgnoreCase));
+			if (LanguageName == null)
+				return true;
+
+			return LanguageName == p.LanguageName;
 		}
 
 		public SolutionItem Item {


### PR DESCRIPTION
Adds DotnetProjectFlavor for F# portable libraries. XS expects this to be used in a few places such as the `.NET Portable Subset` node under references and the new `Service Capabilities` node.
