### PR TITLE
Remove all use of GNOME-specific libraries from GnomePlatform

### DIFF
--- a/main/configure.ac
+++ b/main/configure.ac
@@ -146,8 +146,6 @@ PKG_CHECK_MODULES(GNOME_SHARP, gnome-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [g
 AC_SUBST(GNOME_SHARP_LIBS)
 PKG_CHECK_MODULES(GNOME_VFS_SHARP, gnome-vfs-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gnome_vfs_sharp=yes], [gnome_vfs_sharp=no])
 AC_SUBST(GNOME_VFS_SHARP_LIBS)
-PKG_CHECK_MODULES(GCONF_SHARP, gconf-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gconf_sharp=yes], [gconf_sharp=no])
-AC_SUBST(GCONF_SHARP_LIBS)
 
 gtksharp_prefix="`$PKG_CONFIG --variable=prefix gtk-sharp-2.0`"
 AC_SUBST(gtksharp_prefix)
@@ -210,9 +208,6 @@ if test x$enable_gnomeplatform = xyes; then
 	fi
 	if test x$gnome_vfs_sharp = xno; then
 		AC_MSG_ERROR([Cannot enable GNOME platform without gnome-vfs-sharp-2.0])
-	fi
-	if test x$gconf_sharp = xno; then
-		AC_MSG_ERROR([Cannot enable GNOME platform without gconf-sharp-2.0])
 	fi
 	platform_bindings="${platform_bindings}GNOME "
 fi

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -141,10 +141,6 @@ AC_SUBST(GLADE_SHARP_LIBS)
 PKG_CHECK_MODULES(MONODOC, monodoc >= $MONODOC_REQUIRED_VERSION)
 AC_SUBST(MONODOC_LIBS)
 
-dnl soft dependencies
-PKG_CHECK_MODULES(GNOME_VFS_SHARP, gnome-vfs-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gnome_vfs_sharp=yes], [gnome_vfs_sharp=no])
-AC_SUBST(GNOME_VFS_SHARP_LIBS)
-
 gtksharp_prefix="`$PKG_CONFIG --variable=prefix gtk-sharp-2.0`"
 AC_SUBST(gtksharp_prefix)
 
@@ -201,9 +197,6 @@ AC_ARG_ENABLE(gnomeplatform,
 		enable_gnomeplatform=${enableval}, enable_gnomeplatform=$default_gnomeplatform)
 
 if test x$enable_gnomeplatform = xyes; then
-	if test x$gnome_vfs_sharp = xno; then
-		AC_MSG_ERROR([Cannot enable GNOME platform without gnome-vfs-sharp-2.0])
-	fi
 	platform_bindings="${platform_bindings}GNOME "
 fi
 

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -142,8 +142,6 @@ PKG_CHECK_MODULES(MONODOC, monodoc >= $MONODOC_REQUIRED_VERSION)
 AC_SUBST(MONODOC_LIBS)
 
 dnl soft dependencies
-PKG_CHECK_MODULES(GNOME_SHARP, gnome-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gnome_sharp=yes], [gnome_sharp=no])
-AC_SUBST(GNOME_SHARP_LIBS)
 PKG_CHECK_MODULES(GNOME_VFS_SHARP, gnome-vfs-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gnome_vfs_sharp=yes], [gnome_vfs_sharp=no])
 AC_SUBST(GNOME_VFS_SHARP_LIBS)
 
@@ -203,9 +201,6 @@ AC_ARG_ENABLE(gnomeplatform,
 		enable_gnomeplatform=${enableval}, enable_gnomeplatform=$default_gnomeplatform)
 
 if test x$enable_gnomeplatform = xyes; then
-	if test x$gnome_sharp = xno; then
-		AC_MSG_ERROR([Cannot enable GNOME platform without gnome-sharp-2.0])
-	fi
 	if test x$gnome_vfs_sharp = xno; then
 		AC_MSG_ERROR([Cannot enable GNOME platform without gnome-vfs-sharp-2.0])
 	fi

--- a/main/src/addins/GnomePlatform/Gio.cs
+++ b/main/src/addins/GnomePlatform/Gio.cs
@@ -194,8 +194,10 @@ namespace MonoDevelop.Platform {
 			IntPtr native_attrs = GLib.Marshaller.StringToPtrGStrdup ("standard::content-type");
 			IntPtr error;
 			IntPtr info = g_file_query_info (gfile, native_attrs, 0, IntPtr.Zero, out error);
-			if (error != IntPtr.Zero)
+			if (error != IntPtr.Zero) {
+				g_error_free (error);
 				return null;
+			}
 			IntPtr content_type = g_file_info_get_content_type (info);
 			string mime_type = GLib.Marshaller.Utf8PtrToString (g_content_type_get_mime_type (content_type));
 			GLib.Marshaller.Free (content_type);

--- a/main/src/addins/GnomePlatform/Gio.cs
+++ b/main/src/addins/GnomePlatform/Gio.cs
@@ -59,6 +59,10 @@ namespace MonoDevelop.Platform {
 		static extern IntPtr g_file_new_for_uri (IntPtr uri);
 		[DllImport (gio, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_file_query_info (IntPtr handle, IntPtr attrs, int flags, IntPtr cancellable, out IntPtr error);
+		[DllImport(gio, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr g_settings_get_string(IntPtr gsettings, IntPtr key);
+		[DllImport(gio, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr g_settings_new(IntPtr schema);
 		[DllImport (glib, CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_list_free (IntPtr raw);
 		[DllImport (gobject, CallingConvention = CallingConvention.Cdecl)]
@@ -122,6 +126,20 @@ namespace MonoDevelop.Platform {
 			}
 			g_list_free (ret);
 			return apps;
+		}
+
+		public static string GetGSettingsString(string schema, string key)
+		{
+			IntPtr schema_native = GLib.Marshaller.StringToPtrGStrdup (schema);
+			IntPtr gsettings = g_settings_new (schema_native);
+			GLib.Marshaller.Free (schema_native);
+
+			IntPtr key_native = GLib.Marshaller.StringToPtrGStrdup (key);
+			IntPtr ret = g_settings_get_string (gsettings, key_native);
+			GLib.Marshaller.Free (key_native);
+
+			g_object_unref (gsettings);
+			return GLib.Marshaller.PtrToStringGFree (ret);
 		}
 
 		public static string GetMimeTypeDescription (string mime_type)

--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -29,7 +29,6 @@
 using MonoDevelop.Ide.Desktop;
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.IO;
 using MonoDevelop.Core.Execution;
@@ -41,30 +40,6 @@ namespace MonoDevelop.Platform
 	{
 		static GnomePlatform ()
 		{
-		}
-		
-		DesktopApplication GetGnomeVfsDefaultApplication (string mimeType)
-		{
-			var app = Gnome.Vfs.Mime.GetDefaultApplication (mimeType);
-			if (app != null)
-				return (DesktopApplication) Marshal.PtrToStructure (app.Handle, typeof(DesktopApplication));
-			else
-				return null;
-		}
-		
-		IEnumerable<DesktopApplication> GetGnomeVfsApplications (string mimeType)
-		{
-			var def = GetGnomeVfsDefaultApplication (mimeType);
-			var list = new List<DesktopApplication> ();
-			var apps = Gnome.Vfs.Mime.GetAllApplications (mimeType);
-			foreach (var app in apps) {
-				var dap = (GnomeVfsApp) Marshal.PtrToStructure (app.Handle, typeof(GnomeVfsApp));
-				if (!string.IsNullOrEmpty (dap.Command) && !string.IsNullOrEmpty (dap.DisplayName) && !dap.Command.Contains ("monodevelop ")) {
-					var isDefault = def != null && def.Id == dap.Command;
-					list.Add (new GnomeDesktopApplication (dap.Command, dap.DisplayName, isDefault));
-				}
-			}
-			return list;
 		}
 		
 		public override IEnumerable<DesktopApplication> GetApplications (string filename)

--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -40,18 +40,10 @@ namespace MonoDevelop.Platform
 {
 	public class GnomePlatform : PlatformService
 	{
-		static bool useGio;
-
 		Gnome.ThumbnailFactory thumbnailFactory = new Gnome.ThumbnailFactory (Gnome.ThumbnailSize.Normal);
 
 		static GnomePlatform ()
 		{
-			try {
-				Gio.GetDefaultForType ("text/plain");
-				useGio = true;
-			} catch (Exception ex) {
-				Console.WriteLine (ex);
-			}
 			//apparently Gnome.Icon needs GnomeVFS initialized even when we're using GIO.
 			Gnome.Vfs.Vfs.Initialize ();
 		}
@@ -88,10 +80,7 @@ namespace MonoDevelop.Platform
 
 		IEnumerable<DesktopApplication> GetApplicationsForMimeType (string mimeType)
 		{
-			if (useGio)
-				return Gio.GetAllForType (mimeType);
-			else
-				return GetGnomeVfsApplications (mimeType);
+			return Gio.GetAllForType (mimeType);
 		}
 		
 		struct GnomeVfsApp {
@@ -100,10 +89,7 @@ namespace MonoDevelop.Platform
 
 		protected override string OnGetMimeTypeDescription (string mt)
 		{
-			if (useGio)
-				return Gio.GetMimeTypeDescription (mt);
-			else
-				return Gnome.Vfs.Mime.GetDescription (mt);
+			return Gio.GetMimeTypeDescription (mt);
 		}
 
 		protected override string OnGetMimeTypeForUri (string uri)
@@ -111,12 +97,7 @@ namespace MonoDevelop.Platform
 			if (uri == null)
 				return null;
 			
-			if (useGio) {
-				string mt = Gio.GetMimeTypeForUri (uri);
-				if (mt != null)
-					return mt;
-			}
-			return Gnome.Vfs.MimeType.GetMimeTypeForUri (ConvertFileNameToVFS (uri));
+			return Gio.GetMimeTypeForUri (uri);
 		}
 		
 		protected override bool OnGetMimeTypeIsText (string mimeType)

--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -137,7 +137,7 @@ namespace MonoDevelop.Platform
 		public override string DefaultMonospaceFont {
 			get {
 				try {
-					return (string) (new GConf.Client ().Get ("/desktop/gnome/interface/monospace_font_name"));
+					return (string) (Gio.GetGSettingsString ("org.gnome.desktop.interface","monospace-font-name"));
 				} catch (Exception) {
 					return "Monospace 11";
 				}

--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using Gnome;
 using MonoDevelop.Ide.Desktop;
 using System;
 using System.Collections.Generic;
@@ -40,12 +39,8 @@ namespace MonoDevelop.Platform
 {
 	public class GnomePlatform : PlatformService
 	{
-		Gnome.ThumbnailFactory thumbnailFactory = new Gnome.ThumbnailFactory (Gnome.ThumbnailSize.Normal);
-
 		static GnomePlatform ()
 		{
-			//apparently Gnome.Icon needs GnomeVFS initialized even when we're using GIO.
-			Gnome.Vfs.Vfs.Initialize ();
 		}
 		
 		DesktopApplication GetGnomeVfsDefaultApplication (string mimeType)
@@ -142,10 +137,8 @@ namespace MonoDevelop.Platform
 					return "gnome-fs-regular";
 				
 				string icon = null;
-				Gnome.IconLookupResultFlags result;
 				try {
-					icon = Gnome.Icon.LookupSync (IconTheme.Default, thumbnailFactory, filename, null, 
-					                              Gnome.IconLookupFlags.None, out result);
+					icon = Gio.GetIconIdForFile (filename);
 				} catch {}
 				if (icon != null && icon.Length > 0)
 					return icon;

--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -131,7 +131,7 @@ namespace MonoDevelop.Platform
 
 		public override void ShowUrl (string url)
 		{
-			Gnome.Url.Show (url);
+			Runtime.ProcessService.StartProcess ("xdg-open", url, null, null);
 		}
 		
 		public override string DefaultMonospaceFont {

--- a/main/src/addins/GnomePlatform/GnomePlatform.csproj
+++ b/main/src/addins/GnomePlatform/GnomePlatform.csproj
@@ -51,9 +51,6 @@
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="gnome-sharp, Version=2.24.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="gnome-vfs-sharp, Version=2.24.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/main/src/addins/GnomePlatform/GnomePlatform.csproj
+++ b/main/src/addins/GnomePlatform/GnomePlatform.csproj
@@ -51,9 +51,6 @@
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="gnome-vfs-sharp, Version=2.24.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/GnomePlatform/GnomePlatform.csproj
+++ b/main/src/addins/GnomePlatform/GnomePlatform.csproj
@@ -54,9 +54,6 @@
     <Reference Include="gnome-sharp, Version=2.24.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="gconf-sharp, Version=2.24.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="gnome-vfs-sharp, Version=2.24.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>


### PR DESCRIPTION
GnomePlatform relies on some *super* deprecated libraries, from old versions of GNOME 2. All of the things we use GNOME# for can be done better using more modern replacements, e.g. GIO (part of modern GLib). It'd be nice to have some Gtk+ 2.14+ methods, but that's another story for another day.

For now, this greatly simplifies the dependency chain on Linux, and makes it easier to handle some FlatPak cases in future work.