### PR TITLE
MSBuild 15 detection - Latest Mono

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
@@ -179,7 +179,8 @@ namespace MonoDevelop.Core.Assemblies
 
 			if (monoUseMSBuild) {
 				var path = Path.Combine (monoDir, "msbuild", toolsVersion, "bin");
-				if (File.Exists (Path.Combine (path, "MSBuild.exe"))) {
+				if (File.Exists (Path.Combine (path, "MSBuild.exe")) ||
+				    File.Exists (Path.Combine (path, "msbuild.dll"))) {
 					return path;
 				}
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v14.1.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v14.1.csproj
@@ -43,6 +43,7 @@
 	 Prefer referencing msbuild 15.* assemblies over 14.1 . At runtime, we use correct one anyway
 	 -->
     <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Unix' and '$(MSBuild_OSS_BinDir)' == '' and Exists('$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\MSBuild.exe')">$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\</MSBuild_OSS_BinDir>
+    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Unix' and '$(MSBuild_OSS_BinDir)' == '' and Exists('$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\msbuild.dll')">$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\</MSBuild_OSS_BinDir>
     <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Unix' and '$(MSBuild_OSS_BinDir)' == '' and Exists('$(MSBuildToolsPath)\..\..\..\msbuild\14.1\bin\MSBuild.exe')">$(MSBuildToolsPath)\..\..\..\msbuild\14.1\bin\</MSBuild_OSS_BinDir>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
MSBuild 15 in the latest Mono 4.9.0.671 no longer ships as MSBuild.exe but is instead msbuild.dll. So the detection logic was failing to find the MSBuild bin directory. This breaks building the monodevelop code from source and using MSBuild to build projects inside the IDE.