### PR TITLE
[MSBuild] Guard against empty lines in a solution file.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SlnFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SlnFile.cs
@@ -75,8 +75,11 @@ namespace MonoDevelop.Projects.MSBuild
 			string strVersion;
 			using (var reader = new StreamReader (file)) {
 				var strInput = reader.ReadLine();
-				if (strInput == null)
-					return null;
+				while (string.IsNullOrWhiteSpace (strInput)) {
+					if (strInput == null)
+						return null;
+					strInput = reader.ReadLine ();
+				}
 
 				var match = slnVersionRegex.Match (strInput);
 				if (!match.Success) {
@@ -559,7 +562,8 @@ namespace MonoDevelop.Projects.MSBuild
 				values [name] = val;
 			} else {
 				line = line.Trim ();
-				values.Add (line, null);
+				if (!string.IsNullOrWhiteSpace (line))
+					values.Add (line, null);
 			}
 		}
 


### PR DESCRIPTION
Skip lines which only contain whitespace characters, as they should not be parsed.
Bug 11494 - Exception on opening solution file after Perforce converts line endings to \r\r\n

cc @mhutch 