### PR TITLE
[Ide][Bug 46332] Fix preselection of grouped templates in new project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -346,7 +346,26 @@ namespace MonoDevelop.Ide.Projects
 
 		void SelectTemplate (string templateId)
 		{
-			SelectTemplate (template => template.Id == templateId);
+			SolutionTemplate matchedInGroup = null;
+			SelectTemplate (template => {
+				if (template.HasGroupId) {
+					var inGroup = template.GetTemplate ((t) => t.Id == templateId);
+					// check if the requested template is part of the current group
+					// becasue it may be not referenced by a category directly.
+					// in this case we match/select the group and change the selected
+					// language if required.
+					if (inGroup?.Id == templateId) {
+						matchedInGroup = inGroup;
+						return true;
+					}
+				}
+				return template.Id == templateId;
+			});
+
+			// make sure that the requested language has been selected
+			// if the requested template is part of a group
+			if (matchedInGroup != null)
+				SelectedLanguage = matchedInGroup.Language;
 		}
 
 		void SelectFirstAvailableTemplate ()


### PR DESCRIPTION
SelectTemplate(templateId) does not take into account
that a template can be part of a group, where the parent
category references only the first template.

This patch adds an additional check for template group
members. If a group contains the requested template,
it selects the group in the dialog and the target language
accordingly.

(fixes bug #46332)