### PR TITLE
Fix dynamic type keyword syntax highlighting

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/SemanticHighlighting/SemanticHighlightingVisitor.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/SemanticHighlighting/SemanticHighlightingVisitor.cs
@@ -568,7 +568,6 @@ namespace ICSharpCode.NRefactory6.CSharp.Analysis
 				case "by":
 				case "ascending":
 				case "descending":
-				case "dynamic":
 					// Reset color of contextual keyword to default if it's used as an identifier.
 					// Note that this method does not get called when 'var' or 'dynamic' is used as a type,
 					// because types get highlighted with valueTypeColor/referenceTypeColor instead.


### PR DESCRIPTION
The dynamic keyword is not highlighted properly. In the UI, you can see
that it is actually highlighted as a keyword, but is quickly (< 1 second)
reverted to the default text color.

Removing "dynamic" from the list fixes the problem. There is a comment
that suggests that "var" and "dynamic" should be skipped here. "var" is
already omitted from the list.