### PR TITLE
Bug 45274 - Cannot change the code formatting policy

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Serialization/DataItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Serialization/DataItem.cs
@@ -70,6 +70,7 @@ namespace MonoDevelop.Core.Serialization
 
 		internal void UpdateFromItem (DataItem item, HashSet<DataItem> removedItems)
 		{
+			var items = new List<DataNode> ();
 			foreach (var d in item.ItemData) {
 				var current = ItemData[d.Name];
 				if (current != null) {
@@ -86,6 +87,8 @@ namespace MonoDevelop.Core.Serialization
 					} else if (current is DataItem) {
 						((DataItem)current).UpdateFromItem ((DataItem)d, removedItems);
 					}
+					ItemData.Remove (current);
+					items.Add (current);
 				} else if (!d.IsDefaultValue && !(d is DataDeletedNode)) {
 					var dataItem = d as DataItem;
 					if (dataItem != null) {
@@ -94,12 +97,14 @@ namespace MonoDevelop.Core.Serialization
 							UniqueNames = dataItem.UniqueNames
 						};
 						newDataItem.UpdateFromItem (dataItem, removedItems);
-						ItemData.Add (newDataItem);
+						items.Add (newDataItem);
 					} else {
-						ItemData.Add (d);
+						items.Add (d);
 					}
 				}
 			}
+			foreach (var val in items)
+				this.ItemData.Add (val);
 		}
 		
 		public override string ToString ()


### PR DESCRIPTION
Problem was that Policies have 3 ItemData values with name “TextStylePolicy”(one for plain text, one for C# and one for XML).
Since commit 42b7775af9 when UpdateFromItem was called it overwrote same “TextStylePolicy” 3x, instead of creating 3 separate TextStylePolicy each for one language
With this change.. Once TextStylePolicy is updated it’s removed from list so on next loop, next TextStylePolicy is updated

@slluis can you please review this?