### PR TITLE
[TextMate] Fix MimeType matching for syntax highlighting

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
@@ -493,7 +493,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			foreach (var bundle in languageBundles) {
 				foreach (var h in bundle.Highlightings) {
 					foreach (var fe in h.FileTypes) {
-						var uri = fe.StartsWith (".", StringComparison.Ordinal) ? "a" + fe : fe;
+						var uri = fe.StartsWith (".", StringComparison.Ordinal) ? "a" + fe : "a." + fe;
 						var mime = DesktopService.GetMimeTypeForUri (uri);
 						if (mimeType == mime) {
 							return h;


### PR DESCRIPTION
This problem showed up in case of “xml” where “application/xml” mime type has ending stored as “.xml” and file “xml” didn’t match, with this change “a.xml” matches with “.xml” ending