### PR TITLE
[cycle9][Ide] Fix last used project template not selected

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -769,7 +769,7 @@ namespace MonoDevelop.Ide
 		
 		public SolutionFolderItem CreateProject (SolutionFolder parentFolder)
 		{
-			return CreateProject (parentFolder, string.Empty);
+			return CreateProject (parentFolder, null);
 		}
 
 		public SolutionFolderItem CreateProject (SolutionFolder parentFolder, string selectedTemplateId)


### PR DESCRIPTION
Fixed bug #46701 - New Project template window does not remember
last project template
https://bugzilla.xamarin.com/show_bug.cgi?id=46701

When adding a new project to an existing solution the last created
project template was not selected by default. The problem was that
an empty string was being passed as the template id instead of null
so an attempt was made to select a matching template.