### PR TITLE
Set LANGUAGE from monostub (Cycle 8)

### DIFF
--- a/main/build/MacOSX/monostub.m
+++ b/main/build/MacOSX/monostub.m
@@ -228,6 +228,7 @@ correct_locale(void)
 		preferredLanguage = [[preferredLanguage componentsSeparatedByString:@"-"] objectAtIndex:0];
 
 	setenv("MONODEVELOP_STUB_LANGUAGE", [preferredLanguage UTF8String], 1);
+	setenv("LANGUAGE", [preferredLanguage UTF8String], 1);
 }
 
 int main (int argc, char **argv)


### PR DESCRIPTION
This fixes an issue on OSX Sierra where having a rtl language
second in your list would cause gtk's direction to be set to
rtl.

https://forums.xamarin.com/discussion/82412/xamarin-studio-has-messed-up-and-now-shows-all-its-own-text-ui-from-right-to-left-cant-fix-it

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41969