### PR TITLE
[C9][46585][Ide] Verify file name on category change in New File Dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewFileDialog.cs
@@ -129,9 +129,9 @@ namespace MonoDevelop.Ide.Projects
 			TreeIter treeIter;
 
 			if (catView.Selection.GetSelected (out treeModel, out treeIter)) {
-				okButton.Sensitive = false;
 				FillCategoryTemplates (treeIter);
 				catView.ExpandRow (treeModel.GetPath (treeIter), false);
+				UpdateOkStatus ();
 			}
 		}
 


### PR DESCRIPTION
Rerun name verification on category changes,
instead of just disabling the "New" button.

(fixes bug #46585)

(cherry picked from commit 3d28ae7471ec6ab8a499d5d8b03ccb8a2df99603)