### PR TITLE
[Core] Fix execution error when environment variable used in run config

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1164,8 +1164,10 @@ namespace MonoDevelop.Projects
 					cmd.Arguments = rc.StartArguments;
 				if (!rc.StartWorkingDirectory.IsNullOrEmpty)
 					cmd.WorkingDirectory = rc.StartWorkingDirectory;
-				foreach (var env in rc.EnvironmentVariables)
-					cmd.EnvironmentVariables [env.Key] = env.Value;
+				if (cmd.EnvironmentVariables != rc.EnvironmentVariables) {
+					foreach (var env in rc.EnvironmentVariables)
+						cmd.EnvironmentVariables [env.Key] = env.Value;
+				}
 				cmd.PauseConsoleOutput = rc.PauseConsoleOutput;
 				cmd.ExternalConsole = rc.ExternalConsole;
 				cmd.TargetRuntime = Runtime.SystemAssemblyService.GetTargetRuntime (rc.TargetRuntimeId);


### PR DESCRIPTION
Fixed bug #48017 - Unable to execute run configuration with
environment variable
https://bugzilla.xamarin.com/show_bug.cgi?id=48017

If a run configuration is used where Start external program is
specified and an environment variable is defined for the project then
running the project would show an Execution failed message and the
IDE log would contain:

```
Execution failed
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
  at System.ThrowHelper.ThrowInvalidOperationException (System.ExceptionResource resource) [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/throwhelper.cs:99
  at System.Collections.Generic.List`1+Enumerator[T].MoveNextRare () [0x00016] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs:1180
  at System.Collections.Generic.List`1+Enumerator[T].MoveNext () [0x00050] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs:1174
  at MonoDevelop.Projects.DotNetProject.OnCreateExecutionCommand (MonoDevelop.Projects.ConfigurationSelector configSel, MonoDevelop.Projects.DotNetProjectConfiguration configuration, MonoDevelop.Projects.ProjectRunConfiguration runConfiguration) [0x00102] in /Users/builder/data/lanes/3509/0ccfcd52/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs:1168
  at MonoDevelop.Projects.DotNetProject+DefaultDotNetProjectExtension.OnCreateExecutionCommand (MonoDevelop.Projects.ConfigurationSelector configSel, MonoDevelop.Projects.DotNetProjectConfiguration configuration, MonoDevelop.Projects.ProjectRunConfiguration runConfiguration) [0x00000] in /Users/builder/data/lanes/3509/0ccfcd52/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs:1788
```