### PR TITLE
[C9] Fix Solution Pad Tooltip papercuts

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -141,6 +141,7 @@ namespace MonoDevelop.Ide.Gui.Components
 
 			protected override bool OnScrollEvent (Gdk.EventScroll evnt)
 			{
+				control.HideStatusMessage ();
 				var modifier = !Platform.IsMac? Gdk.ModifierType.ControlMask
 				                    //Mac window manager already uses control-scroll, so use command
 				                    //Command might be either meta or mod1, depending on GTK version
@@ -2030,6 +2031,8 @@ namespace MonoDevelop.Ide.Gui.Components
 		[GLib.ConnectBefore]
 		void OnKeyPress (object o, Gtk.KeyPressEventArgs args)
 		{
+			HideStatusMessage ();
+			
 			if (args.Event.Key == Gdk.Key.Delete || args.Event.Key == Gdk.Key.KP_Delete) {
 				DeleteCurrentItem ();
 				args.RetVal = true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -327,7 +327,11 @@ namespace MonoDevelop.Ide.Gui.Components
 
 			var info = (NodeInfo)model.GetValue (it, NodeInfoColumn);
 			var cell = (CustomCellRendererText)renderer;
+			SetTextCellData (cell, info);
+		}
 
+		static void SetTextCellData (CustomCellRendererText cell, NodeInfo info)
+		{
 			cell.DisabledStyle = info.DisabledStyle;
 			cell.TextMarkup = info.Label;
 			cell.SecondaryTextMarkup = info.SecondaryLabel;
@@ -492,9 +496,12 @@ namespace MonoDevelop.Ide.Gui.Components
 						int sp, w;
 						col.CellGetPosition (text_render, out sp, out w);
 						cellArea.X += sp;
+						cellArea.X++; // GetCellArea is off by 1px compared to the cellArea passed to cell renderers directly
 						cellArea.Width = w;
+						SetTextCellData (text_render, info); // update cell renderer data for size calculations
 						var rect = text_render.GetStatusIconArea (tree, cellArea);
 						if (cx >= rect.X && cx <= rect.Right) {
+							tree.ConvertBinWindowToWidgetCoords (rect.X, rect.Y, out rect.X, out rect.Y);
 							ShowStatusMessage (it, rect, info);
 							popupShown = true;
 						}


### PR DESCRIPTION
Papercut: Fix status tooltip positioning (bug #44564) and hide the tooltip on key presses and scroll events.