### PR TITLE
OnBeforeSaved event added to hookup addins

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DocumentContext.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DocumentContext.cs
@@ -162,6 +162,15 @@ namespace MonoDevelop.Ide.Editor
 				handler (this, e);
 		}
 
+		public event EventHandler BeforeSaved;
+
+		protected virtual void OnBeforeSaved (EventArgs e)
+		{
+			var handler = BeforeSaved;
+			if (handler != null)
+				handler (this, e);
+		}
+
 		internal virtual Task<IReadOnlyList<Editor.Projection.Projection>> GetPartialProjectionsAsync (CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -406,6 +406,7 @@ namespace MonoDevelop.Ide.Gui
                             await Window.ViewContent.Save (fileName + "~");
 							FileService.NotifyFileChanged (fileName + "~");
 						}
+						OnBeforeSaved(EventArgs.Empty);
 						await Window.ViewContent.Save (fileName);
 						FileService.NotifyFileChanged (fileName);
                         OnSaved(EventArgs.Empty);
@@ -494,6 +495,7 @@ namespace MonoDevelop.Ide.Gui
 					await Window.ViewContent.Save (new FileSaveInformation (filename + "~", encoding));
 			}
 			TypeSystemService.RemoveSkippedfile (FileName);
+			OnBeforeSaved(EventArgs.Empty);
 			// do actual save
 			await Window.ViewContent.Save (new FileSaveInformation (filename, encoding));
 			DesktopService.RecentFiles.AddFile (filename, (Project)null);


### PR DESCRIPTION
Hi! 
This pull request adds new `BeforeSaved` event to the `DocumentContext` class in the IDE so that any add-in can use this event to format/cleanup code before file is saved.

This will be very useful for add-ins like [SortRemoveUsings](https://github.com/alexsorokoletov/XamarinStudio.SortRemoveUsings). Right now add-in works with Saved event and when it removes/sorts usings, file becomes modified so user has to save file twice.
With new `BeforeSaved` event extension will be able to sort/remove usings before file saved and will work better from a user prospective.

Maybe there is even better way for that (Ideally would be cool to run add-in on every Cmd+S/Ctrl+S call, why not?).

I've discussed this event with @mhutch during MVP Summit Hackathon.

Please let me know what could be improved in this pull request.