### PR TITLE
Bug 48234 - Unable to determine which `Application Output` pad belongs to which project

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -710,8 +710,19 @@ namespace MonoDevelop.Debugger
 				Engine = engine;
 				Session = session;
 				this.console = console;
+				session.TargetReady += delegate {
+					UpdateConsoleName ();	
+				};
+				UpdateConsoleName ();
 				cancelRegistration = console.CancellationToken.Register (Cancel);
 				debugOperation = new DebugAsyncOperation (session);
+			}
+
+			void UpdateConsoleName ()
+			{
+				var processName = Session.GetProcesses ().FirstOrDefault ()?.Name;
+				if (processName != null)
+					this.console.SetName (processName);
 			}
 
 			void Cancel ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/OperationConsole.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/OperationConsole.cs
@@ -110,6 +110,10 @@ namespace MonoDevelop.Core.Execution
 			if (cancelReg != null)
 				cancelReg.Dispose ();
 		}
+
+		public virtual void SetName (string name)
+		{
+		}
 	}
 
 	class OperationConsoleWrapper : OperationConsole

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -377,6 +377,13 @@ namespace MonoDevelop.Ide.Gui.Components
 			ShowSearchBox ();
 		}
 
+		internal void SetTitle (string title)
+		{
+			TitleChanged?.Invoke (title);
+		}
+
+		internal event Action<string> TitleChanged;
+
 		static StringComparison GetComparer ()
 		{
 			if (PropertyService.Get ("AutoSetPatternCasing", true)) {
@@ -737,7 +744,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				pad.UnsafeEndTask ();
 			}
 		}
-	}
+}
 
 	public class LogViewProgressMonitor : OutputProgressMonitor
 	{
@@ -839,6 +846,11 @@ namespace MonoDevelop.Ide.Gui.Components
 				CancellationSource = monitor.CancellationTokenSource;
 			}
 
+			public override void SetName (string name)
+			{
+				monitor.outputPad.SetTitle (name);
+			}
+
 			public override TextReader In {
 				get {
 					return monitor.inputReader;
@@ -875,7 +887,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				base.Dispose ();
 			}
 		}
-	}
+}
 	
 	class NotSupportedTextReader: TextReader
 	{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Pad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Pad.cs
@@ -63,6 +63,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public string Title {
 			get { return window.Title; }
+			set { window.Title = value; }
 		}
 		
 		public IconId Icon {


### PR DESCRIPTION
@slluis can you do quick check if I did something wrong?
I added SetName to OperationConsole. Logic here is... Console has beside `TextWriter Out`, `TextWriter In`... also string Name(aka. Window Title)...

Once debugger finds out process name(this is same as name of process in ThreadsPad) and calls SetName on Console... This is better then just Project name, because in case if we attach or debug .exe directly without .csproj...

Then Console takes care of setting new title on parent Pad...