### PR TITLE
Bug 48234 - Unable to determine which `Application Output` pad belongs to which project

### DIFF
--- a/main/src/addins/MonoDevelop.Autotools/MakefileProjectServiceExtension.cs
+++ b/main/src/addins/MonoDevelop.Autotools/MakefileProjectServiceExtension.cs
@@ -382,7 +382,8 @@ namespace MonoDevelop.Autotools
 				return;
 			}
 
-			OperationConsole console = context.ConsoleFactory.CreateConsole ();
+			OperationConsole console = context.ConsoleFactory.CreateConsole (
+				OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (Project.Name));
 			monitor.BeginTask (GettextCatalog.GetString ("Executing {0}", Project.Name), 1);
 			try
 			{

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -595,7 +595,7 @@ namespace MonoDevelop.Debugger
 		public static AsyncOperation AttachToProcess (DebuggerEngine debugger, ProcessInfo proc)
 		{
 			var session = debugger.CreateSession ();
-			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor ();
+			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (proc.Name);
 			var sessionManager = new SessionManager (session, monitor.Console, debugger);
 			sessions.Add (session, sessionManager);
 			session.ExceptionHandler = ExceptionHandler;
@@ -670,7 +670,7 @@ namespace MonoDevelop.Debugger
 			// When using an external console, create a new internal console which will be used
 			// to show the debugger log
 			if (startInfo.UseExternalConsole)
-				sessionManager = new SessionManager (session, IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor ().Console, factory);
+				sessionManager = new SessionManager (session, IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileNameWithoutExtension (startInfo.Command)).Console, factory);
 			else
 				sessionManager = new SessionManager (session, c, factory);
 			SetupSession (sessionManager);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -597,7 +597,6 @@ namespace MonoDevelop.Debugger
 			var session = debugger.CreateSession ();
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (proc.Name);
 			var sessionManager = new SessionManager (session, monitor.Console, debugger);
-			sessions.Add (session, sessionManager);
 			session.ExceptionHandler = ExceptionHandler;
 			SetupSession (sessionManager);
 			session.TargetExited += delegate {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.Debugger
 			if (opers.CurrentRunOperation != null && !opers.CurrentRunOperation.IsCompleted)
 				return opers.CurrentRunOperation;
 
-			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor ();
+			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileName (executableFile));
 
 			var oper = DebuggingService.Run (executableFile, args, workingDir, envVars, monitor.Console);
 			opers.AddRunOperation (oper);

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
@@ -385,7 +385,8 @@ namespace MonoDevelop.UnitTesting.NUnit
 			if (runnerExe != null)
 				return RunWithConsoleRunner (runnerExe, test, suiteName, pathName, testName, testContext);
 
-			var console = testContext.ExecutionContext.ConsoleFactory.CreateConsole ();
+			var console = testContext.ExecutionContext.ConsoleFactory.CreateConsole (
+				OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (GettextCatalog.GetString ("Unit Tests")));
 
 			ExternalTestRunner runner = new ExternalTestRunner ();
 			runner.Connect (NUnitVersion, testContext.ExecutionContext.ExecutionHandler, console).Wait ();
@@ -481,7 +482,8 @@ namespace MonoDevelop.UnitTesting.NUnit
 		{
 			var outFile = Path.GetTempFileName ();
 			var xmlOutputConsole = new LocalConsole ();
-			var appDebugOutputConsole = testContext.ExecutionContext.ConsoleFactory.CreateConsole ();
+			var appDebugOutputConsole = testContext.ExecutionContext.ConsoleFactory.CreateConsole (
+				OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (GettextCatalog.GetString ("Unit Tests")));
 			OperationConsole cons;
 			if (appDebugOutputConsole != null) {
 				cons = new MultipleOperationConsoles (appDebugOutputConsole, xmlOutputConsole);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/OperationConsoleFactory.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/OperationConsoleFactory.cs
@@ -38,6 +38,7 @@ namespace MonoDevelop.Core.Execution
 			public static readonly CreateConsoleOptions Default = new CreateConsoleOptions { BringToFront = true };
 
 			public bool BringToFront { get; private set; }
+			public string Title { get; private set; }
 
 			CreateConsoleOptions ()
 			{
@@ -46,6 +47,7 @@ namespace MonoDevelop.Core.Execution
 			CreateConsoleOptions (CreateConsoleOptions options)
 			{
 				this.BringToFront = options.BringToFront;
+				this.Title = options.Title;
 			}
 
 			public CreateConsoleOptions (bool bringToFront)
@@ -59,6 +61,15 @@ namespace MonoDevelop.Core.Execution
 					return this;
 				var result = new CreateConsoleOptions (this);
 				result.BringToFront = bringToFront;
+				return result;
+			}
+
+			public CreateConsoleOptions WithTitle (string title)
+			{
+				if (title == Title)
+					return this;
+				var result = new CreateConsoleOptions (this);
+				result.Title = title;
 				return result;
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CompiledAssemblyProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/CompiledAssemblyProject.cs
@@ -150,7 +150,8 @@ namespace MonoDevelop.Projects
 
 			OperationConsole console = conf.ExternalConsole
 				? context.ExternalConsoleFactory.CreateConsole (!conf.PauseConsoleOutput, monitor.CancellationToken)
-				: context.ConsoleFactory.CreateConsole (monitor.CancellationToken);
+										   : context.ConsoleFactory.CreateConsole (
+											   OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (Path.GetFileName (FileName)), monitor.CancellationToken);
 			
 			try {
 				try {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1644,7 +1644,7 @@ namespace MonoDevelop.Projects
 			}
 
 			var console = externalConsole ? context.ExternalConsoleFactory.CreateConsole (!pauseConsole, monitor.CancellationToken)
-												   : context.ConsoleFactory.CreateConsole (monitor.CancellationToken);
+												   : context.ConsoleFactory.CreateConsole (OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (Name), monitor.CancellationToken);
 		
 			using (console) {
 				ProcessAsyncOperation asyncOp = context.ExecutionHandler.Execute (executionCommand, console);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -401,7 +401,7 @@ namespace MonoDevelop.Ide.Commands
 		{
 			var ce = IdeApp.ProjectOperations.CurrentSelectedBuildTarget as WorkspaceObject;
 			CustomCommand cmd = (CustomCommand) dataItem;
-			ProgressMonitor monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor ();
+			ProgressMonitor monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (cmd.Name);
 			
 			Thread t = new Thread (
 				async delegate () {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/DefaultMonitorPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/DefaultMonitorPad.cs
@@ -59,10 +59,12 @@ namespace MonoDevelop.Ide.Gui.Pads
 		int instanceNum;
 		string typeTag;
 
-		public DefaultMonitorPad (string typeTag, string icon, int instanceNum)
+		public DefaultMonitorPad (string typeTag, string icon, int instanceNum, string title, int titleInstanceNum)
 		{
 			this.instanceNum = instanceNum;
 			this.typeTag = typeTag;
+			this.Title = title;
+			this.TitleInstanceNum = titleInstanceNum;
 			
 			this.icon = icon;
 
@@ -209,6 +211,10 @@ namespace MonoDevelop.Ide.Gui.Pads
 				return typeTag;
 			}
 		}
+
+		public string Title { get; set; }
+
+		public int TitleInstanceNum { get; set; }
 
 		public int InstanceNum {
 			get {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
@@ -206,9 +206,11 @@ namespace MonoDevelop.Ide.Gui
 						if (mon.TypeTag == id) {
 							if (mon.InstanceNum > instanceCount)
 								instanceCount = mon.InstanceNum;
-							if (mon.Title == originalTitle)
+							if (mon.Title == originalTitle && !mon.AllowReuse)
 								usedTitleIds.Add (mon.TitleInstanceNum);
-							if (pad == null && mon.AllowReuse) {
+							if (mon.AllowReuse &&
+							   (pad == null ||
+							    mon.Title == originalTitle)) {//Prefer reusing output with same title(project)
 								pad = mpad;
 							}
 						}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
@@ -146,7 +146,6 @@ namespace MonoDevelop.Ide.Gui
 		{
 			if (!string.IsNullOrEmpty (titleSuffix)) {
 				title += " - " + titleSuffix;
-				id += titleSuffix;//We need different Id to prevent sufixes like "Application Output - MyProject (2)" where (2) is index 2 of AppOutput Id
 			}
 			Pad pad = CreateMonitorPad (id, title, icon, bringToFront, allowMonitorReuse, true);
 			pad.Visible = visible;
@@ -180,44 +179,57 @@ namespace MonoDevelop.Ide.Gui
 			Pad pad = null;
 			if (icon == null)
 				icon = Stock.OutputIcon;
-			
+
+			string originalTitle = title;
 			if (id == null)
-				id = title;
+				id = originalTitle;
 
 			int instanceCount = -1;
+			int titleInstanceCount = 0;
 			if (allowMonitorReuse) {
+				var usedTitleIds = new List<int> ();
 				lock (outputMonitors) {
 					// Look for an available pad
 					for (int n=0; n<outputMonitors.Count; n++) {
-						Pad mpad = (Pad) outputMonitors [n];
+						var mpad = outputMonitors [n];
 						DefaultMonitorPad mon = (DefaultMonitorPad) mpad.Content;
 						if (mon.TypeTag == id) {
 							if (mon.InstanceNum > instanceCount)
 								instanceCount = mon.InstanceNum;
-							if (mon.AllowReuse) {
+							if (mon.Title == originalTitle)
+								usedTitleIds.Add (mon.TitleInstanceNum);
+							if (pad == null && mon.AllowReuse) {
 								pad = mpad;
-								break;
 							}
 						}
 					}
 				}
+				titleInstanceCount = usedTitleIds.Count;//Set pesimisticly to largest possible number
+				for (int i = 0; i < usedTitleIds.Count; i++) {
+					if (!usedTitleIds.Contains (i)) {
+						titleInstanceCount = i;//Find smallest free number
+						break;
+					}
+				}
+				if (titleInstanceCount > 0)
+					title = originalTitle + $" ({titleInstanceCount})";
+				else
+					title = originalTitle;
 				if (pad != null) {
 					if (bringToFront) pad.BringToFront ();
+					pad.Window.Title = title;
+					var mon = (DefaultMonitorPad)pad.Content;
+					mon.Title = originalTitle;
+					mon.TitleInstanceNum = titleInstanceCount;
 					return pad;
 				}
 			}
 
 			instanceCount++;
-			DefaultMonitorPad monitorPad = new DefaultMonitorPad (id, icon, instanceCount);
+			DefaultMonitorPad monitorPad = new DefaultMonitorPad (id, icon, instanceCount, originalTitle, titleInstanceCount);
 			
 			string newPadId = "OutputPad-" + id + "-" + instanceCount;
 			string basePadId = "OutputPad-" + id + "-0";
-			
-			if (instanceCount > 0) {
-				// Translate the title before adding the count
-				title = GettextCatalog.GetString (title);
-				title += " (" + (instanceCount+1) + ")";
-			}
 
 			if (show)
 				pad = IdeApp.Workbench.ShowPad (monitorPad, newPadId, title, basePadId + "/Center Bottom", DockItemStatus.AutoHide, icon);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
@@ -78,9 +78,9 @@ namespace MonoDevelop.Ide.Gui
 			return mon;
 		}
 		
-		public OutputProgressMonitor GetRunProgressMonitor ()
+		public OutputProgressMonitor GetRunProgressMonitor (string titleSuffix = null)
 		{
-			return GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, false, true);
+			return GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, false, true, titleSuffix: titleSuffix);
 		}
 		
 		public OutputProgressMonitor GetToolOutputProgressMonitor (bool bringToFront, CancellationTokenSource cs = null)
@@ -117,7 +117,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			protected override OperationConsole OnCreateConsole (CreateConsoleOptions options)
 			{
-				return ((OutputProgressMonitor)IdeApp.Workbench.ProgressMonitors.GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, options.BringToFront, true)).Console;
+				return ((OutputProgressMonitor)IdeApp.Workbench.ProgressMonitors.GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, options.BringToFront, true, titleSuffix:options.Title)).Console;
 			}
 		}
 
@@ -142,8 +142,12 @@ namespace MonoDevelop.Ide.Gui
 			return GetOutputProgressMonitor (null, title, icon, bringToFront, allowMonitorReuse, visible);
 		}
 		
-		public OutputProgressMonitor GetOutputProgressMonitor (string id, string title, IconId icon, bool bringToFront, bool allowMonitorReuse, bool visible = true)
+		public OutputProgressMonitor GetOutputProgressMonitor (string id, string title, IconId icon, bool bringToFront, bool allowMonitorReuse, bool visible = true, string titleSuffix = null)
 		{
+			if (!string.IsNullOrEmpty (titleSuffix)) {
+				title += " - " + titleSuffix;
+				id += titleSuffix;//We need different Id to prevent sufixes like "Application Output - MyProject (2)" where (2) is index 2 of AppOutput Id
+			}
 			Pad pad = CreateMonitorPad (id, title, icon, bringToFront, allowMonitorReuse, true);
 			pad.Visible = visible;
 			return ((DefaultMonitorPad) pad.Content).BeginProgress (title);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
@@ -77,10 +77,15 @@ namespace MonoDevelop.Ide.Gui
 			mon.AddFollowerMonitor (GetStatusProgressMonitor (statusText, Stock.StatusBuild, false, true, false, pad, true));
 			return mon;
 		}
-		
-		public OutputProgressMonitor GetRunProgressMonitor (string titleSuffix = null)
+
+		public OutputProgressMonitor GetRunProgressMonitor ()
 		{
-			return GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, false, true, titleSuffix: titleSuffix);
+			return GetRunProgressMonitor (null);
+		}
+		
+		public OutputProgressMonitor GetRunProgressMonitor (string titleSuffix)
+		{
+			return GetOutputProgressMonitor ("MonoDevelop.Ide.ApplicationOutput", GettextCatalog.GetString ("Application Output"), Stock.MessageLog, false, true, titleSuffix);
 		}
 		
 		public OutputProgressMonitor GetToolOutputProgressMonitor (bool bringToFront, CancellationTokenSource cs = null)
@@ -141,8 +146,13 @@ namespace MonoDevelop.Ide.Gui
 		{
 			return GetOutputProgressMonitor (null, title, icon, bringToFront, allowMonitorReuse, visible);
 		}
+
+		public OutputProgressMonitor GetOutputProgressMonitor (string id, string title, IconId icon, bool bringToFront, bool allowMonitorReuse, bool visible = true)
+		{
+			return GetOutputProgressMonitor (id, title, icon, bringToFront, allowMonitorReuse, null, visible);
+		}
 		
-		public OutputProgressMonitor GetOutputProgressMonitor (string id, string title, IconId icon, bool bringToFront, bool allowMonitorReuse, bool visible = true, string titleSuffix = null)
+		public OutputProgressMonitor GetOutputProgressMonitor (string id, string title, IconId icon, bool bringToFront, bool allowMonitorReuse, string titleSuffix, bool visible = true)
 		{
 			if (!string.IsNullOrEmpty (titleSuffix)) {
 				title += " - " + titleSuffix;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1126,7 +1126,8 @@ namespace MonoDevelop.Ide
 		{
 			var cmd = Runtime.ProcessService.CreateCommand (file);
 			if (context.ExecutionHandler.CanExecute (cmd))
-				return context.ExecutionHandler.Execute (cmd, context.ConsoleFactory.CreateConsole ());
+				return context.ExecutionHandler.Execute (cmd, context.ConsoleFactory.CreateConsole (
+					OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (Path.GetFileName (file))));
 			else {
 				MessageService.ShowError(GettextCatalog.GetString ("No runnable executable found."));
 				return AsyncOperation.CompleteOperation;


### PR DESCRIPTION
This is different aproach from https://github.com/mono/monodevelop/pull/1697
It sets suffix when Application Output is created and not from debugger when process is started/connected to.

Id of pad needs to be suffixed with title otherwise on reuse title can be wrong. Only downside of this is that we can end with many open Application Output pads because we don't reuse pads with different titles.