### PR TITLE
Re-using monostub.m for ServiceHub

### DIFF
--- a/main/build/MacOSX/monostub.m
+++ b/main/build/MacOSX/monostub.m
@@ -287,7 +287,7 @@ int main (int argc, char **argv)
   char **extra_argv;
   int extra_argc;
 #if USE_SIMPLE_PATH
-  exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: @SIMPLE_PATH];
+  exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: SIMPLE_PATH];
 #else
   NSString *exeName;
 	const char *basename;

--- a/main/build/MacOSX/monostub.m
+++ b/main/build/MacOSX/monostub.m
@@ -37,13 +37,13 @@ exit_with_message (char *reason, char *argv0)
 	NSAlert *alert = [[NSAlert alloc] init];
 	[alert setMessageText:[NSString stringWithFormat:@"Could not launch %@", appName]];
 	NSString *fmt = @"%s\n\nPlease download and install the latest version of Mono.";
-	NSString *msg = [NSString stringWithFormat:fmt, reason]; 
+	NSString *msg = [NSString stringWithFormat:fmt, reason];
 	[alert setInformativeText:msg];
 	[alert addButtonWithTitle:@"Download Mono Framework"];
 	[alert addButtonWithTitle:@"Cancel"];
 	NSInteger answer = [alert runModal];
 	[alert release];
-	
+
 	if (answer == NSAlertFirstButtonReturn) {
 		NSString *mono_download_url = @"http://www.go-mono.com/mono-downloads/download.html";
 		CFURLRef url = CFURLCreateWithString (NULL, (CFStringRef) mono_download_url, NULL);
@@ -66,37 +66,37 @@ decode_qstring (unsigned char **in, unsigned char qchar)
 	unsigned char *start = *in;
 	char *value, *v;
 	size_t len = 0;
-	
+
 	while (*inptr) {
 		if (*inptr == qchar)
 			break;
-		
+
 		if (*inptr == '\\') {
 			if (inptr[1] == '\0')
 				break;
-			
+
 			inptr++;
 		}
-		
+
 		inptr++;
 		len++;
 	}
-	
+
 	v = value = (char *) malloc (len + 1);
 	while (start < inptr) {
 		if (*start == '\\')
 			start++;
-		
+
 		*v++ = (char) *start++;
 	}
-	
+
 	*v = '\0';
-	
+
 	if (*inptr)
 		inptr++;
-	
+
 	*in = inptr;
-	
+
 	return value;
 }
 
@@ -109,21 +109,21 @@ get_mono_env_options (int *count)
 	char *value, **argv;
 	int i, n = 0;
 	size_t size;
-	
+
 	if (env == NULL) {
 		*count = 0;
 		return NULL;
 	}
-	
+
 	inptr = (unsigned char *) env;
-	
+
 	while (*inptr) {
 		while (isblank ((int) *inptr))
 			inptr++;
-		
+
 		if (*inptr == '\0')
 			break;
-		
+
 		start = inptr++;
 		switch (*start) {
 		case '\'':
@@ -133,7 +133,7 @@ get_mono_env_options (int *count)
 		default:
 			while (*inptr && !isblank ((int) *inptr))
 				inptr++;
-			
+
 			// Note: Mac OS X <= 10.6.8 do not have strndup()
 			//value = strndup ((char *) start, (size_t) (inptr - start));
 			size = (size_t) (inptr - start);
@@ -142,37 +142,37 @@ get_mono_env_options (int *count)
 			value[size] = '\0';
 			break;
 		}
-		
+
 		node = (ListNode *) malloc (sizeof (ListNode));
 		node->value = value;
 		node->next = NULL;
 		n++;
-		
+
 		if (tail != NULL)
 			tail->next = node;
 		else
 			list = node;
-		
+
 		tail = node;
 	}
-	
+
 	*count = n;
-	
+
 	if (n == 0)
 		return NULL;
-	
+
 	argv = (char **) malloc (sizeof (char *) * (n + 1));
 	i = 0;
-	
+
 	while (list != NULL) {
 		node = list->next;
 		argv[i++] = list->value;
 		free (list);
 		list = node;
 	}
-	
+
 	argv[i] = NULL;
-	
+
 	return argv;
 }
 
@@ -283,92 +283,97 @@ int main (int argc, char **argv)
 		}
 	}
 
-	NSString *exePath, *exeName;
+  NSString *exePath;
+  char **extra_argv;
+  int extra_argc;
+#if USE_SIMPLE_PATH
+  exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: @SIMPLE_PATH];
+#else
+  NSString *exeName;
 	const char *basename;
 	struct rlimit limit;
-	char **extra_argv;
-	int extra_argc;
-	
+
 	if (!(basename = strrchr (argv[0], '/')))
 		basename = argv[0];
 	else
 		basename++;
-	
+
 	if (update_environment ([[appDir stringByAppendingPathComponent:@"Contents"] UTF8String], need64Bit)) {
 		//printf ("Updated the environment.\n");
 		[pool drain];
-		
+
 		return execv (argv[0], argv);
 	}
 
 	correct_locale();
 	//printf ("Running main app.\n");
-	
+
 	if (getrlimit (RLIMIT_NOFILE, &limit) == 0 && limit.rlim_cur < 1024) {
 		limit.rlim_cur = MIN (limit.rlim_max, 1024);
 		setrlimit (RLIMIT_NOFILE, &limit);
 	}
-	
+
 	exeName = [NSString stringWithFormat:@"%s.exe", basename];
 	exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: exeName];
-	
+#endif
+
 	// allow the MONODEVELOP_USE_SGEN environment variable to override the plist value
 	use_sgen = env2bool ("MONODEVELOP_USE_SGEN", use_sgen);
-	
+
 	libmono = dlopen (use_sgen ? MONO_LIB_PATH ("libmonosgen-2.0.dylib") : MONO_LIB_PATH ("libmono-2.0.dylib"), RTLD_LAZY);
-	
+
 	if (libmono == NULL) {
 		fprintf (stderr, "Failed to load libmono%s-2.0.dylib: %s\n", use_sgen ? "sgen" : "", dlerror ());
-		NSString *msg = [NSString stringWithFormat:@"This application requires Mono %s or newer.", [req_mono_version UTF8String]]; 
+		NSString *msg = [NSString stringWithFormat:@"This application requires Mono %s or newer.", [req_mono_version UTF8String]];
 		exit_with_message ((char *)[msg UTF8String], argv[0]);
 	}
-	
+
 	mono_main _mono_main = (mono_main) dlsym (libmono, "mono_main");
 	if (!_mono_main) {
 		fprintf (stderr, "Could not load mono_main(): %s\n", dlerror ());
 		exit_with_message ("Failed to load the Mono framework.", argv[0]);
 	}
-	
+
 	mono_free _mono_free = (mono_free) dlsym (libmono, "mono_free");
 	if (!_mono_free) {
 		fprintf (stderr, "Could not load mono_free(): %s\n", dlerror ());
 		exit_with_message ("Failed to load the Mono framework.", argv[0]);
 	}
-	
+
 	mono_get_runtime_build_info _mono_get_runtime_build_info = (mono_get_runtime_build_info) dlsym (libmono, "mono_get_runtime_build_info");
 	if (!_mono_get_runtime_build_info) {
 		fprintf (stderr, "Could not load mono_get_runtime_build_info(): %s\n", dlerror ());
 		exit_with_message ("Failed to load the Mono framework.", argv[0]);
 	}
-	
+
 	char *mono_version = _mono_get_runtime_build_info ();
 	if (!check_mono_version (mono_version, [req_mono_version UTF8String])) {
-		NSString *msg = [NSString stringWithFormat:@"This application requires a newer version (%s+) of the Mono framework.", [req_mono_version UTF8String]]; 
+		NSString *msg = [NSString stringWithFormat:@"This application requires a newer version (%s+) of the Mono framework.", [req_mono_version UTF8String]];
 		exit_with_message ((char *)[msg UTF8String], argv[0]);
 	}
-	
+
 	extra_argv = get_mono_env_options (&extra_argc);
-	
+
 	const int injected = 2; /* --debug and exe path */
 	char **new_argv = (char **) malloc (sizeof (char *) * (argc + extra_argc + injected + 1));
 	int i, n = 0;
-	
+
 	new_argv[n++] = argv[0];
 	for (i = 0; i < extra_argc; i++)
 		new_argv[n++] = extra_argv[i];
-	
+
 	// enable --debug so that we can get useful stack traces
 	new_argv[n++] = "--debug";
-	
+
 	new_argv[n++] = strdup ([exePath UTF8String]);
-	
+
 	for (i = 1; i < argc; i++)
 		new_argv[n++] = argv[i];
 	new_argv[n] = NULL;
-	
+
 	free (extra_argv);
 	[pool drain];
-	
+
 	//clock_t end = clock();
 	//printf("%f seconds to start\n", (float)(end - start) / CLOCKS_PER_SEC);
 

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=4a96f4ab5187b22fb8f06d3a480563c832d6ebe7
+DEP_NEEDED_VERSION[0]=cc2657b69b858946de820ba242f129403f213fd4
 DEP_BRANCH_AND_REMOTE[0]="native-servicehub-launcher origin/native-servicehub-launcher"
  
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=cc2657b69b858946de820ba242f129403f213fd4
+DEP_NEEDED_VERSION[0]=e0c07af4acc895a8c660006dadeeff01cc58f6b3
 DEP_BRANCH_AND_REMOTE[0]="native-servicehub-launcher origin/native-servicehub-launcher"
  
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=bd4998ab0b82bd5f7c9cb7ef94a83402aa19b110
+DEP_NEEDED_VERSION[0]=bc600384b0ebdee3f7b036d1170f6697a50cfac6
 DEP_BRANCH_AND_REMOTE[0]="native-servicehub-launcher origin/native-servicehub-launcher"
  
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=bc600384b0ebdee3f7b036d1170f6697a50cfac6
+DEP_NEEDED_VERSION[0]=4a96f4ab5187b22fb8f06d3a480563c832d6ebe7
 DEP_BRANCH_AND_REMOTE[0]="native-servicehub-launcher origin/native-servicehub-launcher"
  
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=20d6c94179a1e8357dddff47fa7b784938765f71
-DEP_BRANCH_AND_REMOTE[0]="master origin/master"
+DEP_NEEDED_VERSION[0]=bd4998ab0b82bd5f7c9cb7ef94a83402aa19b110
+DEP_BRANCH_AND_REMOTE[0]="native-servicehub-launcher origin/native-servicehub-launcher"
  
 # heap-shot
 DEP[1]=heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=e0c07af4acc895a8c660006dadeeff01cc58f6b3
+DEP_NEEDED_VERSION[0]=68c3ec72b64cc876b40e678435347d665af6c3c4
 DEP_BRANCH_AND_REMOTE[0]="native-servicehub-launcher origin/native-servicehub-launcher"
  
 # heap-shot


### PR DESCRIPTION
This makes some changes to monostub.m so we can re-use it for the ServiceHub native launcher.

The difference is that I added `#if USE_SIMPLE_PATH ... #endif` and inside there, it gets the path to use from `SIMPLE_PATH`, then those are passed by the compiler in md-addins.