### PR TITLE
[AutoTest] Add a null conditional in GetErrors

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -249,7 +249,7 @@ namespace MonoDevelop.Components.AutoTest
 				Description = x.Description,
 				File = x.FileName.FileName,
 				Path = x.FileName.FullPath,
-				Project = x.WorkspaceObject.Name
+				Project = x.WorkspaceObject?.Name
 			}).ToList ();
 		}
 


### PR DESCRIPTION
Sometimes the errors pad has errors not associated
with a WorkspaceObject