### PR TITLE
[Core] Add missing path separator in SolutionDir

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Projects.MSBuild
 			evaluatedItemsIgnoringCondition = new List<IMSBuildItemEvaluated> ();
 			evaluatedProperties = new MSBuildEvaluatedPropertyCollection (msproject);
 			if (!project.SolutionDirectory.IsNullOrEmpty)
-				globalProperties.Add ("SolutionDir", project.SolutionDirectory.ToString ());
+				globalProperties.Add ("SolutionDir", project.SolutionDirectory.ToString () + System.IO.Path.DirectorySeparatorChar);
 		}
 
 		public void Dispose ()

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1543,7 +1543,7 @@ namespace MonoDevelop.Projects
 			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 
 			var p = (Project)sol.Items [0];
-			Assert.AreEqual (sol.ItemDirectory.ToString (), p.MSBuildProject.EvaluatedProperties.GetValue ("SolutionDir"));
+			Assert.AreEqual (sol.ItemDirectory.ToString () + "/", p.MSBuildProject.EvaluatedProperties.GetValue ("SolutionDir"));
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes bug #44761 - "Application has not been built" error message when
deploying XM app with a custom TargetOuputPath.