### PR TITLE
[Core] Improve loading of legacy custom commands

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/EnvironmentVariableCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/EnvironmentVariableCollection.cs
@@ -45,6 +45,11 @@ namespace MonoDevelop.Projects
 			dict = dictionary.ToList ();
 		}
 
+		public void CopyFrom (IDictionary<string, string> dictionary)
+		{
+			dict = dictionary.ToList ();
+		}
+
 		void ICustomDataItem.Deserialize (ITypeSerializer handler, DataCollection data)
 		{
 			foreach (var v in data.OfType<DataItem> ()) {


### PR DESCRIPTION
Try to load all legacy execution custom commands from all configurations,
and convert them to run configurations.

Fixes bug #43791 - Not possible to debug a tool using mdtool as the external
program to run with a Run Configuration