### PR TITLE
[Core] Fix fast needs build check issue

### DIFF
--- a/main/tests/test-projects/fast-build-test/FastBuildTest.csproj
+++ b/main/tests/test-projects/fast-build-test/FastBuildTest.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{E0C1595D-2795-43CD-8FD7-1A6E56ED5258}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FastBuildTest</RootNamespace>
+    <AssemblyName>FastBuildTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastLibrary.csproj">
+      <Project>{E816B615-A29F-41DA-99D6-3CA5B5839D80}</Project>
+      <Name>FastLibrary</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/fast-build-test/FastBuildTest.sln
+++ b/main/tests/test-projects/fast-build-test/FastBuildTest.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastBuildTest", "FastBuildTest.csproj", "{E0C1595D-2795-43CD-8FD7-1A6E56ED5258}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastLibrary", "FastLibrary.csproj", "{E816B615-A29F-41DA-99D6-3CA5B5839D80}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E0C1595D-2795-43CD-8FD7-1A6E56ED5258}.Debug|x86.ActiveCfg = Debug|x86
+		{E0C1595D-2795-43CD-8FD7-1A6E56ED5258}.Debug|x86.Build.0 = Debug|x86
+		{E0C1595D-2795-43CD-8FD7-1A6E56ED5258}.Release|x86.ActiveCfg = Release|x86
+		{E0C1595D-2795-43CD-8FD7-1A6E56ED5258}.Release|x86.Build.0 = Release|x86
+		{E816B615-A29F-41DA-99D6-3CA5B5839D80}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E816B615-A29F-41DA-99D6-3CA5B5839D80}.Debug|x86.Build.0 = Debug|Any CPU
+		{E816B615-A29F-41DA-99D6-3CA5B5839D80}.Release|x86.ActiveCfg = Release|Any CPU
+		{E816B615-A29F-41DA-99D6-3CA5B5839D80}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/fast-build-test/FastLibrary.csproj
+++ b/main/tests/test-projects/fast-build-test/FastLibrary.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E816B615-A29F-41DA-99D6-3CA5B5839D80}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>FastLibrary</RootNamespace>
+    <AssemblyName>FastLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/fast-build-test/MyClass.cs
+++ b/main/tests/test-projects/fast-build-test/MyClass.cs
@@ -1,0 +1,4 @@
+﻿public class MyClass
+{
+	public const string Message = "Hello";
+}

--- a/main/tests/test-projects/fast-build-test/Program.cs
+++ b/main/tests/test-projects/fast-build-test/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace FastBuildTest
+{
+	class MainClass
+	{
+		public static void Main (string [] args)
+		{
+			Console.WriteLine (MyClass.Message);
+		}
+	}
+}


### PR DESCRIPTION
When checking if a project needs to be built, also check the flag
for all dependencies, taking into account the time at which the
flag was set.

Fixes bug #45265 - Running Xamarin.Mac app after building library does not
build app