### PR TITLE
Bug 49500 - Null reference when installing a NuGet package

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -331,6 +331,7 @@ namespace MonoDevelop.Ide.Editor
 			DefaultSourceEditorOptions.Instance.Changed -= UpdateTextEditorOptions;
 			RemovePolicyChangeHandler ();
 			RemoveAutoSaveTimer ();
+			textEditor.Dispose ();
 		}
 
 		#endregion


### PR DESCRIPTION
This bug happened with 512768ca3 and 7356c217 aka https://github.com/mono/monodevelop/pull/1636
Reason for this bug was that TextEditor was Disposed only when underlying GTK editor was destroyed which resulted in leaking extensions(which kept event handlers causing exception). Ever since commits mentioned above GTK editor is not created until tab is selected(visible) hence GTK editor was never destroyed(hence no disposing)…