### PR TITLE
Bug 49517 - Cannot create a Forms project (PCL or Shared) using New Project Dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -152,7 +152,6 @@ namespace MonoDevelop.Ide.Projects
 
 		ProcessedTemplateResult processedTemplate;
 		List <SolutionItem> currentEntries;
-		bool disposeNewItem = true;
 
 		public NewProjectDialogController ()
 		{
@@ -174,9 +173,6 @@ namespace MonoDevelop.Ide.Projects
 			dialog.RegisterController (this);
 
 			dialog.ShowDialog ();
-
-			if (disposeNewItem)
-				DisposeExistingNewItems ();
 
 			wizardProvider.Dispose ();
 			imageProvider.Dispose ();
@@ -625,7 +621,6 @@ namespace MonoDevelop.Ide.Projects
 			else {
 				// The item is not a solution being opened, so it is going to be added to
 				// an existing item. In this case, it must not be disposed by the dialog.
-				disposeNewItem = false;
 				RunTemplateActions (processedTemplate);
 				if (wizardProvider.HasWizard)
 					wizardProvider.CurrentWizard.ItemsCreated (processedTemplate.WorkspaceItems);


### PR DESCRIPTION
For Unknown reason dialog sometimes closes before `dialog.CloseDialog ();` is called on line 638. But also user can close dialog by clicking (x) button causing DisposeExistingNewItems to be called. This resulted in disposed solution  while still in progress of saving, hence exception.
It’s save to remove this two lines since this was just defensively placed to dispose objects in all cases(in case of exceptions…)
Disposing is still done after solution is saved and at 2nd defensive place(before creating new project) so also in case of unexpected exception in process we will clean things up