### PR TITLE
[CorDebug] Namespace is adjusted to Mono.Debugging.Win32

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/ArrayAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/ArrayAdaptor.cs
@@ -30,7 +30,7 @@ using System.Collections;
 using Microsoft.Samples.Debugging.CorDebug;
 using Mono.Debugging.Evaluation;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class ArrayAdaptor: ICollectionAdaptor
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerBacktrace.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerBacktrace.cs
@@ -8,7 +8,7 @@ using Mono.Debugging.Client;
 using Mono.Debugging.Evaluation;
 using System.Linq;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class CorBacktrace: BaseBacktrace
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
@@ -16,7 +16,7 @@ using Mono.Debugging.Client;
 using Mono.Debugging.Evaluation;
 using System.Linq;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class CorDebuggerSession: DebuggerSession
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorEvaluationContext.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorEvaluationContext.cs
@@ -3,7 +3,7 @@ using Microsoft.Samples.Debugging.CorDebug;
 using Mono.Debugging.Evaluation;
 using DC = Mono.Debugging.Client;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class CorEvaluationContext: EvaluationContext
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorMethodCall.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorMethodCall.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading;
 using Mono.Debugging.Evaluation;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class CorMethodCall: AsyncOperation
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
@@ -44,7 +44,7 @@ using Microsoft.Samples.Debugging.Extensions;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class CorObjectAdaptor: ObjectValueAdaptor
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorValRef.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorValRef.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Samples.Debugging.CorDebug;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class CorValRef
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/FieldReference.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/FieldReference.cs
@@ -30,7 +30,7 @@ using Microsoft.Samples.Debugging.CorDebug;
 using Mono.Debugging.Client;
 using Mono.Debugging.Evaluation;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class FieldReference: ValueReference
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaBacktrace.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaBacktrace.cs
@@ -1,7 +1,7 @@
 ﻿using Mono.Debugging.Backend;
 using Mono.Debugging.Client;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class MtaBacktrace: IBacktrace
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaObjectValueSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaObjectValueSource.cs
@@ -1,7 +1,7 @@
 ﻿using Mono.Debugging.Backend;
 using Mono.Debugging.Client;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class MtaObjectValueSource: IObjectValueSource
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaObjectValueUpdater.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaObjectValueUpdater.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Debugging.Backend;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class MtaObjectValueUpdater : IObjectValueUpdater
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaRawValue.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaRawValue.cs
@@ -1,7 +1,7 @@
 ﻿using Mono.Debugging.Backend;
 using Mono.Debugging.Client;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class MtaRawValue : IRawValue
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaRawValueArray.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaRawValueArray.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Mono.Debugging.Backend;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class MtaRawValueArray : IRawValueArray
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaRawValueString.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaRawValueString.cs
@@ -1,6 +1,6 @@
 ﻿using Mono.Debugging.Backend;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class MtaRawValueString : IRawValueString
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaThread.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/MtaThread.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public static class MtaThread
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/PropertyReference.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/PropertyReference.cs
@@ -31,7 +31,7 @@ using Mono.Debugging.Evaluation;
 using Microsoft.Samples.Debugging.CorDebug;
 using Microsoft.Samples.Debugging.CorDebug.NativeApi;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	class PropertyReference: ValueReference
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/StringAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/StringAdaptor.cs
@@ -27,7 +27,7 @@
 using Microsoft.Samples.Debugging.CorDebug;
 using Mono.Debugging.Evaluation;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class StringAdaptor: IStringAdaptor
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/VariableReference.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/VariableReference.cs
@@ -28,7 +28,7 @@
 using DC = Mono.Debugging.Client;
 using Mono.Debugging.Evaluation;
 
-namespace MonoDevelop.Debugger.Win32
+namespace Mono.Debugging.Win32
 {
 	public class VariableReference: ValueReference
 	{

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/Win32.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/Win32.cs
@@ -1,54 +1,56 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-[StructLayout (LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-struct STARTUPINFO
+namespace Mono.Debugging.Win32
 {
-	public int cb;
-	public string lpReserved;
-	public string lpDesktop;
-	public string lpTitle;
-	public int dwX;
-	public int dwY;
-	public int dwXSize;
-	public int dwYSize;
-	public int dwXCountChars;
-	public int dwYCountChars;
-	public int dwFillAttribute;
-	public int dwFlags;
-	public short wShowWindow;
-	public short cbReserved2;
-	public IntPtr lpReserved2;
-	public IntPtr hStdInput;
-	public IntPtr hStdOutput;
-	public IntPtr hStdError;
-}
+	[StructLayout (LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+	struct STARTUPINFO
+	{
+		public int cb;
+		public string lpReserved;
+		public string lpDesktop;
+		public string lpTitle;
+		public int dwX;
+		public int dwY;
+		public int dwXSize;
+		public int dwYSize;
+		public int dwXCountChars;
+		public int dwYCountChars;
+		public int dwFillAttribute;
+		public int dwFlags;
+		public short wShowWindow;
+		public short cbReserved2;
+		public IntPtr lpReserved2;
+		public IntPtr hStdInput;
+		public IntPtr hStdOutput;
+		public IntPtr hStdError;
+	}
 
-[StructLayout (LayoutKind.Sequential)]
-internal struct PROCESS_INFORMATION
-{
-	public IntPtr hProcess;
-	public IntPtr hThread;
-	public int dwProcessId;
-	public int dwThreadId;
-}
+	[StructLayout (LayoutKind.Sequential)]
+	internal struct PROCESS_INFORMATION
+	{
+		public IntPtr hProcess;
+		public IntPtr hThread;
+		public int dwProcessId;
+		public int dwThreadId;
+	}
 
-[Flags]
-enum CreationFlags
-{
-	CREATE_BREAKAWAY_FROM_JOB = 0x01000000,
-	CREATE_DEFAULT_ERROR_MODE = 0x04000000,
-	CREATE_NEW_CONSOLE = 0x00000010,
-	CREATE_NEW_PROCESS_GROUP = 0x00000200,
-	CREATE_NO_WINDOW = 0x08000000,
-	CREATE_PROTECTED_PROCESS = 0x00040000,
-	CREATE_PRESERVE_CODE_AUTHZ_LEVEL = 0x02000000,
-	CREATE_SEPARATE_WOW_VDM = 0x00001000,
-	CREATE_SUSPENDED = 0x00000004,
-	CREATE_UNICODE_ENVIRONMENT = 0x00000400,
-	DEBUG_ONLY_THIS_PROCESS = 0x00000002,
-	DEBUG_PROCESS = 0x00000001,
-	DETACHED_PROCESS = 0x00000008,
-	EXTENDED_STARTUPINFO_PRESENT = 0x00080000
+	[Flags]
+	enum CreationFlags
+	{
+		CREATE_BREAKAWAY_FROM_JOB = 0x01000000,
+		CREATE_DEFAULT_ERROR_MODE = 0x04000000,
+		CREATE_NEW_CONSOLE = 0x00000010,
+		CREATE_NEW_PROCESS_GROUP = 0x00000200,
+		CREATE_NO_WINDOW = 0x08000000,
+		CREATE_PROTECTED_PROCESS = 0x00040000,
+		CREATE_PRESERVE_CODE_AUTHZ_LEVEL = 0x02000000,
+		CREATE_SEPARATE_WOW_VDM = 0x00001000,
+		CREATE_SUSPENDED = 0x00000004,
+		CREATE_UNICODE_ENVIRONMENT = 0x00000400,
+		DEBUG_ONLY_THIS_PROCESS = 0x00000002,
+		DEBUG_PROCESS = 0x00000001,
+		DETACHED_PROCESS = 0x00000008,
+		EXTENDED_STARTUPINFO_PRESENT = 0x00080000
+	}
 }
-

--- a/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/MonoDevelop.Debugger.Win32/CorDebuggerEngine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Debugging.Client;
+using Mono.Debugging.Win32;
 using MonoDevelop.Core;
 using MonoDevelop.Core.Execution;
 #if ASPNET


### PR DESCRIPTION
Namespace is adjusted to Mono.Debugging.Win32 to make them consistent with Mono.Debugging.* API.