### PR TITLE
Stop main window disappearing when losing focus [C9]

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
@@ -79,7 +79,7 @@ namespace MonoDevelop.Components
 		{
 			this.DataProvider = provider;
 			this.TransientFor = IdeApp.Workbench.RootWindow;
-			this.TypeHint = Gdk.WindowTypeHint.Menu;
+			this.TypeHint = Gdk.WindowTypeHint.DropdownMenu;
 			this.Decorated = false;
 			this.BorderWidth = 1;
 			list = new ListWidget (this);


### PR DESCRIPTION
If the breadcrumb bar menu is opened and the user clicks outside of the application, the main window disappears. This is caused by the typehint of the
dropdown menu being set to Menu, which deep in the gdk internals sets
hidesOnDeactivate to YES on the menu window, which somehow seems to propagate
to the main window as well.

Setting the typehint to DropdownMenu instead of just Menu fixes this