### PR TITLE
Styles: new button color definitions

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -49,6 +49,8 @@ namespace MonoDevelop.Ide.Gui
 		public static Color BorderColor { get; internal set; }
 		public static Color SecondaryTextColor { get; internal set; }
 		public static Color SecondarySelectionTextColor { get; internal set; }
+		public static Color ButtonBackgroundColor { get; internal set; }
+		public static Color ButtonTextColor { get; internal set; }
 
 		public static Color ErrorForegroundColor { get; internal set; }
 		public static Color WarningForegroundColor { get; internal set; }
@@ -453,6 +455,8 @@ namespace MonoDevelop.Ide.Gui
 			DockBarPrelightColor = Color.FromName ("#eeeeee");
 			BrowserPadBackground = Color.FromName ("#ebedf0");
 			PropertyPadDividerColor = Color.FromName ("#efefef");
+			ButtonBackgroundColor = Color.FromName ("#ffffff");
+			ButtonTextColor = Color.FromName ("#232323");
 
 			// these colors need to match colors from status icons
 			StatusInformationBackgroundColor = Color.FromName ("#87b6f0");
@@ -570,6 +574,8 @@ namespace MonoDevelop.Ide.Gui
 			DockBarPrelightColor = Color.FromName ("#666666");
 			BrowserPadBackground = Color.FromName ("#484b55");
 			PropertyPadDividerColor = SeparatorColor;
+			ButtonBackgroundColor = Color.FromName ("#bbbbbb");
+			ButtonTextColor = Color.FromName ("#232323");
 
 			// these colors need to match colors from status icons
 			StatusInformationBackgroundColor = Color.FromName ("#8fc1ff");


### PR DESCRIPTION
New changes of Project Getting Started (soon in PR based on `md-addins` master and cycle9) need a new theme-based color definition for buttons. This `monodevelop` commit contains them, it's just a simple cherry-pick from master. It's just a color definition, nothing special, but it needs to be available for those upcoming PRs.