### PR TITLE
CorDebug fixes

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Extensions/MetadataExtensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Extensions/MetadataExtensions.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Samples.Debugging.Extensions
 	[CLSCompliant (false)]
 	public static class MetadataHelperFunctionsExtensions
 	{
-		public static Dictionary<CorElementType, Type> CoreTypes = new Dictionary<CorElementType, Type> ();
+		public static readonly Dictionary<CorElementType, Type> CoreTypes = new Dictionary<CorElementType, Type> ();
 		static MetadataHelperFunctionsExtensions ()
 		{
 			CoreTypes.Add (CorElementType.ELEMENT_TYPE_BOOLEAN, typeof (bool));

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
@@ -482,7 +482,14 @@ namespace Microsoft.Samples.Debugging.CorMetadata
         protected override PropertyInfo GetPropertyImpl(String name, BindingFlags bindingAttr,Binder binder,
                                                         Type returnType, Type[] types, ParameterModifier[] modifiers)
         {
-            throw new NotImplementedException();
+            // Temp matched only by name
+            var properties = GetProperties(bindingAttr);
+            foreach (var propertyInfo in properties) {
+                if (propertyInfo.Name == name) {
+                    return propertyInfo;
+                }
+            }
+            return null;
         }
 
         public override EventInfo[] GetEvents(BindingFlags bindingAttr)


### PR DESCRIPTION
* MetadataType.GetPropertyImpl() implementation
* Properly getting module for native types in RuntimeInvoke, because there were exceptions
* try{} block removed, null check for 'method' removed, because it's unnecessary
* try-catch in OverloadResolve()