### PR TITLE
Proper caching of CorTypes

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
@@ -188,8 +188,10 @@ namespace Mono.Debugging.Win32
 			}
 		}
 
-		Dictionary<string, CorType> nameToTypeCache = new Dictionary<string, CorType> ();
-		Dictionary<CorType, string> typeToNameCache = new Dictionary<CorType, string> ();
+		readonly Dictionary<string, CorType> nameToTypeCache = new Dictionary<string, CorType> ();
+		readonly Dictionary<CorType, string> typeToNameCache = new Dictionary<CorType, string> ();
+		readonly HashSet<string> unresolvedNames = new HashSet<string> ();
+
 
 		string GetCacheName(string name, CorType[] typeArgs)
 		{
@@ -214,23 +216,26 @@ namespace Mono.Debugging.Win32
 			CorType fastRet;
 			if (!string.IsNullOrEmpty (cacheName) && nameToTypeCache.TryGetValue (cacheName, out fastRet))
 				return fastRet;
+			if (unresolvedNames.Contains (cacheName ?? name))
+				return null;
 			CorEvaluationContext ctx = (CorEvaluationContext)gctx;
 			foreach (CorModule mod in ctx.Session.GetModules ()) {
 				CorMetadataImport mi = ctx.Session.GetMetadataForModule (mod.Name);
 				if (mi != null) {
-					foreach (Type t in mi.DefinedTypes) {
-						if (t.FullName.Replace ('+', '.') == name.Replace ('+', '.')) {
-							CorClass cls = mod.GetClassFromToken (t.MetadataToken);
-							fastRet = cls.GetParameterizedType (CorElementType.ELEMENT_TYPE_CLASS, typeArgs);
-							if (!string.IsNullOrEmpty (cacheName)) {
-								nameToTypeCache [cacheName] = fastRet;
-								typeToNameCache [fastRet] = cacheName;
-							}
-							return fastRet;
-						}
+					var token = mi.GetTypeTokenFromName (name);
+					if (token == CorMetadataImport.TokenNotFound)
+						continue;
+					var t = mi.GetType(token);
+					CorClass cls = mod.GetClassFromToken (t.MetadataToken);
+					fastRet = cls.GetParameterizedType (CorElementType.ELEMENT_TYPE_CLASS, typeArgs);
+					if (!string.IsNullOrEmpty (cacheName)) {
+						nameToTypeCache [cacheName] = fastRet;
+						typeToNameCache [fastRet] = cacheName;
 					}
+					return fastRet;
 				}
 			}
+			unresolvedNames.Add (cacheName ?? name);
 			return null;
 		}
 


### PR DESCRIPTION
Proper caching of CorTypes:
* unresolved names have to be also cached, otherwise the cache in useless. Greatly increases performance of evaluation.
* type info fetched via mi.GetTypeTokenFromName() instead of iterating over all types in module. This increases performance as well.