### PR TITLE
.editorconfig files for CorDebug projects.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi/.editorconfig
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = crlf

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/.editorconfig
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = crlf

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/.editorconfig
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+indent_style = tab
+indent_size = 4
+end_of_line = crlf


### PR DESCRIPTION
Makes editing easier because CorApi* and Mono.Debugging has different code styles.