### PR TITLE
[C9] Add Gui.Styles.CurrentStyle for easier access and StylesStringTagModel usage

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -39,6 +39,8 @@ namespace MonoDevelop.Ide.Gui
 	{
 		public static event EventHandler Changed;
 
+		public static Theme CurrentStyle { get { return IdeTheme.UserInterfaceTheme; } }
+
 		public static Color BackgroundColor { get; internal set; }        // must be the bg color from Gtkrc
 		public static Color BaseBackgroundColor { get; internal set; }    // must be the base color from Gtkrc
 		public static Color BaseForegroundColor { get; internal set; }    // must be the text color from Gtkrc


### PR DESCRIPTION
This makes it easier to find the current theme API and adds the CurrentStyle tag to the style tag model.