### PR TITLE
Please, add the issues tab!

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,4 @@ monodevelop-bugs@lists.ximian.com *(track MonoDevelop bugzilla component)*
 
 http://bugzilla.xamarin.com *(submit bugs and patches here)*
 
+Also, feel free to create an issue here on github!


### PR DESCRIPTION
Mailing lists are a pain for many reasons.
The same goes for creating accounts on bugzillas/bugtrackers here and where.
Please, let developers pick their preferred information channel and add the "Issues" tab!
It cant hurt, can it?