### PR TITLE
Bug 51137 - Web application can't be debugging when first created

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2349,6 +2349,7 @@ namespace MonoDevelop.Projects
 			foreach (var cgrp in runConfigData)
 				runConfigs.Add (LoadRunConfiguration (monitor, cgrp, cgrp.Config));
 
+			defaultRunConfigurationCreated = false;
 			runConfigurations.SetItems (runConfigs);
 
 			// Read extended properties


### PR DESCRIPTION
Problem is that after creating new project get_RunConfigurations is called which adds default run configuration and sets defaultRunConfigurationCreated to true. But after restoring NuGet packages we call OnReevaluateProject which removes default configurations already created and since we have defaultRunConfigurationCreated set to true, default configurations are not recreated… This seems like best place to reset defaultRunConfigurationCreated to false.