### PR TITLE
[Cycle9][NuGet] Fix the unit tests on Windows

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageCompatibilityRunnerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageCompatibilityRunnerTests.cs
@@ -44,6 +44,16 @@ namespace MonoDevelop.PackageManagement.Tests
 		FakeProgressMonitorFactory progressMonitorFactory;
 		PackageManagementEvents packageManagementEvents;
 		FakeProgressMonitor progressMonitor;
+		NetPortableProfileTable profileTable;
+
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			string appDataFolder = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+			string dummyPath = Path.Combine (appDataFolder, "MonoDevelopPackageManagementTests");
+			Environment.SetEnvironmentVariable ("NuGetPortableReferenceAssemblyPath", dummyPath);
+			profileTable = NetPortableProfileTable.Instance;
+		}
 
 		void CreateRunner ()
 		{

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageCompatibilityTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageCompatibilityTests.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.IO;
 using System.Runtime.Versioning;
 using MonoDevelop.Core.Assemblies;
 using MonoDevelop.PackageManagement.Tests.Helpers;
@@ -39,6 +40,17 @@ namespace MonoDevelop.PackageManagement.Tests
 		FakePackage package;
 		PackageCompatibility packageCompatibility;
 		FakeDotNetProject project;
+
+		NetPortableProfileTable profileTable;
+
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			string appDataFolder = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify);
+			string dummyPath = Path.Combine (appDataFolder, "MonoDevelopPackageManagementTests");
+			Environment.SetEnvironmentVariable ("NuGetPortableReferenceAssemblyPath", dummyPath);
+			profileTable = NetPortableProfileTable.Instance;
+		}
 
 		void CreateProject (string frameworkVersion)
 		{


### PR DESCRIPTION
Wrench builds are failing with access denied errors trying read an
.xml PCL profile file. Avoid using PCL profile .xml files on the
Wrench server by specifying a different directory which does not
exist.