### PR TITLE
Handle either Gtk.Application.Quit() or NSApplication.Terminate()

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -153,6 +153,22 @@ namespace MonoDevelop.MacIntegration
 			GlobalSetup ();
 			timer.EndTiming ();
 
+			var appDelegate = NSApplication.SharedApplication.Delegate as Xwt.Mac.AppDelegate;
+			if (appDelegate != null) {
+				appDelegate.Terminating += (object o, TerminationEventArgs e) => {
+					if (MonoDevelop.Ide.IdeApp.IsRunning) {
+						// If GLib the mainloop is still running that means NSApplication.Terminate() was called
+						// before Gtk.Application.Quit(). Cancel Cocoa termination and exit the mainloop.
+						e.Reply = NSApplicationTerminateReply.Cancel;
+						Gtk.Main.Quit ();
+					} else {
+						// The mainloop has already exited and we've already cleaned up our application state
+						// so it's now safe to terminate Cocoa.
+						e.Reply = NSApplicationTerminateReply.Now;
+					}
+				};
+			}
+
 			return loaded;
 		}
 

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/GtkWorkarounds.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/GtkWorkarounds.cs
@@ -65,7 +65,7 @@ namespace Mono.TextEditor
 
 		[DllImport (LIBOBJC, EntryPoint = "objc_msgSend")]
 		static extern ulong objc_msgSend_NSUInt64 (IntPtr klass, IntPtr selector);
-		
+
 		[DllImport (LIBOBJC, EntryPoint = "objc_msgSend_stret")]
 		static extern void objc_msgSend_CGRect32 (out CGRect32 rect, IntPtr klass, IntPtr selector);
 
@@ -302,7 +302,7 @@ namespace Mono.TextEditor
 
 			return new Gdk.Rectangle (x, y, width, height);
 		}
-		
+
 		public static Gdk.Rectangle GetUsableMonitorGeometry (this Gdk.Screen screen, int monitor)
 		{
 			if (Platform.IsWindows)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -83,6 +83,9 @@ namespace MonoDevelop.Components
 		[DllImport (LIBOBJC, EntryPoint = "objc_msgSend_stret")]
 		static extern void objc_msgSend_CGRect64 (out CGRect64 rect, IntPtr klass, IntPtr selector);
 
+		[DllImport (LIBOBJC, EntryPoint = "objc_msgSend")]
+		static extern void objc_msgSend_NSInt64_NSInt32 (IntPtr klass, IntPtr selector, int arg);
+
 		[DllImport (PangoUtil.LIBQUARTZ)]
 		static extern IntPtr gdk_quartz_window_get_nswindow (IntPtr window);
 
@@ -106,7 +109,7 @@ namespace MonoDevelop.Components
 
 		static IntPtr cls_NSScreen;
 		static IntPtr sel_screens, sel_objectEnumerator, sel_nextObject, sel_frame, sel_visibleFrame,
-		sel_requestUserAttention, sel_setHasShadow, sel_invalidateShadow;
+		sel_requestUserAttention, sel_setHasShadow, sel_invalidateShadow, sel_terminate;
 		static IntPtr sharedApp;
 		static IntPtr cls_NSEvent;
 		static IntPtr sel_modifierFlags;
@@ -171,7 +174,19 @@ namespace MonoDevelop.Components
 			sel_modifierFlags = sel_registerName ("modifierFlags");
 			sel_setHasShadow = sel_registerName ("setHasShadow:");
 			sel_invalidateShadow = sel_registerName ("invalidateShadow");
+			sel_terminate = sel_registerName ("terminate:");
 			sharedApp = objc_msgSend_IntPtr (objc_getClass ("NSApplication"), sel_registerName ("sharedApplication"));
+		}
+
+		static void MacTerminate ()
+		{
+			objc_msgSend_NSInt64_NSInt32 (sharedApp, sel_terminate, 0);
+		}
+
+		public static void Terminate ()
+		{
+			if (Platform.IsMac)
+				MacTerminate ();
 		}
 
 		static Gdk.Rectangle MacGetUsableMonitorGeometry (Gdk.Screen screen, int monitor)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -61,7 +61,8 @@ namespace MonoDevelop.Ide
 		static IdePreferences preferences;
 
 		public const int CurrentRevision = 5;
-		
+
+		static bool isMainRunning;
 		static bool isInitialRun;
 		static bool isInitialRunAfterUpgrade;
 		static int upgradedFromRevision;
@@ -383,10 +384,14 @@ namespace MonoDevelop.Ide
 		public static void Run ()
 		{
 			// finally run the workbench window ...
+			isMainRunning = true;
 			Gtk.Application.Run ();
 		}
-		
-		
+
+		public static bool IsRunning {
+			get { return isMainRunning; }
+		}
+
 		/// <summary>
 		/// Exits MonoDevelop. Returns false if the user cancels exiting.
 		/// </summary>
@@ -394,6 +399,7 @@ namespace MonoDevelop.Ide
 		{
 			if (workbench.Close ()) {
 				Gtk.Application.Quit ();
+				isMainRunning = false;
 				return true;
 			}
 			return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -293,6 +293,8 @@ namespace MonoDevelop.Ide
 			IdeApp.Customizer.OnCoreShutdown ();
 
 			InstrumentationService.Stop ();
+
+			MonoDevelop.Components.GtkWorkarounds.Terminate ();
 			
 			return 0;
 		}


### PR DESCRIPTION
After the GLib mainloop exits, call NSApplication.Terminate() to make sure Cocoa terminates correctly and shuts down threads like those used for animations and such.

If NSApplication.Terminate() is called first, catch that call and cancel termination, instead calling Gtk.Application.Quit() so that we shutdown the GLib mainloop. This will in turn call NSApp.Terminate() a second time, which will *not* cancel termination and will perform
Cocoa cleanup as described above.

https://bugzilla.xamarin.com/show_bug.cgi?id=14789