### PR TITLE
[Debugger] Fix incorrect ordering for evaluated group in Locals window

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1056,10 +1056,10 @@ namespace MonoDevelop.Debugger
 							SetValues (parent, it, null, val.GetArrayItem (0));
 							RegisterValue (val, it);
 							for (int n=1; n<val.ArrayCount; n++) {
-								TreeIter cit = store.InsertNodeAfter (it);
+								it = store.InsertNodeAfter (it);
 								ObjectValue cval = val.GetArrayItem (n);
-								SetValues (parent, cit, null, cval);
-								RegisterValue (cval, cit);
+								SetValues (parent, it, null, cval);
+								RegisterValue (cval, it);
 							}
 						}
 					} else {


### PR DESCRIPTION
When an evaluating group's ObjectValue is updated the items were
added in reverse order in the Locals window. The first item was
replacing the existing item but then the rest were inserted one at
a time after the first item. This resulted in all items after the
first one being added in reverse order.