### PR TITLE
[Cycle9][Packaging] Use PCL profile 111 in multiplatform project template

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/Templates/CrossPlatformLibrary.xpt.xml
+++ b/main/src/addins/MonoDevelop.Packaging/Templates/CrossPlatformLibrary.xpt.xml
@@ -25,7 +25,7 @@
 
 		<Project name="${ProjectName}" directory = "." type="C#PortableLibrary" if="CreatePortableProject">
 			<Options Target="Library"
-				TargetFrameworkVersion=".NETPortable,Version=v4.5,Profile=Profile78"
+				TargetFrameworkVersion=".NETPortable,Version=v4.5,Profile=Profile111"
 				DefaultNamespace="${ProjectName}"
 				HideGettingStarted="true" />
 			<Packages>


### PR DESCRIPTION
Fixed bug #51273 - Multiplatform library uses PCL Profile 78 instead of Profile 111
https://bugzilla.xamarin.com/show_bug.cgi?id=51273

Switching from PCL profile 78 to 111 makes the project template consistent with the standalone PCL project template.