### PR TITLE
CorValRef invalidates only when it actually required

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
@@ -1807,7 +1807,7 @@ namespace Mono.Debugging.Win32
 				ValueReference vr = actx.GetMember (ctx, null, thisVal, "value__");
 				vr.Value = val;
 				// Required to make sure that var returns an up-to-date value object
-				thisVal.IsValid = false;
+				thisVal.Invalidate ();
 				return;
 			}
 				

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
@@ -378,11 +378,8 @@ namespace Mono.Debugging.Win32
 			CorValRef arr = new CorValRef (delegate {
 				return ctx.Session.NewArray (ctx, (CorType)GetValueType (ctx, val), 1);
 			});
-			CorArrayValue array = CorObjectAdaptor.GetRealObject (ctx, arr) as CorArrayValue;
-			
-			ArrayAdaptor realArr = new ArrayAdaptor (ctx, arr, array);
+			ArrayAdaptor realArr = new ArrayAdaptor (ctx, new CorValRef<CorArrayValue> (() => (CorArrayValue) GetRealObject (ctx, arr)));
 			realArr.SetElement (new [] { 0 }, val);
-			arr.IsValid = true;
 			CorType at = (CorType) GetType (ctx, "System.Array");
 			object[] argTypes = { GetType (ctx, "System.Int32") };
 			return (CorValRef)RuntimeInvoke (ctx, at, arr, "GetValue", argTypes, new object[] { CreateValue (ctx, 0) });
@@ -812,7 +809,7 @@ namespace Mono.Debugging.Win32
 			CorValue val = CorObjectAdaptor.GetRealObject (ctx, arr);
 			
 			if (val is CorArrayValue)
-				return new ArrayAdaptor (ctx, (CorValRef)arr, (CorArrayValue)val);
+				return new ArrayAdaptor (ctx, new CorValRef<CorArrayValue> ((CorArrayValue) val, () => (CorArrayValue) GetRealObject (ctx, arr)));
 			return null;
 		}
 		

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorValRef.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorValRef.cs
@@ -1,59 +1,102 @@
-﻿using Microsoft.Samples.Debugging.CorDebug;
+﻿using System.Runtime.InteropServices;
+using Microsoft.Samples.Debugging.CorDebug;
+using Mono.Debugging.Client;
 
 namespace Mono.Debugging.Win32
 {
-	public class CorValRef
+	public class CorValRef : CorValRef<CorValue>
 	{
-		CorValue val;
-		readonly ValueLoader loader;
-		int version;
-
-		public delegate CorValue ValueLoader ( );
-
-		public CorValRef (CorValue val)
+		public CorValRef (CorValue val) : base (val)
 		{
-			this.val = val;
-			this.version = CorDebuggerSession.EvaluationTimestamp;
 		}
 
-		public CorValRef (CorValue val, ValueLoader loader)
+		public CorValRef (CorValue val, ValueLoader loader) : base (val, loader)
+		{
+		}
+
+		public CorValRef (ValueLoader loader) : base (loader)
+		{
+		}
+	}
+
+	public class CorValRef<TValue> where TValue : CorValue
+	{
+		TValue val;
+		readonly ValueLoader loader;
+		bool needToReload = false;
+
+		public delegate TValue ValueLoader ( );
+
+		public CorValRef (TValue val)
+		{
+			this.val = val;
+		}
+
+		public CorValRef (TValue val, ValueLoader loader)
 		{
 			this.val = val;
 			this.loader = loader;
-			this.version = CorDebuggerSession.EvaluationTimestamp;
 		}
 
 		public CorValRef (ValueLoader loader)
 		{
 			this.val = loader ();
 			this.loader = loader;
-			this.version = CorDebuggerSession.EvaluationTimestamp;
+		}
+
+		bool IsAlive ()
+		{
+			if (val == null)
+				return false;
+			try {
+				// ReSharper disable once UnusedVariable
+
+				// https://msdn.microsoft.com/en-us/library/ms232466(v=vs.110).aspx
+				// MSDN says that ICorDebugValue doesn't guarantee that it alives between process Continue and Stop (which occur while evaluating).
+				// But in the most of cases the value remains valid.
+				// Instead of reloading it every time when evalTimestamp changes we try to call GetExactType (because it pure for the value)
+				// and if it fails we reload the value
+				var valExactType = val.ExactType;
+			}
+			catch (COMException e) {
+				if (e.ToHResult<HResult> () == HResult.CORDBG_E_OBJECT_NEUTERED) {
+					DebuggerLoggingService.LogMessage (string.Format ("Value is out of date: {0}", e.Message));
+					return false;
+				}
+				throw;
+			}
+			return true;
 		}
 
 		public bool IsValid {
-			get { return version == CorDebuggerSession.EvaluationTimestamp; }
-			set {
-				if (value)
-					version = CorDebuggerSession.EvaluationTimestamp;
-				else
-					version = -1;
+			get
+			{
+				if (needToReload)
+					return false;
+				return IsAlive ();
 			}
+		}
+
+		public void Invalidate ()
+		{
+			needToReload = true;
 		}
 
 		public void Reload ()
 		{
 			if (loader != null) {
 				// Obsolete value, get a new one
-				CorValue v = loader ();
-				version = CorDebuggerSession.EvaluationTimestamp;
-				if (v != null)
+				var v = loader ();
+				if (v != null) {
 					val = v;
+					needToReload = false;
+				}
 			}
 		}
 
-		public CorValue Val {
+		public TValue Val {
 			get {
-				if (version < CorDebuggerSession.EvaluationTimestamp) {
+				if (!IsValid) {
 					Reload ();
 				}
 				return val;

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/FieldReference.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/FieldReference.cs
@@ -117,8 +117,7 @@ namespace Mono.Debugging.Win32
 				if (thisobj != null) {
 					CorObjectValue cob = CorObjectAdaptor.GetRealObject (Context, thisobj) as CorObjectValue;
 					if (cob != null && cob.IsValueClass)
-						thisobj.IsValid = false; // Required to make sure that thisobj returns an up-to-date value object
-
+						thisobj.Invalidate (); // Required to make sure that thisobj returns an up-to-date value object
 				}
 			}
 		}


### PR DESCRIPTION
 (Zombie state exception thrown). In the most of cases CorValue stays alive between Continue-Stop, and this allows to greatly improve evaluation performance.