### PR TITLE
Cor debug instantiations

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/CorApi2.csproj
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/CorApi2.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Metadata\MetadataParameterInfo.cs" />
     <Compile Include="Metadata\MetadataPropertyInfo.cs" />
     <Compile Include="Metadata\MetadataType.cs" />
+    <Compile Include="Metadata\GenericParameter.cs" />
     <Compile Include="Metahost\Metahost.cs" />
     <Compile Include="SymStore\ISymBinder2.cs" />
     <Compile Include="SymStore\ISymConstant.cs" />

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Extensions/MetadataExtensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Extensions/MetadataExtensions.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using CorApi2.Metadata.Microsoft.Samples.Debugging.CorMetadata;
 using Microsoft.Samples.Debugging.CorDebug.NativeApi;
 using Microsoft.Samples.Debugging.CorMetadata;
 using Microsoft.Samples.Debugging.CorMetadata.NativeApi;
@@ -153,11 +154,6 @@ namespace Microsoft.Samples.Debugging.Extensions
 				argTypes.Add (ReadType (importer, instantiation, ref pData));
 		}
 
-		class GenericType
-		{
-			// Used as marker for generic method args
-		}
-
 		static Type ReadType (IMetadataImport importer, Instantiation instantiation, ref IntPtr pData)
 		{
 			CorElementType et;
@@ -193,15 +189,15 @@ namespace Microsoft.Samples.Debugging.Extensions
 					if (index < instantiation.TypeArgs.Count) {
 						return instantiation.TypeArgs[(int) index];
 					}
-					return typeof(GenericType);
+					return new TypeGenericParameter((int) index);
 				}
-				case CorElementType.ELEMENT_TYPE_MVAR: {
+			case CorElementType.ELEMENT_TYPE_MVAR: {
 					// Generic args in methods not supported. Return a dummy type.
 					var index = MetadataHelperFunctions.CorSigUncompressData (ref pData);
-					return typeof(GenericType);
+					return new MethodGenericParameter((int) index);
 				}
 
-				case CorElementType.ELEMENT_TYPE_GENERICINST: {
+			case CorElementType.ELEMENT_TYPE_GENERICINST: {
 					Type t = ReadType (importer, instantiation, ref pData);
 					var typeArgs = new List<Type> ();
 					uint num = MetadataHelperFunctions.CorSigUncompressData (ref pData);
@@ -256,7 +252,7 @@ namespace Microsoft.Samples.Debugging.Extensions
 					CorCallingConvention cconv;
 					Type retType;
 					List<Type> argTypes;
-					ReadMethodSignature (importer, Instantiation.Empty, ref pData, out cconv, out retType, out argTypes);
+					ReadMethodSignature (importer, instantiation, ref pData, out cconv, out retType, out argTypes);
 					return MetadataExtensions.MakeDelegate (retType, argTypes);
 				}
 

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/CorMetadata.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/CorMetadata.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
             m_importer = importer;
             m_methodToken=methodToken;
 
-	        int size;
+            int size;
             uint pdwAttr;
             IntPtr ppvSigBlob;
             uint pulCodeRVA,pdwImplFlags;

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/CorMetadata.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/CorMetadata.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
         // methods
         public MethodInfo GetMethodInfo(int methodToken)
         {
-            return new MetadataMethodInfo(m_importer,methodToken);
+            return new MetadataMethodInfo(m_importer,methodToken, Instantiation.Empty);
         }
 
         public Type GetType(int typeToken)
@@ -265,7 +265,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
 
     public sealed class MetadataMethodInfo : MethodInfo
     {
-        internal MetadataMethodInfo(IMetadataImport importer,int methodToken)
+        internal MetadataMethodInfo(IMetadataImport importer, int methodToken, Instantiation instantiation)
         {
             if(!importer.IsValidToken((uint)methodToken))
                 throw new ArgumentException();
@@ -273,7 +273,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
             m_importer = importer;
             m_methodToken=methodToken;
 
-            int size;
+	        int size;
             uint pdwAttr;
             IntPtr ppvSigBlob;
             uint pulCodeRVA,pdwImplFlags;
@@ -304,7 +304,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
 
 			// [Xamarin] Expression evaluator.
 			CorCallingConvention callingConv;
-			MetadataHelperFunctionsExtensions.ReadMethodSignature (importer, ref ppvSigBlob, out callingConv, out m_retType, out m_argTypes);
+			MetadataHelperFunctionsExtensions.ReadMethodSignature (importer, instantiation, ref ppvSigBlob, out callingConv, out m_retType, out m_argTypes);
             m_name = szMethodName.ToString();
             m_methodAttributes = (MethodAttributes)pdwAttr;
         }

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/GenericParameter.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/GenericParameter.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+
+namespace CorApi2.Metadata
+{
+    namespace Microsoft.Samples.Debugging.CorMetadata
+    {
+        public class MethodGenericParameter : GenericParameter
+        {
+            public MethodGenericParameter (int index) : base (index)
+            {
+            }
+        }
+
+
+        public class TypeGenericParameter : GenericParameter
+        {
+            public TypeGenericParameter (int index) : base (index)
+            {
+            }
+        }
+
+        public abstract class GenericParameter : Type
+        {
+            public int Index { get; private set; }
+
+            public GenericParameter (int index)
+            {
+                Index = index;
+            }
+
+            public override Type MakeByRefType ()
+            {
+                return this;
+            }
+
+            public override Type MakePointerType ()
+            {
+                return this;
+            }
+
+            public override Type MakeArrayType ()
+            {
+                return this;
+            }
+
+            public override Type MakeArrayType (int rank)
+            {
+                return this;
+            }
+
+            public override Type MakeGenericType (params Type[] typeArguments)
+            {
+                return this;
+            }
+
+            public override object[] GetCustomAttributes (bool inherit)
+            {
+                return new object[0];
+            }
+
+            public override bool IsDefined (Type attributeType, bool inherit)
+            {
+                return false;
+            }
+
+            public override ConstructorInfo[] GetConstructors (BindingFlags bindingAttr)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public override Type GetInterface (string name, bool ignoreCase)
+            {
+                return null;
+            }
+
+            public override Type[] GetInterfaces ()
+            {
+                return EmptyTypes;
+            }
+
+            public override EventInfo GetEvent (string name, BindingFlags bindingAttr)
+            {
+                return null;
+            }
+
+            public override EventInfo[] GetEvents (BindingFlags bindingAttr)
+            {
+                return new EventInfo[0];
+            }
+
+            public override Type[] GetNestedTypes (BindingFlags bindingAttr)
+            {
+                return EmptyTypes;
+            }
+
+            public override Type GetNestedType (string name, BindingFlags bindingAttr)
+            {
+                return null;
+            }
+
+            public override Type GetElementType ()
+            {
+                return null;
+            }
+
+            protected override bool HasElementTypeImpl ()
+            {
+                return false;
+            }
+
+            protected override PropertyInfo GetPropertyImpl (string name, BindingFlags bindingAttr, Binder binder,
+                Type returnType, Type[] types, ParameterModifier[] modifiers)
+            {
+                return null;
+            }
+
+            public override PropertyInfo[] GetProperties (BindingFlags bindingAttr)
+            {
+                return new PropertyInfo[0];
+            }
+
+            protected override MethodInfo GetMethodImpl (string name, BindingFlags bindingAttr, Binder binder,
+                CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+            {
+                return null;
+            }
+
+            public override MethodInfo[] GetMethods (BindingFlags bindingAttr)
+            {
+                return new MethodInfo[0];
+            }
+
+            public override FieldInfo GetField (string name, BindingFlags bindingAttr)
+            {
+                return null;
+            }
+
+            public override FieldInfo[] GetFields (BindingFlags bindingAttr)
+            {
+                return new FieldInfo[0];
+            }
+
+            public override MemberInfo[] GetMembers (BindingFlags bindingAttr)
+            {
+                return new MemberInfo[0];
+            }
+
+            protected override TypeAttributes GetAttributeFlagsImpl ()
+            {
+                throw new NotImplementedException ();
+            }
+
+            protected override bool IsArrayImpl ()
+            {
+                return false;
+            }
+
+            protected override bool IsByRefImpl ()
+            {
+                return false;
+            }
+
+            protected override bool IsPointerImpl ()
+            {
+                return false;
+            }
+
+            protected override bool IsPrimitiveImpl ()
+            {
+                return false;
+            }
+
+            protected override bool IsCOMObjectImpl ()
+            {
+                return false;
+            }
+
+            public override object InvokeMember (string name, BindingFlags invokeAttr, Binder binder, object target,
+                object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public override Type UnderlyingSystemType { get { throw new NotImplementedException (); } }
+
+            protected override ConstructorInfo GetConstructorImpl (BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public override string Name { get { return string.Format("`{0}", Index); }}
+            public override Guid GUID { get {return Guid.Empty;}}
+            public override Module Module { get {throw new NotImplementedException ();} }
+            public override Assembly Assembly { get { throw new NotImplementedException (); } }
+            public override string FullName { get { return Name; }}
+            public override string Namespace { get {throw new NotImplementedException ();} }
+
+            public override string AssemblyQualifiedName { get { throw new NotImplementedException (); }}
+            public override Type BaseType { get {throw new NotImplementedException ();} }
+
+            public override object[] GetCustomAttributes (Type attributeType, bool inherit)
+            {
+                return new object[0];
+            }
+        }
+    }
+}

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataPropertyInfo.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataPropertyInfo.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
 				return null;
 
 			if (m_getter == null)
-				m_getter = new MetadataMethodInfo (m_importer, m_pmdGetter);
+				m_getter = new MetadataMethodInfo (m_importer, m_pmdGetter, Instantiation.Empty);
 
 			if (nonPublic || m_getter.IsPublic)
 				return m_getter;
@@ -139,7 +139,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
 				return null;
 
 			if (m_setter == null)
-				m_setter = new MetadataMethodInfo (m_importer, m_pmdSetter);
+				m_setter = new MetadataMethodInfo (m_importer, m_pmdSetter, Instantiation.Empty);
 
 			if (nonPublic || m_setter.IsPublic)
 				return m_setter;

--- a/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/CorApi2/Metadata/MetadataType.cs
@@ -19,6 +19,23 @@ using Microsoft.Samples.Debugging.Extensions;
 
 namespace Microsoft.Samples.Debugging.CorMetadata
 {
+    public class Instantiation
+    {
+        public static readonly Instantiation Empty = new Instantiation (new List<Type> ());
+
+        public static Instantiation Create (IList<Type> typeArgs)
+        {
+            return new Instantiation (typeArgs);
+        }
+
+        public IList<Type> TypeArgs { get; private set; }
+
+        Instantiation (IList<Type> typeArgs)
+        {
+            TypeArgs = typeArgs;
+        }
+    }
+
     public sealed class MetadataType : Type
     {
         internal MetadataType(IMetadataImport importer,int classToken)
@@ -585,7 +602,7 @@ namespace Microsoft.Samples.Debugging.CorMetadata
                     if(size==0)
                         break;
 					// [Xamarin] Expression evaluator.
-					var met = new MetadataMethodInfo (m_importer, methodToken);
+					var met = new MetadataMethodInfo (m_importer, methodToken, Instantiation.Create (m_typeArgs));
 					if (MetadataExtensions.TypeFlagsMatch (met.IsPublic, met.IsStatic, bindingAttr))
 						al.Add (met);
                 }

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorObjectAdaptor.cs
@@ -32,6 +32,7 @@ using System.Diagnostics;
 using System.Diagnostics.SymbolStore;
 using System.Reflection;
 using System.Text;
+using CorApi2.Metadata.Microsoft.Samples.Debugging.CorMetadata;
 using Microsoft.Samples.Debugging.CorDebug;
 using Microsoft.Samples.Debugging.CorMetadata;
 using Mono.Debugging.Backend;
@@ -629,6 +630,10 @@ namespace Mono.Debugging.Win32
 
 		bool IsAssignableFrom (CorEvaluationContext ctx, Type baseType, CorType ctype)
 		{
+			// the type is method generic parameter, we have to check its constraints, but now we don't have the info about it
+			// and assume that any type is assignable to method generic type parameter
+			if (baseType is MethodGenericParameter)
+				return true;
 			string tname = baseType.FullName;
 			string ctypeName = GetTypeName (ctx, ctype);
 			if (tname == "System.Object")


### PR DESCRIPTION
* MetadataExtensions.ReadType() now takes into account actual instantiation of generic type. It allows to correctly read types of method parameters in generic classes (the case when method parameter has T type).
This fixes overload resolve in evaluation.

* Introduced MethodGenericParameter and TypeGenericParameter to differentiate them in OverloadResolve. Both of the types are implementations of System.Type.
IsAssignableFrom() ignores MethodGenericParameter because we don't have information about it yet (constraints etc.) and returns true always in this case