### PR TITLE
[Core] Add logging in case we find a non-existent target framework

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetRuntime.cs
@@ -247,6 +247,7 @@ namespace MonoDevelop.Core.Assemblies
 					return backend;
 				backend = fx.CreateBackendForRuntime (this);
 				if (backend == null) {
+					LoggingService.LogError ("TargetFramework creation fallback for framework: {0}", fx.Name);
 					backend = CreateBackend (fx);
 					if (backend == null)
 						backend = new NotSupportedFrameworkBackend ();


### PR DESCRIPTION
This can be hit in situations like dc6a7646e17aea9378a4fc44c8b668f6de7de8a4