### PR TITLE
[Ide] Fix missing execution target group header on device selector dr…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -267,6 +267,7 @@ namespace MonoDevelop.Components.MainToolbar
 					if (previous != null)
 						list.Add (new RuntimeModel (this, displayText: null));//Seperator
 
+					list.Add (new RuntimeModel (this, target, true, project));
 					foreach (var device in devices) {
 						if (device is ExecutionTargetGroup) {
 							var versions = (ExecutionTargetGroup)device;


### PR DESCRIPTION
…opdown

Regression in 1d983ae426e141
Bug 51141 - Devices and Emulators should appear into three categories 'Physical device', 'Virtual device' and 'Incompatible API level' for Android application in XS