### PR TITLE
Fix HiDPI rendering issues

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskMiniMapMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskMiniMapMode.cs
@@ -249,9 +249,8 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 					cr = Gdk.CairoHelper.Create (mode.backgroundBuffer);
 					
 					cr.LineWidth = 1;
-					var displayScale = Platform.IsWindows ? GtkWorkarounds.GetScaleFactor (mode) : 1.0;
-					int w = (int)(mode.backgroundBuffer.ClipRegion.Clipbox.Width);
-					int h = (int)(mode.backgroundBuffer.ClipRegion.Clipbox.Height);
+					int w = mode.backgroundBuffer.ClipRegion.Clipbox.Width;
+					int h = mode.backgroundBuffer.ClipRegion.Clipbox.Height;
 					cr.Rectangle (0, 0, w, h);
 					if (mode.TextEditor.ColorStyle != null)
 						cr.SetSourceColor (mode.TextEditor.ColorStyle.PlainText.Background);

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskMiniMapMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskMiniMapMode.cs
@@ -216,12 +216,13 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 				curHeight = Math.Max (Allocation.Height, (int)(lineHeight * (TextEditor.GetTextEditorData ().VisibleLineCount)));
 				if (GdkWindow == null || curWidth < 1 || curHeight < 1)
 					return;
-				backgroundPixbuf = new Pixmap (GdkWindow, curWidth, curHeight);
-				backgroundBuffer = new Pixmap (GdkWindow, curWidth, curHeight);
+				var displayScale = Platform.IsWindows ? GtkWorkarounds.GetScaleFactor (this) : 1.0;
+				backgroundPixbuf = new Pixmap (GdkWindow, (int)(curWidth * displayScale), (int)(curHeight * displayScale));
+				backgroundBuffer = new Pixmap (GdkWindow, (int)(curWidth * displayScale), (int)(curHeight * displayScale));
 				
 				if (TextEditor.ColorStyle != null) {
 					using (var cr = Gdk.CairoHelper.Create (backgroundPixbuf)) {
-						cr.Rectangle (0, 0, curWidth, curHeight);
+						cr.Rectangle (0, 0, curWidth * displayScale, curHeight * displayScale);
 						cr.SetSourceColor (TextEditor.ColorStyle.PlainText.Background);
 						cr.Fill ();
 					}
@@ -248,8 +249,9 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 					cr = Gdk.CairoHelper.Create (mode.backgroundBuffer);
 					
 					cr.LineWidth = 1;
-					int w = mode.backgroundBuffer.ClipRegion.Clipbox.Width;
-					int h = mode.backgroundBuffer.ClipRegion.Clipbox.Height;
+					var displayScale = Platform.IsWindows ? GtkWorkarounds.GetScaleFactor (mode) : 1.0;
+					int w = (int)(mode.backgroundBuffer.ClipRegion.Clipbox.Width);
+					int h = (int)(mode.backgroundBuffer.ClipRegion.Clipbox.Height);
 					cr.Rectangle (0, 0, w, h);
 					if (mode.TextEditor.ColorStyle != null)
 						cr.SetSourceColor (mode.TextEditor.ColorStyle.PlainText.Background);
@@ -312,7 +314,8 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 			int GetBufferYOffset ()
 			{
-				int h = backgroundPixbuf.ClipRegion.Clipbox.Height - Allocation.Height;
+				var displayScale = Platform.IsWindows ? GtkWorkarounds.GetScaleFactor (this) : 1.0;
+				int h = (int)(backgroundPixbuf.ClipRegion.Clipbox.Height / displayScale) - Allocation.Height;
 				if (h < 0)
 					return 0;
 				return Math.Max (0, (int)(h * (vadjustment.Value) / (vadjustment.Upper - vadjustment.Lower - vadjustment.PageSize)));

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
@@ -859,6 +859,8 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 			using (Cairo.Context cr = Gdk.CairoHelper.Create (e.Window)) {
 				var allocation = Allocation;
+				var displayScale = Core.Platform.IsMac ? GtkWorkarounds.GetScaleFactor (this) : 1.0;
+				cr.Scale (1 / displayScale, 1 / displayScale);
 				if (indicatorSurface != null) {
 					cr.SetSourceSurface (indicatorSurface.Surface, 0, 0);
 					cr.Paint ();
@@ -866,7 +868,7 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 					CachedDraw (cr,
 					            ref backgroundSurface,
 					            allocation,
-					            draw: (c, o) => DrawBackground (c, allocation));
+					            draw: (c, o) => DrawBackground (c, allocation), forceScale: displayScale);
 				}
 				if (TextEditor == null)
 					return true;
@@ -908,15 +910,17 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 					}
 				}
 
+				var displayScale = Core.Platform.IsMac ? GtkWorkarounds.GetScaleFactor (mode) : 1.0;
 				if (surface == null) {
 					using (var similiar = CairoHelper.Create (IdeApp.Workbench.RootWindow.GdkWindow))
-						surface = new SurfaceWrapper (similiar, allocation.Width, allocation.Height);
+						surface = new SurfaceWrapper (similiar, (int)(allocation.Width * displayScale), (int)(allocation.Height * displayScale));
 				}
 
 				searchResults = mode.TextEditor.TextViewMargin.SearchResults.ToList().GetEnumerator ();
 				allUsages = mode.AllUsages.GetEnumerator ();
 				allTasks = mode.AllTasks.GetEnumerator ();
 				cr = new Cairo.Context (surface.Surface);
+				cr.Scale (displayScale, displayScale);
 				GLib.Idle.Add (RunHandler);
 			}
 
@@ -942,7 +946,8 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 				bool nextStep = false;
 				switch (drawingStep) {
 				case 0:
-                	CachedDraw (cr, ref mode.backgroundSurface, allocation, draw: (c, o) => mode.DrawBackground (c, allocation));
+					var displayScale = Core.Platform.IsMac ? GtkWorkarounds.GetScaleFactor (mode) : 1.0;
+					CachedDraw (cr, ref mode.backgroundSurface, allocation, draw: (c, o) => mode.DrawBackground (c, allocation), forceScale: displayScale);
 					drawingStep++;
 					return true;
 				case 1:
@@ -1034,12 +1039,22 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			if (redraw) {
 				surface.Data = parameters;
 				using (var context = new Cairo.Context (surface.Surface)) {
-					draw(context, 1.0f);
+					context.Operator = Cairo.Operator.Clear;
+					context.Paint ();
+					context.Operator = Cairo.Operator.Over;
+					context.Save ();
+					context.Scale (displayScale, displayScale);
+					draw (context, 1.0f);
+					context.Restore ();
 				}
 			}
 
+			self.Save ();
+			self.Translate (region.X, region.Y);
+			self.Scale (1 / displayScale, 1 / displayScale);
 			self.SetSourceSurface (surface.Surface, 0, 0);
-			self.Paint ();
+			self.PaintWithAlpha (opacity);
+			self.Restore ();
 		}
 
 		void DrawBackground (Cairo.Context cr, Gdk.Rectangle allocation)


### PR DESCRIPTION
This PR includes some workarounds for broken HiDPI support in Gtk.

6cd6dea: fixes QuickTask icon blurriness on Mac
8998278: fixes MiniMap drawing on Windows

Both are *workarounds* and don't fix the actual issues inside Gtk. Related bugs: https://bugzilla.xamarin.com/show_bug.cgi?id=51376, https://bugzilla.xamarin.com/show_bug.cgi?id=51378