### PR TITLE
[Ide] Run editor commands only if the editor is focused

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -649,6 +649,25 @@ namespace MonoDevelop.SourceEditor
 #endregion
 		
 #region Key bindings
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineEnd)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineStart)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.DeleteLeftChar)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.DeleteRightChar)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.CharLeft)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.CharRight)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineUp)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineDown)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.DocumentStart)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.DocumentEnd)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.DeleteLine)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.MoveBlockUp)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.MoveBlockDown)]
+		[CommandUpdateHandler (MonoDevelop.Ide.Commands.TextEditorCommands.GotoMatchingBrace)]
+		protected void OnUpdateEditorCommand (CommandInfo info)
+		{
+			// ignore command if the editor has no focus
+			info.Bypass = HasFocus == false;
+		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineEnd)]
 		internal void OnLineEnd ()

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -3570,5 +3570,11 @@ namespace MonoDevelop.SourceEditor
 			this.TextEditor.GrabFocus ();
 		}
 
+		public bool HasFocus {
+			get {
+				return this.TextEditor.HasFocus;
+			}
+		}
+
 	}
 } 

--- a/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/core/Mono.Texteditor/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -115,6 +115,12 @@ namespace Mono.TextEditor
 			TextArea.GrabFocus ();
 		}
 
+		public new bool HasFocus {
+			get {
+				return TextArea.HasFocus;
+			}
+		}
+
 		protected override void OnDestroyed ()
 		{
 			UnregisterAdjustments ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
@@ -218,6 +218,7 @@ namespace MonoDevelop.Ide.Editor
 		IEnumerable<IDocumentLine> VisibleLines { get; }
 
 		void GrabFocus ();
+		bool HasFocus { get; }
 
 		event EventHandler<LineEventArgs> LineShown;
 		event EventHandler FocusLost;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1455,5 +1455,9 @@ namespace MonoDevelop.Ide.Editor
 		{
 			this.textEditorImpl.GrabFocus ();
 		}
+
+		public new bool HasFocus {
+			get { return this.textEditorImpl.HasFocus; }
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
@@ -356,7 +356,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			// If the current document is not an editor, just ignore the text
 			// editor commands.
-			info.Bypass = doc.Editor == null;
+			info.Bypass = doc.Editor?.HasFocus == false;
 		}
 		
 		[CommandHandler (TextEditorCommands.LineEnd)]


### PR DESCRIPTION
Allows editor widgets (search and goto line) to handle all keys.

(fix bug #49816)

(cherry picked from commit 1774b260b1c37c16b47e6cec07e8609782d1777c)