### PR TITLE
Fixed mono build on windows

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -10,7 +10,7 @@
 		<AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
 		<RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
 		<BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
-	  	<XBuild>$(MSBuildToolsPath.Contains("xbuild"))</XBuild>
+	  	<XBuild>$(MSBuildToolsPath.ToLower().Contains("xbuild"))</XBuild>
 		<MSBuildLibPath>$(MSBuildExtensionsPath)\12.0\Bin</MSBuildLibPath>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 	</PropertyGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -10,7 +10,7 @@
 		<AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
 		<RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
 		<BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
-	  <XBuild>$(MonoUseMicrosoftBuildDll)</XBuild>
+	  	<XBuild>$(MSBuildToolsPath.Contains("xbuild"))</XBuild>
 		<MSBuildLibPath>$(MSBuildExtensionsPath)\12.0\Bin</MSBuildLibPath>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 	</PropertyGroup>
@@ -44,10 +44,6 @@
 			<CopyLocal>False</CopyLocal>
 		</Reference>
 		<Reference Include="Microsoft.Build.Framework, Version=12.0.0.0">
-			<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
-			<CopyLocal>False</CopyLocal>
-		</Reference>
-		<Reference Include="Microsoft.Build.Utilities.Core, Version=12.0.0.0">
 			<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
 			<CopyLocal>False</CopyLocal>
 		</Reference>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -1,71 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{5C1BC0B9-735E-45DA-ACAC-4BD466917608}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
-    <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
-    <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
-    <BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>..\..\..\build\bin\MSBuild\12.0</OutputPath>
-    <DefineConstants>DEBUG,NET_3_5,NET_4_0,XBUILD_12</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
-    <NoWarn>1591;1573</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\..\..\build\bin\MSBuild\12.0</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <NoWarn>1591;1573</NoWarn>
-    <DefineConstants>NET_3_5,NET_4_0,XBUILD_12</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Runtime.Remoting" />
-    <Reference Include="Microsoft.Build.Engine, Version=12.0.0.0" />
-    <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0" />
-    <Reference Include="Microsoft.Build.Utilities.v12.0" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Main.cs" />
-    <Compile Include="AssemblyInfo.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\ProjectBuilder.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\LocalLogger.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\ILogWriter.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\IProjectBuilder.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\BuildEngine.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\IBuildEngine.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\ConsoleLogger.cs" />
-    <Compile Include="AssemblyInfo.v12.0.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildTargetResult.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildResult.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildEvaluatedItem.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\ProjectBuilder.Shared.cs" />
-    <Compile Include="MonoDevelop.Projects.Formats.MSBuild\BuildEngine.Shared.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.v12.0.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
-    </None>
-  </ItemGroup>
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+		<ProductVersion>8.0.30703</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>{5C1BC0B9-735E-45DA-ACAC-4BD466917608}</ProjectGuid>
+		<OutputType>WinExe</OutputType>
+		<AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
+		<RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
+		<BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
+		<MSBuildLibPath>$(MSBuildExtensionsPath)\12.0\Bin</MSBuildLibPath>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+		<DebugSymbols>True</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>False</Optimize>
+		<OutputPath>..\..\..\build\bin\MSBuild\12.0</OutputPath>
+		<DefineConstants>DEBUG,NET_3_5,NET_4_0,XBUILD_12</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<PlatformTarget>x86</PlatformTarget>
+		<NoWarn>1591;1573</NoWarn>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>..\..\..\build\bin\MSBuild\12.0</OutputPath>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<PlatformTarget>x86</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<NoWarn>1591;1573</NoWarn>
+		<DefineConstants>NET_3_5,NET_4_0,XBUILD_12</DefineConstants>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="System" />
+		<Reference Include="System.Runtime.Remoting" />
+		<Reference Include="Microsoft.Build.Engine, Version=12.0.0.0">
+			<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+			<CopyLocal>False</CopyLocal>
+		</Reference>
+		<Reference Include="Microsoft.Build.Framework, Version=12.0.0.0">
+			<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+			<CopyLocal>False</CopyLocal>
+		</Reference>
+		<Reference Include="Microsoft.Build.Utilities.Core, Version=12.0.0.0">
+			<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+			<CopyLocal>False</CopyLocal>
+		</Reference>
+		<Reference Include="System.Xml" />
+		<Reference Include="Microsoft.Build.Utilities.v12.0">
+			<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Utilities.v12.0.dll</HintPath>
+			<CopyLocal>False</CopyLocal>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="Main.cs" />
+		<Compile Include="AssemblyInfo.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\ProjectBuilder.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\LocalLogger.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\ILogWriter.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\IProjectBuilder.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\BuildEngine.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\IBuildEngine.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\ConsoleLogger.cs" />
+		<Compile Include="AssemblyInfo.v12.0.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildTargetResult.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildResult.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildEvaluatedItem.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\ProjectBuilder.Shared.cs" />
+		<Compile Include="MonoDevelop.Projects.Formats.MSBuild\BuildEngine.Shared.cs" />
+	</ItemGroup>
+	<Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+	<ItemGroup>
+		<Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="app.v12.0.config">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
+		</None>
+	</ItemGroup>
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -10,7 +10,7 @@
 		<AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
 		<RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
 		<BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
-		<XBuild>$([System.Environment]::CommandLine.Contains("mono "))</XBuild>
+	  <XBuild>$(MonoUseMicrosoftBuildDll)</XBuild>
 		<MSBuildLibPath>$(MSBuildExtensionsPath)\12.0\Bin</MSBuildLibPath>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 	</PropertyGroup>
@@ -84,4 +84,7 @@
 			<Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
 		</None>
 	</ItemGroup>
+  <Target Name="AfterBuild">
+    <Message Text="XBuild: $(XBuild)" />
+  </Target>
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -10,7 +10,7 @@
 		<AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
 		<RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
 		<BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
-		<XBuild>$([System.Environment]::CommandLine.ToLower().Contains("mono"))</XBuild>
+		<XBuild>$([System.Environment]::CommandLine.Contains("mono "))</XBuild>
 		<MSBuildLibPath>$(MSBuildExtensionsPath)\12.0\Bin</MSBuildLibPath>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 	</PropertyGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -10,6 +10,7 @@
 		<AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
 		<RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
 		<BaseIntermediateOutputPath>obj\12.0</BaseIntermediateOutputPath>
+		<XBuild>$([System.Environment]::CommandLine.ToLower().Contains("mono"))</XBuild>
 		<MSBuildLibPath>$(MSBuildExtensionsPath)\12.0\Bin</MSBuildLibPath>
 		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 	</PropertyGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
     <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
     <BaseIntermediateOutputPath>obj\14.0</BaseIntermediateOutputPath>
-	  <XBuild>$([System.Environment]::CommandLine.Contains("mono "))</XBuild>
+	  <XBuild>$(MonoUseMicrosoftBuildDll)</XBuild>
 	  <MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
 	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
     <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
     <BaseIntermediateOutputPath>obj\14.0</BaseIntermediateOutputPath>
-	  <XBuild>$([System.Environment]::CommandLine.ToLower().Contains("mono"))</XBuild>
+	  <XBuild>$([System.Environment]::CommandLine.Contains("mono "))</XBuild>
 	  <MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
 	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
@@ -40,15 +40,15 @@
     <Reference Include="System" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="Microsoft.Build.Engine, Version=14.0.0.0">
-		<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+		    <HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
 		<CopyLocal>False</CopyLocal>
 	</Reference>
     <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0">
-		<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+		  <HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
 		<CopyLocal>False</CopyLocal>
 	</Reference>
     <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0">
-		<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+		  <HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
 		<CopyLocal>False</CopyLocal>
 	</Reference>
     <Reference Include="System.Xml" />
@@ -80,4 +80,7 @@
       <Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
     </None>
   </ItemGroup>
+  <Target Name="AfterBuild">
+    <Message Text="XBuild: $(XBuild)" />
+  </Target>
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -10,6 +10,9 @@
     <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
     <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
     <BaseIntermediateOutputPath>obj\14.0</BaseIntermediateOutputPath>
+	<XBuild>$([System.Environment]::CommandLine.ToLower().Contains("mono"))</XBuild>
+	<MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
+	<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
@@ -36,9 +39,18 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Remoting" />
-    <Reference Include="Microsoft.Build.Engine, Version=14.0.0.0" />
-    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0" />
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0" />
+    <Reference Include="Microsoft.Build.Engine, Version=14.0.0.0">
+		<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+		<CopyLocal>False</CopyLocal>
+	</Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0">
+		<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+		<CopyLocal>False</CopyLocal>
+	</Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0">
+		<HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+		<CopyLocal>False</CopyLocal>
+	</Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -10,9 +10,9 @@
     <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
     <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
     <BaseIntermediateOutputPath>obj\14.0</BaseIntermediateOutputPath>
-	<XBuild>$([System.Environment]::CommandLine.ToLower().Contains("mono"))</XBuild>
-	<MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
-	<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+	  <XBuild>$([System.Environment]::CommandLine.ToLower().Contains("mono"))</XBuild>
+	  <MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
+	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
     <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
     <BaseIntermediateOutputPath>obj\14.0</BaseIntermediateOutputPath>
-	  <XBuild>$(MonoUseMicrosoftBuildDll)</XBuild>
+	  <XBuild>$(MSBuildToolsPath.Contains("xbuild"))</XBuild>
 	  <MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
 	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
@@ -47,8 +47,8 @@
 		  <HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
 		<CopyLocal>False</CopyLocal>
 	</Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0">
-		  <HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Engine.dll</HintPath>
+  <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0">
+		  <HintPath Condition=" '$(XBuild)' != 'True' ">$(MSBuildLibPath)\Microsoft.Build.Utilities.Core.dll</HintPath>
 		<CopyLocal>False</CopyLocal>
 	</Reference>
     <Reference Include="System.Xml" />

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>MonoDevelop.Projects.Formats.MSBuild</AssemblyName>
     <RootNamespace>MonoDevelop.Projects.Formats.MSBuild</RootNamespace>
     <BaseIntermediateOutputPath>obj\14.0</BaseIntermediateOutputPath>
-	  <XBuild>$(MSBuildToolsPath.Contains("xbuild"))</XBuild>
+	  <XBuild>$(MSBuildToolsPath.ToLower().Contains("xbuild"))</XBuild>
 	  <MSBuildLibPath>$(MSBuildExtensionsPath)\14.0\Bin</MSBuildLibPath>
 	  <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>


### PR DESCRIPTION
Those projects did not build on Windows, so they were lacking in the
Bin\MSBuild folder of Xamarin Studio, and therefore Mono xbuild was
broken.

I needed to add HintPath's to MSBuildToolsPath when building the projects in NetFX.
