### PR TITLE
[Ide] Fix FilePath.IsChildPathOf regression.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -177,8 +177,11 @@ namespace MonoDevelop.Core
 			if (startsWith && basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar) {
 				// If the last character isn't a path separator character, check whether the string we're searching in
 				// has more characters than the string we're looking for then check the character.
+				// Otherwise, if the path lengths are equal, we return false.
 				if (fileName.Length > basePath.fileName.Length)
 					startsWith &= fileName [basePath.fileName.Length] == Path.DirectorySeparatorChar;
+				else
+					startsWith = false;
 			}
 			return startsWith;
 		}

--- a/main/tests/UnitTests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/FilePathTests.cs
@@ -106,6 +106,9 @@ namespace MonoDevelop.Core
 			parent = FilePath.Build ("base" + Path.DirectorySeparatorChar);
 			child = parent.Combine ("child");
 			Assert.IsTrue (child.IsChildPathOf (parent));
+
+			// https://bugzilla.xamarin.com/show_bug.cgi?id=48212
+			Assert.IsFalse (child.IsChildPathOf (child));
 		}
 
 		[Test]


### PR DESCRIPTION
Bug 48212 - Unnecessary Expand icon is displaying with "Resources"
folder