### PR TITLE
[DotNetCore] Remove xmlns attribute for Sdk style projects

### DIFF
--- a/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/MonoDevelop.Deployment.Linux/LinuxDeployData.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/MonoDevelop.Deployment.Linux/LinuxDeployData.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.Deployment.Linux
 			var data = ser.Serialize (this);
 
 			XmlDocument doc = new XmlDocument ();
-			var writer = new XmlConfigurationWriter { Namespace = MSBuildProject.Schema };
+			var writer = new XmlConfigurationWriter { Namespace = entry.MSBuildProject.Namespace };
 			var elem = writer.Write (doc, data);
 
 			entry.MSBuildProject.SetMonoDevelopProjectExtension ("Deployment.LinuxDeployData", elem);

--- a/main/src/addins/MonoDevelop.Autotools/MakefileData.cs
+++ b/main/src/addins/MonoDevelop.Autotools/MakefileData.cs
@@ -81,8 +81,18 @@ namespace MonoDevelop.Autotools
 
 		public XmlElement Write ()
 		{
+			string xmlns = MSBuildProject.Schema;
+			var msbuildProject = ownerProject?.MSBuildProject;
+			if (msbuildProject != null)
+				xmlns = msbuildProject.Namespace;
+
+			return Write (xmlns);
+		}
+
+		XmlElement Write (string xmlns)
+		{
 			XmlDataSerializer ser = new XmlDataSerializer (new DataContext ());
-			ser.Namespace = MSBuildProject.Schema;
+			ser.Namespace = xmlns;
 			var sw = new StringWriter ();
 			ser.Serialize (new XmlTextWriter (sw), this);
 			XmlDocument doc = new XmlDocument ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IMSBuildPropertySet.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IMSBuildPropertySet.cs
@@ -86,7 +86,8 @@ namespace MonoDevelop.Projects.MSBuild
 					var val = prop.GetValue (ob);
 					if (val != null) {
 						if (cwriter == null) {
-							cwriter = new XmlConfigurationWriter { Namespace = MSBuildProject.Schema, StoreAllInElements = true };
+							string xmlns = (mso?.ParentProject != null) ? mso.ParentProject.Namespace : MSBuildProject.Schema;
+							cwriter = new XmlConfigurationWriter { Namespace = xmlns, StoreAllInElements = true };
 							xdoc = new XmlDocument ();
 						}
 						var data = prop.Serialize (ser.SerializationContext, ob, val);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IMSBuildPropertySet.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IMSBuildPropertySet.cs
@@ -382,7 +382,7 @@ namespace MonoDevelop.Projects.MSBuild
 					if (data != null) {
 						data.Name = prop.Name;
 						if (writer == null)
-							writer = new XmlConfigurationWriter { Namespace = MSBuildProject.Schema };
+							writer = new XmlConfigurationWriter { Namespace = project.Namespace };
 
 						XmlDocument doc = new XmlDocument ();
 						var elem = writer.Write (doc, data);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
@@ -99,7 +99,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (!string.IsNullOrEmpty (Condition))
 				cond = "( " + Condition + " ) AND " + cond;
 			
-			writer.WriteStartElement ("Import", MSBuildProject.Schema);
+			writer.WriteStartElement ("Import", Namespace);
 			writer.WriteAttributeString ("Project", target);
 			writer.WriteAttributeString ("Condition", cond);
 			writer.WriteEndElement ();
@@ -111,7 +111,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (!string.IsNullOrEmpty (Condition))
 				cond = "( " + Condition + " ) AND " + cond;
 
-			writer.WriteStartElement ("Import", MSBuildProject.Schema);
+			writer.WriteStartElement ("Import", Namespace);
 			writer.WriteAttributeString ("Project", MSBuildProjectService.ToMSBuildPath (null, newTarget));
 			writer.WriteAttributeString ("Condition", cond);
 			writer.WriteEndElement ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
@@ -79,7 +79,7 @@ namespace MonoDevelop.Projects.MSBuild
 			base.Write (writer, context);
 		}
 
-		void WritePatchedImport (XmlWriter writer, string newTarget)
+		internal void WritePatchedImport (XmlWriter writer, string newTarget)
 		{
 			/* If an import redirect exists, add a fake import to the project which will be used only
 			   if the original import doesn't exist. That is, the following import:
@@ -102,6 +102,7 @@ namespace MonoDevelop.Projects.MSBuild
 			writer.WriteStartElement ("Import", MSBuildProject.Schema);
 			writer.WriteAttributeString ("Project", target);
 			writer.WriteAttributeString ("Condition", cond);
+			writer.WriteEndElement ();
 
 			// Now add the fake import, with a condition so that it will be used only if the original
 			// import does not exist.
@@ -113,6 +114,7 @@ namespace MonoDevelop.Projects.MSBuild
 			writer.WriteStartElement ("Import", MSBuildProject.Schema);
 			writer.WriteAttributeString ("Project", MSBuildProjectService.ToMSBuildPath (null, newTarget));
 			writer.WriteAttributeString ("Condition", cond);
+			writer.WriteEndElement ();
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
@@ -266,6 +266,8 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal virtual string Namespace {
 			get {
+				if (ParentObject != null)
+					return ParentObject.Namespace;
 				return MSBuildProject.Schema;
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
@@ -264,7 +264,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		internal virtual string Namespace {
+		public virtual string Namespace {
 			get {
 				if (ParentObject != null)
 					return ParentObject.Namespace;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -914,7 +914,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 			value = (XmlElement) elem.OwnerDocument.ImportNode (value, true);
 			var parent = elem;
-			elem = parent ["Properties", Namespace];
+			elem = parent ["Properties", Namespace ?? string.Empty];
 			if (elem == null) {
 				elem = parent.OwnerDocument.CreateElement (null, "Properties", Namespace);
 				parent.AppendChild (elem);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -1051,19 +1051,6 @@ namespace MonoDevelop.Projects.MSBuild
 			return res.ToString ();
 		}
 
-		public static void FormatElement (TextFormatInfo format, XmlElement elem)
-		{
-			// Remove duplicate namespace declarations
-			var nsa = elem.Attributes ["xmlns"];
-			if (nsa != null && nsa.Value == MSBuildProject.Schema)
-				elem.Attributes.Remove (nsa);
-
-			foreach (var e in elem.ChildNodes.OfType<XmlElement> ().ToArray ()) {
-				Indent (format, e, false);
-				FormatElement (format, e);
-			}
-		}
-
 		public static void Indent (TextFormatInfo format, XmlElement elem, bool closeInNewLine)
 		{
 			var prev = FindPreviousSibling (elem);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -305,7 +305,7 @@ namespace MonoDevelop.Projects.MSBuild
 			switch (name) {
 				case "DefaultTargets": return defaultTargets;
 				case "ToolsVersion": return toolsVersion;
-				case "xmlns": return Namespace;
+				case "xmlns": return string.IsNullOrEmpty (Namespace) ? null : Namespace;
 				case "Sdk": return sdk;
 			}
 			return base.WriteAttribute (name);
@@ -521,7 +521,7 @@ namespace MonoDevelop.Projects.MSBuild
 		public override string Namespace {
 			get {
 				if (sdk != null)
-					return null;
+					return string.Empty;
 				return Schema;
 			}
 		}
@@ -886,7 +886,7 @@ namespace MonoDevelop.Projects.MSBuild
 				return XmlNamespaceManager;
 
 			var namespaceManager = new XmlNamespaceManager (new NameTable ());
-			namespaceManager.AddNamespace ("tns", Namespace ?? string.Empty);
+			namespaceManager.AddNamespace ("tns", Namespace);
 			return namespaceManager;
 		}
 
@@ -914,7 +914,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 			value = (XmlElement) elem.OwnerDocument.ImportNode (value, true);
 			var parent = elem;
-			elem = parent ["Properties", Namespace ?? string.Empty];
+			elem = parent ["Properties", Namespace];
 			if (elem == null) {
 				elem = parent.OwnerDocument.CreateElement (null, "Properties", Namespace);
 				parent.AppendChild (elem);
@@ -929,7 +929,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 			XmlUtil.Indent (format, value, false);
 			var xmlns = value.GetAttribute ("xmlns");
-			if (xmlns == (Namespace ?? string.Empty))
+			if (xmlns == Namespace)
 				value.RemoveAttribute ("xmlns");
 			SetProjectExtension (parent);
 			NotifyChanged ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -900,13 +900,13 @@ namespace MonoDevelop.Projects.MSBuild
 			var elem = GetProjectExtension ("MonoDevelop");
 			if (elem == null) {
 				XmlDocument doc = new XmlDocument ();
-				elem = doc.CreateElement (null, "MonoDevelop", MSBuildProject.Schema);
+				elem = doc.CreateElement (null, "MonoDevelop", Namespace);
 			}
 			value = (XmlElement) elem.OwnerDocument.ImportNode (value, true);
 			var parent = elem;
-			elem = parent ["Properties", MSBuildProject.Schema];
+			elem = parent ["Properties", Namespace];
 			if (elem == null) {
-				elem = parent.OwnerDocument.CreateElement (null, "Properties", MSBuildProject.Schema);
+				elem = parent.OwnerDocument.CreateElement (null, "Properties", Namespace);
 				parent.AppendChild (elem);
 				XmlUtil.Indent (format, elem, true);
 			}
@@ -919,7 +919,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 			XmlUtil.Indent (format, value, false);
 			var xmlns = value.GetAttribute ("xmlns");
-			if (xmlns == Schema)
+			if (xmlns == Namespace)
 				value.RemoveAttribute ("xmlns");
 			SetProjectExtension (parent);
 			NotifyChanged ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -929,7 +929,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 			XmlUtil.Indent (format, value, false);
 			var xmlns = value.GetAttribute ("xmlns");
-			if (xmlns == Namespace)
+			if (xmlns == (Namespace ?? string.Empty))
 				value.RemoveAttribute ("xmlns");
 			SetProjectExtension (parent);
 			NotifyChanged ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -59,7 +59,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		TextFormatInfo format = new TextFormatInfo { NewLine = "\r\n" };
 
-		static readonly string [] knownAttributes = { "DefaultTargets", "ToolsVersion", "xmlns" };
+		static readonly string [] knownAttributes = { "Sdk", "DefaultTargets", "ToolsVersion", "xmlns" };
 
 		public static XmlNamespaceManager XmlNamespaceManager
 		{
@@ -295,6 +295,7 @@ namespace MonoDevelop.Projects.MSBuild
 			switch (name) {
 				case "DefaultTargets": defaultTargets = value; return;
 				case "ToolsVersion": toolsVersion = value; return;
+				case "Sdk": sdk = value; return;
 			}
 			base.ReadAttribute (name, value);
 		}
@@ -304,7 +305,8 @@ namespace MonoDevelop.Projects.MSBuild
 			switch (name) {
 				case "DefaultTargets": return defaultTargets;
 				case "ToolsVersion": return toolsVersion;
-				case "xmlns": return Schema;
+				case "xmlns": return Namespace;
+				case "Sdk": return sdk;
 			}
 			return base.WriteAttribute (name);
 		}
@@ -511,6 +513,16 @@ namespace MonoDevelop.Projects.MSBuild
 				AssertCanModify ();
 				toolsVersion = value;
 				NotifyChanged ();
+			}
+		}
+
+		string sdk;
+
+		internal override string Namespace {
+			get {
+				if (sdk != null)
+					return null;
+				return Schema;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -875,9 +875,19 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			var elem = GetProjectExtension ("MonoDevelop");
 			if (elem != null)
-				return elem.SelectSingleNode ("tns:Properties/tns:" + section, XmlNamespaceManager) as XmlElement;
+				return elem.SelectSingleNode ("tns:Properties/tns:" + section, GetNamespaceManagerForProject ()) as XmlElement;
 			else
 				return null;
+		}
+
+		XmlNamespaceManager GetNamespaceManagerForProject ()
+		{
+			if (Namespace == Schema)
+				return XmlNamespaceManager;
+
+			var namespaceManager = new XmlNamespaceManager (new NameTable ());
+			namespaceManager.AddNamespace ("tns", Namespace ?? string.Empty);
+			return namespaceManager;
 		}
 
 		public void SetProjectExtension (XmlElement value)
@@ -942,7 +952,7 @@ namespace MonoDevelop.Projects.MSBuild
 			var md = GetProjectExtension ("MonoDevelop");
 			if (md == null)
 				return;
-			XmlElement elem = md.SelectSingleNode ("tns:Properties/tns:" + section, XmlNamespaceManager) as XmlElement;
+			XmlElement elem = md.SelectSingleNode ("tns:Properties/tns:" + section, GetNamespaceManagerForProject ()) as XmlElement;
 			if (elem != null) {
 				var parent = (XmlElement)elem.ParentNode;
 				XmlUtil.RemoveElementAndIndenting (elem);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -518,7 +518,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		string sdk;
 
-		internal override string Namespace {
+		public override string Namespace {
 			get {
 				if (sdk != null)
 					return null;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProperty.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProperty.cs
@@ -197,7 +197,7 @@ namespace MonoDevelop.Projects.MSBuild
 						elem.Read (cr);
 					}
 					elem.ParentNode = this;
-					elem.SetNamespace (MSBuildProject.Schema);
+					elem.SetNamespace (Namespace);
 
 					elem.StartWhitespace = StartWhitespace;
 					elem.EndWhitespace = EndWhitespace;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildXmlElement.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildXmlElement.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		internal override string Namespace {
+		public override string Namespace {
 			get {
 				if (ns != null)
 					return ns;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
@@ -108,7 +108,7 @@ namespace MonoDevelop.Projects
 			}
 
 			if (msbuildProject != null)
-				return msbuildProject.Namespace ?? string.Empty;
+				return msbuildProject.Namespace;
 
 			return MSBuildProject.Schema;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs
@@ -90,12 +90,27 @@ namespace MonoDevelop.Projects
 			}
 			var vars = XElement.Parse (xml);
 			if (vars != null) {
-				foreach (var val in vars.Elements (XName.Get ("Variable", MSBuildProject.Schema))) {
+				foreach (var val in vars.Elements (XName.Get ("Variable", GetProjectNamespace ()))) {
 					var name = (string)val.Attribute ("name");
 					if (name != null)
 						dict [name] = (string)val.Attribute ("value");
 				}
 			}
+		}
+
+		string GetProjectNamespace ()
+		{
+			var msbuildProject = ParentItem?.MSBuildProject;
+			if (msbuildProject == null) {
+				var projectObject = properties as IMSBuildProjectObject;
+				if (projectObject != null)
+					msbuildProject = projectObject.ParentProject;
+			}
+
+			if (msbuildProject != null)
+				return msbuildProject.Namespace ?? string.Empty;
+
+			return MSBuildProject.Schema;
 		}
 
 		internal protected virtual void Write (IPropertySet pset)
@@ -131,9 +146,10 @@ namespace MonoDevelop.Projects
 
 			if (loadedEnvironmentVariables == null || loadedEnvironmentVariables.Count != environmentVariables.Count || loadedEnvironmentVariables.Any (e => !environmentVariables.ContainsKey (e.Key) || environmentVariables[e.Key] != e.Value)) {
 				if (environmentVariables.Count > 0) {
-					XElement e = new XElement (XName.Get ("EnvironmentVariables", MSBuildProject.Schema));
+					string xmlns = GetProjectNamespace ();
+					XElement e = new XElement (XName.Get ("EnvironmentVariables", xmlns));
 					foreach (var v in environmentVariables) {
-						var val = new XElement (XName.Get ("Variable", MSBuildProject.Schema));
+						var val = new XElement (XName.Get ("Variable", xmlns));
 						val.SetAttributeValue ("name", v.Key);
 						val.SetAttributeValue ("value", v.Value);
 						e.Add (val);

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -734,6 +734,31 @@ namespace MonoDevelop.Projects
 			[ItemProperty ("Value1")]
 			string value1 = "Test";
 		}
+
+		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
+		[TestCase ("ToolsVersion=\"15.0\"")]
+		public void RemoveMonoDevelopProjectExtension (string projectElementAttributes)
+		{
+			string projectXml =
+				"<Project " + projectElementAttributes + ">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+			var config = new TestExternalPropertiesConfig ();
+			p.WriteExternalProjectProperties (config, config.GetType (), true);
+
+			var externalElement = p.GetMonoDevelopProjectExtension ("External");
+			Assert.IsNotNull (externalElement);
+
+			p.RemoveMonoDevelopProjectExtension ("External");
+
+			externalElement = p.GetMonoDevelopProjectExtension ("External");
+			Assert.IsNull (externalElement);
+		}
 	}
 }
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -923,6 +923,7 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (test3Element.HasAttribute ("xmlns"));
 		}
 
+		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
 		[TestCase ("ToolsVersion=\"15.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"")]
 		public void PatchedImport (string projectElementAttributes)
 		{

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -759,6 +759,39 @@ namespace MonoDevelop.Projects
 			externalElement = p.GetMonoDevelopProjectExtension ("External");
 			Assert.IsNull (externalElement);
 		}
+
+		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
+		[TestCase ("ToolsVersion=\"15.0\"")]
+		public void UpdatingMonoDevelopProjectExtensionShouldNotAddAnotherXmlElement (string projectElementAttributes)
+		{
+			string projectXml =
+				"<Project " + projectElementAttributes + ">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+			var config = new TestExternalPropertiesConfig ();
+			p.WriteExternalProjectProperties (config, config.GetType (), true);
+
+			// Update existing extension.
+			config = new TestExternalPropertiesConfig ();
+			p.WriteExternalProjectProperties (config, config.GetType (), true);
+
+			string xml = p.SaveToString ();
+			var doc = new XmlDocument ();
+			doc.LoadXml (xml);
+
+			var projectExtensions = (XmlElement)doc.DocumentElement.ChildNodes[1];
+			var monoDevelopElement = (XmlElement)projectExtensions.ChildNodes[0];
+			var propertiesElement = (XmlElement)monoDevelopElement.ChildNodes[0];
+			var externalElement = (XmlElement)propertiesElement.ChildNodes[0];
+
+			Assert.AreEqual ("External", externalElement.Name);
+			Assert.AreEqual (1, monoDevelopElement.ChildNodes.Count);
+		}
 	}
 }
 


### PR DESCRIPTION
If a project has an Sdk attribute then on saving the xmlns attribute will not be added. If it exists on reading then on saving it will be removed.

There are few other places in the code, shown below, where the MSBuildProject.Schema constant, which holds the MSBuild xml namespace, is used instead of the MSBuildProject's xml namespace. MonoDevelop project extensions and external properties are currently handled. Not sure if we need to change LinuxDeployData and MakefileData to use the project's namespace instead. The others I suspect we will want to change to be consistent even if .NET Core projects are possibly not using them.

- [x] [Patching MSBuildImports](https://github.com/mono/monodevelop/blob/d6f74f3c0029a1025691ce4b9fe722999e7b120c/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs#L102)
- [x] [MSBuildProject.FormatElement - unused?](https://github.com/mono/monodevelop/blob/d6f74f3c0029a1025691ce4b9fe722999e7b120c/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs#L1058)
- [x] [MSBuildProperty writing XML values](https://github.com/mono/monodevelop/blob/d6f74f3c0029a1025691ce4b9fe722999e7b120c/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProperty.cs#L200)
- [x] [ProjectConfiguration environment variables](https://github.com/mono/monodevelop/blob/d6f74f3c0029a1025691ce4b9fe722999e7b120c/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfiguration.cs#L93)
- [x] [LinuxDeployData](https://github.com/mono/monodevelop/blob/d6f74f3c0029a1025691ce4b9fe722999e7b120c/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/MonoDevelop.Deployment.Linux/LinuxDeployData.cs#L69)
- [x] [MakefileData](https://github.com/mono/monodevelop/blob/d6f74f3c0029a1025691ce4b9fe722999e7b120c/main/src/addins/MonoDevelop.Autotools/MakefileData.cs#L85)