### PR TITLE
implemented printTrace for CorDebuggerSession breakpoints

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
@@ -506,6 +506,10 @@ namespace Mono.Debugging.Win32
 					return true;
 			}
 
+			if ((bp.HitAction & HitAction.PrintTrace) != HitAction.None) {
+				OnTargetDebug (0, "", "Breakpoint reached: " + bp.FileName + ":" + bp.Line + Environment.NewLine);
+			}
+
 			if ((bp.HitAction & HitAction.PrintExpression) != HitAction.None) {
 				string exp = EvaluateTrace (thread, bp.TraceExpression);
 				binfo.UpdateLastTraceValue (exp);


### PR DESCRIPTION
Implemented PrintTrace action for CorDebuggerSession breakpoints 
See
https://github.com/mono/debugger-libs/pull/90