### PR TITLE
implemented invalidation of stacks version on setNextStatement for CorDebuggerSession

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
@@ -1728,6 +1728,8 @@ namespace Mono.Debugging.Win32
 				}
 				try {
 					frame.SetIP (offset);
+					OnStopped ();
+					RaiseStopEvent ();
 				} catch {
 					throw new NotSupportedException ();
 				}


### PR DESCRIPTION
See
https://github.com/mono/debugger-libs/pull/91