### PR TITLE
[Cycle9][NuGet] Fix updating all packages installing unexpected pre-releases

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateAllNuGetPackagesInProjectActionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateAllNuGetPackagesInProjectActionTests.cs
@@ -145,7 +145,7 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
-		public void Execute_ProjectHasPrereleasePackage_ActionsResolvedFromNuGetPackageManagerAllowingPrereleasePackages ()
+		public void Execute_ProjectHasPrereleasePackage_ActionsResolvedFromNuGetPackageManagerWithIncludePrereleaseSetToFalse ()
 		{
 			CreateAction ();
 			AddPackageToProject ("Test", "1.0.1-alpha");
@@ -153,7 +153,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			action.Execute ();
 
-			Assert.IsTrue (packageManager.PreviewUpdateResolutionContext.IncludePrerelease);
+			Assert.IsFalse (packageManager.PreviewUpdateResolutionContext.IncludePrerelease);
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
@@ -52,7 +52,6 @@ namespace MonoDevelop.PackageManagement
 		IEnumerable<NuGetProjectAction> actions;
 		List<SourceRepository> primarySources;
 		IEnumerable<PackageReference> packageReferences;
-		bool includePrerelease;
 		string projectName;
 
 		public UpdateAllNuGetPackagesInProjectAction (
@@ -102,8 +101,6 @@ namespace MonoDevelop.PackageManagement
 
 		async Task ExecuteAsync (CancellationToken cancellationToken)
 		{
-			includePrerelease = await ProjectHasPrereleasePackages (cancellationToken);
-
 			await RestoreAnyMissingPackages (cancellationToken);
 
 			actions = await packageManager.PreviewUpdatePackagesAsync (
@@ -138,22 +135,24 @@ namespace MonoDevelop.PackageManagement
 			await OpenReadmeFiles (cancellationToken);
 		}
 
-		async Task<bool> ProjectHasPrereleasePackages (CancellationToken cancellationToken)
-		{
-			packageReferences = await project.GetInstalledPackagesAsync (cancellationToken);
-			return packageReferences.Any (packageReference => packageReference.PackageIdentity.Version.IsPrerelease);
-		}
-
 		public bool HasPackageScriptsToRun ()
 		{
 			return false;
 		}
 
+		/// <summary>
+		/// With NuGet v3 the IncludePrerelease flag does not need to be set to true on the
+		/// resolution context in order to update pre-release NuGet packages. NuGet v3 will
+		/// update pre-release NuGet packages to the latest pre-release version or latest
+		/// stable version if that is a higher version. The IncludePrerelease flag is only
+		/// required to allow a stable version to be updated to a pre-release version which
+		/// is not what we want to do when updating all NuGet packages in a project.
+		/// </summary>
 		ResolutionContext CreateResolutionContext ()
 		{
 			return new ResolutionContext (
 				DependencyBehavior.Lowest,
-				includePrerelease,
+				false,
 				false,
 				VersionConstraints.None
 			);


### PR DESCRIPTION
Fixed bug #51497 - Packages are updated to pre/beta-release version
if you update all packages
https://bugzilla.xamarin.com/show_bug.cgi?id=51497

With a pre-release NuGet package installed in a project and updating
all the NuGet packages in the project could cause the stable NuGet
packages to be updated to pre-release versions. This was because
on updating all the packages if any were pre-release the include
pre-release flag would be set on updating which would allow any
pre-release NuGet packages to be used on updating. Now with this
commit the include pre-release flag is not set on updating. NuGet v3
will still update pre-release NuGet packages to the latest pre-release
or latest stable, depending on which is the latest version, without
this include pre-release flag set. NuGet v2 required the include
pre-release flag set to update a pre-release to the latest pre-release.

An example - project has the following NuGet packages
installed:

Xamarin.Forms 2.3.3.180
Xamarin.Forms.CarouselView 2.3.0-pre1

Latest available packages from nuget.org:

Xamarin.Forms 2.3.3.180 (latest stable)
Xamarin.Forms 2.3.4.184-pre1 (latest pre-release)
Xamarin.Forms.CarouselView 2.3.0-pre2

Expected result on updating all packages in the project:

Xamarin.Forms 2.3.3.180
Xamarin.Forms.CarouselView 2.3.0-pre2

Actual result:

Xamarin.Forms 2.3.4.184-pre1
Xamarin.Forms.CarouselView 2.3.0-pre2