### PR TITLE
[Ide] Fix searchbar unable to be typed in

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/MenuButtonEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/MenuButtonEntry.cs
@@ -190,5 +190,14 @@ namespace MonoDevelop.Components
 			//let GTK reposition the menu if it still doesn't fit on the screen
 			push_in = true;
 		}
+
+		protected override void OnDestroyed ()
+		{
+			if (manager != null) {
+				manager.Dispose ();
+				manager = null;
+			}
+			base.OnDestroyed ();
+		}
 	}
 }


### PR DESCRIPTION
This fixes the assumption that only one commandmanager would exist. MenuButtonEntry would create its own command manager, that would then intercept all native cocoa keypresses.

Moved native cocoa key registration only to commandmanagers with
TopLevelWindows.

Special shout out to bug 51469 for giving us a repro to fix this.

Bug 40414 - [C7] Quick Search does not work at all.