### PR TITLE
[DotNetCore] Support custom attributes on MSBuildItem

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -61,6 +62,11 @@
     <ProjectReference Include="..\..\..\..\tests\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.csproj">
+      <Project>{F218643D-2E74-4309-820E-206A54B7133F}</Project>
+      <Name>MonoDevelop.PackageManagement</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreMSBuildProject.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreMSBuildProject.cs
@@ -26,6 +26,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using MonoDevelop.PackageManagement;
 using MonoDevelop.Projects.MSBuild;
 
 namespace MonoDevelop.DotNetCore
@@ -86,6 +87,12 @@ namespace MonoDevelop.DotNetCore
 			if (HasSdk) {
 				project.RemoveInternalElements ();
 			}
+		}
+
+		public void AddKnownItemAttributes (MSBuildProject project)
+		{
+			if (HasSdk)
+				ProjectPackageReference.AddKnownItemAttributes (project);
 		}
 
 		public bool AddInternalSdkImports (MSBuildProject project, DotNetCoreSdkPaths sdkPaths)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -93,6 +93,8 @@ namespace MonoDevelop.DotNetCore
 
 		protected override void OnReadProject (ProgressMonitor monitor, MSBuildProject msproject)
 		{
+			dotNetCoreMSBuildProject.AddKnownItemAttributes (Project.MSBuildProject);
+
 			base.OnReadProject (monitor, msproject);
 
 			dotNetCoreMSBuildProject.ReadProject (msproject);

--- a/main/src/addins/MonoDevelop.PackageManagement/AssemblyInfo.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/AssemblyInfo.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyVersion ("1.0")]
 [assembly: AssemblyCopyright ("MIT X11")]
 [assembly: InternalsVisibleTo ("MonoDevelop.DotNetCore")]
+[assembly: InternalsVisibleTo ("MonoDevelop.DotNetCore.Tests")]
 [assembly: InternalsVisibleTo ("MonoDevelop.PackageManagement.Cmdlets")]
 [assembly: InternalsVisibleTo ("MonoDevelop.PackageManagement.Extensions")]
 [assembly: InternalsVisibleTo ("MonoDevelop.PackageManagement.Tests")]

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -194,6 +194,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\PackageSpecCreatorTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeMSBuildEvaluatedPropertyCollection.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableProjectPackageReference.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectPackageReferenceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
@@ -1,10 +1,10 @@
 ﻿//
-// TestableProjectPackageReference.cs
+// ProjectPackageReferenceTests.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,21 +24,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Xml;
+using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects.MSBuild;
+using NUnit.Framework;
 
-namespace MonoDevelop.PackageManagement.Tests.Helpers
+namespace MonoDevelop.PackageManagement.Tests
 {
-	class TestableProjectPackageReference : ProjectPackageReference
+	[TestFixture]
+	public class ProjectPackageReferenceTests
 	{
-		public TestableProjectPackageReference (string id, string version)
+		[Test]
+		public void Write_Version_WrittenAsAttribute ()
 		{
-			Include = id;
-			Metadata.SetValue ("Version", version);
-		}
+			var p = new MSBuildProject ();
+			p.LoadXml ("<Project ToolsVersion=\"15.0\" />");
 
-		public void CallWrite (MSBuildItem buildItem)
-		{
-			base.Write (null, buildItem);
+			var item = p.AddNewItem ("PackageReference", "Test");
+			var packageReference = new TestableProjectPackageReference ("Test", "1.2.3");
+			packageReference.CallWrite (item);
+
+			string xml = p.SaveToString ();
+			var doc = new XmlDocument ();
+			doc.LoadXml (xml);
+
+			var itemGroupElement = (XmlElement)doc.DocumentElement.ChildNodes[0];
+			var packageReferenceElement = (XmlElement)itemGroupElement.ChildNodes[0];
+
+			Assert.AreEqual ("PackageReference", packageReferenceElement.Name);
+			Assert.AreEqual ("1.2.3", packageReferenceElement.GetAttribute ("Version"));
+			Assert.AreEqual (0, packageReferenceElement.ChildNodes.Count);
+			Assert.IsTrue (packageReferenceElement.IsEmpty);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
@@ -39,6 +39,7 @@ namespace MonoDevelop.PackageManagement.Tests
 		{
 			var p = new MSBuildProject ();
 			p.LoadXml ("<Project ToolsVersion=\"15.0\" />");
+			ProjectPackageReference.AddKnownItemAttributes (p);
 
 			var item = p.AddNewItem ("PackageReference", "Test");
 			var packageReference = new TestableProjectPackageReference ("Test", "1.2.3");

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Linq;
 using MonoDevelop.Projects;
+using MonoDevelop.Projects.MSBuild;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -88,6 +89,12 @@ namespace MonoDevelop.PackageManagement
 		public override string ToString ()
 		{
 			return string.Format ("[PackageReference: {0} {1}]", Include, Metadata.GetValue ("Version"));
+		}
+
+		protected override void Write (Project project, MSBuildItem buildItem)
+		{
+			buildItem.AddKnownAttributes ("Version");
+			base.Write (project, buildItem);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
@@ -86,15 +86,20 @@ namespace MonoDevelop.PackageManagement
 			return packageReference;
 		}
 
+		internal static ProjectPackageReference Create (string packageId, string version)
+		{
+			var package = new PackageIdentity (packageId, new NuGetVersion (version));
+			return Create (package);
+		}
+
 		public override string ToString ()
 		{
 			return string.Format ("[PackageReference: {0} {1}]", Include, Metadata.GetValue ("Version"));
 		}
 
-		protected override void Write (Project project, MSBuildItem buildItem)
+		public static void AddKnownItemAttributes (MSBuildProject project)
 		{
-			buildItem.AddKnownAttributes ("Version");
-			base.Write (project, buildItem);
+			project.AddKnownItemAttribute ("PackageReference", "Version");
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
@@ -286,7 +286,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal virtual void WriteContent (XmlWriter writer, WriteContext context)
 		{
-			var children = GetChildren ();
+			var children = GetChildren ().Where (c => !c.SkipSerialization).ToArray ();
 			var hasChildren = children.Any ();
 
 			var hasContent = StartInnerWhitespace != null || EndInnerWhitespace != null;
@@ -294,9 +294,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (hasChildren || emptyElementMode == EmptyElementMode.NotEmpty || (emptyElementMode == EmptyElementMode.Unknown && !PreferEmptyElement)) {
 				MSBuildWhitespace.Write (StartInnerWhitespace, writer);
 
-				foreach (var c in GetChildren ()) {
-					if (c.SkipSerialization)
-						continue;
+				foreach (var c in children) {
 					c.Write (writer, context);
 					hasContent = true;
 				}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildObject.cs
@@ -286,7 +286,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal virtual void WriteContent (XmlWriter writer, WriteContext context)
 		{
-			var children = GetChildren ().Where (c => !c.SkipSerialization).ToArray ();
+			var children = GetChildren ().Where (c => !c.SkipSerialization);
 			var hasChildren = children.Any ();
 
 			var hasContent = StartInnerWhitespace != null || EndInnerWhitespace != null;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -48,6 +48,7 @@ namespace MonoDevelop.Projects.MSBuild
 		bool hadXmlDeclaration;
 		bool isShared;
 		ConditionedPropertyCollection conditionedProperties = new ConditionedPropertyCollection ();
+		Dictionary<string, string[]> knownItemAttributes;
 
 		MSBuildEngineManager engineManager;
 		bool engineManagerIsLocal;
@@ -965,6 +966,29 @@ namespace MonoDevelop.Projects.MSBuild
 						bestGroups.Remove (item.Name);
 				}
 			}
+		}
+
+		public void AddKnownItemAttribute (string itemName, params string[] attributes)
+		{
+			AssertCanModify ();
+
+			if (knownItemAttributes == null)
+				knownItemAttributes = new Dictionary<string, string[]> ();
+
+			var mergedAttributes = MSBuildItem.KnownAttributes.Union (attributes).ToArray ();
+			knownItemAttributes [itemName] = mergedAttributes;
+		}
+
+		internal string[] GetKnownItemAttributes (string itemName)
+		{
+			if (knownItemAttributes == null)
+				return MSBuildItem.KnownAttributes;
+
+			string[] attributes = null;
+			if (knownItemAttributes.TryGetValue (itemName, out attributes))
+				return attributes;
+
+			return MSBuildItem.KnownAttributes;
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProperty.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProperty.cs
@@ -52,7 +52,11 @@ namespace MonoDevelop.Projects.MSBuild
 			get {
 				return fromAttribute;
 			}
+			set {
+				fromAttribute = value;
+			}
 		}
+
 		internal string AfterAttribute {
 			get {
 				return afterAttribute;

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -572,6 +572,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("Test", itemElement.Name);
 			Assert.AreEqual ("KnownAttributeValue", itemElement.GetAttribute ("Known"));
 			Assert.AreEqual (0, itemElement.ChildNodes.Count);
+			Assert.IsTrue (itemElement.IsEmpty);
 		}
 
 		[Test]
@@ -601,6 +602,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("KnownAttributeValue", itemElement.GetAttribute ("Known"));
 			Assert.AreEqual ("AnotherValue", itemElement.GetAttribute ("Another"));
 			Assert.AreEqual (0, itemElement.ChildNodes.Count);
+			Assert.IsTrue (itemElement.IsEmpty);
 		}
 
 		[Test]

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -557,10 +557,10 @@ namespace MonoDevelop.Projects
 		{
 			var p = new MSBuildProject ();
 			p.LoadXml ("<Project ToolsVersion=\"15.0\" />");
+			p.AddKnownItemAttribute ("Test", "Known");
 
 			var item = p.AddNewItem ("Test", "Include");
 			item.Metadata.SetValue ("Known", "KnownAttributeValue");
-			item.AddKnownAttributes ("Known");
 
 			string xml = p.SaveToString ();
 			var doc = new XmlDocument ();
@@ -587,8 +587,8 @@ namespace MonoDevelop.Projects
 				"</Project>";
 			p.LoadXml (projectXml);
 
+			p.AddKnownItemAttribute ("Test", "Known", "Another");
 			var item = p.ItemGroups.Single ().Items.Single ();
-			item.AddKnownAttributes ("Known", "Another");
 			item.Metadata.SetValue ("Another", "AnotherValue");
 
 			string xml = p.SaveToString ();

--- a/main/tests/test-projects/dotnetcore-console/dotnetcore-console/dotnetcore-sdk-console.csproj
+++ b/main/tests/test-projects/dotnetcore-console/dotnetcore-console/dotnetcore-sdk-console.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/dotnetcore-console/dotnetcore-sdk-console.sln
+++ b/main/tests/test-projects/dotnetcore-console/dotnetcore-sdk-console.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.25806.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnetcore-console", "dotnetcore-console\dotnetcore-sdk-console.csproj", "{57E09661-7610-453D-8F3D-F4B68461DEFB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
MSBuildItem now has an `void AddKnownAttributes (params string[] names)` method where custom known attributes can be added. When the MSBuildItem is then written the associated properties will be written as attributes instead of child elements.