### PR TITLE
Breakpoints.Clear() deactivates all the breakpoints

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/CorDebuggerSession.cs
@@ -158,6 +158,7 @@ namespace Mono.Debugging.Win32
 		void TerminateDebugger ()
 		{
 			helperOperationsCancellationTokenSource.Cancel();
+			Breakpoints.Clear ();
 			lock (terminateLock) {
 				if (terminated)
 					return;


### PR DESCRIPTION
Breakpoints.Clear() deactivates all the breakpoints. Otherwise COM exception may be thrown on Detach() or Terminate()