### PR TITLE
[Ide] Fix Solution pad tree corruption

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
@@ -65,6 +65,11 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 				return 1;
 			if (otherNode.DataItem is Ide.Gui.Pads.ProjectPad.GettingStartedNode)
 				return 1;
+			
+			var itemType = otherNode.DataItem?.GetType ()?.FullName;
+			if (itemType == "MonoDevelop.ConnectedServices.Gui.SolutionPad.ConnectedServiceFolderNode" ||
+				itemType == "MonoDevelop.ConnectedServices.Gui.SolutionPad.ComponentReferenceFolder")
+				return 1;
 			return -1;
 		}
 

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.NodeBuilders/WebReferenceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.NodeBuilders/WebReferenceFolderNodeBuilder.cs
@@ -74,7 +74,13 @@ namespace MonoDevelop.WebReferences.NodeBuilders
 		/// <returns>An integer containing the sort order for the objects.</returns>
 		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
 		{
-			return (otherNode.DataItem is ProjectReferenceCollection) ? 1 : -1;
+			if (otherNode.DataItem is ProjectReferenceCollection ||
+				otherNode.DataItem is MonoDevelop.Ide.Gui.Pads.ProjectPad.GettingStartedNode)
+				return 1;
+			var itemType = otherNode.DataItem?.GetType ()?.FullName;
+			if (itemType == "MonoDevelop.ConnectedServices.Gui.SolutionPad.ConnectedServiceFolderNode")
+				return 1;
+			return -1;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectReferenceFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectReferenceFolderNodeBuilder.cs
@@ -100,6 +100,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		{
 			if (otherNode.DataItem is GettingStartedNode)
 				return 1;
+			var itemType = otherNode.DataItem?.GetType ()?.FullName;
+			if (itemType == "MonoDevelop.ConnectedServices.Gui.SolutionPad.ConnectedServiceFolderNode")
+				return 1;
 			return -1;
 		}
 


### PR DESCRIPTION
The Gtk.TreeView sort implementation expects the compare function to return consistent results
for both nodes being compared. Hence the result of `NodeBuilder.CompareObjects (nodeB, nodeA)` must always be the opposite of `NodeBuilder.CompareObjects (nodeA, nodeB)`.

This patch is a simple workaround, but its really ugly to get the node types and to compare their names and its also very problematic for external AddIns. We may need a better sorting implementation with some kind of grouping or priorities for example, but I'm not sure how it may look like without badly breaking the API.

(fixes bug #46681)