### PR TITLE
[Ide] Add WelcomePage shown/hidden events

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -35,6 +35,9 @@ namespace MonoDevelop.Ide.WelcomePage
 		static bool visible;
 		static WelcomePageFrame welcomePage;
 
+		public static event EventHandler WelcomePageShown;
+		public static event EventHandler WelcomePageHidden;
+
 		public static void Initialize ()
 		{
 			IdeApp.Workspace.FirstWorkspaceItemOpened += delegate {
@@ -64,6 +67,7 @@ namespace MonoDevelop.Ide.WelcomePage
 					var provider = AddinManager.GetExtensionObjects<IWelcomePageProvider> ().FirstOrDefault ();
 					welcomePage = new WelcomePageFrame (provider != null ? provider.CreateWidget () : new DefaultWelcomePage ());
 				}
+				WelcomePageShown?.Invoke (welcomePage, EventArgs.Empty);
 				welcomePage.UpdateProjectBar ();
 				((DefaultWorkbench)IdeApp.Workbench.RootWindow).BottomBar.Visible = false;
 				((DefaultWorkbench)IdeApp.Workbench.RootWindow).DockFrame.AddOverlayWidget (welcomePage, animate);
@@ -78,6 +82,7 @@ namespace MonoDevelop.Ide.WelcomePage
 				((DefaultWorkbench)IdeApp.Workbench.RootWindow).BottomBar.Show ();
 				((DefaultWorkbench)IdeApp.Workbench.RootWindow).DockFrame.RemoveOverlayWidget (animate);
 			}
+			WelcomePageHidden?.Invoke (welcomePage, EventArgs.Empty);
 		}
 	}
 }


### PR DESCRIPTION
This patch adds shown/hidden events to the WelcomePageService. This is required to fix bug #51576, where we need to hide/show a WebView when the welcome page visibility changes.

(cherry picked from commit 81caa7033bee8aa608d3a6e2c2b0555da5948931)