### PR TITLE
Introduce NodeBuilder.GetSortIndex()

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyReferenceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyReferenceFolderNodeBuilder.cs
@@ -80,10 +80,10 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			return true;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			return -1;
+			return -200;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyResourceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyResourceFolderNodeBuilder.cs
@@ -61,13 +61,11 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			return true;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			if (otherNode.DataItem is AssemblyReferenceFolder)
-				return 1;
-			return -1;
+			return -100;
 		}
-		
+
 	}
 }

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/BaseTypeFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/BaseTypeFolderNodeBuilder.cs
@@ -106,10 +106,10 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			return true;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			return -1;
+			return -100;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.ConnectedServices/Gui.SolutionPad/ConnectedServicesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/Gui.SolutionPad/ConnectedServicesFolderNodeBuilder.cs
@@ -61,9 +61,9 @@ namespace MonoDevelop.ConnectedServices.Gui.SolutionPad
 			}
 		}
 
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			return (otherNode.DataItem is Ide.Gui.Pads.ProjectPad.GettingStartedNode) ? 1 : -1;
+			return -1500;
 		}
 
 		public override void OnNodeAdded (object dataObject)

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/StockIconsNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/StockIconsNodeBuilder.cs
@@ -44,11 +44,10 @@ namespace MonoDevelop.GtkCore.NodeBuilders
 				Console.WriteLine ("Error while loading pixbuf 'image-x-generic.png': " + e);
 			}
 		}
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			return -1;
+			return -100;
 		}
-
 
 		public override string GetNodeName (ITreeNavigator thisNode, object dataObject)
 		{

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/WindowsFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.NodeBuilders/WindowsFolderNodeBuilder.cs
@@ -84,15 +84,12 @@ namespace MonoDevelop.GtkCore.NodeBuilders
 		{
 			return true;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
-		{
-			if (otherNode.DataItem is ProjectReferenceCollection)
-				return 1;
-			else
-				return -1;
-		}
 
+		public override int GetSortIndex (ITreeNavigator node)
+		{
+			return -200;
+		}
+		
 		public override void OnNodeAdded (object dataObject)
 		{
 			WindowsFolder w = (WindowsFolder) dataObject;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNodeBuilder.cs
@@ -59,13 +59,9 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 			nodeInfo.ClosedIcon = Context.GetIcon (node.ClosedIcon);
 		}
 
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			if (otherNode.DataItem is ProjectReferenceCollection)
-				return 1;
-			if (otherNode.DataItem is Ide.Gui.Pads.ProjectPad.GettingStartedNode)
-				return 1;
-			return -1;
+			return -500;
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectReferencesFromPackagesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectReferencesFromPackagesFolderNodeBuilder.cs
@@ -50,12 +50,9 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 			nodeInfo.Icon = Context.GetIcon ("md-reference-package");
 		}
 
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			if (otherNode.NodeName == ".NET Portable Subset") {
-				return 1;
-			}
-			return -1;
+			return -500;
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.NodeBuilders/WebReferenceFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.NodeBuilders/WebReferenceFolderNodeBuilder.cs
@@ -70,11 +70,9 @@ namespace MonoDevelop.WebReferences.NodeBuilders
 				treeBuilder.AddChildren (WebReferencesService.GetWebReferenceItemsWS (folder.Project));
 		}
 		
-		/// <summary>Compare two object with one another and returns a number based on their sort order.</summary>
-		/// <returns>An integer containing the sort order for the objects.</returns>
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			return (otherNode.DataItem is ProjectReferenceCollection) ? 1 : -1;
+			return -200;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.GettingStarted/GettingStartedNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.GettingStarted/GettingStartedNodeBuilder.cs
@@ -36,9 +36,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			return false;
 		}
 
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			return -1;
+			return -2000;
 		}
 
 		public override void OnNodeAdded (object dataObject)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -1587,14 +1587,22 @@ namespace MonoDevelop.Ide.Gui.Components
 				NodeBuilder[] chain1 = (NodeBuilder[]) store.GetValue (a, BuilderChainColumn);
 				if (chain1 == null) return -1;
 
+				NodeBuilder [] chain2 = (NodeBuilder [])store.GetValue (b, BuilderChainColumn);
+				if (chain2 == null) return 1;
+
 				compareNode1.MoveToIter (a);
 				compareNode2.MoveToIter (b);
 
+				var i1 = GetSortIndex (chain1, compareNode1);
+				var i2 = GetSortIndex (chain2, compareNode2);
+
+				if (i1 < i2)
+					return -1;
+				else if (i1 > i2)
+					return 1;
+
 				int sort = CompareObjects (chain1, compareNode1, compareNode2);
 				if (sort != TypeNodeBuilder.DefaultSort) return sort;
-
-				NodeBuilder[] chain2 = (NodeBuilder[]) store.GetValue (b, BuilderChainColumn);
-				if (chain2 == null) return 1;
 
 				if (chain1 != chain2) {
 					sort = CompareObjects (chain2, compareNode2, compareNode1);
@@ -1618,6 +1626,17 @@ namespace MonoDevelop.Ide.Gui.Components
 			int result = NodeBuilder.DefaultSort;
 			for (int n=0; n<chain.Length; n++) {
 				int sort = chain[n].CompareObjects (thisNode, otherNode);
+				if (sort != NodeBuilder.DefaultSort)
+					result = sort;
+			}
+			return result;
+		}
+
+		int GetSortIndex (NodeBuilder [] chain, ITreeNavigator node)
+		{
+			int result = 0;
+			for (int n = 0; n < chain.Length; n++) {
+				int sort = chain [n].GetSortIndex (node);
 				if (sort != NodeBuilder.DefaultSort)
 					result = sort;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/NodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/NodeBuilder.cs
@@ -135,6 +135,21 @@ namespace MonoDevelop.Ide.Gui.Components
 			return DefaultSort;
 		}
 
+		/// <summary>
+		/// Gets the sort index for this node
+		/// </summary>
+		/// <returns>The sort index.</returns>
+		/// <param name="node">A tree node.</param>
+		/// <remarks>
+		/// The sort index is used to determine the relative ordering of nodes. Nodes with a higher sort index are
+		/// placed after nodes with lower index. When the index of two nodes is the same, the CompareObjects
+		/// method is used to determine the ordering. The default value is 0.
+		/// </remarks>
+		public virtual int GetSortIndex (ITreeNavigator node)
+		{
+			return DefaultSort;
+		}
+
 		// Helper methods
 		
 		internal static bool HasAttribute (ITreeNavigator treeNavigator, NodeAttributes attr, NodeBuilder[] chain, object dataObject)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassNodeBuilder.cs
@@ -127,14 +127,6 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 			// info from the db, so we always return true here. After all 99% of classes will have members
 			return true;
 		}
-
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
-		{
-			if (thisNode.DataItem is ClassData)
-				return DefaultSort;
-			else
-				return 1;
-		}
 	}
 
 	public class ClassNodeCommandHandler : NodeCommandHandler

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/CombineNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/CombineNodeBuilder.cs
@@ -82,15 +82,12 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		{
 			return ((SolutionFolder) dataObject).Items.Count > 0;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
-		{
-			if (otherNode.DataItem is SolutionFolder)
-				return DefaultSort;
-			else
-				return -1;
-		}
 
+		public override int GetSortIndex (ITreeNavigator node)
+		{
+			return -100;
+		}
+		
 		public override void OnNodeAdded (object dataObject)
 		{
 			SolutionFolder combine = (SolutionFolder) dataObject;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/PortableFrameworkSubsetNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/PortableFrameworkSubsetNodeBuilder.cs
@@ -84,5 +84,10 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 									 .Where (asm => asm.Package.IsFrameworkPackage && asm.Name != "mscorlib")
 									 .Select (asm => new ImplicitFrameworkAssemblyReference (asm)));
 		}
+
+		public override int GetSortIndex (ITreeNavigator node)
+		{
+			return -1000;
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
@@ -109,9 +109,6 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
 		{
-			if (otherNode.DataItem is ProjectFolder)
-				return 1;
-
 			if (!(thisNode.DataItem is ProjectFile))
 				return DefaultSort;
 			if (!(otherNode.DataItem is ProjectFile))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
@@ -112,6 +112,12 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				tb.UpdateChildren ();
 			}
 		}
+
+		public override int GetSortIndex (ITreeNavigator node)
+		{
+			// Before items, but after references and other collections
+			return -100;
+		}
 	
 		public override void BuildNode (ITreeBuilder treeBuilder, object dataObject, NodeInfo nodeInfo)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectReferenceFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectReferenceFolderNodeBuilder.cs
@@ -95,12 +95,10 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			var p = (DotNetProject) builder.GetParentDataItem (typeof(DotNetProject), true);
 			return p != null && p.IsPortableLibrary;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
+
+		public override int GetSortIndex (ITreeNavigator node)
 		{
-			if (otherNode.DataItem is GettingStartedNode)
-				return 1;
-			return -1;
+			return -1000;
 		}
 
 		void OnRemoveReference (object sender, ProjectReferenceEventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderFileNodeBuilder.cs
@@ -69,14 +69,6 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			else
 				return file.Parent;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
-		{
-			if (otherNode.DataItem is SolutionFolderFileNode)
-				return DefaultSort;
-			else
-				return -1;
-		}
 	}
 	
 	class SolutionFolderFileNodeCommandHandler: NodeCommandHandler

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderNodeBuilder.cs
@@ -84,15 +84,12 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			SolutionFolder sf = (SolutionFolder) dataObject;
 			return sf.IsRoot || sf.ParentFolder.IsRoot ? (object) sf.ParentSolution : (object) sf.ParentFolder;
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
-		{
-			if (otherNode.DataItem is SolutionFolder)
-				return DefaultSort;
-			else
-				return -1;
-		}
 
+		public override int GetSortIndex (ITreeNavigator node)
+		{
+			return -1000;
+		}
+		
 		public override void OnNodeAdded (object dataObject)
 		{
 			SolutionFolder folder = (SolutionFolder) dataObject;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFileNodeBuilder.cs
@@ -80,14 +80,6 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				nodeInfo.Label = "<span foreground='dimgrey'>" + nodeInfo.Label + "</span>";
 			}
 		}
-		
-		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)
-		{
-			if (otherNode.DataItem is ProjectFolder)
-				return 1;
-			else
-				return DefaultSort;
-		}
 	}
 	
 	class SystemFileNodeCommandHandler: NodeCommandHandler


### PR DESCRIPTION
This method is used to get the sorting group of a node. It makes it easier
for add-ins to set node ordering.