### PR TITLE
Fixed ObjectDisposed exception and MS.CodeAnalysis.Solution leak in c…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -83,7 +83,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			initialLoad = false;
 
 			try {
-				emptyWorkspace = new MonoDevelopWorkspace ();
+				emptyWorkspace = new MonoDevelopWorkspace (null);
 			} catch (Exception e) {
 				LoggingService.LogFatalError ("Can't create roslyn workspace", e); 
 			}


### PR DESCRIPTION
…ase if solution was closed soon after opening

ObjectDisposed exception was caused by the fact that even after project was unloaded TypeSystem was still loading causing ObjectDisposed exception(inside `p.GetSourceFilesAsync`). To prevent this TryLoadSolution now also listens to `src.Token` which is cancelled in `Dispose()`. Another `if (token.IsCancellationRequested)` was added just before calling `p.GetSourceFilesAsync` to avoid project being disposed before call being made.

Cause of memory leak was that `workspace` was added to `workspaces` after `TryLoadSolution` call which meant in case if `TypeSystemService.Unload` was called before `TryLoadSolution` finished that `Unload` didn’t `Dispose` workspace. Fix for this is to add `workspace` to `workspaces` before `TryLoadSolution` call, to ensure `monodevelopSolution` is set at all times(so `GetWorkspace` always work) it’s set via constructor. For better readability it was made `readonly`.

HandleActiveConfigurationChanged is now registered only if `solution != null` so check was removed inside method.

I also noticed TypeSystemService.Load is disposing `Counters.ParserService.WorkspaceItemLoaded.BeginTiming` too soon, so I fixed that.