### PR TITLE
[MSBuild] Send “Process Stop” message to RemoteProcess so MSBuild pro…

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -142,6 +142,7 @@ namespace MonoDevelop.Projects.MSBuild
 			try {
 				alive = false;
 				connection.SendMessage (new DisposeRequest ());
+				connection.SendMessage (new BinaryMessage ("Stop", "Process"));
 			} catch {
 				// Ignore
 			}


### PR DESCRIPTION
…cess terminates itself

Dispose did call `doneEvent.Set();` and for which https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/Main.cs#L47 was waiting but problem was that https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessServer.cs#L151 is not background thread, hence process didn't quit, Sending "Process" "Stop" is probably cleanest way to stop process(https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessServer.cs#L168).