### PR TITLE
[GettingStarted] Fix Solution Pad expanding

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.GettingStarted/GettingStartedNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.GettingStarted/GettingStartedNodeBuilder.cs
@@ -25,6 +25,12 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			return "GettingStarted";
 		}
 
+		public override object GetParentObject (object dataObject)
+		{
+			var node = dataObject as GettingStartedNode;
+			return node?.Project ?? base.GetParentObject (dataObject);
+		}
+
 		public override void BuildNode (ITreeBuilder treeBuilder, object dataObject, NodeInfo nodeInfo)
 		{
 			nodeInfo.Label = GettextCatalog.GetString ("Getting Started");


### PR DESCRIPTION
If the project node in the solution pad is not expanded,
we need to provide the project node in order to
select the matching Getting Started node when the
active document changes to the Getting Started view.

(fix bug #51632)

(cherry picked from commit ba6931307bd43d8f316b3a238ba7cf65c41eb896)