### PR TITLE
Multiple-bar touchbar interface 

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -110,8 +110,18 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			Touchbar = aTouchbar;
 
 			aTouchbar.Delegate = this;
-			aTouchbar.DefaultItemIdentifiers = GetItemIdentifiers (true);
 
+
+			/*
+			 * There is a nasty bug that occurs here where after the user dismisses the system's touchbar customization
+			 * UI, there is a significant chance for all windows on the user's computer to become unresponsive until
+			 * MonoDevelop is killed. Until this bug is fixed, I've sealed off the customization functionality.
+			 * (if you can customize the touch bar, changing at least one item,
+			 * five times in a row without running into this bug then it is probably fixed)
+			 */
+
+#if CUSTOMIZATION_WINDOW_FREEZE_BUG_FIXED
+			aTouchbar.DefaultItemIdentifiers = GetItemIdentifiers (true);
 			if (BarType == TouchBarType.TextEditor) {
 				aTouchbar.CustomizationIdentifier = TouchBarType.TextEditor.ToString ();
 				NSApplication.SharedApplication.SetAutomaticCustomizeTouchBarMenuItemEnabled (true);
@@ -119,7 +129,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			} else {
 				NSApplication.SharedApplication.SetAutomaticCustomizeTouchBarMenuItemEnabled (false);
 			}
-				return aTouchbar;
+#else 
+			aTouchbar.DefaultItemIdentifiers = GetItemIdentifiers (false); //without customization all items must be present, not just defaults
+#endif
+
+			return aTouchbar;
 		}
 
 		public void UpdateTouchBar ()

--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -58,6 +58,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		private static NSSegmentedControl navControl = null;
 		private static NSSegmentedControl tabNavControl = null;
 		//End variables decl… *sigh*
+		internal NSImage buildImage;
+		internal NSImage continueImage;
+		internal NSImage stopImage;
 
 		internal TouchBarType BarType = TouchBarType.TextEditor;
 		internal NSTouchBar Touchbar = null;
@@ -73,6 +76,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public AwesomeBar ()
 		{
+			//create & cache images for the touchbar's run button
+			buildImage = MultiResImage.CreateMultiResImage ("build", "");
+			continueImage = MultiResImage.CreateMultiResImage ("continue", "");
+			stopImage = MultiResImage.CreateMultiResImage ("stop", "");
+
 			RunButton = new RunButton ();
 			AddSubview (RunButton);
 
@@ -99,7 +107,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			var aTouchbar = new NSTouchBar ();
 			Touchbar = aTouchbar;
-
 
 			aTouchbar.Delegate = this;
 			aTouchbar.DefaultItemIdentifiers = GetItemIdentifiers (true);
@@ -141,13 +148,13 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			NSImage runImg = null;
 			switch (RunButton.Icon) {
 			case Components.MainToolbar.OperationIcon.Build:
-				runImg = MultiResImage.CreateMultiResImage ("build", "");
+				runImg = buildImage;
 				break;
 			case Components.MainToolbar.OperationIcon.Run:
-				runImg = MultiResImage.CreateMultiResImage ("continue", "");
+				runImg = continueImage;
 				break;
 			case Components.MainToolbar.OperationIcon.Stop:
-				runImg = MultiResImage.CreateMultiResImage ("stop", "");
+				runImg = stopImage;
 				break;
 			}
 			if (runImg != null) {
@@ -208,7 +215,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				item = NSGroupTouchBarItem.CreateGroupItem (identifier, items);
 				return item;
 			}
-			Console.WriteLine (identifier);
+
 			switch (identifier) {
 			case Id.RecentItems:
 				var recentItemsLabel = NSTextField.CreateLabel("placeholder");

--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -34,16 +34,24 @@ using MonoDevelop.Core;
 using Xwt.Mac;
 using MonoDevelop.Ide;
 
-public enum TouchBarType
-{
-	WelcomePage,
-	TextEditor,
-	Debugger,
-	Preferences
-}
+
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
+	public enum TouchBarType
+	{
+		WelcomePage,
+		TextEditor,
+		Debugger,
+		Preferences
+	}
+	public static class Id //unique IDs for TouchBar items
+	{
+		public const string Run = "com.MonoDevelop.TouchBarIdentifiers.Run";
+		public const string Navigation = "com.MonoDevelop.TouchBarIdentifiers.Navigation";
+		public const string TabNavigation = "com.MonoDevelop.TouchBarIdentifiers.TabNavigation";
+		public const string RecentItems = "com.MonoDevelop.TouchBarIdentifiers.RecentItems";
+	}
 	public class AwesomeBar : NSView, INSTouchBarDelegate
 	{
 		//Begin variables declared as static outside of scope to prevent garbage collection crash
@@ -169,15 +177,15 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		{
 			List<string> ids = new List<string> ();
 			if (BarType == TouchBarType.TextEditor) {
-				ids.Add ("run");
-				ids.Add ("navigation");
+				ids.Add (Id.Run);
+				ids.Add (Id.Navigation);
 				if (defaultsOnly) {return ids.ToArray ();}
-				ids.Add ("tabNavigation");
+				ids.Add (Id.TabNavigation);
 				ids.Add ("NSTouchBarItemIdentifierFlexibleSpace");
 				return ids.ToArray ();
 			} 
 			else if (BarType == TouchBarType.WelcomePage) {
-				ids.Add("recentItems");
+				ids.Add(Id.RecentItems);
 				return ids.ToArray ();
 			} 
 			else {return ids.ToArray ();}
@@ -200,17 +208,17 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				item = NSGroupTouchBarItem.CreateGroupItem (identifier, items);
 				return item;
 			}
-
+			Console.WriteLine (identifier);
 			switch (identifier) {
-			case "recentItems":
+			case Id.RecentItems:
 				var recentItemsLabel = NSTextField.CreateLabel("placeholder");
 				recentItemsLabel.StringValue = "placeholder for recent items";
-				var recentItemsCustomItem = new NSCustomTouchBarItem ("recentItems");
+				var recentItemsCustomItem = new NSCustomTouchBarItem (identifier);
 				recentItemsCustomItem.View = recentItemsLabel;
 				item = recentItemsCustomItem;
 
 				return item;
-			case "navigation": //contains navigate back & forward buttons
+			case Id.Navigation: //contains navigate back & forward buttons
 
 				//NSSegmentedControl navControl = null; //declared as static above due to GC bug
 
@@ -235,14 +243,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				navControl = NSSegmentedControl.FromImages (navIcons, NSSegmentSwitchTracking.Momentary, navControlAction);
 				navControl.SegmentStyle = NSSegmentStyle.Separated;
 
-				var customItemNavControl = new NSCustomTouchBarItem ("navigation");
+				var customItemNavControl = new NSCustomTouchBarItem (identifier);
 				customItemNavControl.CustomizationLabel = "Navigation";
 				customItemNavControl.View = navControl;
 				item = customItemNavControl;
 
 				return item;
 				
-			case "tabNavigation": //navigation again, but this time for tabs. Lack of images is a work-in-progress
+			case Id.TabNavigation: //navigation again, but this time for tabs. Lack of images is a work-in-progress
 
 				//NSSegmentedControl tabNavControl = null; //declared as static above due to GC bug
 
@@ -263,7 +271,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				tabNavControl = NSSegmentedControl.FromLabels (new string [] { "<-tab", "tab->" }, NSSegmentSwitchTracking.Momentary, tabNavControlAction);
 				tabNavControl.SegmentStyle = NSSegmentStyle.Separated;
 
-				var customItemTabNavControl = new NSCustomTouchBarItem ("tabNavigation");
+				var customItemTabNavControl = new NSCustomTouchBarItem (identifier);
 				customItemTabNavControl.CustomizationLabel = "Tab Controls";
 				customItemTabNavControl.View = tabNavControl;
 				item = customItemTabNavControl;
@@ -271,7 +279,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				return item;
 
 		
-			case "run":
+			case Id.Run:
 				var customItem = new NSCustomTouchBarItem (identifier);
 
 #if WANT_TO_SEE_BIG_CRASH

--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -240,6 +240,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				if (items == null) {
 					return null;
 				}
+				if (items.Length == 0) {
+					RebuildTouchBar = true;
+					//seems this method is called before buttonBar is init'd, so rebuild until it's ready
+				}
 
 				item = NSGroupTouchBarItem.CreateGroupItem (identifier, items);
 				return item;

--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -47,15 +47,15 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 	public class AwesomeBar : NSView, INSTouchBarDelegate
 	{
 		//Begin variables declared as static outside of scope to prevent garbage collection crash
-		private static NSSegmentedControl navSegments = null;
-		private static NSSegmentedControl tabNavSegments = null;
+		private static NSSegmentedControl navControl = null;
+		private static NSSegmentedControl tabNavControl = null;
 		//End variables decl… *sigh*
 
-		internal TouchBarType barType = TouchBarType.TextEditor;
-		internal NSTouchBar touchbar = null;
+		internal TouchBarType BarType = TouchBarType.TextEditor;
+		internal NSTouchBar Touchbar = null;
 
 		//touch bar items that need to be dynamically updated
-		private NSButton touchBarRunButton;
+		private NSButton TouchBarRunButton;
 
 		internal RunButton RunButton { get; set; }
 		internal SelectorView SelectorView { get; set; }
@@ -90,13 +90,13 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		NSTouchBar MakeTouchBar ()
 		{
 			var aTouchbar = new NSTouchBar ();
-			this.touchbar = aTouchbar;
+			Touchbar = aTouchbar;
 
 
 			aTouchbar.Delegate = this;
 			aTouchbar.DefaultItemIdentifiers = GetItemIdentifiers (true);
 
-			if (this.barType == TouchBarType.TextEditor) {
+			if (BarType == TouchBarType.TextEditor) {
 				aTouchbar.CustomizationIdentifier = TouchBarType.TextEditor.ToString ();
 				NSApplication.SharedApplication.SetAutomaticCustomizeTouchBarMenuItemEnabled (true);
 				aTouchbar.CustomizationAllowedItemIdentifiers = GetItemIdentifiers ();
@@ -108,11 +108,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public void UpdateTouchBar ()
 		{
-			if (this.touchbar == null) {goto Rebuild;} //initialize on launch
+			if (Touchbar == null) {goto Rebuild;} //initialize on launch
 
 			if (MonoDevelop.Ide.WelcomePage.WelcomePageService.WelcomePageVisible) {
-				if (this.barType != TouchBarType.WelcomePage) {
-					this.barType = TouchBarType.WelcomePage;
+				if (BarType != TouchBarType.WelcomePage) {
+					BarType = TouchBarType.WelcomePage;
 					goto Rebuild;
 				} else {
 					goto Update;
@@ -120,8 +120,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			} 
 			else { //if welcomepage is not visible
 				   //TODO: code to determine whether to use preferences or debugging bar
-				if (this.barType == TouchBarType.WelcomePage) {
-					this.barType = TouchBarType.TextEditor;
+				if (BarType == TouchBarType.WelcomePage) {
+					BarType = TouchBarType.TextEditor;
 					goto Rebuild;
 				} else {
 					goto Update;
@@ -143,8 +143,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				break;
 			}
 			if (runImg != null) {
-				if (touchBarRunButton != null) {
-					touchBarRunButton.Image = runImg;
+				if (TouchBarRunButton != null) {
+					TouchBarRunButton.Image = runImg;
 				}
 			}
 			               
@@ -168,7 +168,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		string [] GetItemIdentifiers (bool defaultsOnly) //defaultsOnly means only identifiers for default layout are returned
 		{
 			List<string> ids = new List<string> ();
-			if (this.barType == TouchBarType.TextEditor) {
+			if (BarType == TouchBarType.TextEditor) {
 				ids.Add ("run");
 				ids.Add ("navigation");
 				if (defaultsOnly) {return ids.ToArray ();}
@@ -176,7 +176,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				ids.Add ("NSTouchBarItemIdentifierFlexibleSpace");
 				return ids.ToArray ();
 			} 
-			else if (this.barType == TouchBarType.WelcomePage) {
+			else if (BarType == TouchBarType.WelcomePage) {
 				ids.Add("recentItems");
 				return ids.ToArray ();
 			} 
@@ -212,14 +212,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				return item;
 			case "navigation": //contains navigate back & forward buttons
 
-				//NSSegmentedControl navSegments = null; //declared as static above due to GC bug
+				//NSSegmentedControl navControl = null; //declared as static above due to GC bug
 
-				Action navSegmentsAction = () => {
+				Action navControlAction = () => {
 
-					if (navSegments != null) {
-						if (navSegments.SelectedSegment == 0) {
+					if (navControl != null) {
+						if (navControl.SelectedSegment == 0) {
 							IdeApp.CommandService.DispatchCommand ("MonoDevelop.Ide.Commands.NavigationCommands.NavigateBack");
-						} else if (navSegments.SelectedSegment == 1) {
+						} else if (navControl.SelectedSegment == 1) {
 							IdeApp.CommandService.DispatchCommand ("MonoDevelop.Ide.Commands.NavigationCommands.NavigateForward");
 						}
 					}
@@ -232,41 +232,41 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					};
 
 
-				navSegments = NSSegmentedControl.FromImages (navIcons, NSSegmentSwitchTracking.Momentary, navSegmentsAction);
-				navSegments.SegmentStyle = NSSegmentStyle.Separated;
+				navControl = NSSegmentedControl.FromImages (navIcons, NSSegmentSwitchTracking.Momentary, navControlAction);
+				navControl.SegmentStyle = NSSegmentStyle.Separated;
 
-				var customItemNavSegments = new NSCustomTouchBarItem ("navigation");
-				customItemNavSegments.CustomizationLabel = "Navigation";
-				customItemNavSegments.View = navSegments;
-				item = customItemNavSegments;
+				var customItemNavControl = new NSCustomTouchBarItem ("navigation");
+				customItemNavControl.CustomizationLabel = "Navigation";
+				customItemNavControl.View = navControl;
+				item = customItemNavControl;
 
 				return item;
 				
 			case "tabNavigation": //navigation again, but this time for tabs. Lack of images is a work-in-progress
 
-				//NSSegmentedControl tabNavSegments = null; //declared as static above due to GC bug
+				//NSSegmentedControl tabNavControl = null; //declared as static above due to GC bug
 
-				Action tabNavSegmentsAction = () => {
+				Action tabNavControlAction = () => {
 					
-					if (tabNavSegments != null) {
+					if (tabNavControl != null) {
 						
-						if (tabNavSegments.SelectedSegment == 0) {
+						if (tabNavControl.SelectedSegment == 0) {
 							IdeApp.CommandService.DispatchCommand (MonoDevelop.Ide.Commands.WindowCommands.PrevDocument);
 						} 
-						else if (tabNavSegments.SelectedSegment == 1) {
+						else if (tabNavControl.SelectedSegment == 1) {
 							IdeApp.CommandService.DispatchCommand (MonoDevelop.Ide.Commands.WindowCommands.NextDocument);
 						}
 					}
 
 				};
 
-				tabNavSegments = NSSegmentedControl.FromLabels (new string [] { "<-tab", "tab->" }, NSSegmentSwitchTracking.Momentary, tabNavSegmentsAction);
-				tabNavSegments.SegmentStyle = NSSegmentStyle.Separated;
+				tabNavControl = NSSegmentedControl.FromLabels (new string [] { "<-tab", "tab->" }, NSSegmentSwitchTracking.Momentary, tabNavControlAction);
+				tabNavControl.SegmentStyle = NSSegmentStyle.Separated;
 
-				var customItemTabNavSegments = new NSCustomTouchBarItem ("tabNavigation");
-				customItemTabNavSegments.CustomizationLabel = "Tab Controls";
-				customItemTabNavSegments.View = tabNavSegments;
-				item = customItemTabNavSegments;
+				var customItemTabNavControl = new NSCustomTouchBarItem ("tabNavigation");
+				customItemTabNavControl.CustomizationLabel = "Tab Controls";
+				customItemTabNavControl.View = tabNavControl;
+				item = customItemTabNavControl;
 
 				return item;
 
@@ -282,7 +282,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					RunButton.PerformClick (RunButton);
 				};
 #endif
-				this.touchBarRunButton = button;
+				TouchBarRunButton = button;
 
 				customItem.View = button;
 			

--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -101,7 +101,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 
 			ids.Add ("navigation");
-
+			ids.Add ("tabNavigation");
+			
 			if (ButtonBarContainer != null) {
 				var extraIds = ButtonBarContainer.GetButtonBarTouchBarItems ();
 				if (extraIds != null) {
@@ -153,6 +154,30 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				var customGroupItem = NSGroupTouchBarItem.CreateGroupItem(identifier, items);
 
 				item = customGroupItem;
+
+				return item;
+				
+			case "tabNavigation": //navigation again, but this time for tabs. Lack of images is a work-in-progress
+
+				var customItemTabNavL = new NSCustomTouchBarItem ("tabNavigationLeft");
+				var lButton = NSButton.CreateButton ("tabL", () => { });
+				lButton.Activated += (sender, e) => {
+					IdeApp.CommandService.DispatchCommand (MonoDevelop.Ide.Commands.WindowCommands.PrevDocument);
+				};
+				customItemTabNavL.View = lButton;
+
+				var customItemTabNavR = new NSCustomTouchBarItem("tabNavigationRight");
+				var rButton = NSButton.CreateButton ("tabR", () => { });
+				rButton.Activated += (sender, e) => {
+					IdeApp.CommandService.DispatchCommand (MonoDevelop.Ide.Commands.WindowCommands.NextDocument);
+				};
+				customItemTabNavR.View = rButton;
+
+				NSTouchBarItem [] tabNavItems = { customItemTabNavL, customItemTabNavR };
+
+				var customTabNavGroupItem = NSGroupTouchBarItem.CreateGroupItem (identifier, tabNavItems);
+
+				item = customTabNavGroupItem;
 
 				return item;
 


### PR DESCRIPTION
Hopefully this pull request isn't too big, but it took me this long to get around to reimplementing all of the features present in the base fork. The touchbar now presents different bars depending on the context:
*Welcome Page bar, which displays recent solutions from the Welcome Page allowing for easy access
*Text Editor bar, which is basically the main bar, it is intended to be user-customizable, but a bug means that functionality is currently disabled
*Debug bar, which presents the debug controls
*There are references to a Preferences bar, currently unimplemented, which would allow the user to scrub through tabs in the preferences window

Basically this is a first pass at figuring out how the touchbar features would work, both in terms of UI and structuring in code. This feature isn't done, and I'd like to stress nobody should be afraid to improve upon what I've written here.