### PR TITLE
[CommandManager] Throttle undo/redo on Mac

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -428,6 +428,11 @@ namespace MonoDevelop.Components.Commands
 			}
 		}
 
+#if MAC
+		const uint THROTTLE_TIME_SPREAD = 75;
+		static uint throttleLastEventTime = 0;
+#endif
+
 		internal bool ProcessKeyEvent (Gdk.EventKey ev)
 		{
 			if (!IsEnabled)
@@ -492,6 +497,15 @@ namespace MonoDevelop.Components.Commands
 				}
 
 				if (cinfo.Enabled && cinfo.Visible) {
+#if MAC
+					string id = commands [i].Id as string;
+					if (id == "MonoDevelop.Ide.Commands.EditCommands.Undo" || id == "MonoDevelop.Ide.Commands.EditCommands.Redo") {
+						if (ev.Time - throttleLastEventTime < THROTTLE_TIME_SPREAD)
+							break;
+						throttleLastEventTime = ev.Time;
+					}
+#endif
+
 					if (!dispatched)
 						dispatched = DispatchCommand (commands [i].Id, CommandSource.Keybinding);
 					conflict.Add (commands [i]);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -426,6 +426,8 @@ namespace MonoDevelop.Components.Commands
 				// incomplete accel
 				NotifyIncompleteKeyReleased (e.Event);
 			}
+
+			throttleLastEventTime = 0;
 		}
 
 #if MAC

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -427,7 +427,9 @@ namespace MonoDevelop.Components.Commands
 				NotifyIncompleteKeyReleased (e.Event);
 			}
 
+#if MAC
 			throttleLastEventTime = 0;
+#endif
 		}
 
 #if MAC


### PR DESCRIPTION
Not an ideal solution, but improves user experience noticeably.
This lets the text editor update and render before more undo
commands are fired.

https://bugzilla.xamarin.com/show_bug.cgi?id=34828