### PR TITLE
Always set CommandInfo.DataItem + parametrized connected services command

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -1351,6 +1351,7 @@ namespace MonoDevelop.Components.Commands
 				CommandTargetRoute targetRoute = new CommandTargetRoute (initialTarget);
 				object cmdTarget = GetFirstCommandTarget (targetRoute);
 				CommandInfo info = new CommandInfo (cmd);
+				info.DataItem = dataItem;
 
 				while (cmdTarget != null)
 				{


### PR DESCRIPTION
Usually a command is dispatched from a menu item in the context of the current active IDE element (editor, curretly selected project, etc.). Only array commands (recent files, windows, etc.) have an additional `DataItem` which gets passed to the command handler.

An alternative method to dispatch commands is `CommandService.DispatchCommand` which accepts an optional `dataItem` object as a parameter to any command, but it won't be received by the handler, because we assign `CommandInfo.DataItem` only for array commands.

With a915982 `CommandInfo.DataItem` will be always set, allowing all command handlers to receive parameters from the command service.

The first command making use of the `dataItem` parameter is the connected services gallery, which can be opened in the context of a specific project and receive a special service id, to open a  service page directly.