### PR TITLE
[Ide] Ensure document actions are run on UI thread.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -350,7 +350,7 @@ namespace MonoDevelop.Ide.Gui
 		Task RunAsyncOperation (Func<Task> action)
 		{
 			Runtime.AssertMainThread ();
-			return currentOperationTask = currentOperationTask.ContinueWith (t => action()).Unwrap ();
+			return currentOperationTask = currentOperationTask.ContinueWith (t => action(), Runtime.MainTaskScheduler).Unwrap ();
 		}
 
 		public Task Reload ()


### PR DESCRIPTION
Without the main UI thread's task scheduler being passed to the
ContinueWith the action was run on a thread pool thread instead of
the UI thread. This was causing the FileService.FileChanged event to
fire on a non-UI thread. It was also causing a crash if the project
file is edited in the text editor since the reload was being done on
a non-UI thread.