### PR TITLE
[DotNetCore] Fix OwnerProject null for project ref after reevaluation

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
@@ -76,6 +76,7 @@ namespace MonoDevelop.Projects
 		public void SetItems (IEnumerable<T> items)
 		{
 			AssertCanWrite ();
+			items = ReuseExistingItems (items);
 			var newItems = items.Except (list);
 			var removedItems = list.Except (items);
 			list = ImmutableList<T>.Empty.AddRange (items);
@@ -83,6 +84,19 @@ namespace MonoDevelop.Projects
 				OnItemsAdded (newItems);
 			if (removedItems.Any ())
 				OnItemsRemoved (removedItems);
+		}
+
+		IEnumerable<T> ReuseExistingItems (IEnumerable<T> items)
+		{
+			var updatedItems = new List<T> ();
+			foreach (var item in items) {
+				int index = list.IndexOf (item);
+				if (index == -1)
+					updatedItems.Add (item);
+				else
+					updatedItems.Add (list [index]);
+			}
+			return updatedItems;
 		}
 
 		public void Insert (int index, T item)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2645,10 +2645,26 @@ namespace MonoDevelop.Projects
 				if (loadedItems != null)
 					loadedItems.Add (buildItem.SourceItem);
 			}
-			if (IsReevaluating)
+			if (IsReevaluating) {
 				Items.SetItems (localItems);
-			else
+				SetProjectReferenceOwner (localItems);
+			} else
 				Items.AddRange (localItems);
+		}
+
+		/// <summary>
+		/// Re-evaluated project references do not have the OwnerProject set
+		/// because the Items.SetItems call in LoadItems does not trigger an items added
+		/// notification for new ProjectReferences that were added. The ProjectReference's
+		/// implementation of GetHashCode and Equals prevents the items added notification
+		/// from being fired.
+		/// </summary>
+		void SetProjectReferenceOwner (List<ProjectItem> reevaluatedItems)
+		{
+			foreach (var projectReference in reevaluatedItems.OfType<ProjectReference> ()) {
+				if (projectReference.OwnerProject == null)
+					projectReference.SetOwnerProject (this as DotNetProject);
+			}
 		}
 
 		protected override void OnSetFormat (MSBuildFileFormat format)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2645,9 +2645,9 @@ namespace MonoDevelop.Projects
 				if (loadedItems != null)
 					loadedItems.Add (buildItem.SourceItem);
 			}
-			if (IsReevaluating) {
+			if (IsReevaluating)
 				Items.SetItems (localItems);
-			} else
+			else
 				Items.AddRange (localItems);
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2647,24 +2647,8 @@ namespace MonoDevelop.Projects
 			}
 			if (IsReevaluating) {
 				Items.SetItems (localItems);
-				SetProjectReferenceOwner (localItems);
 			} else
 				Items.AddRange (localItems);
-		}
-
-		/// <summary>
-		/// Re-evaluated project references do not have the OwnerProject set
-		/// because the Items.SetItems call in LoadItems does not trigger an items added
-		/// notification for new ProjectReferences that were added. The ProjectReference's
-		/// implementation of GetHashCode and Equals prevents the items added notification
-		/// from being fired.
-		/// </summary>
-		void SetProjectReferenceOwner (List<ProjectItem> reevaluatedItems)
-		{
-			foreach (var projectReference in reevaluatedItems.OfType<ProjectReference> ()) {
-				if (projectReference.OwnerProject == null)
-					projectReference.SetOwnerProject (this as DotNetProject);
-			}
 		}
 
 		protected override void OnSetFormat (MSBuildFileFormat format)

--- a/main/tests/UnitTests/MonoDevelop.Projects/ProjectReevaluationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/ProjectReevaluationTests.cs
@@ -241,10 +241,10 @@ namespace MonoDevelop.Projects
 
 			var library1Item = p.Items.OfType<ProjectReference> ().First (r => r.Include == @"..\library1\library1.csproj");
 
-			Assert.AreEqual (0, itemAdded); // Should the reference be re-added or the existing one found?
+			Assert.AreEqual (0, itemAdded);
 			Assert.AreEqual (0, itemRemoved);
 			Assert.AreEqual (p, library1Item.OwnerProject);
-			//Assert.AreSame (library1Reference, library1Item); // Not the same object.
+			Assert.AreSame (library1Reference, library1Item);
 			Assert.AreEqual (library1Reference, library1Item);
 		}
 	}


### PR DESCRIPTION
When a new project reference is added and then the project is
reevaluated the project reference is replaced with a new instance
but the OwnerProject is not set. This caused code completion to stop
working in the text editor and types were marked with red error
markers.

A new ProjectReference has a BackingEvalItem which has no properties
so on reevaluating a new ProjectReference is created since no match
is found due to the missing properties. On calling Items.SetItem
there is no items added notification since ProjectReference implements
GetHashCode and Equals and the different instances are considered to
be the same. This resulted in a null OwnerProject for the
ProjectReference and when that was written out to xml a null reference
exception was thrown. To fix this the OwnerProject is set after
reevaluation if it is null.