### PR TITLE
[Ide] Fix Clean failures not reported on Rebuild

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1178,7 +1178,9 @@ namespace MonoDevelop.Ide
 			}
 			
 			if (isRebuilding) {
-				if (EndClean != null) {
+				if (res.HasErrors) {
+					CleanDone (monitor, res, entry, tt);
+				} else if (EndClean != null) {
 					OnEndClean (monitor, tt);
 				}
 			} else {
@@ -1186,22 +1188,6 @@ namespace MonoDevelop.Ide
 			}
 			return res;
 		}
-		
-		void CleanDone (ProgressMonitor monitor, IBuildTarget entry, ITimeTracker tt)
-		{
-			tt.Trace ("Begin reporting clean result");
-			try {
-				monitor.Log.WriteLine ();
-				monitor.Log.WriteLine (GettextCatalog.GetString ("---------------------- Done ----------------------"));
-				tt.Trace ("Reporting result");			
-				monitor.ReportSuccess (GettextCatalog.GetString ("Clean successful."));
-				OnEndClean (monitor, tt);
-			} finally {
-				monitor.Dispose ();
-				tt.End ();
-			}
-		}
-
 
 		void CleanDone (ProgressMonitor monitor, BuildResult result, IBuildTarget entry, ITimeTracker tt)
 		{


### PR DESCRIPTION
Clean failures were reported if a Clean was done but not when a
Rebuild was run. The status bar would not show any error and the
Errors window would not show any failures. Also removed some unused
code that is not used when reporting Clean results.