### PR TITLE
Using buildver variable

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/Mono.Debugging.Win32.nuspec
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/Mono.Debugging.Win32.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Mono.Debugging.Win32</id>
-    <version>$Version$</version>
+    <version>$buildver$</version>
     <title>Mono.Debugging.Win32</title>
     <authors>MonoDevelop team</authors>
     <owners>MonoDevelop team</owners>
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <tags>mono debug debugger cordebug</tags>
     <dependencies>
-      <dependency id="Mono.Debugging" version="$Version$" />
+      <dependency id="Mono.Debugging" version="$buildver$" />
     </dependencies>
   </metadata>
   <files>

--- a/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/Mono.Debugging.Win32.nuspec
+++ b/main/src/addins/MonoDevelop.Debugger.Win32/Mono.Debugging.Win32/Mono.Debugging.Win32.nuspec
@@ -18,7 +18,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\$Configuration$\CorApi.dll" target="lib/net40" />
-    <file src="bin\$Configuration$\CorApi2.dll" target="lib/net40" />
+    <file src="bin\$Configuration$\CorApi.dll" target="lib/net45" />
+    <file src="bin\$Configuration$\CorApi2.dll" target="lib/net45" />
   </files>
 </package>


### PR DESCRIPTION
Using buildver variable instead of Version because Version can't be used in <dependency> tag
