### PR TITLE
Make Connected Services API public

### DIFF
--- a/main/src/addins/MonoDevelop.ConnectedServices/ConnectedServices.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/ConnectedServices.cs
@@ -88,23 +88,23 @@ namespace MonoDevelop.ConnectedServices
 		/// <summary>
 		/// Displays the service details tab for the given service
 		/// </summary>
-		public static void OpenServicesTab (this IConnectedService service)
+		public static Task OpenServicesTab (this IConnectedService service)
 		{
 			if (service == null)
 				throw new ArgumentNullException (nameof (service));
 
-			Runtime.RunInMainThread (() => OpenServicesTab (service.Project, service.Id));
+			return Runtime.RunInMainThread (() => OpenServicesTab (service.Project, service.Id));
 		}
 
 		/// <summary>
 		/// Displays the services gallery tab for the given project
 		/// </summary>
-		public static void OpenServicesTab (this DotNetProject project)
+		public static Task OpenServicesTab (this DotNetProject project)
 		{
 			if (project == null)
 				throw new ArgumentNullException (nameof (project));
 
-			Runtime.RunInMainThread (() => OpenServicesTab (project, null));
+			return Runtime.RunInMainThread (() => OpenServicesTab (project, null));
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.ConnectedServices/ConnectedServices.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/ConnectedServices.cs
@@ -15,7 +15,7 @@ namespace MonoDevelop.ConnectedServices
 	/// <summary>
 	/// Defines a set of constants for the Connected Services addin
 	/// </summary>
-	static class ConnectedServices
+	public static class ConnectedServices
 	{
 		/// <summary>
 		/// The extension point for service providers
@@ -64,8 +64,11 @@ namespace MonoDevelop.ConnectedServices
 		/// <summary>
 		/// Displays the service details tab for the given service in the given project
 		/// </summary>
-		public static void OpenServicesTab(DotNetProject project, string serviceId = null)
+		internal static void OpenServicesTab(DotNetProject project, string serviceId)
 		{
+			if (project == null)
+				project = IdeApp.ProjectOperations.CurrentSelectedProject as DotNetProject;
+
 			ConnectedServicesViewContent servicesView = null;
 
 			foreach (var view in IdeApp.Workbench.Documents) {
@@ -80,6 +83,28 @@ namespace MonoDevelop.ConnectedServices
 			servicesView = new ConnectedServicesViewContent (project);
 			servicesView.UpdateContent (serviceId);
 			IdeApp.Workbench.OpenDocument (servicesView, true);
+		}
+
+		/// <summary>
+		/// Displays the service details tab for the given service
+		/// </summary>
+		public static void OpenServicesTab (this IConnectedService service)
+		{
+			if (service == null)
+				throw new ArgumentNullException (nameof (service));
+
+			Runtime.RunInMainThread (() => OpenServicesTab (service.Project, service.Id));
+		}
+
+		/// <summary>
+		/// Displays the services gallery tab for the given project
+		/// </summary>
+		public static void OpenServicesTab (this DotNetProject project)
+		{
+			if (project == null)
+				throw new ArgumentNullException (nameof (project));
+
+			Runtime.RunInMainThread (() => OpenServicesTab (project, null));
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.ConnectedServices/Gui.ServicesTab/ConnectedServicesViewContent.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/Gui.ServicesTab/ConnectedServicesViewContent.cs
@@ -57,6 +57,7 @@ namespace MonoDevelop.ConnectedServices.Gui.ServicesTab
 					this.widget.ShowServiceDetails (service);
 					return;
 				}
+				LoggingService.LogError ("Showing service details failed, service id {0} not found", serviceId);
 			}
 
 			var services = binding.SupportedServices;

--- a/main/src/addins/MonoDevelop.ConnectedServices/Gui.ServicesTab/ConnectedServicesViewContent.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/Gui.ServicesTab/ConnectedServicesViewContent.cs
@@ -51,13 +51,16 @@ namespace MonoDevelop.ConnectedServices.Gui.ServicesTab
 		public void UpdateContent(string serviceId)
 		{
 			var binding = ((DotNetProject)this.Project).GetConnectedServicesBinding ();
-			if (string.IsNullOrEmpty (serviceId)) {
-				var services = binding.SupportedServices;
-				this.widget.ShowGallery (services, Project);
-			} else {
+			if (!string.IsNullOrEmpty (serviceId)) {
 				var service = binding.SupportedServices.FirstOrDefault (x => x.Id == serviceId);
-				this.widget.ShowServiceDetails (service);
+				if (service != null) {
+					this.widget.ShowServiceDetails (service);
+					return;
+				}
 			}
+
+			var services = binding.SupportedServices;
+			this.widget.ShowGallery (services, Project);
 		}
 
 		object currentNodeObject;


### PR DESCRIPTION
This change makes the following features public:
* Open the services gallery for a given project
* Open the service details view for a given service
* Query services supporting a given project
* Remove a service from a project (asking user for confirmation)

Would it make sense to open more features? Like adding a service to a project and show the confirmation dialog (allowing to add a service to all referencing projects) maybe?

cc @sgmunn