### PR TITLE
[48669] Fix native contextmenu positioning

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPad.cs
@@ -194,7 +194,7 @@ namespace MonoDevelop.Debugger
 
 		void ShowPopup (Gdk.EventButton evt)
 		{
-			IdeApp.CommandService.ShowContextMenu (tree, evt, menuSet, tree);
+			tree.ShowContextMenu (evt, menuSet, tree);
 		}
 		
 		[CommandHandler (LocalCommands.Properties)]

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1969,7 +1969,7 @@ namespace MonoDevelop.Debugger
 		void ShowPopup (Gdk.EventButton evt)
 		{
 			if (AllowPopupMenu)
-				IdeApp.CommandService.ShowContextMenu (this, evt, menuSet, this);
+				this.ShowContextMenu (evt, menuSet, this);
 		}
 
 		[CommandUpdateHandler (EditCommands.SelectAll)]

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/Toolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/Toolbox.cs
@@ -183,9 +183,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				return;
 			CommandEntrySet eset = IdeApp.CommandService.CreateCommandEntrySet ("/MonoDevelop/DesignerSupport/ToolboxItemContextMenu");
 			if (evt != null) {
-				IdeApp.CommandService.ShowContextMenu (this, evt, eset, this);
+				IdeApp.CommandService.ShowContextMenu (toolboxWidget, evt, eset, this);
 			} else {
-				IdeApp.CommandService.ShowContextMenu (this, Allocation.Left, Allocation.Top, eset, this);
+				IdeApp.CommandService.ShowContextMenu (toolboxWidget, Allocation.Left, Allocation.Top, eset, this);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -524,11 +524,9 @@ namespace MonoDevelop.SourceEditor
 
 			if (Platform.IsMac) {
 				if (evt == null) {
-					int x, y;
 					var pt = LocationToPoint (this.Caret.Location);
-					TranslateCoordinates (Toplevel, pt.X, pt.Y, out x, out y);
 
-					IdeApp.CommandService.ShowContextMenu (this, x, y, cset, this);
+					IdeApp.CommandService.ShowContextMenu (this, pt.X, pt.Y, cset, this);
 				} else {
 					IdeApp.CommandService.ShowContextMenu (this, evt, cset, this);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -812,7 +812,7 @@ namespace MonoDevelop.VersionControl.Views
 				} else
 					opset.AddSeparator ();
 			}
-			IdeApp.CommandService.ShowContextMenu (filelist, evnt, opset, commandChain);
+			filelist.ShowContextMenu (evnt, opset, commandChain);
 		}
 
 		public VersionControlItemList GetSelectedItems ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenu.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenu.cs
@@ -81,11 +81,7 @@ namespace MonoDevelop.Components
 		{
 			#if MAC
 			if (Platform.IsMac) {
-				int tx, ty;
-
-				// x, y are in gtk coordinates, so they need to be translated for Cocoa.
-				parent.TranslateCoordinates (parent.Toplevel, x, y, out tx, out ty);
-				ContextMenuExtensionsMac.ShowContextMenu (parent, tx, ty, this, closeHandler, selectFirstItem);
+				ContextMenuExtensionsMac.ShowContextMenu (parent, x, y, this, closeHandler, selectFirstItem);
 				return;
 			}
 			#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -92,6 +92,8 @@ namespace MonoDevelop.Components
 					titleBarOffset = MonoDevelop.Components.Mac.GtkMacInterop.GetTitleBarHeight () + 12;
 				}
 
+				parent.TranslateCoordinates (parent.Toplevel, x, y, out x, out y);
+
 				if (selectFirstItem) {
 					var pt = new CoreGraphics.CGPoint (x, y);
 					lastOpenPositon = pt;
@@ -111,9 +113,12 @@ namespace MonoDevelop.Components
 
 		public static void ShowContextMenu (Gtk.Widget parent, Gdk.EventButton evt, NSMenu menu)
 		{
-			int x, y;
+			int x = 0, y = 0;
 
-			parent.TranslateCoordinates (parent.Toplevel, (int)evt.X, (int)evt.Y, out x, out y);
+			if (evt != null) {
+				x = (int)evt.X;
+				y = (int)evt.Y;
+			}
 
 			ShowContextMenu (parent, x, y, menu);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -777,6 +777,32 @@ namespace MonoDevelop.Components
 				args.RetVal = true;
 			}
 		}
+
+		/// <summary>
+		/// Shows the context menu for a TreeView.
+		/// </summary>
+		/// <returns><c>true</c>, if context menu was shown, <c>false</c> otherwise.</returns>
+		/// <param name="tree">Gtk TreeView for which the context menu is shown</param>
+		/// <param name="evt">The current mouse event, or <c>null</c>.</param>
+		/// <param name="entrySet">Entry set with the command definitions</param>
+		/// <param name="initialCommandTarget">Initial command target.</param>
+		public static bool ShowContextMenu (this Gtk.TreeView tree, Gdk.EventButton evt, Commands.CommandEntrySet entrySet,
+			object initialCommandTarget = null)
+		{
+			if (evt == null) {
+				var paths = tree.Selection.GetSelectedRows ();
+				if (paths != null) {
+					var area = tree.GetCellArea (paths [0], tree.Columns [0]);
+					return Ide.IdeApp.CommandService.ShowContextMenu (tree, area.Left, area.Top, entrySet, initialCommandTarget);
+				} else
+					return Ide.IdeApp.CommandService.ShowContextMenu (tree, 0, 0, entrySet, initialCommandTarget);
+			} else {
+				int x = (int)evt.X, y = (int)evt.Y;
+				if (Platform.IsMac && tree.BinWindow == evt.Window)
+					tree.ConvertBinWindowToWidgetCoords (x, y, out x, out y);
+				return Ide.IdeApp.CommandService.ShowContextMenu (tree, x, y, entrySet, initialCommandTarget);
+			}
+		}
 	}
 
 	class EventKeyWrapper: Gdk.EventKey

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -1946,16 +1946,7 @@ namespace MonoDevelop.Ide.Gui.Components
 			if (entryset == null)
 				return;
 
-			if (evt == null) {
-				var paths = tree.Selection.GetSelectedRows ();
-				if (paths != null) {
-					var area = tree.GetCellArea (paths [0], tree.Columns [0]);
-
-					IdeApp.CommandService.ShowContextMenu (this, area.Left, area.Top, entryset, this);
-				}
-			} else {
-				IdeApp.CommandService.ShowContextMenu (this, evt, entryset, this);
-			}
+			tree.ShowContextMenu (evt, entryset, this);
 		}
 
 		CommandEntrySet BuildEntrySet ()


### PR DESCRIPTION
This patch fixes the positioning of tree context menus, especially when opened using the Shift+F10 key combination.