### PR TITLE
[F#] Merge item groups for VS/Windows compatibility

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/ProjectTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/ProjectTests.fs
@@ -61,8 +61,12 @@ type ProjectTests() =
                 let files =
                     [ path / "MainActivity.fs", "Compile"
                       path / "Properties" / "AssemblyInfo.fs", "Compile"
-                      path / "Resources" / "AboutResources.txt", "None" 
-                      path / "Properties" / "AndroidManifest.xml", "None" ]
+                      path / "Resources" / "AboutResources.txt", "None"
+                      path / "Properties" / "AndroidManifest.xml", "None"
+                      path / "Properties" / "9.txt", "None"
+                      path / "Properties" / "8.txt", "None"
+                      path / "Properties" / "7.txt", "None"
+                      ]
 
                 files |> List.iter(fun (path, buildAction) ->
                                         Directory.CreateDirectory(Path.GetDirectoryName path) |> ignore
@@ -80,6 +84,9 @@ type ProjectTests() =
                     ["MainActivity.fs"
                      "Properties\\AssemblyInfo.fs"
                      "Properties\\AndroidManifest.xml"
+                     "Properties\\9.txt"
+                     "Properties\\8.txt"
+                     "Properties\\7.txt"
                      "Resources\\AboutResources.txt"]
 
         }

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -74,10 +74,8 @@ type FSharpProject() as self =
             groups
             |> Seq.collect (fun grp -> grp.Items)
             |> Seq.filter  (fun item ->
-                                   item.Name = "None"
-                                || item.Name = "Compile"
-                                || item.Name = "AndroidResource" 
-                                || item.Name = "Folder")
+                let absolutePath = MSBuildProjectService.FromMSBuildPath(project.FileName.ParentDirectory.ToString(), item.Include)
+                File.Exists absolutePath)
 
             |> Seq.groupBy directoryNameFromBuildItem
             |> Seq.sortBy (fun (folder, _items) -> folder)

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -87,14 +87,17 @@ type FSharpProject() as self =
             |> List.filter (fun (_, items) -> items.Length > 0)
 
         let isParentDirectory folderName fileName =
-            let absoluteFolder = DirectoryInfo (absolutePath folderName)
-            let absoluteFile = FileInfo (absolutePath fileName)
-            let rec isParentDirRec (dir:DirectoryInfo) =
-                match dir with
-                | null -> false
-                | dir when dir.FullName = absoluteFolder.FullName -> true
-                | _ -> isParentDirRec dir.Parent
-            isParentDirRec absoluteFile.Directory
+            if String.isEmpty folderName then
+                true
+            else
+                let absoluteFolder = DirectoryInfo (absolutePath folderName)
+                let absoluteFile = FileInfo (absolutePath fileName)
+                let rec isParentDirRec (dir:DirectoryInfo) =
+                    match dir with
+                    | null -> false
+                    | dir when dir.FullName = absoluteFolder.FullName -> true
+                    | _ -> isParentDirRec dir.Parent
+                isParentDirRec absoluteFile.Directory
 
         let unsorted = itemGroups |> List.collect snd
         let rec splitFilesByParent (items:MSBuildItem list) parentFolder list1 list2 =

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -73,7 +73,7 @@ type FSharpProject() as self =
         let msbuildItemExistsAsFile (item:MSBuildItem) =
            let projectPath = project.FileName.ParentDirectory |> string
            let itemPath = MSBuildProjectService.FromMSBuildPath(projectPath, item.Include)
-           File.Exists itemPath
+           item.Name <> "ProjectReference" && File.Exists itemPath
 
         let groups = project.ItemGroups |> List.ofSeq
         let itemGroups =


### PR DESCRIPTION
By default, Xamarin Studio creates an ItemGroup for each
build action type like this :-

```
<ItemGroup>
  <Compile Include="MainActivity.fs" />
  <Compile Include="Resources\Resource.designer.fs" />
  <Compile Include="Properties\AssemblyInfo.fs" />
</ItemGroup>
<ItemGroup>
  <None Include="Resources\AboutResources.txt" />
  <None Include="Properties\AndroidManifest.xml" />
  <None Include="Assets\AboutAssets.txt" />
  <None Include="packages.config" />
</ItemGroup>
<ItemGroup>
  <Folder Include="Resources\layout\" />
  <Folder Include="Resources\values\" />
</ItemGroup>
<ItemGroup>
  <AndroidResource Include="Resources\drawable\icon.png" />
  <AndroidResource Include="Resources\drawable-hdpi\icon.png" />
  <AndroidResource Include="Resources\drawable-xhdpi\icon.png" />
  <AndroidResource Include="Resources\drawable-xxhdpi\icon.png" />
</ItemGroup>
```

but Visual Studio on Windows can't load this, so merge these items to a
single ItemGroup ordered by folder name like this :-

```
<ItemGroup>
  <Compile Include="MainActivity.fs" />
  <None Include="Assets\AboutAssets.txt" />
  <Compile Include="Resources\Resource.designer.fs" />
  <None Include="Resources\AboutResources.txt" />
  <AndroidResource Include="Resources\drawable\icon.png" />
  <AndroidResource Include="Resources\drawable-hdpi\icon.png" />
  <AndroidResource Include="Resources\drawable-xhdpi\icon.png" />
  <AndroidResource Include="Resources\drawable-xxhdpi\icon.png" />
  <Compile Include="Properties\AssemblyInfo.fs" />
  <None Include="Properties\AndroidManifest.xml" />
  <None Include="packages.config" />
</ItemGroup>
```

Files within a folder should remain in the original order.

Fixes #50797

 Lines starting