### PR TITLE
[Windows] Pause if launched from explorer.exe and if there is an error.

### DIFF
--- a/main/winbuild-release.bat
+++ b/main/winbuild-release.bat
@@ -2,3 +2,8 @@ git submodule update --init --recursive
 "external\nuget-binary\NuGet.exe" restore Main.sln
 "external\nuget-binary\NuGet.exe" restore external\RefactoringEssentials\RefactoringEssentials.sln
 "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Main.sln /m /p:Configuration=ReleaseWin32 /p:Platform="Any CPU" %*
+
+if NOT [%ERRORLEVEL%] == ["0"] (
+	for %%x in (%CMDCMDLINE%) do if /i "%%~x" == "/c" pause
+	exit /b %ERRORLEVEL%
+)

--- a/main/winbuild.bat
+++ b/main/winbuild.bat
@@ -2,3 +2,8 @@ git submodule update --init --recursive
 "external\nuget-binary\NuGet.exe" restore Main.sln
 "external\nuget-binary\NuGet.exe" restore external\RefactoringEssentials\RefactoringEssentials.sln
 "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Main.sln /m /p:Configuration=DebugWin32 /p:Platform="Any CPU" %*
+
+if NOT [%ERRORLEVEL%] == ["0"] (
+	for %%x in (%CMDCMDLINE%) do if /i "%%~x" == "/c" pause
+	exit /b %ERRORLEVEL%
+)


### PR DESCRIPTION
If something goes wrong when trying to build locally you just see a split second of red in this Windows prompt. Adding pause here will leave the prompt open until you hit a key.