### PR TITLE
[CSharp] Fix gtk call happening on the UI thread

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
@@ -682,7 +682,8 @@ namespace MonoDevelop.CSharp
 			if (reg == null) {
 				entry = new PathEntry (GettextCatalog.GetString ("No region"));
 			} else {
-				entry = new PathEntry (CompilationUnitDataProvider.Pixbuf, GLib.Markup.EscapeText (reg.Name));
+				var pixbuf = await Runtime.RunInMainThread (() => CompilationUnitDataProvider.Pixbuf).ConfigureAwait (false);
+				entry = new PathEntry (pixbuf, GLib.Markup.EscapeText (reg.Name));
 			}
 			entry.Position = EntryPosition.Right;
 			return entry;


### PR DESCRIPTION
```
WARNING **: Gtk operations should be done on the main Thread
at System.Environment.get_StackTrace () [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System/Environment.cs:321
at Gtk.Application.AssertMainThread () [0x00023] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-None/gtk/Application.cs:124
at Gtk.Icon.SizeLookup (Gtk.IconSize size, System.Int32& width, System.Int32& height) [0x00001] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-None/gtk/generated/Icon.cs:50
at MonoDevelop.Components.GtkUtil.GetSize (Gtk.IconSize size, System.Int32& width, System.Int32& height) [0x00000] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs:188
at MonoDevelop.Components.GtkUtil.WithSize (Xwt.Drawing.Image image, Gtk.IconSize size) [0x00000] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs:175
at MonoDevelop.Ide.ImageService.GetIcon (System.String name, Gtk.IconSize size) [0x00009] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs:171
at MonoDevelop.CSharp.PathedDocumentTextEditorExtension+CompilationUnitDataProvider.get_Pixbuf () [0x00000] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs:608
at MonoDevelop.CSharp.PathedDocumentTextEditorExtension+<GetRegionEntry>c__async0.MoveNext () [0x00149] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs:685
at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].Start[TStateMachine] (TStateMachine& stateMachine) [0x00031] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:471
at MonoDevelop.CSharp.PathedDocumentTextEditorExtension.GetRegionEntry (MonoDevelop.Ide.TypeSystem.ParsedDocument unit, MonoDevelop.Ide.Editor.DocumentLocation loc) [0x00000] in <cf44a178d33743a49ac8a16ff1a263b8>:0
at MonoDevelop.CSharp.PathedDocumentTextEditorExtension+<Update>c__AnonStorey1A+<Update>c__async19.MoveNext () [0x0061c] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs:803
at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine] (TStateMachine& stateMachine) [0x00031] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:316
at MonoDevelop.CSharp.PathedDocumentTextEditorExtension+<Update>c__AnonStorey1A.<>m__0 () [0x00008] in /Users/builder/data/lanes/4010/79fea1cb/source/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs:738
```
Thanks @mrward for stacktrace