### PR TITLE
Remove old CSS/HTML/JSON mappings. To be replaced by WebTooling Addin

### DIFF
--- a/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
+++ b/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
@@ -164,9 +164,6 @@
 		            insertafter = "Xml"
 		           _label = "ASP.NET Files"
 		           extensions = "*.aspx,*.ashx,*.asmx,*.ascx,*.master,*.asax,*.cshtml" />
-		<FileFilter id = "Html"
-		            _label = "HTML Files"
-		            extensions = "*.htm,*.html"/>
 	</Extension>
 
 	<Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
@@ -195,7 +192,6 @@
 
 	<Extension path = "/MonoDevelop/TypeSystem/Parser">
 		<Parser class = "MonoDevelop.AspNet.WebForms.WebFormsParser" mimeType="application/x-aspx, application/x-ascx, application/x-master-page" />
-		<Parser class = "MonoDevelop.AspNet.Html.HtmlParser" mimeType="text/html, application/x-spark" />
 		<Parser class = "MonoDevelop.AspNet.Razor.RazorCSharpParser" mimeType="text/x-cshtml" />
 	</Extension>
 
@@ -293,13 +289,6 @@
 		<MimeType id="text/x-less" _description="LESS, CSS document" icon="md-html-file-icon" isText="true">
 			<File pattern="*.less" />
 		</MimeType>
-		<MimeType id="text/html" _description="HTML document" icon="md-html-file-icon" isText="true">
-			<File pattern="*.html|*.htm" />
-		</MimeType>
-		<MimeType id="application/x-spark" _description="Spark View template" icon="md-html-file-icon" isText="true"
-			baseType="text/html">
-			<File pattern="*.spark" />
-		</MimeType>
 		<MimeType id="application/typescript" _description="Typescript source code" icon="md-html-file-icon" isText="true">
 			<File pattern="*.ts" />
 		</MimeType>
@@ -310,7 +299,6 @@
 
 	<Extension path = "/MonoDevelop/Ide/TextEditorExtensions">
 		<Class fileExtensions=".aspx, .ascx, .master" class = "MonoDevelop.AspNet.WebForms.WebFormsEditorExtension" />
-		<Class fileExtensions=".html, .htm, .spark" class = "MonoDevelop.AspNet.Html.HtmlEditorExtension" />
 		<Class fileExtensions=".cshtml" class = "MonoDevelop.AspNet.Razor.RazorCSharpEditorExtension" />
 	</Extension>
 

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MimeTypes.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MimeTypes.addin.xml
@@ -22,9 +22,6 @@
 	<MimeType id="application/png" _description="PNG resource" icon="md-file-image">
 		<File pattern="*.png" />
 	</MimeType>
-	<MimeType id="text/css" _description="CSS document" icon="md-file-css" isText="true">
-		<File pattern="*.css" />
-	</MimeType>
 	<MimeType id="application/config+xml" _description="Configuration File" baseType="application/xml">
 		<File pattern="*.config" />
 	</MimeType>
@@ -82,9 +79,6 @@
 		<File pattern="*.sql" />
 	</MimeType>
 		
-	<MimeType id="application/json" _description="JSON files" isText="true">
-		<File pattern="*.json" />
-	</MimeType>
 	<MimeType id="application/x-sh" _description="Shell script" isText="true">
 		<File pattern="*.sh" />
 	</MimeType>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Templates.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Templates.addin.xml
@@ -64,7 +64,6 @@
 	<FileTemplate id = "EmptyEnum" resource = "EmptyEnum.xft.xml"/>
 	<FileTemplate id = "EmptyInterface" resource = "EmptyInterface.xft.xml"/>
 	<FileTemplate id = "EmptyStruct" resource = "EmptyStruct.xft.xml"/>
-	<FileTemplate id = "EmptyHTMLFile" resource = "EmptyHTMLFile.xft.xml"/>
 	<FileTemplate id = "AppConfigFile" resource = "AppConfigFile.xft.xml"/>
 	<FileTemplate id = "EmptyResourceFile" resource = "EmptyResourceFile.xft.xml"/>
 	<FileTemplate id = "EmptyTextFile" resource = "EmptyTextFile.xft.xml"/>


### PR DESCRIPTION
I wanted to change my file extensions from .css2, .html2, .json2 to the real things, so I needed to update MD so that we wouldn't collide.