### PR TITLE
Bug 36712 - Disabled SdbEvaluationAllowTargetInvokesTests.FormatArray unit test

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/EvaluationTests.cs
@@ -1721,7 +1721,6 @@ namespace MonoDevelop.Debugger.Tests
 			Assert.AreEqual ("int[,,]", val.TypeName);
 			Assert.IsFalse (val.IsNull);
 
-			IgnoreSoftDebugger ("Randomly fails, tracked as Bug 36712");
 			val = Eval ("nulledByteArray");
 			Assert.AreEqual ("(null)", val.Value);
 			Assert.AreEqual ("byte[]", val.TypeName);


### PR DESCRIPTION
Re-enabling unit test which was disabled in past because it randomly failed(only on Wrench), hopefully whatever was causing failure was fixed otherwise I will take a deeper look at cause of this