### PR TITLE
[msbuild] Make msbuild the default build engine, instead of xbuild

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -500,7 +500,7 @@ namespace MonoDevelop.Core
 		public readonly ConfigurationProperty<bool> EnableAutomatedTesting = ConfigurationProperty.Create ("MonoDevelop.EnableAutomatedTesting", false);
 		public readonly ConfigurationProperty<string> UserInterfaceLanguage = ConfigurationProperty.Create ("MonoDevelop.Ide.UserInterfaceLanguage", "");
 		public readonly ConfigurationProperty<MonoDevelop.Projects.MSBuild.MSBuildVerbosity> MSBuildVerbosity = ConfigurationProperty.Create ("MonoDevelop.Ide.MSBuildVerbosity", MonoDevelop.Projects.MSBuild.MSBuildVerbosity.Normal);
-		public readonly ConfigurationProperty<bool> BuildWithMSBuild = ConfigurationProperty.Create ("MonoDevelop.Ide.BuildWithMSBuild", false);
+		public readonly ConfigurationProperty<bool> BuildWithMSBuild = ConfigurationProperty.Create ("MonoDevelop.Ide.BuildWithMSBuild", true);
 		public readonly ConfigurationProperty<bool> ParallelBuild = ConfigurationProperty.Create ("MonoDevelop.ParallelBuild", true);
 
 		public readonly ConfigurationProperty<string> AuthorName = ConfigurationProperty.Create ("Author.Name", Environment.UserName, oldName:"ChangeLogAddIn.Name");

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget.cs
@@ -100,7 +100,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.buildWithMSBuildCheckBox = new global::Gtk.CheckButton();
 			this.buildWithMSBuildCheckBox.CanFocus = true;
 			this.buildWithMSBuildCheckBox.Name = "buildWithMSBuildCheckBox";
-			this.buildWithMSBuildCheckBox.Label = global::Mono.Unix.Catalog.GetString("Build with MSBuild instead of xbuild (EXPERIMENTAL)");
+			this.buildWithMSBuildCheckBox.Label = global::Mono.Unix.Catalog.GetString("Build with MSBuild instead of xbuild");
 			this.buildWithMSBuildCheckBox.DrawIndicator = true;
 			this.buildWithMSBuildCheckBox.UseUnderline = true;
 			this.vbox66.Add(this.buildWithMSBuildCheckBox);

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
@@ -976,7 +976,7 @@
           <widget class="Gtk.CheckButton" id="buildWithMSBuildCheckBox">
             <property name="MemberName" />
             <property name="CanFocus">True</property>
-            <property name="Label" translatable="yes">Build with MSBuild instead of xbuild (EXPERIMENTAL)</property>
+            <property name="Label" translatable="yes">Build with MSBuild instead of xbuild</property>
             <property name="DrawIndicator">True</property>
             <property name="HasLabel">True</property>
             <property name="UseUnderline">True</property>


### PR DESCRIPTION
And drop the "EXPERIMENTAL" tag from the build panel option.