### PR TITLE
Explicitly force serial NuGet restore

### DIFF
--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -22,7 +22,7 @@ clean-local: sln_clean
 	cd build && $(MAKE) clean
 
 NUGET_FOUND = $$(echo $$(which nuget))
-NUGET_RESTORE = mono external/nuget-binary/nuget.exe restore;
+NUGET_RESTORE = mono external/nuget-binary/nuget.exe restore -DisableParallelProcessing;
 
 #FIXME: move the restore logic into MSBuild (Before.sln.targets),
 #       see: https://github.com/kzu/NuGet.Restore


### PR DESCRIPTION
This works around a bug in the Mono runtime which NuGet exposes when restoring lots of packages, and should make the MonoDevelop build much more dependable. See https://bugzilla.xamarin.com/show_bug.cgi?id=51590