### PR TITLE
[CSharp] Fix on the fly formatter performance issue

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs
@@ -103,15 +103,17 @@ namespace MonoDevelop.CSharp.Formatting
 					var caretOffset = editor.CaretOffset;
 
 					int delta = 0;
+					int changeDelta = 0;
 					foreach (var change in newTree.GetChanges (syntaxTree)) {
+						var newText = change.NewText;
+						changeDelta = changeDelta - change.Span.Length + newText.Length;
 						if (!exact && change.Span.Start >= caretOffset)
 							continue;
 						if (exact && !span.Contains (change.Span.Start))
 							continue;
-						var newText = change.NewText;
-						editor.ReplaceText (delta + change.Span.Start, change.Span.Length, newText);
 						delta = delta - change.Span.Length + newText.Length;
 					}
+					editor.ReplaceText (span.Start, span.Length, newTree.ToString ().Substring(span.Start, span.Length + changeDelta));
 					if (startOffset < caretOffset) {
 						var caretEndOffset = caretOffset + delta;
 						if (0 <= caretEndOffset && caretEndOffset < editor.Length)


### PR DESCRIPTION
This issue is surfaced on cutting and pasting a 19k line file
(TensorFlowSharp with Operations.cs)

The code wasn't formatted in the old variant, causing a ton of changed
spans in the document. Because of this, we ended up recalculating the
whole indentation of the document in NRefactory millions of times (I
could count 30 million before it crashed, 18gb of allocations).

With this change, pasting only does one block change of the text with the
formatted text. This causes invalidation of more lines, but since there
is no proper way of batching text span replacements, this is the only
possible fix I could find.

The code has an extra allocation caused by getting the whole document
text then substring-ing it, because there is no way (afaik) to get a
subtext of a given text.

Common usage might be a bit slower than usual, but this provides a
scalable behaviour