### PR TITLE
[Debugger] Added “Help link” to exception dialog and navigation on click

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -104,6 +104,14 @@ namespace MonoDevelop.Debugger
 			ExceptionTypeLabel = new Label { Xalign = 0.0f, Selectable = true, CanFocus = false };
 			ExceptionMessageLabel = new Label { Wrap = true, Xalign = 0.0f, Selectable = true, CanFocus = false };
 			ExceptionHelpLinkLabel = new Label { Wrap = true, Xalign = 0.0f, Selectable = true, CanFocus = false, UseMarkup = true, LineWrapMode = Pango.WrapMode.Char };
+			ExceptionHelpLinkLabel.Name = "exception_help_link_label";
+			Gtk.Rc.ParseString (@"style ""exception-help-link-label""
+{
+	GtkWidget::link-color = ""#ffffff""
+	GtkWidget::visited-link-color = ""#ffffff""
+}
+widget ""*.exception_help_link_label"" style ""exception-help-link-label""
+");
 			ExceptionHelpLinkLabel.ModifyBase (StateType.Prelight, new Gdk.Color (119, 130, 140));
 
 			ExceptionHelpLinkLabel.SetLinkHandler ((str) => DesktopService.ShowUrl (str));

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -618,7 +618,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 
 		internal static string GetHelpLinkMarkup (ExceptionInfo exception)
 		{
-			return GettextCatalog.GetString ("Help link: {0}", $"<a href=\"{System.Security.SecurityElement.Escape (exception.HelpLink)}\">{System.Security.SecurityElement.Escape (exception.HelpLink)}</a>");
+			return $"<a href=\"{System.Security.SecurityElement.Escape (exception.HelpLink)}\">{GettextCatalog.GetString ("More information")}</a>";
 		}
 
 		void ExceptionChanged (object sender, EventArgs e)
@@ -940,7 +940,6 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 		readonly ExceptionInfo exception;
 		Label messageLabel;
 		Label typeLabel;
-		Label helpLinkLabel;
 
 		public ExceptionCaughtButton (ExceptionInfo val, ExceptionCaughtMessage dlg, FilePath file, int line)
 		{
@@ -982,16 +981,6 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 				CanFocus = false
 			};
 			vb.PackStart (messageLabel);
-
-			helpLinkLabel = new Label () {
-				Xalign = 0,
-				NoShowAll = true,
-				Selectable = true,
-				CanFocus = false,
-				LineWrapMode = Pango.WrapMode.Char
-			};
-			helpLinkLabel.SetLinkHandler ((str) => DesktopService.ShowUrl (str));
-			vb.PackStart (helpLinkLabel);
 
 			var detailsBtn = new Xwt.LinkLabel (GettextCatalog.GetString ("Show Details"));
 			var hh = new HBox ();
@@ -1040,16 +1029,6 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 				}
 			} else {
 				messageLabel.Hide ();
-			}
-			if (!string.IsNullOrEmpty (exception.HelpLink)) {
-				helpLinkLabel.Show ();
-				helpLinkLabel.Markup = ExceptionCaughtDialog.GetHelpLinkMarkup (exception);
-				if (helpLinkLabel.SizeRequest ().Width > 400) {
-					helpLinkLabel.WidthRequest = 400;
-					helpLinkLabel.Wrap = true;
-				}
-			} else {
-				helpLinkLabel.Hide ();
 			}
 			if (!string.IsNullOrEmpty (exception.Type)) {
 				typeLabel.Show ();


### PR DESCRIPTION
Before merging this, https://github.com/mono/debugger-libs/pull/98 needs merging and bumping

@vancura can you review this screenshots if I placed "Help link:" correctly and if colors are OK.

Inside editor popup:
![image](https://cloud.githubusercontent.com/assets/774791/22774147/0d6c5978-eea6-11e6-9385-117e595c3f6c.png)

With inner exception:
![image](https://cloud.githubusercontent.com/assets/774791/22774156/1a77b338-eea6-11e6-9015-a07c28b7af4e.png)

Without inner exception:
![image](https://cloud.githubusercontent.com/assets/774791/22774172/2f97fd68-eea6-11e6-83b8-9e63137b93f6.png)
