### PR TITLE
Fixed 'Bug 52378 - Code completion broken on standalone files'

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -856,7 +856,9 @@ namespace MonoDevelop.Ide.Gui
 						adhocSolution = new Solution ();
 						adhocSolution.AddConfiguration ("", true);
 						adhocSolution.DefaultSolutionFolder.AddItem (newProject);
+						MonoDevelopWorkspace.LoadingFinished -= TypeSystemService_WorkspaceItemLoaded;
 						return TypeSystemService.Load (adhocSolution, new ProgressMonitor (), token).ContinueWith (task => {
+							MonoDevelopWorkspace.LoadingFinished += TypeSystemService_WorkspaceItemLoaded;
 							if (token.IsCancellationRequested)
 								return;
 							UnsubscribeRoslynWorkspace ();


### PR DESCRIPTION
Cause was LoadingFinished event cancels the current analysis before
the task continuation so token.IsCancellationRequested was always ==
true.