### PR TITLE
[F#] Make FSharpStylePolicy.xml default

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -149,9 +149,8 @@
 
   <Extension path = "/MonoDevelop/ProjectModel/PolicySets/Mono" >
     <Policies resource="FSharpStylePolicy.xml" />
+    <Policies resource="FSharpFormattingPolicy.xml" />
   </Extension>
-
-  <Policies resource="FSharpFormattingPolicy.xml" />
 
   <Extension path = "/MonoDevelop/ProjectModel/Gui/MimeTypePolicyPanels">
     <Panel id = "FSharpFormatting" _label = "F# Formatting" mimeType="text/x-fsharp" class = "MonoDevelop.FSharp.FSharpFormattingPolicyPanel" />


### PR DESCRIPTION
The F# Addin  has never used the settings in this file by default
because of an issue in how the addin.xml was originally set up here
https://github.com/fsharp/xamarin-monodevelop-fsharp-addin/commit/576b2c574edef126e387379aef77aaca6862d5a5

Now Tabs to Spaces defaults to true. Fixes #37557 and #51499