### PR TITLE
[CSharp] Fix formatting on pasting large blocks of unformatted code

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextPasteHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextPasteHandler.cs
@@ -65,7 +65,7 @@ namespace MonoDevelop.CSharp.Formatting
 					indent.DocumentContext.GetFormattingPolicy (),
 					indent.DocumentContext.Project.Policies.Get<Ide.Gui.Content.TextStylePolicy> (),
 					indent.Editor.GetTextBetween (lineStartOffset, insertionOffset + insertedChars),
-					lineStartOffset,
+					0,
 					formatCharsCount
 				);
 				indent.Editor.ReplaceText (lineStartOffset, formatCharsCount, newText);


### PR DESCRIPTION
On pasting a large block of unformatted code, the formatter would trim
the text. Fix this issue.

cc @DavidKarlas this should fix your issue