### PR TITLE
[AssemblyBrowser] Fix scrolling to type when doing Go To Definition

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
@@ -617,7 +617,8 @@ namespace MonoDevelop.AssemblyBrowser
 				return true;
 			return false;
 		}
-		
+
+		bool expandedMember = true;
 		ITreeNavigator SearchMember (ITreeNavigator nav, string helpUrl, bool expandNode = true)
 		{
 			if (nav == null)
@@ -627,13 +628,11 @@ namespace MonoDevelop.AssemblyBrowser
 				if (IsMatch (nav, helpUrl, searchType)) {
 					inspectEditor.ClearSelection ();
 					nav.ExpandToNode ();
-					if (expandNode) {
-						nav.Selected = nav.Expanded = true;
-						nav.ScrollToNode ();
-					} else {
-						nav.Selected = true;
-						nav.ScrollToNode ();
-					}
+					if (expandNode)
+						nav.Expanded = true;
+					nav.Selected = true;
+					nav.ScrollToNode ();
+					expandedMember = true;
 					return nav;
 				}
 				if (!SkipChildren (nav, helpUrl, searchType) && nav.HasChildren ()) {
@@ -1444,6 +1443,11 @@ namespace MonoDevelop.AssemblyBrowser
 				ITreeNavigator nav = TreeView.GetRootNode ();
 				if (nav == null)
 					return;
+
+				if (expandedMember) {
+					expandedMember = false;
+					return;
+				}
 
 				do {
 					if (nav.DataItem == cu || (nav.DataItem as AssemblyLoader)?.Assembly == cu) {


### PR DESCRIPTION
Before, the code was racy, as it was all attaching a ContinueWith on
LoadingTask, which caused the following semantics:
* On ViewContent loading, it would attach a task to scroll to the loaded
assembly.
* On actual Go To Definition call, it would attach a task that would
scroll to the real type we're searching for.

The order in which these two happen is inverse to the order of
attaching, we would scroll back to the first item, even though we did
all the node expansion and selection work for the real item.

The fix is to only scroll to the assembly if the current selected node
is null or equal to the root node.