### PR TITLE
Fix debug file issue with Mono 4.9.x

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoRuntimeInfo.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoRuntimeInfo.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.Core.Assemblies
 		Dictionary<string,string> envVars = new Dictionary<string, string> ();
 		bool initialized;
 		bool isValidRuntime;
+		Version runtimeVersion;
 		
 		internal MonoRuntimeInfo ()
 		{
@@ -66,6 +67,16 @@ namespace MonoDevelop.Core.Assemblies
 			get {
 				Initialize ();
 				return monoVersion;
+			}
+		}
+		
+		/// <summary>
+		/// Runtime version reported by Mono
+		/// </summary>
+		public Version RuntimeVersion {
+			get {
+				Initialize ();
+				return runtimeVersion;
 			}
 		}
 		
@@ -129,6 +140,8 @@ namespace MonoDevelop.Core.Assemblies
 				return false;
 
 			monoVersion = ver.Substring (i, j - i);
+			if (!Version.TryParse (monoVersion, out runtimeVersion))
+				runtimeVersion = new Version (1, 0, 0, 0);
 
 			i = ver.IndexOf ('(');
 			if (i != -1) {
@@ -189,6 +202,9 @@ namespace MonoDevelop.Core.Assemblies
 				else
 					rt.monoVersion = ver.Substring (i+1);
 			}
+
+			if (!Version.TryParse (rt.monoVersion, out rt.runtimeVersion))
+				rt.runtimeVersion = new Version (1, 0, 0, 0);
 
 			//Pull up assemblies from the installed mono system.
 			rt.prefix = PathUp (typeof (int).Assembly.Location, 4);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
@@ -129,6 +129,8 @@ namespace MonoDevelop.Core.Assemblies
 		
 		public override string GetAssemblyDebugInfoFile (string assemblyPath)
 		{
+			if (monoRuntimeInfo.RuntimeVersion != null && monoRuntimeInfo.RuntimeVersion >= new Version (4,9,0))
+				return Path.ChangeExtension (assemblyPath, ".pdb");
 			return assemblyPath + ".mdb";
 		}
 		

--- a/main/tests/UnitTests/MonoDevelop.Projects/LocalCopyTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/LocalCopyTests.cs
@@ -246,7 +246,7 @@ namespace MonoDevelop.Projects
 
 			AssertOutputFiles (sol, "ConsoleProject", "Debug", new string[] {
 				"ConsoleProject.exe",
-				"ConsoleProject" + exeDebug,
+				p.TargetRuntime.GetAssemblyDebugInfoFile ("ConsoleProject.exe"),
 				"System.Data.dll",
 				"gtk-sharp.dll"
 			});


### PR DESCRIPTION
Fixes bug #52341 - MonoDevelop.Projects.LocalCopyTests.LocalCopyDefault
assumes compiler produces mdb debug file