### PR TITLE
Fixed 'Bug 52553 - Intellisense fails when referencing an iOS binding…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -339,18 +339,18 @@ namespace MonoDevelop.Ide.TypeSystem
 		}
 
 		#region Tracked project handling
-		static readonly List<string> outputTrackedProjects = new List<string> ();
+		static readonly List<TypeSystemOutputTrackingNode> outputTrackedProjects = new List<TypeSystemOutputTrackingNode> ();
 
 		static void IntitializeTrackedProjectHandling ()
 		{
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/TypeSystem/OutputTracking", delegate (object sender, ExtensionNodeEventArgs args) {
-				var projectType = ((TypeSystemOutputTrackingNode)args.ExtensionNode).LanguageName;
+				var node = (TypeSystemOutputTrackingNode)args.ExtensionNode;
 				switch (args.Change) {
 				case ExtensionChange.Add:
-					outputTrackedProjects.Add (projectType);
+					outputTrackedProjects.Add (node);
 					break;
 				case ExtensionChange.Remove:
-					outputTrackedProjects.Remove (projectType);
+					outputTrackedProjects.Remove (node);
 					break;
 				}
 			});
@@ -385,7 +385,8 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			if (project == null)
 				throw new ArgumentNullException ("project");
-			return outputTrackedProjects.Contains (project.LanguageName, StringComparer.OrdinalIgnoreCase);
+			return outputTrackedProjects.Any (otp => string.Equals (otp.LanguageName, project.LanguageName, StringComparison.OrdinalIgnoreCase)) || 
+				project.GetTypeTags().Any (tag => outputTrackedProjects.Any (otp => string.Equals (otp.ProjectType, tag, StringComparison.OrdinalIgnoreCase)));
 		}
 
 		static void CheckProjectOutput (DotNetProject project, bool autoUpdate)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -35,6 +35,7 @@ using System.IO;
 using System.Linq;
 using System.Collections.Immutable;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
@@ -347,7 +348,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				var node = (TypeSystemOutputTrackingNode)args.ExtensionNode;
 				switch (args.Change) {
 				case ExtensionChange.Add:
-					outputTrackedProjects.Add (node);
+					AddOutputTrackingNode (node);
 					break;
 				case ExtensionChange.Remove:
 					outputTrackedProjects.Remove (node);
@@ -358,8 +359,15 @@ namespace MonoDevelop.Ide.TypeSystem
 				IdeApp.ProjectOperations.EndBuild += HandleEndBuild;
 			if (IdeApp.Workspace != null)
 				IdeApp.Workspace.ActiveConfigurationChanged += HandleActiveConfigurationChanged;
+		}
 
-
+		/// <summary>
+		/// Adds an output tracking node for unit testing purposes.
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		internal static void AddOutputTrackingNode (TypeSystemOutputTrackingNode node)
+		{
+			outputTrackedProjects.Add (node);
 		}
 
 		static void HandleEndBuild (object sender, BuildEventArgs args)

--- a/main/tests/UnitTests/MonoDevelop.Ide/TypeSystemServiceTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide/TypeSystemServiceTests.cs
@@ -1,0 +1,98 @@
+﻿//
+// TypeSystemServiceTests.cs
+//
+// Author:
+//       Mike Krüger <mikkrg@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using System.Collections.Generic;
+using MonoDevelop.Ide.Editor.Projection;
+using MonoDevelop.Core.Text;
+using MonoDevelop.Ide.Gui;
+using MonoDevelop.CSharpBinding;
+using UnitTests;
+using MonoDevelop.CSharpBinding.Tests;
+using System.Linq;
+using MonoDevelop.Ide.Editor.Highlighting;
+using MonoDevelop.Ide.Editor.Extension;
+using MonoDevelop.Ide.CodeCompletion;
+using System.Threading.Tasks;
+using MonoDevelop.Components.Commands;
+using MonoDevelop.Ide.Commands;
+using ICSharpCode.NRefactory.CSharp;
+using Gtk;
+using MonoDevelop.Ide.TypeSystem;
+using MonoDevelop.Projects;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide
+{
+	[TestFixture]
+	class TypeSystemServiceTests : TestBase
+	{
+		class TrackTestProject : DotNetProject
+		{
+			readonly string type;
+			protected override void OnGetTypeTags (HashSet<string> types)
+			{
+				types.Add (type);
+			}
+
+			protected override DotNetCompilerParameters OnCreateCompilationParameters (DotNetProjectConfiguration config, ConfigurationKind kind)
+			{
+				throw new NotImplementedException ();
+			}
+
+			protected override ClrVersion [] OnGetSupportedClrVersions ()
+			{
+				throw new NotImplementedException ();
+			}
+
+			public TrackTestProject (string language, string type) : base(language)
+			{
+				this.type = type;
+				Initialize (this);
+			}
+
+		}
+
+		[Test]
+		public void TestOuptutTracking_ProjectType ()
+		{
+			TypeSystemService.AddOutputTrackingNode (new TypeSystemOutputTrackingNode { ProjectType = "TestProjectType" });
+
+			Assert.IsFalse (TypeSystemService.IsOutputTrackedProject (new TrackTestProject ("C#", "Bar")));
+			Assert.IsTrue (TypeSystemService.IsOutputTrackedProject (new TrackTestProject ("C#", "TestProjectType")));
+		}
+
+		[Test]
+		public void TestOuptutTracking_LanguageName ()
+		{
+			TypeSystemService.AddOutputTrackingNode (new TypeSystemOutputTrackingNode { LanguageName = "IL" });
+
+			Assert.IsTrue (TypeSystemService.IsOutputTrackedProject (new TrackTestProject ("IL", "Bar")));
+		}
+
+	}
+}

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -297,6 +297,7 @@
     <Compile Include="MonoDevelop.CSharpBinding\CSharpProjectPropertiesTests.cs" />
     <Compile Include="MonoDevelop.Ide.Editor\DiffTests.cs" />
     <Compile Include="MonoDevelop.Projects\MSBuildProjectServiceTests.cs" />
+    <Compile Include="MonoDevelop.Ide\TypeSystemServiceTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\md.targets" />
@@ -323,5 +324,6 @@
     <Folder Include="MonoDevelop.Ide.Editor\" />
     <Folder Include="MonoDevelop.Ide.Editor\Tests\" />
     <Folder Include="MonoDevelop.Ide.Editor\Commands\" />
+    <Folder Include="MonoDevelop.Ide\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
… project'

The bug got introduced by a change from the F# binding which broke all other output tracked project type scenarios.