### PR TITLE
C9 Bug 51960 - App freezing whilst attempting to debug on iOS Simulator

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -438,8 +438,6 @@ namespace MonoDevelop.Debugger
 			session.OutputWriter = null;
 			session.LogWriter = null;
 
-			sessionManager.Dispose ();
-
 			Runtime.RunInMainThread (delegate {
 				if (cleaningCurrentSession)
 					HideExceptionCaughtDialog ();
@@ -455,8 +453,9 @@ namespace MonoDevelop.Debugger
 				NotifyCallStackChanged ();
 				NotifyCurrentFrameChanged ();
 				NotifyLocationChanged ();
+			}).ContinueWith ((t) => {
+				sessionManager.Dispose ();
 			});
-
 		}
 
 		static string oldLayout;


### PR DESCRIPTION
Problem was that session.Dispose(); happened before StoppedEvent was called which meant that Breakpoints.Remove(entryBreakpoint); that Inspector AddIn did didn’t have effect because session.Dispose(); already disconnected BreakpointStore.