### PR TITLE
Fix document outline

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpOutlineTextEditorExtension.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpOutlineTextEditorExtension.fs
@@ -34,7 +34,7 @@ type FSharpOutlineTextEditorExtension() as x =
                                    |> Array.sortBy(fun xs -> xs.Declaration.Range.StartLine)
 
                     for item in toplevel do
-                        let iter = treeStore.AppendValues(item.Declaration)
+                        let iter = treeStore.AppendValues([| item.Declaration |])
                         let children = item.Nested
                                        |> Array.sortBy(fun xs -> xs.Range.StartLine)
 

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpOutlineTextEditorExtension.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpOutlineTextEditorExtension.fs
@@ -78,19 +78,26 @@ type FSharpOutlineTextEditorExtension() as x =
 
                 let setCellIcon _column (cellRenderer : CellRenderer) (treeModel : TreeModel) (iter : TreeIter) =
                     let pixRenderer = cellRenderer :?> CellRendererImage
-                    let item = treeModel.GetValue(iter, 0) :?> FSharpNavigationDeclarationItem
-                    pixRenderer.Image <- ImageService.GetIcon(ServiceUtils.getIcon item, Gtk.IconSize.Menu)
+                    treeModel.GetValue(iter, 0)
+                    |> Option.tryCast<FSharpNavigationDeclarationItem>
+                    |> Option.iter(fun item ->
+                        pixRenderer.Image <- ImageService.GetIcon(ServiceUtils.getIcon item, Gtk.IconSize.Menu))
 
                 let setCellText _column (cellRenderer : CellRenderer) (treeModel : TreeModel) (iter : TreeIter) =
                     let renderer = cellRenderer :?> CellRendererText
-                    let item = treeModel.GetValue(iter, 0) :?> FSharpNavigationDeclarationItem
-                    renderer.Text <- item.Name
+                    treeModel.GetValue(iter, 0)
+                    |> Option.tryCast<FSharpNavigationDeclarationItem>
+                    |> Option.iter(fun item -> renderer.Text <- item.Name)
+
                 let jumpToDeclaration focus =
                     let iter : TreeIter ref = ref Unchecked.defaultof<_>
                     if padTreeView.Selection.GetSelected(iter) then
-                        let node = padTreeView.Model.GetValue(!iter, 0) :?> FSharpNavigationDeclarationItem
-                        let (scol,sline) = node.Range.StartColumn, node.Range.StartLine
-                        IdeApp.Workbench.OpenDocument (x.Editor.FileName, null, max 1 sline, max 1 scol) |> ignore
+                        padTreeView.Model.GetValue(!iter, 0)
+                        |> Option.tryCast<FSharpNavigationDeclarationItem>
+                        |> Option.iter(fun node ->
+                            let (scol,sline) = node.Range.StartColumn, node.Range.StartLine
+                            IdeApp.Workbench.OpenDocument (x.Editor.FileName, null, max 1 sline, max 1 scol) |> ignore)
+
                     if focus then
                         x.Editor.GrabFocus()
 

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpOutlineTextEditorExtension.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpOutlineTextEditorExtension.fs
@@ -79,22 +79,23 @@ type FSharpOutlineTextEditorExtension() as x =
                 let setCellIcon _column (cellRenderer : CellRenderer) (treeModel : TreeModel) (iter : TreeIter) =
                     let pixRenderer = cellRenderer :?> CellRendererImage
                     treeModel.GetValue(iter, 0)
-                    |> Option.tryCast<FSharpNavigationDeclarationItem>
+                    |> Option.tryCast<FSharpNavigationDeclarationItem[]>
                     |> Option.iter(fun item ->
-                        pixRenderer.Image <- ImageService.GetIcon(ServiceUtils.getIcon item, Gtk.IconSize.Menu))
+                        pixRenderer.Image <- ImageService.GetIcon(ServiceUtils.getIcon item.[0], Gtk.IconSize.Menu))
 
                 let setCellText _column (cellRenderer : CellRenderer) (treeModel : TreeModel) (iter : TreeIter) =
                     let renderer = cellRenderer :?> CellRendererText
                     treeModel.GetValue(iter, 0)
-                    |> Option.tryCast<FSharpNavigationDeclarationItem>
-                    |> Option.iter(fun item -> renderer.Text <- item.Name)
+                    |> Option.tryCast<FSharpNavigationDeclarationItem[]>
+                    |> Option.iter(fun item -> renderer.Text <- item.[0].Name)
 
                 let jumpToDeclaration focus =
                     let iter : TreeIter ref = ref Unchecked.defaultof<_>
                     if padTreeView.Selection.GetSelected(iter) then
                         padTreeView.Model.GetValue(!iter, 0)
-                        |> Option.tryCast<FSharpNavigationDeclarationItem>
-                        |> Option.iter(fun node ->
+                        |> Option.tryCast<FSharpNavigationDeclarationItem[]>
+                        |> Option.iter(fun item ->
+                            let node = item.[0]
                             let (scol,sline) = node.Range.StartColumn, node.Range.StartLine
                             IdeApp.Workbench.OpenDocument (x.Editor.FileName, null, max 1 sline, max 1 scol) |> ignore)
 


### PR DESCRIPTION
Fixes the following exception

```
System.InvalidProgramException: Invalid IL code in <StartupCode$FSharpBinding>.$FSharpOutlineTextEditorExtension/updateDocumentOutline@55:Invoke (): IL_0000: ldarg.1   
  at GLib.Timeout+TimeoutProxy.Handler (System.IntPtr data) [0x0003f] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-None/glib/Timeout.cs:73 
```