### PR TITLE
[SourceEditor] Fix unit tests failing due to DesignerSupport not bein…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/AddinInfo.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/AddinInfo.cs
@@ -15,3 +15,4 @@ using Mono.Addins.Description;
 [assembly:AddinDependency ("Core", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("Ide", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("Debugger", MonoDevelop.BuildInfo.Version)]
+[assembly:AddinDependency ("DesignerSupport", MonoDevelop.BuildInfo.Version)]


### PR DESCRIPTION
…g able to be loaded.

Due to DesignerSupport not being marked as an addin dependency, the
assembly loader would try to load DesignerSupport from the GAC.

Excerpt from MONO_LOG_LEVEL=debug
```
Mono: The following assembly referenced from
/Users/therzok/Work/md/vNext/monodevelop/main/build/AddIns/DisplayBindings/SourceEditor/MonoDevelop.SourceEditor.dll
could not be loaded:
Assembly:   MonoDevelop.DesignerSupport    (assemblyref_index=6)
Version:    2.6.0.0
Public Key: (none)
The assembly was not found in the Global Assembly Cache,
a path listed in the MONO_PATH environment variable, or
in the location of the executing assembly
(/Users/therzok/Work/md/vNext/monodevelop/main/build/AddIns/DisplayBindings/SourceEditor/).

Mono: Failed to load assembly
MonoDevelop.SourceEditor[0x7faa9fd269e0]
```

This should properly fix the issues in https://github.com/mono/monodevelop/pull/1887