### PR TITLE
[vNext][Core] Fix potential race condition on updating MSBuildProject

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -368,6 +368,13 @@ namespace MonoDevelop.Projects.MSBuild
 			});
 		}
 
+		internal Task<bool> SaveAsync (string fileName, string content)
+		{
+			return Task.Run (() => {
+				return TextFile.WriteFile (fileName, content, format.ByteOrderMark, true);
+			});
+		}
+
 		public string SaveToString ()
 		{
 			IsNewProject = false;


### PR DESCRIPTION
Updating the MSBuildProject when writing the project is done with a lock
however the xml generation is done outside of this lock. If a project
builder is requested whilst the project file is being saved the
MSBuildProject can be updated in memory by two different threads. The xml
then passed to the project builder may then be incorrect if another thread
is currently updating the MSBuildProject. Now the MSBuildProject update
and the xml generation is done with the same write lock. Saving to file is
not done inside the write lock.