### PR TITLE
Bug 52855 - Failure to resolve System.Core when executing a t4 script

### DIFF
--- a/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
+++ b/main/src/addins/TextTemplating/Mono.TextTemplating/Mono.TextTemplating/TemplatingEngine.cs
@@ -183,8 +183,11 @@ namespace Mono.TextTemplating
 					continue;
 
 				string resolvedAssem = host.ResolveAssemblyReference (assem);
-				if (!string.IsNullOrEmpty (resolvedAssem) && File.Exists (resolvedAssem)) {
-					resolved [AssemblyName.GetAssemblyName (resolvedAssem).FullName] = resolvedAssem;
+				if (!string.IsNullOrEmpty (resolvedAssem)) {
+					var assemblyName = resolvedAssem;
+					if (File.Exists (resolvedAssem))
+						assemblyName = AssemblyName.GetAssemblyName (resolvedAssem).FullName;
+					resolved [assemblyName] = resolvedAssem;
 				} else {
 					pt.LogError ("Could not resolve assembly reference '" + assem + "'");
 					return null;


### PR DESCRIPTION
Problem started with ca287231cfe2d12 where I required resolving of full path of assembly to be able to remove duplicates by comparing FullName of assembly. Which works fine in case of running inside IDE but when TextTransform.exe is used engine doesn’t resolve to full path but leaves GAC assemblies unresolved, which is OK since compiler can resolve this just fine later in process.