### PR TITLE
[vNext] Support build action changing with wildcard include

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3383,6 +3383,9 @@ namespace MonoDevelop.Projects
 			var existingIncludeItem = globItem.ParentProject.GetAllItems ()
 				.FirstOrDefault (i => i.Include == item.Include);
 			if (existingIncludeItem != null) {
+				foreach (var p in existingIncludeItem.Metadata.GetProperties ().ToArray ())
+					existingIncludeItem.Metadata.RemoveProperty (p.Name);
+
 				foreach (var p in item.Metadata.GetProperties ())
 					existingIncludeItem.Metadata.SetValue (p.Name, p.Value);
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3068,8 +3068,7 @@ namespace MonoDevelop.Projects
 		{
 			None,
 			Exclude,
-			AddUpdateItem,
-			AddRemoveAndIncludeItem
+			AddUpdateItem
 		}
 
 		/// <summary>
@@ -3098,10 +3097,10 @@ namespace MonoDevelop.Projects
 				if (expandedList.Modified || loadedProjectItems.Where (i => i.WildcardItem == globItem).Count () != expandedList.Count) {
 					if (UseAdvancedGlobSupport) {
 						// Add remove items if necessary
-						foreach (var removed in loadedProjectItems.Where (i => i.WildcardItem == globItem && !expandedList.Any (newItem => newItem.ProjectItem.Include == i.Include))) {
+						foreach (var removed in loadedProjectItems.Where (i => i.WildcardItem == globItem && !expandedList.Any (newItem => newItem.ProjectItem.Include == i.Include && newItem.ProjectItem.ItemName == globItem.Name))) {
 							var file = removed as ProjectFile;
 							if (file == null || File.Exists (file.FilePath)) {
-								var removeItem = new MSBuildItem (removed.ItemName) { Remove = removed.Include };
+								var removeItem = new MSBuildItem (globItem.Name) { Remove = removed.Include };
 								msproject.AddItem (removeItem);
 							}
 							unusedItems.UnionWith (FindUpdateItemsForItem (globItem, removed.Include));
@@ -3115,10 +3114,6 @@ namespace MonoDevelop.Projects
 								it.ProjectItem.BackingEvalItem = CreateFakeEvaluatedItem (msproject, it.MSBuildItem, it.MSBuildItem.Include, null);
 								msproject.AddItem (it.MSBuildItem);
 							} else if (it.Action == ExpandedItemAction.AddUpdateItem) {
-								msproject.AddItem (it.MSBuildItem);
-							} else if (it.Action == ExpandedItemAction.AddRemoveAndIncludeItem) {
-								var removeItem = new MSBuildItem (globItem.Name) { Remove = it.MSBuildItem.Include };
-								msproject.AddItem (removeItem);
 								msproject.AddItem (it.MSBuildItem);
 							}
 						}
@@ -3409,7 +3404,7 @@ namespace MonoDevelop.Projects
 			var existingRemoveItem = MSBuildProject.GetAllItems ()
 				.FirstOrDefault (i => i.IsRemove && i.Remove == item.Include);
 			if (existingRemoveItem == null)
-				return ExpandedItemAction.AddRemoveAndIncludeItem;
+				return ExpandedItemAction.AddUpdateItem;
 
 			var existingIncludeItem = MSBuildProject.GetAllItems ()
 				.FirstOrDefault (i => i.Include == item.Include);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3278,7 +3278,7 @@ namespace MonoDevelop.Projects
 			// attribute.
 
 			if (globItem.Name != item.Name) {
-				return ExpandedItemAction.AddRemoveAndIncludeItem;
+				return GenerateItemNameChangedDiff (globItem, item);
 			}
 
 			MSBuildItem updateItem = null;
@@ -3369,6 +3369,22 @@ namespace MonoDevelop.Projects
 						return ExpandedItemAction.Exclude;
 					}
 				}
+			}
+			return ExpandedItemAction.None;
+		}
+
+		ExpandedItemAction GenerateItemNameChangedDiff (MSBuildItem globItem, MSBuildItem item)
+		{
+			var existingRemoveItem = globItem.ParentProject.GetAllItems ()
+				.FirstOrDefault (i => i.IsRemove && i.Remove == item.Include);
+			if (existingRemoveItem == null)
+				return ExpandedItemAction.AddRemoveAndIncludeItem;
+
+			var existingIncludeItem = globItem.ParentProject.GetAllItems ()
+				.FirstOrDefault (i => i.Include == item.Include);
+			if (existingIncludeItem != null) {
+				foreach (var p in item.Metadata.GetProperties ())
+					existingIncludeItem.Metadata.SetValue (p.Name, p.Value);
 			}
 			return ExpandedItemAction.None;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3063,7 +3063,8 @@ namespace MonoDevelop.Projects
 		{
 			None,
 			Exclude,
-			AddUpdateItem
+			AddUpdateItem,
+			AddRemoveAndIncludeItem
 		}
 
 		/// <summary>
@@ -3106,6 +3107,10 @@ namespace MonoDevelop.Projects
 								it.ProjectItem.BackingEvalItem = CreateFakeEvaluatedItem (msproject, it.MSBuildItem, it.MSBuildItem.Include, null);
 								msproject.AddItem (it.MSBuildItem);
 							} else if (it.Action == ExpandedItemAction.AddUpdateItem) {
+								msproject.AddItem (it.MSBuildItem);
+							} else if (it.Action == ExpandedItemAction.AddRemoveAndIncludeItem) {
+								var removeItem = new MSBuildItem (globItem.Name) { Remove = it.MSBuildItem.Include };
+								msproject.AddItem (removeItem);
 								msproject.AddItem (it.MSBuildItem);
 							}
 						}
@@ -3271,6 +3276,10 @@ namespace MonoDevelop.Projects
 			// This method compares the evaluated item that was used to load a project item with the msbuild
 			// item that has now been saved. If there are changes, it saves the changes in an item with Update
 			// attribute.
+
+			if (globItem.Name != item.Name) {
+				return ExpandedItemAction.AddRemoveAndIncludeItem;
+			}
 
 			MSBuildItem updateItem = null;
 			HashSet<MSBuildItem> itemsToDelete = null;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3307,9 +3307,9 @@ namespace MonoDevelop.Projects
 			// attribute.
 
 			if (globItem.Name != item.Name) {
-				return GenerateItemNameChangedDiff (globItem, item);
+				return GenerateItemNameChangedDiff (item);
 			} else {
-				RemoveExistingRemoveAndIncludeItems (globItem, item);
+				RemoveExistingRemoveAndIncludeItems (item);
 			}
 
 			MSBuildItem updateItem = null;
@@ -3404,14 +3404,14 @@ namespace MonoDevelop.Projects
 			return ExpandedItemAction.None;
 		}
 
-		ExpandedItemAction GenerateItemNameChangedDiff (MSBuildItem globItem, MSBuildItem item)
+		ExpandedItemAction GenerateItemNameChangedDiff (MSBuildItem item)
 		{
-			var existingRemoveItem = globItem.ParentProject.GetAllItems ()
+			var existingRemoveItem = MSBuildProject.GetAllItems ()
 				.FirstOrDefault (i => i.IsRemove && i.Remove == item.Include);
 			if (existingRemoveItem == null)
 				return ExpandedItemAction.AddRemoveAndIncludeItem;
 
-			var existingIncludeItem = globItem.ParentProject.GetAllItems ()
+			var existingIncludeItem = MSBuildProject.GetAllItems ()
 				.FirstOrDefault (i => i.Include == item.Include);
 			if (existingIncludeItem != null) {
 				foreach (var p in existingIncludeItem.Metadata.GetProperties ().ToArray ())
@@ -3423,10 +3423,10 @@ namespace MonoDevelop.Projects
 			return ExpandedItemAction.None;
 		}
 
-		void RemoveExistingRemoveAndIncludeItems (MSBuildItem globItem, MSBuildItem item)
+		void RemoveExistingRemoveAndIncludeItems (MSBuildItem item)
 		{
 			List<MSBuildItem> itemsToDelete = null;
-			foreach (var it in globItem.ParentProject.GetAllItems ()) {
+			foreach (var it in MSBuildProject.GetAllItems ()) {
 				if (it.Remove == item.Include || it.Include == item.Include) {
 					if (itemsToDelete == null)
 						itemsToDelete = new List<MSBuildItem> ();
@@ -3436,7 +3436,7 @@ namespace MonoDevelop.Projects
 
 			if (itemsToDelete != null) {
 				foreach (var it in itemsToDelete)
-					globItem.ParentProject.RemoveItem (it);
+					MSBuildProject.RemoveItem (it);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3206,6 +3206,16 @@ namespace MonoDevelop.Projects
 									MSBuildItem = it
 								};
 								items.Add (einfo);
+
+								if (buildItem == null && item.BackingItem != null && globItem.Name != item.BackingItem.Name) {
+									it.Update = item.Include;
+									sourceItems = new [] { globItem };
+									item.BackingItem = globItem;
+									item.BackingEvalItem = CreateFakeEvaluatedItem (msproject, it, globItem.Include, sourceItems);
+									einfo.Action = ExpandedItemAction.AddUpdateItem;
+									items.Modified = true;
+									return;
+								}
 							}
 						}
 					}
@@ -3465,7 +3475,7 @@ namespace MonoDevelop.Projects
 			((MSBuildPropertyGroupEvaluated)eit.Metadata).SetProperties (md);
 			if (sourceItems != null) {
 				foreach (var s in sourceItems)
-					eit.AddSourceItem (item);
+					eit.AddSourceItem (s);
 			} else
 				eit.AddSourceItem (item);
 			return eit;

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1044,6 +1044,50 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task SaveProjectWithWildcardsBuildActionChangedThenCopyToOutputChanged ()
+		{
+			string projFile = Util.GetSampleProject ("console-project-with-wildcards", "ConsoleProject.csproj");
+
+			var p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			Assert.IsInstanceOf<Project> (p);
+			var mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+
+			var f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			f.BuildAction = BuildAction.EmbeddedResource;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			f.CopyToOutputDirectory = FileCopyMode.PreserveNewest;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved4")), File.ReadAllText (p.FileName));
+		}
+
+		[Test]
+		public async Task SaveProjectWithWildcardsBuildActionChangedProjectReloadThenCopyToOutputChanged ()
+		{
+			string projFile = Util.GetSampleProject ("console-project-with-wildcards", "ConsoleProject.csproj");
+
+			var p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			Assert.IsInstanceOf<Project> (p);
+			var mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+
+			var f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			f.BuildAction = BuildAction.EmbeddedResource;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+			f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			f.CopyToOutputDirectory = FileCopyMode.PreserveNewest;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved4")), File.ReadAllText (p.FileName));
+		}
+
+		[Test]
 		//[Ignore ("xbuild bug: RecursiveDir metadata returns the wrong value")]
 		public async Task LoadProjectWithWildcardLinks ()
 		{

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1021,6 +1021,29 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task SaveProjectWithWildcardsAfterBuildActionChanged ()
+		{
+			string projFile = Util.GetSampleProject ("console-project-with-wildcards", "ConsoleProject.csproj");
+
+			var p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			Assert.IsInstanceOf<Project> (p);
+			var mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+
+			// Changing the text1-1.txt. file to EmbeddedResource should result in the following
+			// being added:
+			//
+			// <Content Remove="Content\text1-1.txt" />
+			// <EmbeddedResource Include="Content\text1-1.txt" />
+			var f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			f.BuildAction = BuildAction.EmbeddedResource;
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved3")), File.ReadAllText (p.FileName));
+		}
+
+		[Test]
 		//[Ignore ("xbuild bug: RecursiveDir metadata returns the wrong value")]
 		public async Task LoadProjectWithWildcardLinks ()
 		{

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1140,6 +1140,54 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task SaveProjectWithWildcardsBuildActionChangedBackAgain ()
+		{
+			string projFile = Util.GetSampleProject ("console-project-with-wildcards", "ConsoleProject.csproj");
+			string originalProjectFileText = File.ReadAllText (projFile);
+
+			var p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			Assert.IsInstanceOf<Project> (p);
+			var mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+
+			var f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			var originalBuildAction = f.BuildAction;
+			f.BuildAction = BuildAction.EmbeddedResource;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			f.BuildAction = originalBuildAction;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			Assert.AreEqual (Util.ToSystemEndings (originalProjectFileText), File.ReadAllText (p.FileName));
+		}
+
+		[Test]
+		public async Task SaveProjectWithWildcardsBuildActionChangedBackAgainAfterReload ()
+		{
+			string projFile = Util.GetSampleProject ("console-project-with-wildcards", "ConsoleProject.csproj");
+			string originalProjectFileText = File.ReadAllText (projFile);
+
+			var p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			Assert.IsInstanceOf<Project> (p);
+			var mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+
+			var f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			var originalBuildAction = f.BuildAction;
+			f.BuildAction = BuildAction.EmbeddedResource;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			mp = (Project)p;
+			mp.UseAdvancedGlobSupport = true;
+			f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "text1-1.txt");
+			f.BuildAction = originalBuildAction;
+			await p.SaveAsync (Util.GetMonitor ());
+
+			Assert.AreEqual (Util.ToSystemEndings (originalProjectFileText), File.ReadAllText (p.FileName));
+		}
+
+		[Test]
 		//[Ignore ("xbuild bug: RecursiveDir metadata returns the wrong value")]
 		public async Task LoadProjectWithWildcardLinks ()
 		{

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject-import.csproj
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject-import.csproj
@@ -1,0 +1,45 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ConsoleProject-import.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject-import.csproj.saved1
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject-import.csproj.saved1
@@ -1,0 +1,53 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ConsoleProject-import.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Remove="Content\text1-1.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Content\text1-1.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject-import.targets
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject-import.targets
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Content\**\*.cs" />
+    <Content Include="*.txt" />
+    <Content Include="Content\*.txt" />
+    <Content Include="Content\Data\*.txt" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved3
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved3
@@ -1,0 +1,55 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Content\**\*.cs" />
+    <Content Include="*.txt" />
+    <Content Include="Content\*.txt" />
+    <Content Include="Content\Data\*.txt" />
+    <Content Remove="Content\text1-1.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Content\text1-1.txt" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved4
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved4
@@ -1,0 +1,57 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Content\**\*.cs" />
+    <Content Include="*.txt" />
+    <Content Include="Content\*.txt" />
+    <Content Include="Content\Data\*.txt" />
+    <Content Remove="Content\text1-1.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Content\text1-1.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved5
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved5
@@ -1,0 +1,56 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Content\**\*.cs" />
+    <Content Include="*.txt" />
+    <Content Include="Content\*.txt" />
+    <Content Include="Content\Data\*.txt" />
+    <Content Remove="Content\text1-1.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Content\text1-1.txt">
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved6
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved6
@@ -1,0 +1,54 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Content\**\*.cs" />
+    <Content Include="*.txt" />
+    <Content Include="Content\*.txt" />
+    <Content Include="Content\Data\*.txt" />
+    <Content Update="Content\text1-1.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
When an MSBuildItem is included with a wildcard and then its BuildAction is changed the project should add a Remove item and an Include item. The Remove item will remove it from the original
wildcard group.

Wildcard:

    <Content Include="**\*.txt" />

Changing a .txt file to be an EmbeddedResource should add the following items to the project:

    <Content Remove="TextFile.txt" />
    <EmbeddedResource Include="TextFile.txt" />

A simple fix for the above with a test has been added.

**TODO**

The following need to be tested and/or implemented.
 - [x] Add Remove and Include item when BuildAction is changed.
 - [ ] ~~MSBuild item ordering.~~ To be done in another pull request. Affects more than just Remove and Include items.
    - [ ] ~~Remove items for the same item type (e.g. None) should be grouped together.~~
    - [ ] ~~Include items should be added in their own item group after the Remove items.~~
 - [x] Changing the BuildAction back to its original value should remove the Remove item and the Include item.
    - [x] Project loaded from disk before action
    - [x] Project not reloaded before action
 - [x] Changing a property and then changing the BuildAction back to its original value should remove the Remove item and the Include item but add an Update item for the changed property.
    - [x] Project loaded from disk before action
    - [x] Project not reloaded before action
 - [x] Properties can be set on the new item (e.g. Copy to output directory).
    - [x] Project loaded from disk before action
    - [x] Project not reloaded before action
 - [x] Properties can be removed from the new item.
    - [x] Project loaded from disk before action
    - [x] Project not reloaded before action