### PR TITLE
1) Implement TextDocument.ApplyTextChanges to take in a MD TextChange…

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
@@ -24,14 +24,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.Collections.Generic;
 
 namespace MonoDevelop.Core.Text
 {
+	[DebuggerDisplay("({offset}, {removedText.Length}, {insertedText.Text})")]
 	public sealed class TextChange
 	{
 		readonly int offset;
+		int newOffset;
 		readonly ITextSource removedText;
 		readonly ITextSource insertedText;
 
@@ -40,6 +43,7 @@ namespace MonoDevelop.Core.Text
 			if (offset < 0)
 				throw new ArgumentOutOfRangeException (nameof (offset), offset, "offset must not be negative");
 			this.offset = offset;
+			this.newOffset = offset;
 			this.removedText = removedText != null ? new StringTextSource (removedText) : StringTextSource.Empty;
 			this.insertedText = insertedText != null ? new StringTextSource (insertedText) : StringTextSource.Empty;
 		}
@@ -49,8 +53,19 @@ namespace MonoDevelop.Core.Text
 			if (offset < 0)
 				throw new ArgumentOutOfRangeException(nameof (offset), offset, "offset must not be negative");
 			this.offset = offset;
+			this.newOffset = offset;
 			this.removedText = removedText ?? StringTextSource.Empty;
 			this.insertedText = insertedText ?? StringTextSource.Empty;
+		}
+
+		public TextChange(int offset, int newOffset, string removedText, string insertedText)
+		{
+			if (offset < 0)
+				throw new ArgumentOutOfRangeException(nameof(offset), offset, "offset must not be negative");
+			this.offset = offset;
+			this.newOffset = newOffset;
+			this.removedText = removedText != null ? new StringTextSource(removedText) : StringTextSource.Empty;
+			this.insertedText = insertedText != null ? new StringTextSource(insertedText) : StringTextSource.Empty;
 		}
 
 		/// <summary>
@@ -58,6 +73,14 @@ namespace MonoDevelop.Core.Text
 		/// </summary>
 		public int Offset {
 			get { return offset; }
+		}
+
+		/// <summary>
+		/// The offset at which the change occurs relative to the new buffer.
+		/// </summary>
+		public int NewOffset
+		{
+			get { return newOffset; }
 		}
 
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/HighlightUrlExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/HighlightUrlExtension.cs
@@ -113,10 +113,10 @@ namespace MonoDevelop.Ide.Editor.Extension
 		void Editor_TextChanged (object sender, TextChangeEventArgs e)
 		{
 			foreach (var change in e.TextChanges) {
-				var startLine = Editor.GetLineByOffset (change.Offset);
+				var startLine = Editor.GetLineByOffset (change.NewOffset);
 				int startLineOffset = startLine.Offset;
 
-				var segments = scannedSegmentTree.GetSegmentsOverlapping (change.Offset, change.RemovalLength).ToList ();
+				var segments = scannedSegmentTree.GetSegmentsOverlapping (change.NewOffset, change.RemovalLength).ToList ();
 				foreach (var seg in segments) {
 					foreach (var u in seg.UrlTextMarker) {
 						Editor.RemoveMarker (u);


### PR DESCRIPTION
… enumeration

2) Modify UndoOperation.Undo/Redo to use batched edits
3) Add TextChange.NewOffset to allow event listeners to work off the new buffer coordinate space
4) Modified HighlightUrlExtension.Editor_TextChanged event to use the NewOffset as it was throwing otherwise
5) Added some DebuggerDisplay goo to TextChange to simplify debugging