### PR TITLE
[vNext] Do not add Remove MSBuild item if file does not exist

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3093,8 +3093,11 @@ namespace MonoDevelop.Projects
 					if (UseAdvancedGlobSupport) {
 						// Add remove items if necessary
 						foreach (var removed in loadedProjectItems.Where (i => i.WildcardItem == globItem && !expandedList.Any (newItem => newItem.ProjectItem.Include == i.Include))) {
-							var removeItem = new MSBuildItem (removed.ItemName) { Remove = removed.Include };
-							msproject.AddItem (removeItem);
+							var file = removed as ProjectFile;
+							if (file == null || File.Exists (file.FilePath)) {
+								var removeItem = new MSBuildItem (removed.ItemName) { Remove = removed.Include };
+								msproject.AddItem (removeItem);
+							}
 							unusedItems.UnionWith (FindUpdateItemsForItem (globItem, removed.Include));
 						}
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -66,6 +66,31 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task DeleteFile ()
+		{
+			string projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-test.csproj");
+			var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.UseAdvancedGlobSupport = true;
+
+			Assert.AreEqual (3, p.Files.Count);
+
+			var f = p.Files.First (fi => fi.FilePath.FileName == "c1.cs");
+			p.Files.Remove (f);
+			string text = File.ReadAllText (f.FilePath);
+			File.Delete (f.FilePath);
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName.ChangeName ("glob-test-saved2")));
+
+			File.WriteAllText (f.FilePath, text);
+			p.AddFile (f.FilePath);
+			await p.SaveAsync (Util.GetMonitor ());
+			Assert.AreEqual (File.ReadAllText (p.FileName), File.ReadAllText (p.FileName.ChangeName ("glob-test-saved2")));
+		}
+
+		[Test]
 		public async Task AddFile ()
 		{
 			// When adding a file, if the new file is included in a glob, there is no need to add a new project item.


### PR DESCRIPTION
If a file is deleted then there is no need to add a Remove MSBuild item for that file. Only if the file is removed from the project but not deleted will a Remove MSBuild item be added.