### PR TITLE
[vNext][MSBuild] Fix global properties not available for project build

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -63,6 +63,7 @@ namespace MonoDevelop.Projects.MSBuild
 			MSBuildResult result = null;
 			BuildEngine.RunSTA (taskId, delegate {
 				Project project = null;
+				Dictionary<string, string> originalGlobalProperties = null;
 				try {
 					project = SetupProject (configurations);
 					InitLogger (logWriter);
@@ -78,6 +79,9 @@ namespace MonoDevelop.Projects.MSBuild
 					}
 
 					if (globalProperties != null) {
+						originalGlobalProperties = new Dictionary<string, string> ();
+						foreach (var p in project.GlobalProperties)
+							originalGlobalProperties [p.Key] = p.Value;
 						foreach (var p in globalProperties)
 							project.SetGlobalProperty (p.Key, p.Value);
 						project.ReevaluateIfNecessary ();
@@ -123,7 +127,7 @@ namespace MonoDevelop.Projects.MSBuild
 					if (project != null && globalProperties != null) {
 						foreach (var p in globalProperties)
 							project.RemoveGlobalProperty (p.Key);
-						foreach (var p in engine.GlobalProperties)
+						foreach (var p in originalGlobalProperties)
 							project.SetGlobalProperty (p.Key, p.Value);
 						project.ReevaluateIfNecessary ();
 					}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -123,6 +123,8 @@ namespace MonoDevelop.Projects.MSBuild
 					if (project != null && globalProperties != null) {
 						foreach (var p in globalProperties)
 							project.RemoveGlobalProperty (p.Key);
+						foreach (var p in engine.GlobalProperties)
+							project.SetGlobalProperty (p.Key, p.Value);
 						project.ReevaluateIfNecessary ();
 					}
 				}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -85,10 +85,6 @@ namespace MonoDevelop.Projects.MSBuild
 
 					//building the project will create items and alter properties, so we use a new instance
 					var pi = project.CreateProjectInstance ();
-
-					if (globalProperties != null)
-						foreach (var p in globalProperties)
-							pi.SetProperty (p.Key, p.Value);
 					
 					pi.Build (runTargets, loggers);
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1504,6 +1504,32 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("Something failed: show", res.Errors [0].ErrorText);
 		}
 
+		/// <summary>
+		/// As above but the property is used to import different .targets files
+		/// and MSBuild is used
+		/// </summary>
+		[Test]
+		public async Task BuildWithCustomProps2 ()
+		{
+			string projFile = Util.GetSampleProject ("msbuild-tests", "project-with-custom-build-target2.csproj");
+			var p = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.RequiresMicrosoftBuild = true;
+
+			var ctx = new ProjectOperationContext ();
+			ctx.GlobalProperties.SetValue ("TestProp", "foo");
+			var res = await p.Build (Util.GetMonitor (), p.Configurations [0].Selector, ctx);
+
+			Assert.AreEqual (1, res.Errors.Count);
+			Assert.AreEqual ("Something failed (foo.targets): foo", res.Errors [0].ErrorText);
+
+			await p.Clean (Util.GetMonitor (), p.Configurations [0].Selector);
+			res = await p.Build (Util.GetMonitor (), p.Configurations [0].Selector, true);
+
+			// Check that the global property is reset
+			Assert.AreEqual (1, res.Errors.Count);
+			Assert.AreEqual ("Something failed (show.targets): show", res.Errors [0].ErrorText);
+		}
+
 		[Test]
 		public async Task CopyConfiguration ()
 		{

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1530,6 +1530,33 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("Something failed (show.targets): show", res.Errors [0].ErrorText);
 		}
 
+		/// <summary>
+		/// As above but the property has the same as a default global property defined
+		/// by the IDE. This test makes sures the existing global properties are
+		/// restored.
+		/// </summary>
+		[Test]
+		public async Task BuildWithCustomProps3 ()
+		{
+			string projFile = Util.GetSampleProject ("msbuild-tests", "project-with-custom-build-target3.csproj");
+			var p = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.RequiresMicrosoftBuild = true;
+
+			var ctx = new ProjectOperationContext ();
+			ctx.GlobalProperties.SetValue ("BuildingInsideVisualStudio", "false");
+			var res = await p.Build (Util.GetMonitor (), p.Configurations [0].Selector, ctx);
+
+			Assert.AreEqual (1, res.Errors.Count);
+			Assert.AreEqual ("Something failed (false.targets): false", res.Errors [0].ErrorText);
+
+			await p.Clean (Util.GetMonitor (), p.Configurations [0].Selector);
+			res = await p.Build (Util.GetMonitor (), p.Configurations [0].Selector, true);
+
+			// Check that the global property is reset
+			Assert.AreEqual (1, res.Errors.Count);
+			Assert.AreEqual ("Something failed (true.targets): true", res.Errors [0].ErrorText);
+		}
+
 		[Test]
 		public async Task CopyConfiguration ()
 		{

--- a/main/tests/test-projects/msbuild-tests/false.targets
+++ b/main/tests/test-projects/msbuild-tests/false.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Build">
+    <Error Text="Something failed (false.targets): $(BuildingInsideVisualStudio)" />
+  </Target>
+</Project>

--- a/main/tests/test-projects/msbuild-tests/foo.targets
+++ b/main/tests/test-projects/msbuild-tests/foo.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Build">
+    <Error Text="Something failed (foo.targets): $(TestProp)" />
+  </Target>
+</Project>

--- a/main/tests/test-projects/msbuild-tests/project-with-custom-build-target2.csproj
+++ b/main/tests/test-projects/msbuild-tests/project-with-custom-build-target2.csproj
@@ -1,0 +1,42 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TestProp Condition="'$(TestProp)' == ''">show</TestProp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(TestProp).targets" Condition="Exists('$(TestProp).targets')"/>
+</Project>

--- a/main/tests/test-projects/msbuild-tests/project-with-custom-build-target3.csproj
+++ b/main/tests/test-projects/msbuild-tests/project-with-custom-build-target3.csproj
@@ -1,0 +1,41 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(BuildingInsideVisualStudio).targets" Condition="Exists('$(BuildingInsideVisualStudio).targets')"/>
+</Project>

--- a/main/tests/test-projects/msbuild-tests/show.targets
+++ b/main/tests/test-projects/msbuild-tests/show.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Build">
+    <Error Text="Something failed (show.targets): $(TestProp)" />
+  </Target>
+</Project>

--- a/main/tests/test-projects/msbuild-tests/true.targets
+++ b/main/tests/test-projects/msbuild-tests/true.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Build">
+    <Error Text="Something failed (true.targets): $(BuildingInsideVisualStudio)" />
+  </Target>
+</Project>


### PR DESCRIPTION
Fixed bug #45276 - Global MSBuild properties not available when
building project programmatically
https://bugzilla.xamarin.com/show_bug.cgi?id=45276

Properties set when building a single project would not cause a
re-evaluation of the project and would not affect the build.

var context = new ProjectOperationContext ();
context.GlobalProperties.SetValue ("PackOnBuild", "true");
IdeApp.ProjectOperations.Build (project, operationContext: context);

Here PackOnBuild whilst set would not change any existing properties
that used its value when using MSBuild. This problem did not affect
xbuild.

Now the project is re-evaluated if global properties are set. These
properties are removed after the build and the project is re-evaluated
again so they do not affect the next build.