### PR TITLE
[vNext] Remove Update item for wildcard after changes reverted 

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3356,7 +3356,7 @@ namespace MonoDevelop.Projects
 						updateItems = FindUpdateItemsForItem (globItem, item.Include).ToList ();
 					foreach (var it in updateItems.Where (i => i.ParentNode != null)) {
 						if (it.Metadata.RemoveProperty (p.Name) && !it.Metadata.GetProperties ().Any ())
-							it.ParentGroup.RemoveItem (it);
+							it.ParentProject.RemoveItem (it);
 					}
 					// If this metadata is defined in the glob item, the only option is to exclude the item from the glob.
 					if (globItem.Metadata.HasProperty (p.Name)) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3370,11 +3370,11 @@ namespace MonoDevelop.Projects
 				}
 			}
 
-			if (evalItem.Metadata.GetProperties ().Count () == 0 && item.Metadata.GetProperties ().Count () == 0) {
+			if (!evalItem.Metadata.GetProperties ().Any () && !item.Metadata.GetProperties ().Any ()) {
 				updateItems = FindUpdateItemsForItem (globItem, item.Include).ToList ();
 				foreach (var it in updateItems) {
 					if (it.ParentNode != null)
-						it.ParentGroup.RemoveItem (it);
+						it.ParentProject.RemoveItem (it);
 				}
 			}
 			return ExpandedItemAction.None;
@@ -3387,6 +3387,13 @@ namespace MonoDevelop.Projects
 				if (!globItemFound)
 					globItemFound = (it == globItem);
 				else {
+					if (it.Update == include)
+						yield return it;
+				}
+			}
+
+			if (globItemFound && globItem.ParentProject != MSBuildProject) {
+				foreach (var it in MSBuildProject.GetAllItems ()) {
 					if (it.Update == include)
 						yield return it;
 				}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3364,6 +3364,14 @@ namespace MonoDevelop.Projects
 					}
 				}
 			}
+
+			if (evalItem.Metadata.GetProperties ().Count () == 0 && item.Metadata.GetProperties ().Count () == 0) {
+				updateItems = FindUpdateItemsForItem (globItem, item.Include).ToList ();
+				foreach (var it in updateItems) {
+					if (it.ParentNode != null)
+						it.ParentGroup.RemoveItem (it);
+				}
+			}
 			return ExpandedItemAction.None;
 		}
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -363,6 +363,42 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task FileUpdateChangeThenRemoveMetadataAfterReload ()
+		{
+			// An update item is created by adding a property.
+			// Then the metadata is removed.
+			// The update item has to be removed
+
+			string projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-test.csproj");
+			string originalProjFile = new FilePath (projFile).ChangeName ("glob-test-original.csproj");
+			File.Copy (projFile, originalProjFile);
+			var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.UseAdvancedGlobSupport = true;
+
+			Assert.AreEqual (3, p.Files.Count);
+
+			var f = p.Files.First (fi => fi.FilePath.FileName == "c2.cs");
+			f.Metadata.SetValue ("foo", "bar");
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update1-test")), projectXml);
+
+			// Reload the project.
+			p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.UseAdvancedGlobSupport = true;
+			f = p.Files.First (fi => fi.FilePath.FileName == "c2.cs");
+
+			f.Metadata.RemoveProperty ("foo");
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (File.ReadAllText (originalProjFile), projectXml);
+		}
+
+		[Test]
 		public async Task FileUpdateChangeMetadataDefinedInGlob ()
 		{
 			// The glob item defines a metadata. All evaluated items have that value.

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -332,6 +332,37 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task FileUpdateChangeThenRemoveMetadata ()
+		{
+			// An update item is created by adding a property.
+			// Then the metadata is removed.
+			// The update item has to be removed
+
+			string projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-test.csproj");
+			string originalProjFile = new FilePath (projFile).ChangeName ("glob-test-original.csproj");
+			File.Copy (projFile, originalProjFile);
+			var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.UseAdvancedGlobSupport = true;
+
+			Assert.AreEqual (3, p.Files.Count);
+
+			var f = p.Files.First (fi => fi.FilePath.FileName == "c2.cs");
+			f.Metadata.SetValue ("foo", "bar");
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update1-test")), projectXml);
+
+			f.Metadata.RemoveProperty ("foo");
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (File.ReadAllText (originalProjFile), projectXml);
+		}
+
+		[Test]
 		public async Task FileUpdateChangeMetadataDefinedInGlob ()
 		{
 			// The glob item defines a metadata. All evaluated items have that value.

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-test.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-test.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="glob-import-test.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-test.targets
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-test.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="*9.cs" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-update1-test.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-update1-test.csproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="glob-import-test.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="c2.cs">
+      <foo>bar</foo>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Setting CopyToOutputDirectory to PreserveNewest will generate an
Update item for a wildcard item. If CopyToOutputDirectory is then
changed back to None the Update item would not be removed from
the project file.