### PR TITLE
[Core] Memoize ConditionParser usage.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionRelationalExpression.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionRelationalExpression.cs
@@ -149,32 +149,39 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			}
 		}
 
+		List<string> combinedProperty = null;
+		List<string> combinedValue = null;
+		bool combinedPropertySet;
+		object conditionPropertiesLock = new object ();
 		public override void CollectConditionProperties (ConditionedPropertyCollection properties)
 		{
-			if ((op == RelationOperator.Equal || op == RelationOperator.NotEqual) && left is ConditionFactorExpression && right is ConditionFactorExpression) {
-				var leftString = ((ConditionFactorExpression)left).Token.Value;
-				var rightString = ((ConditionFactorExpression)right).Token.Value;
-				List<string> combinedProperty = null;
-				List<string> combinedValue = null;
+			lock (conditionPropertiesLock) {
+				if (!combinedPropertySet) {
+					combinedPropertySet = true;
+					if ((op == RelationOperator.Equal || op == RelationOperator.NotEqual) && left is ConditionFactorExpression && right is ConditionFactorExpression) {
+						var leftString = ((ConditionFactorExpression)left).Token.Value;
+						var rightString = ((ConditionFactorExpression)right).Token.Value;
 
-				int il = 0;
-				int rl = 0;
-				while (il < leftString.Length && rl < rightString.Length) {
-					if (il < leftString.Length - 2 && leftString [il] == '$' && leftString [il + 1] == '(')
-						ReadPropertyCondition (leftString, ref combinedProperty, ref combinedValue, ref il, rightString, ref rl);
-					else if (rl < rightString.Length - 2 && rightString [rl] == '$' && rightString [rl + 1] == '(')
-						ReadPropertyCondition (rightString, ref combinedProperty, ref combinedValue, ref rl, leftString, ref il);
-					else if (leftString [il] != rightString [rl])
-						return; // Condition can't be true
-					il++; rl++;
+						int il = 0;
+						int rl = 0;
+						while (il < leftString.Length && rl < rightString.Length) {
+							if (il < leftString.Length - 2 && leftString [il] == '$' && leftString [il + 1] == '(')
+								ReadPropertyCondition (leftString, ref combinedProperty, ref combinedValue, ref il, rightString, ref rl);
+							else if (rl < rightString.Length - 2 && rightString [rl] == '$' && rightString [rl + 1] == '(')
+								ReadPropertyCondition (rightString, ref combinedProperty, ref combinedValue, ref rl, leftString, ref il);
+							else if (leftString [il] != rightString [rl])
+								return; // Condition can't be true
+							il++; rl++;
+						}
+					}
 				}
-
-				// This condition sets values for more that one property. In addition to the individual values, also register
-				// the combination of values. So for example if the condition has "$(Configuration)|$(Platform) == Foo|Bar",
-				// the conditioned property collection would contain Configuration=Foo, Platform=Bar, (Configuration|Platfrom)=Foo|Bar
-				if (combinedProperty != null)
-					properties.AddPropertyValues (combinedProperty, combinedValue);
 			}
+
+			// This condition sets values for more that one property. In addition to the individual values, also register
+			// the combination of values. So for example if the condition has "$(Configuration)|$(Platform) == Foo|Bar",
+			// the conditioned property collection would contain Configuration=Foo, Platform=Bar, (Configuration|Platfrom)=Foo|Bar
+			if (combinedProperty != null)
+				properties.AddPropertyValues (combinedProperty, combinedValue);
 		}
 
 		void ReadPropertyCondition (string propString, ref List<string> combinedProperty, ref List<string> combinedValue, ref int i, string valString, ref int j)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -242,7 +242,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildPropertyGroup group)
 		{
-			if (!string.IsNullOrEmpty (group.Condition) && !SafeParseAndEvaluate (project, context, group.Condition, conditionCache, true))
+			if (!string.IsNullOrEmpty (group.Condition) && !SafeParseAndEvaluate (project, context, group.Condition, true))
 				return;
 
 			foreach (var prop in group.GetProperties ())
@@ -254,29 +254,29 @@ namespace MonoDevelop.Projects.MSBuild
 			bool conditionIsTrue = true;
 
 			if (!string.IsNullOrEmpty (items.Condition))
-				conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition, conditionCache);
+				conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition);
 
 			foreach (var item in items.Items) {
 
 				var include = context.EvaluateString (item.Include);
 				var exclude = context.EvaluateString (item.Exclude);
 
-				var it = CreateEvaluatedItem (context, project, project.Project, item, include, conditionCache);
+				var it = CreateEvaluatedItem (context, project, project.Project, item, include);
 
-				var trueCond = conditionIsTrue && (string.IsNullOrEmpty (it.Condition) || SafeParseAndEvaluate (project, context, it.Condition, conditionCache));
+				var trueCond = conditionIsTrue && (string.IsNullOrEmpty (it.Condition) || SafeParseAndEvaluate (project, context, it.Condition));
 
 				var excludeRegex = !string.IsNullOrEmpty (exclude) ? new Regex (ExcludeToRegex (exclude)) : null;
 
 				if (it.Include.IndexOf (';') == -1)
-					AddItem (project, context, item, it, it.Include, excludeRegex, trueCond, conditionCache);
+					AddItem (project, context, item, it, it.Include, excludeRegex, trueCond);
 				else {
 					foreach (var inc in it.Include.Split (new [] {';'}, StringSplitOptions.RemoveEmptyEntries))
-						AddItem (project, context, item, it, inc, excludeRegex, trueCond, conditionCache);
+						AddItem (project, context, item, it, inc, excludeRegex, trueCond);
 				}
 			}
 		}
 
-		static void AddItem (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item, MSBuildItemEvaluated it, string include, Regex excludeRegex, bool trueCond, Dictionary<string, ConditionExpression> conditionCache)
+		void AddItem (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item, MSBuildItemEvaluated it, string include, Regex excludeRegex, bool trueCond)
 		{
 			// Don't add the result from any item that has an empty include. MSBuild never returns those.
 			if (include == string.Empty)
@@ -286,7 +286,7 @@ namespace MonoDevelop.Projects.MSBuild
 				// This is a transform
 				List<MSBuildItemEvaluated> evalItems;
 				var transformExp = include.Substring (2, include.Length - 3);
-				if (ExecuteTransform (project, context, item, transformExp, out evalItems, conditionCache)) {
+				if (ExecuteTransform (project, context, item, transformExp, out evalItems)) {
 					foreach (var newItem in evalItems) {
 						project.EvaluatedItemsIgnoringCondition.Add (newItem);
 						if (trueCond)
@@ -298,7 +298,7 @@ namespace MonoDevelop.Projects.MSBuild
 				if (path == "**" || path.EndsWith ("\\**"))
 					path = path + "/*";
 				var subpath = path.Split ('\\');
-				foreach (var eit in ExpandWildcardFilePath (project, project.Project, context, item, project.Project.BaseDirectory, FilePath.Null, false, subpath, 0, conditionCache)) {
+				foreach (var eit in ExpandWildcardFilePath (project, project.Project, context, item, project.Project.BaseDirectory, FilePath.Null, false, subpath, 0)) {
 					if (excludeRegex != null && excludeRegex.IsMatch (eit.Include))
 						continue;
 					project.EvaluatedItemsIgnoringCondition.Add (eit);
@@ -308,7 +308,7 @@ namespace MonoDevelop.Projects.MSBuild
 			} else if (include != it.Include) {
 				if (excludeRegex != null && excludeRegex.IsMatch (include))
 					return;
-				it = CreateEvaluatedItem (context, project, project.Project, item, include, conditionCache);
+				it = CreateEvaluatedItem (context, project, project.Project, item, include);
 				project.EvaluatedItemsIgnoringCondition.Add (it);
 				if (trueCond)
 					project.EvaluatedItems.Add (it);
@@ -321,7 +321,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		static bool ExecuteTransform (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item, string transformExp, out List<MSBuildItemEvaluated> items, Dictionary<string, ConditionExpression> conditionCache)
+		bool ExecuteTransform (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item, string transformExp, out List<MSBuildItemEvaluated> items)
 		{
 			bool ignoreMetadata = false;
 
@@ -379,7 +379,7 @@ namespace MonoDevelop.Projects.MSBuild
 						}
 						// Now override metadata from the new item definition
 						foreach (var c in item.Metadata.GetProperties ()) {
-							if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (project, context, c.Condition, conditionCache, true))
+							if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (project, context, c.Condition, true))
 								md [c.Name] = new MSBuildPropertyEvaluated (project.Project, c.Name, c.Value, context.EvaluateString (c.Value));
 						}
 						((MSBuildPropertyGroupEvaluated)newItem.Metadata).SetProperties (md);
@@ -600,14 +600,14 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildImportGroup imports, bool evalItems)
 		{
-			if (!string.IsNullOrEmpty (imports.Condition) && !SafeParseAndEvaluate (project, context, imports.Condition, conditionCache, true))
+			if (!string.IsNullOrEmpty (imports.Condition) && !SafeParseAndEvaluate (project, context, imports.Condition, true))
 				return;
 
 			foreach (var item in imports.Imports)
 				Evaluate (project, context, item, evalItems);
 		}
 
-		static IEnumerable<MSBuildItemEvaluated> ExpandWildcardFilePath (ProjectInfo pinfo, MSBuildProject project, MSBuildEvaluationContext context, MSBuildItem sourceItem, FilePath basePath, FilePath baseRecursiveDir, bool recursive, string[] filePath, int index, Dictionary<string, ConditionExpression> conditionCache)
+		IEnumerable<MSBuildItemEvaluated> ExpandWildcardFilePath (ProjectInfo pinfo, MSBuildProject project, MSBuildEvaluationContext context, MSBuildItem sourceItem, FilePath basePath, FilePath baseRecursiveDir, bool recursive, string[] filePath, int index)
 		{
 			var res = Enumerable.Empty<MSBuildItemEvaluated> ();
 
@@ -617,10 +617,10 @@ namespace MonoDevelop.Projects.MSBuild
 			var path = filePath [index];
 
 			if (path == "..")
-				return ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath.ParentDirectory, baseRecursiveDir, recursive, filePath, index + 1, conditionCache);
+				return ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath.ParentDirectory, baseRecursiveDir, recursive, filePath, index + 1);
 			
 			if (path == ".")
-				return ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath, baseRecursiveDir, recursive, filePath, index + 1, conditionCache);
+				return ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath, baseRecursiveDir, recursive, filePath, index + 1);
 
 			if (!Directory.Exists (basePath))
 				return res;
@@ -634,13 +634,13 @@ namespace MonoDevelop.Projects.MSBuild
 				if (baseRecursiveDir.IsNullOrEmpty)
 					baseRecursiveDir = basePath;
 				
-				return ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath, baseRecursiveDir, true, filePath, index + 1, conditionCache);
+				return ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath, baseRecursiveDir, true, filePath, index + 1);
 			}
 
 			if (recursive) {
 				// Recursive search. Try to match the remaining subpath in all subdirectories.
 				foreach (var dir in Directory.EnumerateDirectories (basePath))
-					res = res.Concat (ExpandWildcardFilePath (pinfo, project, context, sourceItem, dir, baseRecursiveDir, true, filePath, index, conditionCache));
+					res = res.Concat (ExpandWildcardFilePath (pinfo, project, context, sourceItem, dir, baseRecursiveDir, true, filePath, index));
 			}
 
 			if (index == filePath.Length - 1) {
@@ -654,7 +654,7 @@ namespace MonoDevelop.Projects.MSBuild
 				res = res.Concat (Directory.EnumerateFiles (basePath, path).Select (f => {
 					context.SetItemContext (f, recursiveDir);
 					var ev = baseDir + Path.GetFileName (f);
-					return CreateEvaluatedItem (context, pinfo, project, sourceItem, ev, conditionCache);
+					return CreateEvaluatedItem (context, pinfo, project, sourceItem, ev);
 				}));
 			}
 			else {
@@ -665,9 +665,9 @@ namespace MonoDevelop.Projects.MSBuild
 
 				if (path.IndexOfAny (wildcards) != -1) {
 					foreach (var dir in Directory.EnumerateDirectories (basePath, path))
-						res = res.Concat (ExpandWildcardFilePath (pinfo, project, context, sourceItem, dir, baseRecursiveDir, false, filePath, index + 1, conditionCache));
+						res = res.Concat (ExpandWildcardFilePath (pinfo, project, context, sourceItem, dir, baseRecursiveDir, false, filePath, index + 1));
 				} else
-					res = res.Concat (ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath.Combine (path), baseRecursiveDir, false, filePath, index + 1, conditionCache));
+					res = res.Concat (ExpandWildcardFilePath (pinfo, project, context, sourceItem, basePath.Combine (path), baseRecursiveDir, false, filePath, index + 1));
 			}
 
 			return res;
@@ -713,14 +713,14 @@ namespace MonoDevelop.Projects.MSBuild
 			return include.Length > 3 && include [0] == '@' && include [1] == '(' && include [include.Length - 1] == ')';
 		}
 
-		static MSBuildItemEvaluated CreateEvaluatedItem (MSBuildEvaluationContext context, ProjectInfo pinfo, MSBuildProject project, MSBuildItem sourceItem, string include, Dictionary<string, ConditionExpression> conditionCache)
+		MSBuildItemEvaluated CreateEvaluatedItem (MSBuildEvaluationContext context, ProjectInfo pinfo, MSBuildProject project, MSBuildItem sourceItem, string include)
 		{
 			var it = new MSBuildItemEvaluated (project, sourceItem.Name, sourceItem.Include, include);
 			var md = new Dictionary<string,IMSBuildPropertyEvaluated> ();
 			// Only evaluate properties for non-transforms.
 			if (!IsIncludeTransform (include)) {
 				foreach (var c in sourceItem.Metadata.GetProperties ()) {
-					if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (pinfo, context, c.Condition, conditionCache, true))
+					if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (pinfo, context, c.Condition, true))
 						md [c.Name] = new MSBuildPropertyEvaluated (project, c.Name, c.Value, context.EvaluateString (c.Value));
 				}
 			}
@@ -734,7 +734,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildProperty prop)
 		{
-			if (string.IsNullOrEmpty (prop.Condition) || SafeParseAndEvaluate (project, context, prop.Condition, conditionCache, true)) {
+			if (string.IsNullOrEmpty (prop.Condition) || SafeParseAndEvaluate (project, context, prop.Condition, true)) {
 				bool needsItemEvaluation;
 				var val = context.Evaluate (prop.UnevaluatedValue, out needsItemEvaluation);
 				if (needsItemEvaluation)
@@ -746,7 +746,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		MSBuildItemEvaluated Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item)
 		{
-			return CreateEvaluatedItem (context, project, project.Project, item, context.EvaluateString (item.Include), conditionCache);
+			return CreateEvaluatedItem (context, project, project.Project, item, context.EvaluateString (item.Include));
 		}
 
 		IEnumerable<ProjectInfo> GetImportedProjects (ProjectInfo project, MSBuildImport import)
@@ -830,7 +830,7 @@ namespace MonoDevelop.Projects.MSBuild
 			var pr = context.EvaluateString (import.Project);
 			project.Imports [import] = pr;
 
-			if (!string.IsNullOrEmpty (import.Condition) && !SafeParseAndEvaluate (project, context, import.Condition, conditionCache, true))
+			if (!string.IsNullOrEmpty (import.Condition) && !SafeParseAndEvaluate (project, context, import.Condition, true))
 				return null;
 
 			var path = MSBuildProjectService.FromMSBuildPath (project.Project.BaseDirectory, pr);
@@ -873,7 +873,7 @@ namespace MonoDevelop.Projects.MSBuild
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildChoose choose, bool evalItems)
 		{
 			foreach (var op in choose.GetOptions ()) {
-				if (op.IsOtherwise || SafeParseAndEvaluate (project, context, op.Condition, conditionCache, true)) {
+				if (op.IsOtherwise || SafeParseAndEvaluate (project, context, op.Condition, true)) {
 					EvaluateObjects (project, context, op.GetAllObjects (), evalItems);
 					break;
 				}
@@ -882,7 +882,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildTarget target)
 		{
-			bool condIsTrue = SafeParseAndEvaluate (project, context, target.Condition, conditionCache);
+			bool condIsTrue = SafeParseAndEvaluate (project, context, target.Condition);
 			var newTarget = new MSBuildTarget (target.Name, target.Tasks);
 			newTarget.AfterTargets = context.EvaluateString (target.AfterTargets);
 			newTarget.Inputs = context.EvaluateString (target.Inputs);
@@ -897,7 +897,7 @@ namespace MonoDevelop.Projects.MSBuild
 		}
 
 		Dictionary<string, ConditionExpression> conditionCache = new Dictionary<string, ConditionExpression> ();
-		static bool SafeParseAndEvaluate (ProjectInfo project, MSBuildEvaluationContext context, string condition, Dictionary<string, ConditionExpression> conditionCache = null, bool collectConditionedProperties = false)
+		bool SafeParseAndEvaluate (ProjectInfo project, MSBuildEvaluationContext context, string condition, bool collectConditionedProperties = false)
 		{
 			try {
 				if (String.IsNullOrEmpty (condition))


### PR DESCRIPTION
This reduces duplicate string parsing and condition tokenizing/ConditionExpression creation.
Reduces runtime and allocations on a simple console project from 17MB to 8.1MB and runtime from 500ms to 300ms.