### PR TITLE
[DotNetCore] Update .NET Core SDK download url

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
@@ -33,9 +33,7 @@ namespace MonoDevelop.DotNetCore
 {
 	class DotNetCoreNotInstalledDialog : IDisposable
 	{
-		// TODO: This link needs to be changed.
-		// public static readonly string DotNetCoreDownloadUrl = "https://aka.ms/vs/mac/install-netcore";
-		public static readonly string DotNetCoreDownloadUrl = "https://github.com/dotnet/core/blob/master/release-notes/rc4-download.md";
+		public static readonly string DotNetCoreDownloadUrl = "https://aka.ms/vs/mac/install-netcore";
 
 		GenericMessage message;
 		AlertButton downloadButton;


### PR DESCRIPTION
Switch to main .NET Core SDK download instead of RC 4 now that
.NET Core SDK 1.0.1 has been released.