### PR TITLE
[vNext] Order and group new Remove and Update items

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -815,8 +815,9 @@ namespace MonoDevelop.Projects.MSBuild
 				if (group != null)
 					return group.AddNewItem (name, include, beforeItem);
 			}
-			MSBuildItemGroup grp = FindBestGroupForItem (name);
-			return grp.AddNewItem (name, include);
+			MSBuildItem it = CreateItem (name, include);
+			AddItem (it);
+			return it;
 		}
 
 		public MSBuildItem CreateItem (string name, string include)
@@ -843,32 +844,61 @@ namespace MonoDevelop.Projects.MSBuild
 					return;
 				}
 			}
-			MSBuildItemGroup grp = FindBestGroupForItem (it.Name);
+			MSBuildItemGroup grp = FindBestGroupForItem (it);
 			grp.AddItem (it);
 		}
 
-		MSBuildItemGroup FindBestGroupForItem (string itemName)
+		MSBuildItemGroup FindBestGroupForItem (MSBuildItem newItem)
 		{
+			string groupId = GetBestGroupId (newItem);
 			MSBuildItemGroup group;
 
 			if (bestGroups == null)
 				bestGroups = new Dictionary<string, MSBuildItemGroup> ();
 			else {
-				if (bestGroups.TryGetValue (itemName, out group))
+				if (bestGroups.TryGetValue (groupId, out group))
 					return group;
 			}
 
+			MSBuildItemGroup insertBefore = null;
 			foreach (MSBuildItemGroup grp in ItemGroups) {
 				foreach (MSBuildItem it in grp.Items) {
-					if (it.Name == itemName) {
-						bestGroups [itemName] = grp;
+					if (ShouldAddItemToGroup (it, newItem)) {
+						bestGroups [groupId] = grp;
 						return grp;
+					} else if (insertBefore == null && ShouldInsertItemGroupBefore (it, newItem)) {
+						insertBefore = grp;
 					}
 				}
 			}
-			group = AddNewItemGroup ();
-			bestGroups [itemName] = group;
+			group = AddNewItemGroup (insertBefore);
+			bestGroups [groupId] = group;
 			return group;
+		}
+
+		static string GetBestGroupId (MSBuildItem it)
+		{
+			if (it.IsRemove)
+				return it.Name + ":Remove";
+			else if (it.IsUpdate)
+				return it.Name + ":Update";
+			return it.Name;
+		}
+
+		static bool ShouldAddItemToGroup (MSBuildItem existingItem, MSBuildItem newItem)
+		{
+			return existingItem.Name == newItem.Name &&
+				existingItem.IsRemove == newItem.IsRemove &&
+				existingItem.IsUpdate == newItem.IsUpdate;
+		}
+
+		static bool ShouldInsertItemGroupBefore (MSBuildItem existing, MSBuildItem newItem)
+		{
+			if (newItem.IsInclusion)
+				return existing.IsUpdate;
+			if (newItem.IsRemove)
+				return existing.IsUpdate || (existing.IsInclusion && !existing.IsWildcardItem);
+			return false;
 		}
 
 		public XmlElement GetProjectExtension (string section)

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -1022,6 +1022,252 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (import1.HasAttribute ("xmlns"));
 			Assert.IsFalse (import2.HasAttribute ("xmlns"));
 		}
+
+		/// <summary>
+		/// Remove items should be grouped together with MSBuildItems with the same type.
+		/// </summary>
+		[Test]
+		public void AddRemoveItem ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			var removeItem = p.CreateItem ("None", "Text2.txt");
+			removeItem.Remove = "Text2.txt";
+			removeItem.Include = null;
+			p.AddItem (removeItem);
+
+			p.AddNewItem ("None", "Text1.txt");
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Remove=\"Text2.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Include=\"Text1.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+		}
+
+		/// <summary>
+		/// Remove items should be added before Include items in their own ItemGroup.
+		/// </summary>
+		[Test]
+		public void AddRemoveItemBeforeIncludeItem ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			p.AddNewItem ("None", "Text1.txt");
+
+			var removeItem = p.CreateItem ("None", "Text2.txt");
+			removeItem.Remove = "Text2.txt";
+			removeItem.Include = null;
+			p.AddItem (removeItem);
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Remove=\"Text2.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Include=\"Text1.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+		}
+
+
+		/// <summary>
+		/// Remove items should be added before Update items in their own ItemGroup.
+		/// </summary>
+		[Test]
+		public void AddRemoveItemBeforeUpdateItem ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			var updateItem = p.CreateItem ("None", "Text1.txt");
+			updateItem.Update = "Text1.txt";
+			updateItem.Include = null;
+			p.AddItem (updateItem);
+
+			var removeItem = p.CreateItem ("None", "Text2.txt");
+			removeItem.Remove = "Text2.txt";
+			removeItem.Include = null;
+			p.AddItem (removeItem);
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Remove=\"Text2.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Update=\"Text1.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+		}
+
+		/// <summary>
+		/// Remove items should be added before Include items in their own ItemGroup.
+		/// </summary>
+		[Test]
+		public void AddRemoveItemAfterWildcardIncludeItem ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			MSBuildItem item = p.AddNewItem ("None", @"**\*.txt");
+			item.EvaluatedItemCount = 2;
+
+			var removeItem = p.CreateItem ("None", "Text2.txt");
+			removeItem.Remove = "Text2.txt";
+			removeItem.Include = null;
+			p.AddItem (removeItem);
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Include=\"**\\*.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Remove=\"Text2.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+		}
+
+		/// <summary>
+		/// Update items should be grouped together with MSBuildItems with the same type.
+		/// </summary>
+		[Test]
+		public void AddUpdateItem ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			p.AddNewItem ("None", "Text1.txt");
+
+			var updateItem = p.CreateItem ("None", "Text2.txt");
+			updateItem.Update = "Text2.txt";
+			updateItem.Include = null;
+			p.AddItem (updateItem);
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Include=\"Text1.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Update=\"Text2.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+		}
+
+		/// <summary>
+		/// Include items should be inserted before existing Update items
+		/// in their own ItemGroup.
+		/// </summary>
+		[Test]
+		public void AddIncludeItemBeforeUpdateItem ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			var updateItem = p.CreateItem ("None", "Text2.txt");
+			updateItem.Update = "Text2.txt";
+			updateItem.Include = null;
+			p.AddItem (updateItem);
+
+			p.AddNewItem ("None", "Text1.txt");
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Include=\"Text1.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <None Update=\"Text2.txt\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+		}
 	}
 }
 


### PR DESCRIPTION
Remove and Update items are now added to their own ItemGroups
instead of being added to ItemGroups containing just the same
MSBuild items.

ItemGroups created for Remove items are inserted before Include
and Update ItemGroups. Remove items are inserted after Include
ItemGroups that have wildcard glob includes.

ItemGroups created for Include items are inserted before Update
ItemGroups.

TODO:

 - [ ] Fix MSBuildGlobTests - broken due to new ordering and grouping of items.