### PR TITLE
Fix issues with linked text.

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -252,7 +252,7 @@ namespace Mono.TextEditor
 			InterruptFoldWorker();
 			TextChanging?.Invoke(this, textChange);           
 			// After TextChanging notification has been sent, we can update the cached snapshot
-			this.currentSnapshot = this.TextBuffer.CurrentSnapshot;
+			this.currentSnapshot = args.After;
       
 			if (!isInUndo) {
 				operation = new UndoOperation(textChange);


### PR DESCRIPTION
Fix an issue with link text (53005). Root cause was that the TextDocument's "currentSnapshot" was wrong in the middle of an edit in which people were making edits from inside the TextChanged event.