### PR TITLE
Add support for custom MSBuild search paths

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetRuntime.cs
@@ -63,7 +63,9 @@ namespace MonoDevelop.Core.Assemblies
 		ComposedAssemblyContext composedAssemblyContext;
 		ITimeTracker timer;
 		TargetFramework[] customFrameworks = new TargetFramework[0];
-		
+
+		static int internalIdCounter;
+
 		protected bool ShuttingDown { get; private set; }
 		
 		public TargetRuntime ()
@@ -72,6 +74,8 @@ namespace MonoDevelop.Core.Assemblies
 			composedAssemblyContext = new ComposedAssemblyContext ();
 			composedAssemblyContext.Add (Runtime.SystemAssemblyService.UserAssemblyContext);
 			composedAssemblyContext.Add (assemblyContext);
+
+			InternalId = Interlocked.Increment (ref internalIdCounter);
 			
 			Runtime.ShuttingDown += delegate {
 				ShuttingDown = true;
@@ -140,6 +144,12 @@ namespace MonoDevelop.Core.Assemblies
 		/// Returns 'true' if this runtime is the one currently running MonoDevelop.
 		/// </summary>
 		public abstract bool IsRunning { get; }
+
+		/// <summary>
+		/// Internal id, to be used at run time
+		/// </summary>
+		/// <value>The internal identifier.</value>
+		internal int InternalId { get; private set; }
 		
 		public virtual IEnumerable<FilePath> GetReferenceFrameworkDirectories ()
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
@@ -160,8 +160,12 @@
 		<ExtensionNode name="Item" customAttributeType="MonoDevelop.Projects.ExportProjectItemTypeAttribute" />
 	</ExtensionPoint>
 
+	<ExtensionPoint path = "/MonoDevelop/ProjectModel/MSBuildImportSearchPaths" name = "MSBuild project import search paths">
+		<Description>Allows defining fallback search paths for MSBuild project imports</Description>
+		<ExtensionNode name="SearchPath" type="MonoDevelop.Projects.Extensions.ImportSearchPathExtensionNode" />
+	</ExtensionPoint>
+
 	<!-- Extensions -->
-	
 	
 	<Extension path = "/MonoDevelop/Core/ExecutionModes">
 		<ModeSet id="Run" _name="Run" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -634,6 +634,7 @@
     </Compile>
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildEvent.cs" />
     <Compile Include="MonoDevelop.Projects\MSBuildLogger.cs" />
+    <Compile Include="MonoDevelop.Projects.Extensions\ImportSearchPathExtensionNode.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/ImportSearchPathExtensionNode.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/ImportSearchPathExtensionNode.cs
@@ -1,0 +1,39 @@
+﻿//
+// ImportSearchPathExtensionNode.cs
+//
+// Author:
+//       Lluis Sanchez Gual <lluis@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Mono.Addins;
+
+namespace MonoDevelop.Projects.Extensions
+{
+	class ImportSearchPathExtensionNode: ExtensionNode
+	{
+		[NodeAttribute ("property")]
+		public string Property { get; set; }
+
+		[NodeAttribute ("path")]
+		public new string Path { get; set; }
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -939,43 +939,64 @@ namespace MonoDevelop.Projects.MSBuild
 				return;
             }
 
-			// For some reason, Mono can have several extension paths, so we need to try each of them
-			foreach (var ep in MSBuildEvaluationContext.GetApplicableExtensionsPaths ()) {
-				var files = GetImportFiles (project, context, import, ep);
-				if (files == null || files.Length == 0)
-					continue;
+
+			// Try importing the files using the import as is
+
+			bool keepSearching;
+
+			var files = GetImportFiles (project, context, import, null, null, out keepSearching);
+			if (files != null) {
 				foreach (var f in files)
 					ImportFile (project, context, import, f);
-				return;
 			}
 
-			// No import was found
+			// We may need to keep searching if the import was not found, or if the import had a wildcard.
+			// In that case, look in fallback search paths
+
+			if (keepSearching) {
+				foreach (var prop in context.GetProjectImportSearchPaths ()) {
+					if (import.Project.IndexOf ("$(" + prop.Property + ")", StringComparison.OrdinalIgnoreCase) == -1)
+						continue;
+					files = GetImportFiles (project, context, import, prop.Property, prop.Path, out keepSearching);
+					if (files != null) {
+						foreach (var f in files)
+							ImportFile (project, context, import, f);
+					}
+					if (!keepSearching)
+						break;
+				}
+			}
 		}
 
-		string[] GetImportFiles (ProjectInfo project, MSBuildEvaluationContext context, MSBuildImport import, string extensionsPath)
+		string[] GetImportFiles (ProjectInfo project, MSBuildEvaluationContext context, MSBuildImport import, string pathProperty, string pathPropertyValue, out bool keepSearching)
 		{
-			if (extensionsPath != null) {
+			// This methods looks for targets in location specified by the import, and replacing pathProperty by a specific value.
+
+			if (pathPropertyValue != null) {
 				var tempCtx = new MSBuildEvaluationContext (context);
-				var mep = MSBuildProjectService.ToMSBuildPath (null, extensionsPath);
-				tempCtx.SetPropertyValue ("MSBuildExtensionsPath", mep);
-				tempCtx.SetPropertyValue ("MSBuildExtensionsPath32", mep);
-				tempCtx.SetPropertyValue ("MSBuildExtensionsPath64", mep);
+				var mep = MSBuildProjectService.ToMSBuildPath (null, pathPropertyValue);
+				tempCtx.SetPropertyValue (pathProperty, mep);
 				context = tempCtx;
 			}
 
 			var pr = context.EvaluateString (import.Project);
 			project.Imports [import] = pr;
 
-			if (!string.IsNullOrEmpty (import.Condition) && !SafeParseAndEvaluate (project, context, import.Condition, true))
+			if (!string.IsNullOrEmpty (import.Condition) && !SafeParseAndEvaluate (project, context, import.Condition, true)) {
+				keepSearching = false;
 				return null;
+			}
 
 			var path = MSBuildProjectService.FromMSBuildPath (project.Project.BaseDirectory, pr);
 			var fileName = Path.GetFileName (path);
 
 			if (fileName.IndexOfAny (new [] { '*', '?' }) == -1) {
-				return File.Exists (path) ? new [] { path } : null;
+				var result = File.Exists (path) ? new [] { path } : null;
+				keepSearching = result == null;
+				return result;
 			}
 			else {
+				keepSearching = true;
 				path = Path.GetDirectoryName (path);
 				if (!Directory.Exists (path))
 					return null;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -39,6 +39,7 @@ using MonoDevelop.Projects.MSBuild.Conditions;
 using System.Globalization;
 using Microsoft.Build.Evaluation;
 using System.Web.UI.WebControls;
+using MonoDevelop.Projects.Extensions;
 
 namespace MonoDevelop.Projects.MSBuild
 {
@@ -48,6 +49,8 @@ namespace MonoDevelop.Projects.MSBuild
 		static Dictionary<string, string> envVars = new Dictionary<string, string> ();
 		HashSet<string> propertiesWithTransforms = new HashSet<string> ();
 		List<string> propertiesWithTransformsSorted = new List<string> ();
+		List<ImportSearchPathExtensionNode> searchPaths;
+
 		public Dictionary<string, bool> ExistsEvaluationCache { get; } = new Dictionary<string, bool> ();
 
 		bool allResolved;
@@ -106,7 +109,7 @@ namespace MonoDevelop.Projects.MSBuild
 				string toolsVersion = "15.0";
 				properties.Add ("MSBuildAssemblyVersion", "15.0");
 
-				var toolsPath = Runtime.SystemAssemblyService.DefaultRuntime.GetMSBuildToolsPath (toolsVersion);
+				var toolsPath = (project.TargetRuntime ?? Runtime.SystemAssemblyService.DefaultRuntime).GetMSBuildToolsPath (toolsVersion);
 
 				var frameworkToolsPath = ToolLocationHelper.GetPathToDotNetFramework (TargetDotNetFrameworkVersion.VersionLatest);
 
@@ -160,8 +163,8 @@ namespace MonoDevelop.Projects.MSBuild
 						extensionsPath = extensionsPath32;
 					properties.Add ("MSBuildExtensionsPath", extensionsPath);
 				}
-				else if (!String.IsNullOrEmpty (DefaultExtensionsPath)) {
-					var ep = MSBuildProjectService.ToMSBuildPath (null, extensionsPath);
+				else {
+					var ep = MSBuildProjectService.ToMSBuildPath (null, project.TargetRuntime.GetMSBuildExtensionsPath ());
 					properties.Add ("MSBuildExtensionsPath", ep);
 					properties.Add ("MSBuildExtensionsPath32", ep);
 					properties.Add ("MSBuildExtensionsPath64", ep);
@@ -170,6 +173,22 @@ namespace MonoDevelop.Projects.MSBuild
 				// Environment
 
 				properties.Add ("MSBuildProgramFiles32", MSBuildProjectService.ToMSBuildPath (null, Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86)));
+
+				// Search paths
+
+				searchPaths = MSBuildProjectService.GetProjectImportSearchPaths (project.TargetRuntime, true).ToList ();
+
+				// Custom override of MSBuildExtensionsPath using an env var
+
+				var customExtensionsPath = Environment.GetEnvironmentVariable ("MSBuildExtensionsPath");
+				if (!string.IsNullOrEmpty (customExtensionsPath)) {
+					if (IsExternalMSBuildExtensionsPath (customExtensionsPath))
+						// This is actually an override of the mono extensions path. Don't replace the default MSBuildExtensionsPath value since
+						// core targets still need to be loaded from there.
+						searchPaths.Insert (0, new ImportSearchPathExtensionNode { Property = "MSBuildExtensionsPath", Path = customExtensionsPath });
+					else
+						properties ["MSBuildExtensionsPath"] = MSBuildProjectService.ToMSBuildPath (null, customExtensionsPath);
+				}
 			}
 		}
 
@@ -177,45 +196,11 @@ namespace MonoDevelop.Projects.MSBuild
 			get { return project; }
 		}
 
-		static string extensionsPath;
-
-		internal static string DefaultExtensionsPath {
-			get {
-				if (extensionsPath == null) {
-					var path = Environment.GetEnvironmentVariable ("MSBuildExtensionsPath");
-					if (path != null && !IsExternalMSBuildExtensionsPath (path))
-						extensionsPath = path;
-				}
-
-				if (extensionsPath == null) {
-					// NOTE: code from mcs/tools/gacutil/driver.cs
-					PropertyInfo gac = typeof (System.Environment).GetProperty (
-						"GacPath", BindingFlags.Static | BindingFlags.NonPublic);
-
-					if (gac != null) {
-						MethodInfo get_gac = gac.GetGetMethod (true);
-						string gac_path = (string) get_gac.Invoke (null, null);
-						extensionsPath = Path.GetFullPath (Path.Combine (
-							gac_path, Path.Combine ("..", "xbuild")));
-					}
-				}
-				return extensionsPath;
-			}
-		}
-
-		static string macOSXExternalXBuildDir;
-
-		static string DefaultMacOSXExternalXBuildDir {
-			get {
-				if (macOSXExternalXBuildDir == null) {
-					var path = Environment.GetEnvironmentVariable ("MSBuildExtensionsPath");
-					if (path != null && IsExternalMSBuildExtensionsPath (path))
-						macOSXExternalXBuildDir = path;
-					else
-						macOSXExternalXBuildDir = MacOSXExternalXBuildDir;
-				}
-				return macOSXExternalXBuildDir;
-			}
+		public IEnumerable<ImportSearchPathExtensionNode> GetProjectImportSearchPaths ()
+		{
+			if (parentContext != null)
+				return parentContext.GetProjectImportSearchPaths ();
+			return searchPaths;
 		}
 
 		static bool IsExternalMSBuildExtensionsPath (string path)
@@ -235,20 +220,6 @@ namespace MonoDevelop.Projects.MSBuild
 			// targets path.
 
 			return Platform.IsMac && path.Contains ("Mono.framework/External/xbuild");
-		}
-
-		static string DotConfigExtensionsPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData), Path.Combine ("xbuild", "tasks"));
-		const string MacOSXExternalXBuildDir = "/Library/Frameworks/Mono.framework/External/xbuild";
-
-		internal static IEnumerable<string> GetApplicableExtensionsPaths ()
-		{
-			// On windows there is a single extension path, which is already properly defined in the engine
-			if (Platform.IsWindows)
-				yield return null;
-			if (Platform.IsMac)
-				yield return DefaultMacOSXExternalXBuildDir;
-			yield return DotConfigExtensionsPath;
-			yield return DefaultExtensionsPath;
 		}
 
 		internal void SetItemContext (string itemFile, string recursiveDir, IMSBuildPropertyGroupEvaluated metadata = null)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -36,6 +36,7 @@ using MonoDevelop.Projects.Utility;
 using System.Linq;
 using MonoDevelop.Projects.Text;
 using System.Threading.Tasks;
+using MonoDevelop.Core.Assemblies;
 
 namespace MonoDevelop.Projects.MSBuild
 {
@@ -189,6 +190,8 @@ namespace MonoDevelop.Projects.MSBuild
 				engineManager = value;
 			}
 		}
+
+		public TargetRuntime TargetRuntime { get; set; } = Runtime.SystemAssemblyService.DefaultRuntime;
 
 		public static Task<MSBuildProject> LoadAsync (string file)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -44,6 +44,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using MonoDevelop.Core.Execution;
+using System.Xml.Linq;
 
 namespace MonoDevelop.Projects.MSBuild
 {
@@ -54,6 +55,7 @@ namespace MonoDevelop.Projects.MSBuild
 		internal const string GlobalPropertyProvidersExtensionPath = "/MonoDevelop/ProjectModel/MSBuildGlobalPropertyProviders";
 		internal const string UnknownMSBuildProjectTypesExtensionPath = "/MonoDevelop/ProjectModel/UnknownMSBuildProjectTypes";
 		internal const string MSBuildProjectItemTypesPath = "/MonoDevelop/ProjectModel/MSBuildProjectItemTypes";
+		internal const string MSBuildImportSearchPathsPath = "/MonoDevelop/ProjectModel/MSBuildImportSearchPaths";
 
 		public const string GenericItemGuid = "{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}";
 		public const string FolderTypeGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
@@ -70,6 +72,10 @@ namespace MonoDevelop.Projects.MSBuild
 		static Dictionary<string,string> importRedirects = new Dictionary<string, string> ();
 		static UnknownProjectTypeNode[] unknownProjectTypeNodes;
 		static IDictionary<string,TypeExtensionNode> projecItemTypeNodes;
+
+		static Dictionary<TargetRuntime, List<ImportSearchPathExtensionNode>> defaultImportSearchPaths = new Dictionary<TargetRuntime, List<ImportSearchPathExtensionNode>> ();
+		static List<ImportSearchPathExtensionNode> importSearchPaths = new List<ImportSearchPathExtensionNode> ();
+		static bool searchPathConfigNeedsUpdate;
 
 		static AsyncCriticalSection buildersLock = new AsyncCriticalSection ();
 
@@ -109,6 +115,8 @@ namespace MonoDevelop.Projects.MSBuild
 				specialCharactersEscaped [specialCharacters [i]] = '%' + escaped;
 				specialCharactersUnescaped [escaped] = specialCharacters [i];
 			}
+
+			CleanCachedMSBuildExes ();
 		}
 
 		static void OnExtensionChanged (object sender, ExtensionEventArgs args)
@@ -119,6 +127,13 @@ namespace MonoDevelop.Projects.MSBuild
 				args.Path == GlobalPropertyProvidersExtensionPath ||
 				args.Path == MSBuildProjectItemTypesPath)
 				LoadExtensionData ();
+
+			if (args.Path == MSBuildImportSearchPathsPath) {
+				searchPathConfigNeedsUpdate = true;
+
+				// Reload all builders since search paths have changed
+				RecycleAllBuilders ().Ignore ();
+			}
 		}
 
 		static void LoadExtensionData ()
@@ -163,6 +178,81 @@ namespace MonoDevelop.Projects.MSBuild
 		internal static void UnregisterCustomProjectItemType (string name)
 		{
 			customProjectItemTypes.Remove (name);
+		}
+
+		/// <summary>
+		/// Registers a custom project import search path. This path will be used as a fallback when evaluating
+		/// an import and targets file is not found using the value assigned by MSBuild to the property.
+		/// </summary>
+		/// <param name="propertyName">Name of the property for which to add a fallback path</param>
+		/// <param name="path">The fallback path</param>
+		public static void RegisterProjectImportSearchPath (string propertyName, FilePath path)
+		{
+			importSearchPaths.Add (new ImportSearchPathExtensionNode { Property = propertyName, Path = path });
+			searchPathConfigNeedsUpdate = true;
+			RecycleAllBuilders ().Ignore ();
+		}
+
+		/// <summary>
+		/// Unregisters a previously registered import search path
+		/// </summary>
+		/// <param name="propertyName">Name of the property for which a fallback path was added.</param>
+		/// <param name="path">The fallback path to remove</param>
+		public static void UnregisterProjectImportSearchPath (string propertyName, FilePath path)
+		{
+			importSearchPaths.RemoveAll (i => i.Property == propertyName && i.Path == path);
+			searchPathConfigNeedsUpdate = true;
+			RecycleAllBuilders ().Ignore ();
+		}
+
+		/// <summary>
+		/// Gets a list of all search paths assigned to properties
+		/// </summary>
+		/// <returns>The search paths</returns>
+		/// <param name="runtime">Runtime for which to get the search paths.</param>
+		/// <param name="includeImplicitImports">If set to <c>true</c>, it returns all search paths, including those registered by
+		/// MSBuild and those registered using RegisterProjectImportSearchPath. If <c>false</c>, it only returns the paths
+		/// registered by RegisterProjectImportSearchPath.</param>
+		internal static IEnumerable<ImportSearchPathExtensionNode> GetProjectImportSearchPaths (TargetRuntime runtime, bool includeImplicitImports)
+		{
+			var result = AddinManager.GetExtensionNodes<ImportSearchPathExtensionNode> (MSBuildImportSearchPathsPath).Concat (importSearchPaths);
+			if (includeImplicitImports)
+				result = LoadDefaultProjectImportSearchPaths (runtime).Concat (result);
+			return result;
+		}
+
+		static List<ImportSearchPathExtensionNode> LoadDefaultProjectImportSearchPaths (TargetRuntime runtime)
+		{
+			// Load the default search paths defined in MSBuild.dll.config
+
+			lock (defaultImportSearchPaths) {
+				List<ImportSearchPathExtensionNode> list;
+				if (defaultImportSearchPaths.TryGetValue (runtime, out list))
+					return list;
+
+				list = new List<ImportSearchPathExtensionNode> ();
+				defaultImportSearchPaths [runtime] = list;
+
+				string binDir;
+				GetNewestInstalledToolsVersion (runtime, true, out binDir);
+
+				var configFile = Path.Combine (binDir, "MSBuild.dll.config");
+				if (File.Exists (configFile)) {
+					var doc = XDocument.Load (configFile);
+					var projectImportSearchPaths = doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")?.FirstOrDefault ()?.Element ("projectImportSearchPaths");
+					if (projectImportSearchPaths != null) {
+						var os = Platform.IsMac ? "osx" : Platform.IsWindows ? "windows" : "unix";
+						foreach (var searchPaths in projectImportSearchPaths.Elements ("searchPaths")) {
+							var pathOs = (string)searchPaths.Attribute ("os")?.Value;
+							if (!string.IsNullOrEmpty (pathOs) && pathOs != os)
+								continue;
+							foreach (var property in searchPaths.Elements ("property"))
+								list.Add (new ImportSearchPathExtensionNode { Property = property.Attribute ("name").Value, Path = property.Attribute ("value").Value });
+						}
+					}
+				}
+				return list;
+			}
 		}
 
 		static async void HandleGlobalPropertyProviderChanged (object sender, EventArgs e)
@@ -927,6 +1017,23 @@ namespace MonoDevelop.Projects.MSBuild
 			throw new Exception ("Did not find MSBuild for runtime " + runtime.Id);
 		}
 
+		/// <summary>
+		/// Forces the reload of all project builders
+		/// </summary>
+		/// <remarks>
+		/// This method can be used to discard all currently active project builders, and force the creation
+		/// of new ones. This method is useful when there is a change in the MSBuild options or environment
+		/// that has an effect on all builders. If a builder is running a task, it will be discarded when
+		/// the task ends.
+		/// </remarks>
+		public static async Task RecycleAllBuilders ()
+		{
+			using (await buildersLock.EnterAsync ()) {
+				foreach (var b in builders.GetAllBuilders ())
+					b.Shutdown ();
+			}
+		}
+
 		internal static async Task<RemoteProjectBuilder> GetProjectBuilder (TargetRuntime runtime, string minToolsVersion, string file, string solutionFile, int customId, bool requiresMicrosoftBuild, bool lockBuilder = false)
 		{
 			Version mtv = Version.Parse (minToolsVersion);
@@ -953,6 +1060,8 @@ namespace MonoDevelop.Projects.MSBuild
 
 				if (lockBuilder) {
 					foreach (var b in builders.GetBuilders (builderKey)) {
+						if (b.IsShuttingDown)
+							continue;
 						if (b.Lock ()) {
 							builder = b;
 							break;
@@ -960,13 +1069,11 @@ namespace MonoDevelop.Projects.MSBuild
 						b.Unlock ();
 					}
 				} else
-					builder = builders.GetBuilders (builderKey).FirstOrDefault ();
+					builder = builders.GetBuilders (builderKey).FirstOrDefault (b => !b.IsShuttingDown);
 				
 				if (builder != null) {
 					builder.ReferenceCount++;
-					var pb = new RemoteProjectBuilder (file, builder);
-					await pb.Load ();
-					return pb;
+					return await builder.CreateRemoteProjectBuilder (file).ConfigureAwait (false);
 				}
 
 				return await Task.Run (async () => {
@@ -1013,9 +1120,7 @@ namespace MonoDevelop.Projects.MSBuild
 					};
 					if (lockBuilder)
 						builder.Lock ();
-					var pb = new RemoteProjectBuilder (file, builder);
-					await pb.Load ().ConfigureAwait (false);
-					return pb;
+					return await builder.CreateRemoteProjectBuilder (file).ConfigureAwait (false);
 				});
 			}
 		}
@@ -1042,9 +1147,33 @@ namespace MonoDevelop.Projects.MSBuild
 
 			return dictionary;;
 		}
-		
+
+#region MSBuild exe file location
+
+		/// <summary>
+		/// Gets the project builder exe to be used to for a specific runtime and tools version
+		/// </summary>
 		static string GetExeLocation (TargetRuntime runtime, string toolsVersion, bool requiresMicrosoftBuild)
 		{
+			// If the builder for the latest MSBuild tools is being requested, return a local copy of the exe.
+			// That local copy is configured to add additional msbuild search paths defined by add-ins.
+
+			var mainExe = GetMSBuildExeLocationInBundle (runtime);
+			var exe = GetExeLocationInBundle (runtime, toolsVersion, requiresMicrosoftBuild);
+			if (exe == mainExe)
+				return GetLocalMSBuildExeLocation (runtime);
+			return exe;
+		}
+
+		static string GetMSBuildExeLocationInBundle (TargetRuntime runtime)
+		{
+			return GetExeLocationInBundle (runtime, "15.0", true);
+		}
+
+		static string GetExeLocationInBundle (TargetRuntime runtime, string toolsVersion, bool requiresMicrosoftBuild)
+		{
+			// Locate the project builder exe in the MD directory
+
 			var builderDir = new FilePath (typeof(MSBuildProjectService).Assembly.Location).ParentDirectory.Combine ("MSBuild");
 
 			var version = Version.Parse (toolsVersion);
@@ -1063,6 +1192,136 @@ namespace MonoDevelop.Projects.MSBuild
 			
 			throw new InvalidOperationException ("Unsupported MSBuild ToolsVersion '" + version + "'");
 		}
+
+		static string GetLocalMSBuildExeLocation (TargetRuntime runtime)
+		{
+			// Gets a path to the local copy of the project builder for the provided runtime.
+			// If no local copy exists, create one.
+
+			// Builders are copied to a folder inside the cache folder. This folder is cleaned
+			// every time XS is started, removing unused builders. The process id is used
+			// as folder name, so it is easy to check if the folder is currently in use or not.
+
+			var dirId = Process.GetCurrentProcess ().Id.ToString () + "_" + runtime.InternalId;
+			var exesDir = UserProfile.Current.CacheDir.Combine ("MSBuild").Combine (dirId);
+
+			if (!Directory.Exists (exesDir)) {
+				// Copy the builder to the local dir, including the debug file and config file.
+				Directory.CreateDirectory (exesDir);
+				var exe = GetMSBuildExeLocationInBundle (runtime);
+				File.Copy (exe, exesDir.Combine (Path.GetFileName (exe)));
+				var exeMdb = exe + ".mdb";
+				if (File.Exists (exeMdb))
+					File.Copy (exeMdb, exesDir.Combine (Path.GetFileName (exeMdb)));
+				var exePdb = Path.ChangeExtension (exe, ".pdb");
+				if (File.Exists (exePdb))
+					File.Copy (exePdb, exesDir.Combine (Path.GetFileName (exePdb)));
+				var exeConfig = exe + ".config";
+				if (File.Exists (exeConfig))
+					File.Copy (exeConfig, exesDir.Combine (Path.GetFileName (exeConfig + ".original")));
+
+				searchPathConfigNeedsUpdate = true;
+			}
+
+			if (searchPathConfigNeedsUpdate) {
+				// There is already a local copy of the builder, but the config file needs to be updated.
+				searchPathConfigNeedsUpdate = false;
+				UpdateMSBuildExeConfigFile (runtime);
+			}
+			return exesDir.Combine ("MonoDevelop.Projects.Formats.MSBuild.exe");
+		}
+
+		static void UpdateMSBuildExeConfigFile (TargetRuntime runtime)
+		{
+			// Creates an MSBuild config file with the search paths registered by add-ins.
+
+			foreach (var configFile in Directory.GetFiles (Path.GetDirectoryName (GetLocalMSBuildExeLocation (runtime)), "*.config.original")) {
+
+				var localConfigFile = configFile.Substring (0, configFile.Length - 9);
+
+				var doc = XDocument.Load (configFile);
+				var toolset = doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")?.FirstOrDefault ();
+
+				if (toolset != null) {
+					
+					string binDir;
+					GetNewestInstalledToolsVersion (runtime, true, out binDir);
+
+					// This is required for MSBuild to properly load the searchPaths element (@radical knows why)
+					SetMSBuildConfigProperty (toolset, "MSBuildBinPath", binDir, false, true);
+
+					var projectImportSearchPaths = doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")?.FirstOrDefault ()?.Element ("projectImportSearchPaths");
+					if (projectImportSearchPaths != null) {
+						var os = Platform.IsMac ? "osx" : Platform.IsWindows ? "windows" : "unix";
+						XElement searchPaths = projectImportSearchPaths.Elements ("searchPaths").FirstOrDefault (sp => sp.Attribute ("os")?.Value == os);
+						if (searchPaths == null) {
+							searchPaths = new XElement ("searchPaths");
+							searchPaths.SetAttributeValue ("os", os);
+							projectImportSearchPaths.Add (searchPaths);
+						}
+						foreach (var path in GetProjectImportSearchPaths (runtime, false))
+							SetMSBuildConfigProperty (searchPaths, path.Property, path.Path, true, false);
+					}
+					doc.Save (localConfigFile);
+				}
+			}
+		}
+
+		static void SetMSBuildConfigProperty (XElement elem, string name, string value, bool append, bool insertBefore)
+		{
+			var prop = elem.Elements ("property").FirstOrDefault (p => p.Attribute ("name")?.Value == name);
+			if (prop != null) {
+				var val = prop.Attribute ("value")?.Value;
+				if (append)
+					prop.SetAttributeValue ("value", val + ";" + value);
+				else
+					prop.SetAttributeValue ("value", value);
+			} else {
+				prop = new XElement ("property");
+				prop.SetAttributeValue ("name", name);
+				prop.SetAttributeValue ("value", value);
+				if (insertBefore)
+					elem.AddFirst (prop);
+				else
+					elem.Add (prop);
+			}
+		}
+
+		static void CleanCachedMSBuildExes ()
+		{
+			// Removes local copies of project builders that are not currently being used.
+
+			var exesDir = UserProfile.Current.CacheDir.Combine ("MSBuild");
+			if (!Directory.Exists (exesDir))
+				return;
+			
+			foreach (var dir in Directory.GetDirectories (exesDir)) {
+				// The file name has to parts: <process-id>_<runtime-id>
+				var spid = Path.GetFileName (dir);
+				int i = spid.IndexOf ('_');
+				if (i == -1)
+					continue;
+				spid = spid.Substring (0, i);
+				int pid;
+				if (int.TryParse (Path.GetFileName (spid), out pid)) {
+					try {
+						// If there is a process running with this id it means the builder is still being used
+						if (Process.GetProcessById (pid) != null)
+							continue;
+					} catch {
+						// Ignore
+					}
+					// No process for this id, it should be safe to delete the folder
+					try {
+						Directory.Delete (dir, true);
+					} catch (Exception ex) {
+						LoggingService.LogError ("Could not delete MSBuild cache folder", ex);
+					}
+				}
+			}
+		}
+
+#endregion
 
 		internal static async void ReleaseProjectBuilder (RemoteBuildEngine engine)
 		{

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/Main.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/Main.cs
@@ -44,6 +44,9 @@ namespace MonoDevelop.Projects.MSBuild
 		[STAThread]
 		public static void Main (string[] args)
 		{
+			// This is required for MSBuild to properly load the .exe.config configuration file for this executable.
+			Environment.SetEnvironmentVariable ("MSBUILD_EXE_PATH", typeof(MainClass).Assembly.Location);
+
 			RemoteProcessServer server = new RemoteProcessServer ();
 			server.Connect (args, new AssemblyResolver (server));
 		}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
@@ -32,8 +32,11 @@
 	</runtime>
 	<msbuildToolsets default="15.0">
 		<toolset toolsVersion="15.0">
-			<property name="MSBuildBinPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" />
-			<property name="MSBuildToolsPath" value="/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin" />
+			<property name="MSBuildRuntimeVersion" value="4.0.30319" />
+			<property name="MSBuildToolsPath" value="$(MSBuildBinPath)" />
+			<property name="MSBuildToolsPath32" value="$(MSBuildBinPath)" />
+			<property name="MSBuildToolsPath64" value="$(MSBuildBinPath)" />
+			<property name="RoslynTargetsPath" value="$(MSBuildToolsPath)\Roslyn" />
 			<property name="TargetFrameworkRootPathSearchPathsOSX" value="/Library/Frameworks/Mono.framework/External/xbuild-frameworks/" />
 			<projectImportSearchPaths>
 				<searchPaths os="osx">

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildSearchPathTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildSearchPathTests.cs
@@ -1,0 +1,52 @@
+﻿//
+// MSBuildSearchPathTests.cs
+//
+// Author:
+//       Lluis Sanchez Gual <lluis@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnitTests;
+using System.IO;
+
+namespace MonoDevelop.Projects
+{
+	[TestFixture]
+	public class MSBuildSearchPathTests: TestBase
+	{
+		[Test]
+		public async Task InjectTarget ()
+		{
+			string extPath = Util.GetSampleProjectPath ("msbuild-search-paths", "extensions-path");
+			MonoDevelop.Projects.MSBuild.MSBuildProjectService.RegisterProjectImportSearchPath ("MSBuildExtensionsPath", extPath + Path.DirectorySeparatorChar);
+
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+
+			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var project = (Project)sol.Items [0];
+			var res = await project.RunTarget (Util.GetMonitor (false), "TestInjected", project.Configurations[0].Selector);
+			Assert.AreEqual (1, res.BuildResult.WarningCount);
+			Assert.AreEqual ("Works!", res.BuildResult.Errors[0].ErrorText);
+		}
+	}
+}

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -306,6 +306,7 @@
     <Compile Include="MonoDevelop.Projects\MSBuildLoggerTests.cs" />
     <Compile Include="MonoDevelop.Core\MonoExecutionParametersTests.cs" />
     <Compile Include="MonoDevelop.Components.PropertyGrid\EditorManagerTests.cs" />
+    <Compile Include="MonoDevelop.Projects\MSBuildSearchPathTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\md.targets" />

--- a/main/tests/test-projects/msbuild-search-paths/ConsoleProject.csproj
+++ b/main/tests/test-projects/msbuild-search-paths/ConsoleProject.csproj
@@ -1,0 +1,42 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\simple.props" />
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/extensions-path/15.0/Microsoft.Common.targets/ImportAfter/injected-target.targets
+++ b/main/tests/test-projects/msbuild-search-paths/extensions-path/15.0/Microsoft.Common.targets/ImportAfter/injected-target.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="TestInjected">
+		<Warning Text="Works!" />
+	</Target>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/extensions-path/simple.props
+++ b/main/tests/test-projects/msbuild-search-paths/extensions-path/simple.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<TestTarget>Works!</TestTarget>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR introduces a new extension point and additional api that allows registering custom fallback search paths for MSBuild properties. For example, it can be used to define additional search paths for $(MSBuildExtensionsPath), which means that add-ins can provide their own target files to be imported in projects.

Since MSBuild loads search paths from the builder's config file, and there is no API to dynamically register those paths, what MD does is to make a copy of the project builder into the local cache directory and then modifies the config file, adding the required search paths.

