### PR TITLE
Add support for SDKs fallback search paths

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using MonoDevelop.Core;
+using MonoDevelop.Projects.MSBuild;
 
 namespace MonoDevelop.DotNetCore
 {
@@ -55,9 +56,7 @@ namespace MonoDevelop.DotNetCore
 
 			MSBuildSDKsPath = Path.Combine (SdksParentDirectory, "Sdks");
 
-			// HACK: Set MSBuildSDKsPath environment variable so MSBuild will find the
-			// SDK files when building and running targets.
-			Environment.SetEnvironmentVariable ("MSBuildSDKsPath", MSBuildSDKsPath + Path.DirectorySeparatorChar);
+			MSBuildProjectService.RegisterProjectImportSearchPath ("MSBuildSDKsPath", MSBuildSDKsPath);
 		}
 
 		public void FindSdkPaths (string sdk)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -996,7 +996,9 @@ namespace MonoDevelop.Projects.MSBuild
 			project.Imports [import] = pr;
 
 			if (!string.IsNullOrEmpty (import.Condition) && !SafeParseAndEvaluate (project, context, import.Condition, true)) {
-				keepSearching = false;
+				// Condition evaluates to false. Keep searching because maybe another value for the path property makes
+				// the condition evaluate to true.
+				keepSearching = true;
 				return null;
 			}
 
@@ -1004,11 +1006,13 @@ namespace MonoDevelop.Projects.MSBuild
 			var fileName = Path.GetFileName (path);
 
 			if (fileName.IndexOfAny (new [] { '*', '?' }) == -1) {
+				// Not a wildcard. Keep searching if the file doesn't exist.
 				var result = File.Exists (path) ? new [] { path } : null;
 				keepSearching = result == null;
 				return result;
 			}
 			else {
+				// Wildcard import. Always keep searching since we want to import all files that match from all search paths.
 				keepSearching = true;
 				path = Path.GetDirectoryName (path);
 				if (!Directory.Exists (path))

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -891,6 +891,17 @@ namespace MonoDevelop.Projects.MSBuild
 				return null;
 		}
 
+		/// <summary>
+		/// Returns a list of SDKs referenced by this project
+		/// </summary>
+		public string[] GetReferencedSDKs ()
+		{
+			if (!string.IsNullOrEmpty (Sdk))
+				return Sdk.Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+			else
+				return new string [0];
+		}
+
 		XmlNamespaceManager GetNamespaceManagerForProject ()
 		{
 			if (Namespace == Schema)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -68,9 +68,9 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		public async Task<RemoteProjectBuilder> CreateRemoteProjectBuilder (string projectFile)
+		public async Task<RemoteProjectBuilder> CreateRemoteProjectBuilder (string projectFile, string sdksPath)
 		{
-			var builder = await LoadProject (projectFile).ConfigureAwait (false);
+			var builder = await LoadProject (projectFile, sdksPath).ConfigureAwait (false);
 			var pb = new RemoteProjectBuilder (projectFile, builder, this);
 			lock (remoteProjectBuilders) {
 				remoteProjectBuilders.Add (pb);
@@ -82,10 +82,10 @@ namespace MonoDevelop.Projects.MSBuild
 			return pb;
 		}
 
-		async Task<ProjectBuilder> LoadProject (string projectFile)
+		async Task<ProjectBuilder> LoadProject (string projectFile, string sdksPath)
 		{
 			try {
-				var pid = (await connection.SendMessage (new LoadProjectRequest { ProjectFile = projectFile})).ProjectId;
+				var pid = (await connection.SendMessage (new LoadProjectRequest { ProjectFile = projectFile, SDKsPath = sdksPath })).ProjectId;
 				return new ProjectBuilder (connection, pid);
 			} catch {
 				await CheckDisconnected ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1335,7 +1335,7 @@ namespace MonoDevelop.Projects
 						projectBuilder.Shutdown ();
 						projectBuilder.ReleaseReference ();
 					}
-					var sdkPath = !string.IsNullOrEmpty (MSBuildProject.Sdk) ? MSBuildProjectService.FindSdkPath (runtime, MSBuildProject.Sdk) : null;
+					var sdkPath = !string.IsNullOrEmpty (MSBuildProject.Sdk) ? MSBuildProjectService.FindSdkPath (runtime, MSBuildProject.GetReferencedSDKs ()) : null;
 					var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild);
 					pb.AddReference ();
 					pb.Disconnected += delegate {
@@ -1379,7 +1379,7 @@ namespace MonoDevelop.Projects
 			var sln = ParentSolution;
 			var slnFile = sln != null ? sln.FileName : null;
 
-			var sdkPath = !string.IsNullOrEmpty (MSBuildProject.Sdk) ? MSBuildProjectService.FindSdkPath (runtime, MSBuildProject.Sdk) : null;
+			var sdkPath = !string.IsNullOrEmpty (MSBuildProject.Sdk) ? MSBuildProjectService.FindSdkPath (runtime, MSBuildProject.GetReferencedSDKs ()) : null;
 			var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild, true);
 			pb.AddReference ();
 			if (modifiedInMemory) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1335,7 +1335,8 @@ namespace MonoDevelop.Projects
 						projectBuilder.Shutdown ();
 						projectBuilder.ReleaseReference ();
 					}
-					var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, 0, RequiresMicrosoftBuild);
+					var sdkPath = !string.IsNullOrEmpty (MSBuildProject.Sdk) ? MSBuildProjectService.FindSdkPath (runtime, MSBuildProject.Sdk) : null;
+					var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild);
 					pb.AddReference ();
 					pb.Disconnected += delegate {
 						CleanupProjectBuilder ();
@@ -1378,7 +1379,8 @@ namespace MonoDevelop.Projects
 			var sln = ParentSolution;
 			var slnFile = sln != null ? sln.FileName : null;
 
-			var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, 0, RequiresMicrosoftBuild, true);
+			var sdkPath = !string.IsNullOrEmpty (MSBuildProject.Sdk) ? MSBuildProjectService.FindSdkPath (runtime, MSBuildProject.Sdk) : null;
+			var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild, true);
 			pb.AddReference ();
 			if (modifiedInMemory) {
 				try {

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Projects.MSBuild
 				gp.SetProperty (p.Key, p.Value);
 		}
 
-		public ProjectBuilder LoadProject (string file)
+		public ProjectBuilder LoadProject (string file, string sdksPath)
 		{
 			return new ProjectBuilder (this, file);
 		}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.v4.0.cs
@@ -53,9 +53,9 @@ namespace MonoDevelop.Projects.MSBuild
 				engine.SetGlobalProperty (p.Key, p.Value);
 		}
 
-		public ProjectBuilder LoadProject (string file)
+		public ProjectBuilder LoadProject (string file, string sdksPath)
 		{
-			return new ProjectBuilder (this, engine, file);
+			return new ProjectBuilder (this, engine, file, sdksPath);
 		}
 		
 		public void UnloadProject (ProjectBuilder pb)

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -44,10 +44,12 @@ namespace MonoDevelop.Projects.MSBuild
 		readonly ProjectCollection engine;
 		readonly string file;
 		readonly BuildEngine buildEngine;
+		readonly string sdksPath;
 
-		public ProjectBuilder (BuildEngine buildEngine, ProjectCollection engine, string file)
+		public ProjectBuilder (BuildEngine buildEngine, ProjectCollection engine, string file, string sdksPath)
 		{
 			this.file = file;
+			this.sdksPath = sdksPath;
 			this.engine = engine;
 			this.buildEngine = buildEngine;
 			Refresh ();
@@ -65,6 +67,8 @@ namespace MonoDevelop.Projects.MSBuild
 				Project project = null;
 				Dictionary<string, string> originalGlobalProperties = null;
 				try {
+					if (sdksPath != null)
+						Environment.SetEnvironmentVariable ("MSBuildSDKsPath", sdksPath);
 					project = SetupProject (configurations);
 					InitLogger (logWriter);
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/BuildEngine.Shared.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/BuildEngine.Shared.cs
@@ -128,7 +128,7 @@ namespace MonoDevelop.Projects.MSBuild
 		[MessageHandler]
 		public LoadProjectResponse LoadProject (LoadProjectRequest msg)
 		{
-			var pb = LoadProject (msg.ProjectFile);
+			var pb = LoadProject (msg.ProjectFile, msg.SDKsPath);
 			lock (projects) {
 				var id = ++projectIdCounter;
 				projects [id] = pb;

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/RemoteBuildEngineMessages.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/RemoteBuildEngineMessages.cs
@@ -50,6 +50,9 @@ namespace MonoDevelop.Projects.MSBuild
 	{
 		[MessageDataProperty]
 		public string ProjectFile { get; set; }
+
+		[MessageDataProperty]
+		public string SDKsPath { get; set; }
 	}
 
 	[MessageDataTypeAttribute]

--- a/main/tests/test-projects/msbuild-search-paths/ProjectUsingMultiSdk.csproj
+++ b/main/tests/test-projects/msbuild-search-paths/ProjectUsingMultiSdk.csproj
@@ -1,0 +1,41 @@
+<Project DefaultTargets="Build" Sdk="Foo.Sdk;Bar.Sdk">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/ProjectUsingSdk.csproj
+++ b/main/tests/test-projects/msbuild-search-paths/ProjectUsingSdk.csproj
@@ -1,0 +1,41 @@
+<Project DefaultTargets="Build" Sdk="Foo.Sdk">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/ProjectUsingSdk2.csproj
+++ b/main/tests/test-projects/msbuild-search-paths/ProjectUsingSdk2.csproj
@@ -1,0 +1,41 @@
+<Project DefaultTargets="Build" Sdk="Bar.Sdk">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-2/Bar.Sdk/Sdk/Sdk.props
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-2/Bar.Sdk/Sdk/Sdk.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<BarProp>Works!</BarProp>
+	</PropertyGroup>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-2/Bar.Sdk/Sdk/Sdk.targets
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-2/Bar.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="BarTarget">
+		<Warning Text="Works!" />
+	</Target>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Bar.Sdk/Sdk/Sdk.props
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Bar.Sdk/Sdk/Sdk.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<BarProp>Works!</BarProp>
+	</PropertyGroup>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Bar.Sdk/Sdk/Sdk.targets
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Bar.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="BarTarget">
+		<Warning Text="Works!" />
+	</Target>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Foo.Sdk/Sdk/Sdk.props
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Foo.Sdk/Sdk/Sdk.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<SdkProp>Works!</SdkProp>
+	</PropertyGroup>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Foo.Sdk/Sdk/Sdk.targets
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-all/Foo.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="SdkTarget">
+		<Warning Text="Works!" />
+	</Target>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path/Foo.Sdk/Sdk/Sdk.props
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path/Foo.Sdk/Sdk/Sdk.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<SdkProp>Works!</SdkProp>
+	</PropertyGroup>
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path/Foo.Sdk/Sdk/Sdk.targets
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path/Foo.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="SdkTarget">
+		<Warning Text="Works!" />
+	</Target>
+</Project>


### PR DESCRIPTION
Search paths for MSBuildSDKsPath are now supported, but they are handled in a special way, since MSBuild really doesn't support fallback paths for MSBuildSDKsPath. When loading a new project that has a reference to an SDK we now look for that SDK in any of the registered locations. If a location is found, the path is provided to the project builder, which sets the MSBuildSDKsPath env var before loading the project.

I have checked this with regular projects, but not with .NET Core projects. It may be necessary to remove custom SDK handling code from the .NET Core add-in.