### PR TITLE
[GTK#] Fix designer toolbox to show custom widget from assembly references

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderProject.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderProject.cs
@@ -435,7 +435,7 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 				if (p != null)
 					path = p.GetOutputFileName (IdeApp.Workspace.ActiveConfiguration);
 			} else if (pref.ReferenceType == ReferenceType.Assembly) {
-				path = pref.Reference;
+				path = pref.HintPath;
 			} else if (pref.ReferenceType == ReferenceType.Package) {
 				path = pref.Reference;
 			}


### PR DESCRIPTION
While trying to reproduce https://bugzilla.xamarin.com/show_bug.cgi?id=38967 I noticed bug...