### PR TITLE
Bug 52716 - [Cycle 9] "Quick Fix > Encapsulate field: '...' (and use property)" refactoring command does nothing

### DIFF
--- a/main/src/addins/CSharpBinding/Util/SymbolKeyExtensions.cs
+++ b/main/src/addins/CSharpBinding/Util/SymbolKeyExtensions.cs
@@ -68,7 +68,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 		internal static SymbolKey Create(ISymbol symbol, Compilation compilation = null, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			try {
-				var instance = createMethod.Invoke (null, new object [] { symbol, compilation, cancellationToken });
+				var instance = createMethod.Invoke (null, new object [] { symbol, cancellationToken });
 				return new SymbolKey (instance);
 			} catch (TargetInvocationException ex) {
 				ExceptionDispatchInfo.Capture(ex.InnerException).Throw();


### PR DESCRIPTION
This API was changed here:
https://github.com/dotnet/roslyn/commit/7ce073360b455fa7ba0054a377687e392b6cebd2#diff-0305ff927cc9a81ca44025667b546ccbR105

There is no need to fix this on master because roslyn-ivt branch doesnt have this code anymore(no more reflection ftw).