### PR TITLE
[CSharpBinding] Remove ProtocolMemberContextHandler from .addin.xml

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -324,10 +324,6 @@
 		</Condition>
 	</Extension>
 
-	<Extension path = "/MonoDevelop/CSharp/Completion/ContextHandler">
-		<Class class="MonoDevelop.CSharp.Completion.ProtocolMemberContextHandler" />
-	</Extension>
-	
 	<Extension path = "/MonoDevelop/Ide/BraceMatcher">
 		<Class class="MonoDevelop.CSharp.CSharpBraceMatcher" />
 	</Extension>


### PR DESCRIPTION
This class was removed in 1a7513e22 but it was not removed from .addin.xml which is causing errors in log files