### PR TITLE
[NuGet] Handle missing project when restoring a .NET Core project

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
@@ -29,6 +29,7 @@ using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 using NUnit.Framework;
 
@@ -40,9 +41,13 @@ namespace MonoDevelop.PackageManagement.Tests
 		PackageSpec spec;
 		FakeDotNetProject project;
 		FakeSolution solution;
+		PackageManagementEvents packageManagementEvents;
+		PackageManagementLogger logger;
 
 		void CreateProject (string name, string fileName = @"d:\projects\MyProject\MyProject.csproj")
 		{
+			packageManagementEvents = new PackageManagementEvents ();
+			logger = new PackageManagementLogger (packageManagementEvents);
 			solution = new FakeSolution ();
 			project = new FakeDotNetProject (fileName.ToNativePath ());
 			project.ParentSolution = solution;
@@ -56,7 +61,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 		void CreatePackageSpec ()
 		{
-			spec = PackageSpecCreator.CreatePackageSpec (project);
+			spec = PackageSpecCreator.CreatePackageSpec (project, logger);
 		}
 
 		void AddPackageReference (string id, string version)
@@ -174,6 +179,34 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("MyProject", spec.RestoreMetadata.ProjectName);
 			Assert.AreEqual ("netcoreapp1.0", spec.RestoreMetadata.OriginalTargetFrameworks.Single ());
 			Assert.AreEqual (".NETCoreApp,Version=v1.0", targetFramework.FrameworkName.ToString ());
+			Assert.AreEqual (0, targetFramework.ProjectReferences.Count);
+		}
+
+		[Test]
+		public void CreatePackageSpec_OneProjectReferenceWhichCannotBeResolved_WarningLoggedAndNoProjectReferencedAddedToPackageSpec ()
+		{
+			CreateProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			AddTargetFramework ("netcoreapp1.0");
+			string referencedProjectFileName = @"d:\projects\MyProject\Lib\Lib.csproj".ToNativePath ();
+			string include = @"Lib\Lib.csproj".ToNativePath ();
+			AddProjectReference ("Lib", referencedProjectFileName, include);
+			solution.OnResolveProject = pr => {
+				return null;
+			};
+			PackageOperationMessage messageLogged = null;
+			packageManagementEvents.PackageOperationMessageLogged += (sender, e) => {
+				messageLogged = e.Message;
+			};
+			CreatePackageSpec ();
+
+			var targetFramework = spec.RestoreMetadata.TargetFrameworks.Single ();
+			string expectedMessage = string.Format ("WARNING: Unable to resolve project '{0}' referenced by 'MyProject'.", include);
+			Assert.AreEqual ("MyProject", spec.Name);
+			Assert.AreEqual ("MyProject", spec.RestoreMetadata.ProjectName);
+			Assert.AreEqual ("netcoreapp1.0", spec.RestoreMetadata.OriginalTargetFrameworks.Single ());
+			Assert.AreEqual (".NETCoreApp,Version=v1.0", targetFramework.FrameworkName.ToString ());
+			Assert.AreEqual (expectedMessage, messageLogged.ToString ());
+			Assert.AreEqual (MessageLevel.Warning, messageLogged.Level);
 			Assert.AreEqual (0, targetFramework.ProjectReferences.Count);
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -203,7 +203,7 @@ namespace MonoDevelop.PackageManagement
 				return new [] { existingPackageSpec };
 			}
 
-			PackageSpec packageSpec = await CreateProjectPackageSpec ();
+			PackageSpec packageSpec = await CreateProjectPackageSpec (context);
 
 			if (context != null) {
 				AddToCache (context, packageSpec);
@@ -223,15 +223,15 @@ namespace MonoDevelop.PackageManagement
 			return packageSpec;
 		}
 
-		async Task<PackageSpec> CreateProjectPackageSpec ()
+		async Task<PackageSpec> CreateProjectPackageSpec (DependencyGraphCacheContext context)
 		{
-			PackageSpec packageSpec = await Runtime.RunInMainThread (() => CreateProjectPackageSpec (project));
+			PackageSpec packageSpec = await Runtime.RunInMainThread (() => CreateProjectPackageSpec (project, context));
 			return packageSpec;
 		}
 
-		static PackageSpec CreateProjectPackageSpec (DotNetProject project)
+		static PackageSpec CreateProjectPackageSpec (DotNetProject project, DependencyGraphCacheContext context)
 		{
-			PackageSpec packageSpec = PackageSpecCreator.CreatePackageSpec (project);
+			PackageSpec packageSpec = PackageSpecCreator.CreatePackageSpec (project, context.Logger);
 			return packageSpec;
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSpecCreator.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSpecCreator.cs
@@ -24,8 +24,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MonoDevelop.Core;
 using MonoDevelop.Projects;
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
@@ -36,12 +38,12 @@ namespace MonoDevelop.PackageManagement
 {
 	static class PackageSpecCreator
 	{
-		public static PackageSpec CreatePackageSpec (DotNetProject project)
+		public static PackageSpec CreatePackageSpec (DotNetProject project, ILogger logger)
 		{
-			return CreatePackageSpec (new DotNetProjectProxy (project));
+			return CreatePackageSpec (new DotNetProjectProxy (project), logger);
 		}
 
-		public static PackageSpec CreatePackageSpec (IDotNetProject project)
+		public static PackageSpec CreatePackageSpec (IDotNetProject project, ILogger logger)
 		{
 			var packageSpec = new PackageSpec (GetTargetFrameworks (project));
 			packageSpec.FilePath = project.FileName;
@@ -50,7 +52,7 @@ namespace MonoDevelop.PackageManagement
 
 			packageSpec.RestoreMetadata = CreateRestoreMetadata (packageSpec, project);
 			packageSpec.RuntimeGraph = GetRuntimeGraph (project);
-			AddProjectReferences (packageSpec, project);
+			AddProjectReferences (packageSpec, project, logger);
 			AddPackageReferences (packageSpec, project);
 			AddPackageTargetFallbacks (packageSpec, project);
 
@@ -116,7 +118,7 @@ namespace MonoDevelop.PackageManagement
 			return new string[0];
 		}
 
-		static void AddProjectReferences (PackageSpec spec, IDotNetProject project)
+		static void AddProjectReferences (PackageSpec spec, IDotNetProject project, ILogger logger)
 		{
 			// Add groups for each spec framework
 			var frameworkGroups = new Dictionary<NuGetFramework, List<ProjectRestoreReference>> ();
@@ -125,7 +127,8 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			var flatReferences = project.References.Where (IsProjectReference)
-				.Select (projectReference => GetProjectRestoreReference (projectReference, project));
+				.Select (projectReference => GetProjectRestoreReference (projectReference, project, logger))
+				.Where (projectReference => projectReference != null);
 
 			// Add project paths
 			foreach (var frameworkPair in flatReferences) {
@@ -168,11 +171,16 @@ namespace MonoDevelop.PackageManagement
 
 		static Tuple<List<NuGetFramework>, ProjectRestoreReference> GetProjectRestoreReference (
 			ProjectReference item,
-			IDotNetProject project)
+			IDotNetProject project,
+			ILogger logger)
 		{
 			var frameworks = GetFrameworks (project).ToList ();
 
 			var referencedProject = project.ParentSolution.ResolveProject (item);
+			if (referencedProject == null) {
+				logger.LogWarning (GettextCatalog.GetString ("WARNING: Unable to resolve project '{0}' referenced by '{1}'.", item.Include, project.Name));
+				return null;
+			}
 
 			var reference = new ProjectRestoreReference () {
 				ProjectPath = referencedProject.FileName,


### PR DESCRIPTION
If a project reference cannot be resolved when restoring a .NET
Core project a null reference exception was reported in the Package
Console output. Now a warning is logged in the Package Console
output and the restore is allowed to complete.