### PR TITLE
Fix for https://bugzilla.xamarin.com/show_bug.cgi?id=53412

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
@@ -167,14 +167,14 @@ namespace MonoDevelop.Core.Text
 		{
 			int changeDelta = 0;
 			foreach (var change in TextChanges) {
-				if (offset >= change.Offset && offset <= change.Offset + change.RemovalLength) {
-					changeDelta += change.ChangeDelta;
-					break;
-				} else if (offset > change.Offset) {
-					changeDelta += change.ChangeDelta;
-				} else {
+				if (offset <= change.Offset + change.RemovalLength) {
+					if (offset >= change.Offset) {
+						changeDelta = changeDelta - (offset - change.Offset) + change.InsertionLength;
+					}
 					break;
 				}
+
+				changeDelta += change.ChangeDelta;
 			}
 
 			return offset + changeDelta;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
@@ -119,23 +119,6 @@ namespace MonoDevelop.Core.Text
 				return InsertionLength - RemovalLength;
 			}
 		}
-
-		/// <summary>
-		/// Gets the new offset where the specified offset moves after this document change.
-		/// </summary>
-		public int GetNewOffset(int offset)
-		{
-			if (offset >= this.Offset && offset <= this.Offset + this.RemovalLength) {
-//				if (movementType == AnchorMovementType.BeforeInsertion)
-//					return this.Offset;
-//				else
-					return this.Offset + this.InsertionLength;
-			} else if (offset > this.Offset) {
-				return offset + this.InsertionLength - this.RemovalLength;
-			} else {
-				return offset;
-			}
-		}
 	}
 
 	/// <summary>
@@ -182,10 +165,19 @@ namespace MonoDevelop.Core.Text
 		/// </summary>
 		public virtual int GetNewOffset(int offset)
 		{
+			int changeDelta = 0;
 			foreach (var change in TextChanges) {
-				offset = change.GetNewOffset (offset);
+				if (offset >= change.Offset && offset <= change.Offset + change.RemovalLength) {
+					changeDelta += change.ChangeDelta;
+					break;
+				} else if (offset > change.Offset) {
+					changeDelta += change.ChangeDelta;
+				} else {
+					break;
+				}
 			}
-			return offset;
+
+			return offset + changeDelta;
 		}
 
 		/// <summary>


### PR DESCRIPTION
The issue here is that TextChangeEventArgs.GetNewOffset was using an updated position to pass to later calls. I've gone ahead and got rid of TextChange.GetNewOffset (only this caller remained), and instead of updating the position, updated a changeDelta.

The *real* fix here is to switch things over to using tracking or snapshot points, but this at least fixes the issue at hand (and potentially others), and we can debate switching over to the other data structures later.