### PR TITLE
[Gtk] Don't show Gtk# File Templates if no Gtk# reference exists.

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore/GtkDesignInfo.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore/GtkDesignInfo.cs
@@ -201,9 +201,16 @@ namespace MonoDevelop.GtkCore
 		static bool steticDisabled = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("DISABLE_STETIC"));
 		public static bool SupportsDesigner (Project project)
 		{
-			if (steticDisabled) {
-				return false;
+			return SupportsDesigner (project, true);
+		}
+
+		internal static bool SupportsDesigner (Project project, bool shouldCheckSteticDisabled)
+		{
+			if (shouldCheckSteticDisabled) {
+				if (steticDisabled)
+					return false;
 			}
+
 			DotNetProject dnp = project as DotNetProject;
 			return dnp != null && HasGtkReference (dnp) && SupportsRefactoring (dnp);
 		}

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore/WidgetFileDescriptionTemplate.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore/WidgetFileDescriptionTemplate.cs
@@ -74,12 +74,12 @@ namespace MonoDevelop.GtkCore
 		
 		public override bool SupportsProject (Project project, string projectPath)
 		{
-			return (project is DotNetProject) && GtkDesignInfo.SupportsRefactoring (project as DotNetProject);
+			return (project is DotNetProject) && GtkDesignInfo.SupportsDesigner (project);
 		}
 		
 		public override bool AddToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
 		{
-			if (!GtkDesignInfo.SupportsDesigner (project)) {
+			if (!GtkDesignInfo.SupportsDesigner (project, false)) {
 				ReferenceManager mgr = new ReferenceManager (project as DotNetProject);
 				mgr.GtkPackageVersion = mgr.DefaultGtkVersion;
 				mgr.Dispose ();


### PR DESCRIPTION
This came up on the XPlat Code Editor mailing list. Right now, this will disable gtk# file templates on a project which does not reference gtk-sharp.