### PR TITLE
[Core] Fix build error when building ASP.NET Core project

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -82,12 +82,16 @@ namespace MonoDevelop.Projects.MSBuild
 						loggers = new ILogger[] { logger };
 					}
 
-					if (globalProperties != null) {
+					if (globalProperties != null || sdksPath != null) {
 						originalGlobalProperties = new Dictionary<string, string> ();
 						foreach (var p in project.GlobalProperties)
 							originalGlobalProperties [p.Key] = p.Value;
-						foreach (var p in globalProperties)
-							project.SetGlobalProperty (p.Key, p.Value);
+						if (globalProperties != null) {
+							foreach (var p in globalProperties)
+								project.SetGlobalProperty (p.Key, p.Value);
+						}
+						if (sdksPath != null)
+							project.SetGlobalProperty ("MSBuildSDKsPath", sdksPath);
 						project.ReevaluateIfNecessary ();
 					}
 

--- a/main/tests/test-projects/dotnetcore-console/Sdks/Test.Import.Sdk/Sdk/Sdk.props
+++ b/main/tests/test-projects/dotnetcore-console/Sdks/Test.Import.Sdk/Sdk/Sdk.props
@@ -1,0 +1,6 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+ <Import Project="$(MSBuildSdksPath)\Test.Import.Sdk\Sdk\test-import.targets" 
+        Condition="Exists('$(MSBuildSdksPath)\Test.Import.Sdk\Sdk\test-import.targets')" />
+
+</Project>

--- a/main/tests/test-projects/dotnetcore-console/Sdks/Test.Import.Sdk/Sdk/Sdk.targets
+++ b/main/tests/test-projects/dotnetcore-console/Sdks/Test.Import.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+</Project>

--- a/main/tests/test-projects/dotnetcore-console/Sdks/Test.Import.Sdk/Sdk/test-import.targets
+++ b/main/tests/test-projects/dotnetcore-console/Sdks/Test.Import.Sdk/Sdk/test-import.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Build">
+    <Error Text="Something failed (test-import.targets): $(MSBuildSDKsPath)" />
+  </Target>
+</Project>

--- a/main/tests/test-projects/dotnetcore-console/dotnetcore-console/dotnetcore-msbuildsdkspath-import.csproj
+++ b/main/tests/test-projects/dotnetcore-console/dotnetcore-console/dotnetcore-msbuildsdkspath-import.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Test.Import.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/dotnetcore-console/dotnetcore-msbuildsdkspath-import.sln
+++ b/main/tests/test-projects/dotnetcore-console/dotnetcore-msbuildsdkspath-import.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.25806.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnetcore-console", "dotnetcore-console\dotnetcore-msbuildsdkspath-import.csproj", "{57E09661-7610-453D-8F3D-F4B68461DEFB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57E09661-7610-453D-8F3D-F4B68461DEFB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Fixed 'The target "Build" does not exist in the project.' error when
building an ASP.NET Core project. The Microsoft.NET.Web.Sdk MSBuild props and targets use the MSBuildSdksPath property when importing other
MSBuild files. The MSBuildSDKsPath property is now explicitly
set as a global property for the project so the MSBuild props and
targets are now correctly imported.