### PR TITLE
Always set workspace ActiveConfigurationId to a fully expanded one

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
@@ -1181,7 +1181,7 @@ namespace MonoDevelop.Projects
 				EntryModified (this, args);
 		}
 		
-		internal /*protected virtual*/ void OnEntrySaved (SolutionItemEventArgs args)
+		internal /*protected virtual*/ void OnEntrySaved (SolutionItemSavedEventArgs args)
 		{
 			if (EntrySaved != null)
 				EntrySaved (this, args);
@@ -1210,7 +1210,7 @@ namespace MonoDevelop.Projects
 		public event ProjectReferenceEventHandler ReferenceAddedToProject;
 		public event ProjectReferenceEventHandler ReferenceRemovedFromProject;
 		public event SolutionItemModifiedEventHandler EntryModified;
-		public event SolutionItemEventHandler EntrySaved;
+		public event SolutionItemSavedEventHandler EntrySaved;
 		public event EventHandler<SolutionItemEventArgs> ItemReloadRequired;
 
 		protected override IEnumerable<WorkspaceObjectExtension> CreateDefaultExtensions ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -835,7 +835,7 @@ namespace MonoDevelop.Projects
 			OnItemModified (e);
 		}
 		
-		internal void NotifyItemSaved (object sender, SolutionItemEventArgs e)
+		internal void NotifyItemSaved (object sender, SolutionItemSavedEventArgs e)
 		{
 			OnItemSaved (e);
 		}
@@ -976,7 +976,7 @@ namespace MonoDevelop.Projects
 				ItemModified (this, e);
 		}
 		
-		void OnItemSaved (SolutionItemEventArgs e)
+		void OnItemSaved (SolutionItemSavedEventArgs e)
 		{
 			if (ParentFolder == null && ParentSolution != null)
 				ParentSolution.OnEntrySaved (e);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -58,7 +58,6 @@ namespace MonoDevelop.Projects
 
 		int loading;
 		ItemCollection<SolutionItem> dependencies = new ItemCollection<SolutionItem> ();
-		SolutionItemEventArgs thisItemArgs;
 		FileStatusTracker<SolutionItemEventArgs> fileStatusTracker;
 		FilePath fileName;
 		string name;
@@ -83,7 +82,6 @@ namespace MonoDevelop.Projects
 			TypeGuid = MSBuildProjectService.GetTypeGuidForItem (this);
 
 			fileFormat = MSBuildFileFormat.DefaultFormat;
-			thisItemArgs = new SolutionItemEventArgs (this);
 			configurations = new SolutionItemConfigurationCollection (this);
 			configurations.ConfigurationAdded += OnConfigurationAddedToCollection;
 			configurations.ConfigurationRemoved += OnConfigurationRemovedFromCollection;
@@ -445,7 +443,7 @@ namespace MonoDevelop.Projects
 			try {
 				fileStatusTracker.BeginSave ();
 				await OnSave (monitor);
-				OnSaved (thisItemArgs);
+				OnSaved (new SolutionItemSavedEventArgs (this, ParentSolution, SavingSolution));
 			} finally {
 				fileStatusTracker.EndSave ();
 			}
@@ -1216,7 +1214,7 @@ namespace MonoDevelop.Projects
 			base.OnNameChanged (e);
 		}
 		
-		protected virtual void OnSaved (SolutionItemEventArgs args)
+		protected virtual void OnSaved (SolutionItemSavedEventArgs args)
 		{
 			if (Saved != null)
 				Saved (this, args);
@@ -1476,7 +1474,7 @@ namespace MonoDevelop.Projects
 			// Do nothing by default
 		}
 
-		public event SolutionItemEventHandler Saved;
+		public event SolutionItemSavedEventHandler Saved;
 
 		/// <summary>
 		/// Occurs when the object is being disposed

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemEventArgs.cs
@@ -62,10 +62,32 @@ namespace MonoDevelop.Projects
 			this.entry = entry;
 		}
 	}
+
+	public delegate void SolutionItemSavedEventHandler (object sender, SolutionItemSavedEventArgs e);
+
+	public class SolutionItemSavedEventArgs : SolutionItemEventArgs
+	{
+		bool savingSolution;
+
+		public SolutionItemSavedEventArgs (SolutionFolderItem item, Solution parentSolution, bool savingSolution) : base (item, parentSolution)
+		{
+			this.savingSolution = savingSolution;
+		}
+
+		public bool SavingSolution {
+			get { return savingSolution; }
+		}
+
+		/// <summary>
+		/// When Reloading is true, it returns the original solution item that is being reloaded
+		/// </summary>
+		/// <value>The replaced item.</value>
+		public SolutionFolderItem ReplacedItem { get; internal set; }
+	}
 	
 	public delegate void SolutionItemChangeEventHandler (object sender, SolutionItemChangeEventArgs e);
-	
-	public class SolutionItemChangeEventArgs: SolutionItemEventArgs
+
+	public class SolutionItemChangeEventArgs : SolutionItemEventArgs
 	{
 		bool reloading;
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -547,16 +547,16 @@ namespace MonoDevelop.Components.MainToolbar
 		{
 			if (currentSolution != null) {
 				currentSolution.StartupConfigurationChanged -= HandleStartupItemChanged;
-				currentSolution.Saved -= HandleUpdateCombosWidthDelay;
-				currentSolution.EntrySaved -= HandleUpdateCombosWidthDelay;
+				currentSolution.Saved -= HandleSolutionSaved;
+				currentSolution.EntrySaved -= HandleSolutionEntrySaved;
 			}
 
 			currentSolution = e.Solution;
 
 			if (currentSolution != null) {
 				currentSolution.StartupConfigurationChanged += HandleStartupItemChanged;
-				currentSolution.Saved += HandleUpdateCombosWidthDelay;
-				currentSolution.EntrySaved += HandleUpdateCombosWidthDelay;
+				currentSolution.Saved += HandleSolutionSaved;
+				currentSolution.EntrySaved += HandleSolutionEntrySaved;
 			}
 
 			TrackStartupProject ();
@@ -589,17 +589,16 @@ namespace MonoDevelop.Components.MainToolbar
 			}
 		}
 
-		bool updatingCombos;
-		void HandleUpdateCombosWidthDelay (object sender, EventArgs e)
+		void HandleSolutionSaved (object sender, EventArgs e)
 		{
-			if (!updatingCombos) {
-				updatingCombos = true;
-				GLib.Timeout.Add (100, () => {
-					updatingCombos = false;
-					UpdateCombos ();
-					return false;
-				});
-			}
+			UpdateCombos ();
+		}
+
+		void HandleSolutionEntrySaved (object sender, SolutionItemSavedEventArgs e)
+		{
+			// Skip the per-project update when a solution is being saved. The solution Saved callback will do the final update.
+			if (!e.SavingSolution)
+				HandleSolutionSaved (sender, e);
 		}
 
 		void HandleStartupItemChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -425,8 +425,8 @@ namespace MonoDevelop.Components.MainToolbar
 					foreach (var item in confs) {
 						string config = item.OriginalId;
 						if (config == name) {
-							IdeApp.Workspace.ActiveConfigurationId = config;
 							ToolbarView.ActiveConfiguration = item;
+							UpdateBuildConfiguration ();
 							selected = true;
 							break;
 						}
@@ -434,7 +434,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 					if (!selected) {
 						ToolbarView.ActiveConfiguration = ToolbarView.ConfigurationModel.First ();
-						IdeApp.Workspace.ActiveConfigurationId = defaultConfig;
+						UpdateBuildConfiguration ();
 					}
 				}
 			} finally {


### PR DESCRIPTION
Always set workspace ActiveConfigurationId to a fully expanded one to
prevent unnecessary reloading of project files. For some projects the
SelectActiveConfiguration method first set the ActiveConfigurationId to
non-expanded version (eg. “Debug”) and later called SelectActiveRuntime
which set it again to an expanded one (eg. “Debug|Mixed Platforms”).
This resulted in double reloading of the project files.