### PR TITLE
[53089][Ide] Fix IWorkbenchWindow.Closing event handling with async operations

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TestWorkbenchWindow.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TestWorkbenchWindow.fs
@@ -1,5 +1,6 @@
 ﻿namespace MonoDevelopTests
 open System
+open System.Threading.Tasks
 open Mono.Addins
 open MonoDevelop.Ide.Gui
 
@@ -23,7 +24,7 @@ type TestWorkbenchWindow(viewContent) =
         member x.ViewContent with get() = viewContent
         member x.ActiveViewContent with get() = viewContent :> BaseViewContent and set v = ()
         member x.ExtensionContext with get() = AddinManager.AddinEngine :> _
-        member x.CloseWindow (force) = true
+        member x.CloseWindow (force) = Task.FromResult true
         member x.AttachViewContent (subViewContent) = ()
         member x.InsertViewContent(index, subViewContent) = ()
         member x.SubViewContents with get() = Seq.empty

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -413,7 +413,7 @@ namespace MonoDevelop.MacIntegration
 				{
 					// We can only attempt to quit safely if all windows are GTK windows and not modal
 					if (!IsModalDialogRunning ()) {
-						e.UserCancelled = !IdeApp.Exit ();
+						e.UserCancelled = !IdeApp.Exit ().Result; // FIXME: could this block in rare cases?
 						e.Handled = true;
 						return;
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -147,11 +147,10 @@ namespace MonoDevelop.Components.AutoTest
 		public void ExitApp ()
 		{
 			Sync (delegate {
-				try {
-					IdeApp.Exit ();
-				} catch (Exception e) {
-					Console.WriteLine (e);
-				}
+				IdeApp.Exit ().ContinueWith ((arg) => {
+					if (arg.IsFaulted)
+						Console.WriteLine (arg.Exception);
+				});
 				return true;
 			});
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -687,13 +687,21 @@ namespace MonoDevelop.Ide.Gui
 				}
 			}
 		}
-		
-		protected /*override*/ void OnClosing(object o, Gtk.DeleteEventArgs e)
+
+		bool closing;
+		protected /*override*/ async void OnClosing(object o, Gtk.DeleteEventArgs e)
 		{
-			if (Close()) {
+			// close the window in case DeleteEvent fires again after a successful close
+			if (closing) 
+				return;
+			
+			// don't allow Gtk to close the workspace, in case Close() leaves the synchronization context
+			// Gtk.Application.Quit () will handle it for us.
+			e.RetVal = true;
+			if (await Close ()) {
+				closing = true;
+				Destroy (); // default delete action
 				Gtk.Application.Quit ();
-			} else {
-				e.RetVal = true;
 			}
 		}
 		
@@ -720,7 +728,7 @@ namespace MonoDevelop.Ide.Gui
 			Destroy ();
 		}
 		
-		public bool Close() 
+		public async Task<bool> Close()
 		{
 			if (!IdeApp.OnExit ())
 				return false;
@@ -745,7 +753,7 @@ namespace MonoDevelop.Ide.Gui
 				}
 			}
 			
-			if (!IdeApp.Workspace.Close (false, false))
+			if (!await IdeApp.Workspace.Close (false, false))
 				return false;
 			
 			CloseAllViews ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -516,9 +516,9 @@ namespace MonoDevelop.Ide.Gui
 			await UpdateParseDocument ();
 		}
 		
-		public bool Close ()
+		public async Task<bool> Close ()
 		{
-			return ((SdiWorkspaceWindow)Window).CloseWindow (false, true);
+			return await ((SdiWorkspaceWindow)Window).CloseWindow (false, true);
 		}
 
 		protected override void OnSaved (EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/HiddenWorkbenchWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/HiddenWorkbenchWindow.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Mono.Addins;
 
 namespace MonoDevelop.Ide.Gui
@@ -74,9 +75,9 @@ namespace MonoDevelop.Ide.Gui
 			set {}
 		}
 		
-		public bool CloseWindow (bool force)
+		public Task<bool> CloseWindow (bool force)
 		{
-			return true;
+			return Task.FromResult (true);
 		}
 		
 		public void SelectWindow ()
@@ -112,7 +113,7 @@ namespace MonoDevelop.Ide.Gui
 
 		public event EventHandler TitleChanged { add {} remove {} }
 		public event EventHandler DocumentChanged { add {} remove {} }
-		public event MonoDevelop.Ide.Gui.WorkbenchWindowEventHandler Closing { add {} remove {} }
+		public event MonoDevelop.Ide.Gui.WorkbenchWindowAsyncEventHandler Closing { add {} remove {} }
 		public event MonoDevelop.Ide.Gui.WorkbenchWindowEventHandler Closed { add {} remove {} }
 		public event MonoDevelop.Ide.Gui.ActiveViewContentEventHandler ActiveViewContentChanged { add {} remove {} }
 		public event EventHandler ViewsChanged { add {} remove {} }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IWorkbenchWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IWorkbenchWindow.cs
@@ -30,6 +30,7 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using Mono.Addins;
 using MonoDevelop.Components.Docking;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.Gui
 {
@@ -53,7 +54,7 @@ namespace MonoDevelop.Ide.Gui
 		void SwitchView (BaseViewContent subViewContent);
 		int FindView <T>();
 		
-		bool CloseWindow (bool force);
+		Task<bool> CloseWindow (bool force);
 		void SelectWindow ();
 
 		/// <summary>
@@ -63,11 +64,12 @@ namespace MonoDevelop.Ide.Gui
 
 		event EventHandler DocumentChanged;
 		event WorkbenchWindowEventHandler Closed;
-		event WorkbenchWindowEventHandler Closing;
+		event WorkbenchWindowAsyncEventHandler Closing;
 		event ActiveViewContentEventHandler ActiveViewContentChanged;
 		event EventHandler ViewsChanged;
 	}
 
+	public delegate Task WorkbenchWindowAsyncEventHandler (object o, WorkbenchWindowEventArgs e);
 	public delegate void WorkbenchWindowEventHandler (object o, WorkbenchWindowEventArgs e);
 	public class WorkbenchWindowEventArgs : CancelEventArgs
 	{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -38,6 +38,7 @@ using MonoDevelop.Components.Commands;
 using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Components.DockNotebook;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.Gui
 {
@@ -443,17 +444,17 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 		
-		public bool CloseWindow (bool force)
+		public Task<bool> CloseWindow (bool force)
 		{
 			return CloseWindow (force, false);
 		}
 
-		public bool CloseWindow (bool force, bool animate)
+		public async Task<bool> CloseWindow (bool force, bool animate)
 		{
 			bool wasActive = workbench.ActiveWorkbenchWindow == this;
 			WorkbenchWindowEventArgs args = new WorkbenchWindowEventArgs (force, wasActive);
 			args.Cancel = false;
-			OnClosing (args);
+			await OnClosing (args);
 			if (args.Cancel)
 				return false;
 			
@@ -808,10 +809,10 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
-		protected virtual void OnClosing (WorkbenchWindowEventArgs e)
+		protected virtual async System.Threading.Tasks.Task OnClosing (WorkbenchWindowEventArgs e)
 		{
 			if (Closing != null) {
-				Closing (this, e);
+				await Closing (this, e);
 			}
 		}
 
@@ -830,7 +831,7 @@ namespace MonoDevelop.Ide.Gui
 
 		public event EventHandler TitleChanged;
 		public event WorkbenchWindowEventHandler Closed;
-		public event WorkbenchWindowEventHandler Closing;
+		public event WorkbenchWindowAsyncEventHandler Closing;
 		public event ActiveViewContentEventHandler ActiveViewContentChanged;
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -809,10 +809,11 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
-		protected virtual async System.Threading.Tasks.Task OnClosing (WorkbenchWindowEventArgs e)
+		protected virtual async Task OnClosing (WorkbenchWindowEventArgs e)
 		{
 			if (Closing != null) {
-				await Closing (this, e);
+				foreach (var handler in Closing.GetInvocationList ().Cast<WorkbenchWindowAsyncEventHandler> ())
+					await handler (this, e);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -142,9 +142,9 @@ namespace MonoDevelop.Ide.Gui
 			Present ();
 		}
 		
-		internal bool Close ()
+		internal async Task<bool> Close ()
 		{
-			return workbench.Close();
+			return await workbench.Close();
 		}
 
 		public ImmutableList<Document> Documents {
@@ -584,7 +584,7 @@ namespace MonoDevelop.Ide.Gui
 							}
 							return doc;
 						} else {
-							if (!doc.Close ())
+							if (!await doc.Close ())
 								return doc;
 							break;
 						}
@@ -841,7 +841,7 @@ namespace MonoDevelop.Ide.Gui
 			return pad;
 		}
 		
-		async void OnWindowClosing (object sender, WorkbenchWindowEventArgs args)
+		async Task OnWindowClosing (object sender, WorkbenchWindowEventArgs args)
 		{
 			var window = (IWorkbenchWindow) sender;
 			var viewContent = window.ViewContent;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -46,6 +46,7 @@ using MonoDevelop.Components.AutoTest;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Ide.Templates;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide
 {
@@ -395,9 +396,9 @@ namespace MonoDevelop.Ide
 		/// <summary>
 		/// Exits MonoDevelop. Returns false if the user cancels exiting.
 		/// </summary>
-		public static bool Exit ()
+		public static async Task<bool> Exit ()
 		{
-			if (workbench.Close ()) {
+			if (await workbench.Close ()) {
 				Gtk.Application.Quit ();
 				isMainRunning = false;
 				return true;
@@ -414,9 +415,9 @@ namespace MonoDevelop.Ide
 		/// Starts a new MonoDevelop instance in a new process and 
 		/// stops the current MonoDevelop instance.
 		/// </remarks>
-		public static bool Restart (bool reopenWorkspace = false)
+		public static async Task<bool> Restart (bool reopenWorkspace = false)
 		{
-			if (Exit ()) {
+			if (await Exit ()) {
 				try {
 					DesktopService.RestartIde (reopenWorkspace);
 				} catch (Exception ex) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -354,17 +354,17 @@ namespace MonoDevelop.Ide
 				SavePreferences (it);
 		}
 		
-		public bool Close ()
+		public async Task<bool> Close ()
 		{
-			return Close (true);
+			return await Close (true);
 		}
 
-		public bool Close (bool saveWorkspacePreferencies)
+		public async Task<bool> Close (bool saveWorkspacePreferencies)
 		{
-			return Close (saveWorkspacePreferencies, true);
+			return await Close (saveWorkspacePreferencies, true);
 		}
 		
-		internal bool Close (bool saveWorkspacePreferencies, bool closeProjectFiles)
+		internal async Task<bool> Close (bool saveWorkspacePreferencies, bool closeProjectFiles)
 		{
 			if (Items.Count > 0) {
 				ITimeTracker timer = Counters.CloseWorkspaceTimer.BeginTiming ();
@@ -380,7 +380,7 @@ namespace MonoDevelop.Ide
 
 					if (closeProjectFiles) {
 						foreach (Document doc in IdeApp.Workbench.Documents.ToArray ()) {
-							if (!doc.Close ())
+							if (!await doc.Close ())
 								return false;
 						}
 					}
@@ -400,14 +400,14 @@ namespace MonoDevelop.Ide
 			return true;
 		}
 		
-		public void CloseWorkspaceItem (WorkspaceItem item, bool closeItemFiles = true)
+		public async Task CloseWorkspaceItem (WorkspaceItem item, bool closeItemFiles = true)
 		{
 			if (!Items.Contains (item))
 				throw new InvalidOperationException ("Only top level items can be closed.");
 
 			if (Items.Count == 1 && closeItemFiles) {
 				// There is only one item, close the whole workspace
-				Close (true, closeItemFiles);
+				await Close (true, closeItemFiles);
 				return;
 			}
 
@@ -415,7 +415,7 @@ namespace MonoDevelop.Ide
 				if (closeItemFiles) {
 					var projects = item.GetAllItems<Project> ();
 					foreach (Document doc in IdeApp.Workbench.Documents.Where (d => d.Project != null && projects.Contains (d.Project)).ToArray ()) {
-						if (!doc.Close ())
+						if (!await doc.Close ())
 							return;
 					}
 				}
@@ -469,7 +469,7 @@ namespace MonoDevelop.Ide
 			}
 
 			if (closeCurrent) {
-				if (!Close ())
+				if (!await Close ())
 					return false;
 			}
 
@@ -719,14 +719,16 @@ namespace MonoDevelop.Ide
 		async Task OnCheckWorkspaceItem (WorkspaceItem item)
 		{
 			if (item.NeedsReload) {
-				IEnumerable<string> closedDocs;
-				if (AllowReload (item.GetAllItems<Project> (), out closedDocs)) {
+				var result = await AllowReload (item.GetAllItems<Project> ());
+				bool allowReload = result.Item1;
+				IEnumerable<string> closedDocs = result.Item2;
+				if (result.Item1) {
 					if (item.ParentWorkspace == null) {
 						string file = item.FileName;
 						try {
 							SetReloading (true);
 							SavePreferences ();
-							CloseWorkspaceItem (item, false);
+							await CloseWorkspaceItem (item, false);
 							await OpenWorkspaceItem (file, false, false);
 						} finally {
 							SetReloading (false);
@@ -735,7 +737,8 @@ namespace MonoDevelop.Ide
 					else {
 						using (ProgressMonitor m = IdeApp.Workbench.ProgressMonitors.GetSaveProgressMonitor (true)) {
 							await item.ParentWorkspace.ReloadItem (m, item);
-							ReattachDocumentProjects (closedDocs);
+							if (closedDocs != null)
+								ReattachDocumentProjects (closedDocs);
 						}
 					}
 
@@ -765,14 +768,17 @@ namespace MonoDevelop.Ide
 				} else if (entry is SolutionFolder) {
 					projects = ((SolutionFolder)entry).GetAllProjects ();
 				}
+
+				var result = await AllowReload (projects);
+				bool allowReload = result.Item1;
+				IEnumerable<string> closedDocs = result.Item2;
 				
-				IEnumerable<string> closedDocs;
-				
-				if (AllowReload (projects, out closedDocs)) {
+				if (allowReload) {
 					using (ProgressMonitor m = IdeApp.Workbench.ProgressMonitors.GetProjectLoadProgressMonitor (true)) {
 						// Root folders never need to reload
 						await entry.ParentFolder.ReloadItem (m, entry);
-						ReattachDocumentProjects (closedDocs);
+						if (closedDocs != null)
+							ReattachDocumentProjects (closedDocs);
 					}
 					return;
 				} else
@@ -794,12 +800,12 @@ namespace MonoDevelop.Ide
 //			return AllowReload (projects, out closedDocs);
 //		}
 		
-		bool AllowReload (IEnumerable projects, out IEnumerable<string> closedDocs)
+		async Task<Tuple<bool, IEnumerable<string>>> AllowReload (IEnumerable projects)
 		{
-			closedDocs = null;
+			IEnumerable<string> closedDocs = null;
 			
 			if (projects == null)
-				return true;
+				return Tuple.Create (true, closedDocs);
 			
 			List<Document> docs = new List<Document> ();
 			foreach (Project p in projects) {
@@ -807,7 +813,7 @@ namespace MonoDevelop.Ide
 			}
 			
 			if (docs.Count == 0)
-				return true;
+				return Tuple.Create (true, closedDocs);
 			
 			// Find a common project reload capability
 			
@@ -844,7 +850,7 @@ namespace MonoDevelop.Ide
 			}
 			if (msg != null) {
 				if (!MessageService.Confirm (GettextCatalog.GetString ("The project '{0}' has been modified by an external application. Do you want to reload it?", docs[0].Project.Name), msg, AlertButton.Reload))
-					return false;
+					return Tuple.Create (true, closedDocs);
 			}
 			
 			List<string> closed = new List<string> ();
@@ -862,8 +868,8 @@ namespace MonoDevelop.Ide
 					};
 					doc.Saved += saved;
 					try {
-						if (!doc.Close ())
-							return false;
+						if (!await doc.Close ())
+							return Tuple.Create (true, closedDocs);
 						else if (!file.IsNullOrEmpty && File.Exists (file))
 							closed.Add (file);
 					} finally {
@@ -873,7 +879,7 @@ namespace MonoDevelop.Ide
 			}
 			closedDocs = closed;
 
-			return true;
+			return Tuple.Create (true, closedDocs);
 		}
 		
 		internal static List<Document> GetOpenDocuments (Project project, bool modifiedOnly)

--- a/main/tests/UnitTests/MonoDevelop.CSharpBinding/TestWorkbenchWindow.cs
+++ b/main/tests/UnitTests/MonoDevelop.CSharpBinding/TestWorkbenchWindow.cs
@@ -32,6 +32,7 @@ using System.Collections;
 using MonoDevelop.Ide.Gui;
 using System.Collections.Generic;
 using Mono.Addins;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.CSharpBinding
 {
@@ -79,9 +80,9 @@ namespace MonoDevelop.CSharpBinding
 			set {}
 		}
 		
-		public bool CloseWindow (bool force)
+		public Task<bool> CloseWindow (bool force)
 		{
-			return true;
+			return Task.FromResult (true);
 		}
 		
 		public void SelectWindow ()
@@ -120,7 +121,7 @@ namespace MonoDevelop.CSharpBinding
 		}
 
 		public event EventHandler DocumentChanged;
-		public event WorkbenchWindowEventHandler Closing;
+		public event WorkbenchWindowAsyncEventHandler Closing;
 		public event WorkbenchWindowEventHandler Closed;
 		public event ActiveViewContentEventHandler ActiveViewContentChanged;
 		public event EventHandler ViewsChanged;


### PR DESCRIPTION
If a workbench window contains an unsaved document, we ask the user to save it and run the save operation asynchronously. This is controlled by the WorkbenchWindowEventArgs.Cancel property and the result contols whether we set specific Gtk/GLib events as hanled or not (i.e. in order to allow or disallow Gtk to close a window).

The first problem here was the async EventHandler for the Closing event (https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs#L844-L868) which was not awaited and the window was closed before the Save operation had a chance to run to completion. This is solved by an EventHandler delegate returning a Task, making it possible to await the handlers subscribed to the event (see https://github.com/mono/monodevelop/pull/1983/files#diff-8da6280a955ed74b6e47759bb5b27f1fR815).

The second problem with this approach was that Gtk doesn't know anything about awaiting Tasks and if one of its event handlers leaves the synchronization context (like the asynchrounous
file saving), it will let the signal pass without waiting for its handled state to be updated. This is solved by delaying window closing/destruction (always set the initial delete/close event
handled state and close the window in a continuation task synchronized with the UI thread)

(fix bug #53089)