### PR TITLE
[52984][Ide] Update default format document key in VS key bindings

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/TitleMenuItem.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/TitleMenuItem.cs
@@ -61,7 +61,7 @@ namespace WindowsPlatform.MainToolbar
 
 				// FIXME: Use proper keybinding text.
 				if (actionCommand.KeyBinding != null)
-					InputGestureText = actionCommand.KeyBinding.ToString ();
+					InputGestureText = KeyBindingManager.BindingToDisplayLabel (actionCommand.KeyBinding, true);
 				
 				try {
 					if (!actionCommand.Icon.IsNull)

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
@@ -30,7 +30,7 @@
     <binding command="MonoDevelop.FSharp.FSharpCommands.SendLine" shortcut="" />
     <binding command="MonoDevelop.FSharp.FSharpCommands.SendReferences" shortcut="" />
     <binding command="MonoDevelop.FSharp.FSharpCommands.SendSelection" shortcut="" />
-    <binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer" shortcut="Meta+E|D Meta+K|D Meta+K|Meta+D" />
+    <binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer" shortcut="Meta+K|D Meta+K|Meta+D Meta+E|D" />
     <binding command="MonoDevelop.Ide.Commands.EditCommands.AddCodeComment" shortcut="Meta+E|C" />
     <binding command="MonoDevelop.Ide.Commands.EditCommands.Copy" shortcut="Meta+C" />
     <binding command="MonoDevelop.Ide.Commands.EditCommands.Cut" shortcut="Meta+X" />

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
@@ -30,7 +30,7 @@
     <binding command="MonoDevelop.FSharp.FSharpCommands.SendLine" shortcut="" />
     <binding command="MonoDevelop.FSharp.FSharpCommands.SendReferences" shortcut="" />
     <binding command="MonoDevelop.FSharp.FSharpCommands.SendSelection" shortcut="" />
-    <binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer" shortcut="Control+E|D Control+K|D Control+K|Control+D" />
+    <binding command="MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer" shortcut="Control+K|Control+D Control+K|D Control+E|D" />
     <binding command="MonoDevelop.Ide.Commands.EditCommands.AddCodeComment" shortcut="Control+E|C" />
     <binding command="MonoDevelop.Ide.Commands.EditCommands.Copy" shortcut="Control+C" />
     <binding command="MonoDevelop.Ide.Commands.EditCommands.Cut" shortcut="Control+X" />


### PR DESCRIPTION
+Concise key binding shortcuts in menu items on Windows to be more consistant with VS (turn `Control+XXX` into `Ctrl+XXX`)

(fix bug #52984)