### PR TITLE
[53443][Ide] Filter recent templates by visibility in new project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -333,7 +333,10 @@ namespace MonoDevelop.Ide.Projects
 		{
 			Predicate<SolutionTemplate> templateMatch = GetTemplateFilter ();
 			templateCategories = IdeApp.Services.TemplatingService.GetProjectTemplateCategories (templateMatch).ToList ();
-			recentTemplates = IdeApp.Services.TemplatingService.RecentTemplates.GetTemplates ().ToList ();
+			if (IsNewSolution)
+				recentTemplates = IdeApp.Services.TemplatingService.RecentTemplates.GetTemplates ().Where ((t) => t.IsMatch (SolutionTemplateVisibility.NewSolution)).ToList ();
+			else
+				recentTemplates = IdeApp.Services.TemplatingService.RecentTemplates.GetTemplates ().ToList ();
 		}
 
 		Predicate<SolutionTemplate> GetTemplateFilter ()


### PR DESCRIPTION
This patch adds recent template filtering by the template visibility (solution/project) to the new project dialog.

(fix bug #53443)