### PR TITLE
[Core] Fix save failed after deleting file from .NET Core project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3134,8 +3134,11 @@ namespace MonoDevelop.Projects
 			// Remove unused items
 
 			foreach (var it in unusedItems) {
-				if (it.ParentGroup != null) // It may already have been deleted
-					msproject.RemoveItem (it);
+				if (it.ParentGroup != null) { // It may already have been deleted
+					// Remove wildcard item if it is not imported.
+					if (!it.IsWildcardItem || it.ParentProject == msproject)
+						msproject.RemoveItem (it);
+				}
 				loadedItems.Remove (it);
 			}
 			loadedProjectItems = new HashSet<ProjectItem> (Items);

--- a/main/tests/test-projects/console-project-imported-wildcard/ConsoleProject-imported-wildcard.csproj
+++ b/main/tests/test-projects/console-project-imported-wildcard/ConsoleProject-imported-wildcard.csproj
@@ -1,0 +1,45 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Imports\AllCSharpFiles.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/main/tests/test-projects/console-project-imported-wildcard/Imports/AllCSharpFiles.props
+++ b/main/tests/test-projects/console-project-imported-wildcard/Imports/AllCSharpFiles.props
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/console-project-imported-wildcard/Program.cs
+++ b/main/tests/test-projects/console-project-imported-wildcard/Program.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConsoleProject
+{
+    class Program
+    {
+        static void Main (string[] args)
+        {
+            Console.WriteLine ("Hello world");
+        }
+    }
+}

--- a/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved7
+++ b/main/tests/test-projects/console-project-with-wildcards/ConsoleProject.csproj.saved7
@@ -1,0 +1,44 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Fixed bug #53428 - Erroneous "Save failed" popup dialogs when adding
a new file to a .NET Standard Library
https://bugzilla.xamarin.com/show_bug.cgi?id=53428

Creating a new .NET Standard Library, then removing the single
Class1.cs file from the project and then adding a new C# class
file would result in two Save failed dialogs being displayed due to
a null reference exception. The problem was that when the last file
was removed from the project the unused glob item was being removed.
This glob item was imported and would then have its parent project
set to null. This glob item was then re-used when saving the project
again a second time after the new file was added and resulted in a
null reference exception. To fix this the unused glob item is not
removed if it is imported and does not exist in the main project.

```
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Projects.Project+<FindUpdateItemsForItem>c__Iterator12.MoveNext () [0x0002e] in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs:3386
  at System.Collections.Generic.List`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection) [0x0008b] in mono-x86/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs:99
  at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00011] in mono-x86/mcs/class/referencesource/System.Core/System/Linq/Enumerable.cs:861
  at MonoDevelop.Projects.Project.GenerateItemDiff (MonoDevelop.Projects.MSBuild.MSBuildItem globItem, MonoDevelop.Projects.MSBuild.MSBuildItem item, MonoDevelop.Projects.MSBuild.IMSBuildItemEvaluated evalItem) [0x0040f] in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs:3374
  at MonoDevelop.Projects.Project.SaveProjectItem (MonoDevelop.Core.ProgressMonitor monitor, MonoDevelop.Projects.MSBuild.MSBuildProject msproject, MonoDevelop.Projects.ProjectItem item, System.Collections.Generic.Dictionary`2[TKey,TValue] expandedItems, System.Collections.Generic.HashSet`1[T] unusedItems, System.Collections.Generic.HashSet`1[T] loadedItems, System.String pathPrefix) [0x00100] in main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs:3166
  at MonoDevelop.Projects.Project.SaveProjectItems (MonoDevelop.Core.ProgressMonitor monitor, MonoDevelop.Projects.MSBuild.MSBuildProject msproject, System.Collections.Generic.HashSet`1[T] loadedItems, System.String pathPrefix) [0x00047] in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs:3090
  at MonoDevelop.Projects.Project.OnWriteProject (MonoDevelop.Core.ProgressMonitor monitor, MonoDevelop.Projects.MSBuild.MSBuildProject msproject) [0x00019] in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs:2808
  at MonoDevelop.Projects.DotNetProject.OnWriteProject (MonoDevelop.Core.ProgressMonitor monitor, MonoDevelop.Projects.MSBuild.MSBuildProject msproject) [0x00000] in monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs:1819
```