### PR TITLE
[DotNetCore] Hide project templates if .NET Core Sdk is not installed

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreProjectTestSuite.cs
@@ -91,8 +91,7 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 
 		protected override void OnCreateTests ()
 		{
-			var dotNetCorePath = new DotNetCorePath ();
-			if (dotNetCorePath.IsMissing) {
+			if (DotNetCoreRuntime.IsMissing) {
 				LoggingService.LogError (".NET Core not installed.");
 				Status = TestStatus.LoadError;
 				testPlatformAdapter.HasDiscoveryFailed = true;
@@ -104,7 +103,6 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 				string assemblyFileName = GetAssemblyFileName ();
 				if (File.Exists (assemblyFileName)) {
 					Status = TestStatus.Loading;
-					testPlatformAdapter.DotNetCorePath = dotNetCorePath;
 					testPlatformAdapter.StartDiscovery (assemblyFileName);
 				}
 			}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
@@ -82,8 +82,6 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 			DiscoveryFailed?.Invoke (this, new EventArgs ());
 		}
 
-		public DotNetCorePath DotNetCorePath { get; set; } = new DotNetCorePath ();
-
 		public void StartDiscovery (string testAssemblyPath)
 		{
 			try {
@@ -97,7 +95,7 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 		{
 			this.testAssemblyPath = testAssemblyPath;
 
-			if (DotNetCorePath.IsMissing) {
+			if (DotNetCoreRuntime.IsMissing) {
 				throw new ApplicationException (".NET Core is not installed.");
 			}
 
@@ -132,7 +130,7 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 		ProcessWrapper StartDotNetProcess (int port)
 		{
 			return Runtime.ProcessService.StartProcess (
-				DotNetCorePath.FileName,
+				DotNetCoreRuntime.FileName,
 				GetVSTestArguments (port),
 				null,
 				DotNetCoreProcessExited);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -137,6 +137,7 @@
     <Compile Include="MonoDevelop.DotNetCore.NodeBuilders\SdkDependenciesNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRunConfigurationEditor.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRunConfiguration.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdkInstalledCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -140,6 +140,7 @@
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdkInstalledCondition.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdk.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRuntime.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\MSBuildSdks.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -138,6 +138,7 @@
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRunConfigurationEditor.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRunConfiguration.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdkInstalledCondition.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdk.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -139,6 +139,7 @@
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRunConfiguration.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdkInstalledCondition.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSdk.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRuntime.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -370,8 +370,7 @@ namespace MonoDevelop.DotNetCore
 			if (!HasSdk)
 				return;
 
-			sdkPaths = new DotNetCoreSdkPaths ();
-			sdkPaths.FindSdkPaths (dotNetCoreMSBuildProject.Sdk);
+			sdkPaths = DotNetCoreSdk.FindSdkPaths (dotNetCoreMSBuildProject.Sdk);
 			if (!sdkPaths.Exist)
 				return;
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -184,7 +184,7 @@ namespace MonoDevelop.DotNetCore
 
 		protected override Task OnExecute (ProgressMonitor monitor, ExecutionContext context, ConfigurationSelector configuration, SolutionItemRunConfiguration runConfiguration)
 		{
-			if (!IdeApp.Preferences.BuildBeforeExecuting && DotNetCoreRuntime.IsMissing) {
+			if (DotNetCoreRuntime.IsMissing) {
 				return ShowCannotExecuteDotNetCoreApplicationDialog ();
 			}
 
@@ -268,7 +268,7 @@ namespace MonoDevelop.DotNetCore
 			if (!IdeApp.IsInitialized)
 				return;
 
-			if (HasSdk && !sdkPaths.Exist) {
+			if (HasSdk && !IsDotNetCoreSdkInstalled ()) {
 				ShowDotNetCoreNotInstalledDialog (sdkPaths.IsUnsupportedSdkVersion);
 			}
 		}
@@ -301,7 +301,7 @@ namespace MonoDevelop.DotNetCore
 		{
 			if (ProjectNeedsRestore ()) {
 				return CreateNuGetRestoreRequiredBuildResult ();
-			} else if (HasSdk && !sdkPaths.Exist) {
+			} else if (HasSdk && !IsDotNetCoreSdkInstalled ()) {
 				return CreateDotNetCoreSdkRequiredBuildResult (sdkPaths.IsUnsupportedSdkVersion);
 			}
 			return null;
@@ -454,9 +454,7 @@ namespace MonoDevelop.DotNetCore
 
 		public bool IsDotNetCoreSdkInstalled ()
 		{
-			if (sdkPaths != null)
-				return sdkPaths.Exist;
-			return true;
+			return DotNetCoreSdk.IsInstalled || MSBuildSdks.Installed;
 		}
 
 		public bool IsUnsupportedDotNetCoreSdkInstalled ()

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -184,17 +184,11 @@ namespace MonoDevelop.DotNetCore
 
 		protected override Task OnExecute (ProgressMonitor monitor, ExecutionContext context, ConfigurationSelector configuration, SolutionItemRunConfiguration runConfiguration)
 		{
-			if (!IdeApp.Preferences.BuildBeforeExecuting && !IsDotNetCoreInstalled ()) {
+			if (!IdeApp.Preferences.BuildBeforeExecuting && DotNetCoreRuntime.IsMissing) {
 				return ShowCannotExecuteDotNetCoreApplicationDialog ();
 			}
 
 			return base.OnExecute (monitor, context, configuration, runConfiguration);
-		}
-
-		bool IsDotNetCoreInstalled ()
-		{
-			var dotNetCorePath = new DotNetCorePath ();
-			return !dotNetCorePath.IsMissing;
 		}
 
 		Task ShowCannotExecuteDotNetCoreApplicationDialog ()

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectReader.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectReader.cs
@@ -80,18 +80,12 @@ namespace MonoDevelop.DotNetCore
 		{
 			return Task.Run (() => {
 				if (CanRead (fileName, typeof(SolutionItem))) {
-					ConfigureMSBuildSDKsPath ();
+					DotNetCoreSdk.EnsureInitialized ();
 					return MSBuildProjectService.LoadItem (monitor, fileName, MSBuildFileFormat.VS2017, typeGuid, itemGuid, ctx);
 				}
 
 				throw new NotSupportedException ();
 			});
-		}
-
-		void ConfigureMSBuildSDKsPath ()
-		{
-			var paths = new DotNetCoreSdkPaths ();
-			paths.FindMSBuildSDKsPath ();
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
@@ -1,10 +1,10 @@
 ﻿//
-// DotNetCoreExecutionCommand.cs
+// DotNetCoreRuntime.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,30 +24,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using MonoDevelop.Core.Execution;
-
 namespace MonoDevelop.DotNetCore
 {
-	class DotNetCoreExecutionCommand : ProcessExecutionCommand
+	static class DotNetCoreRuntime
 	{
-		public DotNetCoreExecutionCommand (string directory, string outputPath, string arguments)
+		static DotNetCoreRuntime ()
 		{
-			WorkingDirectory = directory;
-			OutputPath = outputPath;
-			DotNetArguments = arguments;
-
-			Command = DotNetCoreRuntime.FileName;
-			Arguments = string.Format ("\"{0}\" {1}", outputPath, arguments);
+			var path = new DotNetCorePath ();
+			IsInstalled = !path.IsMissing;
+			FileName = path.FileName;
 		}
 
-		public string OutputPath { get; private set; }
-		public string DotNetArguments { get; private set; }
+		public static string FileName { get; private set; }
 
-		public bool PauseConsoleOutput { get; set; }
-		public bool ExternalConsole { get; set; }
-		public bool LaunchBrowser { get; set; }
-		public string LaunchURL { get; set; }
-		public string ApplicationURL { get; set; }
-		public PipeTransportSettings PipeTransport { get; set; }
+		public static bool IsInstalled { get; private set; }
+
+		public static bool IsMissing {
+			get { return !IsInstalled; }
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -1,5 +1,5 @@
 ﻿//
-// DotNetCoreSdkInstalledCondition.cs
+// DotNetCoreSdk.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
@@ -24,15 +24,35 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Mono.Addins;
+using System;
 
 namespace MonoDevelop.DotNetCore
 {
-	class DotNetCoreSdkInstalledCondition : ConditionType
+	static class DotNetCoreSdk
 	{
-		public override bool Evaluate (NodeElement conditionNode)
+		static DotNetCoreSdk ()
 		{
-			return DotNetCoreSdk.IsInstalled;
+			var sdkPaths = new DotNetCoreSdkPaths ();
+			sdkPaths.FindMSBuildSDKsPath ();
+
+			MSBuildSDKsPath = sdkPaths.MSBuildSDKsPath;
+			IsInstalled = !string.IsNullOrEmpty (MSBuildSDKsPath);
+		}
+
+		public static bool IsInstalled { get; private set; }
+		public static string MSBuildSDKsPath { get; private set; }
+
+		internal static void EnsureInitialized ()
+		{
+		}
+
+		public static DotNetCoreSdkPaths FindSdkPaths (string sdk)
+		{
+			var sdkPaths = new DotNetCoreSdkPaths ();
+			sdkPaths.MSBuildSDKsPath = MSBuildSDKsPath;
+			sdkPaths.FindSdkPaths (sdk);
+
+			return sdkPaths;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -1,0 +1,40 @@
+﻿//
+// DotNetCoreSdkInstalledCondition.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Mono.Addins;
+
+namespace MonoDevelop.DotNetCore
+{
+	class DotNetCoreSdkInstalledCondition : ConditionType
+	{
+		public override bool Evaluate (NodeElement conditionNode)
+		{
+			var sdksPath = new DotNetCoreSdkPaths ();
+			sdksPath.FindMSBuildSDKsPath ();
+			return sdksPath.MSBuildSDKsPath != null;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.DotNetCore
 	{
 		List<string> projectImportProps = new List<string> ();
 		List<string> projectImportTargets = new List<string> ();
+		string msbuildSDKsPath;
 
 		public void FindMSBuildSDKsPath ()
 		{
@@ -54,15 +55,13 @@ namespace MonoDevelop.DotNetCore
 			if (SdksParentDirectory == null)
 				return;
 
-			MSBuildSDKsPath = Path.Combine (SdksParentDirectory, "Sdks");
+			msbuildSDKsPath = Path.Combine (SdksParentDirectory, "Sdks");
 
 			MSBuildProjectService.RegisterProjectImportSearchPath ("MSBuildSDKsPath", MSBuildSDKsPath);
 		}
 
 		public void FindSdkPaths (string sdk)
 		{
-			FindMSBuildSDKsPath ();
-
 			if (string.IsNullOrEmpty (MSBuildSDKsPath))
 				return;
 
@@ -86,7 +85,17 @@ namespace MonoDevelop.DotNetCore
 
 		public bool IsUnsupportedSdkVersion { get; private set; }
 		public bool Exist { get; private set; }
-		public string MSBuildSDKsPath { get; private set; }
+
+		public string MSBuildSDKsPath {
+			get { return msbuildSDKsPath; }
+			internal set {
+				msbuildSDKsPath = value;
+				if (!string.IsNullOrEmpty (msbuildSDKsPath)) {
+					SdksParentDirectory = Path.GetDirectoryName (msbuildSDKsPath);
+				}
+			}
+		}
+
 		string SdksParentDirectory { get; set; }
 
 		public IEnumerable<string> ProjectImportProps {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetMigrate.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetMigrate.cs
@@ -77,14 +77,13 @@ namespace MonoDevelop.DotNetCore
 				projectFile = project.FileName;
 				migrationFile = Path.Combine (Path.GetDirectoryName (projectFile), "project.json");
 			}
-			var dotnetPath = new DotNetCorePath ();
-			if (dotnetPath.IsMissing) {
+			if (DotNetCoreRuntime.IsMissing) {
 				monitor.ReportError (GettextCatalog.GetString (".NET Core is not installed"));
 				return false;
 			}
 
 			var process = Runtime.ProcessService.StartProcess (
-				dotnetPath.FileName,
+				DotNetCoreRuntime.FileName,
 				$"migrate \"{migrationFile}\"",
 				Path.GetDirectoryName (migrationFile),
 				monitor.Log,

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdks.cs
@@ -1,5 +1,5 @@
 ﻿//
-// DotNetCoreSdkInstalledCondition.cs
+// MSBuildSdks.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
@@ -24,37 +24,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Mono.Addins;
+using System.IO;
+using MonoDevelop.Core.Assemblies;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.DotNetCore
 {
-	class DotNetCoreSdkInstalledCondition : ConditionType
+	/// <summary>
+	/// .NET Core SDKs that ship with MSBuild.
+	/// </summary>
+	static class MSBuildSdks
 	{
-		public override bool Evaluate (NodeElement conditionNode)
+		static MSBuildSdks ()
 		{
-			if (DotNetCoreSdk.IsInstalled)
-				return true;
+			TargetRuntime runtime = IdeApp.Preferences.DefaultTargetRuntime;
+			string binPath = runtime.GetMSBuildBinPath ("15.0");
+			string sdksPath = Path.Combine (binPath, "Sdks");
 
-			if (MSBuildSdks.Installed)
-				return DotNetCoreRuntime.IsInstalled || !RequiresRuntime (conditionNode);
-
-			return false;
+			if (Directory.Exists (sdksPath)) {
+				Installed = true;
+				MSBuildSDKsPath = sdksPath;
+			}
 		}
 
-		/// <summary>
-		/// .NET Standard library projects do not require the .NET Core runtime.
-		/// </summary>
-		static bool RequiresRuntime (NodeElement conditionNode)
-		{
-			string value = conditionNode.GetAttribute ("requiresRuntime");
-			if (string.IsNullOrEmpty (value))
-				return true;
-
-			bool result = true;
-			if (bool.TryParse (value, out result))
-				return result;
-
-			return true;
-		}
+		public static bool Installed { get; private set; }
+		public static string MSBuildSDKsPath { get; private set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -38,6 +38,8 @@
 			icon="md-console-project"
 			imageId="md-console-project"
 			category="netcore/app/general"/>
+		</Condition>
+		<Condition id="DotNetCoreSdkInstalled" requiresRuntime="false">
 		<Template
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
@@ -54,6 +56,8 @@
 			icon="md-library-project"
 			imageId="md-library-project"
 			category="multiplat/library/general" />
+		</Condition>
+		<Condition id="DotNetCoreSdkInstalled">
 		<Template
 			id="Microsoft.Test.xUnit.CSharp"
 			_overrideDescription="Creates a new xUnit test project."

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionModel>
+
+	<ConditionType id="DotNetCoreSdkInstalled" type="MonoDevelop.DotNetCore.DotNetCoreSdkInstalledCondition" />
+
 	<Extension path="/MonoDevelop/Core/ExecutionHandlers">
 		<ExecutionHandler id="DotNetCore" class="MonoDevelop.DotNetCore.DotNetCoreExecutionHandler" />
 	</Extension>
+
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateCategories">
 		<Category id="netcore" name=".NET Core" icon="md-platform-other" insertbefore="other">
 			<Category id="app" name="App">
@@ -19,6 +23,7 @@
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/Templates">
+		<Condition id="DotNetCoreSdkInstalled">
 		<Template
 			id="Microsoft.Common.Console.CSharp"
 			_overrideDescription="Creates a new .NET Core console project."
@@ -91,6 +96,7 @@
 			icon="md-aspnet-empty-project"
 			imageId="md-aspnet-empty-project"
 			category="netcore/app/aspnet" />
+		</Condition>
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateWizards">


### PR DESCRIPTION
Also cache the .NET Core Sdk location and whether it is installed to prevent it from being run multiple times when checking the project templates should be hidden or not.