### PR TITLE
[DotNetCore] Fix duplicate F# files in Solution window

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -567,6 +568,13 @@ namespace MonoDevelop.DotNetCore
 		{
 			if (!BuildAction.DotNetActions.Contains (buildItem.Name))
 				return false;
+
+			if (IsFSharpSdkProject ()) {
+				// Ignore imported F# files. F# files are defined in the main project.
+				// This prevents duplicate F# files when a new project is first created.
+				if (buildItem.Include.EndsWith (".fs", StringComparison.OrdinalIgnoreCase))
+					return false;
+			}
 
 			// HACK: Remove any imported items that are not in the EvaluatedItems
 			// This may happen if a condition excludes the item. All items passed to the


### PR DESCRIPTION
Creating a new F# .NET Core project would display duplicate F# files
(.fs) in the Solution window. Reloading the project would fix the
duplicates. When creating a new project the FSharp.NET.Sdk NuGet
package's imported MSBuild properties are not available so the
imported F# files from the default Microsoft.NET.Sdk MSBuild imports
are applied. This results in imported F# files as well as those
defined in the project and causes duplicate files in the Solution
window. To fix this imported F# files are ignored and not added to
the project since they will be defined directly in the project.