### PR TITLE
[NewProjectDialog] Disable 'Create a project directory within the solution directory' when adding projects to existing solution

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/FinalProjectConfigurationPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/FinalProjectConfigurationPage.cs
@@ -161,7 +161,7 @@ namespace MonoDevelop.Ide.Projects
 		}
 
 		public bool IsCreateProjectDirectoryInsideSolutionDirectoryEnabled {
-			get { return HasProjects; }
+			get { return HasProjects && IsNewSolution; }
 		}
 
 		public bool IsGitIgnoreEnabled {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
@@ -204,7 +204,7 @@ namespace MonoDevelop.Ide.Projects
 			solutionNameTextBox.Sensitive = projectConfiguration.IsSolutionNameEnabled;
 			projectNameTextBox.Sensitive = projectConfiguration.IsProjectNameEnabled;
 			createProjectWithinSolutionDirectoryCheckBox.Sensitive = projectConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled;
-			createProjectWithinSolutionDirectoryCheckBox.Active = projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory;
+			createProjectWithinSolutionDirectoryCheckBox.Active = projectConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled ? projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory : true;
 			useGitCheckBox.Sensitive = projectConfiguration.IsUseGitEnabled;
 			useGitCheckBox.Active = projectConfiguration.UseGit;
 			createGitIgnoreFileCheckBox.Sensitive = projectConfiguration.IsGitIgnoreEnabled;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -199,7 +199,8 @@ namespace MonoDevelop.Ide.Projects
 		void UpdateDefaultSettings ()
 		{
 			UpdateDefaultGitSettings ();
-			PropertyService.Set (CreateProjectSubDirectoryPropertyName, projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			if (IsNewSolution)
+				PropertyService.Set (CreateProjectSubDirectoryPropertyName, projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
 			PropertyService.Set (SelectedLanguagePropertyName, GetLanguageForTemplateProcessing ());
 			DefaultSelectedCategoryPath = GetSelectedCategoryPath ();
 			DefaultSelectedTemplate = GetDefaultSelectedTemplateId ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -58,7 +58,6 @@ namespace MonoDevelop.Ide.Projects
 		const string UseGitPropertyName = "Dialogs.NewProjectDialog.UseGit";
 		const string CreateGitIgnoreFilePropertyName = "Dialogs.NewProjectDialog.CreateGitIgnoreFile";
 		const string CreateProjectSubDirectoryPropertyName = "MonoDevelop.Core.Gui.Dialogs.NewProjectDialog.AutoCreateProjectSubdir";
-		const string CreateProjectSubDirectoryInExistingSolutionPropertyName = "Dialogs.NewProjectDialog.AutoCreateProjectSubdirInExistingSolution";
 		const string NewSolutionLastSelectedCategoryPropertyName = "Dialogs.NewProjectDialog.LastSelectedCategoryPath";
 		const string NewSolutionLastSelectedTemplatePropertyName = "Dialogs.NewProjectDialog.LastSelectedTemplate";
 		const string NewProjectLastSelectedCategoryPropertyName = "Dialogs.NewProjectDialog.AddNewProjectLastSelectedCategoryPath";
@@ -194,21 +193,13 @@ namespace MonoDevelop.Ide.Projects
 			SetDefaultLocation ();
 			SetDefaultGitSettings ();
 			SelectedLanguage = PropertyService.Get (SelectedLanguagePropertyName, "C#");
-			projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory = GetDefaultCreateProjectDirectorySetting ();
-		}
-
-		bool GetDefaultCreateProjectDirectorySetting ()
-		{
-			if (IsNewSolution) {
-				return PropertyService.Get (CreateProjectSubDirectoryPropertyName, true);
-			}
-			return PropertyService.Get (CreateProjectSubDirectoryInExistingSolutionPropertyName, true);
+			projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory = PropertyService.Get (CreateProjectSubDirectoryPropertyName, true);
 		}
 
 		void UpdateDefaultSettings ()
 		{
 			UpdateDefaultGitSettings ();
-			UpdateDefaultCreateProjectDirectorySetting ();
+			PropertyService.Set (CreateProjectSubDirectoryPropertyName, projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
 			PropertyService.Set (SelectedLanguagePropertyName, GetLanguageForTemplateProcessing ());
 			DefaultSelectedCategoryPath = GetSelectedCategoryPath ();
 			DefaultSelectedTemplate = GetDefaultSelectedTemplateId ();
@@ -254,15 +245,6 @@ namespace MonoDevelop.Ide.Projects
 				return SelectedTemplate.Id;
 			}
 			return null;
-		}
-
-		void UpdateDefaultCreateProjectDirectorySetting ()
-		{
-			if (IsNewSolution) {
-				PropertyService.Set (CreateProjectSubDirectoryPropertyName, projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
-			} else {
-				PropertyService.Set (CreateProjectSubDirectoryInExistingSolutionPropertyName, projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
-			}
 		}
 
 		void SetDefaultLocation ()


### PR DESCRIPTION
Fix bug #53670: [New Project Dialog] Remove "Create a project directory within the solution directory" when adding projects to existing solution
(https://bugzilla.xamarin.com/show_bug.cgi?id=53670)

We need to prevent users from unchecking "Create a project directory within the solution directory" when adding projects to existing solution.

This is an action that can break projects if the user chooses to override files (users mistake because we ask confirmation but still there's no point in allowing that).