### PR TITLE
[DotNetCore] Remove F# build workaround

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -465,32 +465,9 @@ namespace MonoDevelop.DotNetCore
 			return false;
 		}
 
-		// HACK: The FSharp.NET.Core.Sdk.targets defines the path to dotnet using:
-		// <_DotNetHostExecutableDirectory>$(MSBuildExtensionsPath)/../..</_DotNetHostExecutableDirectory>
-		// MSBuildExtensionsPath points to MSBuild supplied with Mono so building FSharp
-		// projects fails using this path since dotnet does not ship with Mono. The
-		// _DotNetHostExecutableDirectory cannot be overridden so as a workaround for
-		// F# projects the MSBuildExtensionsPath is redefined to point to the .NET Core
-		// SDK folder.
-		protected override Task<TargetEvaluationResult> OnRunTarget (ProgressMonitor monitor, string target, ConfigurationSelector configuration, TargetEvaluationContext context)
-		{
-			if (target == ProjectService.BuildTarget) {
-				if (IsFSharpSdkProject ()) {
-					OverrideMSBuildExtensionsPathToFixBuild (context);
-				}
-			}
-			return base.OnRunTarget (monitor, target, configuration, context);
-		}
-
 		bool IsFSharpSdkProject ()
 		{
 			return HasSdk && dotNetCoreMSBuildProject.Sdk.Contains ("FSharp");
-		}
-
-		void OverrideMSBuildExtensionsPathToFixBuild (TargetEvaluationContext context)
-		{
-			string path = Path.GetFullPath (Path.Combine (sdkPaths.MSBuildSDKsPath, ".."));
-			context.GlobalProperties.SetValue ("MSBuildExtensionsPath", path);
 		}
 
 		internal IEnumerable<TargetFramework> GetSupportedTargetFrameworks ()


### PR DESCRIPTION
When FSharp.NET.Sdk 1.0.0 was used by a project the build would fail
without the MSBuildExtensionsPath being overridden to point to the
correct folder where the .NET Core sdk was installed. Creating a new
F# project uses FSharp.NET.Sdk 1.0.* which installs the latest
version which currently is 1.0.2. FSharp.NET.Sdk 1.0.1 and above
now use the MSBuildSDKsPath instead of the MSBuildExtensionsPath so
the workaround is no longer needed.