### PR TITLE
[RoslynSymbolCompletionData] Handle Deprecated and Obsoleted attributes

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
@@ -465,7 +465,7 @@ namespace MonoDevelop.CSharp.Completion
 
 		static bool IsObsolete (ISymbol symbol)
 		{
-			return symbol.GetAttributes ().Any (attr => attr.AttributeClass.Name == "ObsoleteAttribute" && attr.AttributeClass.ContainingNamespace.GetFullName () == "System");
+			return symbol.GetAttributes ().Any (attr => attr.AttributeClass.Name == "ObsoleteAttribute" || attr.AttributeClass.Name == "ObsoletedAttribute" || attr.AttributeClass.Name == "DeprecatedAttribute");
 		}
 
 


### PR DESCRIPTION
Xamarin.iOS for instance is using those custom attributes and this seems to be the simplest change to handle them.
Also their `ContainingNamespace` isn't `System`.
This change is unlikely to clash with something else.