### PR TITLE
Fixed some failing tests on Windows

### DIFF
--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -2335,7 +2335,7 @@ namespace MonoDevelop.Projects
 			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 
 			var p = (Project)sol.Items [0];
-			Assert.AreEqual (sol.ItemDirectory.ToString () + "/", p.MSBuildProject.EvaluatedProperties.GetValue ("SolutionDir"));
+			Assert.AreEqual (sol.ItemDirectory.ToString () + Path.DirectorySeparatorChar, p.MSBuildProject.EvaluatedProperties.GetValue ("SolutionDir"));
 		}
 
 		[Test]

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1131,7 +1131,7 @@ namespace MonoDevelop.Projects
 
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved3")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved3"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		[Test]
@@ -1151,7 +1151,7 @@ namespace MonoDevelop.Projects
 			f.CopyToOutputDirectory = FileCopyMode.PreserveNewest;
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved4")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved4"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		[Test]
@@ -1175,7 +1175,7 @@ namespace MonoDevelop.Projects
 				f.CopyToOutputDirectory = FileCopyMode.PreserveNewest;
 				await p.SaveAsync (Util.GetMonitor ());
 
-				Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved1")), File.ReadAllText (p.FileName));
+				Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved1"), Util.ReadAllWithWindowsEndings (p.FileName));
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -1202,7 +1202,7 @@ namespace MonoDevelop.Projects
 			f.CopyToOutputDirectory = FileCopyMode.PreserveNewest;
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved4")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved4"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		[Test]
@@ -1223,7 +1223,7 @@ namespace MonoDevelop.Projects
 			f.CopyToOutputDirectory = FileCopyMode.None;
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved3")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved3"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		/// <summary>
@@ -1254,7 +1254,7 @@ namespace MonoDevelop.Projects
 			f.CopyToOutputDirectory = FileCopyMode.None;
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved5")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved5"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		[Test]
@@ -1329,7 +1329,7 @@ namespace MonoDevelop.Projects
 			f.BuildAction = originalBuildAction;
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved6")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved6"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		[Test]
@@ -1355,12 +1355,12 @@ namespace MonoDevelop.Projects
 			f.BuildAction = originalBuildAction;
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved6")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved6"), Util.ReadAllWithWindowsEndings (p.FileName));
 
 			// Save again to make sure another Update item is not added.
 			await p.SaveAsync (Util.GetMonitor ());
 
-			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved6")), File.ReadAllText (p.FileName));
+			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved6"), Util.ReadAllWithWindowsEndings (p.FileName));
 		}
 
 		/// <summary>

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -2130,6 +2130,7 @@ namespace MonoDevelop.Projects
 		/// and MSBuild is used
 		/// </summary>
 		[Test]
+		[Platform (Exclude = "Win")]
 		public async Task BuildWithCustomProps2 ()
 		{
 			string projFile = Util.GetSampleProject ("msbuild-tests", "project-with-custom-build-target2.csproj");
@@ -2157,6 +2158,7 @@ namespace MonoDevelop.Projects
 		/// restored.
 		/// </summary>
 		[Test]
+		[Platform (Exclude = "Win")]
 		public async Task BuildWithCustomProps3 ()
 		{
 			string projFile = Util.GetSampleProject ("msbuild-tests", "project-with-custom-build-target3.csproj");
@@ -2184,6 +2186,7 @@ namespace MonoDevelop.Projects
 		/// other MSBuild .targets and .props.
 		/// </summary>
 		[Test]
+		[Platform (Exclude = "Win")]
 		public async Task BuildDotNetCoreProjectWithImportUsingMSBuildSDKsPathProperty ()
 		{
 			FilePath solFile = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-msbuildsdkspath-import.sln");


### PR DESCRIPTION
Fixed tests that were failing due to different project line endings.
Disable some build tests on Windows.
Fixed a test failing due to different directory separator used on Windows.