### PR TITLE
[DotNetCore] Change default for ExternalConsole to true for .Net Core projects(to match .NET projects)

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRunConfiguration.cs
@@ -43,6 +43,7 @@ namespace MonoDevelop.DotNetCore
 		protected override void Initialize (Project project)
 		{
 			base.Initialize (project);
+			ExternalConsole = true;
 			if (project.GetFlavor<DotNetCoreProjectExtension> ()?.IsWeb ?? false && string.IsNullOrEmpty (ApplicationURL)) {
 				var tcpListner = new TcpListener (IPAddress.Loopback, 0);
 				tcpListner.Start ();


### PR DESCRIPTION
https://trello.com/c/n8OQw3tp/136-use-external-console-by-default-for-net-core-console-projects-and-web-projects