### PR TITLE
Bug 52946 - Exception catchpoint dialog should have System.Exception selected by default

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
@@ -221,6 +221,9 @@ namespace MonoDevelop.Debugger
 				case BreakpointType.Catchpoint:
 					stopOnException.Active = true;
 					entryExceptionType.SetFocus ();
+					entryExceptionType.Text = "System.Exception";
+					entryExceptionType.SelectionStart = 0;
+					entryExceptionType.SelectionLength = entryExceptionType.TextLength;
 					break;
 				}
 			}


### PR DESCRIPTION
@slluis can you verify this is something that we want?

Logic behind selecting whole text is that if user wants to change exception type... it just has to start typing and since text is selected it will delete it...