### PR TITLE
[F#] Fix empty ItemGroups added to .NET Core project

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -126,7 +126,7 @@ type FSharpProject() as self =
             | [_single, items] when items = sortedItems -> false
             | _ -> true
 
-        if needsSort then
+        if needsSort && sortedItems.Length > 0 then
             let newGroup = project.AddNewItemGroup()
 
             for item in sortedItems do


### PR DESCRIPTION
Adding a new F# file to an xUnit .NET Core project would add four
empty ItemGroup elements to the project file. xUnit .NET Core
projects use a wildcard include for F# files unlike the other F#
.NET Core projects.