### PR TITLE
[Core] Added `GetReferencedExtensionsFromFlavor` to `SolutionItem`.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -375,6 +375,24 @@ namespace MonoDevelop.Projects
 			return ItemExtension.OnGetReferencedItems (configuration);
 		}
 
+		public T [] GetReferencedExtensionsFromFlavor<T> (string projectTypeName, ConfigurationSelector configuration) where T : ProjectExtension
+		{
+			var extensions = new List<T> ();
+			var projects = ParentSolution.GetAllProjects ();
+			var extensionFlavor = Type.GetType (projectTypeName, true);
+
+			foreach (var p in projects) {
+				if (p == this
+					|| !p.GetReferencedItems (configuration).Contains (this))
+					continue;
+
+				T extension = p.GetService (extensionFlavor) as T;
+				if (extension != null)
+					extensions.Add (extension);
+			}
+			return extensions.ToArray ();
+		}
+
 		protected virtual IEnumerable<SolutionItem> OnGetReferencedItems (ConfigurationSelector configuration)
 		{
 			return dependencies;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -375,7 +375,7 @@ namespace MonoDevelop.Projects
 			return ItemExtension.OnGetReferencedItems (configuration);
 		}
 
-		public T [] GetReferencedExtensionsFromFlavor<T> (string projectTypeName, ConfigurationSelector configuration) where T : ProjectExtension
+		public IEnumerable<T>  GetReferencedExtensionsFromFlavor<T> (string projectTypeName, ConfigurationSelector configuration) where T : ProjectExtension
 		{
 			var extensions = new List<T> ();
 			var projects = ParentSolution.GetAllProjects ();
@@ -390,7 +390,7 @@ namespace MonoDevelop.Projects
 				if (extension != null)
 					extensions.Add (extension);
 			}
-			return extensions.ToArray ();
+			return extensions;
 		}
 
 		protected virtual IEnumerable<SolutionItem> OnGetReferencedItems (ConfigurationSelector configuration)


### PR DESCRIPTION
* This method is used by the XAML forms previewer and by the iOS Designer.
When a storyboard belong to a Shared Asset project we need to find the iOS project which references that shared asset project.