### PR TITLE
Bug 53371 - "Debugger Operation Failed" when trying to debug an NUnittest after the test finishes

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/ExternalTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/ExternalTestRunner.cs
@@ -59,6 +59,11 @@ namespace MonoDevelop.UnitTesting.NUnit.External
 			return connection.Connect ();
 		}
 
+		public Task Disconnect ()
+		{
+			return connection.Disconnect ();
+		}
+
 		public async Task<UnitTestResult> Run (IRemoteEventListener listener, string[] nameFilter, string path, string suiteName, List<string> supportAssemblies, string testRunnerType, string testRunnerAssembly, string crashLogFile)
 		{
 			this.listener = listener;

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
@@ -446,6 +446,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 				}
 			} finally {
 				// Dispose the runner before the console, to make sure the console is available until the runner is disposed.
+				runner.Disconnect ().Wait ();
 				runner.Dispose ();
 				if (console != null)
 					console.Dispose ();


### PR DESCRIPTION
Since 06a9d3ef1d Dispose was not blocking anymore for process to finish, causing dispose of console to happen before process terminated hence NRE exceptions.