### PR TITLE
Prevent exception from being thrown on startup

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdks.cs
@@ -39,11 +39,13 @@ namespace MonoDevelop.DotNetCore
 		{
 			TargetRuntime runtime = IdeApp.Preferences.DefaultTargetRuntime;
 			string binPath = runtime.GetMSBuildBinPath ("15.0");
-			string sdksPath = Path.Combine (binPath, "Sdks");
+			if (binPath != null) {
+				string sdksPath = Path.Combine(binPath, "Sdks");
 
-			if (Directory.Exists (sdksPath)) {
-				Installed = true;
-				MSBuildSDKsPath = sdksPath;
+				if (Directory.Exists(sdksPath)) {
+					Installed = true;
+					MSBuildSDKsPath = sdksPath;
+				}
 			}
 		}
 


### PR DESCRIPTION
I was getting an exception on startup -- leading to the dialog that extensions ... couldn't be loaded -- because binPath was coming up null.

This is just a Band-Aid. Matt should take a look at decide whether this is the proper fix (and either merge it or just remove the Don't Merge Yet label).