### PR TITLE
When an ad-hoc document is renamed unload the Adhoc project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -171,6 +171,7 @@ namespace MonoDevelop.Ide.Gui
 			window.ViewsChanged += HandleViewsChanged;
 			window.ViewContent.ContentNameChanged += delegate {
 				UnsubscibeAnalysisdocument ();
+				UnloadAdhocProject();
 			};
 			MonoDevelopWorkspace.LoadingFinished += TypeSystemService_WorkspaceItemLoaded;
 		}


### PR DESCRIPTION
Otherwise it will try to find the new document in the old project and fail, causing analysisDocument to be null. And when analysisDocument is null, various language services are turned off.

The symptom was when calling Save As on a .css file completion stopped working. I've verified that after this call is made completion works fine after SaveAs on a .css file.