### PR TITLE
Fixed 'Bug 54010 - NullReference in SearchAndReplaceWidget kills XS'.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
@@ -374,16 +374,17 @@ namespace MonoDevelop.Components
 		}
 
 		event EventHandler requestMenu;
+		object requestMenuLock = new object ();
 		public event EventHandler RequestMenu {
 			add {
-				lock (requestMenu) {
+				lock (requestMenuLock) {
 					requestMenu += value;
 					filter_button.Accessible.SetShouldIgnore (false);
 				}
 			}
 
 			remove {
-				lock (requestMenu) {
+				lock (requestMenuLock) {
 					requestMenu -= value;
 					if (requestMenu == null) {
 						filter_button.Accessible.SetShouldIgnore (true);


### PR DESCRIPTION
Not exactly sure how that bug happened. The search entry threw an
exception before that search & replace widget lock. Remember: always
include full logs when reporting bugs.
Catched an exception in search & replace widget - that event handler
should never crash the IDE.