### PR TITLE
[DotNetCore] Set properties for sdk and runtime being available

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -25,11 +25,18 @@
 // THE SOFTWARE.
 
 using Mono.Addins;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.DotNetCore
 {
 	class DotNetCoreSdkInstalledCondition : ConditionType
 	{
+		static DotNetCoreSdkInstalledCondition ()
+		{
+			PropertyService.Set ("DotNetCore.CanCompileDotNetCoreProject", DotNetCoreSdk.IsInstalled || MSBuildSdks.Installed);
+			PropertyService.Set ("DotNetCore.IsRuntimeInstalled", DotNetCoreRuntime.IsInstalled);
+		}
+
 		public override bool Evaluate (NodeElement conditionNode)
 		{
 			if (DotNetCoreSdk.IsInstalled)


### PR DESCRIPTION
Allows other addins to enable/disable features, such as project
creation when the .NET Core SDK or runtime is not installed without
taking a directly dependency on the .NET Core addin.