### PR TITLE
[Highlighting] Implement :ascii: class

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/Sublime3Format.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/Sublime3Format.cs
@@ -601,6 +601,9 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 					AddRange ('A', 'Z');
 					AddRange ('0', '9');
 					break;
+				case "ascii":
+					AddRange ((char)0, (char)127);
+					break;
 				case "alpha": // Alphabetic character
 					AddRange ('a', 'z');
 					AddRange ('A', 'Z');


### PR DESCRIPTION
This adds support for :ascii: regex class, for 0-127 char values.
Fixes css and C++ syntax files which were triggering 'unknown unicode category : ^ascii'

cc @mkrueger: I'm not sure this is supposed to be just _printable_ ascii characters, which in turn would be 0x20 - 0x7E.