### PR TITLE
[DotNetCore] .NET Core SDK and runtime detection are now public

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
@@ -26,7 +26,7 @@
 
 namespace MonoDevelop.DotNetCore
 {
-	static class DotNetCoreRuntime
+	public static class DotNetCoreRuntime
 	{
 		static DotNetCoreRuntime ()
 		{

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace MonoDevelop.DotNetCore
 {
-	static class DotNetCoreSdk
+	public static class DotNetCoreSdk
 	{
 		static DotNetCoreSdk ()
 		{
@@ -46,7 +46,7 @@ namespace MonoDevelop.DotNetCore
 		{
 		}
 
-		public static DotNetCoreSdkPaths FindSdkPaths (string sdk)
+		internal static DotNetCoreSdkPaths FindSdkPaths (string sdk)
 		{
 			var sdkPaths = new DotNetCoreSdkPaths ();
 			sdkPaths.MSBuildSDKsPath = MSBuildSDKsPath;

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdks.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.DotNetCore
 	/// <summary>
 	/// .NET Core SDKs that ship with MSBuild.
 	/// </summary>
-	static class MSBuildSdks
+	public static class MSBuildSdks
 	{
 		static MSBuildSdks ()
 		{


### PR DESCRIPTION
Allow other addins to check if the .NET Core SDKs and the runtime is
installed.