### PR TITLE
Fix tooltips in editor

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1036,6 +1036,7 @@ namespace MonoDevelop.Ide.Editor
 
 			FileNameChanged += TextEditor_FileNameChanged;
 			MimeTypeChanged += TextEditor_MimeTypeChanged;
+			TextEditor_MimeTypeChanged (null, null);
 		}
 
 		void TextEditor_FileNameChanged (object sender, EventArgs e)


### PR DESCRIPTION
Bug was caused in ffc89f1c0 with changes in main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorDisplayBinding.cs [Direct Link](https://github.com/mono/monodevelop/commit/ffc89f1c0b40e7883269fa5035d70e925991d6bb#diff-e9cb993b3a2ae4b0bf4a2c716a2a9bd0) file which changed to set MimeType during construction instead after construction which resulted in MimeTypeChanged event not being triggered hence tooltip providers not set, hence no tooltips

@mkrueger 
/cc: @slluis @sevoku 