### PR TITLE
[Regex] Fix parsing negative character classes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/Sublime3Format.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/Sublime3Format.cs
@@ -203,7 +203,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 
 		class CharacterClass
 		{
-			bool first = true;
+			bool first = true, firstInSubClass = false;
 			bool negativeGroup;
 			StringBuilder wordBuilder;
 			StringBuilder unicodeGroupBuilder = new StringBuilder ();
@@ -228,6 +228,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 						wordBuilder = new StringBuilder ();
 						subClass = new CharacterClass ();
 						subClass.Add (':');
+						firstInSubClass = true;
 					} else {
 						if (wordBuilder != null) {
 							ConvertUnicodeCategory (wordBuilder.ToString ());
@@ -238,7 +239,8 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 					}
 					break;
 				case '^':
-					if (first) {
+					if (first || firstInSubClass) {
+						firstInSubClass = false;
 						negativeGroup = true;
 						break;
 					}


### PR DESCRIPTION
This allows patterns such as [^:ascii:] used in the LESS.tmLanguage file.