### PR TITLE
[Core] Fix build error when .NET Core project is referenced

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -72,6 +72,7 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			var builder = await LoadProject (projectFile, sdksPath).ConfigureAwait (false);
 			var pb = new RemoteProjectBuilder (projectFile, builder, this);
+			pb.SdksPath = sdksPath;
 			lock (remoteProjectBuilders) {
 				remoteProjectBuilders.Add (pb);
 
@@ -306,6 +307,8 @@ namespace MonoDevelop.Projects.MSBuild
 			referenceCache = new Dictionary<string, AssemblyReference[]> ();
 			packageDependenciesCache = new Dictionary<string, PackageDependency[]> ();
 		}
+
+		internal string SdksPath { get; set; }
 
 		public event EventHandler Disconnected;
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1350,12 +1350,12 @@ namespace MonoDevelop.Projects
 
 			using (await builderLock.EnterAsync ()) {
 				bool refAdded = false;
-				if (projectBuilder == null || !(refAdded = projectBuilder.AddReference ()) || lastBuildToolsVersion != ToolsVersion || lastBuildRuntime != runtime.Id || lastFileName != FileName || lastSlnFileName != slnFile) {
+				var sdkPath = GetMSBuildSdkPath (runtime);
+				if (projectBuilder == null || !(refAdded = projectBuilder.AddReference ()) || lastBuildToolsVersion != ToolsVersion || lastBuildRuntime != runtime.Id || lastFileName != FileName || lastSlnFileName != slnFile || sdkPath != projectBuilder.SdksPath) {
 					if (projectBuilder != null && refAdded) {
 						projectBuilder.Shutdown ();
 						projectBuilder.ReleaseReference ();
 					}
-					var sdkPath = GetMSBuildSdkPath (runtime);
 					var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild);
 					pb.AddReference ();
 					pb.Disconnected += delegate {

--- a/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreNetStandardProject/Class1.cs
+++ b/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreNetStandardProject/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace DotNetCoreNetStandardProject
+{
+    public class Class1
+    {
+    }
+}

--- a/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreNetStandardProject/DotNetCoreNetStandardProject.csproj
+++ b/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreNetStandardProject/DotNetCoreNetStandardProject.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference.sln
+++ b/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetFrameworkProject", "DotNetCoreProjectReference\DotNetFrameworkProject.csproj", "{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCoreNetStandardProject", "DotNetCoreNetStandardProject\DotNetCoreNetStandardProject.csproj", "{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference/DotNetFrameworkProject.csproj
+++ b/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference/DotNetFrameworkProject.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>DotNetCoreProjectReference</RootNamespace>
+    <AssemblyName>DotNetCoreProjectReference</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetCoreNetStandardProject\DotNetCoreNetStandardProject.csproj">
+      <Project>{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}</Project>
+      <Name>DotNetCoreNetStandardProject</Name>
+      <Private>false</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference/MyClass.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace DotNetCoreProjectReference
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/DotNetCoreProjectReference/DotNetCoreProjectReference/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("DotNetCoreProjectReference")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("(c) Matt Ward")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference.sln
+++ b/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoProjectReference", "NoProjectReference\DotNetFrameworkProject.csproj", "{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference/DotNetFrameworkProject.csproj
+++ b/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference/DotNetFrameworkProject.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>NoProjectReference</RootNamespace>
+    <AssemblyName>NoProjectReference</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference/MyClass.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace DotNetCoreProjectReference
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/DotNetCoreProjectReference/NoProjectReference/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("DotNetCoreProjectReference")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("(c) Matt Ward")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]


### PR DESCRIPTION
When a non .NET Core project references a .NET Core project the
build would fail with an error similar to:

Error MSB4019: The imported project
"~/Library/Caches/VisualStudio/7.0/MSBuild/8209_1/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.props" was not found.

The MSBuildSDKsPath was not defined when building the project that
references the .NET Core project. Now a check is made of the
referenced projects and the MSBuildSDKsPath is set there is a
.NET Core project referenced.