### PR TITLE
[Designer (Gtk#)] Fix generating invalid code

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/libsteticui/CodeGenerator.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/libsteticui/CodeGenerator.cs
@@ -1,10 +1,11 @@
 using System;
-using System.Reflection;
 using System.CodeDom;
 using System.CodeDom.Compiler;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Stetic
 {
@@ -119,9 +120,10 @@ namespace Stetic
 				CodeExpression createDelegate;
 				
 				if (options.UsePartialClasses) {
+					var rgx = new Regex (@"`\d+");
 					createDelegate =
 						new CodeDelegateCreateExpression (
-							new CodeTypeReference (descriptor.HandlerTypeName, CodeTypeReferenceOptions.GlobalReference),
+							new CodeTypeReference (rgx.Replace (descriptor.HandlerTypeName, ""), CodeTypeReferenceOptions.GlobalReference),
 							new CodeThisReferenceExpression (),
 							signal.Handler);
 				} else {


### PR DESCRIPTION
If events has type Generic EventHandler, Gtk designer generate invalid code in auto generated cs. Like:
this.tdiMain.TabAdded += new global::System.EventHandler<>< QSTDI.TabAddedEventArgs > (this.OnTdiMainTabAdded);
Added unnecessary <>. It because descriptor.HandlerTypeName was like "System.EventHandler`1<QSTDI.TabAddedEventArgs>" with "`1". We remove "`1" from name.