### PR TITLE
Fixed 'Bug 54152 - Crash caused by regex tests'

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RegexEngine/Regex.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RegexEngine/Regex.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 // <copyright file="Regex.cs" company="Microsoft">
 //     Copyright (c) Microsoft Corporation.  All rights reserved.
 // </copyright>                                                                
@@ -1361,7 +1361,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting.RegexEngine {
         /// <devdoc>
         /// </devdoc>
         protected bool UseOptionC() {
-            return(roptions & RegexOptions.Compiled) != 0;
+			return false;
         }
 #endif
 

--- a/main/tests/UnitTests/MonoDevelop.Ide.Editor/RegexTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Editor/RegexTests.cs
@@ -50,7 +50,6 @@ namespace MonoDevelop.Ide.Editor
 		}
 
 		[Test]
-		[Ignore ("Ignore until bug #54152 is fixed")]
 		public void TestHRefSearching ()
 		{
 			var editor = TextEditorFactory.CreateNewEditor ();


### PR DESCRIPTION
Was caused by a change in the regex engine usage. With the switch to
the vs editor editor operations have become too unefficient for
regular expressions and regexes have been switched to plain strings
again.