### PR TITLE
[Core] Handle generic projects with first element not PropertyGroup

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -776,6 +776,10 @@ namespace MonoDevelop.Projects.MSBuild
 					return null;
 				tr.ReadStartElement ();
 				tr.MoveToContent ();
+				while (tr.LocalName != "PropertyGroup" && !tr.EOF) {
+					tr.Skip ();
+					tr.MoveToContent ();
+				}
 				if (tr.LocalName != "PropertyGroup")
 					return null;
 				if (tr.IsEmptyElement)

--- a/main/tests/UnitTests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/ProjectTests.cs
@@ -556,6 +556,20 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task LoadGenericProjectWithImportBeforePropertyGroup ()
+		{
+			string solFile = Util.GetSampleProject ("generic-project-with-import", "generic-project.sln");
+
+			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = sol.Items[0];
+
+			Assert.IsInstanceOf<GenericProject> (p);
+
+			var pl = (GenericProject)p;
+			Assert.AreEqual ("Default", pl.Configurations [0].Name);
+		}
+
+		[Test]
 		public void SanitizeProjectNamespace ()
 		{
 			var info = new ProjectCreateInformation {

--- a/main/tests/test-projects/generic-project-with-import/GenericProject/GenericProject.mdproj
+++ b/main/tests/test-projects/generic-project-with-import/GenericProject/GenericProject.mdproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="test.props" Condition="Exists('test.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Default</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ItemType>GenericProject</ItemType>
+    <ProjectGuid>{72304CEE-0002-4615-AF53-00E0E572CDC1}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Default|AnyCPU' ">
+    <OutputPath>.\</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/generic-project-with-import/generic-project.sln
+++ b/main/tests/test-projects/generic-project-with-import/generic-project.sln
@@ -1,0 +1,14 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "GenericProject", "GenericProject\GenericProject.mdproj", "{72304CEE-0002-4615-AF53-00E0E572CDC1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Default|Any CPU = Default|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{72304CEE-0002-4615-AF53-00E0E572CDC1}.Default|Any CPU.ActiveCfg = Default|Any CPU
+		{72304CEE-0002-4615-AF53-00E0E572CDC1}.Default|Any CPU.Build.0 = Default|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Keep reading the project file for a PropertyGroup element. This
fixes the unknown project type message currently shown when opening
the po.mdproj project.