### PR TITLE
Add the .yml file extension for Yaml

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/syntaxes/Yaml/Yaml.sublime-syntax
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/syntaxes/Yaml/Yaml.sublime-syntax
@@ -28,6 +28,7 @@
 name: "Yaml"
 file_extensions:
   - yaml
+  - yml
   - sublime-syntax
 scope: source.yaml
 contexts:


### PR DESCRIPTION
@madskristensen wanted to make sure MonoDevelop has support for .yml files. Turns out we already have support but just don't support the .yml extension. This one-liner adds that.