### PR TITLE
Fixed ' Bug 54228 - AsyncMethodHighlighter null reference exception'.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/KeywordHighlighters/AbstractAsyncHighlighter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/KeywordHighlighters/AbstractAsyncHighlighter.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
 
 			// Highlight await keywords
 			var awaitExpression = node as AwaitExpressionSyntax;
-			{
+			if (awaitExpression != null) {
                     // Note if there is already a highlight for the previous token, merge it
                     // with this span. That way, we highlight nested awaits with a single span.
                     var handled = false;


### PR DESCRIPTION
Haven't found a use case where it could happen - fixing the exception
is easy. I guess that an invalid/incomplete c# AST construct could
cause that.