### PR TITLE
Bug 54156 - double clicking on error bubble in editor crashes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrameTopLevel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrameTopLevel.cs
@@ -142,7 +142,8 @@ namespace MonoDevelop.Components.Docking
 
 		internal string Title {
 			set {
-				ContainerWindow.Title = value;
+				if (ContainerWindow != null)
+					ContainerWindow.Title = value;
 			}
 		}
 	}


### PR DESCRIPTION
This happens in case of ErrorPad being in AutoShow pad… Problem is that DockerFrame.UseWindowsForTopLevelFrames == false on Windows which results in ContainerWindow=null, hence exception

@iainx This was added for a11y to put title on window on Mac.. what will outcome of not setting this on Windows since it's not implemented as window...