### PR TITLE
Fixed 'Bug 43741 - Double clicking on search result or reference

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyNodeBuilder.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.AssemblyBrowser
 			bool publicOnly = Widget.PublicApiOnly;
 			
 			foreach (var type in compilationUnit.UnresolvedAssembly.TopLevelTypeDefinitions) {
-				string namespaceName = string.IsNullOrEmpty (type.Namespace) ? "-" : type.Namespace;
+				string namespaceName = string.IsNullOrEmpty (type.Namespace) ? "" : type.Namespace;
 				if (!namespaces.ContainsKey (namespaceName))
 					namespaces [namespaceName] = new Namespace (namespaceName);
 				
@@ -90,7 +90,14 @@ namespace MonoDevelop.AssemblyBrowser
 				ns.Types.Add (type);
 			}
 
-			treeBuilder.AddChildren (namespaces.Values.Where (ns => !publicOnly || ns.Types.Any (t => t.IsPublic)));
+			treeBuilder.AddChildren (namespaces.Where (ns => ns.Key != "" && (!publicOnly || ns.Value.Types.Any (t => t.IsPublic))).Select (n => n.Value));
+			if (namespaces.ContainsKey ("")) {
+				foreach (var child in namespaces [""].Types) {
+					if (child.Name == "<Module>")
+						continue;
+					treeBuilder.AddChild (child);
+				}
+			}
 		}
 		
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/NamespaceBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/NamespaceBuilder.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // NamespaceBuilder.cs
 //
 // Author:
@@ -59,9 +59,9 @@ namespace MonoDevelop.AssemblyBrowser
 				if (e1 == null && e2 == null)
 					return 0;
 				if (e1 == null)
-					return -1;
-				if (e2 == null)
 					return 1;
+				if (e2 == null)
+					return -1;
 				
 				return e1.Name.CompareTo (e2.Name);
 			} catch (Exception e) {


### PR DESCRIPTION
doesn't do anything for things without a namespace'

There wasn't a reason that global types were put into the '-'
namespace now they're ordered in the tree at the right position so the
find algorithm can find them properly.