### PR TITLE
Dispose solutions and projects in unit tests

### DIFF
--- a/main/tests/UnitTests/MonoDevelop.Projects/FlavorMigration.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/FlavorMigration.cs
@@ -83,6 +83,7 @@ namespace MonoDevelop.Projects
 			Assert.IsInstanceOf<Project> (p);
 			Assert.IsFalse (((Project)p).HasFlavor<NewFlavor> ());
 			Assert.IsTrue (((Project)p).HasFlavor<ObsoleteFlavor> ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -95,6 +96,7 @@ namespace MonoDevelop.Projects
 			Assert.IsInstanceOf<Project> (p);
 			Assert.IsTrue (((Project)p).HasFlavor<NewFlavor> ());
 			Assert.IsFalse (((Project)p).HasFlavor<ObsoleteFlavor> ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -108,6 +110,7 @@ namespace MonoDevelop.Projects
 			Assert.IsInstanceOf<Project> (p);
 			Assert.IsFalse (((Project)p).HasFlavor<NewFlavor> ());
 			Assert.IsTrue (((Project)p).HasFlavor<ObsoleteFlavor> ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -121,6 +124,7 @@ namespace MonoDevelop.Projects
 			Assert.IsInstanceOf<Project> (p);
 			Assert.IsTrue (((Project)p).HasFlavor<NewFlavor> ());
 			Assert.IsFalse (((Project)p).HasFlavor<ObsoleteFlavor> ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -134,6 +138,7 @@ namespace MonoDevelop.Projects
 			Assert.IsInstanceOf<Project> (p);
 			Assert.IsTrue (((Project)p).HasFlavor<NewFlavor> ());
 			Assert.IsFalse (((Project)p).HasFlavor<ObsoleteFlavor> ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -146,6 +151,7 @@ namespace MonoDevelop.Projects
 				var m = new CustomProjectLoadProgressMonitor { ShouldMigrateValue = MigrationType.Ignore };
 				var p = await LoadProject (m);
 				Assert.IsInstanceOf<UnknownSolutionItem> (p);
+				p.Dispose ();
 			} finally {
 				migrator.IsMigrationRequired = false;
 			}
@@ -163,6 +169,7 @@ namespace MonoDevelop.Projects
 				Assert.IsInstanceOf<Project> (p);
 				Assert.IsTrue (((Project)p).HasFlavor<NewFlavor> ());
 				Assert.IsFalse (((Project)p).HasFlavor<ObsoleteFlavor> ());
+				p.Dispose ();
 			} finally {
 				migrator.IsMigrationRequired = false;
 			}
@@ -180,6 +187,7 @@ namespace MonoDevelop.Projects
 				var p = await LoadProject (m);
 				Assert.IsTrue (((Project)p).HasFlavor<NewFlavor> ());
 				Assert.IsFalse (((Project)p).HasFlavor<ObsoleteFlavor> ());
+				p.Dispose ();
 			} finally {
 				migrator.IsMigrationRequired = false;
 			}
@@ -195,6 +203,7 @@ namespace MonoDevelop.Projects
 				var m = new CustomProjectLoadProgressMonitor { ShouldMigrateValue = MigrationType.Migrate };
 				var p = await LoadProject (m);
 				Assert.IsInstanceOf<UnknownSolutionItem> (p);
+				p.Dispose ();
 			} finally {
 				migrator.IsMigrationRequired = false;
 			}
@@ -210,6 +219,7 @@ namespace MonoDevelop.Projects
 				var m = new CustomProjectLoadProgressMonitor { ShouldMigrateValue = MigrationType.Migrate };
 				var p = await LoadProject (m);
 				Assert.IsInstanceOf<UnknownSolutionItem> (p);
+				p.Dispose ();
 			} finally {
 				migrationHandler.MigrationResult = true;
 			}

--- a/main/tests/UnitTests/MonoDevelop.Projects/GetSourceFilesAsyncTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/GetSourceFilesAsyncTests.cs
@@ -72,6 +72,7 @@ namespace MonoDevelop.Projects
 				Assert.IsNotNull (sourceFile, msg);
 			}
 			Assert.IsTrue (sourceFiles.Any (f => f.FilePath.FileName == "Foo.cs"));
+			project.Dispose ();
 		}
 
 		[Test()]
@@ -91,6 +92,7 @@ namespace MonoDevelop.Projects
 				var sourceFile = sourceFiles.FirstOrDefault (sf => sf.FilePath == file.FilePath);
 				Assert.IsNotNull (sourceFile, msg + ": " + file.FilePath.FileName + " not found");
 			}
+			project.Dispose ();
 		}
 
 		[Test()]
@@ -119,6 +121,7 @@ namespace MonoDevelop.Projects
 			});
 			          
 			Assert.IsTrue (fileChangeNotification.Task.IsCompleted, "Performing the generator should have fired a file change event");
+			project.Dispose ();
 		}
 
 		[Test()]
@@ -138,6 +141,7 @@ namespace MonoDevelop.Projects
 				var sourceFile = sourceFiles.FirstOrDefault (sf => sf.FilePath == file.FilePath);
 				Assert.IsNotNull (sourceFile, msg);
 			}
+			project.Dispose ();
 		}
 
 		void FileService_FileChanged (object sender, FileEventArgs e)
@@ -162,6 +166,7 @@ namespace MonoDevelop.Projects
 			sourceFiles = await project.GetSourceFilesAsync (project.Configurations ["Release|x86"].Selector);
 
 			Assert.IsFalse (sourceFiles.Any (f => f.FilePath.FileName == "Conditioned.cs"));
+			project.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/ItemMetadataTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/ItemMetadataTests.cs
@@ -70,6 +70,7 @@ namespace MonoDevelop.Projects
 				return LoadElement (p.FileName, it.Include);
 			} finally {
 				System.IO.File.Delete (p.FileName);
+				p.Dispose ();
 			}
 		}
 
@@ -194,6 +195,7 @@ namespace MonoDevelop.Projects
 				prop = item.Metadata.GetProperty ("Test");
 				Assert.AreEqual (testFile.ToString (), prop.GetPathValue ().ToString ());
 				Assert.AreEqual ("$(MSBuildProjectDirectory)\\Test.txt", prop.UnevaluatedValue);
+				p.Dispose ();
 
 			} finally {
 				if (File.Exists (p.FileName))

--- a/main/tests/UnitTests/MonoDevelop.Projects/LocalCopyTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/LocalCopyTests.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // LocalCopyTests.cs
 // 
 // Author:
@@ -148,6 +148,8 @@ namespace MonoDevelop.Projects
 			AssertOutputFiles (sol, "ClassLibrary5", "Release", new string[] {
 				"ClassLibrary5.dll"
 			});
+
+			item.Dispose ();
 		}
 				
 		static void AssertOutputFiles (Solution solution, string projectName, string configuration, string[] expectedFiles)
@@ -254,6 +256,8 @@ namespace MonoDevelop.Projects
 			string projectXml1 = Util.GetXmlFileInfoset (p.FileName.ParentDirectory.Combine ("ConsoleProject.csproj.saved"));
 			string projectXml2 = Util.GetXmlFileInfoset (p.FileName);
 			Assert.AreEqual (projectXml1, projectXml2);
+
+			item.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -63,6 +63,8 @@ namespace MonoDevelop.Projects
 			p.AddFile (f.FilePath);
 			await p.SaveAsync (Util.GetMonitor ());
 			Assert.AreEqual (File.ReadAllText (p.FileName), File.ReadAllText (p.FileName.ChangeName ("glob-test-saved2")));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -88,6 +90,8 @@ namespace MonoDevelop.Projects
 			p.AddFile (f.FilePath);
 			await p.SaveAsync (Util.GetMonitor ());
 			Assert.AreEqual (File.ReadAllText (p.FileName), File.ReadAllText (p.FileName.ChangeName ("glob-test-saved2")));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -112,6 +116,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName.ChangeName ("glob-test-saved2")));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -137,6 +143,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName.ChangeName ("glob-test-saved4")));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -160,6 +168,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName.ChangeName ("glob-test-saved3")));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -223,6 +233,8 @@ namespace MonoDevelop.Projects
 
 			await p.SaveAsync (Util.GetMonitor ());
 			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -244,6 +256,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-test-saved5")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -266,6 +280,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update1-test-saved")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -288,6 +304,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update2-test-saved")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -309,6 +327,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update1-test-saved2")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -329,6 +349,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update2-test-saved2")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -360,6 +382,8 @@ namespace MonoDevelop.Projects
 
 			projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (originalProjFile), projectXml);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -395,6 +419,8 @@ namespace MonoDevelop.Projects
 
 				projectXml = File.ReadAllText (p.FileName);
 				Assert.AreEqual (File.ReadAllText (originalProjFile), projectXml);
+
+				p.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -434,6 +460,8 @@ namespace MonoDevelop.Projects
 
 			projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (originalProjFile), projectXml);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -462,6 +490,7 @@ namespace MonoDevelop.Projects
 
 				string projectXml = File.ReadAllText (p.FileName);
 				Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-import-update1-test")), projectXml);
+				p.Dispose ();
 
 				// Reload the project.
 				p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
@@ -474,6 +503,8 @@ namespace MonoDevelop.Projects
 
 				projectXml = File.ReadAllText (p.FileName);
 				Assert.AreEqual (File.ReadAllText (originalProjFile), projectXml);
+
+				p.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -502,6 +533,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update3-test-saved")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -528,6 +561,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update3-test-saved2")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -550,6 +585,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update4-test-saved")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -574,6 +611,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (File.ReadAllText (p.FileName.ChangeName ("glob-update3-test-saved3")), projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildLoggerTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildLoggerTests.cs
@@ -61,6 +61,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (1, started);
 			Assert.AreEqual (1, finished);
 			Assert.IsTrue (targetStarted > 0);
+
+			item.Dispose ();
 		}
 
 		[Test]
@@ -79,6 +81,8 @@ namespace MonoDevelop.Projects
 			myLogger.EventRaised += (sender, e) => events++;
 			await item.Build (Util.GetMonitor (), "Debug", ctx);
 			Assert.AreEqual (0, events);
+
+			item.Dispose ();
 		}
 
 		[Test]
@@ -117,6 +121,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (taskStarted, taskFinished);
 			Assert.AreEqual (targetStarted, targetFinished);
 			Assert.AreNotEqual (string.Empty, mon.GetLogText ());
+
+			item.Dispose ();
 		}
 
 		[Test]
@@ -130,6 +136,8 @@ namespace MonoDevelop.Projects
 			var mon = new StringMonitor ();
 			await item.Build (mon, "Debug", ctx);
 			Assert.AreEqual (string.Empty, mon.GetLogText ());
+
+			item.Dispose ();
 		}
 	}
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // MSBuildProject.cs
 //
 // Author:
@@ -66,6 +66,8 @@ namespace MonoDevelop.Projects
 			var pg = p.GetGlobalPropertyGroup ();
 			Assert.AreEqual ("8.0.50727", pg.GetValue ("ProductVersion"));
 			Assert.AreEqual ("$(TestProp)", pg.GetValue ("EvalProp"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -85,6 +87,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("ExtraVal", pg.GetValue ("EvalExtraProp"));
 			Assert.AreEqual ("value2", pg.GetValue ("Case2"));
 			Assert.AreEqual ("value2", pg.GetValue ("Case3"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -144,6 +148,8 @@ namespace MonoDevelop.Projects
 			it = ar [6];
 			Assert.AreEqual ("Transformed", it.Name);
 			Assert.AreEqual ("@(None -> WithMetadataValue('Meta2', 'Debug'))", it.Include);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -252,6 +258,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("Debug", it.Metadata.GetValue ("Meta3"));
 			Assert.IsNotNull (it.SourceItem);
 			Assert.AreSame (it.SourceItem, p.ItemGroups.ToArray () [1].Items.ToArray () [6]);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -267,6 +275,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (tn.Contains ("ResolveReferences"));
 			Assert.IsTrue (tn.Contains ("GetReferenceAssemblyPaths"));
 			Assert.IsFalse (tn.Contains ("Conditioned"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -282,6 +292,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (tn.Contains ("ResolveReferences"));
 			Assert.IsTrue (tn.Contains ("GetReferenceAssemblyPaths"));
 			Assert.IsTrue (tn.Contains ("Conditioned"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -291,6 +303,8 @@ namespace MonoDevelop.Projects
 			p.Evaluate ();
 			var res = p.EvaluatedProperties.GetValue ("ExistsTest");
 			Assert.AreEqual ("OK", res);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -302,6 +316,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("one", p.EvaluatedProperties.GetValue ("PropFromTest1"));
 			Assert.AreEqual ("two", p.EvaluatedProperties.GetValue ("PropFromTest2"));
 			Assert.AreEqual ("three", p.EvaluatedProperties.GetValue ("PropFromFoo"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -319,6 +335,8 @@ namespace MonoDevelop.Projects
 			pi.SetGlobalProperty ("Configuration", "Alt");
 			pi.Evaluate ();
 			Assert.AreEqual ("Three", pi.EvaluatedProperties.GetValue ("Foo"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -326,6 +344,7 @@ namespace MonoDevelop.Projects
 		{
 			var p = LoadAndEvaluate ("msbuild-tests", "condition-parse.csproj");
 			Assert.AreEqual (new [] {"aa","vv","test"}, p.EvaluatedItems.Select (i => i.Include).ToArray ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -333,6 +352,7 @@ namespace MonoDevelop.Projects
 		{
 			var p = LoadAndEvaluate ("msbuild-tests", "property-eval-order.csproj");
 			Assert.AreEqual (new [] {"Two"}, p.EvaluatedItems.Select (i => i.Include).ToArray ());
+			p.Dispose ();
 		}
 
 		[Test]
@@ -370,6 +390,8 @@ namespace MonoDevelop.Projects
 
 			var dir = System.IO.Path.GetFullPath (System.IO.Path.Combine (System.IO.Path.GetDirectoryName (p.FileName), "foo"));
 			Assert.AreEqual (dir, p.EvaluatedProperties.GetValue ("FullPath"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -418,6 +440,8 @@ namespace MonoDevelop.Projects
 				new ValueSet (new [] { "cond1", "cond2" }, new [] { "val14_4", "val14_3" }),
 				new ValueSet (new [] { "cond1", "cond2" }, new [] { "val14_5", "val14_6" }),
 			}, Is.EquivalentTo (p.ConditionedProperties.GetCombinedPropertyValues ("cond1", "cond2").ToArray ()));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -429,6 +453,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (p.TextFormat.NewLine, p.StartWhitespace);
 			Assert.AreEqual ("  ", import.StartWhitespace);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -445,6 +471,7 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (p.TextFormat.NewLine, p.StartWhitespace);
 			Assert.AreEqual ("  ", import.StartWhitespace);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -454,6 +481,7 @@ namespace MonoDevelop.Projects
 			var p = LoadAndEvaluate ("msbuild-tests", "condition-parse.csproj");
 			Assert.AreEqual ("Foo", p.EvaluatedProperties.GetValue ("Test1"));
 			Assert.AreEqual ("Bar", p.EvaluatedProperties.GetValue ("Test2"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -461,6 +489,7 @@ namespace MonoDevelop.Projects
 		{
 			var p = LoadAndEvaluate ("msbuild-project-test", "test-user.csproj");
 			Assert.AreEqual ("Bar", p.EvaluatedProperties.GetValue ("TestProp"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -482,6 +511,7 @@ namespace MonoDevelop.Projects
 			// Includes can contain several transforms
 			Assert.AreEqual ("a.txt;b.txt;t1.txt;TT;AA;BB;CC", p.EvaluatedProperties.GetValue ("MultiValue"));
 			Assert.AreEqual ("a;b;t1;TT;AA;BB;CC", p.EvaluatedProperties.GetValue ("MultiValue2"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -505,6 +535,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("@", p.EvaluatedProperties.GetValue ("Func2"));
 
 			Assert.AreEqual ("t0 - []", p.EvaluatedProperties.GetValue ("FadaResPrev"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -555,6 +586,7 @@ namespace MonoDevelop.Projects
 
 			// get_Chars
 			Assert.AreEqual ("t;t;.", p.EvaluatedProperties.GetValue ("get_Chars"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -578,6 +610,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("KnownAttributeValue", itemElement.GetAttribute ("Known"));
 			Assert.AreEqual (0, itemElement.ChildNodes.Count);
 			Assert.IsTrue (itemElement.IsEmpty);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -608,6 +641,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("AnotherValue", itemElement.GetAttribute ("Another"));
 			Assert.AreEqual (0, itemElement.ChildNodes.Count);
 			Assert.IsTrue (itemElement.IsEmpty);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -623,6 +657,7 @@ namespace MonoDevelop.Projects
 
 			items = p.EvaluatedItems.Where (it => it.Name == "Test3").Select (it => it.Include).ToArray ();
 			Assert.AreEqual (new [] { "file2.txt" }, items);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -636,6 +671,7 @@ namespace MonoDevelop.Projects
 			doc.LoadXml (xml);
 
 			Assert.IsFalse (doc.DocumentElement.HasAttribute ("xmlns"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -650,6 +686,7 @@ namespace MonoDevelop.Projects
 
 			var xmlnsAttributeValue = doc.DocumentElement.GetAttribute ("xmlns");
 			Assert.AreEqual ("http://schemas.microsoft.com/developer/msbuild/2003", xmlnsAttributeValue);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -663,6 +700,7 @@ namespace MonoDevelop.Projects
 			doc.LoadXml (xml);
 
 			Assert.IsFalse (doc.DocumentElement.HasAttribute ("xmlns"));
+			p.Dispose ();
 		}
 
 		[Test]
@@ -677,6 +715,7 @@ namespace MonoDevelop.Projects
 
 			var xmlnsAttributeValue = doc.DocumentElement.GetAttribute ("xmlns");
 			Assert.AreEqual ("http://schemas.microsoft.com/developer/msbuild/2003", xmlnsAttributeValue);
+			p.Dispose ();
 		}
 
 		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
@@ -700,6 +739,7 @@ namespace MonoDevelop.Projects
 			var propertyGroup = (XmlElement)doc.DocumentElement.ChildNodes[0];
 			Assert.IsFalse (propertyGroup.HasAttribute ("xmlns"));
 			Assert.AreEqual ("PropertyGroup", propertyGroup.Name);
+			p.Dispose ();
 		}
 
 		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
@@ -738,6 +778,7 @@ namespace MonoDevelop.Projects
 			commandsElement = (XmlElement)commandsElement.ChildNodes[0];
 			Assert.IsFalse (commandsElement.HasAttribute ("xmlns"));
 			Assert.AreEqual ("CustomCommands", commandsElement.Name);
+			p.Dispose ();
 		}
 
 		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
@@ -772,6 +813,7 @@ namespace MonoDevelop.Projects
 			var externalElement = (XmlElement)propertiesElement.ChildNodes[0];
 			Assert.IsFalse (externalElement.HasAttribute ("xmlns"));
 			Assert.AreEqual ("External", externalElement.Name);
+			p.Dispose ();
 		}
 
 		public class TestExternalPropertiesConfig : ItemConfiguration
@@ -815,6 +857,7 @@ namespace MonoDevelop.Projects
 
 			externalElement = p.GetMonoDevelopProjectExtension ("External");
 			Assert.IsNull (externalElement);
+			p.Dispose ();
 		}
 
 		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
@@ -848,6 +891,7 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual ("External", externalElement.Name);
 			Assert.AreEqual (1, monoDevelopElement.ChildNodes.Count);
+			p.Dispose ();
 		}
 
 		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"",
@@ -893,6 +937,7 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (expectedHasXmlAttribute, extensionDataElement.HasAttribute ("xmlns"));
 			Assert.AreEqual ("ExtensionData", extensionDataElement.Name);
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -933,6 +978,7 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (test1Element.HasAttribute ("xmlns"));
 			Assert.IsFalse (test2Element.HasAttribute ("xmlns"));
 			Assert.IsFalse (test3Element.HasAttribute ("xmlns"));
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -977,6 +1023,7 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (test1Element.HasAttribute ("xmlns"));
 			Assert.IsFalse (test2Element.HasAttribute ("xmlns"));
 			Assert.IsFalse (test3Element.HasAttribute ("xmlns"));
+			p.Dispose ();
 		}
 
 		[TestCase ("Sdk=\"Microsoft.NET.Sdk\" ToolsVersion=\"15.0\"")]
@@ -1021,6 +1068,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("!Exists('Original.targets')", import2.GetAttribute ("Condition"));
 			Assert.IsFalse (import1.HasAttribute ("xmlns"));
 			Assert.IsFalse (import2.HasAttribute ("xmlns"));
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1061,6 +1109,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1101,6 +1150,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1144,6 +1194,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1187,6 +1238,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1233,6 +1285,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1274,6 +1327,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1314,6 +1368,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1355,6 +1410,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1398,6 +1454,7 @@ namespace MonoDevelop.Projects
 				"  </ItemGroup>\r\n" +
 				"</Project>";
 			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildSearchPathTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildSearchPathTests.cs
@@ -54,6 +54,7 @@ namespace MonoDevelop.Projects
 				string projectFile = Util.GetSampleProject ("msbuild-search-paths", "ConsoleProject.csproj");
 				DotNetProject p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile) as DotNetProject;
 				Assert.AreEqual ("Works!", p.MSBuildProject.EvaluatedProperties.GetValue ("TestTarget"));
+				p.Dispose ();
 			} finally {
 				UnregisterSearchPath ();
 			}
@@ -71,6 +72,7 @@ namespace MonoDevelop.Projects
 				var res = await project.RunTarget (Util.GetMonitor (false), "TestInjected", project.Configurations [0].Selector);
 				Assert.AreEqual (1, res.BuildResult.WarningCount);
 				Assert.AreEqual ("Works!", res.BuildResult.Errors [0].ErrorText);
+				sol.Dispose ();
 			} finally {
 				UnregisterSearchPath ();
 			}
@@ -99,6 +101,7 @@ namespace MonoDevelop.Projects
 			res = await project.RunTarget (Util.GetMonitor (false), "TestInjected", project.Configurations [0].Selector);
 			Assert.AreEqual (0, res.BuildResult.WarningCount);
 			Assert.AreEqual (1, res.BuildResult.ErrorCount);
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -115,6 +118,7 @@ namespace MonoDevelop.Projects
 				var res = await p.RunTarget (Util.GetMonitor (false), "SdkTarget", p.Configurations [0].Selector);
 				Assert.AreEqual (1, res.BuildResult.WarningCount);
 				Assert.AreEqual ("Works!", res.BuildResult.Errors [0].ErrorText);
+				p.Dispose ();
 			} finally {
 				MonoDevelop.Projects.MSBuild.MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdkPath);
 			}
@@ -155,6 +159,9 @@ namespace MonoDevelop.Projects
 				Assert.AreEqual (1, res.BuildResult.WarningCount);
 				Assert.AreEqual ("Works!", res.BuildResult.Errors [0].ErrorText);
 
+				p1.Dispose ();
+				p2.Dispose ();
+
 			} finally {
 				MonoDevelop.Projects.MSBuild.MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdkPath1);
 				MonoDevelop.Projects.MSBuild.MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdkPath2);
@@ -187,6 +194,7 @@ namespace MonoDevelop.Projects
 				Assert.AreEqual (1, res.BuildResult.WarningCount);
 				Assert.AreEqual ("Works!", res.BuildResult.Errors [0].ErrorText);
 				Assert.AreEqual ("Works!", p.MSBuildProject.EvaluatedProperties.GetValue ("BarProp"));
+				p.Dispose ();
 
 			} finally {
 				MonoDevelop.Projects.MSBuild.MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdkPath1);

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1,4 +1,4 @@
-// MSBuildTests.cs
+﻿// MSBuildTests.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -77,6 +77,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (solXml, File.ReadAllText (solFile));
 			Assert.AreEqual (projectXml, File.ReadAllText (projectFile));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -88,6 +90,8 @@ namespace MonoDevelop.Projects
 			// Ensure the project is buildable
 			var result = await sol.Build (Util.GetMonitor (), "Debug");
 			Assert.AreEqual (0, result.ErrorCount, "#1");
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -100,6 +104,8 @@ namespace MonoDevelop.Projects
 			ProjectOptionsDialog.RenameItem (sol.GetAllProjects ().First (), "Test");
 			var result = await sol.Build (Util.GetMonitor (), "Release");
 			Assert.AreEqual (0, result.ErrorCount, "#2");
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -125,6 +131,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (Util.ToWindowsEndings (File.ReadAllText (solFile)), solXml);
 			Assert.AreEqual (Util.ToWindowsEndings (File.ReadAllText (projectFile)), projectXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -146,6 +154,8 @@ namespace MonoDevelop.Projects
 			string projectFile = Util.GetSampleProjectPath ("generated-console-project", "TestProject2.csproj");
 
 			Assert.AreEqual (Util.ToWindowsEndings (File.ReadAllText (projectFile)), projectXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -218,6 +228,8 @@ namespace MonoDevelop.Projects
 
 			string savedFile = Path.Combine (p.BaseDirectory, "TestConfigurationMergingSaved.csproj");
 			Assert.AreEqual (File.ReadAllText (savedFile), File.ReadAllText (p.FileName));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -240,6 +252,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (originalContent, File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -260,6 +274,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -286,6 +302,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -307,6 +325,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -329,6 +349,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -351,6 +373,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -364,6 +388,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (refXml, File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -377,6 +403,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (refXml, File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -392,6 +420,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (1, p.References.Count);
 			Assert.AreEqual ("some - library", p.References [0].Reference);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -412,6 +442,8 @@ namespace MonoDevelop.Projects
 			conf = ((DotNetProjectConfiguration)p.Configurations [0]);
 
 			Assert.AreEqual (value, conf.OutputAssembly);
+
+			sol.Dispose ();
 		}
 
 
@@ -428,6 +460,8 @@ namespace MonoDevelop.Projects
 			p.Configurations.Insert (0, configuration);
 			await p.SaveAsync (Util.GetMonitor ());
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -445,6 +479,8 @@ namespace MonoDevelop.Projects
 			string projectXml2 = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (projectXml1, projectXml2);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -460,6 +496,8 @@ namespace MonoDevelop.Projects
 			string projectXml2 = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (projectXml1, projectXml2);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -481,6 +519,8 @@ namespace MonoDevelop.Projects
 			var testRef = Path.Combine (dir, "MonoDevelop.Core.dll");
 			var asms = (await p.GetReferencedAssemblies (sol.Configurations [0].Selector)).Select (ar => ar.FilePath).ToArray ();
 			Assert.IsTrue (asms.Contains (testRef));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -492,6 +532,8 @@ namespace MonoDevelop.Projects
 			var p = (DotNetProject)sol.GetAllProjects ().First ();
 
 			Assert.AreEqual ("yes", p.ProjectProperties.GetValue ("Imported"));
+
+			sol.Dispose ();
 		}
 
 		//[Ignore ("xbuild bug. It is not returning correct values for evaluated-items-without-condition list")]
@@ -505,6 +547,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("Program9_yes.cs", p.Files [8].FilePath.FileName, "Non-evaluable property group clears properties");
 			Assert.AreEqual ("Program10_$(AAA", p.Files [9].FilePath.FileName, "Invalid property reference");
 			Assert.AreEqual ("Program11_EnvTest.cs", p.Files [10].FilePath.FileName, "Environment variable");
+
+			sol.Dispose ();
 		}
 
 		async Task LoadBuildVSConsoleProject (string vsVersion, string toolsVersion)
@@ -539,6 +583,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (monitor.Warnings.Length == 0);
 
 			Assert.AreEqual (projectXml, Util.ReadAllWithWindowsEndings (projectFile));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -572,6 +618,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml2 = File.ReadAllText (proj);
 			Assert.AreEqual (projectXml1, projectXml2);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -590,6 +638,8 @@ namespace MonoDevelop.Projects
 
 			Assert.IsNotNull (import);
 			Assert.IsFalse (import.HasAttribute ("Condition"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -608,6 +658,8 @@ namespace MonoDevelop.Projects
 			XmlElement import = (XmlElement)doc.SelectSingleNode (@"//ms:Import[@Project='packages\Xamarin.Forms\build\Xamarin.Forms.targets']", manager);
 
 			Assert.AreEqual (condition, import.GetAttribute ("Condition"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -623,6 +675,8 @@ namespace MonoDevelop.Projects
 
 			string projectXml2 = File.ReadAllText (proj);
 			Assert.AreEqual (projectXml1, projectXml2);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -647,6 +701,8 @@ namespace MonoDevelop.Projects
 				string projectXml1 = File.ReadAllText (referenceFile);
 				string projectXml2 = File.ReadAllText (mp.FileName);
 				Assert.AreEqual (Util.ToWindowsEndings (projectXml1), projectXml2);
+
+				p.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 			}
@@ -667,6 +723,8 @@ namespace MonoDevelop.Projects
 				Assert.NotNull (mp.Data);
 				Assert.AreEqual (mp.Data.Foo, "bar");
 				Assert.AreEqual (mp.SimpleData, "Test");
+
+				p.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 			}
@@ -695,6 +753,8 @@ namespace MonoDevelop.Projects
 
 				string projectXml2 = File.ReadAllText (projFile);
 				Assert.AreEqual (projectXml1, projectXml2);
+
+				p.Dispose ();
 
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
@@ -728,6 +788,8 @@ namespace MonoDevelop.Projects
 				string projectXml2 = File.ReadAllText (projFile);
 				Assert.AreEqual (projectXml1, projectXml2);
 
+				p.Dispose ();
+
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 			}
@@ -759,6 +821,7 @@ namespace MonoDevelop.Projects
 
 				string projectXml2 = File.ReadAllText (projFile);
 				Assert.AreEqual (projectXml1, projectXml2);
+				p.Dispose ();
 
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
@@ -783,6 +846,7 @@ namespace MonoDevelop.Projects
 				Assert.NotNull (f.Data);
 				Assert.AreEqual (f.Data.Foo, "bar");
 				Assert.AreEqual (f.SimpleData, "Test");
+				p.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 				WorkspaceObject.UnregisterCustomExtension (fn);
@@ -809,6 +873,7 @@ namespace MonoDevelop.Projects
 				Assert.NotNull (f.Data);
 				Assert.AreEqual (f.Data.Foo, "bar");
 				Assert.AreEqual (f.SimpleData, "Test");
+				p.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 				WorkspaceObject.UnregisterCustomExtension (fn);
@@ -841,6 +906,8 @@ namespace MonoDevelop.Projects
 
 				string projectXml2 = File.ReadAllText (projFile);
 				Assert.AreEqual (projectXml1, projectXml2);
+
+				p.Dispose ();
 
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
@@ -878,6 +945,8 @@ namespace MonoDevelop.Projects
 				string projectXml2 = File.ReadAllText (projFile);
 				Assert.AreEqual (projectXml1, projectXml2);
 
+				p.Dispose ();
+
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 				WorkspaceObject.UnregisterCustomExtension (fn);
@@ -914,6 +983,8 @@ namespace MonoDevelop.Projects
 				string projectXml2 = File.ReadAllText (projFile);
 				Assert.AreEqual (projectXml1, projectXml2);
 
+				p.Dispose ();
+
 			} finally {
 				MSBuildProjectService.UnregisterCustomItemType (tn);
 				WorkspaceObject.UnregisterCustomExtension (fn);
@@ -943,6 +1014,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (actions.Contains ("Content"), "'Content' not found");
 			Assert.IsTrue (actions.Contains ("ItemOne"), "'ItemOne' not found");
 			Assert.IsTrue (actions.Contains ("ItemTwo"), "'ItemTwo' not found");
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -966,6 +1039,8 @@ namespace MonoDevelop.Projects
 				"text3-1.txt",
 				"text3-2.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -984,6 +1059,8 @@ namespace MonoDevelop.Projects
 				"p5.txt",
 				"text3-1.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1011,6 +1088,8 @@ namespace MonoDevelop.Projects
 				"p5.txt",
 				"text3-1.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1029,6 +1108,8 @@ namespace MonoDevelop.Projects
 				"p5.txt",
 				"text3-1.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1047,6 +1128,8 @@ namespace MonoDevelop.Projects
 				"p5.txt",
 				"text3-1.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1072,6 +1155,8 @@ namespace MonoDevelop.Projects
 				Assert.AreEqual (new string [] {
 					"Program.cs"
 				}, files);
+
+				sol.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdksPath);
 			}
@@ -1102,6 +1187,7 @@ namespace MonoDevelop.Projects
 				var itemGroup = mp.MSBuildProject.ItemGroups.LastOrDefault ();
 				Assert.IsTrue (itemGroup.Items.Any (item => item.Include == "NewFile.cs"));
 				Assert.AreEqual (2, itemGroup.Items.Count ());
+				sol.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdksPath);
 			}
@@ -1120,6 +1206,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved1")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1140,6 +1228,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved2")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1163,6 +1253,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved3"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1183,6 +1275,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved4"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1207,6 +1301,8 @@ namespace MonoDevelop.Projects
 				await p.SaveAsync (Util.GetMonitor ());
 
 				Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved1"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+				p.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -1234,6 +1330,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved4"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1255,6 +1353,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved3"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1286,6 +1386,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved5"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1308,6 +1410,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (originalProjectFileText), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1334,6 +1438,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (originalProjectFileText), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1361,6 +1467,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved6"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1379,6 +1487,8 @@ namespace MonoDevelop.Projects
 			f.CopyToOutputDirectory = FileCopyMode.PreserveNewest;
 			await p.SaveAsync (Util.GetMonitor ());
 
+			p.Dispose ();
+
 			p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
 			mp = (Project)p;
 			mp.UseAdvancedGlobSupport = true;
@@ -1392,6 +1502,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ReadAllWithWindowsEndings (p.FileName + ".saved6"), Util.ReadAllWithWindowsEndings (p.FileName));
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1421,6 +1533,8 @@ namespace MonoDevelop.Projects
 				await p.SaveAsync (Util.GetMonitor ());
 
 				Assert.AreEqual (Util.ToSystemEndings (originalProjectFileText), File.ReadAllText (p.FileName));
+
+				p.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -1445,6 +1559,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual ("Xamagon_1.png", f1.Link.ToString ());
 			Assert.AreEqual (Path.Combine ("Subdir", "Xamagon_2.png"), f2.Link.ToString ());
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -1469,6 +1585,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (Path.Combine ("Data", "t1.txt"), f1.Link.ToString ());
 			Assert.AreEqual (Path.Combine ("Data", "t2.txt"), f2.Link.ToString ());
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -1493,6 +1611,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual ("t1.dat", f1.Link.ToString ());
 			Assert.AreEqual ("t2.dat", f2.Link.ToString ());
+
+			sol.Dispose ();
 		}
 
 		/// <summary>
@@ -1518,6 +1638,8 @@ namespace MonoDevelop.Projects
 				"text2-1.txt",
 				"text2-2.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1551,6 +1673,8 @@ namespace MonoDevelop.Projects
 				"text2-1.txt",
 				"text2-2.txt",
 			}, filesToCopyToOutputDirectory);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1575,6 +1699,8 @@ namespace MonoDevelop.Projects
 				"text2-1.txt",
 				"text2-2.txt",
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1614,6 +1740,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (2, mp.MSBuildProject.ItemGroups.Count ());
 			Assert.IsFalse (itemGroup.Items.Any (item => item.Include == @"Content\newfile.txt"));
 			Assert.AreEqual (3, itemGroup.Items.Count ());
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1636,6 +1764,8 @@ namespace MonoDevelop.Projects
 				@"Content\Data3.cs",
 				"Program.cs"
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1661,6 +1791,8 @@ namespace MonoDevelop.Projects
 			var itemGroup = mp.MSBuildProject.ItemGroups.FirstOrDefault ();
 			Assert.AreEqual (1, mp.MSBuildProject.ItemGroups.Count ());
 			Assert.IsFalse (itemGroup.Items.Any (item => item.Name != "Reference"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1695,6 +1827,8 @@ namespace MonoDevelop.Projects
 
 				var savedProjFileText = File.ReadAllText (projFile);
 				Assert.AreEqual (originalProjectFileText, savedProjFileText);
+
+				p.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -1714,6 +1848,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (Util.ToSystemEndings (File.ReadAllText (p.FileName + ".saved7")), File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1736,6 +1872,8 @@ namespace MonoDevelop.Projects
 				@"Content\text1-1.txt",
 				@"Content\text1-2.txt"
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1756,6 +1894,8 @@ namespace MonoDevelop.Projects
 				@"Content\Data3.cs",
 				"Program.cs"
 			}, files);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1782,6 +1922,8 @@ namespace MonoDevelop.Projects
 			var copyToOutputDirectory = mp.MSBuildProject.EvaluatedItems.Where (item => item.Name == "None")
 				.Select (item => item.Metadata.GetValue ("CopyToOutputDirectory")).ToArray ();
 			Assert.IsTrue (copyToOutputDirectory.All (propertyValue => propertyValue == "PreserveNewest"));
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -1821,6 +1963,8 @@ namespace MonoDevelop.Projects
 				"text3-1.txt",
 				"text3-2.txt"
 			}, nonUpdatedTextFiles);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1858,6 +2002,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (refXml1, savedXml1);
 			Assert.AreEqual (refXml2, savedXml2);
 			Assert.AreEqual (refXml3, savedXml3);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -1880,6 +2026,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (solContent, savedSol);
 			Assert.AreEqual (refXml1, savedXml1);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -1902,6 +2050,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (refSol, savedSol);
 			Assert.AreEqual (refProj, savedProj);
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -1916,6 +2066,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -1930,6 +2082,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -1969,6 +2123,8 @@ namespace MonoDevelop.Projects
 			refXml = Util.ToSystemEndings (File.ReadAllText (projFile + ".saved4"));
 			savedXml = File.ReadAllText (projFile);
 			Assert.AreEqual (refXml, savedXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -1995,6 +2151,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (refXml, savedXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2023,6 +2181,8 @@ namespace MonoDevelop.Projects
 			conf = p.Configurations.OfType<ProjectConfiguration> ().FirstOrDefault (c => c.Name == "Test");
 			Assert.AreEqual ("TestValue", conf.Properties.GetValue ("TestProperty"));
 			Assert.AreEqual (p.BaseDirectory.Combine ("Subdir", "SomeFile.txt"), conf.Properties.GetPathValue ("TestPath"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2048,6 +2208,8 @@ namespace MonoDevelop.Projects
 			var refXml = Util.ToSystemEndings (File.ReadAllText (p.FileName + ".config-renamed"));
 			var savedXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2083,6 +2245,8 @@ namespace MonoDevelop.Projects
 				Assert.IsNotNull (it);
 				Assert.AreEqual ("TestInclude", it.Include);
 				Assert.AreEqual ("FooTest", it.SomeMetadata);
+
+				sol.Dispose ();
 			} finally {
 				MSBuildProjectService.UnregisterCustomProjectItemType ("CustomItem");
 			}
@@ -2115,6 +2279,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (1, items.Length);
 			Assert.AreEqual ("bar", items [0].Include);
 			Assert.AreEqual ("Hello", items [0].Metadata.GetValue ("MyMetadata"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2133,6 +2299,8 @@ namespace MonoDevelop.Projects
 			FilePath path = null;
 			bool foundProperty = res.Properties.TryGetPathValue ("MissingProperty", out path);
 			Assert.IsFalse (foundProperty);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2154,6 +2322,8 @@ namespace MonoDevelop.Projects
 			// Check that the global property is reset
 			Assert.AreEqual (1, res.Errors.Count);
 			Assert.AreEqual ("Something failed: show", res.Errors [0].ErrorText);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -2181,6 +2351,8 @@ namespace MonoDevelop.Projects
 			// Check that the global property is reset
 			Assert.AreEqual (1, res.Errors.Count);
 			Assert.AreEqual ("Something failed (show.targets): show", res.Errors [0].ErrorText);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -2209,6 +2381,8 @@ namespace MonoDevelop.Projects
 			// Check that the global property is reset
 			Assert.AreEqual (1, res.Errors.Count);
 			Assert.AreEqual ("Something failed (true.targets): true", res.Errors [0].ErrorText);
+
+			p.Dispose ();
 		}
 
 		/// <summary>
@@ -2240,6 +2414,8 @@ namespace MonoDevelop.Projects
 				string expectedMessage = string.Format ("Something failed (test-import.targets): {0}", sdksPath);
 				Assert.AreEqual (expectedMessage, buildResult.Errors [0].ErrorText);
 
+				sol.Dispose ();
+
 			} finally {
 				MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdksPath);
 			}
@@ -2269,6 +2445,8 @@ namespace MonoDevelop.Projects
 			var buildResult = res.BuildResult;
 
 			Assert.AreEqual (0, buildResult.Errors.Count);
+
+			sol.Dispose ();
 		}
 
 		/// <summary>
@@ -2306,6 +2484,8 @@ namespace MonoDevelop.Projects
 			var buildResult = res.BuildResult;
 
 			Assert.AreEqual (0, buildResult.Errors.Count);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2328,6 +2508,8 @@ namespace MonoDevelop.Projects
 			var refXml = Util.ToWindowsEndings (File.ReadAllText (p.FileName + ".config-copied"));
 			var savedXml = Util.ToWindowsEndings (File.ReadAllText (p.FileName));
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2338,6 +2520,8 @@ namespace MonoDevelop.Projects
 			MSBuildProjectService.CheckHandlerUsesMSBuildEngine (project, out byDefault, out require);
 			Assert.IsTrue (byDefault);
 			Assert.IsFalse (require);
+
+			project.Dispose ();
 		}
 
 		[Test]
@@ -2357,6 +2541,8 @@ namespace MonoDevelop.Projects
 			mp.Evaluate ();
 			Assert.IsTrue (mp.EvaluatedItems.FirstOrDefault (i => i.Name == "Compile" && i.Include == "test.cs") != null);
 			Assert.IsTrue (mp.EvaluatedItems.FirstOrDefault (i => i.Name == "Compile" && i.Include == "Program.cs") == null);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2368,6 +2554,8 @@ namespace MonoDevelop.Projects
 			p.References.Add (pr);
 
 			Assert.AreEqual ("System", pr.Include);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2383,6 +2571,8 @@ namespace MonoDevelop.Projects
 
 			var savedXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2419,6 +2609,8 @@ namespace MonoDevelop.Projects
 
 			savedXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -2430,6 +2622,8 @@ namespace MonoDevelop.Projects
 
 			var p = (Project)sol.Items [0];
 			Assert.AreEqual (sol.ItemDirectory.ToString () + Path.DirectorySeparatorChar, p.MSBuildProject.EvaluatedProperties.GetValue ("SolutionDir"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2451,6 +2645,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 			var compXml = Util.ToSystemEndings (File.ReadAllText (p.FileName.ChangeName ("ConsoleProject-conf-renamed")));
 			Assert.AreEqual (compXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -2475,6 +2671,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 			var refXml = File.ReadAllText (p.FileName.ChangeName ("project-with-duplicated-conf-saved"));
 			Assert.AreEqual (refXml, savedXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2496,6 +2694,8 @@ namespace MonoDevelop.Projects
 
 			var savedXml = File.ReadAllText (p.FileName);
 			Assert.AreEqual (refXml, savedXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2517,6 +2717,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (p.ProjectProperties.HasProperty ("TargetName"));
 			Assert.IsTrue (p.MSBuildProject.EvaluatedProperties.HasProperty ("TargetName"));
 			Assert.IsTrue (c.Properties.HasProperty ("TargetName"));
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -2547,6 +2749,8 @@ namespace MonoDevelop.Projects
 
 				Assert.AreEqual (solXml, File.ReadAllText (solFile));
 				Assert.AreEqual (projectXml, File.ReadAllText (projectFile));
+
+				sol.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (fn);
 			}
@@ -2567,6 +2771,8 @@ namespace MonoDevelop.Projects
 			await p.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -2586,6 +2792,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("Foo", ar.Aliases);
 		
 			Assert.AreEqual (4, asms.Length);
+
+			p.Dispose ();
 		}
 	}
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/MakefileTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MakefileTests.cs
@@ -1,4 +1,4 @@
-// MakefileTests.cs
+﻿// MakefileTests.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -114,6 +114,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("System", values [0]);
 			Assert.AreEqual ("System.Data", values [1]);
 			Assert.AreEqual ("System.Web", values [2]);
+
+			sol.Dispose ();
 		}
 		
 		string GetVariable (string content, string var)

--- a/main/tests/UnitTests/MonoDevelop.Projects/MdsTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MdsTests.cs
@@ -1,4 +1,4 @@
-// MdsTests.cs
+﻿// MdsTests.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -57,6 +57,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (File.Exists (ws.FileName));
 			Assert.IsTrue (File.Exists (sol.FileName));
 			Assert.IsTrue (File.Exists (p.FileName));
+
+			ws.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/PolicyTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/PolicyTests.cs
@@ -63,6 +63,8 @@ namespace MonoDevelop.Projects
 
 				expectedSetting = !expectedSetting;
 			}
+
+			solution.Dispose ();
 		}
 
 		/// <summary>
@@ -93,6 +95,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (missingItem, s.Properties.SingleOrDefault (p => p.Key.Contains ("IndentBlock")));
 			Assert.AreEqual (missingItem, s.Properties.SingleOrDefault (p => p.Key.Contains ("SpaceBeforeDot")));
 			Assert.AreEqual (missingItem, s.Properties.SingleOrDefault (p => p.Key.Contains ("NewLineForElse")));
+
+			solution.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/ProjectCapabilityTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/ProjectCapabilityTests.cs
@@ -71,6 +71,8 @@ namespace MonoDevelop.Projects
 			var defaultCaps = await GetDefaultCapabilities ();
 
 			Assert.AreEqual (new [] { "Zero" }, item.GetProjectCapabilities ().Except (defaultCaps).ToArray ());
+
+			item.Dispose ();
 		}
 
 		[Test ()]
@@ -107,6 +109,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (new [] { "Zero" }, item.GetProjectCapabilities ().Except (defaultCaps).ToArray ());
 			ext = item.GetFlavor<CustomCapabilityExtension> ();
 			Assert.IsNull (ext);
+
+			item.Dispose ();
 		}
 	}
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/ProjectReevaluationTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/ProjectReevaluationTests.cs
@@ -74,6 +74,8 @@ namespace MonoDevelop.Projects
 			await sol.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (projectXml, File.ReadAllText (p.FileName));
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -121,6 +123,8 @@ namespace MonoDevelop.Projects
 			await sol.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (File.ReadAllText (p.FileName), File.ReadAllText (p.FileName.ChangeName ("ConsoleProject-refresh-saved")));
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -172,6 +176,8 @@ namespace MonoDevelop.Projects
 			await sol.SaveAsync (Util.GetMonitor ());
 
 			Assert.AreEqual (File.ReadAllText (p.FileName), File.ReadAllText (p.FileName.ChangeName ("ConsoleProject-refresh-item-changed-saved")));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -202,6 +208,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (p, library2Item.OwnerProject);
 			Assert.AreSame (library1Reference, library1Item);
 			Assert.AreSame (library2Reference, library2Item);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -246,6 +254,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (p, library1Item.OwnerProject);
 			Assert.AreSame (library1Reference, library1Item);
 			Assert.AreEqual (library1Reference, library1Item);
+
+			sol.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/ProjectTests.cs
@@ -1,4 +1,4 @@
-// ProjectTests.cs
+﻿// ProjectTests.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -65,6 +65,8 @@ namespace MonoDevelop.Projects
 			
 			file = project.Files.GetFile (Util.Combine (dir, "aaa", "..", "bbb", "test2.cs"));
 			Assert.AreEqual (file2, file);
+
+			project.Dispose ();
 		}
 		
 		[Test()]
@@ -88,6 +90,8 @@ namespace MonoDevelop.Projects
 
 			// msbuild doesn't delete this directory
 			// Assert.IsFalse (Directory.Exists (Path.GetDirectoryName (spath)), "Satellite assembly directory not removed");
+
+			sol.Dispose ();
 		}
 		
 		public static void CheckResourcesSolution (Solution sol)
@@ -189,6 +193,8 @@ namespace MonoDevelop.Projects
 			
 			Assert.AreEqual ("Some.Test", ((DotNetProjectConfiguration) p.Configurations [0]).OutputAssembly);
 			Assert.AreEqual ("Some.Test", ((DotNetProjectConfiguration) p.Configurations [1]).OutputAssembly);
+
+			p.Dispose ();
 		}
 		
 		[Test()]
@@ -198,6 +204,7 @@ namespace MonoDevelop.Projects
 			p.Name = "HiThere";
 			DotNetProjectConfiguration c = (DotNetProjectConfiguration) p.CreateConfiguration ("First");
 			Assert.AreEqual ("HiThere", c.OutputAssembly);
+			p.Dispose ();
 		}
 		
 		[Test()]
@@ -222,6 +229,7 @@ namespace MonoDevelop.Projects
 			
 			cmd.WorkingDir = NormalizePath ("/some/${ProjectName}/place");
 			Assert.AreEqual (Path.GetFullPath (NormalizePath ("/some/SomeProject/place")), (string)cmd.GetCommandWorkingDir (p, c.Selector));
+			p.Dispose ();
 		}
 		
 		[Test()]
@@ -284,6 +292,7 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (file5, file4.DependsOnFile);
 			Assert.AreEqual (1, file5.DependentChildren.Count);
 			Assert.IsTrue (file5.DependentChildren.Contains (file4));
+			sol.Dispose ();
 		}
 
 		public static string NormalizePath (string path)
@@ -438,6 +447,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (r.ReferenceType, ReferenceType.Assembly);
 			Assert.AreEqual (r.GetReferencedFileNames(project.DefaultConfiguration.Selector).Single (), project.BaseDirectory.Combine ("gtk-sharp.dll").FullPath.ToString ());
 			Assert.IsTrue (r.IsValid);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -478,6 +489,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (r.ReferenceType, ReferenceType.Assembly);
 			Assert.AreEqual (r.GetReferencedFileNames(project.DefaultConfiguration.Selector).Single (), project.BaseDirectory.Combine ("test.dll").FullPath.ToString ());
 			Assert.IsTrue (r.IsValid);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -508,6 +521,8 @@ namespace MonoDevelop.Projects
 
 			var pl = (DotNetProject)p;
 			Assert.AreEqual (".NETPortable", pl.GetDefaultTargetFrameworkId ().Identifier);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -517,6 +532,7 @@ namespace MonoDevelop.Projects
 			Solution sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var res = await sol.Build (Util.GetMonitor (), "Debug");
 			Assert.IsNull (res.Errors.FirstOrDefault ()?.ToString ());
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -526,6 +542,7 @@ namespace MonoDevelop.Projects
 			Solution sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var p = (DotNetProject) sol.FindProjectByName ("PortableLibrary");
 			var refs = (await p.GetReferencedAssemblies (p.Configurations [0].Selector)).Select (r => r.FilePath.FileName).ToArray ();
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -539,6 +556,7 @@ namespace MonoDevelop.Projects
 			var p = (GenericProject) Services.ProjectService.CreateProject ("GenericProject", info, projectOptions);
 			Assert.AreEqual ("Default", p.Configurations [0].Name);
 			Assert.AreEqual (MSBuildSupport.NotSupported, p.MSBuildEngineSupport);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -553,6 +571,7 @@ namespace MonoDevelop.Projects
 
 			var pl = (GenericProject)p;
 			Assert.AreEqual ("Default", pl.Configurations [0].Name);
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -569,10 +588,12 @@ namespace MonoDevelop.Projects
 
 			DotNetProject project = (DotNetProject) Services.ProjectService.CreateProject ("C#", info, projectOptions);
 			Assert.AreEqual ("abc", project.DefaultNamespace);
+			project.Dispose ();
 
 			info.ProjectName = "a.";
 			project = (DotNetProject) Services.ProjectService.CreateProject ("C#", info, projectOptions);
 			Assert.AreEqual ("a", project.DefaultNamespace);
+			project.Dispose ();
 		}
 
 		[Test]
@@ -589,6 +610,7 @@ namespace MonoDevelop.Projects
 			var refs = (await p.GetReferencedAssemblies (ConfigurationSelector.Default)).ToArray ();
 
 			Assert.IsTrue (refs.Any (r => r.FilePath.FileName == "System.Xml.Linq.dll"));
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -610,6 +632,8 @@ namespace MonoDevelop.Projects
 
 			// Check that the in-memory project data is used when the builder is loaded for the first time.
 			Assert.IsTrue (refs.Any (r => r.FilePath.FileName == "System.Xml.Linq.dll"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -619,6 +643,7 @@ namespace MonoDevelop.Projects
 			Solution sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var p = (DotNetProject) sol.Items [0];
 			Assert.AreEqual (MSBuildSupport.Supported, p.MSBuildEngineSupport);
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -637,6 +662,7 @@ namespace MonoDevelop.Projects
 				await op1;
 				await op2;
 				Assert.AreEqual (2, SerializedSaveTestExtension.SaveCount);
+				sol.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (node);
 			}
@@ -660,6 +686,8 @@ namespace MonoDevelop.Projects
 			var p2 = (DotNetProject) await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), p.FileName);
 			f = p2.GetProjectFile (f.FilePath);
 			Assert.AreEqual ("ConsoleProject.foo.SomeFile.txt", f.ResourceId);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -680,6 +708,8 @@ namespace MonoDevelop.Projects
 			var p2 = (DotNetProject) await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), p.FileName);
 			f = p2.GetProjectFile (f.FilePath);
 			Assert.AreEqual ("SomeFile.txt", f.ResourceId);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -693,6 +723,8 @@ namespace MonoDevelop.Projects
 
 			var pol = p.Policies.Get<DotNetNamingPolicy> ();
 			Assert.AreEqual (ResourceNamePolicy.FileName, pol.ResourceNamePolicy);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -715,6 +747,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -744,6 +778,8 @@ namespace MonoDevelop.Projects
 			savedXml = File.ReadAllText (p.FileName);
 
 			Assert.AreEqual (refXml, savedXml);
+
+			sol.Dispose ();
 		}
 
 		[Test()]
@@ -758,6 +794,8 @@ namespace MonoDevelop.Projects
 
 			var res = await sol.Build (Util.GetMonitor (), "Debug");
 			Assert.AreEqual (0, res.ErrorCount);
+
+			sol.Dispose ();
 		}
 
 		[Test ()]
@@ -776,6 +814,8 @@ namespace MonoDevelop.Projects
 
 			res = await p.Build (Util.GetMonitor (), (SolutionConfigurationSelector)"Debug", true);
 			Assert.AreEqual (0, res.ErrorCount);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -785,6 +825,7 @@ namespace MonoDevelop.Projects
 			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var fsharpLibrary = sol.Items.FirstOrDefault (pr => pr.Name == "fslib") as DotNetProject;
 			Assert.IsTrue (TypeSystemService.IsOutputTrackedProject (fsharpLibrary));
+			sol.Dispose ();
 		}
 
 		[Test()]
@@ -800,6 +841,8 @@ namespace MonoDevelop.Projects
 
 			var res = await p.Build (Util.GetMonitor (), (SolutionConfigurationSelector) "Debug", true);
 			Assert.AreEqual (1, res.ErrorCount);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -818,6 +861,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual ("foo", sol.UserProperties.GetValue<string> ("SolProp"));
 			Assert.AreEqual ("bar", p.UserProperties.GetValue<string> ("ProjectProp"));
+
+			sol.Dispose ();
 		}
 
 		/// <summary>
@@ -855,6 +900,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (1, p.References.Count);
 			Assert.AreEqual ("System.Xml", p.References[0].Include);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -876,6 +923,8 @@ namespace MonoDevelop.Projects
 			var savedXml = File.ReadAllText (p.FileName);
 
 			Assert.That (savedXml, Contains.Substring ("<Import Project=\"MyImport.targets\""));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -950,6 +999,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (1, modifiedRefs);
 			Assert.AreEqual (1, modifiedItems);
 			Assert.AreEqual (1, refsChanged);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -959,6 +1010,7 @@ namespace MonoDevelop.Projects
 			var p = (DotNetProject) Services.ProjectService.CreateProject ("C#");
 			p.References.Add (pref);
 			Assert.IsTrue (pref.IsValid);
+			p.Dispose ();
 		}
 
 		[Test]
@@ -995,6 +1047,8 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (res.HasErrors);
 			Assert.IsFalse (lib.FastCheckNeedsBuild (cs));
 			Assert.IsFalse (app.FastCheckNeedsBuild (cs));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -1025,6 +1079,8 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (environmentVariablesProperty.HasAttribute ("xmlns"));
 			Assert.IsFalse (environmentVariablesChildProperty.HasAttribute ("xmlns"));
 			Assert.IsFalse (variableProperty.HasAttribute ("xmlns"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -1068,6 +1124,8 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (environmentVariablesProperty.HasAttribute ("xmlns"));
 			Assert.IsFalse (environmentVariablesChildProperty.HasAttribute ("xmlns"));
 			Assert.IsFalse (variableProperty.HasAttribute ("xmlns"));
+
+			sol.Dispose ();
 		}
 	}
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/RunConfigurations.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/RunConfigurations.cs
@@ -63,6 +63,8 @@ namespace MonoDevelop.Projects
 			string projFile = Util.GetSampleProject ("run-configurations", "ConsoleProject", "ConsoleProject.new-project.csproj");
 			string newProjectXml = File.ReadAllText (projFile);
 			Assert.AreEqual (Util.ToWindowsEndings (newProjectXml), projectXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -99,6 +101,8 @@ namespace MonoDevelop.Projects
 			projectXml = File.ReadAllText (p.FileName + ".user");
 			newProjectXml = File.ReadAllText (projFile + ".user");
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -125,6 +129,8 @@ namespace MonoDevelop.Projects
 			string projectXml = File.ReadAllText (p.FileName);
 			string newProjectXml = File.ReadAllText (p.FileName.ChangeName ("ConsoleProject.configs-added"));
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -142,6 +148,8 @@ namespace MonoDevelop.Projects
 			es = p.RunConfigurations [2];
 			Assert.AreEqual (es.Name, "Test2");
 			Assert.AreEqual (es.Properties.GetValue ("SomeValue"), "Bar");
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -161,6 +169,8 @@ namespace MonoDevelop.Projects
 			string projectXml = File.ReadAllText (p.FileName);
 			string newProjectXml = File.ReadAllText (p.FileName.ChangeName ("ConsoleProject.configs-modified"));
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -178,6 +188,8 @@ namespace MonoDevelop.Projects
 			string projectXml = File.ReadAllText (p.FileName);
 			string newProjectXml = File.ReadAllText (p.FileName.ChangeName ("ConsoleProject"));
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -209,6 +221,8 @@ namespace MonoDevelop.Projects
 			projectXml = File.ReadAllText (p.FileName + ".user");
 			newProjectXml = File.ReadAllText (p.FileName.ChangeName ("ConsoleProject.configs-user-added") + ".user");
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -228,6 +242,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (es.StoreInUserFile);
 			Assert.AreEqual (es.Name, "Test2");
 			Assert.AreEqual (es.Properties.GetValue ("SomeValue"), "Bar");
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -255,6 +271,8 @@ namespace MonoDevelop.Projects
 			projectXml = File.ReadAllText (p.FileName + ".user");
 			newProjectXml = File.ReadAllText (p.FileName.ChangeName ("ConsoleProject.configs-user-switched") + ".user");
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -275,6 +293,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (newProjectXml, projectXml);
 
 			Assert.IsFalse (File.Exists (p.FileName + ".user"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -301,6 +321,8 @@ namespace MonoDevelop.Projects
 			projectXml = File.ReadAllText (p.FileName + ".user");
 			newProjectXml = File.ReadAllText (p.FileName.ChangeName ("ConsoleProject.default-modified") + ".user");
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -324,6 +346,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (newProjectXml, projectXml);
 
 			Assert.IsFalse (File.Exists (p.FileName + ".user"));
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -348,6 +372,8 @@ namespace MonoDevelop.Projects
 			newConf2.ExternalConsole = false;
 			p.RunConfigurations.Add (newConf2);
 			Assert.IsFalse (newConf2.ExternalConsole);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -379,6 +405,8 @@ namespace MonoDevelop.Projects
 			projectXml = File.ReadAllText (p.FileName + ".user");
 			newProjectXml = File.ReadAllText (projUserFile);
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -416,6 +444,8 @@ namespace MonoDevelop.Projects
 			projectXml = File.ReadAllText (p.FileName + ".user");
 			newProjectXml = File.ReadAllText (projUserFile);
 			Assert.AreEqual (newProjectXml, projectXml);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -429,6 +459,8 @@ namespace MonoDevelop.Projects
 			rc.EnvironmentVariables.Add ("abc","${TargetDir}");
 			var cmd = (DotNetExecutionCommand) p.CreateExecutionCommand (conf.Selector, conf, rc);
 			Assert.AreEqual (conf.OutputDirectory.ToString (), cmd.EnvironmentVariables["abc"]);
+
+			p.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
@@ -64,6 +64,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (pcs.Files.GetFile (sharedFile) != null);
 
 			Assert.AreEqual ("SharedNamespace", pcs.DefaultNamespace);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -75,6 +77,8 @@ namespace MonoDevelop.Projects
 			var res = await pc1.Build (Util.GetMonitor (), ConfigurationSelector.Default, true);
 			Assert.AreEqual (0, res.ErrorCount);
 			Assert.AreEqual (0, res.WarningCount);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -120,6 +124,8 @@ namespace MonoDevelop.Projects
 			pc2f = pc2.Files.GetFile (sharedFile);
 			Assert.IsTrue (pc1f == null);
 			Assert.IsTrue (pc2f == null);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -143,6 +149,8 @@ namespace MonoDevelop.Projects
 			Assert.IsNotNull (r);
 
 			Assert.IsTrue (pc3.Files.GetFile (sharedFile) != null);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -167,6 +175,8 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (pc1.Files.GetFile (sharedFile) != null);
 			Assert.IsTrue (pc2.Files.GetFile (sharedFile) != null);
 			Assert.IsTrue (pcs.Files.GetFile (sharedFile) != null);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -278,6 +288,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (refProjectXml, projectXml);
 			Assert.AreEqual (refSharedProjectXml, sharedProjectXml);
 			Assert.AreEqual (refSharedProjectItemsXml, sharedProjectItemsXml);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -298,6 +310,8 @@ namespace MonoDevelop.Projects
 			var project = Services.ProjectService.CreateDotNetProject ("C#");
 			sol.RootFolder.AddItem (project);
 			Assert.IsTrue (sol.StartupItem == project);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -315,6 +329,8 @@ namespace MonoDevelop.Projects
 			sol.RootFolder.AddItem (main);
 
 			Assert.IsNotNull (main.Files.GetFile ("Foo.cs"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -332,6 +348,8 @@ namespace MonoDevelop.Projects
 			sol.RootFolder.AddItem (shared);
 
 			Assert.IsNotNull (main.Files.GetFile ("Foo.cs"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -358,6 +376,8 @@ namespace MonoDevelop.Projects
 
 			Assert.IsNull (main.Files.GetFile ("Foo.cs"));
 			Assert.IsFalse (main.References.Contains (pref));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -421,6 +441,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (refProj, savedProj);
 			Assert.AreEqual (refItems, savedItems);
+
+			p.Dispose ();
 		}
 
 		[Test]
@@ -447,6 +469,8 @@ namespace MonoDevelop.Projects
 			sourceFiles = await pc1.GetSourceFilesAsync (ConfigurationSelector.Default);
 
 			Assert.IsTrue (sourceFiles.Any (pf => pf.Name.EndsWith ("NewClass.cs", System.StringComparison.Ordinal)), "Source files list doesn't contain NewClass.cs");
+
+			sol.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/SolutionFolderTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/SolutionFolderTests.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // ProjectFolderTests.cs
 //
 // Author:
@@ -43,6 +43,8 @@ namespace MonoDevelop.Projects
 			folder.AddItem (project);
 
 			Assert.IsNotNull (folder.GetProjectContainingFile (project.FileName), "#1");
+
+			project.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/SolutionTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/SolutionTests.cs
@@ -1,4 +1,4 @@
-// SolutionTests.cs
+﻿// SolutionTests.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -160,6 +160,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (2, countReferenceRemovedFromProject);
 			Assert.AreEqual (3, countSolutionItemAdded);
 			Assert.AreEqual (3, countSolutionItemRemoved);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -198,6 +200,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("test4", sol.Name);
 			Assert.AreEqual (Path.Combine (tmp, "test4.sln"), (string) sol.FileName);
 			Assert.AreEqual (4, nameChanges);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -253,6 +257,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("test4", prj.Name);
 			Assert.AreEqual (Path.Combine (Path.GetTempPath (), "test4.csproj"), (string) prj.FileName);
 			Assert.AreEqual (4, nameChanges);
+
+			prj.Dispose ();
 		}
 		
 		[Test()]
@@ -306,6 +312,8 @@ namespace MonoDevelop.Projects
 			await sol.SaveAsync (Util.GetMonitor ());
 			
 			Assert.IsTrue (sol3.NeedsReload);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -322,6 +330,8 @@ namespace MonoDevelop.Projects
 			await lib2.ParentFolder.ReloadItem (Util.GetMonitor (), lib2);
 			
 			Assert.AreEqual (3, p.References.Count);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -352,6 +362,8 @@ namespace MonoDevelop.Projects
 
 			p = (DotNetProject) await p.ParentFolder.ReloadItem (Util.GetMonitor (), p);
 			Assert.AreSame (sol.StartupItem, p);
+
+			sol.Dispose ();
 		}
 
 		[Test()]
@@ -380,6 +392,8 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (files.Contains (p.FileName));
 			foreach (ProjectFile pf in p.Files)
 				Assert.IsTrue (files.Contains (pf.FilePath), "Contains " + pf.FilePath);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -423,6 +437,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (0, res.ErrorCount);
 			Assert.AreEqual (0, res.WarningCount);
 			Assert.AreEqual (1, res.BuildCount);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -570,6 +586,8 @@ namespace MonoDevelop.Projects
 			
 			sol.RootFolder.Items.Add (newp);
 			Assert.AreEqual ("MSBuild05", mp.FileFormat.Id);
+
+			sol.Dispose ();
 		}
 		
 		[Test()]
@@ -610,6 +628,8 @@ namespace MonoDevelop.Projects
 			await CheckProjectBuildClean (lib3, "Release");
 			await CheckProjectBuildClean (lib4, "Debug");
 			await CheckProjectBuildClean (lib4, "Release");
+
+			sol.Dispose ();
 		}
 		
 		async Task CheckSolutionBuildClean (Solution sol, string configuration)
@@ -719,6 +739,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (Util.GetXmlFileInfoset (p.FileName + ".saved"), Util.GetXmlFileInfoset (p.FileName));
 			Assert.AreEqual (solText, File.ReadAllLines (solFile));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -747,6 +769,8 @@ namespace MonoDevelop.Projects
 			// Regular project not referencing anything else. Should build.
 			res = await app.Build (Util.GetMonitor (), ConfigurationSelector.Default, true);
 			Assert.IsTrue (res.ErrorCount == 0);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -796,6 +820,8 @@ namespace MonoDevelop.Projects
 			lib1 = sol.FindProjectByName ("library1");
 			Assert.IsNotNull (lib1);
 			Assert.IsTrue (sol.Configurations [0].BuildEnabledForItem (lib1));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -890,6 +916,8 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (1, item.UnboundEvents);
 			Assert.AreEqual (0, item.InternalItem.BoundEvents);
 			Assert.AreEqual (1, item.InternalItem.UnboundEvents);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -935,6 +963,8 @@ namespace MonoDevelop.Projects
 			Assert.AreNotEqual (lib2, lib2Reloaded);
 			Assert.IsTrue (p.ItemDependencies.Contains (lib2Reloaded));
 			Assert.AreEqual (1, p.ItemDependencies.Count);
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -957,6 +987,7 @@ namespace MonoDevelop.Projects
 				var savedFile = solFile + ".saved.sln";
 				await sol.SaveAsync (savedFile, Util.GetMonitor ());
 				Assert.AreEqual (File.ReadAllText (solFile), File.ReadAllText (savedFile));
+				sol.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (en);
 			}
@@ -978,6 +1009,7 @@ namespace MonoDevelop.Projects
 				Assert.NotNull (ext.Extra);
 				Assert.AreEqual ("three", ext.Extra.Prop3);
 				Assert.AreEqual ("four", ext.Extra.Prop4);
+				sol.Dispose ();
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (en);
 			}
@@ -1004,6 +1036,8 @@ namespace MonoDevelop.Projects
 
 				Assert.AreEqual (File.ReadAllText (refFile), File.ReadAllText (sol.FileName));
 
+				sol.Dispose ();
+
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (en);
 			}
@@ -1028,6 +1062,8 @@ namespace MonoDevelop.Projects
 				await sol.SaveAsync (Util.GetMonitor ());
 
 				Assert.AreEqual (File.ReadAllText (refFile), File.ReadAllText (sol.FileName));
+
+				sol.Dispose ();
 
 			} finally {
 				WorkspaceObject.UnregisterCustomExtension (en);

--- a/main/tests/UnitTests/MonoDevelop.Projects/StringTagTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/StringTagTests.cs
@@ -88,6 +88,8 @@ namespace MonoDevelop.Projects
 			Assert.That (tt.Contains ("TargetPath"));
 			Assert.That (tt.Contains ("TargetName"));
 			Assert.That (tt.Contains ("TargetDir"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -110,6 +112,8 @@ namespace MonoDevelop.Projects
 			Assert.That (tt.Contains ("SolutionFile"));
 			Assert.That (tt.Contains ("SolutionName"));
 			Assert.That (tt.Contains ("SolutionDir"));
+
+			sol.Dispose ();
 		}
 
 		[Test]
@@ -129,6 +133,8 @@ namespace MonoDevelop.Projects
 
 				var model = project.GetStringTagModel (ConfigurationSelector.Default);
 				Assert.AreEqual ("bar", model.GetValue ("foo"));
+
+				project.Dispose ();
 			}
 			finally {
 				StringParserService.UnregisterStringTagProvider (p);

--- a/main/tests/UnitTests/MonoDevelop.Projects/TestProjectsChecks.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/TestProjectsChecks.cs
@@ -1,4 +1,4 @@
-// TestProjectsChecks.cs
+﻿// TestProjectsChecks.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -271,6 +271,8 @@ namespace Foo {
 			
 			it = (GenericItem) sol2.Items [0];
 			Assert.AreEqual ("hi", it.SomeValue);
+
+			sol.Dispose ();
 		}
 		
 		public static async Task TestLoadSaveSolutionFolders (MSBuildFileFormat fileFormat)
@@ -360,6 +362,8 @@ namespace Foo {
 			Assert.AreEqual ("p4", f2.Items [1].Name);
 			Assert.AreEqual (idp3, f2.Items [0].ItemId, "idp4");
 			Assert.AreEqual (idp4, f2.Items [1].ItemId, "idp4");
+
+			sol.Dispose ();
 		}
 		
 		public static async Task TestCreateLoadSaveConsoleProject (MSBuildFileFormat fileFormat)
@@ -377,6 +381,8 @@ namespace Foo {
 			await sol.SaveAsync (Util.GetMonitor ());
 			sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			CheckConsoleProject (sol);
+
+			sol.Dispose ();
 		}
 		
 		public static async Task TestLoadSaveResources (MSBuildFileFormat fileFormat)
@@ -388,7 +394,9 @@ namespace Foo {
 			
 			await sol.SaveAsync (Util.GetMonitor ());
 			solFile = sol.FileName;
-			
+
+			sol.Dispose ();
+
 			sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			ProjectTests.CheckResourcesSolution (sol);
 			
@@ -397,12 +405,16 @@ namespace Foo {
 			ProjectFile pf = p.Files.GetFile (f);
 			pf.ResourceId = "SomeBitmap.bmp";
 			await sol.SaveAsync (Util.GetMonitor ());
-			
+
+			sol.Dispose ();
+
 			sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			p = (DotNetProject) sol.Items [0];
 			f = Path.Combine (p.BaseDirectory, "Bitmap1.bmp");
 			pf = p.Files.GetFile (f);
 			Assert.AreEqual ("SomeBitmap.bmp", pf.ResourceId);
+
+			sol.Dispose ();
 		}
 	}
 	

--- a/main/tests/UnitTests/MonoDevelop.Projects/WebProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/WebProjectTests.cs
@@ -48,6 +48,8 @@ namespace MonoDevelop.Projects
 			Project project = solution.GetAllProjects ().First ();
 
 			Assert.That (project.FlavorGuids, Contains.Item ("{349C5851-65DF-11DA-9384-00065B846F21}"));
+
+			solution.Dispose ();
 		}
 	}
 }

--- a/main/tests/UnitTests/MonoDevelop.Projects/WorkspaceTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/WorkspaceTests.cs
@@ -1,4 +1,4 @@
-// WorkspaceTests.cs
+﻿// WorkspaceTests.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -78,6 +78,8 @@ namespace MonoDevelop.Projects
 			cws1.Items.Remove (sol);
 			Assert.AreEqual (2, descItemsRemovedRoot);
 			Assert.AreEqual (1, itemsRemovedRoot);
+
+			ws.Dispose ();
 		}
 		
 		[Test()]
@@ -191,6 +193,8 @@ namespace MonoDevelop.Projects
 			
 			configs = ws.GetConfigurations ();
 			Assert.AreEqual (0, configs.Count);
+
+			ws.Dispose ();
 		}
 		
 		[Test()]
@@ -283,6 +287,9 @@ namespace MonoDevelop.Projects
 			
 			fi = sol2.FindProjectByName ("it2");
 			Assert.IsNull (fi);
+
+			ws.Dispose ();
+			cws.Dispose ();
 		}
 		
 		[Test]
@@ -339,6 +346,8 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (1, sol.Items.Count);
 			Assert.IsInstanceOf<Project> (sol.Items[0]);
+
+			ws.Dispose ();
 		}
 
 		[Test]
@@ -354,6 +363,8 @@ namespace MonoDevelop.Projects
 			Assert.IsFalse (ws.UserProperties.IsEmpty);
 			Assert.IsNotNull (userData);
 			Assert.AreEqual ("Release", userData.ActiveConfiguration);
+
+			ws.Dispose ();
 		}
 	}
 	


### PR DESCRIPTION
Potentially reduce the risk of running out of resources (such as thread pool
threads) due to having too many project builders active.