### PR TITLE
[gtk] Get the size from the UI thread.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -171,8 +171,8 @@ namespace MonoDevelop.Components
 
 		public static Xwt.Drawing.Image WithSize (this Xwt.Drawing.Image image, Gtk.IconSize size)
 		{
-			int w, h;
-			size.GetSize (out w, out h);
+			int w = 0, h = 0;
+			Gtk.Application.Invoke ( delegate { size.GetSize (out w, out h); });
 			return image.WithSize (w, h);
 		}
 


### PR DESCRIPTION
I'm seeing this warning in the logfiles for a bug I'm looking at:

```
** (VisualStudio:8643): WARNING **: Gtk operations should be done on the main Thread
  at System.Environment.get_StackTrace () [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System/Environment.cs:321 
  at Gtk.Application.AssertMainThread () [0x00023] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-None/gtk/Application.cs:124 
  at Gtk.Icon.SizeLookup (Gtk.IconSize size, System.Int32& width, System.Int32& height) [0x00001] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/gtk-sharp-None/gtk/generated/Icon.cs:50 
  at MonoDevelop.Components.GtkUtil.GetSize (Gtk.IconSize size, System.Int32& width, System.Int32& height) [0x00000] in /Users/builder/data/lanes/3943/1b72513a/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs:188 
  at MonoDevelop.Components.GtkUtil.WithSize (Xwt.Drawing.Image image, Gtk.IconSize size) [0x00000] in /Users/builder/data/lanes/3943/1b72513a/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs:175 
  at MonoDevelop.Ide.ImageService.GetIcon (System.String name, Gtk.IconSize size) [0x00009] in /Users/builder/data/lanes/3943/1b72513a/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs:171 
  at MonoDevelop.CSharp.PathedDocumentTextEditorExtension+<Update>c__AnonStorey1A+<Update>c__async19.MoveNext () [0x00473] in /Users/builder/data/lanes/3943/1b72513a/source/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs:777 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine] (TStateMachine& stateMachine) [0x00031] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:316 
  at MonoDevelop.CSharp.PathedDocumentTextEditorExtension+<Update>c__AnonStorey1A.<>m__0 () [0x00008] in /Users/builder/data/lanes/3943/1b72513a/source/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs:738 
  at System.Threading.Tasks.Task`1[TResult].InnerInvoke () [0x00012] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/Tasks/Future.cs:680 
  at System.Threading.Tasks.Task.Execute () [0x00016] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2502 
  at System.Threading.Tasks.Task.ExecutionContextCallback (System.Object obj) [0x00007] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2865 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x0008d] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:957 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:904 
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task& currentTaskSlot) [0x0005f] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2827 
  at System.Threading.Tasks.Task.ExecuteEntry (System.Boolean bPreventDoubleExecution) [0x0006f] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2760 
  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2707 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00096] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:854 
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1209 
```

I think this should fix it. @Therzok ?