### PR TITLE
[F#] Faster project reference parsing

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -357,7 +357,7 @@ type LanguageService(dirtyNotify, _extraProjectInfo) as x =
                                      | Some outFile, Some opts  -> (outFile, opts) :: acc
                                      | _ -> acc) ([])
                                     
-                (Some (referencedProject.GetOutputFileName(config).ToString()), Some ({ projOptions with ReferencedProjects = referencedProjectOptions |> Array.ofList } ))
+                (Some (referencedProject.GetOutputFileName(config).ChangeExtension(".ref").ToString()), Some ({ projOptions with ReferencedProjects = referencedProjectOptions |> Array.ofList } ))
             | None -> None, None
         let _file, projectOptions = getOptions project
         projectOptions


### PR DESCRIPTION
Was seeing operation cancelled messages from the compiler when
passing in the output file name along with the source files
themselves for project references.

The key just needs to be unique for each project.. and as we have the
source code, there is no need for the compiler to parse the assemblies.

This results in _much_ faster time before intellisense etc. works