### PR TITLE
[TextEditor] Use the byte offset into the UTF8 string

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextSegmentMarker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextSegmentMarker.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Text;
 using Cairo;
 using Mono.TextEditor.Highlighting;
 using System.Collections.Generic;
@@ -142,11 +143,16 @@ namespace Mono.TextEditor
 				int start = startOffset < markerStart ? markerStart : startOffset;
 				int end = endOffset < markerEnd ? endOffset : markerEnd;
 				int /*lineNr,*/ x_pos;
+
+				var substring = layout.Text.Substring (0, end - startOffset);
+				var asciiLength = Encoding.ASCII.GetByteCount (substring);
+				var utf8Length = Encoding.UTF8.GetByteCount (substring);
+				var encodingDiff = utf8Length - asciiLength;
 				
-				x_pos = layout.IndexToPos (System.Math.Max (0, start - startOffset)).X;
+				x_pos = layout.IndexToPos (System.Math.Max (0, start - startOffset + encodingDiff)).X;
 				@from = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
 				
-				x_pos = layout.IndexToPos (System.Math.Max (0, end - startOffset)).X;
+				x_pos = layout.IndexToPos (System.Math.Max (0, end - startOffset + encodingDiff)).X;
 				
 				to = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
 				var line = editor.GetLineByOffset (endOffset);

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextSegmentMarker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextSegmentMarker.cs
@@ -109,31 +109,32 @@ namespace Mono.TextEditor
 				var range = editor.SelectionRange;
 				if (range.Contains (markerStart)) {
 					int end = System.Math.Min (markerEnd, range.EndOffset);
-					InternalDraw (markerStart, end, editor, cr, layout, true, startOffset, endOffset, y, startXPos, endXPos);
-					InternalDraw (range.EndOffset, markerEnd, editor, cr, layout, false, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (markerStart, end, editor, cr, metrics, true, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (range.EndOffset, markerEnd, editor, cr, metrics, false, startOffset, endOffset, y, startXPos, endXPos);
 					return;
 				}
 				if (range.Contains (markerEnd)) {
-					InternalDraw (markerStart, range.Offset, editor, cr, layout, false, startOffset, endOffset, y, startXPos, endXPos);
-					InternalDraw (range.Offset, markerEnd, editor, cr, layout, true, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (markerStart, range.Offset, editor, cr, metrics, false, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (range.Offset, markerEnd, editor, cr, metrics, true, startOffset, endOffset, y, startXPos, endXPos);
 					return;
 				}
 				if (markerStart <= range.Offset && range.EndOffset <= markerEnd) {
-					InternalDraw (markerStart, range.Offset, editor, cr, layout, false, startOffset, endOffset, y, startXPos, endXPos);
-					InternalDraw (range.Offset, range.EndOffset, editor, cr, layout, true, startOffset, endOffset, y, startXPos, endXPos);
-					InternalDraw (range.EndOffset, markerEnd, editor, cr, layout, false, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (markerStart, range.Offset, editor, cr, metrics, false, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (range.Offset, range.EndOffset, editor, cr, metrics, true, startOffset, endOffset, y, startXPos, endXPos);
+					InternalDraw (range.EndOffset, markerEnd, editor, cr, metrics, false, startOffset, endOffset, y, startXPos, endXPos);
 					return;
 				}
 				
 			}
 			
-			InternalDraw (markerStart, markerEnd, editor, cr, layout, false, startOffset, endOffset, y, startXPos, endXPos);
+			InternalDraw (markerStart, markerEnd, editor, cr, metrics, false, startOffset, endOffset, y, startXPos, endXPos);
 		}
 		
-		void InternalDraw (int markerStart, int markerEnd, MonoTextEditor editor, Cairo.Context cr, Pango.Layout layout, bool selected, int startOffset, int endOffset, double y, double startXPos, double endXPos)
+		void InternalDraw (int markerStart, int markerEnd, MonoTextEditor editor, Cairo.Context cr, LineMetrics metrics, bool selected, int startOffset, int endOffset, double y, double startXPos, double endXPos)
 		{
 			if (markerStart > markerEnd)
 				return;
+			var layout = metrics.Layout.Layout;
 			double @from;
 			double to;
 			if (markerStart < startOffset && endOffset < markerEnd) {
@@ -143,16 +144,16 @@ namespace Mono.TextEditor
 				int start = startOffset < markerStart ? markerStart : startOffset;
 				int end = endOffset < markerEnd ? endOffset : markerEnd;
 				int /*lineNr,*/ x_pos;
-
-				var substring = layout.Text.Substring (0, end - startOffset);
-				var asciiLength = Encoding.ASCII.GetByteCount (substring);
-				var utf8Length = Encoding.UTF8.GetByteCount (substring);
-				var encodingDiff = utf8Length - asciiLength;
+				uint curIndex = 0;
+				uint byteIndex = 0;
+				metrics.Layout.TranslateToUTF8Index ((uint)(start - startOffset), ref curIndex, ref byteIndex);
 				
-				x_pos = layout.IndexToPos (System.Math.Max (0, start - startOffset + encodingDiff)).X;
+				x_pos = layout.IndexToPos (System.Math.Max (0, (int)byteIndex)).X;
 				@from = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
+
+				metrics.Layout.TranslateToUTF8Index ((uint)(end - startOffset), ref curIndex, ref byteIndex);
 				
-				x_pos = layout.IndexToPos (System.Math.Max (0, end - startOffset + encodingDiff)).X;
+				x_pos = layout.IndexToPos (System.Math.Max (0, (int)byteIndex)).X;
 				
 				to = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
 				var line = editor.GetLineByOffset (endOffset);


### PR DESCRIPTION
PangoLayout's IndexToPos wants the byte offset into the
string and is storing data in UTF-8. Since we're currently
passing in the character offset the red wavy underlines are
misplaced when text before the error includes any multi-byte
characters.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53000