### PR TITLE
Restore Paket references before building on Windows.

### DIFF
--- a/main/winbuild.bat
+++ b/main/winbuild.bat
@@ -18,6 +18,8 @@ git submodule sync || goto :error
 git submodule update --init --recursive || goto :error
 "external\nuget-binary\NuGet.exe" restore Main.sln || goto :error
 
+"%MSBUILD_EXE%" external\fsharpbinding\.paket\paket.targets /t:RestorePackages /p:PaketReferences="%~dp0external\fsharpbinding\MonoDevelop.FSharpBinding\paket.references"
+
 set "CONFIG=DebugWin32"
 set "PLATFORM=Any CPU"
 


### PR DESCRIPTION
The way the F# projects are set up right now at the bottom of the .fsproj we import StrongNamer.targets, but at the time of evaluation the packages are not restored yet and so the StrongNamer.targets are not imported. They are only imported during subsequent builds when the targets file is already present on disk.

This change calls into Paket and restores packages for the MonoDevelop.FSharpBinding project, which includes StrongNamer. This ensures that by the time the build evaluation happens the targets file for StrongNamer is already on disk.