### PR TITLE
Try to fix F# unit test failures

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TestHelpers.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TestHelpers.fs
@@ -16,6 +16,7 @@ module FixtureSetup =
             //Environment.SetEnvironmentVariable ("MONO_ADDINS_REGISTRY", "/tmp")
             //Environment.SetEnvironmentVariable ("XDG_CONFIG_HOME", "/tmp")
             MonoDevelop.FSharp.MDLanguageService.DisableVirtualFileSystem()
+            Xwt.Application.Initialize (Xwt.ToolkitType.Gtk)
             Runtime.Initialize (true)
             MonoDevelop.Ide.DesktopService.Initialize()
 


### PR DESCRIPTION
Initialize XWT before initializing the desktop service, otherwise
the Mac platform initialization crashes.