### PR TITLE
[F#] Semantic highlighting fix

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/SemanticHighlighting.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/SemanticHighlighting.fs
@@ -9,7 +9,7 @@ open FsUnit
 [<TestFixture>]
 type SemanticHighlighting() =
     let getStyle (content : string) =
-        let fixedc = content.Replace("§", "")
+        let fixedc = content.Replace("$", "")
         let doc = TestHelpers.createDoc fixedc "defined"
         let tsc = SyntaxMode.tryGetTokensSymbolsAndColours doc
 
@@ -28,8 +28,8 @@ type SemanticHighlighting() =
                     seg.Length )
             printfn "\n"
 
-        let offset = content.IndexOf("§")
-        let endOffset = content.LastIndexOf("§") - 1
+        let offset = content.IndexOf("$")
+        let endOffset = content.LastIndexOf("$") - 1
         let segment = segments |> Seq.concat |>  Seq.tryFind (fun s -> s.Offset = offset && s.EndOffset = endOffset)
         match segment with
         | Some(s) -> s.ColorStyleKey
@@ -40,7 +40,7 @@ type SemanticHighlighting() =
        let content ="""
 #if undefined
 let sub = (-)
-§let§ add = (+)
+$let$ add = (+)
 #endif"""
        getStyle content |> should equal "punctuation.definition.comment.source"
 
@@ -51,7 +51,7 @@ module MyModule =
     let someFunc() = ()
 
 module Consumer =
-    §MyModule§.someFunc()"""
+    $MyModule$.someFunc()"""
         let output = getStyle content
         output |> should equal "entity.name.class"
 
@@ -60,7 +60,7 @@ module Consumer =
         let content = 
             """
             module MyModule =
-            let x = §Some§ 1
+            let x = $Some$ 1
             """
         let output = getStyle content
         output |> should equal "entity.name.class"
@@ -71,37 +71,39 @@ module Consumer =
 open System
 
 module MyModule =
-    let guid = §Guid§.NewGuid()"""
+    let guid = $Guid$.NewGuid()"""
         let output = getStyle content
         output |> should equal "entity.name.struct"
 
     [<Test>]
     member x.Add_is_plain_text() =
-        let content = "let §add§ = (+)"
+        let content = "let $add$ = (+)"
         getStyle content |> should equal "entity.name.function"
 
-    [<TestCase("let §add§ = (+)", "entity.name.function")>]
-    [<TestCase("let §simpleBinding§ = 1", "entity.name.field")>]
+    [<TestCase("let $add$ = (+)", "entity.name.function")>]
+    [<TestCase("let $simpleBinding$ = 1", "entity.name.field")>]
+    [<TestCase("type o = $System$.Object", "source.fs")>]
+    [<TestCase("type o = System.$Object$", "entity.name.class")>]
     member x.Semantic_highlighting(source, expectedStyle) =
         getStyle source |> should equal expectedStyle
         
     [<Test>]    
     member x.Generics_are_highlighted() =
         let content = """
-type Class<§'a§>() = class end
+type Class<$'a$>() = class end
     let _ = new Class<_>()"""
         let output = getStyle content
         output |> should equal "entity.name.typeparameter"
      
     [<Test>]    
     member x.Type_constraints_are_highlighted() =
-        let content = "type Constrained<'a when §'a§ :> IDisposable> = class end"
+        let content = "type Constrained<'a when $'a$ :> IDisposable> = class end"
         let output = getStyle content
         output |> should equal "entity.name.typeparameter"
 
     [<Test>]    
     member x.Static_inlined_type_constraints_are_highlighted() =
-        let content = "let inline test (x: §^a§) (y: ^b) = x + y"
+        let content = "let inline test (x: $^a$) (y: ^b) = x + y"
         let output = getStyle content
         output |> should equal "entity.name.typeparameter"
 
@@ -109,7 +111,7 @@ type Class<§'a§>() = class end
     member x.``Computation expression is highlighted as a keyword``() =
         let content = """
         module ComputationExpressions
-        let x2 = §query§ { for i in 0 .. 100 do
+        let x2 = $query$ { for i in 0 .. 100 do
                          where (i = 0)
                          select (i,i) }
         """

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
@@ -292,7 +292,7 @@ module Patterns =
                 | GenericParameter _ ->
                     makeSeg EditorThemeColors.UserTypesTypeParameters
                 | Namespace _ ->
-                    makeSeg "source"
+                    makeSeg "source.fs"
                 | Property fromDef ->
                     if fromDef then makeSeg EditorThemeColors.UserPropertyDeclaration 
                     else makeSeg EditorThemeColors.UserPropertyUsage


### PR DESCRIPTION
In the following code

```fsharp
type o = System.Object
```

the word System is highlighted incorrectly. Fixed to highlight as a
namespace.