### PR TITLE
Bug 54301 - Implement interface missing from Quick Fixes

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -176,7 +176,7 @@ namespace MonoDevelop.CodeActions
 									var validDiagnostics = g.Where (d => provider.FixableDiagnosticIds.Contains (d.Id)).ToImmutableArray ();
 									if (validDiagnostics.Length == 0)
 										continue;
-									if (diagnosticSpan.Start < 0 || diagnosticSpan.End > root.Span.Length)
+									if (diagnosticSpan.Start < 0 || diagnosticSpan.End > root.Span.End)
 										continue;
 									await provider.RegisterCodeFixesAsync (new CodeFixContext (ad, diagnosticSpan, validDiagnostics, (ca, d) => codeIssueFixes.Add (new ValidCodeDiagnosticAction (cfp, ca, validDiagnostics, diagnosticSpan)), token));
 


### PR DESCRIPTION
Problem was that root.Span.Start starts with `using System;` but file has a lot of comment(license) before `using System;` which meant that root.Span.Length was very small(.End-.Start) and was outside of diagnostics, hence comparing with .End is more correct…