### PR TITLE
Use the LargeAddressAware NuGet package to reliably find editbin.exe.

### DIFF
--- a/main/src/core/MonoDevelop.Startup/MonoDevelop.Startup.csproj
+++ b/main/src/core/MonoDevelop.Startup/MonoDevelop.Startup.csproj
@@ -86,6 +86,9 @@
     <PlatformTarget>x64</PlatformTarget>
     <Commandlineparameters>-no-redirect</Commandlineparameters>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Unix'">
+    <LargeAddressAware>true</LargeAddressAware>
+  </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
@@ -124,18 +127,5 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-
-  <Target Name="MakeLargeAddressAware" AfterTargets="Build" Condition=" '$(OS)' != 'Unix' ">
-    <PropertyGroup>
-      <VsComnTools Condition=" '$(VsComnTools)' == '' ">$(VS150COMNTOOLS)</VsComnTools>
-      <VsComnTools Condition=" '$(VsComnTools)' == '' ">$(VS140COMNTOOLS)</VsComnTools>
-      <VsComnTools Condition=" '$(VsComnTools)' == '' ">$(VS130COMNTOOLS)</VsComnTools>
-      <VsComnTools Condition=" '$(VsComnTools)' == '' ">$(VS120COMNTOOLS)</VsComnTools>
-      <VsComnTools Condition=" '$(VsComnTools)' == '' ">$(VS110COMNTOOLS)</VsComnTools>
-      <VsComnTools Condition=" '$(VsComnTools)' != '' And !HasTrailingSlash('$(VsComnTools)') ">$(VsComnTools)\</VsComnTools>
-      <EditBin Condition=" '$(VsComnTools)' != '' ">$(VsComnTools)..\..\VC\bin\editbin.exe</EditBin>
-    </PropertyGroup>
-
-    <Exec Command='"$(EditBin)" /largeaddressaware "$(TargetPath)"' Condition="Exists('$(EditBin)')" />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\packages\LargeAddressAware.1.0.0\build\LargeAddressAware.targets" Condition="$(OS) != 'Unix' AND Exists('$(MSBuildThisFileDirectory)..\..\..\packages\LargeAddressAware.1.0.0\build\LargeAddressAware.targets')" />
 </Project>

--- a/main/src/core/MonoDevelop.Startup/packages.config
+++ b/main/src/core/MonoDevelop.Startup/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LargeAddressAware" version="1.0.0" />
+</packages>


### PR DESCRIPTION
The problem is that editbin.exe is only found inside VS 2017 install path and that path isn't even well defined (unlike in previous VS releases). Additionally if we want to build on CI servers that path may not be available.

After much deliberation on where to get editbin.exe I've decided to create a NuGet package "LargeAddressAware" that downloads editbin.exe (and link.exe which is required, editbin.exe just calls into link.exe) and has a targets file that injects a call to editbin after CoreCompile is done.

See https://github.com/KirillOsenkov/LargeAddressAware

The target will only run on Windows (OS != Unix) and only when the LargeAddressAware MSBuild property is set.

Note that this is all temporary since Roslyn already has a plan to add LARGEADDRESSAWARE support to the compiler directly:
https://github.com/dotnet/roslyn/issues/9209