### PR TITLE
Fix bad sdk import

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -931,7 +931,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (!string.IsNullOrEmpty (Sdk))
 				return Sdk.Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 			else
-				return new string [0];
+				return Array.Empty<string> ();
 		}
 
 		XmlNamespaceManager GetNamespaceManagerForProject ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1384,16 +1384,11 @@ namespace MonoDevelop.Projects
 
 		string GetMSBuildSdkPath (TargetRuntime runtime)
 		{
-			var tt = System.Diagnostics.Stopwatch.StartNew ();
-			try {
-				HashSet<string> sdks = null;
-				GetReferencedSDKs (runtime, this, ref sdks);
-				if (sdks != null)
-					return MSBuildProjectService.FindSdkPath (runtime, sdks.ToArray ());
-				return null;
-			} finally {
-				Console.WriteLine ("GetMSBuildSdkPath " + tt.ElapsedMilliseconds);
-			}
+			HashSet<string> sdks = null;
+			GetReferencedSDKs (runtime, this, ref sdks);
+			if (sdks != null)
+				return MSBuildProjectService.FindSdkPath (runtime, sdks.ToArray ());
+			return null;
 		}
 
 		void GetReferencedSDKs (TargetRuntime runtime, Project project, ref HashSet<string> sdks)


### PR DESCRIPTION
When determining the MSBuildSdkPath to be used for a project, take into
account all referenced projects, including references of references.