### PR TITLE
[Core] Improve load times for ASP.NET Core projects

### DIFF
--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -634,6 +634,26 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		[Test]
+		public async Task AllFilesExcludedFromDirectory ()
+		{
+			FilePath projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-test2.csproj");
+			FilePath ignoredDirectory = projFile.ParentDirectory.Combine ("ignored");
+			Directory.CreateDirectory (ignoredDirectory);
+			File.WriteAllText (ignoredDirectory.Combine ("c4.cs"), "");
+			var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			p.UseAdvancedGlobSupport = true;
+
+			var files = p.Files.Select (f => f.FilePath.FileName).OrderBy (f => f).ToArray ();
+			Assert.AreEqual (new string [] {
+				"c1.cs",
+				"c2.cs",
+				"c3.cs",
+			}, files);
+
+			p.Dispose ();
+		}
+
 		class SupportImportedProjectFilesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override bool OnGetSupportsImportedItem (IMSBuildItemEvaluated buildItem)

--- a/main/tests/test-projects/msbuild-glob-tests/glob-test2.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-test2.csproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="**\ignored\**" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Fixed bug #54342 - Long load times for .NET Core projects with
node_modules
https://bugzilla.xamarin.com/show_bug.cgi?id=54342

If an ASP.NET Core project uses say Gulp that will add lots of files
into the node_modules directory. This was causing a long load time.
The slow part was the DefaultMSBuildEngine's Evaluate method which
with 4200+ files in the node_modules directory would take around 2.5s
for each Evaluate method call. On loading a solution with one project
the Evaluate method would be called 6 times. Without the node_modules
directory the Evaluate method would take about 150ms for each call.

To fix this a regex is created when adding items for the excluded
directories. Directories and files inside these excluded directories
are ignored. For .NET Core there are wildcard includes and removes
which are now prevented from looking for files in the node_modules
directory. The fix is not perfect - the remove items happen to have
the same wildcard as the included items so the correct directory
exclude regex can be found with an exact match when looking at the
globs for the project. With this fix the Evaluate method now takes
the same time (about 150ms) as if there is no node_modules directory.