### PR TITLE
Bug 54315 - ASP.NET Core project - Start without debugging and then s…

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -243,10 +243,13 @@ namespace MonoDevelop.DotNetCore
 			using (console) {
 				ProcessAsyncOperation asyncOp = context.ExecutionHandler.Execute (executionCommand, console);
 
-				using (var stopper = monitor.CancellationToken.Register (asyncOp.Cancel))
-					await asyncOp.Task;
+				try {
+					using (var stopper = monitor.CancellationToken.Register (asyncOp.Cancel))
+						await asyncOp.Task;
 
-				monitor.Log.WriteLine (GettextCatalog.GetString ("The application exited with code: {0}", asyncOp.ExitCode));
+					monitor.Log.WriteLine (GettextCatalog.GetString ("The application exited with code: {0}", asyncOp.ExitCode));
+				} catch (OperationCanceledException) {
+				}
 			}
 		}
 


### PR DESCRIPTION
…top, error shows with message 'Cannot execute Webapi_core_2.exe'