### PR TITLE
[NuGet] Fix null reference on restoring packages

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
@@ -109,24 +109,21 @@ namespace MonoDevelop.PackageManagement
 					cancellationToken);
 
 				packagesToRestore = packages.ToList ();
-				if (packagesToRestore.Any (package => package.IsMissing)) {
-					return true;
-				}
 			}
 
 			if (buildIntegratedRestorer != null) {
 				var projects = await buildIntegratedRestorer.GetProjectsRequiringRestore (GetBuildIntegratedNuGetProjects ());
 				buildIntegratedProjectsToBeRestored = projects.ToList ();
-				return buildIntegratedProjectsToBeRestored.Any ();
 			}
 
 			if (nugetAwareRestorer != null) {
 				var projects = await nugetAwareRestorer.GetProjectsRequiringRestore (nugetAwareProjects);
 				nugetAwareProjectsToBeRestored = projects.ToList ();
-				return nugetAwareProjectsToBeRestored.Any ();
 			}
 
-			return false;
+			return packagesToRestore.Any (package => package.IsMissing) ||
+				buildIntegratedProjectsToBeRestored?.Any () == true ||
+				nugetAwareProjectsToBeRestored?.Any () == true;
 		}
 
 		public void Execute ()


### PR DESCRIPTION
If the solution contained .NET Core and non .NET Core projects
then the restore for the .NET Core projects would fail with a
null reference exception since the projects list was not populated.