### PR TITLE
[NuGet] Fix new .NET Core projects not being restored after creation

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
@@ -121,7 +121,7 @@ namespace MonoDevelop.PackageManagement
 				nugetAwareProjectsToBeRestored = projects.ToList ();
 			}
 
-			return packagesToRestore.Any (package => package.IsMissing) ||
+			return packagesToRestore?.Any (package => package.IsMissing) == true ||
 				buildIntegratedProjectsToBeRestored?.Any () == true ||
 				nugetAwareProjectsToBeRestored?.Any () == true;
 		}


### PR DESCRIPTION
Fixed a null reference exception preventing .NET Core projects from being
restored when they are created. This null ref was introduced by the change
made in the previous commit 42c209064228cfbbb4d6dbf0190032212f0fd927