### PR TITLE
Fixed 'Bug 54423 - Code completion automatically closes parenthesis,

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
@@ -386,19 +386,22 @@ namespace MonoDevelop.CSharp.Completion
 
 		internal static bool HasAnyOverloadWithParameters (IMethodSymbol method)
 		{
-			if (method.MethodKind == MethodKind.Constructor) 
-				return method.ContainingType.GetMembers()
-					.OfType<IMethodSymbol>()
-					.Where(m => m.MethodKind == MethodKind.Constructor)
+			switch (method.MethodKind) {
+			case MethodKind.Constructor:
+				return method.ContainingType.GetMembers ()
+					.OfType<IMethodSymbol> ()
+					.Where (m => m.MethodKind == MethodKind.Constructor)
 					.Any (m => m.Parameters.Length > 0);
-			return method.ContainingType
-				.GetMembers()
-				.OfType<IMethodSymbol>()
-				.Any (m => m.Name == method.Name && m.Parameters.Length > 0);
+			case MethodKind.LocalFunction:
+				return method.Parameters.Length > 0;
+			default:
+				return method.ContainingType
+					         .GetMembers ()
+					         .OfType<IMethodSymbol> ()
+					         .Any (m => m.Name == method.Name && m.Parameters.Length > 0);
+			}
 		}
-
-
-
+		
 		static bool RequireGenerics (IMethodSymbol method)
 		{
 			System.Collections.Immutable.ImmutableArray<ITypeSymbol> typeArgs;

--- a/main/tests/UnitTests/MonoDevelop.CSharpBinding/AutomaticBracketInsertionTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.CSharpBinding/AutomaticBracketInsertionTests.cs
@@ -210,8 +210,9 @@ namespace MonoDevelop.CSharpBinding
 			Ide.IdeApp.Preferences.AddParenthesesAfterCompletion.Set (true);
 			Ide.IdeApp.Preferences.AddOpeningOnly.Set (false);
 
-			var t = model.Compilation.GetTypeByMetadataName (type); 
-			var method = member != null ? t.GetMembers().First (m => m.Name == member) : t.GetMembers ().OfType<IMethodSymbol> ().First (m => m.MethodKind == MethodKind.Constructor);
+			var t = model.Compilation.GetTypeByMetadataName (type);
+
+			var method = member != null ? model.LookupSymbols (s.Item1.Editor.CaretOffset).OfType<IMethodSymbol> ().First (m => m.Name == member) : t.GetMembers ().OfType<IMethodSymbol> ().First (m => m.MethodKind == MethodKind.Constructor);
 			var factory = new RoslynCodeCompletionFactory (ext, model);
 			var data = new RoslynSymbolCompletionData (null, factory, method);
 			data.IsDelegateExpected = isDelegateExpected;
@@ -482,6 +483,25 @@ class MyClass
 			Assert.AreEqual ("Test(|);", completion);
 		}
 
+		/// <summary>
+		/// Bug 54423 - Code completion automatically closes parenthesis, instead of offering completions
+		/// </summary> 
+		[Test]
+		public async Task TestBug54423 ()
+		{
+			string completion = await Test (@"
+class MyClass
+{
+	void FooBar ()
+	{
+		void Test (int foo)
+		{
+		}
+		$
+	}
+}", "MyClass", "Test");
+			Assert.AreEqual ("Test(|);", completion);
+		}
 
 	}
 }


### PR DESCRIPTION
instead of offering completions'