### PR TITLE
[Core] Fix NRE in project builder

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -156,7 +156,9 @@ namespace MonoDevelop.Projects.MSBuild
 					project = p;
 			}
 
-			Environment.CurrentDirectory = Path.GetDirectoryName (file);
+			var projectDir = Path.GetDirectoryName (file);
+			if (!string.IsNullOrEmpty (projectDir))
+				Environment.CurrentDirectory = projectDir;
 			return project;
 		}
 


### PR DESCRIPTION
It happens when trying to run a target on a project that has not yet
been saved to disk.