### PR TITLE
[DotNetCore] Support refreshing the solution window

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeBuilderExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeBuilderExtension.cs
@@ -62,5 +62,9 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 
 			return GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build .NET Core projects. {0}", DotNetCoreNotInstalledDialog.DotNetCoreDownloadUrl);
 		}
+
+		public override Type CommandHandlerType {
+			get { return typeof (DotNetCoreProjectNodeCommandHandler); }
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeCommandHandler.cs
@@ -1,0 +1,42 @@
+﻿//
+// DotNetCoreProjectNodeCommandHandler.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui.Components;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.DotNetCore.NodeBuilders
+{
+	class DotNetCoreProjectNodeCommandHandler : NodeCommandHandler
+	{
+		public override void RefreshItem ()
+		{
+			var project = (DotNetProject)CurrentNode.DataItem;
+			if (project.HasFlavor<DotNetCoreProjectExtension> ())
+				project.ReevaluateProject (new ProgressMonitor ());
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -141,6 +141,7 @@
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRuntime.cs" />
     <Compile Include="MonoDevelop.DotNetCore\MSBuildSdks.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSystemInformation.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.NodeBuilders\DotNetCoreProjectNodeCommandHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -568,12 +568,23 @@ namespace MonoDevelop.DotNetCore
 		protected override void OnItemsAdded (IEnumerable<ProjectItem> objs)
 		{
 			if (Project.Loading) {
-				foreach (var file in objs.OfType<ProjectFile> ()) {
-					if (file.FilePath.ShouldBeHidden ())
-						file.Flags = ProjectItemFlags.Hidden;
-				}
+				UpdateHiddenFiles (objs.OfType<ProjectFile> ());
 			}
 			base.OnItemsAdded (objs);
+		}
+
+		void UpdateHiddenFiles (IEnumerable<ProjectFile> files)
+		{
+			foreach (var file in files) {
+				if (file.FilePath.ShouldBeHidden ())
+					file.Flags = ProjectItemFlags.Hidden;
+			}
+		}
+
+		protected override async Task OnReevaluateProject (ProgressMonitor monitor)
+		{
+			await base.OnReevaluateProject (monitor);
+			UpdateHiddenFiles (Project.Files);
 		}
 	}
 }


### PR DESCRIPTION
If a file is copied into the project folder, or Save As is used with a file open in the editor, the file will not appear in the Solution window until the project is reloaded. Currently there is no file watcher support so for now the Refresh menu when you right click a project in the Solution window will re-evaluate the project so the files added will be displayed.

This is a partial fix for [bug #54474](https://bugzilla.xamarin.com/show_bug.cgi?id=54474)