### PR TITLE
Fixed 'Bug 54631 - First two characters in project file removed when

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextFileUtility.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextFileUtility.cs
@@ -161,17 +161,9 @@ namespace MonoDevelop.Core.Text
 			return encoding.GetString (bytes, start, bytes.Length - start);
 		}
 
+		[Obsolete("Use encoding.GetString")]
 		public static string GetText (byte[] bytes, Encoding encoding)
 		{
-			byte[] bom = encoding.GetPreamble ();
-			if (bom != null && bom.Length > 0 && bom.Length <= bytes.Length) {
-				for (int i = 0; i < bom.Length; i++) {
-					if (bytes [i] != bom [i]) {
-						break;
-					}
-				}
-				return encoding.GetString (bytes, bom.Length, bytes.Length - bom.Length);
-			}
 			return encoding.GetString (bytes);
 		}
 
@@ -359,7 +351,7 @@ namespace MonoDevelop.Core.Text
 				throw new ArgumentNullException ("encoding");
 
 			byte[] content = File.ReadAllBytes (fileName);
-			return GetText (content, encoding); 
+			return encoding.GetString (content); 
 		}
 
 		public static async Task<TextContent> ReadAllTextAsync (string fileName, Encoding encoding)
@@ -371,7 +363,7 @@ namespace MonoDevelop.Core.Text
 
 			byte[] content = await ReadAllBytesAsync (fileName).ConfigureAwait (false);
 
-			var txt = GetText (content, encoding); 
+			var txt = encoding.GetString (content); 
 			return new TextContent {
 				Text = txt,
 				Encoding = encoding

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextFileUtility.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextFileUtility.cs
@@ -161,12 +161,6 @@ namespace MonoDevelop.Core.Text
 			return encoding.GetString (bytes, start, bytes.Length - start);
 		}
 
-		[Obsolete("Use encoding.GetString")]
-		public static string GetText (byte[] bytes, Encoding encoding)
-		{
-			return encoding.GetString (bytes);
-		}
-
 		public static string GetText (Stream inputStream)
 		{
 			using (var stream = OpenStream (inputStream)) {


### PR DESCRIPTION
adding file or folder'.

The encodings handle the boms. Stripping them before just strips the
first chars of the file.