### PR TITLE
[NuGet] Fix .NET Core project build error after location changed 

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
@@ -112,8 +112,7 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			if (buildIntegratedRestorer != null) {
-				var projects = await buildIntegratedRestorer.GetProjectsRequiringRestore (GetBuildIntegratedNuGetProjects ());
-				buildIntegratedProjectsToBeRestored = projects.ToList ();
+				buildIntegratedProjectsToBeRestored = GetBuildIntegratedNuGetProjects ().ToList ();
 			}
 
 			if (nugetAwareRestorer != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -248,7 +248,8 @@ namespace MonoDevelop.Ide.TypeSystem
 				await Task.WhenAll (allTasks.ToArray ()).ConfigureAwait (false);
 				if (token.IsCancellationRequested)
 					return null;
-				var modifiedWhileLoading = modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
+				var modifiedWhileLoading = modifiedProjects;
+				modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
 				var solutionInfo = SolutionInfo.Create (GetSolutionId (solution), VersionStamp.Create (), solution.FileName, projects);
 				foreach (var project in modifiedWhileLoading) {
 					if (solution.ContainsItem (project)) {


### PR DESCRIPTION
Fixed bug #54327 - .NET Core project build fails when solution's location is moved
https://bugzilla.xamarin.com/show_bug.cgi?id=54327

Creating a new ASP.NET Core project, building it, closing the
solution, moving the solution to another folder, then opening it and
building it would show lots of build errors. The problem is that
the generated projectname.nuget.g.props file specifies the full path
to the project.assets.json file. The project.assets.json file
defines the NuGet packages and assemblies referenced. Since the
path to this file is now incorrect on moving the solution no
references are found by MSBuild since it cannot find the
project.assets.json file. Visual Studio handles this by always
restoring the solution when it is opened. So we now do the same for
.NET Core projects.

Also fixed a type system problem where the reference information was not updated if a restore occurs on opening the solution and the type system is currently still loading the projects.