### PR TITLE
Fix bug #54691 - Preferences aren't stored

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicySet.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicySet.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // PolicySet.cs
 // 
 // Author:
@@ -80,18 +80,18 @@ namespace MonoDevelop.Projects.Policies
 			get { return null; }
 		}
 		
-		protected override T GetDefaultPolicy<T> ()
+		protected override object GetDefaultPolicy (Type type)
 		{
 			// The default policy set always resturns a value for any type of policy.
 			if (IsDefaultSet)
-				return new T ();
+				return Activator.CreateInstance (type);
 			return null;
 		}
 		
-		protected override T GetDefaultPolicy<T> (IEnumerable<string> scopes)
+		protected override object GetDefaultPolicy (Type type, IEnumerable<string> scopes)
 		{
 			if (IsDefaultSet)
-				return new T ();
+				return Activator.CreateInstance (type);
 			return null;
 		}
 		


### PR DESCRIPTION
Sanitized a bit the policy container code. There Get(Type) and Get<T> methods
were supposed to have the same behavior, but they had different
implementations. Now all Get methods are based on the same code.

The real fix is that inheritsSet and inheritsScope are serialized only when
a policy was really found for that set and scope. Until now it was always
stored, so when deserializing, if the policy wasn't in the set for that
scope, it would crash.