### PR TITLE
[AspNet] Add ASP.NET Core Web API Controller file template

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
@@ -370,6 +370,7 @@
     <Compile Include="gtk-gui\generated.cs" />
     <Compile Include="Projects\GtkAspNetProjectTemplateWizardPageWidget.cs" />
     <Compile Include="gtk-gui\MonoDevelop.AspNet.Projects.GtkAspNetProjectTemplateWizardPageWidget.cs" />
+    <Compile Include="Projects\AspNetCoreFileTemplateCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
@@ -550,6 +551,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Templates\Projects\Files\Test.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Templates\AspNetCore\WebApiController.xft.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/main/src/addins/AspNet/Projects/AspNetCoreFileTemplateCondition.cs
+++ b/main/src/addins/AspNet/Projects/AspNetCoreFileTemplateCondition.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Xml;
+//
+// AspNetCoreFileTemplateCondition.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Ide.Templates;
+using MonoDevelop.Projects;
+using System.Linq;
+
+namespace MonoDevelop.AspNet.Projects
+{
+	class AspNetCoreFileTemplateCondition : FileTemplateCondition
+	{
+		public override void Load (XmlElement element)
+		{
+		}
+
+		public override bool ShouldEnableFor (Project proj, string projectPath)
+		{
+			return proj.GetProjectCapabilities ().Contains ("AspNetCore");
+		}
+
+		public override bool ShouldEnableFor (Project proj, string projectPath, string language)
+		{
+			return ShouldEnableFor (proj, projectPath);
+		}
+	}
+}

--- a/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
+++ b/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
@@ -60,6 +60,8 @@
 		<Import file = "Templates/WebConfig-Application.xft.xml"/>
 		<Import file = "Templates/WebConfig-SubDir.xft.xml"/>
 
+		<Import file = "Templates/AspNetCore/WebApiController.xft.xml"/>
+
 		<Import file = "CodeTemplates/CSharp/AddController/ControllerWithEmptyReadAndWriteActions.tt" />
 		<Import file = "CodeTemplates/CSharp/AddController/Empty.tt" />
 		<Import file = "CodeTemplates/CSharp/AddView/Aspx/Empty.tt" />
@@ -153,6 +155,9 @@
 		              file     = "Templates/Mvc/PartialViewPageRazor.xft.xml" />
 		<FileTemplate id       = "PreprocessedRazorTemplate"
 		              file     = "Templates/PreprocessedRazorTemplate.xft.xml" />
+
+		<FileTemplate id   = "AspNetCoreWebApiController"
+		              file = "Templates/AspNetCore/WebApiController.xft.xml"/>
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/FileTemplateTypes">
@@ -368,6 +373,7 @@
 
 	<Extension path = "/MonoDevelop/Ide/FileTemplateConditionTypes">
 		<FileTemplateConditionType name = "AspNetMvc" class = "MonoDevelop.AspNet.Projects.AspNetMvcFileTemplateCondition"/>
+		<FileTemplateConditionType name = "AspNetCore" class = "MonoDevelop.AspNet.Projects.AspNetCoreFileTemplateCondition" />
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateWizards">

--- a/main/src/addins/AspNet/Templates/AspNetCore/WebApiController.xft.xml
+++ b/main/src/addins/AspNet/Templates/AspNetCore/WebApiController.xft.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0"?>
+<Template
+	originator="Matt Ward"
+	created="2017/04/07"
+	lastModified="2017/04/07">
+
+	<TemplateConfiguration>
+		<_Name>Web API Controller</_Name>
+		<Icon>md-html-file-icon</Icon>
+		<_Category>ASP.NET Core</_Category>
+		<LanguageName>C#</LanguageName>
+		<DefaultFilename>ValuesController</DefaultFilename>
+		<_Description>Creates an ASP.NET Core Web API Controller.</_Description>
+	</TemplateConfiguration>
+
+	<Conditions>
+		<AspNetCore />
+	</Conditions>
+	
+	<!-- Template Content -->
+	<TemplateFiles>
+		<File name="${Name}.cs">
+<![CDATA[using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ${Namespace}.Controllers
+{
+	[Route("api/[controller]")]
+	public class ${EscapedIdentifier} : Controller
+	{
+	}
+}
+]]>
+		</File>
+	</TemplateFiles>
+</Template>


### PR DESCRIPTION
Fixed bug #54313 - ASP.NET Core project - Add New File should have a
template for Controller class
https://bugzilla.xamarin.com/show_bug.cgi?id=54313

Add a basic file template for an ASP.NET Core Web API Controller.
This file template is only available for ASP.NET Core Web projects.