### PR TITLE
[MSBuild] Fix item metadata evaluation issue

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // DefaultMSBuildEngine.cs
 //
 // Author:
@@ -491,7 +491,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			foreach (var eit in transformItems) {
 				// Some item functions cause the erasure of metadata. Take that into account now.
-				context.SetItemContext (eit.Include, null, ignoreMetadata || item == null ? null : eit.Metadata);
+				context.SetItemContext (null, eit.Include, null, ignoreMetadata || item == null ? null : eit.Metadata);
 				try {
 					// If there is a function that transforms the include of the item, it needs to be applied now. Otherwise just use the transform expression
 					// as include, or the transformed item include if there is no expression.
@@ -563,7 +563,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			int count = 0;
 			foreach (var eit in transformItems) {
-				context.SetItemContext (eit.Include, null, eit.Metadata);
+				context.SetItemContext (null, eit.Include, null, eit.Metadata);
 				try {
 					string evaluatedInclude; bool skip;
 					if (itemFunction != null && ExecuteTransformIncludeItemFunction (context, eit, itemFunction, itemFunctionArgs, out evaluatedInclude, out skip)) {
@@ -753,8 +753,7 @@ namespace MonoDevelop.Projects.MSBuild
 		
 			MSBuildProject project = pinfo.Project;
 			WildcardExpansionFunc<MSBuildItemEvaluated> func = delegate (string file, string include, string recursiveDir) {
-				context.SetItemContext (file, recursiveDir);
-				return CreateEvaluatedItem (context, pinfo, project, sourceItem, include);
+				return CreateEvaluatedItem (context, pinfo, project, sourceItem, include, file, recursiveDir);
 			};
 			MSBuildProject rootProject = pinfo.GetRootMSBuildProject ();
 			return ExpandWildcardFilePath (rootProject, rootProject.BaseDirectory, FilePath.Null, false, subpath, 0, func, directoryExcludeRegex);
@@ -891,15 +890,20 @@ namespace MonoDevelop.Projects.MSBuild
 			return include.Length > 3 && include [0] == '@' && include [1] == '(' && include [include.Length - 1] == ')';
 		}
 
-		MSBuildItemEvaluated CreateEvaluatedItem (MSBuildEvaluationContext context, ProjectInfo pinfo, MSBuildProject project, MSBuildItem sourceItem, string include)
+		MSBuildItemEvaluated CreateEvaluatedItem (MSBuildEvaluationContext context, ProjectInfo pinfo, MSBuildProject project, MSBuildItem sourceItem, string include, string evaluatedFile = null, string recursiveDir = null)
 		{
 			var it = new MSBuildItemEvaluated (project, sourceItem.Name, sourceItem.Include, include);
 			var md = new Dictionary<string,IMSBuildPropertyEvaluated> ();
 			// Only evaluate properties for non-transforms.
 			if (!IsIncludeTransform (include)) {
-				foreach (var c in sourceItem.Metadata.GetProperties ()) {
-					if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (pinfo, context, c.Condition, true))
-						md [c.Name] = new MSBuildPropertyEvaluated (project, c.Name, c.Value, context.EvaluateString (c.Value)) { Condition = c.Condition };
+				try {
+					context.SetItemContext (include, evaluatedFile, recursiveDir);
+					foreach (var c in sourceItem.Metadata.GetProperties ()) {
+						if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (pinfo, context, c.Condition, true))
+							md [c.Name] = new MSBuildPropertyEvaluated (project, c.Name, c.Value, context.EvaluateString (c.Value)) { Condition = c.Condition };
+					}
+				} finally {
+					context.ClearItemContext ();
 				}
 			}
 			((MSBuildPropertyGroupEvaluated)it.Metadata).SetProperties (md);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.Projects.MSBuild
 		IMSBuildPropertyGroupEvaluated itemMetadata;
 		string directoryName;
 
+		string itemInclude;
 		string itemFile;
 		string recursiveDir;
 
@@ -260,8 +261,9 @@ namespace MonoDevelop.Projects.MSBuild
 			return Platform.IsMac && path.Contains ("Mono.framework/External/xbuild");
 		}
 
-		internal void SetItemContext (string itemFile, string recursiveDir, IMSBuildPropertyGroupEvaluated metadata = null)
+		internal void SetItemContext (string itemInclude, string itemFile, string recursiveDir, IMSBuildPropertyGroupEvaluated metadata = null)
 		{
+			this.itemInclude = itemInclude;
 			this.itemFile = itemFile;
 			this.recursiveDir = recursiveDir;
 			this.itemMetadata = metadata;
@@ -269,6 +271,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal void ClearItemContext ()
 		{
+			this.itemInclude = null;
 			this.itemFile = null;
 			this.recursiveDir = null;
 			this.itemMetadata = null;
@@ -292,6 +295,14 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public string GetMetadataValue (string name)
 		{
+			// First of all check if the metadata is explicitly set
+			if (itemMetadata != null && itemMetadata.HasProperty (name))
+				return itemMetadata.GetValue (name, "");
+
+			// Now check for file metadata. We avoid a FromMSBuildPath call by checking after item metadata
+			if (itemFile == null && itemInclude != null)
+				itemFile = MSBuildProjectService.FromMSBuildPath (project.BaseDirectory, itemInclude);
+			
 			if (itemFile == null)
 				return "";
 
@@ -326,8 +337,6 @@ namespace MonoDevelop.Projects.MSBuild
 						return File.GetLastAccessTime (itemFile).ToString ("yyyy-MM-dd hh:mm:ss");
 					}
 				}
-				if (itemMetadata != null)
-					return itemMetadata.GetValue (name, "");
 			} catch (Exception ex) {
 				LoggingService.LogError ("Failure in MSBuild file", ex);
 				return "";

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1549,7 +1549,7 @@ namespace MonoDevelop.Projects
 			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 
 			var mp = (Project)sol.Items [0];
-			Assert.AreEqual (6, mp.Files.Count);
+			Assert.AreEqual (7, mp.Files.Count);
 
 			var f1 = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "Xamagon_1.png");
 			var f2 = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "Xamagon_2.png");
@@ -1613,6 +1613,25 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("t2.dat", f2.Link.ToString ());
 
 			sol.Dispose ();
+		}
+
+		[Test]
+		public async Task LoadProjectWithWildcardLinks4 ()
+		{
+			// %(RecursiveDir) is empty when used in a non-recursive include with a single file
+
+			string solFile = Util.GetSampleProject ("project-with-wildcard-links", "PortableTest.sln");
+
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var mp = (Project)sol.Items [0];
+
+			var f = mp.Files.FirstOrDefault (pf => pf.FilePath.FileName == "other.rst");
+
+			Assert.IsNotNull(f);
+			Assert.AreEqual("other.rst", f.Link.ToString());
+
+			sol.Dispose();
 		}
 
 		/// <summary>

--- a/main/tests/test-projects/project-with-wildcard-links/PortableTest/PortableTest.csproj
+++ b/main/tests/test-projects/project-with-wildcard-links/PortableTest/PortableTest.csproj
@@ -47,6 +47,9 @@
     <EmbeddedResource Include="..\test\*.dat">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\test\other.rst">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Item metadata was not correctly evaluated since the item context was not
always set when evaluating an item.