### PR TITLE
[Windows] HDPI icon scaling fixes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -178,9 +178,10 @@ namespace MonoDevelop.Components
 
 		public static Xwt.Size GetSize (this IconSize size)
 		{
+			var displayScale = Platform.IsWindows ? GtkWorkarounds.GetScaleFactor () : 1.0;
 			int w, h;
 			size.GetSize (out w, out h);
-			return new Xwt.Size (w, h);
+			return new Xwt.Size ((double)w / displayScale, (double)h / displayScale);
 		}
 
 		public static void GetSize (this IconSize size, out int width, out int height)


### PR DESCRIPTION
This is probably a simple fix inside gtk+ but I'm having trouble getting my gtk Windows build scripts working. Would it be okay to merge this into monodevelop, and then if I can get it fixed in gtk then we can revert it?

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=54155
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40188
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40174