### PR TITLE
[Core] Fix build action when adding new shared project to solution

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -82,8 +82,12 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 
 		protected override void OnInitializeFromTemplate (ProjectCreateInformation projectCreateInfo, XmlElement projectOptions)
 		{
-			base.OnInitializeFromTemplate (projectCreateInfo, projectOptions);
+			// Get the language before calling OnInitializeFromTemplate so the language binding
+			// is available when adding new files to the project if the project is added to
+			// an existing solution.
 			languageName = projectOptions.GetAttribute ("language");
+
+			base.OnInitializeFromTemplate (projectCreateInfo, projectOptions);
 
 			string templateDefaultNamespace = GetDefaultNamespace (projectCreateInfo, projectOptions);
 			DefaultNamespace = templateDefaultNamespace ?? projectCreateInfo.ProjectName;


### PR DESCRIPTION
Fixed bug #54909 - Adding new shared project to existing solution has
MyClass.cs defined as None MSBuild item
https://bugzilla.xamarin.com/show_bug.cgi?id=54909

Adding a new shared project to an existing solution was defining the
language name too late so the language binding was null on adding
the MyClass.cs file to the project so its build action was not
marked as Compile. The SharedAssetsProject was calling
the base class OnInitializeFromTemplate method before setting the
language name. On adding a new shared assets project to an existing
solution the ProjectCreateInfo's TemplateInitializationCallback is
set which causes the MyClass.cs file to be added to the project.
The TemplateInitializationCallback is null when a new solution is
being created but not when adding a project to an existing solution.