### PR TITLE
Bug 54647 - You cannot disable implicit property evaluation in XS anymore

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ImmediatePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ImmediatePad.cs
@@ -65,7 +65,7 @@ namespace MonoDevelop.Debugger
 				FinishPrinting ();
 			} else {
 				var frame = DebuggingService.CurrentFrame;
-				var ops = GetEvaluationOptions ();
+				var ops = GetEvaluationOptions (false);
 				var expression = e.Text;
 
 				var vres = frame.ValidateExpression (expression, ops);
@@ -85,15 +85,18 @@ namespace MonoDevelop.Debugger
 			}
 		}	
 
-		static EvaluationOptions GetEvaluationOptions ()
+		static EvaluationOptions GetEvaluationOptions (bool membersPrint)
 		{
-			var ops = EvaluationOptions.DefaultOptions;
-			ops.AllowMethodEvaluation = true;
-			ops.AllowToStringCalls = true;
-			ops.AllowTargetInvoke = true;
+			var ops = DebuggingService.GetUserOptions ().EvaluationOptions;
+			if (!membersPrint) {
+				ops.AllowMethodEvaluation = true;
+				ops.AllowToStringCalls = true;
+				ops.AllowTargetInvoke = true;
+			}
 			ops.EvaluationTimeout = 20000;
 			ops.EllipsizeStrings = false;
 			ops.MemberEvaluationTimeout = 20000;
+			ops.GroupPrivateMembers = false;
 			return ops;
 		}
 
@@ -116,7 +119,7 @@ namespace MonoDevelop.Debugger
 				view.WriteOutput (GetErrorText (val));
 				FinishPrinting ();
 			} else {
-				var ops = GetEvaluationOptions ();
+				var ops = GetEvaluationOptions (true);
 				var children = val.GetAllChildren (ops);
 				var hasMore = false;
 


### PR DESCRIPTION
Bug name says “anymore” suggesting it’s regression, which I think is not true…
Problem was that Immidate pad on purpose ignore disabled implicit evaluation since thats exactly what user invoked, but it also ignored for members which caused unintended effects by users, hence bugs, this is same as VS does it…
Also noticed VS does `ops.GroupPrivateMembers = false;`