### PR TITLE
[DotNetCore] ASP.NET Core projects do not use external console by default

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRunConfiguration.cs
@@ -43,8 +43,9 @@ namespace MonoDevelop.DotNetCore
 		protected override void Initialize (Project project)
 		{
 			base.Initialize (project);
-			ExternalConsole = true;
-			if (project.GetFlavor<DotNetCoreProjectExtension> ()?.IsWeb ?? false && string.IsNullOrEmpty (ApplicationURL)) {
+			bool webProject = project.GetFlavor<DotNetCoreProjectExtension> ()?.IsWeb ?? false;
+			ExternalConsole = !webProject;
+			if (webProject && string.IsNullOrEmpty (ApplicationURL)) {
 				var tcpListner = new TcpListener (IPAddress.Loopback, 0);
 				tcpListner.Start ();
 				ApplicationURL = $"http://localhost:{((IPEndPoint)tcpListner.LocalEndpoint).Port}";


### PR DESCRIPTION
Fixed bug #54316 - ASP.NET Core project - Start debugging and then
stop, it does not close the terminal window
https://bugzilla.xamarin.com/show_bug.cgi?id=54316

New ASP.NET Core projects now do not use an external console by
default. New .NET Core console projects will still use an external
console by default. This makes new ASP.NET Core project's behaviour
the same as the existing ASP.NET projects.