### PR TITLE
[AspNet] Fix MVC project templates after default policy changes

### DIFF
--- a/main/src/addins/AspNet/Templates/AspNetCore/WebApiController.xft.xml
+++ b/main/src/addins/AspNet/Templates/AspNetCore/WebApiController.xft.xml
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
-namespace ${Namespace}.Controllers
+namespace ${RootNamespace}.Controllers
 {
 	[Route("api/[controller]")]
 	public class ${EscapedIdentifier} : Controller

--- a/main/src/addins/AspNet/Templates/Mvc/Controller.xft.xml
+++ b/main/src/addins/AspNet/Templates/Mvc/Controller.xft.xml
@@ -19,7 +19,7 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml">
+		<File name="${Name}.cs">
 <![CDATA[using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/main/src/addins/AspNet/Templates/Mvc/Controller.xft.xml
+++ b/main/src/addins/AspNet/Templates/Mvc/Controller.xft.xml
@@ -27,7 +27,7 @@ using System.Web;
 using System.Web.Mvc;
 using System.Web.Mvc.Ajax;
 
-namespace ${Namespace}.Controllers
+namespace ${RootNamespace}.Controllers
 {
 	public class ${EscapedIdentifier} : Controller
 	{

--- a/main/src/addins/AspNet/Templates/Mvc/WebConfigViews.xft.xml
+++ b/main/src/addins/AspNet/Templates/Mvc/WebConfigViews.xft.xml
@@ -37,7 +37,7 @@
 				<add namespace="System.Web.Mvc.Ajax" />
 				<add namespace="System.Web.Mvc.Html" />
 				<add namespace="System.Web.Routing" />
-				<add namespace="${Namespace}" />
+				<add namespace="${RootNamespace}" />
 			</namespaces>
 		</pages>
 	</system.web.webPages.razor>

--- a/main/src/addins/AspNet/Templates/MvcCommon/HomeController.cs
+++ b/main/src/addins/AspNet/Templates/MvcCommon/HomeController.cs
@@ -5,7 +5,7 @@ using System.Web;
 using System.Web.Mvc;
 using System.Web.Mvc.Ajax;
 
-namespace ${Namespace}.Controllers
+namespace ${RootNamespace}.Controllers
 {
 	public class HomeController : Controller
 	{

--- a/main/src/addins/AspNet/Templates/RouteConfig.cs
+++ b/main/src/addins/AspNet/Templates/RouteConfig.cs
@@ -1,7 +1,7 @@
 ﻿using System.Web.Mvc;
 using System.Web.Routing;
 
-namespace ${Namespace}
+namespace ${RootNamespace}
 {
 	public class RouteConfig
 	{

--- a/main/src/addins/AspNet/Templates/WebApiConfig.cs
+++ b/main/src/addins/AspNet/Templates/WebApiConfig.cs
@@ -1,6 +1,6 @@
 ﻿using System.Web.Http;
 
-namespace ${Namespace}
+namespace ${RootNamespace}
 {
 	public static class WebApiConfig
 	{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplateTagsModifier.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplateTagsModifier.cs
@@ -46,9 +46,13 @@ namespace MonoDevelop.Ide.Templates
 			}
 
 			//need a default namespace or if there is no project, substitutions can get very messed up
-			string ns;
+			string ns = "Application";
+			string rootNamespace = ns;
 			var dotNetFileContainer = project as IDotNetFileContainer;
-			ns = dotNetFileContainer != null ? dotNetFileContainer.GetDefaultNamespace (fileName) : "Application";
+			if (dotNetFileContainer != null) {
+				ns = dotNetFileContainer.GetDefaultNamespace (fileName);
+				rootNamespace = dotNetFileContainer.GetDefaultNamespace (null);
+			}
 
 			//need an 'identifier' for tag substitution, e.g. class name or page name
 			//if not given an identifier, use fileName
@@ -73,6 +77,7 @@ namespace MonoDevelop.Ide.Templates
 			}
 
 			tags ["Namespace"] = ns;
+			tags ["RootNamespace"] = rootNamespace;
 			if (policyParent != null)
 				tags ["SolutionName"] = policyParent.Name;
 			if (project != null) {


### PR DESCRIPTION
Fixed bug #55012 - New ASP.NET projects do not compile
https://bugzilla.xamarin.com/show_bug.cgi?id=55012

The default naming policy was changed for new files so it matches
Visual Studio: f8d5ae2

This change broke the ASP.NET MVC project templates since they expect
the files to have specific namespaces and now no longer compile.
The ASP.NET Project templates now use the RootNamespace instead of
the Namespace property in certain file templates so the expected
namespaces are created. The RootNamespace is the default namespace
used by the project if the file is created in the project's directory
and not in a sub-folder. This also means that the project templates
should now work for any namespace policy configured.