### PR TITLE
[F#] Fix PCL project template

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Templates/PortableLibrary.xpt.xml
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Templates/PortableLibrary.xpt.xml
@@ -35,7 +35,7 @@
 			<References>
 			</References>
       <Packages>
-        <Package Id="FSharp.Core" Version="4.1.0.2" local="true" /> 
+        <Package Id="FSharp.Core" Version="4.1.0.2" />
       </Packages>
 			<Files>
 				<FileTemplateReference TemplateID="FSharpAssemblyInfo" name="AssemblyInfo.fs" />
@@ -47,7 +47,7 @@ type Class1() =
 ]]></UnformattedFile>
 				<UnformattedFile name = "Script.fsx" AddStandardHeader="True">
 				<![CDATA[// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
- for more guidance on F# programming.
+// for more guidance on F# programming.
 
 #load "Component1.fs"
 open ${Namespace}


### PR DESCRIPTION
Creating a new F# PCL project would fail to install the FSharp.Core
NuGet package since some of its dependencies were not available
with the F# addin. Also fixed a compilation error due to an
uncommented line.