### PR TITLE
Add StrongNamer to MonoDevelop.TextTemplating and MonoDevelop.AspNet.

### DIFF
--- a/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
@@ -606,4 +606,5 @@
     <Folder Include="Templates\images\" />
     <Folder Include="WebForms\CSharp\" />
   </ItemGroup>
+  <Import Project="..\..\..\packages\StrongNamer.0.0.3\build\StrongNamer.targets" Condition="Exists('..\..\..\packages\StrongNamer.0.0.3\build\StrongNamer.targets')" />
 </Project>

--- a/main/src/addins/AspNet/packages.config
+++ b/main/src/addins/AspNet/packages.config
@@ -5,4 +5,5 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Mono.TextTemplating" version="1.3.0" targetFramework="net45" />
+  <package id="StrongNamer" version="0.0.3" targetFramework="net45" />
 </packages>

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.csproj
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.csproj
@@ -133,4 +133,5 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\..\packages\StrongNamer.0.0.3\build\StrongNamer.targets" Condition="Exists('..\..\..\..\packages\StrongNamer.0.0.3\build\StrongNamer.targets')" />
 </Project>

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/packages.config
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.TextTemplating" version="1.3.0" targetFramework="net45" />
+  <package id="StrongNamer" version="0.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This way that the reference Mono.TextTemplating.dll is automatically signed when copied to output directory.

This fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=54679 where MonoDevelop crashes with:

Could not load file or assembly 'Mono.TextTemplating, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)