### PR TITLE
Fixed 'Bug 55051 - Save As of a file that is part of a Core project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -515,6 +515,7 @@ namespace MonoDevelop.Ide.Gui
 			TypeSystemService.RemoveSkippedfile (FileName);
 			// do actual save
 			Window.ViewContent.ContentName = filename;
+			Window.ViewContent.Project = Workbench.GetProjectContainingFile (filename);
 			await Window.ViewContent.Save (new FileSaveInformation (filename, encoding));
 			DesktopService.RecentFiles.AddFile (filename, (Project)null);
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -893,7 +893,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		// When looking for the project to which the file belongs, look first
 		// in the active project, then the active solution, and so on
-		static Project GetProjectContainingFile (FilePath fileName)
+		internal static Project GetProjectContainingFile (FilePath fileName)
 		{
 			Project project = null;
 			if (IdeApp.ProjectOperations.CurrentSelectedProject != null) {


### PR DESCRIPTION
breaks IntelliSense'

It was caused by the project wasn't set correctly after save as.