### PR TITLE
[Ide] Allow CustomToolNamespace to be set in project templates

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
@@ -58,6 +58,7 @@ namespace MonoDevelop.Ide.Templates
 		string dependsOn;
 		string buildAction;
 		string customTool;
+		string customToolNamespace;
 		List<string> references = new List<string> ();
 		
 		public override void Load (XmlElement filenode, FilePath baseDirectory)
@@ -68,6 +69,7 @@ namespace MonoDevelop.Ide.Templates
 			defaultExtensionDefined = filenode.Attributes ["DefaultExtension"] != null;
 			dependsOn = filenode.GetAttribute ("DependsOn");
 			customTool = filenode.GetAttribute ("CustomTool");
+			customToolNamespace = filenode.GetAttribute ("CustomToolNamespace");
 			
 			buildAction = BuildAction.Compile;
 			buildAction = filenode.GetAttribute ("BuildAction");
@@ -129,6 +131,11 @@ namespace MonoDevelop.Ide.Templates
 				
 				if (!string.IsNullOrEmpty (customTool))
 					projectFile.Generator = customTool;
+
+				if (!string.IsNullOrEmpty (customToolNamespace)) {
+					var model = CombinedTagModel.GetTagModel (ProjectTagModel, policyParent, project, language, name, generatedFile);
+					projectFile.CustomToolNamespace = StringParserService.Parse (customToolNamespace, model);
+				}
 				
 				DotNetProject netProject = project as DotNetProject;
 				if (netProject != null) {


### PR DESCRIPTION
Project templates can now specify the CustomToolNamespace for files
that are added to a project.

<File
  name="MyRazorView.cshtml"
  src="MyRazorView.cshtml"
  CustomTool="RazorTemplatePreprocessor"
  CustomToolNamespace="${RootNamespace}" />