### PR TITLE
[About] Don't print out machine node name

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/UnixSystemInformation.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/UnixSystemInformation.cs
@@ -31,7 +31,7 @@ namespace MonoDevelop.Core
 	{
 		internal override void AppendOperatingSystem (System.Text.StringBuilder sb)
 		{
-			var psi = new System.Diagnostics.ProcessStartInfo ("uname", "-a") {
+			var psi = new System.Diagnostics.ProcessStartInfo ("uname", "-mrsv") {
 				RedirectStandardOutput = true,
 				UseShellExecute = false,
 			};


### PR DESCRIPTION
Strip out identifying data from the logs. The same as -a but without the network nodename.

Two options that would not appear on Linux because of this would be processor and hardware platform information.