### PR TITLE
Disable TreatWarningsAsErrors in MD.VersionControl.csproj

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{19DE0F35-D204-4FD8-A553-A19ECE05E24D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>MonoDevelop.VersionControl</AssemblyName>
@@ -19,7 +17,6 @@
     <OutputPath>..\..\..\..\build\AddIns\VersionControl\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Execution>
       <Execution clr-version="Net_2_0" />
     </Execution>


### PR DESCRIPTION
 The generated gtk-gui files have warnings in them.