### PR TITLE
Fixed 'Bug 55108 - Undo commented region deletes extra text'

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -956,9 +956,6 @@ namespace Mono.TextEditor
 		/// </summary>
 		public void SetNotDirtyState ()
 		{
-			OptimizeTypedUndo ();
-			if (undoStack.Count > 0 && undoStack.Peek () is KeyboardStackUndo)
-				((KeyboardStackUndo)undoStack.Peek ()).IsClosed = true;
 			savePoint = undoStack.ToArray ();
 			this.CommitUpdateAll ();
 			DiffTracker.SetBaseDocument (CreateDocumentSnapshot ());
@@ -969,7 +966,7 @@ namespace Mono.TextEditor
 			if (undoStack.Count == 0)
 				return;
 			UndoOperation top = undoStack.Pop ();
-			if (top.Changes == null) {
+			if (top.Changes == null || top.Changes.Count > 1) {
 				undoStack.Push (top);
 				return;
 			}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextLinkEditMode.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextLinkEditMode.cs
@@ -275,7 +275,6 @@ namespace Mono.TextEditor
 			if (SelectPrimaryLink)
 				Setlink (firstLink);
 			Editor.Document.CommitUpdateAll ();
-			editor.Document.OptimizeTypedUndo ();
 			this.undoDepth = Editor.Document.GetCurrentUndoDepth ();
 			ShowHelpWindow ();
 		}


### PR DESCRIPTION
The undo stack optimization only works for typing - not for the multi step undos introduced with the vs model.