### PR TITLE
[DotNetCore] Set application output window name

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -238,7 +238,7 @@ namespace MonoDevelop.DotNetCore
 			}
 
 			OperationConsole console = externalConsole ? context.ExternalConsoleFactory.CreateConsole (!pauseConsole, monitor.CancellationToken)
-				: context.ConsoleFactory.CreateConsole (monitor.CancellationToken);
+				: context.ConsoleFactory.CreateConsole (OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (Project.Name), monitor.CancellationToken);
 
 			using (console) {
 				ProcessAsyncOperation asyncOp = context.ExecutionHandler.Execute (executionCommand, console);


### PR DESCRIPTION
When running or debugging a .NET Core project without using the
external console the Application Output window created now has the
project name in its title. This matches the behaviour for .NET
projects.