### PR TITLE
[NuGet] Do not clear package console if action being processed

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundPackageActionRunner.cs
@@ -76,7 +76,7 @@ namespace MonoDevelop.PackageManagement
 
 		public void Run (ProgressMonitorStatusMessage progressMessage, IPackageAction action)
 		{
-			Run (progressMessage, action, clearConsole: true);
+			Run (progressMessage, action, clearConsole: !IsRunning);
 		}
 
 		public void Run (ProgressMonitorStatusMessage progressMessage, IPackageAction action, bool clearConsole)
@@ -86,7 +86,7 @@ namespace MonoDevelop.PackageManagement
 
 		public void Run (ProgressMonitorStatusMessage progressMessage, IEnumerable<IPackageAction> actions)
 		{
-			Run (progressMessage, actions, clearConsole: true);
+			Run (progressMessage, actions, clearConsole: !IsRunning);
 		}
 
 		public void Run (
@@ -117,7 +117,7 @@ namespace MonoDevelop.PackageManagement
 
 		public Task RunAsync (ProgressMonitorStatusMessage progressMessage, IEnumerable<IPackageAction> actions)
 		{
-			return RunAsync (progressMessage, actions, clearConsole: true);
+			return RunAsync (progressMessage, actions, clearConsole: !IsRunning);
 		}
 
 		public Task RunAsync (

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitorFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitorFactory.cs
@@ -29,6 +29,7 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide;
 using MonoDevelop.Core.Execution;
 using MonoDevelop.Ide.Gui.Pads;
+using System;
 using System.Linq;
 
 namespace MonoDevelop.PackageManagement
@@ -73,7 +74,7 @@ namespace MonoDevelop.PackageManagement
 		void ConfigureConsoleClearing (bool clearConsole)
 		{
 			var workbench = (DefaultWorkbench)IdeApp.Workbench.RootWindow;
-			var codon = workbench.PadContentCollection.FirstOrDefault (pad => pad.PadId.Contains ("PackageConsole"));
+			var codon = workbench.PadContentCollection.FirstOrDefault (pad => pad.PadId.StartsWith ("OutputPad-PackageConsole-", StringComparison.Ordinal));
 			if (codon != null) {
 				var pad = codon.PadContent as DefaultMonitorPad;
 				if (pad != null) {


### PR DESCRIPTION
Prevent NuGet package errors being missed if another NuGet background
action is started whilst one is still being run. This was happening
when creating a new Forms project which installs NuGet packages
but also runs a .NET Core project restore. The .NET Core project
restore was clearing the Package Console so the full information
was not available.

Also make the package console pad id check more strict so the
correct pad is found.