### PR TITLE
[Core] use 64bit if 32bit is not preferred/required

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntime.cs
@@ -351,7 +351,7 @@ namespace MonoDevelop.Core.Assemblies
 				monoPath = Path.Combine (MonoRuntimeInfo.Prefix, "bin", "mono32");
 				if (File.Exists (monoPath))
 					return monoPath;
-			} else if ((peKind & IKVM.Reflection.PortableExecutableKinds.PE32Plus) != 0) {
+			} else {
 				monoPath = Path.Combine (MonoRuntimeInfo.Prefix, "bin", "mono64");
 				if (File.Exists (monoPath))
 					return monoPath;


### PR DESCRIPTION
This seems like a saner way of approaching the problem of
'should Xamarin Studio start 64bit or 32bit'. The PE header
has a clear set of values we can base our decision on.
* Is the assembly compiled for x86? Use 32bit
* Is the assembly compiled for x64? Use 64bit
* Is the assembly platform agnostic and prefers 32bit? Use 32bit
* Is the assembly platform agnostic and *does not* prefer 32bit? Use 64bit

This change implements the above logic, which will allow us to easily
choose the correct bitness of the process Xamarin Studio starts by
setting the correct set of flags on our binary.