### PR TITLE
[msbuild] Set `$(VisualStudioVersion)==15.0` in the app.config

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
@@ -38,6 +38,7 @@
 			<property name="MSBuildToolsPath64" value="$(MSBuildBinPath)" />
 			<property name="RoslynTargetsPath" value="$(MSBuildToolsPath)\Roslyn" />
 			<property name="TargetFrameworkRootPathSearchPathsOSX" value="/Library/Frameworks/Mono.framework/External/xbuild-frameworks/" />
+			<property name="VisualStudioVersion" value="15.0" />
 			<projectImportSearchPaths>
 				<searchPaths os="osx">
 					<property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>


### PR DESCRIPTION
VS2017's command prompt sets an environment variable of the same name,
with a comment:

```
@REM Set VisualStudioVersion for compatibility with previous revisions of the
@REM VS Developer Command Prompt.
set "VisualStudioVersion=15.0
```

And the IDE seems to have the property set.

This is required because there might be targets that need to use it
before `Microsoft.Common.props`, which imports
`Microsoft.VisualStudioVersion.v*`, is imported. msbuild/mono has this
this in it's app.config .

This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=54653 by
allowing `Microsoft.Portable.CurrentVersion.props` to be imported.