### PR TITLE
https://bugzilla.xamarin.com/show_bug.cgi?id=53033

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/Dialogs/OpenFileDialogHandler.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/Dialogs/OpenFileDialogHandler.cs
@@ -196,7 +196,7 @@ namespace MonoDevelop.Platform
 
 			foreach (var e in TextEncoding.ConversionEncodings) {
 				combo.Items.Add (new EncodingComboItem (Encoding.GetEncoding (e.CodePage), string.Format ("{0} ({1})", e.Name, e.Id)));
-				if (selectedEncoding != null && e.CodePage == selectedEncoding.WindowsCodePage)
+				if (selectedEncoding != null && e.CodePage == selectedEncoding.CodePage)
 					combo.SelectedIndex = i;
 				i++;
 			}


### PR DESCRIPTION
The windows save-as dialog was not able to select the UTF8 codepage, even when the OpenFileDialogHandler.BuildEncodingsCombo took in the UTF8 encoding. UTF8 and UTF16 have the same WindowsCodePage (1200) which happens to match the UTF16 CodePage but not the UTF8 CodePage (65001)