### PR TITLE
Use correct MSBuild 15.0 location in MSNetTargetRuntime.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MsNetTargetRuntime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MsNetTargetRuntime.cs
@@ -55,7 +55,8 @@ namespace MonoDevelop.Core.Assemblies
 			
 			string programFilesX86 = GetProgramFilesX86 ();
 			newFxDir = programFilesX86 + "\\Reference Assemblies\\Microsoft\\Framework";
-			msbuildDir = programFilesX86 + "\\MSBuild";
+			msbuildDir = GetMSBuildBinPath ("15.0"); // C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin
+			msbuildDir = Path.GetDirectoryName (Path.GetDirectoryName (msbuildDir)); // C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild
 			
 			this.running = running;
 			execHandler = new MsNetExecutionHandler ();


### PR DESCRIPTION
Change the MSNetTargetRuntime to locate MSBuild 15 from the VS 2017 installed location as opposed to Program Files (x86)\MSBuild.