### PR TITLE
Fixed 'Bug 53380 - [Webtools] Editor inserts BOMs sometimes'

### DIFF
--- a/main/src/core/Mono.TextEditor.Platform/Platform/Text/Impl/TextModel/TextDocumentFactoryService.cs
+++ b/main/src/core/Mono.TextEditor.Platform/Platform/Text/Impl/TextModel/TextDocumentFactoryService.cs
@@ -31,9 +31,9 @@ namespace Microsoft.VisualStudio.Text.Implementation
         [Import]
         internal GuardedOperations _guardedOperations { get; set; }
 
-        #endregion
+		#endregion
 
-        internal static Encoding DefaultEncoding = Encoding.Default; // Exposed for unit tests.
+		internal static Encoding DefaultEncoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false); // Exposed for unit tests.
 
         #region ITextDocumentFactoryService Members
 

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -282,11 +282,16 @@ namespace Mono.TextEditor
 				foldedSegments.Remove (e.Node);
 		}
 
-		public TextDocument(string fileName, string mimeType)
+		public TextDocument (string fileName, string mimeType)
 		{
-			var contentType = GetContentTypeFromMimeType(mimeType);
+			var contentType = GetContentTypeFromMimeType (mimeType);
+			Encoding enc;
+			var text = TextFileUtility.GetText (fileName, out enc);
+			var buffer = PlatformCatalog.Instance.TextBufferFactoryService.CreateTextBuffer (text ?? string.Empty,
+			                                                                                 PlatformCatalog.Instance.TextBufferFactoryService.InertContentType);
 
-			this.VsTextDocument = PlatformCatalog.Instance.TextDocumentFactoryService.CreateAndLoadTextDocument(fileName, contentType ?? PlatformCatalog.Instance.ContentTypeRegistryService.UnknownContentType);
+			this.VsTextDocument = PlatformCatalog.Instance.TextDocumentFactoryService.CreateTextDocument (buffer, string.Empty);
+			this.VsTextDocument.Encoding = enc;
 
 			this.Initialize();
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -289,8 +289,8 @@ namespace Mono.TextEditor
 			var text = TextFileUtility.GetText (fileName, out enc);
 			var buffer = PlatformCatalog.Instance.TextBufferFactoryService.CreateTextBuffer (text ?? string.Empty,
 			                                                                                 PlatformCatalog.Instance.TextBufferFactoryService.InertContentType);
-
-			this.VsTextDocument = PlatformCatalog.Instance.TextDocumentFactoryService.CreateTextDocument (buffer, string.Empty);
+			
+			this.VsTextDocument = PlatformCatalog.Instance.TextDocumentFactoryService.CreateTextDocument (buffer, fileName);
 			this.VsTextDocument.Encoding = enc;
 
 			this.Initialize();

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/DocumentTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/DocumentTests.cs
@@ -28,6 +28,8 @@
 
 using System;
 using NUnit.Framework;
+using System.IO;
+using System.Text;
 
 namespace Mono.TextEditor.Tests
 {
@@ -175,6 +177,20 @@ namespace Mono.TextEditor.Tests
 				Assert.AreEqual (i, document.Length);
 				Assert.AreEqual (text, document.Text);
 			}
+		}
+
+		/// <summary>
+		/// Bug 53380 - [Webtools] Editor inserts BOMs sometimes
+		/// </summary>
+		[Test]
+		public void TestBug53380 ()
+		{
+			var path = Path.GetTempFileName ();
+			File.WriteAllText (path, "Hello World", Encoding.ASCII);
+			var document = new TextDocument (path, "text");
+
+			Assert.AreEqual (0, document.Encoding.GetPreamble ().Length);
+			File.Delete (path);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/DocumentTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/DocumentTests.cs
@@ -187,10 +187,13 @@ namespace Mono.TextEditor.Tests
 		{
 			var path = Path.GetTempFileName ();
 			File.WriteAllText (path, "Hello World", Encoding.ASCII);
-			var document = new TextDocument (path, "text");
+			try {
+				var document = new TextDocument (path, "text");
 
-			Assert.AreEqual (0, document.Encoding.GetPreamble ().Length);
-			File.Delete (path);
+				Assert.AreEqual (0, document.Encoding.GetPreamble ().Length);
+			} finally {
+				File.Delete (path);
+			}
 		}
 	}
 }


### PR DESCRIPTION
It's a fairly complex bug to fix. The behavior of VS.NET and XS
clearly differs. VS just uses the system default locale to dertmine
encoding. That's Encoding.Default on mono that's always UTF8 with bom.
So the vs loading routines assume that ascii files are always UTF8+BOM
on mono. Unfortunately we need to be able to consume the locales and
sometimes it clashes with UTF8 - the text file utility contains logic
to prevent these clashes. CP1252 files would be converted to UTF8
otherwise - it's not just a BOM bug - it's more an encoding
detection+incompatibilty bug - mosly caused by a bad design decision
from VS.NET.

Only way to fix that is using the text file utililty logic - it has
work arounded that issue since years.