### PR TITLE
Fix bug #55244 - VS Mac not remembering some code formatting options

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyService.cs
@@ -328,8 +328,12 @@ namespace MonoDevelop.Projects.Policies
 				// Store the set and scope that was used for the diff serialization, if necessary
 				if (usedBaseSet)
 					((DataItem)node).ItemData.Add (new DataValue ("inheritsSet", diffBasePolicySet.Id));
+				else if (keepDeletedNodes)
+					((DataItem)node).ItemData.Add (new DataDeletedNode ("inheritsSet"));
 				if (usedBaseScope)
 					((DataItem)node).ItemData.Add (new DataValue ("inheritsScope", scope));
+				else if (keepDeletedNodes)
+					((DataItem)node).ItemData.Add (new DataDeletedNode ("inheritsScope"));
 				
 			} else {
 				node = raw;


### PR DESCRIPTION
When saving a policy, if a base policy set is not used for diff serialization
make sure the inheritsSet and inheritsScope values are removed from
the project or solution file, if they were previously set.