### PR TITLE
Add default fallback path for Xcode.app

### DIFF
--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -63,7 +63,8 @@ xcode_get_dev_path ()
 	if ((len = readlink ("/var/db/xcode_select_link", (char*) &buf, PATH_MAX)) > 0) {
 		return strndup (buf, len);
 	}
-	return NULL;
+
+	return strdup("/Applications/Xcode.app/Contents/Developer");
 }
 
 static char *


### PR DESCRIPTION
Bug 53324 - Svn is not working on latest version of Xamarin Studio 6.2

cc @mhutch 