### PR TITLE
Fixed 'Bug 55308 - Save as, then open original CSS or HTML file, you

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -232,6 +232,8 @@ namespace MonoDevelop.Ide.Editor
 		{
 			if (!string.IsNullOrEmpty (fileSaveInformation.FileName))
 				AutoSave.RemoveAutoSaveFile (fileSaveInformation.FileName);
+			if (textEditorImpl.ContentName != fileSaveInformation.FileName && !string.IsNullOrEmpty (textEditorImpl.ContentName))
+				AutoSave.RemoveAutoSaveFile (textEditorImpl.ContentName);
 			return textEditorImpl.ViewContent.Save (fileSaveInformation);
 		}
 


### PR DESCRIPTION
get "An Autosave file has been found for this file"'