### PR TITLE
Fixed 'Bug 55298 - Autocomplete () doesn't work'

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/ObjectCreationContextHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/ObjectCreationContextHandler.cs
@@ -92,6 +92,11 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 			SyntaxKind.StringKeyword
 		};
 
+		public override Task<bool> IsExclusiveAsync (CompletionContext completionContext, SyntaxContext syntaxContext, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken)
+		{
+			return Task.FromResult (true);
+		}
+
 		protected async override Task<IEnumerable<CompletionData>> GetItemsWorkerAsync (CompletionResult result, CompletionEngine engine, CompletionContext completionContext, CompletionTriggerInfo info, SyntaxContext ctx, CancellationToken cancellationToken)
 		{
 			var list = new List<CompletionData> ();
@@ -243,7 +248,6 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 
 			return null;
 		}
-
 	}
 }
 


### PR DESCRIPTION
That () completion confusion was caused by a wrong completion item -
in the object creation context only the object creation items should
be shown which handle the parens. That's the same behavior like in
VS.NET where the object creation handler is exclusive too.