### PR TITLE
Fixed 'Bug 55298 - Autocomplete () doesn't work'

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/ObjectCreationContextHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/ObjectCreationContextHandler.cs
@@ -92,11 +92,6 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 			SyntaxKind.StringKeyword
 		};
 
-		public override Task<bool> IsExclusiveAsync (CompletionContext completionContext, SyntaxContext syntaxContext, CompletionTriggerInfo triggerInfo, CancellationToken cancellationToken)
-		{
-			return Task.FromResult (true);
-		}
-
 		protected async override Task<IEnumerable<CompletionData>> GetItemsWorkerAsync (CompletionResult result, CompletionEngine engine, CompletionContext completionContext, CompletionTriggerInfo info, SyntaxContext ctx, CancellationToken cancellationToken)
 		{
 			var list = new List<CompletionData> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionDataList.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionDataList.cs
@@ -191,7 +191,9 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			                  // default - word with highest match rating in the list.
 			int idx = -1;
-
+			if (DefaultCompletionString != null && DefaultCompletionString.StartsWith (partialWord, StringComparison.OrdinalIgnoreCase)) {
+				partialWord = DefaultCompletionString;
+			}
 			StringMatcher matcher = null;
 			if (!string.IsNullOrEmpty (partialWord)) {
 				matcher = CompletionMatcher.CreateCompletionMatcher (partialWord);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionListWindow.cs
@@ -735,9 +735,13 @@ namespace MonoDevelop.Ide.CodeCompletion
 			//sort, sinking obsolete items to the bottoms
 			//the string comparison is ordinal as that makes it an order of magnitude faster, which 
 			//which makes completion triggering noticeably more responsive
-			if (!completionDataList.IsSorted)
-				completionDataList.Sort (ListWidget.GetComparerForCompletionList (completionDataList));
-
+			if (!completionDataList.IsSorted) {
+				try {
+					completionDataList.Sort (ListWidget.GetComparerForCompletionList (completionDataList));
+				} catch (Exception e) {
+					LoggingService.LogWarning ("Can't sort completion list.", e);
+				}
+			}
 			Reposition (true);
 			return true;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ListWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ListWidget.cs
@@ -791,8 +791,10 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			public int Compare (CompletionData a, CompletionData b)
 			{
+				if (a == b)
+					return 0;
 				if (a is IComparable && b is IComparable)
-					return ((IComparable)a).CompareTo (b);
+						return ((IComparable)a).CompareTo (b);
 				return CompletionData.Compare (a, b);
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateService.cs
@@ -95,7 +95,14 @@ namespace MonoDevelop.Ide.CodeTemplates
 			var savedTemplates = templates;
 			if (savedTemplates == null || string.IsNullOrEmpty (mimeType))
 				return new CodeTemplate [0];
-			return savedTemplates.ToArray ().Where (t => t != null && DesktopService.GetMimeTypeIsSubtype (mimeType, t.MimeType));
+			return savedTemplates.ToArray ().Where (delegate (CodeTemplate t) {
+				try {
+					return t != null && DesktopService.GetMimeTypeIsSubtype (mimeType, t.MimeType);
+				} catch (Exception) {
+					// required for some unit tests
+					return t != null && mimeType == t.MimeType;
+				}	
+			});
 		}
 
 		public static async Task<IEnumerable<CodeTemplate>> GetCodeTemplatesAsync (TextEditor editor, CancellationToken cancellationToken = default(CancellationToken))

--- a/main/tests/UnitTests/MonoDevelop.Ide.Gui/CompletionListWindowTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Gui/CompletionListWindowTests.cs
@@ -998,5 +998,20 @@ namespace MonoDevelop.Ide.Gui
 			string output = RunSimulation ("", "String(\t", true, true, false, "StringBuilder()", "FooBar");
 			Assert.AreEqual ("StringBuilder()", output);
 		}
+
+
+		/// <summary>
+		/// Bug 55298 - Autocomplete () doesn't work
+		/// </summary>
+		[Test]
+		public void TestBug55298 ()
+		{
+			string output = RunSimulation (new SimulationSettings () {
+				DefaultCompletionString ="Random()",
+				SimulatedInput = "Ran\t",
+				CompletionData = new string [] { "Random", "Random()" }
+			});
+			Assert.AreEqual ("Random()", output);
+		}
 	}
 }


### PR DESCRIPTION
Different approach to solve the problem - now the constructor is
preselected. Unfortunately it's not possible to do the former approach
- there are some use cases for a bigger list. Analyzing these cases is
IMO not 100% possible - that patch allows fluent typing flow.