### PR TITLE
Update default target framework

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
@@ -246,6 +246,14 @@ namespace MonoDevelop.Core.Assemblies
 			get { return new TargetFrameworkMoniker ("4.5"); }
 		}
 
+		public static TargetFrameworkMoniker NET_4_6 {
+			get { return new TargetFrameworkMoniker ("4.6"); }
+		}
+
+		public static TargetFrameworkMoniker NET_4_6_1 {
+			get { return new TargetFrameworkMoniker ("4.6.1"); }
+		}
+
 		public static TargetFrameworkMoniker NET_4_6_2 {
 			get { return new TargetFrameworkMoniker ("4.6.2"); }
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Projects
 		TargetFramework defaultTargetFramework;
 		
 		string defaultPlatformTarget = "x86";
-		static readonly TargetFrameworkMoniker DefaultTargetFrameworkId = TargetFrameworkMoniker.NET_4_6_2;
+		static readonly TargetFrameworkMoniker DefaultTargetFrameworkId = TargetFrameworkMoniker.NET_4_6_1;
 		
 		public const string BuildTarget = "Build";
 		public const string CleanTarget = "Clean";


### PR DESCRIPTION
Use .NET 4.6.1 as default target framework for new projects, since
4.6.2 is not installed by default on Windows.

Fixes bug #55346 - MonoDevelop on Windows relies on 4.6.2 targeting
pack for standalone C# files