### PR TITLE
[Loc] Allow native file dialogs to be localized using the locale

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -263,5 +263,22 @@
 	</array>
 	<key>Mono64Bit</key>
 	<true/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>cs</string>
+		<string>de</string>
+		<string>es</string>
+		<string>en</string>
+		<string>fr</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>ko</string>
+		<string>pl</string>
+		<string>pt_BR</string>
+		<string>ru</string>
+		<string>tr</string>
+		<string>zh_TW</string>
+		<string>zh_CN</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Unless we explicitly set these keys, NSOpenPanel and NSSavePanel do not get localized.

ಠ_ಠ cocoa