### PR TITLE
[DONT_MERGE][msbuild] Handle tasks with Microsoft.Build.{Tasks,Utilities}.{v4.0/v…

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -1275,6 +1275,37 @@ namespace MonoDevelop.Projects.MSBuild
 					}
 				}
 
+				// Mono has Microsoft.Build.{Tasks,Utilities}.{v4.0,v12.0} assemlies, which are xbuild's
+				// implementation, installed in the GAC.
+				//
+				// With msbuild, we want to use the facade assemblies of the same name, installed with
+				// msbuild, which redirect to the corresponding .Core assemblies.
+				//
+				// We have an AssemblyResolve event handler which resolves some msbuild assemblies from
+				// the correct path. But that is fired only if the runtime fails to resolve the assembly, which
+				// happens when, for example, MSBuild.dll is requesting Microsoft.Build, 15.1.0.0 .
+				//
+				// But for the v4.0/v12.0 assemblies, the runtime is able to resolve them from the GAC and
+				// so the event handler never gets fired.
+				//
+				// To ensure that msbuild is able to load the facade assemblies, we copy them over next to
+				// the builder. This is temporary though. It can be removed when xbuild is removed from mono,
+				// and we can put these in the proper locations in mono (GAC/facades?).
+				//
+				if (Platform.IsMac || Platform.IsLinux) {
+					var assemblies = new string[] {
+								"Microsoft.Build.Tasks.v4.0.dll",
+								"Microsoft.Build.Utilities.v4.0.dll",
+								"Microsoft.Build.Tasks.v12.0.dll",
+								"Microsoft.Build.Utilities.v12.0.dll" };
+
+					foreach (var asm in assemblies) {
+						var dest = Path.Combine (exesDir, asm);
+						if (File.Exists (dest))
+							File.Copy (Path.Combine(binDir, asm), dest);
+					}
+				}
+
 				searchPathConfigNeedsUpdate = true;
 			}
 


### PR DESCRIPTION
…12.0} references

If a project is using an msbuild task built against the v4.0/v12.0
assemblies, then Mono would load the xbuild implementations from GAC.
But when building with msbuild, we want to use the newer .Core
assemblies from msbuild. For facilitating that, msbuild now has facade
assemblies for v4.0/v12.0 installed in msbuild's bin directory. But XS
still resolves them GAC.

- This can cause issues, for example, the target tries to use property of the
task which was missing in xbuild's implementation (Eg.
`ToolTask.StandardErrorImportance`), then we get errors like (bxc#54981):

```
The "StandardErrorImportance" parameter is not supported by the "Exec" task. Verify the parameter exists on the task, and it is a settable public instance property.
```

- Or build getting stuck due to an exception in msbuild (bxc#55255):

```
System.Runtime.Remoting.RemotingException: Cannot resolve method Xamarin.Forms.Build.Tasks.XamlCTask:set_BuildEngine

Server stack trace:
  at System.Runtime.Remoting.RemotingServices.InternalExecuteMessage (System.MarshalByRefObject target, System.Runtime.Remoting.Messaging.IMethodCallMessage reqMsg) [0x00181] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting/RemotingServices.cs:180
  at System.Runtime.Remoting.Messaging.StackBuilderSink.SyncProcessMessage (System.Runtime.Remoting.Messaging.IMessage msg) [0x0001c] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting.Messaging/StackBuilderSink.cs:59
  at System.Runtime.Remoting.Messaging.ServerObjectTerminatorSink.SyncProcessMessage (System.Runtime.Remoting.Messaging.IMessage msg) [0x00016] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting.Messaging/ServerObjectTerminatorSink.cs:53
  at System.Runtime.Remoting.Lifetime.LeaseSink.SyncProcessMessage (System.Runtime.Remoting.Messaging.IMessage msg) [0x00007] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting.Lifetime/LeaseSink.cs:52
  at System.Runtime.Remoting.ClientActivatedIdentity.SyncObjectProcessMessage (System.Runtime.Remoting.Messaging.IMessage msg) [0x00035] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting/ServerIdentity.cs:191
  at System.Runtime.Remoting.Messaging.ServerContextTerminatorSink.SyncProcessMessage (System.Runtime.Remoting.Messaging.IMessage msg) [0x0001f] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting.Messaging/ServerContextTerminatorSink.cs:50
  at System.Runtime.Remoting.Contexts.CrossContextChannel.SyncProcessMessage (System.Runtime.Remoting.Messaging.IMessage msg) [0x0003f] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Runtime.Remoting.Contexts/CrossContextChannel.cs:57
Exception rethrown at [0]:
  at (wrapper managed-to-native) System.Object:__icall_wrapper_mono_remoting_wrapper (intptr,intptr)
  at (wrapper remoting-invoke) Microsoft.Build.Utilities.AppDomainIsolatedTask:set_BuildEngine (Microsoft.Build.Framework.IBuildEngine)
  at (wrapper xdomain-invoke) Microsoft.Build.Utilities.AppDomainIsolatedTask:set_BuildEngine (Microsoft.Build.Framework.IBuildEngine)
  at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.InitializeForBatch (Microsoft.Build.BackEnd.Logging.TaskLoggingContext loggingContext, Microsoft.Build.BackEnd.ItemBucket batchBucket, System.Collections.Generic.IDictionary`2[TKey,TValue] taskIdentityParameters) [0x000a2] in /Users/ankit/dev/msbuild/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs:369                                                                                                                                                                                                                                         at Microsoft.Build.BackEnd.TaskBuilder+<InitializeAndExecuteTask>d__24.MoveNext () [0x00012] in /Users/ankit/dev/msbuild/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs:680
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:151
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x00037] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:187
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:156                                                                                                                                                                                                                                                                                                                           at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in /private/tmp/source-mono-2017-02/bockbuild-2017-02/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:128
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <164469fa6d844a078126fd8006807335>:0
  at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteBucket>d__19.MoveNext () [0x00372] in /Users/ankit/dev/msbuild/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs:459
```

Cause:

Mono has Microsoft.Build.{Tasks,Utilities}.{v4.0,v12.0} assemlies, which are xbuild's
implementation, installed in the GAC.

With msbuild, we want to use the facade assemblies of the same name, installed with
msbuild, which redirect to the corresponding .Core assemblies.

We have an AssemblyResolve event handler which resolves some msbuild assemblies from
the correct path. But that is fired only if the runtime fails to resolve the assembly, which
happens when, for example, MSBuild.dll is requesting Microsoft.Build, 15.1.0.0 .

But for the v4.0/v12.0 assemblies, the runtime is able to resolve them from the GAC and
so the event handler never gets fired.

Solution:

To ensure that msbuild is able to load the facade assemblies, we copy them over next to
the builder. This is temporary though. It can be removed when xbuild is removed from mono,
and we can put these in the proper locations in mono (GAC/facades?).

Note: This is not an issue when using msbuild from command line, as the facade assemblies are
      located next to the main assembly (MSBuild.dll) .

Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=55255
       https://bugzilla.xamarin.com/show_bug.cgi?id=54981 (fixes the reported issue)