### PR TITLE
Fix potential msbuild failure

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -157,7 +157,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 
 			var projectDir = Path.GetDirectoryName (file);
-			if (!string.IsNullOrEmpty (projectDir))
+			if (!string.IsNullOrEmpty (projectDir) && Directory.Exists (projectDir))
 				Environment.CurrentDirectory = projectDir;
 			return project;
 		}
@@ -178,7 +178,7 @@ namespace MonoDevelop.Projects.MSBuild
 				if (content == null)
 					p = engine.LoadProject (file);
 				else {
-					if (!string.IsNullOrEmpty (projectDir))
+					if (!string.IsNullOrEmpty (projectDir) && Directory.Exists (projectDir))
 						Environment.CurrentDirectory = projectDir;
 					var projectRootElement = ProjectRootElement.Create (new XmlTextReader (new StringReader (content)));
 					projectRootElement.FullPath = file;


### PR DESCRIPTION
Avoid unhandled exception when trying to build a project that has been
deleted after being loaded in the project builder.