### PR TITLE
Fix builder crash

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
@@ -557,9 +557,9 @@ namespace MonoDevelop.Core.Execution
 		void ProcessResponse (BinaryMessage msg)
 		{
 			DateTime respTime = DateTime.Now;
+			MessageRequest req;
 
 			lock (messageWaiters) {
-				MessageRequest req;
 				if (messageWaiters.TryGetValue (msg.Id, out req)) {
 					messageWaiters.Remove (msg.Id);
 					try {
@@ -578,12 +578,15 @@ namespace MonoDevelop.Core.Execution
 						LogMessage (MessageType.Response, msg, time);
 					}
 
-					if (!req.Request.OneWay)
-						NotifyResponse (req, msg);
-				}
-				else if (DebugMode)
+				} else if (DebugMode) {
+					req = null;
 					LogMessage (MessageType.Response, msg, -1);
+				}
 			}
+
+			// Notify the response outside the lock to avoid deadlocks
+			if (req != null && !req.Request.OneWay)
+				NotifyResponse (req, msg);
 		}
 
 		void NotifyResponse (MessageRequest req, BinaryMessage res)

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/BuildEngine.Shared.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/BuildEngine.Shared.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // ProjectBuilder.cs
 //  
 // Author:
@@ -43,7 +43,7 @@ namespace MonoDevelop.Projects.MSBuild
 {
 	partial class BuildEngine
 	{
-		static readonly AutoResetEvent workDoneEvent = new AutoResetEvent (false);
+		static AutoResetEvent workDoneEvent;
 		static ThreadStart workDelegate;
 		static readonly object workLock = new object ();
 		static Thread workThread;
@@ -266,13 +266,18 @@ namespace MonoDevelop.Projects.MSBuild
 			lock (workLock) {
 				if (IsTaskCancelled (taskId))
 					return;
+
+				AutoResetEvent doneEvent;
+
 				lock (threadLock) {
 					// Last chance to check for canceled task before the thread is started
 					if (IsTaskCancelled (taskId))
 						return;
-					
+
+					doneEvent = workDoneEvent = new AutoResetEvent (false);
 					workDelegate = ts;
 					workError = null;
+
 					if (workThread == null) {
 						workThread = new Thread (STARunner);
 						workThread.SetApartmentState (ApartmentState.STA);
@@ -290,7 +295,7 @@ namespace MonoDevelop.Projects.MSBuild
 					return;
 				}
 
-				workDoneEvent.WaitOne ();
+				doneEvent.WaitOne ();
 
 				ResetCurrentTask ();
 			}
@@ -307,19 +312,28 @@ namespace MonoDevelop.Projects.MSBuild
 		
 		static void STARunner ()
 		{
-			lock (threadLock) {
-				do {
-					try {
-						workDelegate ();
+			try {
+				lock (threadLock) {
+					do {
+						var doneEvent = workDoneEvent;
+						try {
+							workDelegate ();
+						} catch (ThreadAbortException) {
+							// Gracefully stop the thread
+							Thread.ResetAbort ();
+							return;
+						} catch (Exception ex) {
+							workError = ex;
+						}
+						doneEvent.Set ();
 					}
-					catch (Exception ex) {
-						workError = ex;
-					}
-					workDoneEvent.Set ();
+					while (Monitor.Wait (threadLock, 60000));
+
+					workThread = null;
 				}
-				while (Monitor.Wait (threadLock, 60000));
-				
-				workThread = null;
+			} catch (ThreadAbortException) {
+				// Gracefully stop the thread
+				Thread.ResetAbort ();
 			}
 		}
 	}


### PR DESCRIPTION
Fix race in project builder.
Don't reuse the workDoneEvent event anymore. In some cases it may
happen that the event is signaled twice (once when the work is
finished, and maybe once if the work is aborted just after it
finished. In those cases the second time the event is signaled it
could actually signal that the next task has been completed, which is
wrong. Also improve handling of thread abort exceptions, those
exceptions should never generate an error.
Should fix bug #52645 - XS cannot recover if the external MSBuild
builder dies

Fix deadlock in RemoteProcessConnection.
When processing a message response, the response should be notified
outside the messageWaiters lock, otherwise it may deadlock if the task
that handles the response is blocked in another lock.