### PR TITLE
[Core] Smarter import evaluation

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionFunctionExpression.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionFunctionExpression.cs
@@ -104,11 +104,13 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 
 			file = MSBuildProjectService.FromMSBuildPath (directory, file);
 			bool res;
-			if (context.ExistsEvaluationCache.TryGetValue (file, out res))
-				return res;
-			
-			res = File.Exists (file) || Directory.Exists (file);
-			context.ExistsEvaluationCache [file] = res;
+			lock (context.ExistsEvaluationCache) {
+				if (context.ExistsEvaluationCache.TryGetValue (file, out res))
+					return res;
+
+				res = File.Exists (file) || Directory.Exists (file);
+				context.ExistsEvaluationCache[file] = res;
+			}
 			return res;
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -74,6 +74,7 @@ namespace MonoDevelop.Projects.MSBuild
 			this.project = parentContext.project;
 			this.propertiesWithTransforms = parentContext.propertiesWithTransforms;
 			this.propertiesWithTransformsSorted = parentContext.propertiesWithTransformsSorted;
+			this.ExistsEvaluationCache = parentContext.ExistsEvaluationCache;
 		}
 
 		internal void InitEvaluation (MSBuildProject project)


### PR DESCRIPTION
This commit introduces the inheritance of the file existence cache at
MSBuildEvaluationContext level.

By inheriting the parent exists evaluation cache, we end up doing less
IO on grabbing Condition='Exists(x)'.

The lock on the evaluation cache introduces an extra 300ms locking
contention, but Evaluate(ProjectInfo, MSBuildEvaluationCache,
MSBuildImport, bool) ends having a total lock contention time reduced by
3000ms. (8900ms -> 5612ms)

Time spent in the above method is reduced from 57639ms to 48601ms.