### PR TITLE
Fixed 'Bug 55459 - Undo doesn't bring files back to unmodified status'

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -349,7 +349,9 @@ namespace MonoDevelop.SourceEditor
 		void HandleEndUndo (object sender, TextDocument.UndoOperationEventArgs e)
 		{
 			OnEndUndo (EventArgs.Empty);
+			IsDirty = Document.IsDirty;
 		}
+
 
 		void HandleBeginUndo (object sender, EventArgs e)
 		{

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -922,7 +922,7 @@ namespace Mono.TextEditor
 					return true;
 				if (savePoint == null)
 					return CanUndo;
-				if (undoStack.Count != savePoint.Length) 
+				if (undoStack.Count != savePoint.Length)
 					return true;
 				UndoOperation[] currentStack = undoStack.ToArray ();
 				for (int i = 0; i < currentStack.Length; i++) {
@@ -1160,18 +1160,20 @@ namespace Mono.TextEditor
 			Debug.Assert (atomicUndoLevel >= 0); 
 			
 			if (atomicUndoLevel == 0 && currentAtomicOperation != null) {
-				if (currentAtomicOperation.Operations.Count > 1) {
-					undoStack.Push (currentAtomicOperation);
-					OnEndUndo (new UndoOperationEventArgs (currentAtomicOperation));
+				var cuao = currentAtomicOperation;
+				currentAtomicOperation = null;
+
+				if (cuao.Operations.Count > 1) {
+					undoStack.Push (cuao);
+					OnEndUndo (new UndoOperationEventArgs (cuao));
 				} else {
-					if (currentAtomicOperation.Operations.Count > 0) {
-						undoStack.Push (currentAtomicOperation.Operations [0]);
-						OnEndUndo (new UndoOperationEventArgs (currentAtomicOperation.Operations [0]));
+					if (cuao.Operations.Count > 0) {
+						undoStack.Push (cuao.Operations [0]);
+						OnEndUndo (new UndoOperationEventArgs (cuao.Operations [0]));
 					} else {
 						OnEndUndo (null);
 					}
 				}
-				currentAtomicOperation = null;
 			}
 			currentAtomicUndoOperationType.Pop ();
 		}

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorDataTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorDataTests.cs
@@ -53,5 +53,20 @@ namespace Mono.TextEditor.Tests
 			data.Replace (0, data.Length, "\t");
 			Assert.AreEqual ("    ", data.Text);
 		}
+
+		/// <summary>
+		/// Bug 55459 - Undo doesn't bring files back to unmodified status (edit)
+		/// </summary>
+		[Test]
+		public void TestBug55459 ()
+		{
+			var data = new TextEditorData ();
+			data.InsertAtCaret ("a");
+			Assert.AreEqual (true, data.Document.IsDirty);
+			data.Document.EndUndo += delegate {
+				Assert.AreEqual (false, data.Document.IsDirty);
+			};
+			data.Document.Undo ();
+		}
  	}
 }


### PR DESCRIPTION
Dirty state after undo needs to be checked. Seems to be caused by
event order changes in the vs text editor. Redo dirty checkworks btw.
This fixes a little bug in the dirty state of the enduno event as
well.