### PR TITLE
[msbuild] Fix v4/v12 assemblies use with older mono

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/Main.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild.Shared/Main.cs
@@ -76,11 +76,7 @@ namespace MonoDevelop.Projects.MSBuild
 							"Microsoft.Build.Framework",
 							"Microsoft.Build.Tasks.Core",
 							"Microsoft.Build.Utilities.Core",
-							"System.Reflection.Metadata",
-							"Microsoft.Build.Tasks.v4.0",
-							"Microsoft.Build.Utilities.v4.0",
-							"Microsoft.Build.Tasks.v12.0",
-							"Microsoft.Build.Utilities.v12.0" };
+							"System.Reflection.Metadata"};
 
 				var asmName = new AssemblyName (args.Name);
 				if (!msbuildAssemblies.Any (n => string.Compare (n, asmName.Name, StringComparison.OrdinalIgnoreCase) == 0))

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
@@ -28,26 +28,6 @@
 				<assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
-
-			<!-- Redirect Microsoft.Build.{Tasks,Utilities}.{v4.0,v12.0} to 4.1.0.0/12.1.0.0 to avoid resolving from the GAC and instead use the Facades -->
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Build.Tasks.v4.0" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="4.0.0.0" newVersion="4.1.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Build.Utilities.v4.0" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="4.0.0.0" newVersion="4.1.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Build.Tasks.v12.0" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="12.0.0.0" newVersion="12.1.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Build.Utilities.v12.0" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="12.0.0.0" newVersion="12.1.0.0" />
-			</dependentAssembly>
-
 		</assemblyBinding>
 	</runtime>
 	<msbuildToolsets default="15.0">


### PR DESCRIPTION
This switches to local copying the facade assemblies instead of using binding redirects,
to work with older mono.