### PR TITLE
[Ide] New project dialog not displayed when modified file saved

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -358,7 +358,7 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
-		internal bool SaveAllDirtyFiles ()
+		internal async Task<bool> SaveAllDirtyFiles ()
 		{
 			Document[] docs = Documents.Where (doc => doc.IsDirty && doc.Window.ViewContent != null).ToArray ();
 			if (!docs.Any ())
@@ -369,7 +369,7 @@ namespace MonoDevelop.Ide.Gui
 				if (result == AlertButton.Cancel)
 					return false;
 
-				doc.Save ();
+				await doc.Save ();
 				if (doc.IsDirty) {
 					doc.Select ();
 					return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -712,9 +712,9 @@ namespace MonoDevelop.Ide
 			NewSolution (defaultTemplate, true);
 		}
 
-		public void NewSolution (string defaultTemplate, bool showTemplateSelection)
+		public async void NewSolution (string defaultTemplate, bool showTemplateSelection)
 		{
-			if (!IdeApp.Workbench.SaveAllDirtyFiles ())
+			if (!await IdeApp.Workbench.SaveAllDirtyFiles ())
 				return;
 
 			var newProjectDialog = new NewProjectDialogController ();


### PR DESCRIPTION
Fixed bug #55457 - Issue when trying to create a new project while a
file has changes
https://bugzilla.xamarin.com/show_bug.cgi?id=55457

With a file modified and open in the text editor, selecting New
Solution shows a dialog asking to save the modified file. Clicking the
Save button would then not open the New Project dialog. The problem
was that the Document.Save method returns a task and the code
was checking the Document's IsDirty property before the save
completed which prevented the New Project dialog from being opened.