### PR TITLE
Fixed 'Bug 55462 - Syntax highlighting breaks after using literal

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/syntaxes/CSharp/C#.sublime-syntax
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/syntaxes/CSharp/C#.sublime-syntax
@@ -96,7 +96,7 @@ contexts:
       push:
         - match: '""'
           scope: constant.character.interpolated.verbatim.escape.source.cs
-        - match: '")'
+        - match: '"'
           pop: true
         - match: '({)'
           captures:

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -32,7 +32,6 @@ using System.Text;
 
 namespace Mono.TextEditor.Tests
 {
-	[Ignore("Redo")]
 	[TestFixture]
 	class SyntaxHighlightingTests : TextEditorTestBase
 	{
@@ -50,7 +49,9 @@ namespace Mono.TextEditor.Tests
 		public static string GetMarkup (string input, string syntaxMode)
 		{
 			var data = new TextEditorData (new TextDocument (input));
-			//data.Document.SyntaxMode = SyntaxModeService.GetSyntaxMode (data.Document, syntaxMode);
+			data.Options.EditorThemeName = EditorTheme.DefaultDarkThemeName;
+				
+			data.Document.MimeType = syntaxMode;
 			//data.ColorStyle = SyntaxModeService.GetColorStyle ("Light");
 			return data.GetMarkup (0, data.Length, false);
 		}
@@ -71,28 +72,28 @@ namespace Mono.TextEditor.Tests
 		public void TestSpans ()
 		{
 			TestOutput ("/* TestMe */",
-			            "<span foreground=\"#888A85\">/* TestMe */</span>");
+			            "<span foreground=\"#888a85\">/* TestMe */</span>");
 		}
 		
 		[Test]
 		public void TestStringEscapes ()
 		{
 			TestOutput ("\"Escape:\\\" \"outtext",
-			            "<span foreground=\"#DB7100\">\"Escape:</span><span foreground=\"#A53E00\">\\\"</span><span foreground=\"#DB7100\"> \"</span><span foreground=\"#222222\">outtext</span>");
+			            "<span foreground=\"#e5da73\">\"Escape:</span><span foreground=\"#8ae232\">\\\"</span><span foreground=\"#e5da73\"> \"</span><span foreground=\"#eeeeec\">outtext</span>");
 		}
 		
 		[Test]
 		public void TestVerbatimStringEscapes ()
 		{
 			TestOutput ("@\"Escape:\"\" \"outtext",
-			            "<span foreground=\"#DB7100\">@\"Escape:</span><span foreground=\"#A53E00\">\"\"</span><span foreground=\"#DB7100\"> \"</span><span foreground=\"#222222\">outtext</span>");
+			            "<span foreground=\"#e5da73\">@\"Escape:</span><span foreground=\"#8ae232\">\"\"</span><span foreground=\"#e5da73\"> \"</span><span foreground=\"#eeeeec\">outtext</span>");
 		}
 
 		[Test]
 		public void TestDoubleVerbatimStringEscapes ()
 		{
 			TestOutput ("@\"Escape:\"\"\"\" \"outtext",
-			            "<span foreground=\"#DB7100\">@\"Escape:</span><span foreground=\"#A53E00\">\"\"\"\"</span><span foreground=\"#DB7100\"> \"</span><span foreground=\"#222222\">outtext</span>");
+			            "<span foreground=\"#e5da73\">@\"Escape:</span><span foreground=\"#8ae232\">\"\"\"\"</span><span foreground=\"#e5da73\"> \"</span><span foreground=\"#eeeeec\">outtext</span>");
 		}
 
 		[Test]
@@ -107,21 +108,21 @@ namespace Mono.TextEditor.Tests
 		public void TestHexDigit ()
 		{
 			TestOutput ("0x12345679AFFEuL",
-			            "<span foreground=\"#DB7100\">0x12345679AFFEuL</span>");
+			            "<span foreground=\"#8ae232\">0x12345679AFFEuL</span>");
 		}
 		
 		[Test]
 		public void TestDoubleDigit ()
 		{
 			TestOutput ("123.45678e-09d",
-			            "<span foreground=\"#DB7100\">123.45678e-09d</span>");
+			            "<span foreground=\"#8ae232\">123.45678e-09d</span>");
 		}
 		
 		[Test]
 		public void TestCDATASection ()
 		{
 			TestOutput ("<![CDATA[ test]]>",
-			            "<span foreground=\"#222222\">&lt;![CDATA[ test]]&gt;</span>",
+			            "<span foreground=\"#e5da73\">&lt;![CDATA[ test]]&gt;</span>",
 			            "application/xml");
 		}
 		
@@ -133,7 +134,7 @@ namespace Mono.TextEditor.Tests
 		public void TestBug603 ()
 		{
 			TestOutput ("///<summary>foo bar</summary>",
-			            "<span foreground=\"#C8B97B\">///&lt;summary&gt;</span><span foreground=\"#97B488\">foo bar</span><span foreground=\"#C8B97B\">&lt;/summary&gt;</span>");
+			            "<span foreground=\"#888a85\">///&lt;summary&gt;foo bar&lt;/summary&gt;</span>");
 		}
 
 		[Test]
@@ -141,7 +142,7 @@ namespace Mono.TextEditor.Tests
 		{
 			TestOutput (
 				"\n\n\nlet x = 2",
-				"<span foreground=\"#009695\">let</span><span foreground=\"#222222\"> x = </span><span foreground=\"#DB7100\">2</span>",
+				"<span foreground=\"#719dcf\">let</span><span foreground=\"#eeeeec\"> x = </span><span foreground=\"#8ae232\">2</span>",
 				"text/x-fsharp");
 		}
 
@@ -165,5 +166,16 @@ namespace Mono.TextEditor.Tests
 				sb.Append (data.GetTextAt (chunk));
 			Assert.AreEqual (text, sb.ToString ());
 		}
+
+		/// <summary>
+		/// Bug 55462 - Syntax highlighting breaks after using literal string with "$@" prefix
+		/// </summary>
+		[Test]
+		public void Test55462 ()
+		{
+			TestOutput ("$@\"test\" // test",
+			  			"<span foreground=\"#e5da73\">$@\"test\"</span><span foreground=\"#eeeeec\"> </span><span foreground=\"#888a85\">// test</span>");
+		}
+
 	}
 }


### PR DESCRIPTION
string with "$@" prefix '

Was just a simple typo in the syntax files - hower it's now part of
the unit test suite.