### PR TITLE
Fixed 'Bug 55456 - Incorrect behavior and exception when trying to

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -310,7 +310,8 @@ namespace MonoDevelop.SourceEditor
 
 		protected override void OnContentNameChanged ()
 		{
-			Document.FileName = ContentName;
+			if (!string.IsNullOrEmpty (ContentName))
+				Document.FileName = ContentName;
 			UpdateMimeType (Document.FileName);
 			if (!String.IsNullOrEmpty (ContentName) && File.Exists (ContentName))
 				lastSaveTimeUtc = File.GetLastWriteTimeUtc (ContentName);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -666,14 +666,14 @@ namespace MonoDevelop.Ide.Gui
 					var views = new ViewContent [viewContentCollection.Count];
 					viewContentCollection.CopyTo (views, 0);
 					foreach (var content in views) {
-						if (content.ContentName.StartsWith (e.SourceFile, FilePath.PathComparison)) {
+						if (e.SourceFile.IsChildPathOf (content.ContentName)) {
 							content.ContentName = e.TargetFile + content.ContentName.Substring (e.SourceFile.ToString ().Length);
 						}
 					}
 				} else {
 					foreach (var content in viewContentCollection) {
 						if (content.ContentName != null &&
-						    FilePath.PathComparer.Compare (content.ContentName, e.SourceFile) == 0) {
+						    content.ContentName == e.SourceFile) {
 							content.ContentName = e.TargetFile;
 							return;
 						}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -273,7 +273,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			// FIXME: GTKize
 			IdeApp.ProjectOperations.CurrentProjectChanged += (s,a) => SetWorkbenchTitle ();
-
+			FileService.FileMoved   += CheckFileMoved;
 			FileService.FileRemoved += CheckRemovedFile;
 			FileService.FileRenamed += CheckRenamedFile;
 			
@@ -658,7 +658,30 @@ namespace MonoDevelop.Ide.Gui
 				Decorated = true;
 			}
 		}
-		
+
+		void CheckFileMoved (object sender, FileCopyEventArgs args)
+		{
+			foreach (var e in args) {
+				if (e.IsDirectory) {
+					var views = new ViewContent [viewContentCollection.Count];
+					viewContentCollection.CopyTo (views, 0);
+					foreach (var content in views) {
+						if (content.ContentName.StartsWith (e.SourceFile, StringComparison.CurrentCulture)) {
+							content.ContentName = e.TargetFile + content.ContentName.Substring (e.SourceFile.ToString ().Length);
+						}
+					}
+				} else {
+					foreach (var content in viewContentCollection) {
+						if (content.ContentName != null &&
+						    content.ContentName == e.SourceFile) {
+							content.ContentName = e.TargetFile;
+							return;
+						}
+					}
+				}
+			}
+		}
+
 		void CheckRemovedFile (object sender, FileEventArgs args)
 		{
 			foreach (var e in args) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -666,14 +666,14 @@ namespace MonoDevelop.Ide.Gui
 					var views = new ViewContent [viewContentCollection.Count];
 					viewContentCollection.CopyTo (views, 0);
 					foreach (var content in views) {
-						if (content.ContentName.StartsWith (e.SourceFile, StringComparison.CurrentCulture)) {
+						if (content.ContentName.StartsWith (e.SourceFile, FilePath.PathComparison)) {
 							content.ContentName = e.TargetFile + content.ContentName.Substring (e.SourceFile.ToString ().Length);
 						}
 					}
 				} else {
 					foreach (var content in viewContentCollection) {
 						if (content.ContentName != null &&
-						    content.ContentName == e.SourceFile) {
+						    FilePath.PathComparer.Compare (content.ContentName, e.SourceFile) == 0) {
 							content.ContentName = e.TargetFile;
 							return;
 						}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -666,7 +666,7 @@ namespace MonoDevelop.Ide.Gui
 					var views = new ViewContent [viewContentCollection.Count];
 					viewContentCollection.CopyTo (views, 0);
 					foreach (var content in views) {
-						if (e.SourceFile.IsChildPathOf (content.ContentName)) {
+						if (((FilePath)content.ContentName).IsChildPathOf (e.SourceFile)) {
 							content.ContentName = e.TargetFile + content.ContentName.Substring (e.SourceFile.ToString ().Length);
 						}
 					}


### PR DESCRIPTION
move a file that is modified in the editor'

The real bug was that the open file closed when moving to another
location. This patch ensures that the move file event is handled
properly.