### PR TITLE
Fixed 'Bug 55308 - Save as, then open original CSS or HTML file, you

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -80,6 +80,8 @@ namespace MonoDevelop.Ide.Editor
 		protected override void OnContentNameChanged ()
 		{
 			base.OnContentNameChanged ();
+			if (ContentName != textEditorImpl.ContentName && !string.IsNullOrEmpty (textEditorImpl.ContentName))
+				AutoSave.RemoveAutoSaveFile (textEditorImpl.ContentName);
 			textEditorImpl.ContentName = this.ContentName;
 			if (this.WorkbenchWindow?.Document != null)
 				textEditor.InitializeExtensionChain (this.WorkbenchWindow.Document);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -232,8 +232,6 @@ namespace MonoDevelop.Ide.Editor
 		{
 			if (!string.IsNullOrEmpty (fileSaveInformation.FileName))
 				AutoSave.RemoveAutoSaveFile (fileSaveInformation.FileName);
-			if (textEditorImpl.ContentName != fileSaveInformation.FileName && !string.IsNullOrEmpty (textEditorImpl.ContentName))
-				AutoSave.RemoveAutoSaveFile (textEditorImpl.ContentName);
 			return textEditorImpl.ViewContent.Save (fileSaveInformation);
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -513,10 +513,6 @@ namespace MonoDevelop.Ide.Gui
 			}
 			TypeSystemService.RemoveSkippedfile (FileName);
 
-			// remove auto save file for old file name.
-			if (Window.ViewContent.ContentName != filename && !string.IsNullOrEmpty (Window.ViewContent.ContentName))
-				AutoSave.RemoveAutoSaveFile (Window.ViewContent.ContentName);
-			
 			// do actual save
 			Window.ViewContent.ContentName = filename;
 			Window.ViewContent.Project = Workbench.GetProjectContainingFile (filename);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -512,6 +512,11 @@ namespace MonoDevelop.Ide.Gui
 					await Window.ViewContent.Save (new FileSaveInformation (filename + "~", encoding));
 			}
 			TypeSystemService.RemoveSkippedfile (FileName);
+
+			// remove auto save file for old file name.
+			if (Window.ViewContent.ContentName != filename && !string.IsNullOrEmpty (Window.ViewContent.ContentName))
+				AutoSave.RemoveAutoSaveFile (Window.ViewContent.ContentName);
+			
 			// do actual save
 			Window.ViewContent.ContentName = filename;
 			Window.ViewContent.Project = Workbench.GetProjectContainingFile (filename);


### PR DESCRIPTION
get "An Autosave file has been found for this file"'