### PR TITLE
[DotNetCore] Fixed Test Results pad - Rerun Tests failing

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
@@ -484,6 +484,7 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 				startInfo.Arguments
 			);
 			command.Command = startInfo.FileName;
+			command.Arguments = startInfo.Arguments;
 			command.EnvironmentVariables = startInfo.EnvironmentVariables;
 
 			debugOperation = currentTestContext.ExecutionContext.ExecutionHandler.Execute (command, console);


### PR DESCRIPTION
Running the unit tests for a .NET Core project would fail if run
from the Test Results pad. The Application Output window would
open and the following error message would be displayed:

    No executable found matching command "dotnet-/usr/local/share/dotnet/dotnet"

The command line arguments used were incorrect when the .NET Core
debugger is not used. The fix causes the tests to not be run in the
same way as they are run from the Unit Tests window. They are run
using the same command line as when debugging the tests instead of
with being run by the test runner process. The only difference
for the end user is that an Application Output window is displayed.
Possibly when the tests are run from the Unit Tests window they
should be run in the same way so test output to make it consistent.