### PR TITLE
[DotNetCore] Fix Test Results output messages on single line

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
@@ -346,7 +346,7 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 				return;
 
 			var payload = dataSerializer.DeserializePayload<TestMessagePayload> (message);
-			currentContext.Monitor.WriteGlobalLog (payload.Message);
+			currentContext.Monitor.WriteGlobalLog (payload.Message + Environment.NewLine);
 		}
 
 		void OnTestRunComplete (Message message)


### PR DESCRIPTION
Fixed bug #55543 - .NET Core test runner output shown on single line
in Test Results window
https://bugzilla.xamarin.com/show_bug.cgi?id=55543

The Test Results - Output window had the test runner output
messages on a single line since they were added without a new line
at the end of the message.