### PR TITLE
Bug 55158 - XS hangs if MSBuild returns 2000 errors

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -638,12 +638,10 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 			descriptionCol.AddNotification("width", delegate
 			{
+				if (descriptionCellRenderer.WrapWidth == descriptionCol.Width)
+					return;
 				descriptionCellRenderer.WrapWidth = descriptionCol.Width;
-				store.Foreach((model, path, iter) =>
-				{
-					model.EmitRowChanged(path, iter);
-					return false;
-				});
+				descriptionCol.QueueResize ();
 			});
 			
 			col = view.AppendColumn (GettextCatalog.GetString ("File"), view.TextRenderer);


### PR DESCRIPTION
Majority of fix is in checking if Width actually changed, since it turns out notification is sent multiple times even when size is not changed… While looking at GTK+ code I noticed there is much better way to invalidate recalculation of width for all rows: https://github.com/GNOME/gtk/blob/gtk-2-24/gtk/gtktreeviewcolumn.c#L3749-L3765