### PR TITLE
[Ide] Don't log a message if the parent is already set correctly.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -205,6 +205,11 @@ namespace MonoDevelop.Components.Docking
 
 		protected override void OnAdded (Widget widget)
 		{
+			// Break the add signal cycle
+			if (widget.Parent == this) {
+				return;
+			}
+
 			System.Diagnostics.Debug.Assert (
 				widget.Parent == null,
 				"Widget is already parented on another widget");


### PR DESCRIPTION
This can happen because we manually emit the add signal.