### PR TITLE
[NuGet] Fix updating NuGet package not updating project.assets.json

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectProxy.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectProxy.cs
@@ -151,9 +151,18 @@ namespace MonoDevelop.PackageManagement
 			DotNetProject.RefreshReferenceStatus ();
 		}
 
+		/// <summary>
+		/// Returns imported package references (e.g. NETStandard.Library) from the
+		/// evaluated items and package references defined directly in the project file.
+		/// Only imported package references are taken from the evaluated items to
+		/// avoid duplicate package references and also to avoid old versions being
+		/// returned since the evaluated items may still have old values if the
+		/// package references have just been updated. This avoids the wrong value being
+		/// added to the project.assets.json file.
+		/// </summary>
 		public IEnumerable<ProjectPackageReference> GetPackageReferences ()
 		{
-			foreach (var item in DotNetProject.MSBuildProject.GetEvaluatedPackageReferences ()) {
+			foreach (var item in DotNetProject.MSBuildProject.GetImportedPackageReferences ()) {
 				yield return item;
 			}
 			foreach (var item in DotNetProject.Items.OfType<ProjectPackageReference> ()) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MSBuildProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MSBuildProjectExtensions.cs
@@ -109,5 +109,16 @@ namespace MonoDevelop.PackageManagement
 		{
 			return project.GetEvaluatedPackageReferenceItems ().Any ();
 		}
+
+		/// <summary>
+		/// Returns package references (e.g. NETStandard.Library) that are not directly defined
+		/// in the project file but included due to the sdk and target framework being used.
+		/// </summary>
+		public static IEnumerable<ProjectPackageReference> GetImportedPackageReferences (this MSBuildProject project)
+		{
+			return project.GetEvaluatedPackageReferenceItems ()
+				.Where (item => item.IsImported)
+				.Select (ProjectPackageReference.Create);
+		}
 	}
 }


### PR DESCRIPTION
Fixed bug #55563 - Updating NuGet package in .NET Core project does
not update project.assets.json file
https://bugzilla.xamarin.com/show_bug.cgi?id=55563

With an old version of a NuGet package installed in a .NET Core
project, updating the NuGet package would update the version correctly
in the project file but the project.assets.json file would have the
old version. This resulted in the wrong version displayed in the
Solution window. The problem was that the old package reference
version could be picked up since all package references were taken
from the evaluated items, as well as those defined in the project,
and only the first one is used when updating the project.assets.json
file. So now only imported package references are taken from the
evaluated items which ensures the correct package reference versions
are used from the project file.