### PR TITLE
[NuGet] Add workaround for license dialog UI hang

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
@@ -49,11 +49,9 @@ namespace MonoDevelop.PackageManagement
 		bool ShowLicenseAcceptanceDialog (IEnumerable<NuGetPackageLicense> licenses)
 		{
 			bool result = false;
-			Xwt.Toolkit.NativeEngine.Invoke (delegate {
-				using (LicenseAcceptanceDialog dialog = CreateLicenseAcceptanceDialog (licenses)) {
-					result = dialog.Run (Xwt.MessageDialog.RootWindow);
-				}
-			});
+			using (LicenseAcceptanceDialog dialog = CreateLicenseAcceptanceDialog (licenses)) {
+				result = dialog.Run (Xwt.MessageDialog.RootWindow);
+			}
 			return result;
 		}
 


### PR DESCRIPTION
Added workaround for bug #55089 - UI hang if main menu is open when
Licence Acceptance dialog displayed

Showing the XWT dialog using the GTK# backend instead of the native
Mac backend prevents the UI hang where the license dialog does not
respond to its buttons being clicked.