### PR TITLE
[C#] Improve editor performance while typing.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/ParameterHinting/ParameterHintingEngine.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/ParameterHinting/ParameterHintingEngine.cs
@@ -154,7 +154,7 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 			var addedMethods = new List<IMethodSymbol> ();
 			var filterMethod = new HashSet<IMethodSymbol> ();
 			for (;type != null; type = type.BaseType) {
-				foreach (var method in type.GetMembers ().OfType<IMethodSymbol> ().Concat (GetExtensionMethods(semanticModel, type, node, cancellationToken)).Where (m => m.Name == name)) {
+				foreach (var method in type.GetMembers (name).OfType<IMethodSymbol> ().Concat (GetExtensionMethods(semanticModel, type, node, name, cancellationToken))) {
 					if (staticLookup && !method.IsStatic)
 						continue;
 					if (method.OverriddenMethod != null)
@@ -225,7 +225,9 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 					}
 					if (!type.MightContainExtensionMethods)
 						continue;
-					foreach (var extMethod in type.GetMembers ().OfType<IMethodSymbol> ().Where (method => method.IsExtensionMethod)) {
+					foreach (var extMethod in type.GetMembers (name).OfType<IMethodSymbol> ().Where (method => method.IsExtensionMethod)) {
+						if (!extMethod.IsAccessibleWithin (semanticModel.Compilation.Assembly))
+							continue;
 						var reducedMethod = extMethod.ReduceExtensionMethod (typeToExtend);
 						if (reducedMethod != null) {
 							yield return reducedMethod;


### PR DESCRIPTION
Reduce allocations done while typing parameters for a method. Searching for a method to see overloads would've triggered a lot of calls throughout the whole compilation to see whether we could find extension methods.
Trim searching so we don't try to reduce all the extension methods we find, only reducing the ones which match the name of the caller.
Also, do name trimming at roslyn level, so we don't allocate unnecessarily.
Reduce allocation of typing MapEvent(PasswordEntryEvent.Activated, typeof(PasswordEntry), OnActivated); in Xwt's PasswordEntry static constructor.