### PR TITLE
[Project] Add VS-like AppliesTo extension condition

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
@@ -108,6 +108,9 @@
 		<ConditionType id="ItemType" type="MonoDevelop.Core.Gui.Dialogs.OptionPanels.ItemTypeCondition">
 			<Description>Type of the item. If no namespace is provided, MonoDevelop.Projects is assumed.</Description>
 		</ConditionType>
+		<ConditionType id="AppliesTo" type="MonoDevelop.Projects.Extensions.AppliesToCondition">
+			<Description>Project capability expression.</Description>
+		</ConditionType>
 	</ExtensionPoint>
 
 	<ExtensionPoint path = "/MonoDevelop/ProjectModel/LanguageBindings" name = "Language bindings">

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -358,6 +358,7 @@
     <Compile Include="Mono.Options.cs" />
     <Compile Include="MonoDevelop.Core.Logging\InstrumentationLogger.cs" />
     <Compile Include="MonoDevelop.Core.Instrumentation\TimerCounter.cs" />
+    <Compile Include="MonoDevelop.Projects\AppliesToAttribute.cs" />
     <Compile Include="MonoDevelop.Projects\ProjectService.cs" />
     <Compile Include="MonoDevelop.Projects\ProjectPathItemPropertyAttribute.cs" />
     <Compile Include="MonoDevelop.Projects\SolutionConfiguration.cs" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -703,6 +703,7 @@
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildEvent.cs" />
     <Compile Include="MonoDevelop.Projects\MSBuildLogger.cs" />
     <Compile Include="MonoDevelop.Projects.Extensions\ImportSearchPathExtensionNode.cs" />
+    <Compile Include="MonoDevelop.Projects.Extensions\AppliesToCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/AppliesToCondition.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/AppliesToCondition.cs
@@ -1,0 +1,46 @@
+﻿//
+// AppliesToCondition.cs
+//
+// Author:
+//       Mikayla Hutchinson <m.j.hutchinson@gmail.com>
+//
+// Copyright (c) 2017 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Mono.Addins;
+
+namespace MonoDevelop.Projects.Extensions
+{
+	public class AppliesToCondition : ConditionType
+	{
+		Project project;
+
+		public AppliesToCondition (Project project)
+		{
+			this.project = project;
+		}
+
+		public override bool Evaluate (NodeElement conditionNode)
+		{
+			var expr = conditionNode.GetAttribute ("capability");
+			return project.IsCapabilityMatch (expr);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/AppliesToCondition.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/AppliesToCondition.cs
@@ -30,15 +30,19 @@ namespace MonoDevelop.Projects.Extensions
 {
 	public class AppliesToCondition : ConditionType
 	{
-		Project project;
+		readonly WorkspaceObject workspaceObject;
 
-		public AppliesToCondition (Project project)
+		public AppliesToCondition (WorkspaceObject workspaceObject)
 		{
-			this.project = project;
+			this.workspaceObject = workspaceObject;
 		}
 
 		public override bool Evaluate (NodeElement conditionNode)
 		{
+			var project = workspaceObject as Project;
+			if (project == null) {
+				return false;
+			}
 			var expr = conditionNode.GetAttribute ("capability");
 			return project.IsCapabilityMatch (expr);
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AppliesToAttribute.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AppliesToAttribute.cs
@@ -1,0 +1,48 @@
+﻿//
+// AppliesToAttribute.cs
+//
+// Copyright (c) Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Mono.Addins;
+
+namespace MonoDevelop.Projects
+{
+	/// <summary>
+	/// Restricts an extension to projects matching a capability expression.
+	/// </summary>
+	public class AppliesToAttribute : CustomConditionAttribute
+	{
+		/// <summary>
+		/// Initializes the attribute with a project capability expression.
+		/// </summary>
+		/// <param name="capability">Project capability expression.</param>
+		public AppliesToAttribute ([NodeAttribute("capability")] string capability)
+		{
+			this.Capability = capability;
+		}
+
+		/// <summary>
+		/// Project capability expression.
+		/// </summary>
+		[NodeAttribute ("capability")]
+		public string Capability { get; set; }
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -183,6 +183,8 @@ namespace MonoDevelop.Projects
 				}
 			}
 
+			ExtensionContext.RegisterCondition ("AppliesTo", new AppliesToCondition (this));
+
 			if (sourceProject == null) {
 				sourceProject = new MSBuildProject ();
 				sourceProject.FileName = FileName;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -183,8 +183,6 @@ namespace MonoDevelop.Projects
 				}
 			}
 
-			ExtensionContext.RegisterCondition ("AppliesTo", new AppliesToCondition (this));
-
 			if (sourceProject == null) {
 				sourceProject = new MSBuildProject ();
 				sourceProject.FileName = FileName;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs
@@ -69,6 +69,7 @@ namespace MonoDevelop.Projects
 
 				extensionContext = AddinManager.CreateExtensionContext ();
 				extensionContext.RegisterCondition ("ItemType", new ItemTypeCondition (GetType ()));
+				ExtensionContext.RegisterCondition ("AppliesTo", new AppliesToCondition (this));
 
 				OnInitialize ();
 				InitializeExtensionChain ();

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/ItemOptionPanels.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/ItemOptionPanels.addin.xml
@@ -12,6 +12,9 @@
 	<ConditionType id="ProjectTypeId" type="MonoDevelop.Projects.Extensions.ProjectTypeIdCondition">
 		<Description>The id can be a project type guid or a flavor guid, or the corresponding type alias</Description>
 	</ConditionType>
+	<ConditionType id="AppliesTo" type="MonoDevelop.Projects.Extensions.AppliesToCondition">
+		<Description>Project capability expression.</Description>
+	</ConditionType>
 	<ConditionType id="SupportsTarget" type="MonoDevelop.Projects.Extensions.SupportsTargetCondition">
 		<Description>MSBuild Target that a project must have.</Description>
 	</ConditionType>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Templates.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Templates.addin.xml
@@ -4,6 +4,15 @@
 <ExtensionPoint path = "/MonoDevelop/Ide/FileTemplates" name = "File templates">
 	<Description>File templates to be shown in the New File dialog.</Description>
 	<ExtensionNode name="FileTemplate" type="MonoDevelop.Ide.Codons.ProjectTemplateCodon"/>
+	<ConditionType id="FlavorType" type="MonoDevelop.Projects.Extensions.FlavorTypeCondition">
+		<Description>Type of a flavor that a project must have. If no namespace is provided, MonoDevelop.Projects is assumed.</Description>
+	</ConditionType>
+	<ConditionType id="ProjectTypeId" type="MonoDevelop.Projects.Extensions.ProjectTypeIdCondition">
+		<Description>The id can be a project type guid or a flavor guid, or the corresponding type alias</Description>
+	</ConditionType>
+	<ConditionType id="AppliesTo" type="MonoDevelop.Projects.Extensions.AppliesToCondition">
+		<Description>Project capability expression.</Description>
+	</ConditionType>
 </ExtensionPoint>
 
 <ExtensionPoint path = "/MonoDevelop/Ide/FileTemplateTypes" name = "File template types">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ItemOptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ItemOptionsDialog.cs
@@ -51,10 +51,12 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			extensionContext.RegisterCondition ("ItemType", new ItemTypeCondition (DataObject.GetType ()));
 			extensionContext.RegisterCondition ("ActiveLanguage", new ProjectLanguageCondition (DataObject));
 			if (DataObject is Project) {
+				extensionContext.RegisterCondition ("AppliesTo", new AppliesToCondition ((Project)DataObject));
 				extensionContext.RegisterCondition ("FlavorType", new FlavorTypeCondition ((Project)DataObject));
 				extensionContext.RegisterCondition ("ProjectTypeId", new ProjectTypeIdCondition ((Project)DataObject));
 				extensionContext.RegisterCondition ("SupportsTarget", new SupportsTargetCondition ((Project)DataObject));
 			} else {
+				extensionContext.RegisterCondition ("AppliesTo", new FalseCondition ());
 				extensionContext.RegisterCondition ("FlavorType", new FalseCondition ());
 				extensionContext.RegisterCondition ("ProjectTypeId", new FalseCondition ());
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
@@ -41,6 +41,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.Codons;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Projects;
+using MonoDevelop.Projects.Extensions;
 
 namespace MonoDevelop.Ide.Templates
 {
@@ -59,8 +60,6 @@ namespace MonoDevelop.Ide.Templates
 		public string Description { get; private set; } = String.Empty;
 
 		public List<FileDescriptionTemplate> Files { get; private set; } = new List<FileDescriptionTemplate> ();
-
-		public static List<FileTemplate> fileTemplates = new List<FileTemplate> ();
 
 		public IconId Icon { get; private set; } = String.Empty;
 
@@ -191,58 +190,65 @@ namespace MonoDevelop.Ide.Templates
 			return fileTemplate;
 		}
 
-		static FileTemplate ()
+		static FileTemplate LoadTemplate (ProjectTemplateCodon codon)
 		{
-			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/FileTemplates", OnExtensionChanged);
+			try {
+				FileTemplate t = LoadFileTemplate (codon.Addin, codon);
+				t.Id = codon.Id;
+				return t;
+			} catch (Exception e) {
+				string extId = null, addinId = null;
+				if (codon != null) {
+					if (codon.HasId)
+						extId = codon.Id;
+					if (codon.Addin != null)
+						addinId = codon.Addin.Id;
+				}
+				LoggingService.LogError ("Error loading template id {0} in addin {1}:\n{2}",
+					extId ?? "(null)", addinId ?? "(null)", e.ToString ());
+			}
+			return null;
 		}
 
-		static void OnExtensionChanged (object s, ExtensionNodeEventArgs args)
-		{
-			if (args.Change == ExtensionChange.Add) {
-				var codon = (ProjectTemplateCodon)args.ExtensionNode;
-				try {
-					FileTemplate t = LoadFileTemplate (codon.Addin, codon);
-					t.Id = codon.Id;
-					fileTemplates.Add (t);
-				} catch (Exception e) {
-					string extId = null, addinId = null;
-					if (codon != null) {
-						if (codon.HasId)
-							extId = codon.Id;
-						if (codon.Addin != null)
-							addinId = codon.Addin.Id;
-					}
-					LoggingService.LogError ("Error loading template id {0} in addin {1}:\n{2}",
-						extId ?? "(null)", addinId ?? "(null)", e.ToString ());
-				}
-			} else {
-				var codon = (ProjectTemplateCodon)args.ExtensionNode;
-				foreach (FileTemplate t in fileTemplates) {
-					if (t.Id == codon.Id) {
-						fileTemplates.Remove (t);
-						break;
-					}
-				}
-			}
-		}
+		static string EXTENSION_PATH = "/MonoDevelop/Ide/FileTemplates";
 
 		internal static List<FileTemplate> GetFileTemplates (Project project, string projectPath)
 		{
-			var list = new List<FileTemplate> ();
-			foreach (var t in fileTemplates) {
-				if (t.IsValidForProject (project, projectPath))
-					list.Add (t);
+			var extensionContext = AddinManager.CreateExtensionContext ();
+			if (project != null) {
+				extensionContext.RegisterCondition ("AppliesTo", new AppliesToCondition (project));
+				extensionContext.RegisterCondition ("FlavorType", new FlavorTypeCondition (project));
+				extensionContext.RegisterCondition ("ProjectTypeId", new ProjectTypeIdCondition (project));
+			} else {
+				extensionContext.RegisterCondition ("AppliesTo", new TrueCondition ());
+				extensionContext.RegisterCondition ("FlavorType", new TrueCondition ());
+				extensionContext.RegisterCondition ("ProjectTypeId", new TrueCondition ());
 			}
+
+			var list = new List<FileTemplate> ();
+			foreach (var node in extensionContext.GetExtensionNodes<ProjectTemplateCodon> (EXTENSION_PATH)) {
+				var template = LoadTemplate (node); 
+				if (template.IsValidForProject (project, projectPath)) {
+					list.Add (template);
+				}
+			}
+
 			return list;
+		}
+
+		class TrueCondition : ConditionType
+		{
+			public override bool Evaluate (NodeElement conditionNode)
+			{
+				return true;
+			}
 		}
 
 		internal static FileTemplate GetFileTemplateByID (string templateID)
 		{
-			foreach (FileTemplate t in fileTemplates)
-				if (t.Id == templateID)
-					return t;
-
-			return null;
+			var node = AddinManager.GetExtensionNodes<ProjectTemplateCodon> (EXTENSION_PATH)
+								   .FirstOrDefault (n => n.Id == templateID);
+			return node == null ? null : LoadTemplate (node);
 		}
 
 		public virtual bool Create (SolutionFolderItem policyParent, Project project, string directory, string language, string name)


### PR DESCRIPTION
This condition can be used to specify that a project extension, file template, or option panel apply to projects that match a particular capability expression.