### PR TITLE
[F#] Fix build error with Mono 5.0.0.88

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/MonoDevelop.FSharpInteractive.Service.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/MonoDevelop.FSharpInteractive.Service.fsproj
@@ -50,7 +50,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="FSharp.Compiler.Interactive.Settings">
-      <HintPath>lib\FSharp.Compiler.Interactive.Settings.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\lib\FSharp.Compiler.Interactive.Settings.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
   </ItemGroup>


### PR DESCRIPTION
Add workaround for MSBuild not finding the assembly:
FSharp.Compiler.Interactive.Settings.dll