### PR TITLE
Fixed 'Bug 55701 - Autocompletion too aggressive when using backspace'

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
@@ -202,6 +202,8 @@ namespace MonoDevelop.Ide.Editor.Extension
 			}
 
 			if ((descriptor.SpecialKey == SpecialKey.Delete || descriptor.SpecialKey == SpecialKey.BackSpace) && CompletionWidget != null && !CompletionWindowManager.IsVisible) {
+				if (!char.IsLetterOrDigit (deleteOrBackspaceTriggerChar) && deleteOrBackspaceTriggerChar != '_')
+					return res;
 				CurrentCompletionContext = CompletionWidget.CurrentCodeCompletionContext;
 
 				int cpos, wlen;
@@ -209,6 +211,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 					cpos = Editor.CaretOffset;
 					wlen = 0;
 				}
+
 				CurrentCompletionContext.TriggerOffset = cpos;
 				CurrentCompletionContext.TriggerWordLength = wlen;
 				


### PR DESCRIPTION
This ensures that completion on backspace & delete only is triggered
when an identifier part was removed and not on word boundaries like in
the bug report.