### PR TITLE
Fix document save logic

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -815,8 +815,11 @@ namespace MonoDevelop.Ide.Gui
 		protected virtual async Task OnClosing (WorkbenchWindowEventArgs e)
 		{
 			if (Closing != null) {
-				foreach (var handler in Closing.GetInvocationList ().Cast<WorkbenchWindowAsyncEventHandler> ())
+				foreach (var handler in Closing.GetInvocationList ().Cast<WorkbenchWindowAsyncEventHandler> ()) {
 					await handler (this, e);
+					if (e.Cancel)
+						break;
+				}
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -855,21 +855,21 @@ namespace MonoDevelop.Ide.Gui
 					GettextCatalog.GetString ("If you don't save, all changes will be permanently lost."),
 					AlertButton.CloseWithoutSave, AlertButton.Cancel, viewContent.IsUntitled ? AlertButton.SaveAs : AlertButton.Save);
 				if (result == AlertButton.Save) {
-					args.Cancel = true;
-					await FindDocument (window).Save ();
-					viewContent.IsDirty = false;
-					window.CloseWindow (true);
-					return;
-				} else if (result == AlertButton.SaveAs) {
-					args.Cancel = true;
-					var resultSaveAs = await FindDocument (window).SaveAs ();
-					if (resultSaveAs) {
-						viewContent.IsDirty = false;
-						window.CloseWindow (true);
-					} else {
-						window.SelectWindow ();
+					var doc = FindDocument (window);
+					await doc.Save ();
+					if (viewContent.IsDirty) {
+						// This may happen if the save operation failed
+						args.Cancel = true;
+						doc.Select ();
 					}
-					return;
+				} else if (result == AlertButton.SaveAs) {
+					var doc = FindDocument (window);
+					var resultSaveAs = await doc.SaveAs ();
+					if (!resultSaveAs || viewContent.IsDirty) {
+						// This may happen if the save operation failed or Save As was canceled
+						args.Cancel = true;
+						doc.Select ();
+					}
 				} else {
 					args.Cancel |= result != AlertButton.CloseWithoutSave;
 					if (!args.Cancel)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -861,6 +861,7 @@ namespace MonoDevelop.Ide.Gui
 						// This may happen if the save operation failed
 						args.Cancel = true;
 						doc.Select ();
+						return;
 					}
 				} else if (result == AlertButton.SaveAs) {
 					var doc = FindDocument (window);
@@ -869,6 +870,7 @@ namespace MonoDevelop.Ide.Gui
 						// This may happen if the save operation failed or Save As was canceled
 						args.Cancel = true;
 						doc.Select ();
+						return;
 					}
 				} else {
 					args.Cancel |= result != AlertButton.CloseWithoutSave;


### PR DESCRIPTION
Fixed bug in the logic that saves a document when it is closed.
args.Cancel was always set to true, which was wrong since
the Close method of the document would always return false,
even when properly saving the document.

This change was done to fix an issue with asyc save
of documents, which I think was properly fixed by
https://github.com/mono/monodevelop/commit/9c9f2aa021b3f48cb865f4307ae9b59372611b25

Fixes bug #55713 - Selecting recent solution when unsaved files
open does not open solution