### PR TITLE
Fix threading issue when reevaluating project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3580,34 +3580,38 @@ namespace MonoDevelop.Projects
 		/// <remarks>
 		/// Reevaluates the underlying msbuild project and updates the project information acording to the new items and properties.
 		/// </remarks>
-		public async Task ReevaluateProject (ProgressMonitor monitor)
+		public Task ReevaluateProject (ProgressMonitor monitor)
 		{
-			var oldCapabilities = new HashSet<string> (projectCapabilities);
+			return BindTask (ct => Runtime.RunInMainThread (async () => {
+				using (await writeProjectLock.EnterAsync ()) {
+					var oldCapabilities = new HashSet<string> (projectCapabilities);
 
-			try {
-				IsReevaluating = true;
+					try {
+						IsReevaluating = true;
 
-				// Reevaluate the msbuild project
-				await sourceProject.EvaluateAsync ();
+						// Reevaluate the msbuild project
+						await sourceProject.EvaluateAsync ();
 
-				// Loads minimal data required to instantiate extensions and prepare for project loading
-				InitBeforeProjectExtensionLoad ();
+						// Loads minimal data required to instantiate extensions and prepare for project loading
+						InitBeforeProjectExtensionLoad ();
 
-				// Activate / deactivate extensions based on the new status
-				RefreshExtensions ();
+						// Activate / deactivate extensions based on the new status
+						RefreshExtensions ();
 
-				await ProjectExtension.OnReevaluateProject (monitor);
-		
-			} finally {
-				IsReevaluating = false;
-			}
+						await ProjectExtension.OnReevaluateProject (monitor);
 
-			ResetCachedCompileItems ();
+					} finally {
+						IsReevaluating = false;
+					}
 
-			if (!oldCapabilities.SetEquals (projectCapabilities))
-				NotifyProjectCapabilitiesChanged ();
+					ResetCachedCompileItems ();
 
-			NotifyExecutionTargetsChanged (); // Maybe...
+					if (!oldCapabilities.SetEquals (projectCapabilities))
+						NotifyProjectCapabilitiesChanged ();
+
+					NotifyExecutionTargetsChanged (); // Maybe...
+				}
+			}));
 		}
 
 		protected virtual async Task OnReevaluateProject (ProgressMonitor monitor)


### PR DESCRIPTION
Run project reevaluation inside a writeProjectLock lock, otherwise
it may happen that the project is rewritten in the middle of
a reevaluation, and this will cause crashes.

Fixes bug #55658 - NRE when trying to restore packages in xUnit project