### PR TITLE
[Ide] TextFileNavigation points remove text source version on document

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/DocumentNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/DocumentNavigationPoint.cs
@@ -37,10 +37,22 @@ namespace MonoDevelop.Ide.Navigation
 	public class DocumentNavigationPoint : NavigationPoint
 	{
 		Document doc;
+
+		public Document Document {
+			get {
+				return doc;
+			}
+		}
+
 		FilePath fileName;
 		string project;
 		
 		public DocumentNavigationPoint (Document doc)
+		{
+			SetDocument (doc);
+		}
+
+		protected void SetDocument (Document doc)
 		{
 			this.doc = doc;
 			doc.Closed += HandleClosed;
@@ -59,10 +71,14 @@ namespace MonoDevelop.Ide.Navigation
 			}
 			base.Dispose ();
 		}
-		
+
+		protected virtual void OnDocumentClosing ()
+		{
+		}
 
 		void HandleClosed (object sender, EventArgs e)
 		{
+			OnDocumentClosing ();
 			fileName = doc.FileName;
 			project = doc.HasProject ? doc.Project.ItemId : null;
 			if (fileName == FilePath.Null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
@@ -64,6 +64,7 @@ namespace MonoDevelop.Ide.Navigation
 			var location = editor.CaretLocation;
 			line = location.Line;
 			column = location.Column;
+			version = null;
 		}
 
 		public TextFileNavigationPoint (FilePath file, int line, int column)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
@@ -34,27 +34,38 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Editor;
 using System.Threading.Tasks;
 using MonoDevelop.Core.Text;
+using System.Linq;
 
 namespace MonoDevelop.Ide.Navigation
 {
 	public class TextFileNavigationPoint : DocumentNavigationPoint
 	{
-		readonly int line;
-		readonly int column;
+		int line;
+		int column;
 
-		readonly int offset;
-		readonly ITextSourceVersion version;
+		int offset;
+		ITextSourceVersion version;
 
 		public TextFileNavigationPoint (Document doc, TextEditor buffer)
 			: base (doc)
 		{
 			var location = buffer.CaretLocation;
 			version = buffer.Version;
+			offset = buffer.CaretOffset;
 			line = location.Line;
 			column = location.Column;
-			offset = buffer.CaretOffset;
 		}
-		
+
+		protected override void OnDocumentClosing ()
+		{
+			// text source version becomes invalid on document close.
+			var editor = Document.Editor;
+			offset = version.MoveOffsetTo (editor.Version, offset);
+			var location = editor.CaretLocation;
+			line = location.Line;
+			column = location.Column;
+		}
+
 		public TextFileNavigationPoint (FilePath file, int line, int column)
 			: base (file)
 		{
@@ -107,6 +118,12 @@ namespace MonoDevelop.Ide.Navigation
 				var loc = editor.OffsetToLocation (currentOffset);
 				editor.SetCaretLocation (loc);
 			} else {
+				var doc = IdeApp.Workbench.Documents.FirstOrDefault (d => d.Editor == editor);
+				if (doc != null) {
+					version = editor.Version;
+					offset = editor.LocationToOffset (line, column);
+					SetDocument (doc);
+				}
 				editor.SetCaretLocation (Math.Max (line, 1), Math.Max (column, 1));
 			}
 		}


### PR DESCRIPTION
close.

Versions become invalid after closing the document & leak documents in
memory.