### PR TITLE
[Core] Handle unknown MSBuild property being evaluated during build

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/BinaryMessage.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/BinaryMessage.cs
@@ -257,7 +257,7 @@ namespace MonoDevelop.Core.Execution
 			} else if (et == typeof(string)) {
 				bw.Write ((byte)TypeCode.String);
 				foreach (var v in (string [])val)
-					bw.Write (v);
+					bw.Write (v ?? "");
 			} else if (et == typeof(bool)) {
 				bw.Write ((byte)TypeCode.Boolean);
 				foreach (var v in (bool [])val)

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.cs
@@ -103,7 +103,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 					if (evaluateProperties != null) {
 						foreach (var name in evaluateProperties)
-							result.Properties [name] = project.GetEvaluatedProperty (name);
+							result.Properties [name] = project.GetEvaluatedProperty (name) ?? string.Empty;
 					}
 
 					if (evaluateItems != null) {

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Projects.MSBuild
 					if (evaluateProperties != null) {
 						foreach (var name in evaluateProperties) {
 							var prop = pi.GetProperty (name);
-							result.Properties [name] = prop != null? prop.EvaluatedValue : null;
+							result.Properties [name] = prop != null? prop.EvaluatedValue : string.Empty;
 						}
 					}
 

--- a/main/tests/UnitTests/MonoDevelop.Core/RemoteProcessConnectionTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/RemoteProcessConnectionTests.cs
@@ -133,6 +133,31 @@ namespace MonoDevelop.Core
 		}
 
 		[Test]
+		public void BinaryMessageSerializeDictionaryWithNullStringValues ()
+		{
+			var data1 = new Dictionary<string, string> ();
+			data1 ["one"] = "a";
+			data1 ["two"] = null;
+
+			var m = new BinaryMessage ("Test");
+			m.AddArgument ("map1", data1);
+
+			MemoryStream ms = new MemoryStream ();
+			m.Write (ms);
+			ms.Position = 0;
+
+			m = BinaryMessage.Read (ms);
+			var readData1 = m.GetArgument ("map1") as Dictionary<string, string>;
+			Assert.AreEqual (1, m.Args.Count);
+			Assert.AreEqual (2, readData1.Keys.Count);
+			Assert.AreEqual ("a", readData1 ["one"]);
+
+			// Null value in dictionary is converted to empty string
+			// on writing to the stream.
+			Assert.AreEqual (string.Empty, readData1 ["two"]);
+		}
+
+		[Test]
 		public void BinaryMessageCustomMapSerialization ()
 		{
 			var data = new Dictionary<string, CustomData[]> ();

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -82,6 +82,31 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		[TestCase (true)]
+		[TestCase (false)]
+		public async Task EvaluateUnknownPropertyDuringBuild (bool requiresMSBuild)
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+
+			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var project = ((Project)sol.Items [0]);
+			project.RequiresMicrosoftBuild = requiresMSBuild;
+
+			var context = new TargetEvaluationContext ();
+			context.PropertiesToEvaluate.Add ("TestUnknownPropertyToEvaluate");
+
+			var res = await project.RunTarget (Util.GetMonitor (), "Build", project.Configurations [0].Selector, context);
+			Assert.IsNotNull (res);
+			Assert.IsNotNull (res.BuildResult);
+			Assert.AreEqual (0, res.BuildResult.ErrorCount);
+			Assert.AreEqual (0, res.BuildResult.WarningCount);
+			Assert.AreEqual ("", res.Properties.GetValue ("TestUnknownPropertyToEvaluate"));
+
+			sol.Dispose ();
+		}
+
+		[Test]
 		public async Task BuildConsoleProject ()
 		{
 			Solution sol = TestProjectsChecks.CreateConsoleSolution ("console-project-msbuild");


### PR DESCRIPTION
Fixed bug #55751 - [iOS] Uploading iOS Forms PCL app from Xamarin
Studio to Test Cloud fails build step with "Unknown MSBuild Failure"
https://bugzilla.xamarin.com/show_bug.cgi?id=55751

Two fixes have been made. Both on their own fix the above bug. One fix is in the BinaryMessage so it handles a null dictionary value. Another fix is in the project builders for xbuild and MSBuild so they return an empty string for unknown properties that are being evaluated instead of null, which allows the BinaryMessage to send the message back to the IDE.