### PR TITLE
Fixed 'Bug 55893 - Holding down Shift and the down key continues to

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/SelectionActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/SelectionActions.cs
@@ -86,6 +86,7 @@ namespace Mono.TextEditor
 				data.Caret.PositionChanged -= handler.DataCaretPositionChanged;
 				data.Caret.AutoScrollToCaret = true;
 				data.Caret.PreserveSelection = false;
+				data.ScrollToCaret ();
 			}
 		}
 


### PR DESCRIPTION
select text past the viewport'