### PR TITLE
[master][DotNetCore] Import generated nuget targets

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -378,21 +378,11 @@ namespace MonoDevelop.DotNetCore
 			dotNetCoreMSBuildProject.ReadDefaultCompileTarget (project);
 		}
 
-		/// <summary>
-		/// HACK: Remove any C# files found in the intermediate obj directory. This avoids
-		/// a type system error if a file in the obj directory is modified but the type
-		/// system does not have that file in the workspace. This can happen if the file
-		/// was not filtered out initially and added to the project by the wildcard import
-		/// and then later on after a re-evaluation of the project is filtered out from the
-		/// source files returned by Project.OnGetSourceFiles.
-		/// </summary>
 		protected override async Task<ProjectFile[]> OnGetSourceFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			var sourceFiles = await base.OnGetSourceFiles (monitor, configuration);
 
-			sourceFiles = AddMissingProjectFiles (sourceFiles);
-
-			return RemoveFilesFromIntermediateDirectory (sourceFiles);
+			return AddMissingProjectFiles (sourceFiles);
 		}
 
 		ProjectFile[] AddMissingProjectFiles (ProjectFile[] files)
@@ -411,20 +401,6 @@ namespace MonoDevelop.DotNetCore
 
 			missingFiles.AddRange (files);
 			return missingFiles.ToArray ();
-		}
-
-		ProjectFile[] RemoveFilesFromIntermediateDirectory (ProjectFile[] files)
-		{
-			var filteredFiles = new List<ProjectFile> ();
-			FilePath intermediateOutputPath = Project.BaseIntermediateOutputPath;
-
-			foreach (var file in files) {
-				if (!file.FilePath.IsChildPathOf (intermediateOutputPath)) {
-					filteredFiles.Add (file);
-				}
-			}
-
-			return filteredFiles.ToArray ();
 		}
 
 		protected override void OnSetFormat (MSBuildFileFormat format)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -320,11 +320,17 @@ namespace MonoDevelop.PackageManagement
 			DotNetProject.NotifyModified ("References");
 		}
 
+		/// <summary>
+		/// Always returns true so the project is re-evaluated after a restore.
+		/// This ensures any imports in the generated .nuget.g.targets are
+		/// re-evaluated. Without this custom MSBuild targets used by a NuGet package
+		/// that was restored into the local NuGet package cache would not be available
+		/// until the solution is closed and re-opened. Also handles the project file
+		/// being edited by hand and a new package reference being added that has a
+		/// custom MSBuild target.
+		/// </summary>
 		public bool ProjectRequiresReloadAfterRestore ()
 		{
-			if (project.DotNetCoreNuGetMSBuildFilesExist ())
-				return false;
-
 			return true;
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -219,6 +219,10 @@ namespace MonoDevelop.Projects.MSBuild
 					list.Insert (index++, new MSBuildImport { Project = propsPath, Condition = $"Exists('{propsPath}')" });
 					list.Add (new MSBuildImport { Project = targetsPath, Condition = $"Exists('{targetsPath}')" });
 				}
+				var nugetPropsPath = $"$(BaseIntermediateOutputPath)\\{pi.Project.FileName.FileName}.nuget.g.props";
+				var nugetTargetsPath = $"$(BaseIntermediateOutputPath)\\{pi.Project.FileName.FileName}.nuget.g.targets";
+				list.Insert (index, new MSBuildImport { Project = nugetPropsPath, Condition = $"Exists('{nugetPropsPath}')" });
+				list.Add (new MSBuildImport { Project = nugetTargetsPath, Condition = $"Exists('{nugetTargetsPath}')" });
 				objects = list;
 			}
 

--- a/main/tests/test-projects/dotnetcore-console/Sdks/Test.Sdk/Sdk/Sdk.props
+++ b/main/tests/test-projects/dotnetcore-console/Sdks/Test.Sdk/Sdk/Sdk.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
    <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
    <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
+   <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
    <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
     <Compile Include="**/*.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />


### PR DESCRIPTION
Cherry picked from d15-2 branch.

Fixed bug #55593 - The name 'InitializeComponent' does not exist in the
current context with .NETStandard/new csproj format portable library
https://bugzilla.xamarin.com/show_bug.cgi?id=55593

.NET Core projects add MSBuild imports to the generated nuget files:
ProjectName.csproj.nuget.g.targets and ProjectName.csproj.nuget.g.props.
These files are now implicitly added to ensure any imports from these
files are evaluated. This allows generated C# files from the
Xamarin.Forms NuGet package to be made available to the type system.