### PR TITLE
Bug 55869 - Can not inspect variables in .Net core applications

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VsCodeObjectSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VsCodeObjectSource.cs
@@ -22,7 +22,7 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 
 		public VSCodeObjectSource (VSCodeDebuggerSession vsCodeDebuggerSession, int variablesReference, int parentVariablesReference, string name, string type, string evalName, int frameId, string val)
 		{
-			this.type = type;
+			this.type = type ?? string.Empty;
 			this.frameId = frameId;
 			this.evalName = evalName;
 			this.name = name;
@@ -84,17 +84,11 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 
 		public ObjectValue GetValue (ObjectPath path, EvaluationOptions options)
 		{
-			string shortName = name;
-			var indexOfSpace = name.IndexOf (' ');
-			if (indexOfSpace != -1)//Remove " [TypeName]" from variable name
-				shortName = name.Remove (indexOfSpace);
-			if (type == null)
-				return ObjectValue.CreateError (null, new ObjectPath (shortName), "", val, ObjectValueFlags.None);
 			if (val == "null")
-				return ObjectValue.CreateNullObject (this, shortName, type, parentVariablesReference > 0 ? ObjectValueFlags.None : ObjectValueFlags.ReadOnly);
+				return ObjectValue.CreateNullObject (this, name, type, parentVariablesReference > 0 ? ObjectValueFlags.None : ObjectValueFlags.ReadOnly);
 			if (variablesReference == 0)//This is some kind of primitive...
-				return ObjectValue.CreatePrimitive (this, new ObjectPath (shortName), type, new EvaluationResult (val), parentVariablesReference > 0 ? ObjectValueFlags.None : ObjectValueFlags.ReadOnly);
-			return ObjectValue.CreateObject (this, new ObjectPath (shortName), type, new EvaluationResult (val), parentVariablesReference > 0 ? ObjectValueFlags.None : ObjectValueFlags.ReadOnly, null);
+				return ObjectValue.CreatePrimitive (this, new ObjectPath (name), type, new EvaluationResult (val), parentVariablesReference > 0 ? ObjectValueFlags.None : ObjectValueFlags.ReadOnly);
+			return ObjectValue.CreateObject (this, new ObjectPath (name), type, new EvaluationResult (val), parentVariablesReference > 0 ? ObjectValueFlags.None : ObjectValueFlags.ReadOnly, null);
 		}
 
 		public void SetRawValue (ObjectPath path, object value, EvaluationOptions options)


### PR DESCRIPTION
There are legit cases of type being null, like “Static members” and “Non-public members” groups, but also when evaluating variables(hover, repl…) .NET Core debugger doesn’t set Type which we in past considered as error, now we just ignore it and set it to empty string…