### PR TITLE
Bug 55875 - Call Stack Disappears when a thread selection is made whi…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -87,12 +87,10 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 			var threadsResponse = protocolClient.SendRequestSync (new ThreadsRequest ());
 			var threads = new ThreadInfo [threadsResponse.Threads.Count];
 			for (int i = 0; i < threads.Length; i++) {
-				var backtrace = this.GetThreadBacktrace (threadsResponse.Threads [i].Id);
 				threads [i] = new ThreadInfo (processId,
-										  threadsResponse.Threads [i].Id,
+											  threadsResponse.Threads [i].Id,
 											  threadsResponse.Threads [i].Name,
-											  backtrace.FrameCount > 0 ? backtrace.GetFrame (0).ToString () : "",
-											  backtrace);
+											  null);
 			}
 			return threads;
 		}
@@ -280,8 +278,8 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 					}
 					currentThreadId = body.ThreadId ?? -1;
 					//TODO: what happens if thread is not specified?
-					args.Process = OnGetProcesses () [0];
-					args.Thread = GetThread (args.Process, (long)body.ThreadId);
+					args.Process = GetProcesses () [0];
+					args.Thread = args.Process.GetThreads ().Single (t => t.Id == currentThreadId);
 					args.Backtrace = args.Thread.Backtrace;
 
 					OnTargetEvent (args);
@@ -310,15 +308,6 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 					break;
 				}
 			});
-		}
-
-		ThreadInfo GetThread (ProcessInfo process, long threadId)
-		{
-			foreach (var threadInfo in OnGetThreads (process.Id)) {
-				if (threadInfo.Id == threadId)
-					return threadInfo;
-			}
-			return null;
 		}
 
 		List<string> pathsWithBreakpoints = new List<string> ();


### PR DESCRIPTION
…le debugging .NET Core application

Problem was that Backtrace.DebuggingSession was null, that was based because Backtrace.Attach(session); was not called, this was caused by setting backtrace directly on ThreadInfo constructor instead via ThreadInfo.Backtrace method which takes care of calling Backtrace.Attach(session);, same was needed to be done by OnGetThreads->GetThreads and OnGetProcesses->GetProcesses