### PR TITLE
[RTW][DotNetCore] Update project templates

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>MonoDevelop.DotNetCore</RootNamespace>
     <AssemblyName>MonoDevelop.DotNetCore</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <TemplatesVersion>1.0.0-beta1-20170223-126</TemplatesVersion>
+    <TemplatesVersion>1.0.0-beta1-20170427-174</TemplatesVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -27,14 +27,14 @@
 		<Template
 			id="Microsoft.Common.Console.CSharp"
 			_overrideDescription="Creates a new .NET Core console project."
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-console-project"
 			imageId="md-netcore-console-project"
 			category="netcore/app/general"/>
 		<Template
 			id="Microsoft.Common.Console.FSharp"
 			_overrideDescription="Creates a new .NET Core console project."
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-console-project"
 			imageId="md-netcore-console-project"
 			category="netcore/app/general"/>
@@ -44,7 +44,7 @@
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.CSharp"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-library-project"
 			imageId="md-library-project"
 			category="multiplat/library/general" />
@@ -52,7 +52,7 @@
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.CSharp"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			category="netcore/library/general" />
@@ -60,7 +60,7 @@
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.FSharp"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-library-project"
 			imageId="md-library-project"
 			category="multiplat/library/general" />
@@ -68,7 +68,7 @@
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.FSharp"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			category="netcore/library/general" />
@@ -77,42 +77,42 @@
 		<Template
 			id="Microsoft.Test.xUnit.CSharp"
 			_overrideDescription="Creates a new xUnit test project."
-			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			category="netcore/test/general" />
 		<Template
 			id="Microsoft.Test.xUnit.FSharp"
 			_overrideDescription="Creates a new xUnit test project."
-			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			category="netcore/test/general" />
 		<Template
 			id="Microsoft.Web.Empty.CSharp"
 			_overrideDescription="Creates a new ASP.NET Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			category="netcore/app/aspnet" />
 		<Template
 			id="Microsoft.Web.Mvc.CSharp"
 			_overrideDescription="Creates a new ASP.NET MVC Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			category="netcore/app/aspnet" />
 		<Template
 			id="Microsoft.Web.Mvc.FSharp"
 			_overrideDescription="Creates a new ASP.NET MVC Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			category="netcore/app/aspnet" />
 		<Template
 			id="Microsoft.Web.WebApi.CSharp"
 			_overrideDescription="Creates a new ASP.NET Web API Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170223-126.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta1-20170427-174.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			category="netcore/app/aspnet" />

--- a/main/src/addins/MonoDevelop.DotNetCore/packages.config
+++ b/main/src/addins/MonoDevelop.DotNetCore/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.Common.ProjectTemplates.1.x" version="1.0.0-beta1-20170223-126" targetFramework="net46" />
-  <package id="Microsoft.DotNet.Test.ProjectTemplates.1.x" version="1.0.0-beta1-20170223-126" targetFramework="net46" />
-  <package id="Microsoft.DotNet.Web.ProjectTemplates.1.x" version="1.0.0-beta1-20170223-126" targetFramework="net46" />
+  <package id="Microsoft.DotNet.Common.ProjectTemplates.1.x" version="1.0.0-beta1-20170427-174" targetFramework="net46" />
+  <package id="Microsoft.DotNet.Test.ProjectTemplates.1.x" version="1.0.0-beta1-20170427-174" targetFramework="net46" />
+  <package id="Microsoft.DotNet.Web.ProjectTemplates.1.x" version="1.0.0-beta1-20170427-174" targetFramework="net46" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Update the project templates to use the 1.0.0-beta1-20170427-174
templating NuGet packages.

The ASP.NET Core web project templates use unpublished NuGet packages so they currently will not restore.