### PR TITLE
[master][Xml] Prevent DTD being resolved when formatting xml

### DIFF
--- a/main/src/addins/Xml/Formatting/XmlFormatter.cs
+++ b/main/src/addins/Xml/Formatting/XmlFormatter.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.Xml.Formatting
 			XmlDocument doc;
 			try {
 				doc = new XmlDocument ();
+				doc.XmlResolver = null; // Prevent DTDs from being downloaded.
 				doc.LoadXml (input);
 			} catch (XmlException ex) {
 				// handle xml files without root element (https://bugzilla.xamarin.com/show_bug.cgi?id=4748)


### PR DESCRIPTION
Cherry picked from d15-2.

If an xml file contained a DTD then the xml formatter would try
to resolve and download the DTD.

```
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
<svg xmlns="http://www.w3.org/2000/svg">
...
```

This could cause the UI to hang.

There is no need to resolve any DTDs when formatting the xml so
the resolver is disabled. This fixes the long time spent waiting for
files to be formatted when a new ASP.NET Core web project is created.