### PR TITLE
[Core] Support null dictionary string values in BinaryMessage

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/BinaryMessage.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/BinaryMessage.cs
@@ -30,6 +30,7 @@ namespace MonoDevelop.Core.Execution
 			TimeSpan = 14,
 		}
 
+		static readonly string NullString = "\0";
 		static object dataTypesLock = new object ();
 		static Dictionary<Type, TypeMap> dataTypes = new Dictionary<Type, TypeMap> ();
 
@@ -257,7 +258,7 @@ namespace MonoDevelop.Core.Execution
 			} else if (et == typeof(string)) {
 				bw.Write ((byte)TypeCode.String);
 				foreach (var v in (string [])val)
-					bw.Write (v ?? "");
+					bw.Write (v ?? NullString);
 			} else if (et == typeof(bool)) {
 				bw.Write ((byte)TypeCode.Boolean);
 				foreach (var v in (bool [])val)
@@ -386,8 +387,12 @@ namespace MonoDevelop.Core.Execution
 				}
 			case TypeCode.String: {
 					var a = new string [count];
-					for (int n = 0; n < count; n++)
-						a [n] = br.ReadString ();
+					for (int n = 0; n < count; n++) {
+						string s = br.ReadString ();
+						if (s == NullString)
+							s = null;
+						a [n] = s;
+					}
 					return a;
 				}
 			case TypeCode.Boolean: {

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.cs
@@ -103,7 +103,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 					if (evaluateProperties != null) {
 						foreach (var name in evaluateProperties)
-							result.Properties [name] = project.GetEvaluatedProperty (name) ?? string.Empty;
+							result.Properties [name] = project.GetEvaluatedProperty (name);
 					}
 
 					if (evaluateItems != null) {

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Projects.MSBuild
 					if (evaluateProperties != null) {
 						foreach (var name in evaluateProperties) {
 							var prop = pi.GetProperty (name);
-							result.Properties [name] = prop != null? prop.EvaluatedValue : string.Empty;
+							result.Properties [name] = prop != null? prop.EvaluatedValue : null;
 						}
 					}
 

--- a/main/tests/UnitTests/MonoDevelop.Core/RemoteProcessConnectionTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core/RemoteProcessConnectionTests.cs
@@ -149,12 +149,7 @@ namespace MonoDevelop.Core
 			m = BinaryMessage.Read (ms);
 			var readData1 = m.GetArgument ("map1") as Dictionary<string, string>;
 			Assert.AreEqual (1, m.Args.Count);
-			Assert.AreEqual (2, readData1.Keys.Count);
-			Assert.AreEqual ("a", readData1 ["one"]);
-
-			// Null value in dictionary is converted to empty string
-			// on writing to the stream.
-			Assert.AreEqual (string.Empty, readData1 ["two"]);
+			Assert.AreEqual (data1, readData1);
 		}
 
 		[Test]

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -101,7 +101,7 @@ namespace MonoDevelop.Projects
 			Assert.IsNotNull (res.BuildResult);
 			Assert.AreEqual (0, res.BuildResult.ErrorCount);
 			Assert.AreEqual (0, res.BuildResult.WarningCount);
-			Assert.AreEqual ("", res.Properties.GetValue ("TestUnknownPropertyToEvaluate"));
+			Assert.IsNull (res.Properties.GetValue ("TestUnknownPropertyToEvaluate"));
 
 			sol.Dispose ();
 		}


### PR DESCRIPTION
Reworked the original fix for Bug #55751 - [iOS] Uploading iOS Forms
PCL app from Xamarin Studio to Test Cloud fails build step with
"Unknown MSBuild Failure"

Null dictionary string values are now handled in a simple way by
replacing the null with a place holder in the BinaryMessage.
The changes made to the ProjectBuilders have been reverted since
nulls are supported and no longer need to be replaced with empty
strings.