### PR TITLE
Fix bug when restoring document splits

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebookContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebookContainer.cs
@@ -89,7 +89,16 @@ namespace MonoDevelop.Components.DockNotebook
 		protected override void OnSizeAllocated (Gdk.Rectangle allocation)
 		{
 			base.OnSizeAllocated (allocation);
-			if (!splitsInitialized) {
+
+			// When showing the dock frame for the first time, the dock container is assigned a size of 1x1 before
+			// it gets the real size. This causes the splits to be initialized with position set to 0, which
+			// means the first widget of the split is not visible. To avoid this problem, we now initialize
+			// the splits only when the size is > 1.
+			// This didn't happen before, and it is not clear why is it happening now.
+			// Maybe the accessibility changes are causing the dock container to be realized earlier, or maybe
+			// it is due to some change in gtk.
+
+			if (!splitsInitialized && allocation.Width > 1 && allocation.Height > 1) {
 				splitsInitialized = true;
 				if (Child is HPaned) {
 					var p = (HPaned)Child;


### PR DESCRIPTION
Fixes bug #55399 - Editor columns become stacked hiding
one one column behind the other when VS is closed and reopen.