### PR TITLE
[Refactoring] Report success when analyzers found no issues

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/AnalyzeWholeSolutionHandler.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/AnalyzeWholeSolutionHandler.cs
@@ -165,7 +165,10 @@ namespace MonoDevelop.Refactoring
 			}));
 
 			monitor.EndTask ();
-			ShowAnalyzationResults ();
+			if (!allDiagnostics.Any ())
+				monitor.ReportSuccess (GettextCatalog.GetString ("Analysis successful."));
+			else
+				ShowAnalyzationResults ();
 		}
 
 		static void ShowAnalyzationResults ()


### PR DESCRIPTION
Previously, when no issue was raised by the analyzers we still opened the error pad.
It's clearer to not open the error pad and report success like we do when building so people know that something happened, success, there are no issues.

<img width="452" alt="screenshot 2017-05-04 15 28 37" src="https://cloud.githubusercontent.com/assets/7839202/25721738/89f09088-30df-11e7-8d10-0ee28e80e36e.png">
