### PR TITLE
Check if keybinding file exists before opening it

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingService.cs
@@ -168,7 +168,12 @@ namespace MonoDevelop.Components.Commands
 		public static void LoadCurrentBindings (string defaultSchemaId)
 		{
 			XmlTextReader reader = null;
-			
+
+			if (!File.Exists (ConfigFileName)) {
+				ResetCurrent (defaultSchemaId);
+				return;
+			}
+
 			try {
 				reader = new XmlTextReader (ConfigFileName);
 				current.LoadScheme (reader, "current");


### PR DESCRIPTION
This avoids a first-chance exception on startup when we try to read from a file that doesn't exist.