### PR TITLE
Fixed 'Bug 56006 - Backspace deleting too far'

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/IndentationTracker.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/IndentationTracker.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 	{
 		public virtual IndentationTrackerFeatures SupportedFeatures {
 			get {
-				return IndentationTrackerFeatures.All;
+				return IndentationTrackerFeatures.None;
 			}
 		}
 


### PR DESCRIPTION
That turns off smart backspace - this is only useful for some
programming languages like c#, vb - but not for web, xml, text etc.