### PR TITLE
Use VSMEF for MEF composition.

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -85,6 +85,10 @@
       <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Composition.Runtime">
+      <HintPath>..\..\..\build\bin\System.Composition.Runtime.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
@@ -190,7 +190,7 @@
 		<StockIcon stockid="md-prefs-completion" resource="prefs-completion-16.png" size="Menu" />
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
+	<Extension path="/MonoDevelop/Ide/Composition">
 		<Assembly file="MonoDevelop.SourceEditor.dll"/>
 	</Extension>
 </ExtensionModel>

--- a/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
+++ b/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
@@ -30,7 +30,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.VisualStudio.Platform
 {
 	[Export]
-	internal class PlatformCatalog : IPartImportsSatisfiedNotification
+	class PlatformCatalog : IPartImportsSatisfiedNotification
 	{
 		[Export]                                        //HACK
 		[Name ("csharp")]                               //HACK

--- a/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
+++ b/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using Mono.Addins;
 using MonoDevelop.Core;
 using MonoDevelop.Core.AddIns;
+using MonoDevelop.Ide.Composition;
 using MonoDevelop.Ide.Editor.Highlighting;
 
 using Microsoft.VisualStudio.Text;
@@ -28,98 +29,66 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Platform
 {
-    public class PlatformCatalog
-    {
-        public static PlatformCatalog Instance = new PlatformCatalog();
+	[Export]
+	internal class PlatformCatalog : IPartImportsSatisfiedNotification
+	{
+		[Export]                                        //HACK
+		[Name ("csharp")]                               //HACK
+		[BaseDefinition ("code")]                       //HACK
+		public ContentTypeDefinition CodeContentType;   //HACK
 
-        public CompositionContainer CompositionContainer { get; }
+		private static PlatformCatalog instance;
+		public static PlatformCatalog Instance {
+			get {
+				if (instance == null) {
+					lock (typeof(PlatformCatalog)) {
+						if (instance == null) {
+							instance = CompositionManager.GetExportedValue<PlatformCatalog> ();
+						}
+					}
+				}
 
-        public ITextBufferFactoryService2 TextBufferFactoryService { get; }
+				return instance;
+			}
+		}
 
-        private PlatformCatalog()
-        {
-            var container = PlatformCatalog.CreateContainer();
-            container.SatisfyImportsOnce(this);
+		[Import]
+		internal ITextBufferFactoryService TextBufferFactoryService { get; private set; }
 
-            this.CompositionContainer = container;
-            this.TextBufferFactoryService = (ITextBufferFactoryService2)_textBufferFactoryService;
+		internal ITextBufferFactoryService2 TextBufferFactoryService2 => TextBufferFactoryService as ITextBufferFactoryService2;
 
-            this.MimeToContentTypeRegistryService.LinkTypes("text/plain", this.ContentTypeRegistryService.GetContentType("text"));		  //HACK
-            this.MimeToContentTypeRegistryService.LinkTypes("text/x-csharp", this.ContentTypeRegistryService.GetContentType("csharp"));   //HACK
+		[Import]
+		internal ITextDocumentFactoryService TextDocumentFactoryService { get; private set; }
 
-            if (null != this.ContentTypeRegistryService.GetContentType("css"))
-            {
-                this.MimeToContentTypeRegistryService.LinkTypes("text/x-css", this.ContentTypeRegistryService.GetContentType("css"));   //HACK
-                this.MimeToContentTypeRegistryService.LinkTypes("text/x-html", this.ContentTypeRegistryService.GetContentType("htmlx"));   //HACK
-                this.MimeToContentTypeRegistryService.LinkTypes("text/x-json", this.ContentTypeRegistryService.GetContentType("JSON"));   //HACK
-            }
-        }
+		[Import]
+		internal ITextEditorFactoryService TextEditorFactoryService { get; private set; }
 
-        private static CompositionContainer CreateContainer()
-        {
-            // TODO: Read these from manifest.addin.xml?
-            AggregateCatalog catalog = new AggregateCatalog();
-            catalog.Catalogs.Add(new AssemblyCatalog(typeof(PlatformCatalog).Assembly));
+		[Import]
+		internal IMimeToContentTypeRegistryService MimeToContentTypeRegistryService { get; private set; }
 
-            foreach (var node in AddinManager.GetExtensionNodes("/MonoDevelop/Ide/TypeService/PlatformMefHostServices"))
-            {
-                var assemblyNode = node as AssemblyExtensionNode;
-                if (assemblyNode != null)
-                {
-                    try
-                    {
-						// Make sure the add-in that registered the assembly is loaded, since it can bring other
-						// other assemblies required to load this one
-						AddinManager.LoadAddin(null, assemblyNode.Addin.Id);
+		[Import]
+		internal IContentTypeRegistryService ContentTypeRegistryService { get; private set; }
 
-                        var assemblyFilePath = assemblyNode.Addin.GetFilePath(assemblyNode.FileName);
-                        var assembly = MonoDevelop.Core.Platform.AssemblyLoad(assemblyFilePath);
-                        catalog.Catalogs.Add(new AssemblyCatalog(assembly));
-                    }
-                    catch (Exception e)
-                    {
-                        LoggingService.LogError("Workspace can't load assembly " + assemblyNode.FileName + " to host mef services.", e);
-                    }
-                }
-            }
+		[Import]
+		internal IBufferTagAggregatorFactoryService BufferTagAggregatorFactoryService { get; private set; }
 
-            //Create the CompositionContainer with the parts in the catalog
-            CompositionContainer container = new CompositionContainer(catalog,
-                                                                      CompositionOptions.DisableSilentRejection |
-                                                                      CompositionOptions.IsThreadSafe |
-                                                                      CompositionOptions.ExportCompositionService);
+		[Import]
+		internal IClassifierAggregatorService ClassifierAggregatorService { get; private set; }
 
-            return container;
-        }
+		void IPartImportsSatisfiedNotification.OnImportsSatisfied ()
+		{
+			this.MimeToContentTypeRegistryService.LinkTypes ("text/plain", this.ContentTypeRegistryService.GetContentType ("text"));          //HACK
+			this.MimeToContentTypeRegistryService.LinkTypes ("text/x-csharp", this.ContentTypeRegistryService.GetContentType ("csharp"));   //HACK
 
-        [Export]                                        //HACK
-        [Name("csharp")]                                //HACK
-        [BaseDefinition("code")]                        //HACK
-        public ContentTypeDefinition codeContentType;   //HACK
+			if (null != this.ContentTypeRegistryService.GetContentType ("css")) {
+				this.MimeToContentTypeRegistryService.LinkTypes ("text/x-css", this.ContentTypeRegistryService.GetContentType ("css"));   //HACK
+				this.MimeToContentTypeRegistryService.LinkTypes ("text/x-html", this.ContentTypeRegistryService.GetContentType ("htmlx"));   //HACK
+				this.MimeToContentTypeRegistryService.LinkTypes ("text/x-json", this.ContentTypeRegistryService.GetContentType ("JSON"));   //HACK
+			}
+		}
+	}
 
-        [Import]
-        internal ITextBufferFactoryService _textBufferFactoryService { get; private set; }
-
-        [Import]
-        internal ITextDocumentFactoryService TextDocumentFactoryService { get; private set; }
-
-        [Import]
-        internal ITextEditorFactoryService TextEditorFactoryService { get; private set; }
-
-        [Import]
-        internal IMimeToContentTypeRegistryService MimeToContentTypeRegistryService { get; private set; }
-
-        [Import]
-        internal IContentTypeRegistryService ContentTypeRegistryService { get; private set; }
-
-        [Import]
-        internal IBufferTagAggregatorFactoryService BufferTagAggregatorFactoryService { get; private set; }
-
-        [Import]
-        internal IClassifierAggregatorService ClassifierAggregatorService { get; private set; }
-    }
-
-    [Export(typeof(IThreadHelper))]
+	[Export(typeof(IThreadHelper))]
     public class PlatformThreadHelper : IThreadHelper
     {
         public Task RunOnUIThread(Action action)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -206,7 +206,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
       <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.1.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.1.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -226,11 +226,7 @@
 		<ExtensionNode name = "Class" objectType = "MonoDevelop.Ide.LocaleSetProvider" />
 	</ExtensionPoint>
 	
-	<ExtensionPoint path="/MonoDevelop/Ide/TypeService/MefHostServices">
-		<ExtensionNode name = "Assembly" type = "MonoDevelop.Core.AddIns.AssemblyExtensionNode" />
-	</ExtensionPoint>
-
-	<ExtensionPoint path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
+	<ExtensionPoint path="/MonoDevelop/Ide/Composition">
 		<ExtensionNode name = "Assembly" type = "MonoDevelop.Core.AddIns.AssemblyExtensionNode" />
 	</ExtensionPoint>
 
@@ -391,7 +387,14 @@
 		<Class class = "MonoDevelop.Ide.GettingStarted.GettingStartedProjectExtension"/>
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
+	<Extension path="/MonoDevelop/Ide/Composition">
+		<Assembly file="Microsoft.CodeAnalysis.CSharp.Features.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.CSharp.Workspaces.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.Features.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.Workspaces.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" />
 		<Assembly file="Microsoft.VisualStudio.Text.Logic.dll"/>
+		<Assembly file="MonoDevelop.Ide.dll"/>
 	</Extension>
 </ExtensionModel>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -1,0 +1,164 @@
+// ConfigFileUtilities.cs
+//
+// Author:
+//   Kirill Osenkov <https://github.com/KirillOsenkov>
+//
+// Copyright (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+using Mono.Addins;
+using MonoDevelop.Core;
+using MonoDevelop.Core.AddIns;
+
+namespace MonoDevelop.Ide.Composition
+{
+	/// <summary>
+	/// The host of the MonoDevelop MEF composition. Uses https://github.com/Microsoft/vs-mef.
+	/// </summary>
+	public class CompositionManager
+	{
+		private static Task<CompositionManager> creationTask;
+		private static CompositionManager instance;
+
+		private static readonly Resolver StandardResolver = Resolver.DefaultInstance;
+		private static readonly PartDiscovery Discovery = PartDiscovery.Combine (
+			new AttributedPartDiscoveryV1 (StandardResolver),
+			new AttributedPartDiscovery (StandardResolver, true));
+
+		public static CompositionManager Instance {
+			get {
+				if (instance == null) {
+					instance = InitializeAsync ().Result;
+				}
+
+				return instance;
+			}
+		}
+
+		/// <summary>
+		/// Starts initializing the MEF composition on a background thread. Thread-safe.
+		/// </summary>
+		public static Task<CompositionManager> InitializeAsync ()
+		{
+			if (creationTask == null) {
+				lock (typeof (CompositionManager)) {
+					if (creationTask == null) {
+						creationTask = Task.Run (() => CreateInstanceAsync ());
+					}
+				}
+			}
+
+			return creationTask;
+		}
+
+		/// <summary>
+		/// Returns an instance of type T that is exported by some composition part. The instance is shared (singleton).
+		/// </summary>
+		public static T GetExportedValue<T> ()
+		{
+			return Instance.ExportProvider.GetExportedValue<T> ();
+		}
+
+		public RuntimeComposition RuntimeComposition { get; private set; }
+		public IExportProviderFactory ExportProviderFactory { get; private set; }
+		public ExportProvider ExportProvider { get; private set; }
+
+		internal CompositionManager ()
+		{
+		}
+
+		private static async Task<CompositionManager> CreateInstanceAsync ()
+		{
+			var compositionManager = new CompositionManager ();
+			await compositionManager.InitializeInstanceAsync ();
+			return compositionManager;
+		}
+
+		private async Task InitializeInstanceAsync ()
+		{
+			ComposableCatalog catalog = ComposableCatalog.Create (StandardResolver)
+				.WithCompositionService ()
+				.WithDesktopSupport ();
+
+			var assemblies = new HashSet<Assembly> ();
+			ReadAssembliesFromAddins (assemblies, "/MonoDevelop/Ide/Composition");
+
+			// spawn discovery tasks in parallel for each assembly
+			var tasks = new List<Task<DiscoveredParts>> (assemblies.Count);
+			foreach (var assembly in assemblies) {
+				var task = Discovery.CreatePartsAsync (assembly);
+				tasks.Add (task);
+			}
+
+			await Task.WhenAll (tasks);
+
+			foreach (var task in tasks) {
+				catalog = catalog.AddParts (task.Result);
+			}
+
+			var discoveryErrors = catalog.DiscoveredParts.DiscoveryErrors;
+			if (!discoveryErrors.IsEmpty) {
+				throw new ApplicationException ($"Catalog scanning errors encountered.\n{string.Join ("\n", discoveryErrors)}");
+			}
+
+			CompositionConfiguration configuration = CompositionConfiguration.Create (catalog);
+
+			if (!configuration.CompositionErrors.IsEmpty) {
+				// capture the errors in an array for easier debugging
+				var errors = configuration.CompositionErrors.ToArray ();
+				configuration.ThrowOnErrors ();
+			}
+
+			RuntimeComposition = RuntimeComposition.CreateRuntimeComposition (configuration);
+			ExportProviderFactory = RuntimeComposition.CreateExportProviderFactory ();
+			ExportProvider = ExportProviderFactory.CreateExportProvider ();
+		}
+
+		private void ReadAssembliesFromAddins (HashSet<Assembly> assemblies, string extensionPath)
+		{
+			foreach (var node in AddinManager.GetExtensionNodes (extensionPath)) {
+				var assemblyNode = node as AssemblyExtensionNode;
+				if (assemblyNode != null) {
+					try {
+						// Make sure the add-in that registered the assembly is loaded, since it can bring other
+						// other assemblies required to load this one
+						AddinManager.LoadAddin (null, assemblyNode.Addin.Id);
+
+						var assemblyFilePath = assemblyNode.Addin.GetFilePath (assemblyNode.FileName);
+						var assembly = MonoDevelop.Core.Platform.AssemblyLoad (assemblyFilePath);
+						assemblies.Add (assembly);
+					}
+					catch (Exception e) {
+						LoggingService.LogError ("Composition can't load assembly " + assemblyNode.FileName, e);
+					}
+				}
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -43,11 +43,11 @@ namespace MonoDevelop.Ide.Composition
 	/// </summary>
 	public class CompositionManager
 	{
-		private static Task<CompositionManager> creationTask;
-		private static CompositionManager instance;
+		static Task<CompositionManager> creationTask;
+		static CompositionManager instance;
 
-		private static readonly Resolver StandardResolver = Resolver.DefaultInstance;
-		private static readonly PartDiscovery Discovery = PartDiscovery.Combine (
+		static readonly Resolver StandardResolver = Resolver.DefaultInstance;
+		static readonly PartDiscovery Discovery = PartDiscovery.Combine (
 			new AttributedPartDiscoveryV1 (StandardResolver),
 			new AttributedPartDiscovery (StandardResolver, true));
 
@@ -93,14 +93,14 @@ namespace MonoDevelop.Ide.Composition
 		{
 		}
 
-		private static async Task<CompositionManager> CreateInstanceAsync ()
+		static async Task<CompositionManager> CreateInstanceAsync ()
 		{
 			var compositionManager = new CompositionManager ();
 			await compositionManager.InitializeInstanceAsync ();
 			return compositionManager;
 		}
 
-		private async Task InitializeInstanceAsync ()
+		async Task InitializeInstanceAsync ()
 		{
 			ComposableCatalog catalog = ComposableCatalog.Create (StandardResolver)
 				.WithCompositionService ()
@@ -140,7 +140,7 @@ namespace MonoDevelop.Ide.Composition
 			ExportProvider = ExportProviderFactory.CreateExportProvider ();
 		}
 
-		private void ReadAssembliesFromAddins (HashSet<Assembly> assemblies, string extensionPath)
+		void ReadAssembliesFromAddins (HashSet<Assembly> assemblies, string extensionPath)
 		{
 			foreach (var node in AddinManager.GetExtensionNodes (extensionPath)) {
 				var assemblyNode = node as AssemblyExtensionNode;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		internal static HostServices HostServices {
+		public static HostServices HostServices {
 			get {
 				return services;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -48,6 +48,8 @@ using System.ComponentModel;
 using Mono.Addins;
 using MonoDevelop.Core.AddIns;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using MonoDevelop.Ide.Composition;
+using Microsoft.VisualStudio.Composition;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
@@ -71,19 +73,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		static string[] mefHostServices = new [] {
-			"Microsoft.CodeAnalysis.Workspaces",
-			//FIXME: this does not load yet. We should provide alternate implementations of its services.
-			//"Microsoft.CodeAnalysis.Workspaces.Desktop",
-			"Microsoft.CodeAnalysis.Features",
-			"Microsoft.CodeAnalysis.CSharp",
-			"Microsoft.CodeAnalysis.CSharp.Workspaces",
-			"Microsoft.CodeAnalysis.CSharp.Features",
-			"Microsoft.CodeAnalysis.VisualBasic",
-			"Microsoft.CodeAnalysis.VisualBasic.Workspaces",
-			"Microsoft.CodeAnalysis.VisualBasic.Features",
-		};
-
 		internal static HostServices HostServices {
 			get {
 				return services;
@@ -92,33 +81,7 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		static MonoDevelopWorkspace ()
 		{
-			List<Assembly> assemblies = new List<Assembly> ();
-			assemblies.Add (typeof (MonoDevelopWorkspace).Assembly);
-			foreach (var asmName in mefHostServices) {
-				try {
-					var asm = Assembly.Load (asmName);
-					if (asm == null)
-						continue;
-					assemblies.Add (asm);
-				} catch (Exception ex) {
-					LoggingService.LogError ("Error - can't load host service assembly: " + asmName, ex);
-				}
-			}
-			assemblies.Add (typeof(MonoDevelopWorkspace).Assembly);
-			foreach (var node in AddinManager.GetExtensionNodes ("/MonoDevelop/Ide/TypeService/MefHostServices")) {
-				var assemblyNode = node as AssemblyExtensionNode;
-				if (assemblyNode == null)
-					continue;
-				try {
-					var assemblyFilePath = assemblyNode.Addin.GetFilePath(assemblyNode.FileName);
-					var assembly = Assembly.LoadFrom(assemblyFilePath);
-					assemblies.Add (assembly);
-				} catch (Exception e) {
-					LoggingService.LogError ("Workspace can't load assembly " + assemblyNode.FileName + " to host mef services.", e);
-					continue;
-				}
-			}
-			services = MefHostServices.Create (assemblies);
+			services = MefV1HostServices.Create (CompositionManager.Instance.ExportProvider.AsExportProvider());
 		}
 
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -132,6 +132,10 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\netstandard1.0\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Xamarin.Mac" Condition=" '$(Configuration)' == 'DebugMac' Or '$(Configuration)' == 'ReleaseMac' ">
       <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
     </Reference>
@@ -141,6 +145,10 @@
     <Reference Include="WindowsBase" Condition=" '$(Configuration)' == 'DebugWin32' Or '$(Configuration)' == 'ReleaseWin32' " />
     <Reference Include="WindowsFormsIntegration" Condition=" '$(Configuration)' == 'DebugWin32' Or '$(Configuration)' == 'ReleaseWin32' " />
     <Reference Include="System.Xaml" />
+    <Reference Include="Microsoft.VisualStudio.Composition, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Composition.15.3.38\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
@@ -152,6 +160,10 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.UI">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Text.UI.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="ICSharpCode.SharpZipLib">
@@ -172,14 +184,18 @@
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.1.0\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Composition.AttributedModel.1.0.31\lib\netstandard1.0\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.Runtime">
-      <HintPath>..\..\..\build\bin\System.Composition.Runtime.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Composition.Runtime.1.0.31\lib\netstandard1.0\System.Composition.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet">
       <HintPath>..\..\..\packages\YamlDotNet.Signed.4.0.1-pre291\lib\net35\YamlDotNet.dll</HintPath>
@@ -8371,6 +8387,7 @@
     <Compile Include="MonoDevelop.Ide.Commands\ToolsCommands.cs" />
     <Compile Include="MonoDevelop.Ide.Commands\ViewCommands.cs" />
     <Compile Include="MonoDevelop.Ide.Commands\WindowCommands.cs" />
+    <Compile Include="MonoDevelop.Ide.Composition\CompositionManager.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\DisplayBindingService.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\BackgroundProgressMonitor.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\StatusProgressMonitor.cs" />
@@ -9462,8 +9479,6 @@
   <Import Project="..\..\core\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Def.projitems" Label="Shared" Condition="Exists('..\..\core\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Def.projitems')" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Components.MainToolbar\Theme\" />
-    <Folder Include="MonoDevelop.Components\Xwt\" />
-    <Folder Include="MonoDevelop.Components.AtkCocoaHelper\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="gtkrc">

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -6,12 +6,17 @@
   <package id="Microsoft.TemplateEngine.Edge" version="1.0.0-beta1-20170223-126" targetFramework="net45" />
   <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta1-20170223-126" targetFramework="net45" />
   <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta1-20170223-126" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Composition" version="15.3.38" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Data" version="15.0.26201" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.0.26201" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.0.26201" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
   <package id="YamlDotNet.Signed" version="4.0.1-pre291" targetFramework="net45" />
 </packages>

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -12,7 +12,6 @@
 				<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="2.0.0.0-4.4.0.0" newVersion="4.4.1.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
@@ -83,6 +82,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-1.0.31.0" newVersion="1.0.31.0" />
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.6.1.0" newVersion="4.6.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
@@ -119,6 +122,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces.Desktop" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
 			</dependentAssembly>
@@ -145,6 +152,10 @@
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.Text.UI" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="15.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=b7191416eb55822831a2ae7cda726eb62a76d83f
-DEP_BRANCH_AND_REMOTE[0]="master origin/master"
+DEP_NEEDED_VERSION[0]=e1262f9c8a778d8a591601d3ed76acad4b43b9ff
+DEP_BRANCH_AND_REMOTE[0]="vsmef origin/vsmef"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
 * Add a MonoDevelop.Ide.Composition.CompositionManager class hosting the VSMEF container. It is responsible for initializing the composition, gathering assemblies from addins, composing on a background thread and returning an ExportProvider ready to use by consumers.

 * Change PlatformCatalog to be a simple Editor-specific class exposing a few imports used by the editor.

 * Change the addin path to /MonoDevelop/Ide/Composition (MEF is not TypeService or Platform specific).

 * Add a reference to Microsoft.CodeAnalysis.Workspaces.Desktop.dll (but not add it to MEF!) so that we can use MefV1HostServices to use in MonoDevelopWorkspace. This is the same thing Visual Studio uses.