### PR TITLE
Fixed 'Bug 55970 - Backspace shows no code completion items in

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/CompletionEngine.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/CompletionEngine.cs
@@ -119,7 +119,7 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 				}
 
 				foreach (var handler in handlerList) {
-					if (info.CompletionTriggerReason == CompletionTriggerReason.CompletionCommand || handler.IsTriggerCharacter (text, position - 1)) {
+					if (info.CompletionTriggerReason == CompletionTriggerReason.CompletionCommand || info.CompletionTriggerReason == CompletionTriggerReason.BackspaceOrDeleteCommand || handler.IsTriggerCharacter (text, position - 1)) {
 						if (await handler.IsExclusiveAsync (completionContext, ctx, info, cancellationToken)) {
 							exclusiveHandlers.Add (handler);
 						} else {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/SpeculativeNameContextHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/SpeculativeNameContextHandler.cs
@@ -45,9 +45,10 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 		protected async override Task<IEnumerable<CompletionData>> GetItemsWorkerAsync (CompletionResult completionResult, CompletionEngine engine, CompletionContext completionContext, CompletionTriggerInfo info, SyntaxContext ctx, CancellationToken cancellationToken)
 		{
 			var tree = await completionContext.Document.GetCSharpSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-			if (tree.IsInNonUserCode(completionContext.Position, cancellationToken) ||
-				tree.IsPreProcessorDirectiveContext(completionContext.Position, cancellationToken) || 
-				info.CompletionTriggerReason != CompletionTriggerReason.CompletionCommand)
+			if (tree.IsInNonUserCode (completionContext.Position, cancellationToken) ||
+				tree.IsPreProcessorDirectiveContext (completionContext.Position, cancellationToken) ||
+				info.CompletionTriggerReason != CompletionTriggerReason.CompletionCommand &&
+			    info.CompletionTriggerReason != CompletionTriggerReason.BackspaceOrDeleteCommand)
 				return Enumerable.Empty<CompletionData>();
 
 			var token = tree.FindTokenOnLeftOfPosition(completionContext.Position, cancellationToken);

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/XmlDocCommentContextHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/XmlDocCommentContextHandler.cs
@@ -49,6 +49,8 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 			{
 				return null;
 			}
+			if (info.CompletionTriggerReason == CompletionTriggerReason.BackspaceOrDeleteCommand)
+				return null;
 			var document = completionContext.Document;
 			var position = completionContext.Position;
 


### PR DESCRIPTION
comments'

Backspace now has a special trigger info but was filered out in the
backend - the trigger info was introduced later. The xml doc
completion now takes that trigger info into account when suggesting
items.