### PR TITLE
[d15-3-preview][DotNetCore] Allow .NET Core 2.0 pre-release projects to restore 

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreProjectTests.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreMSBuildProjectTests.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreSdkVersionTests.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreVersionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreVersionTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreVersionTests.cs
@@ -1,0 +1,188 @@
+﻿﻿﻿﻿//
+// DotNetCoreVersionTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace MonoDevelop.DotNetCore.Tests
+{
+	[TestFixture]
+	class DotNetCoreVersionTests
+	{
+		[Test]
+		public void Parse_StableVersion ()
+		{
+			var version = DotNetCoreVersion.Parse ("1.2.3");
+
+			Assert.AreEqual (1, version.Major);
+			Assert.AreEqual (2, version.Minor);
+			Assert.AreEqual (3, version.Patch);
+			Assert.AreEqual ("1.2.3", version.Version.ToString ());
+			Assert.IsFalse (version.IsPrerelease);
+			Assert.AreEqual ("1.2.3", version.OriginalString);
+			Assert.AreEqual ("1.2.3", version.ToString ());
+		}
+
+		[Test]
+		public void Parse_InvalidVersion ()
+		{
+			Assert.Throws<FormatException> (() => {
+				DotNetCoreVersion.Parse ("invalid");
+			});
+		}
+
+		[Test]
+		public void Parse_NullVersion ()
+		{
+			Assert.Throws<ArgumentException> (() => {
+				DotNetCoreVersion.Parse (null);
+			});
+		}
+
+		[Test]
+		public void Parse_VersionIsEmptyString ()
+		{
+			Assert.Throws<ArgumentException> (() => {
+				DotNetCoreVersion.Parse (null);
+			});
+		}
+
+		[Test]
+		public void Parse_PrereleaseVersion ()
+		{
+			var version = DotNetCoreVersion.Parse ("2.0.0-preview2-002093-00");
+
+			Assert.AreEqual (2, version.Major);
+			Assert.AreEqual (0, version.Minor);
+			Assert.AreEqual (0, version.Patch);
+			Assert.AreEqual ("2.0.0", version.Version.ToString ());
+			Assert.IsTrue (version.IsPrerelease);
+			Assert.AreEqual ("2.0.0-preview2-002093-00", version.OriginalString);
+			Assert.AreEqual ("2.0.0-preview2-002093-00", version.ToString ());
+		}
+
+		[Test]
+		public void TryParse_NullVersion ()
+		{
+			DotNetCoreVersion version = null;
+			bool result = DotNetCoreVersion.TryParse (null, out version);
+
+			Assert.IsFalse (result);
+		}
+
+		[Test]
+		public void TryParse_VersionIsEmptyString ()
+		{
+			DotNetCoreVersion version = null;
+			bool result = DotNetCoreVersion.TryParse (string.Empty, out version);
+
+			Assert.IsFalse (result);
+		}
+
+		[TestCase ("1.0.2", "1.0.2", true)]
+		[TestCase ("1.2.3", "1.0.2", false)]
+		[TestCase ("1.0.2", "1.0.2-preview1-002912-00", false)]
+		[TestCase ("1.0.2-preview1-002912-00", "1.0.2-preview1-002912-00", true)]
+		public void Equals_Version (string x, string y, bool expected)
+		{
+			var versionX = DotNetCoreVersion.Parse (x);
+			var versionY = DotNetCoreVersion.Parse (y);
+			Assert.AreEqual (expected, versionX.Equals (versionY));
+		}
+
+		[Test]
+		public void Equals_NullVersion ()
+		{
+			var x = DotNetCoreVersion.Parse ("1.0");
+			Assert.IsFalse (x.Equals (null));
+		}
+
+		[Test]
+		public void CompareTo_StableVersion ()
+		{
+			var versionX = DotNetCoreVersion.Parse ("1.0.2");
+			var versionY = DotNetCoreVersion.Parse ("1.2.3");
+
+			Assert.IsTrue (versionX.CompareTo (versionX) == 0);
+			Assert.IsTrue (versionY.CompareTo (versionY) == 0);
+			Assert.IsTrue (versionX.CompareTo (versionY) < 0);
+			Assert.IsTrue (versionY.CompareTo (versionX) > 0);
+		}
+
+		[Test]
+		public void CompareTo_PrereleaseVersions ()
+		{
+			var versionX = DotNetCoreVersion.Parse ("1.0.2");
+			var versionY = DotNetCoreVersion.Parse ("1.0.2-preview1-002912-00");
+
+			Assert.IsTrue (versionX.CompareTo (versionX) == 0);
+			Assert.IsTrue (versionY.CompareTo (versionY) == 0);
+			Assert.IsTrue (versionX.CompareTo (versionY) > 0);
+			Assert.IsTrue (versionY.CompareTo (versionX) < 0);
+		}
+
+		[Test]
+		public void SortingPrereleaseVersions ()
+		{
+			var version100 = DotNetCoreVersion.Parse ("1.0.0");
+			var version102 = DotNetCoreVersion.Parse ("1.0.2");
+			var version102preview1_1 = DotNetCoreVersion.Parse ("1.0.2-preview1-002912-00");
+			var version102preview1_2 = DotNetCoreVersion.Parse ("1.0.2-preview1-003912-00");
+			var version102preview2_1 = DotNetCoreVersion.Parse ("1.0.2-preview2-001112-00");
+			var version200preview2_1 = DotNetCoreVersion.Parse ("2.0.0-preview2-002093-00");
+			var version200preview2_2 = DotNetCoreVersion.Parse ("2.0.0-preview2-002094-00");
+			var version200 = DotNetCoreVersion.Parse ("2.0.0");
+			var version201 = DotNetCoreVersion.Parse ("2.0.1");
+
+			var expected = new [] {
+				version100,
+				version102preview1_1,
+				version102preview1_2,
+				version102preview2_1,
+				version102,
+				version200preview2_2,
+				version200,
+				version201
+			};
+
+			var unsorted = new [] {
+				version200,
+				version102,
+				version102preview1_2,
+				version201,
+				version102preview2_1,
+				version100,
+				version102preview1_1,
+				version200preview2_2,
+			};
+
+			var sorted = unsorted.OrderBy (v => v).ToArray ();
+
+			Assert.AreEqual (expected, sorted);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -142,6 +142,8 @@
     <Compile Include="MonoDevelop.DotNetCore\MSBuildSdks.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreSystemInformation.cs" />
     <Compile Include="MonoDevelop.DotNetCore.NodeBuilders\DotNetCoreProjectNodeCommandHandler.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\DotNetCoreVersion.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\DotNetCoreRuntimeVersions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -51,6 +51,25 @@ namespace MonoDevelop.DotNetCore
 		public DotNetCoreProjectExtension ()
 		{
 			DotNetCoreProjectReloadMonitor.Initialize ();
+			PackageManagement.MSBuildProjectExtensions.ModifyImportedPackageReference = ModifyImportedPackageReference;
+		}
+
+		/// <summary>
+		/// HACK: Ensure NuGet packages can be restored for .NET Core 2.0 projects if
+		/// a preview version of .NET Core 2.0 is installed by mapping the Microsoft.NETCore.App
+		/// 2.0 package reference to the installed preview version. When MSBuild supports this
+		/// with the sdk resolver this code can be removed.
+		/// </summary>
+		static void ModifyImportedPackageReference (ProjectPackageReference packageReference)
+		{
+			if (packageReference.Include == "Microsoft.NETCore.App") {
+				string version = packageReference.Metadata.GetValue ("Version");
+				if (version == "2.0") {
+					string previewVersion = DotNetCoreRuntime.PreviewNetCore20AppVersion;
+					if (previewVersion != null)
+						packageReference.Metadata.SetValue ("Version", previewVersion);
+				}
+			}
 		}
 
 		protected override bool SupportsObject (WorkspaceObject item)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
@@ -1,0 +1,144 @@
+﻿﻿//
+// DotNetCoreVersion.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace MonoDevelop.DotNetCore
+{
+	class DotNetCoreVersion : IEquatable<DotNetCoreVersion>, IComparable<DotNetCoreVersion>
+	{
+		DotNetCoreVersion (Version version)
+		{
+			Version = version;
+		}
+
+		public Version Version { get; private set; }
+
+		public int Major {
+			get { return Version.Major; }
+		}
+
+		public int Minor {
+			get { return Version.Minor; }
+		}
+
+		public int Patch {
+			get { return Version.Build; }
+		}
+
+		public string OriginalString { get; private set; }
+
+		public bool IsPrerelease { get; private set; }
+		public string ReleaseLabel { get; private set; }
+
+		public override string ToString ()
+		{
+			return OriginalString;
+		}
+
+		/// <summary>
+		/// Stable runtime version: 1.0.3
+		/// Pre-release runtime version: 2.0.0-preview2-002093-00
+		/// </summary>
+		public static DotNetCoreVersion Parse (string input)
+		{
+			if (string.IsNullOrEmpty (input))
+				throw new ArgumentException (".NET Core version cannot be null or an empty string.", nameof (input));
+
+			DotNetCoreVersion version = null;
+			if (TryParse (input, out version))
+				return version;
+
+			throw new FormatException (string.Format ("Invalid .NET Core version: '{0}'", input));
+		}
+
+		public static bool TryParse (string input, out DotNetCoreVersion result)
+		{
+			result = null;
+
+			if (string.IsNullOrEmpty (input))
+				return false;
+
+			string versionString = input;
+			string releaseLabel = string.Empty;
+
+			int prereleaseLabelStart = input.IndexOf ('-');
+			if (prereleaseLabelStart >= 0) {
+				versionString = input.Substring (0, prereleaseLabelStart);
+				releaseLabel = input.Substring (prereleaseLabelStart + 1);
+			}
+
+			Version version = null;
+			if (!Version.TryParse (versionString, out version))
+				return false;
+
+			result = new DotNetCoreVersion (version) {
+				OriginalString = input,
+				IsPrerelease = prereleaseLabelStart >= 0,
+				ReleaseLabel = releaseLabel
+			};
+
+			return true;
+		}
+
+		public override int GetHashCode ()
+		{
+			return OriginalString.GetHashCode ();
+		}
+
+		public override bool Equals (object obj)
+		{
+			return Equals (obj as DotNetCoreVersion);
+		}
+
+		public bool Equals (DotNetCoreVersion other)
+		{
+			return CompareTo (other) == 0;
+		}
+
+		public int CompareTo (DotNetCoreVersion other)
+		{
+			if (other == null)
+				return 1;
+
+			int result = Version.CompareTo (other.Version);
+			if (result != 0)
+				return result;
+
+			if (!IsPrerelease && !other.IsPrerelease)
+				return result;
+
+			// Pre-release versions are lower than stable versions.
+			if (IsPrerelease && !other.IsPrerelease)
+				return -1;
+
+			if (!IsPrerelease && other.IsPrerelease)
+				return 1;
+
+			return StringComparer.OrdinalIgnoreCase.Compare (ReleaseLabel, other.ReleaseLabel);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MSBuildProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MSBuildProjectExtensions.cs
@@ -118,7 +118,16 @@ namespace MonoDevelop.PackageManagement
 		{
 			return project.GetEvaluatedPackageReferenceItems ()
 				.Where (item => item.IsImported)
-				.Select (ProjectPackageReference.Create);
+				.Select (CreateImportedPackageReference);
+		}
+
+		public static Action<ProjectPackageReference> ModifyImportedPackageReference;
+
+		static ProjectPackageReference CreateImportedPackageReference (IMSBuildItemEvaluated item)
+		{
+			var packageReference = ProjectPackageReference.Create (item);
+			ModifyImportedPackageReference?.Invoke (packageReference);
+			return packageReference;
 		}
 	}
 }


### PR DESCRIPTION
If the latest version of the .NET Core runtime installed is a 2.0
pre-release then the default Microsoft.NETCore.App version, which
will be 2.0, is modified before it is written to the
project.assets.json file so it is the pre-release version. This allows
the NuGet restore to work.