### PR TITLE
[A11y] Turn on focus ring for checkbuttons and radiobuttons

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -176,6 +176,7 @@ namespace MonoDevelop.MacIntegration
 			// 2 - All controls
 			if (keyboardMode == 2) {
 				Gtk.Rc.ParseString ("style \"default\" { engine \"xamarin\" { focusstyle = 2 } }");
+				Gtk.Rc.ParseString ("style \"radio-or-check-box\" { engine \"xamarin\" { focusstyle = 2 } } ");
 			}
 
 			return loaded;


### PR DESCRIPTION
When Full Keyboard Access is enabled, turn on the focus ring for checkbuttons and radiobuttons

Fixes BXC #53829 and 45 duplicates :)