### PR TITLE
Don't throw NREX when a template is unavailable.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
@@ -228,7 +228,7 @@ namespace MonoDevelop.Ide.Templates
 			var list = new List<FileTemplate> ();
 			foreach (var node in extensionContext.GetExtensionNodes<ProjectTemplateCodon> (EXTENSION_PATH)) {
 				var template = LoadTemplate (node); 
-				if (template.IsValidForProject (project, projectPath)) {
+				if (template != null && template.IsValidForProject (project, projectPath)) {
 					list.Add (template);
 				}
 			}


### PR DESCRIPTION
It happens when an add-in is disabled during the build and the NREX
prevents the solution-level "Add new file" dialog from showing up.