### PR TITLE
[Packaging] Exclude tests on Linux which don't work there

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
@@ -51,6 +51,7 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
+		[Platform (Exclude = "Linux")]
 		public async Task AddAndroidProjectForPCLProject ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";
@@ -135,6 +136,7 @@ namespace MonoDevelop.Packaging.Tests
 
 		[Test]
 		[Platform (Exclude = "Win")]
+		[Platform (Exclude = "Linux")]
 		public async Task AddIOSProjectForPCLProject ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";
@@ -216,6 +218,7 @@ namespace MonoDevelop.Packaging.Tests
 
 		[Test]
 		[Platform (Exclude = "Win")]
+		[Platform (Exclude = "Linux")]
 		public async Task AddSharedProjectForPCLProject ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";
@@ -346,6 +349,7 @@ namespace MonoDevelop.Packaging.Tests
 
 		[Test]
 		[Platform (Exclude = "Win")]
+		[Platform (Exclude = "Linux")]
 		public async Task PCLProjectInSameDirectoryAsSolution ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -122,6 +122,7 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
+		[Platform (Exclude = "Linux")]
 		public async Task CreateMultiPlatformProjectFromTemplateWithAndroidOnly ()
 		{
 			string templateId = "MonoDevelop.Packaging.CrossPlatformLibrary";


### PR DESCRIPTION
Some tests fail on Linux because there's no MonoDroid or XamarinIOS
solution item there:

`MonoDevelop.Projects.MSBuild.UnknownSolutionItemTypeException : Unknown solution item type: XamarinIOS`