### PR TITLE
Fixed 'Bug 56257 - FooButton_Clicked handler completion does not

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/EventCreationCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/EventCreationCompletionData.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.CSharp.Completion
 			var parsedDocument = document.UpdateParseDocument ().Result;
 			var semanticModel = parsedDocument.GetAst<SemanticModel> ();
 
-			var declaringType = semanticModel.GetEnclosingSymbol (position, default(CancellationToken)) as ITypeSymbol;
+			var declaringType = semanticModel.GetEnclosingSymbolMD<INamedTypeSymbol> (position, default(CancellationToken));
 			var enclosingSymbol = semanticModel.GetEnclosingSymbol (position, default(CancellationToken));
 
 			var insertionPoints = InsertionPointService.GetInsertionPoints (


### PR DESCRIPTION
generate method stub'

Broke during roslyn 2 port.