### PR TITLE
[A11y] Improve the way check/radio buttons are focus highlighted

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -83,6 +83,9 @@ style "default" {
 
     GtkCheckButton::indicator-size = 14
     GtkCheckButton::indicator-spacing = 4
+    GtkCheckButton::interior-focus = 0
+
+    GtkRadioButton::interior-focus = 0
 
     GtkTreeView::odd-row-color = "#fafafa"
 

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -84,6 +84,9 @@ style "default" {
 
     GtkCheckButton::indicator-size = 14
     GtkCheckButton::indicator-spacing = 4
+    GtkCheckButton::interior-focus = 1
+
+    GtkRadioButton::interior-focus = 1
 
     GtkTreeView::odd-row-color = "#3b3b3b"
 


### PR DESCRIPTION
Turn on interior focus for check/radio buttons so the focus gets drawn less squashed

To draw this nicely needs changes in both gtk and the xamarin-gtk-theme and I don't have time to do that now, so we'll leave it like this for now.