### PR TITLE
[VCS] Don't set tabs to spaces due to default policy in the diff editor.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/ComparisonWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/ComparisonWidget.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Components;
 using System.ComponentModel;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui;
+using MonoDevelop.Ide.Gui.Content;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -68,9 +69,10 @@ namespace MonoDevelop.VersionControl.Views
 		
 		protected override void CreateComponents ()
 		{
+			var options = GetTextEditorOptions ();
 			this.editors = new [] {
-				new MonoTextEditor (new TextDocument (), CommonTextEditorOptions.Instance),
-				new MonoTextEditor (new TextDocument (), CommonTextEditorOptions.Instance),
+				new MonoTextEditor (new TextDocument (), options),
+				new MonoTextEditor (new TextDocument (), options),
 			};
 
 			if (!viewOnly) {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
@@ -250,7 +250,15 @@ namespace MonoDevelop.VersionControl.Views
 		protected virtual void OnSetVersionControlInfo (VersionControlDocumentInfo info)
 		{
 		}
-		
+
+		internal virtual TextEditorOptions GetTextEditorOptions ()
+		{
+			var options = new TextEditorOptions ();
+			options.CopyFrom (CommonTextEditorOptions.Instance);
+			options.TabsToSpaces = false;
+			return options;
+		}
+
 		protected abstract void CreateComponents ();
 		
 		internal static ICollection<Cairo.Rectangle> GetDiffRectangles (MonoTextEditor editor, int startOffset, int endOffset)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeWidget.cs
@@ -100,10 +100,11 @@ namespace MonoDevelop.VersionControl.Views
 
 		protected override void CreateComponents ()
 		{
+			var options = GetTextEditorOptions ();
 			this.editors = new [] {
-				new MonoTextEditor (new TextDocument (), CommonTextEditorOptions.Instance),
-				new MonoTextEditor (new TextDocument (), CommonTextEditorOptions.Instance),
-				new MonoTextEditor (new TextDocument (), CommonTextEditorOptions.Instance),
+				new MonoTextEditor (new TextDocument (), options),
+				new MonoTextEditor (new TextDocument (), options),
+				new MonoTextEditor (new TextDocument (), options),
 			};
 			
 			this.editors[0].Document.IsReadOnly = true;


### PR DESCRIPTION
When setting the local text, the text setter would end up formatting the tabs to spaces due to how the policy was set. Disable that setting.