### PR TITLE
Fixed 'Bug 56425 - Clicking nodes in Document Outline don't navigate

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
@@ -225,6 +225,7 @@ namespace MonoDevelop.CSharp.ClassOutline
 			} else {
 				Editor.CaretOffset = ((SyntaxTrivia)o).SpanStart;
 			}
+			Editor.CenterToCaret ();
 
 			if (focusEditor) {
 				GLib.Timeout.Add (10, delegate {


### PR DESCRIPTION
to code'