### PR TITLE
Make CompletionData comparer stable.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
@@ -451,7 +451,7 @@ namespace MonoDevelop.CSharp.Completion
 				var sym = Symbol;
 				var other = obj as RoslynSymbolCompletionData;
 				if (other == null)
-					return 0;
+					return -1;
 				if (sym.Kind == other.Symbol.Kind) {
 					var m1 = sym as IMethodSymbol;
 					var m2 = other.Symbol as IMethodSymbol;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
@@ -159,7 +159,13 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			int IComparer<CompletionData>.Compare (CompletionData a, CompletionData b)
 			{
-				return Compare (a, b);
+				if (a == b)
+					return 0;
+				if (a != null && b == null)
+					return -1;
+				if (a == null && b != null)
+					return 1;
+				return a.CompareTo (b);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionData.cs
@@ -39,7 +39,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 	public class CompletionData : IComparable
 	{
 		protected CompletionData () {}
-		
+
 		public virtual IconId Icon { get; set; }
 		public virtual string DisplayText { get; set; }
 		public virtual string Description { get; set; }
@@ -112,7 +112,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 		public CompletionData (string text) : this (text, null, null) {}
 		public CompletionData (string text, IconId icon) : this (text, icon, null) {}
 		public CompletionData (string text, IconId icon, string description) : this (text, icon, description, text) {}
-		
+
 		public CompletionData (string displayText, IconId icon, string description, string completionText)
 		{
 			this.DisplayText = displayText;
@@ -140,7 +140,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 			var currentWord = GetCurrentWord (window, descriptor);
 			window.CompletionWidget.SetCompletionText (window.CodeCompletionContext, currentWord, CompletionText);
 		}
-		
+
 		public override string ToString ()
 		{
 			return string.Format ("[CompletionData: Icon={0}, DisplayText={1}, Description={2}, CompletionText={3}, DisplayFlags={4}]", Icon, DisplayText, Description, CompletionText, DisplayFlags);
@@ -150,30 +150,54 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		public virtual int CompareTo (object obj)
 		{
-			if (!(obj is CompletionData))
-				return 0;
-			return Compare (this, (CompletionData)obj);
+			return Compare (this, obj as CompletionData);
+		}
+
+		public static IComparer<CompletionData> Comparer { get; } = new CompletionDataComparer ();
+
+		private class CompletionDataComparer : IComparer<CompletionData>
+		{
+			int IComparer<CompletionData>.Compare (CompletionData a, CompletionData b)
+			{
+				return Compare (a, b);
+			}
 		}
 
 		public static int Compare (CompletionData a, CompletionData b)
 		{
-			var result =  ((a.DisplayFlags & DisplayFlags.Obsolete) == (b.DisplayFlags & DisplayFlags.Obsolete)) ? StringComparer.OrdinalIgnoreCase.Compare (a.DisplayText, b.DisplayText) : (a.DisplayFlags & DisplayFlags.Obsolete) != 0 ? 1 : -1;
-			if (result == 0) {
-				var aIsImport = (a.DisplayFlags & DisplayFlags.IsImportCompletion) != 0;
-				var bIsImport = (b.DisplayFlags & DisplayFlags.IsImportCompletion) != 0;
-				if (!aIsImport && bIsImport)
-					return -1;
-				if (aIsImport && !bIsImport)
-					return 1;
-				if (aIsImport && bIsImport)
-					return StringComparer.Ordinal.Compare (((CompletionData)a).Description, ((CompletionData)b).Description);
-				var ca = a as CompletionData;
-				var cb = b as CompletionData;
-				if (ca != null && cb != null && !ca.Icon.IsNull && !cb.Icon.IsNull) {
-					return string.Compare(cb.Icon.Name, ca.Icon.Name, StringComparison.Ordinal);
-				}
-			}
-			return result;
+			if (a == b)
+				return 0;
+			if (a != null && b == null)
+				return -1;
+			if (a == null && b != null)
+				return 1;
+
+			bool aIsObsolete = (a.DisplayFlags & DisplayFlags.Obsolete) != 0;
+			bool bIsObsolete = (b.DisplayFlags & DisplayFlags.Obsolete) != 0;
+			if (!aIsObsolete && bIsObsolete)
+				return -1;
+			if (aIsObsolete && !bIsObsolete)
+				return 1;
+
+			var result = StringComparer.OrdinalIgnoreCase.Compare (a.DisplayText, b.DisplayText);
+			if (result != 0)
+				return result;
+
+			var aIsImport = (a.DisplayFlags & DisplayFlags.IsImportCompletion) != 0;
+			var bIsImport = (b.DisplayFlags & DisplayFlags.IsImportCompletion) != 0;
+			if (!aIsImport && bIsImport)
+				return -1;
+			if (aIsImport && !bIsImport)
+				return 1;
+
+			result = StringComparer.Ordinal.Compare (a.Description, b.Description);
+			if (result != 0)
+				return result;
+
+			if (!a.Icon.IsNull && !b.Icon.IsNull)
+				return string.Compare (a.Icon.Name, b.Icon.Name, StringComparison.Ordinal);
+
+			return 0;
 		}
 
 		#endregion
@@ -211,7 +235,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 		}
 
 		const string commitChars = " <>()[]{}=+-*/%~&^|!.,;:?\"'";
-		
+
 		public virtual bool IsCommitCharacter (char keyChar, string partialWord)
 		{
 			return commitChars.Contains (keyChar);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ListWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ListWidget.cs
@@ -797,19 +797,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 			return new CompletionListFilterResult (filteredItems, newCategories);
 		}
 
-
-		class DataItemComparer : IComparer<CompletionData>
-		{
-			public int Compare (CompletionData a, CompletionData b)
-			{
-				if (a == b)
-					return 0;
-				if (a is IComparable && b is IComparable)
-						return ((IComparable)a).CompareTo (b);
-				return CompletionData.Compare (a, b);
-			}
-		}
-		internal static readonly IComparer<CompletionData> overloadComparer = new DataItemComparer ();
+		internal static readonly IComparer<CompletionData> overloadComparer = CompletionData.Comparer;
 		internal static IComparer<CompletionData> defaultComparer;
 
 		internal static int CompareTo (ICompletionDataList completionDataList, int n, int m)
@@ -830,7 +818,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 		internal static IComparer<CompletionData> GetComparerForCompletionList (ICompletionDataList dataList)
 		{
 			var concrete = dataList as CompletionDataList;
-			return concrete != null && concrete.Comparer != null ? concrete.Comparer : new DataItemComparer ();
+			return concrete != null && concrete.Comparer != null ? concrete.Comparer : CompletionData.Comparer;
 		}
 
 		public void FilterWords ()


### PR DESCRIPTION
Instead of having a DataItemComparer externally to CompletionData, have a CompletionData.Comparer singleton and use that.

Make sure all logic is concentrated in one place and does comparisons one step at a time.

The whitespace changes are the result of unifying the entire file to use LF consistently.