### PR TITLE
[Core] Add limited support for multi target framework projects

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -945,6 +945,53 @@ namespace MonoDevelop.Projects.MSBuild
 				return Array.Empty<string> ();
 		}
 
+		/// <summary>
+		/// If an SDK project targets multiple target frameworks then this returns the first
+		/// target framework. Otherwise it returns null. This also handles the odd case if
+		/// the TargetFrameworks property is being used but only one framework is defined
+		/// there. Since here an active target framework must be returned even though multiple
+		/// target frameworks are not being used.
+		/// </summary>
+		internal string GetActiveTargetFramework ()
+		{
+			if (string.IsNullOrEmpty (Sdk))
+				return null;
+
+			var frameworks = GetTargetFrameworks ();
+			if (frameworks != null && frameworks.Any ())
+				return frameworks.FirstOrDefault ();
+
+			return null;
+		}
+
+		string[] targetFrameworks;
+
+		/// <summary>
+		/// Returns target frameworks defined in the TargetFrameworks property for SDK projects
+		/// if the TargetFramework property is not defined. It returns null otherwise.
+		/// </summary>
+		string[] GetTargetFrameworks ()
+		{
+			if (string.IsNullOrEmpty (Sdk))
+				return null;
+
+			if (targetFrameworks != null)
+				return targetFrameworks;
+
+			var propertyGroup = GetGlobalPropertyGroup ();
+			string propertyValue = propertyGroup.GetValue ("TargetFramework", null);
+			if (propertyValue != null)
+				return null;
+
+			propertyValue = propertyGroup.GetValue ("TargetFrameworks", null);
+			if (propertyValue != null) {
+				targetFrameworks = propertyValue.Split (new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+				return targetFrameworks;
+			}
+
+			return null;
+		}
+
 		XmlNamespaceManager GetNamespaceManagerForProject ()
 		{
 			if (Namespace == Schema)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -53,8 +53,7 @@ namespace MonoDevelop.Projects.MSBuild
 			msproject = project;
 			evaluatedItemsIgnoringCondition = new List<IMSBuildItemEvaluated> ();
 			evaluatedProperties = new MSBuildEvaluatedPropertyCollection (msproject);
-			if (!project.SolutionDirectory.IsNullOrEmpty)
-				globalProperties.Add ("SolutionDir", project.SolutionDirectory.ToString () + System.IO.Path.DirectorySeparatorChar);
+			globalProperties = new Dictionary<string, string> (project.GlobalProperties);
 		}
 
 		public void Dispose ()
@@ -96,10 +95,6 @@ namespace MonoDevelop.Projects.MSBuild
 			try {
 				foreach (var prop in globalProperties)
 					engine.SetGlobalProperty (projectInstance, prop.Key, prop.Value);
-
-				string targetFramework = msproject.GetActiveTargetFramework ();
-				if (targetFramework != null)
-					engine.SetGlobalProperty (projectInstance, "TargetFramework", targetFramework);
 
 				engine.Evaluate (projectInstance);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -97,6 +97,10 @@ namespace MonoDevelop.Projects.MSBuild
 				foreach (var prop in globalProperties)
 					engine.SetGlobalProperty (projectInstance, prop.Key, prop.Value);
 
+				string targetFramework = msproject.GetActiveTargetFramework ();
+				if (targetFramework != null)
+					engine.SetGlobalProperty (projectInstance, "TargetFramework", targetFramework);
+
 				engine.Evaluate (projectInstance);
 
 				SyncBuildProject (info.ItemMap, info.Engine, projectInstance);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -896,10 +896,11 @@ namespace MonoDevelop.Projects
 				RemoteProjectBuilder builder = await GetProjectBuilder ();
 				try {
 					var configs = GetConfigurations (configuration, false);
+					var globalProperties = CreateGlobalProperties ();
 
 					AssemblyReference [] refs;
 					using (Counters.ResolveMSBuildReferencesTimer.BeginTiming (GetProjectEventMetadata (configuration)))
-						refs = await builder.ResolveAssemblyReferences (configs, CancellationToken.None);
+						refs = await builder.ResolveAssemblyReferences (configs, globalProperties, CancellationToken.None);
 					foreach (var r in refs)
 						result.Add (r);
 				} finally {
@@ -990,10 +991,11 @@ namespace MonoDevelop.Projects
 				RemoteProjectBuilder builder = await GetProjectBuilder ();
 				try {
 					var configs = GetConfigurations (configuration, false);
+					var globalProperties = CreateGlobalProperties ();
 
 					PackageDependency [] dependencies;
 					using (Counters.ResolveMSBuildReferencesTimer.BeginTiming (GetProjectEventMetadata (configuration)))
-						dependencies = await builder.ResolvePackageDependencies (configs, cancellationToken);
+						dependencies = await builder.ResolvePackageDependencies (configs, globalProperties, cancellationToken);
 					foreach (var d in dependencies)
 						result.Add (d);
 				} finally {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1357,6 +1357,7 @@ namespace MonoDevelop.Projects
 						projectBuilder.ReleaseReference ();
 					}
 					var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild);
+					pb.ActiveTargetFramework = MSBuildProject.GetActiveTargetFramework ();
 					pb.AddReference ();
 					pb.Disconnected += delegate {
 						CleanupProjectBuilder ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1171,7 +1171,7 @@ namespace MonoDevelop.Projects
 				string [] evaluateItems = context != null ? context.ItemsToEvaluate.ToArray () : new string [0];
 				string [] evaluateProperties = context != null ? context.PropertiesToEvaluate.ToArray () : new string [0];
 
-				var globalProperties = new Dictionary<string, string> ();
+				var globalProperties = CreateGlobalProperties ();
 				if (context != null) {
 					var md = (ProjectItemMetadata)context.GlobalProperties;
 					md.SetProject (sourceProject);
@@ -1281,6 +1281,15 @@ namespace MonoDevelop.Projects
 			return null;
 		}
 
+		internal Dictionary<string, string> CreateGlobalProperties ()
+		{
+			var properties = new Dictionary<string, string> ();
+			string framework = MSBuildProject.GetActiveTargetFramework ();
+			if (framework != null)
+				properties ["TargetFramework"] = framework;
+			return properties;
+		}
+
 		internal ProjectConfigurationInfo [] GetConfigurations (ConfigurationSelector configuration, bool includeReferencedProjects = true)
 		{
 			var visitedProjects = new HashSet<Project> ();
@@ -1357,7 +1366,6 @@ namespace MonoDevelop.Projects
 						projectBuilder.ReleaseReference ();
 					}
 					var pb = await MSBuildProjectService.GetProjectBuilder (runtime, ToolsVersion, FileName, slnFile, sdkPath, 0, RequiresMicrosoftBuild);
-					pb.ActiveTargetFramework = MSBuildProject.GetActiveTargetFramework ();
 					pb.AddReference ();
 					pb.Disconnected += delegate {
 						CleanupProjectBuilder ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -166,6 +166,9 @@ namespace MonoDevelop.Projects
 
 				if (creationContext.Project != null) {
 					this.sourceProject = creationContext.Project;
+					// Configure target framework here for projects that target multiple frameworks so the
+					// project capabilities are correct when they are initialized in InitBeforeProjectExtensionLoad.
+					ConfigureActiveTargetFramework ();
 					projectTypeGuids = sourceProject.EvaluatedProperties.GetValue ("ProjectTypeGuids");
 					if (projectTypeGuids != null) {
 						var subtypeGuids = new List<string> ();
@@ -1281,10 +1284,58 @@ namespace MonoDevelop.Projects
 			return null;
 		}
 
+		string activeTargetFramework;
+
+		void ConfigureActiveTargetFramework ()
+		{
+			activeTargetFramework = GetActiveTargetFramework ();
+			if (activeTargetFramework != null) {
+				MSBuildProject.SetGlobalProperty ("TargetFramework", activeTargetFramework);
+				MSBuildProject.Evaluate ();
+			}
+		}
+
+		/// <summary>
+		/// If an SDK project targets multiple target frameworks then this returns the first
+		/// target framework. Otherwise it returns null. This also handles the odd case if
+		/// the TargetFrameworks property is being used but only one framework is defined
+		/// there. Since here an active target framework must be returned even though multiple
+		/// target frameworks are not being used.
+		/// </summary>
+		string GetActiveTargetFramework ()
+		{
+			var frameworks = GetTargetFrameworks (MSBuildProject);
+			if (frameworks != null && frameworks.Any ())
+				return frameworks.FirstOrDefault ();
+
+			return null;
+		}
+
+		/// <summary>
+		/// Returns target frameworks defined in the TargetFrameworks property for SDK projects
+		/// if the TargetFramework property is not defined. It returns null otherwise.
+		/// </summary>
+		static string[] GetTargetFrameworks (MSBuildProject project)
+		{
+			if (string.IsNullOrEmpty (project.Sdk))
+				return null;
+
+			var propertyGroup = project.GetGlobalPropertyGroup ();
+			string propertyValue = propertyGroup.GetValue ("TargetFramework", null);
+			if (propertyValue != null)
+				return null;
+
+			propertyValue = propertyGroup.GetValue ("TargetFrameworks", null);
+			if (propertyValue != null)
+				return propertyValue.Split (new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+			return null;
+		}
+
 		internal Dictionary<string, string> CreateGlobalProperties ()
 		{
 			var properties = new Dictionary<string, string> ();
-			string framework = MSBuildProject.GetActiveTargetFramework ();
+			string framework = activeTargetFramework;
 			if (framework != null)
 				properties ["TargetFramework"] = framework;
 			return properties;

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -2613,6 +2613,31 @@ namespace MonoDevelop.Projects
 			sol.Dispose ();
 		}
 
+		/// <summary>
+		/// Tests that the first target framework is used to evaluate the project.
+		/// </summary>
+		[Test]
+		public async Task LoadDotNetCoreProjectWithMultipleTargetFrameworks ()
+		{
+			FilePath solFile = Util.GetSampleProject ("DotNetCoreMultiTargetFramework", "DotNetCoreMultiTargetFramework.sln");
+
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (Project)sol.Items [0];
+			var capabilities = p.GetProjectCapabilities ().ToList ();
+
+			Assert.That (capabilities, Contains.Item ("TestCapabilityNetStandard"));
+			Assert.That (capabilities, Has.None.EqualTo ("TestCapabilityNetCoreApp"));
+
+			await p.ReevaluateProject (Util.GetMonitor ());
+
+			capabilities = p.GetProjectCapabilities ().ToList ();
+
+			Assert.That (capabilities, Contains.Item ("TestCapabilityNetStandard"));
+			Assert.That (capabilities, Has.None.EqualTo ("TestCapabilityNetCoreApp"));
+
+			sol.Dispose ();
+		}
+
 		[Test]
 		public async Task CopyConfiguration ()
 		{

--- a/main/tests/test-projects/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework.sln
+++ b/main/tests/test-projects/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCoreMultiTargetFramework", "DotNetCoreMultiTargetFramework\DotNetCoreMultiTargetFramework.csproj", "{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework/Class1.cs
+++ b/main/tests/test-projects/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace DotNetCoreNetStandardProject
+{
+    public class Class1
+    {
+    }
+}

--- a/main/tests/test-projects/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework.csproj
+++ b/main/tests/test-projects/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework/DotNetCoreMultiTargetFramework.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.1;netcoreapp1.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+    <ProjectCapability Include="TestCapabilityNetStandard" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <ProjectCapability Include="TestCapabilityNetCoreApp" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixed bug #55508 - Support multiple target framework projects
https://bugzilla.xamarin.com/show_bug.cgi?id=55508

SDK style projects that target multiple frameworks can now be opened
and will show source files and dependency information. Currently
the support is limited. The project is treated as though it only has
one target framework which is the first one specified in the
TargetFrameworks property in the project file.

This is not a complete solution but it is better than the existing support. NuGet restore will only consider one target framework which is incorrect. Also it is not currently supported to install a NuGet package conditionally into the supported target frameworks if it is not compatible with all of them.