### PR TITLE
Restore breakpoints for pinnedwatches

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -156,13 +156,10 @@ namespace MonoDevelop.Debugger
 
 			watch.LiveUpdate = liveUpdate;
 			if (liveUpdate) {
-				var bp = new Breakpoint (watch.File, watch.Line);
-				bp.TraceExpression = "{" + watch.Expression + "}";
-				bp.HitAction = HitAction.PrintExpression;
-				bp.NonUserBreakpoint = true;
-				lock (breakpoints)
-					breakpoints.Add (bp);
+				var bp = pinnedWatches.CreateLiveUpdateBreakpoint (watch);
 				pinnedWatches.Bind (watch, bp);
+				lock (breakpoints)
+					breakpoints.Add(bp);
 			} else {
 				pinnedWatches.Bind (watch, null);
 				lock (breakpoints)
@@ -1194,6 +1191,9 @@ namespace MonoDevelop.Debugger
 
 			lock (breakpoints)
 				pinnedWatches.BindAll (breakpoints);
+
+			lock (breakpoints)
+				pinnedWatches.SetAllLiveUpdateBreakpoints (breakpoints);
 
 			return Task.FromResult (true);
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/PinnedWatchStore.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/PinnedWatchStore.cs
@@ -100,6 +100,28 @@ namespace MonoDevelop.Debugger
 			}
 		}
 		
+		internal void SetAllLiveUpdateBreakpoints (BreakpointStore bps)
+		{
+			lock (watches) {
+				foreach (PinnedWatch w in watches) {
+					if (w.LiveUpdate) {
+						var bp = CreateLiveUpdateBreakpoint (w);
+						Bind(w, bp);
+						bps.Add(bp);
+					}
+				}
+			}
+		}
+
+		internal Breakpoint CreateLiveUpdateBreakpoint (PinnedWatch watch)
+		{
+			var bp = new Breakpoint (watch.File, watch.Line);
+			bp.TraceExpression = "{" + watch.Expression + "}";
+			bp.HitAction = HitAction.PrintExpression;
+			bp.NonUserBreakpoint = true;
+			return bp;
+		}
+
 		internal bool UpdateLiveWatch (Breakpoint bp, string trace)
 		{
 			lock (watches) {


### PR DESCRIPTION
when loading user preferences.
Fixed bug #52527 : Hard crash while debugging simple console app
https://bugzilla.xamarin.com/show_bug.cgi?id=52527
This crash happens because it seems not to restore tracing breakpoints
even though it restores LiveUpdate property when loading user
preferences.

The same crash doesn't happen with this patch, but not useful yet due
to bug #52528