### PR TITLE
[NuGet] Support non .NET Core projects using PackageReference

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestablePackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestablePackageReferenceNuGetProject.cs
@@ -1,0 +1,57 @@
+﻿//
+// TestableDotNetCoreNuGetProject.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Threading.Tasks;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.PackageManagement.Tests.Helpers
+{
+	class TestablePackageReferenceNuGetProject : PackageReferenceNuGetProject
+	{
+		public TestablePackageReferenceNuGetProject (DotNetProject project)
+			: this (project, new PackageManagementEvents ())
+		{
+		}
+
+		public TestablePackageReferenceNuGetProject (
+			DotNetProject project,
+			PackageManagementEvents packageManagementEvents)
+			: base (project, packageManagementEvents)
+		{
+			PackageManagementEvents = packageManagementEvents;
+		}
+
+		public PackageManagementEvents PackageManagementEvents { get; set; }
+
+		public bool IsSaved { get; set; }
+
+		public override Task SaveProject ()
+		{
+			IsSaved = true;
+			return Task.FromResult (0);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -208,6 +208,8 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectPackageReferenceTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\UninstallNuGetPackagesActionTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableUninstallNuGetPackagesAction.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\PackageReferenceNuGetProjectTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestablePackageReferenceNuGetProject.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
@@ -1,0 +1,259 @@
+﻿//
+// PackageReferenceNuGetProjectTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class PackageReferenceNuGetProjectTests
+	{
+		DotNetProject dotNetProject;
+		TestablePackageReferenceNuGetProject project;
+		FakeNuGetProjectContext context;
+		DependencyGraphCacheContext dependencyGraphCacheContext;
+
+		void CreateNuGetProject (string projectName = "MyProject", string fileName = @"d:\projects\MyProject\MyProject.csproj")
+		{
+			context = new FakeNuGetProjectContext ();
+			dotNetProject = new DummyDotNetProject ();
+			dotNetProject.Name = projectName;
+			dotNetProject.FileName = fileName.ToNativePath ();
+			project = new TestablePackageReferenceNuGetProject (dotNetProject);
+		}
+
+		void AddDotNetProjectPackageReference (string packageId, string version)
+		{
+			var packageReference = ProjectPackageReference.Create (packageId, version);
+
+			dotNetProject.Items.Add (packageReference);
+		}
+
+		Task<bool> UninstallPackageAsync (string packageId, string version)
+		{
+			var packageIdentity = new PackageIdentity (packageId, NuGetVersion.Parse (version));
+			return project.UninstallPackageAsync (packageIdentity, context, CancellationToken.None);
+		}
+
+		Task<bool> InstallPackageAsync (string packageId, string version)
+		{
+			var packageIdentity = new PackageIdentity (packageId, NuGetVersion.Parse (version));
+			var versionRange = new VersionRange (packageIdentity.Version);
+			return project.InstallPackageAsync (packageId, versionRange, context, null, CancellationToken.None);
+		}
+
+		Task<PackageSpec> GetPackageSpecsAsync ()
+		{
+			dependencyGraphCacheContext = new DependencyGraphCacheContext ();
+			return GetPackageSpecsAsync (dependencyGraphCacheContext);
+		}
+
+		async Task<PackageSpec> GetPackageSpecsAsync (DependencyGraphCacheContext cacheContext)
+		{
+			var specs = await project.GetPackageSpecsAsync (cacheContext);
+			return specs.Single ();
+		}
+
+		[Test]
+		public async Task GetInstalledPackagesAsync_OnePackageReference_ReturnsOnePackageReference ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+
+			var packageReferences = await project.GetInstalledPackagesAsync (CancellationToken.None);
+
+			var packageReference = packageReferences.Single ();
+			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
+			Assert.AreEqual ("2.6.1", packageReference.PackageIdentity.Version.ToNormalizedString ());
+		}
+
+		[Test]
+		public async Task UninstallPackageAsync_OldPackageInstalled_PackageReferenceRemoved ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+
+			bool result = await UninstallPackageAsync ("NUnit", "2.6.1");
+
+			Assert.IsFalse (dotNetProject.Items.OfType<ProjectPackageReference> ().Any ());
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task UninstallPackageAsync_OldPackageIsNotInstalled_PackageReferenceRemoved ()
+		{
+			CreateNuGetProject ();
+			dotNetProject.Name = "MyProject";
+
+			bool result = await UninstallPackageAsync ("NUnit", "2.6.1");
+
+			Assert.IsFalse (result);
+			Assert.IsFalse (project.IsSaved);
+			Assert.AreEqual (MessageLevel.Warning, context.LastLogLevel);
+			Assert.AreEqual ("Package 'NUnit' does not exist in project 'MyProject'", context.LastMessageLogged);
+		}
+
+		[Test]
+		public async Task UninstallPackageAsync_DifferentPackageVersionInstalled_PackageReferenceRemoved ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+
+			bool result = await UninstallPackageAsync ("NUnit", "3.5");
+
+			Assert.IsFalse (dotNetProject.Items.OfType<ProjectPackageReference> ().Any ());
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_PackageNotInstalled_PackageReferenceAdded ()
+		{
+			CreateNuGetProject ();
+
+			bool result = await InstallPackageAsync ("NUnit", "2.6.1");
+
+			var packageReference = dotNetProject.Items.OfType<ProjectPackageReference> ()
+				.Single ()
+				.CreatePackageReference ();
+
+			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
+			Assert.AreEqual ("2.6.1", packageReference.PackageIdentity.Version.ToNormalizedString ());
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_PackageAlreadyInstalled_PackageReferenceNotAdded ()
+		{
+			CreateNuGetProject ("MyProject");
+			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+
+			bool result = await InstallPackageAsync ("NUnit", "2.6.1");
+
+			var packageReference = dotNetProject.Items.OfType<ProjectPackageReference> ()
+				.Single ()
+				.CreatePackageReference ();
+
+			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
+			Assert.AreEqual ("2.6.1", packageReference.PackageIdentity.Version.ToNormalizedString ());
+			Assert.IsFalse (result);
+			Assert.IsFalse (project.IsSaved);
+			Assert.AreEqual ("Package 'NUnit.2.6.1' already exists in project 'MyProject'", context.LastMessageLogged);
+			Assert.AreEqual (MessageLevel.Warning, context.LastLogLevel);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_PackageAlreadyInstalledWithDifferentVersion_OldPackageReferenceIsRemoved ()
+		{
+			CreateNuGetProject ("MyProject");
+			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+
+			bool result = await InstallPackageAsync ("NUnit", "3.6.0");
+
+			var packageReference = dotNetProject.Items.OfType<ProjectPackageReference> ()
+				.Single ()
+				.CreatePackageReference ();
+
+			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
+			Assert.AreEqual ("3.6.0", packageReference.PackageIdentity.Version.ToNormalizedString ());
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+			Assert.IsFalse (packageReference.HasAllowedVersions);
+			Assert.IsNull (packageReference.AllowedVersions);
+		}
+
+		[Test]
+		public async Task GetAssetsFilePathAsync_BaseIntermediatePathNotSet_BaseIntermediatePathUsedForProjectAssetsJsonFile ()
+		{
+			CreateNuGetProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			string expectedAssetsFilePath = @"d:\projects\MyProject\obj\project.assets.json".ToNativePath ();
+
+			string assetsFilePath = await project.GetAssetsFilePathAsync ();
+
+			Assert.AreEqual (expectedAssetsFilePath, assetsFilePath);
+		}
+
+		[Test]
+		public async Task GetPackageSpecsAsync_NewProject_BaseIntermediatePathUsedForProjectAssetsJsonFile ()
+		{
+			CreateNuGetProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+
+			PackageSpec spec = await GetPackageSpecsAsync ();
+
+			Assert.AreEqual (dotNetProject.FileName.ToString (), spec.FilePath);
+			Assert.AreEqual ("MyProject", spec.Name);
+			Assert.AreEqual ("1.0.0", spec.Version.ToString ());
+			Assert.AreEqual (ProjectStyle.PackageReference, spec.RestoreMetadata.ProjectStyle);
+			Assert.AreEqual ("MyProject", spec.RestoreMetadata.ProjectName);
+			Assert.AreEqual (dotNetProject.FileName.ToString (), spec.RestoreMetadata.ProjectPath);
+			Assert.AreEqual (dotNetProject.FileName.ToString (), spec.RestoreMetadata.ProjectUniqueName);
+			Assert.AreEqual (dotNetProject.BaseIntermediateOutputPath.ToString (), spec.RestoreMetadata.OutputPath);
+			Assert.AreSame (spec, dependencyGraphCacheContext.PackageSpecCache[dotNetProject.FileName.ToString ()]);
+
+			// Cannot currently test this - needs the target framework to be available in the 
+			// MSBuild.EvaluatedProperties
+			//Assert.AreEqual ("netcoreapp1.0", spec.RestoreMetadata.OriginalTargetFrameworks.Single ());
+		}
+
+		[Test]
+		public async Task GetPackageSpecsAsync_PackageSpecExistsInCache_CachedPackageSpecReturned ()
+		{
+			CreateNuGetProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			var cachedSpec = new PackageSpec ();
+			dependencyGraphCacheContext = new DependencyGraphCacheContext ();
+			dependencyGraphCacheContext.PackageSpecCache.Add (dotNetProject.FileName.ToString (), cachedSpec);
+
+			PackageSpec spec = await GetPackageSpecsAsync (dependencyGraphCacheContext);
+
+			Assert.AreSame (cachedSpec, spec);
+		}
+
+		[Test]
+		public async Task GetInstalledPackagesAsync_FloatingVersion_ReturnsOnePackageReference ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0-*");
+
+			var packageReferences = await project.GetInstalledPackagesAsync (CancellationToken.None);
+
+			var packageReference = packageReferences.Single ();
+			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
+			Assert.IsTrue (packageReference.IsFloating ());
+			Assert.AreEqual ("2.6.0-*", packageReference.AllowedVersions.Float.ToString ());
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System.Linq;
+using MonoDevelop.Core.Assemblies;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
 using NuGet.Frameworks;
@@ -125,6 +126,31 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("MyProject", spec.RestoreMetadata.ProjectName);
 			Assert.AreEqual ("netcoreapp1.0", spec.RestoreMetadata.OriginalTargetFrameworks.Single ());
 			Assert.AreEqual (".NETCoreApp,Version=v1.0", targetFramework.FrameworkName.ToString ());
+			Assert.AreEqual ("Newtonsoft.Json", dependency.Name);
+			Assert.AreEqual (LibraryDependencyType.Default, dependency.Type);
+			Assert.AreEqual (LibraryIncludeFlags.All, dependency.IncludeType);
+			Assert.AreEqual (LibraryIncludeFlagUtils.DefaultSuppressParent, dependency.SuppressParent);
+			Assert.AreEqual ("[9.0.1, )", dependency.LibraryRange.VersionRange.ToString ());
+			Assert.AreEqual (LibraryDependencyTarget.Package, dependency.LibraryRange.TypeConstraint);
+			Assert.AreEqual ("Newtonsoft.Json", dependency.LibraryRange.Name);
+		}
+
+		[Test]
+		public void CreatePackageSpec_NonDotNetCoreProjectWithOnePackageReference_TargetFrameworkTakenFromProjectNotTargetFrameworkProperty ()
+		{
+			CreateProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			project.TargetFrameworkMoniker = TargetFrameworkMoniker.Parse (".NETFramework,Version=v4.6.1");
+			AddPackageReference ("Newtonsoft.Json", "9.0.1");
+
+			CreatePackageSpec ();
+
+			var targetFramework = spec.TargetFrameworks.Single ();
+			var dependency = targetFramework.Dependencies.Single ();
+			Assert.AreEqual ("MyProject", spec.Name);
+			Assert.AreEqual (ProjectStyle.PackageReference, spec.RestoreMetadata.ProjectStyle);
+			Assert.AreEqual ("MyProject", spec.RestoreMetadata.ProjectName);
+			Assert.AreEqual (".NETFramework,Version=v4.6.1", targetFramework.FrameworkName.ToString ());
+			Assert.AreEqual ("net461", spec.RestoreMetadata.OriginalTargetFrameworks.Single ());
 			Assert.AreEqual ("Newtonsoft.Json", dependency.Name);
 			Assert.AreEqual (LibraryDependencyType.Default, dependency.Type);
 			Assert.AreEqual (LibraryIncludeFlags.All, dependency.IncludeType);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -416,6 +416,7 @@
     <Compile Include="MonoDevelop.PackageManagement\HttpClientFactory.cs" />
     <Compile Include="NuGet.CommandLine\SettingsCredentialProvider.cs" />
     <Compile Include="MonoDevelop.PackageManagement\UninstallNuGetPackagesAction.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\PackageReferenceNuGetProject.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopNuGetProjectFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopNuGetProjectFactory.cs
@@ -76,6 +76,10 @@ namespace MonoDevelop.PackageManagement
 			if (dotNetCoreProject != null)
 				return dotNetCoreProject;
 
+			NuGetProject packageReferenceProject = PackageReferenceNuGetProject.Create (project);
+			if (packageReferenceProject != null)
+				return packageReferenceProject;
+
 			var projectSystem = new MonoDevelopMSBuildNuGetProjectSystem (project, context);
 
 			string projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath (project.BaseDirectory, project.Name);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -1,0 +1,304 @@
+﻿//
+// PackageReferenceNuGetProject.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NuGet.Frameworks;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace MonoDevelop.PackageManagement
+{
+	/// <summary>
+	/// Supports projects that use PackageReference MSBuild items but do not use a SDK style
+	/// project used by .NET Core projects.
+	/// </summary>
+	class PackageReferenceNuGetProject : BuildIntegratedNuGetProject, IBuildIntegratedNuGetProject, IHasDotNetProject
+	{
+		DotNetProject project;
+		IPackageManagementEvents packageManagementEvents;
+		string msbuildProjectPath;
+		string projectName;
+
+		public PackageReferenceNuGetProject (DotNetProject project)
+			: this (project, PackageManagementServices.PackageManagementEvents)
+		{
+		}
+
+		public PackageReferenceNuGetProject (
+			DotNetProject project,
+			IPackageManagementEvents packageManagementEvents)
+		{
+			this.project = project;
+			this.packageManagementEvents = packageManagementEvents;
+
+			var targetFramework = NuGetFramework.Parse (project.TargetFramework.Id.ToString ());
+
+			InternalMetadata.Add (NuGetProjectMetadataKeys.TargetFramework, targetFramework);
+			InternalMetadata.Add (NuGetProjectMetadataKeys.Name, project.Name);
+			InternalMetadata.Add (NuGetProjectMetadataKeys.FullPath, project.BaseDirectory);
+
+			msbuildProjectPath = project.FileName;
+			projectName = project.Name;
+		}
+
+		internal DotNetProject DotNetProject {
+			get { return project; }
+		}
+
+		public override string ProjectName {
+			get { return projectName; }
+		}
+
+		public override string MSBuildProjectPath {
+			get { return msbuildProjectPath; }
+		}
+
+		public static NuGetProject Create (DotNetProject project)
+		{
+			if (project.Items.OfType<ProjectPackageReference> ().Any ())
+				return new PackageReferenceNuGetProject (project);
+
+			return null;
+		}
+
+		public virtual Task SaveProject ()
+		{
+			return project.SaveAsync (new ProgressMonitor ());
+		}
+
+		public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync (CancellationToken token)
+		{
+			return Task.FromResult (GetPackageReferences ());
+		}
+
+		IEnumerable<PackageReference> GetPackageReferences ()
+		{
+			return project.Items.OfType<ProjectPackageReference> ()
+				.Select (projectItem => projectItem.CreatePackageReference ())
+				.ToList ();
+		}
+
+		public async override Task<bool> InstallPackageAsync (
+			string packageId,
+			VersionRange range,
+			INuGetProjectContext nuGetProjectContext,
+			BuildIntegratedInstallationContext installationContext,
+			CancellationToken token)
+		{
+			var packageIdentity = new PackageIdentity (packageId, range.MinVersion);
+
+			bool added = await Runtime.RunInMainThread (() => {
+				return AddPackageReference (packageIdentity, nuGetProjectContext);
+			});
+
+			if (added) {
+				await SaveProject ();
+			}
+
+			return added;
+		}
+
+		bool AddPackageReference (PackageIdentity packageIdentity, INuGetProjectContext context)
+		{
+			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity);
+			if (packageReference != null) {
+				context.Log (MessageLevel.Warning, GettextCatalog.GetString ("Package '{0}' already exists in project '{1}'", packageIdentity, project.Name));
+				return false;
+			}
+
+			RemoveExistingPackageReference (packageIdentity);
+
+			packageReference = ProjectPackageReference.Create (packageIdentity);
+			project.Items.Add (packageReference);
+
+			return true;
+		}
+
+		void RemoveExistingPackageReference (PackageIdentity packageIdentity)
+		{
+			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity, matchVersion: false);
+			if (packageReference != null) {
+				project.Items.Remove (packageReference);
+			}
+		}
+
+		public override async Task<bool> UninstallPackageAsync (
+			PackageIdentity packageIdentity,
+			INuGetProjectContext nuGetProjectContext,
+			CancellationToken token)
+		{
+			bool removed = await Runtime.RunInMainThread (() => {
+				return RemovePackageReference (packageIdentity, nuGetProjectContext);
+			});
+
+			if (removed) {
+				await SaveProject ();
+			}
+
+			return removed;
+		}
+
+		bool RemovePackageReference (PackageIdentity packageIdentity, INuGetProjectContext context)
+		{
+			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity, matchVersion: false);
+
+			if (packageReference == null) {
+				context.Log (MessageLevel.Warning, GettextCatalog.GetString ("Package '{0}' does not exist in project '{1}'", packageIdentity.Id, project.Name));
+				return false;
+			}
+
+			project.Items.Remove (packageReference);
+
+			return true;
+		}
+
+		public override Task<string> GetAssetsFilePathAsync ()
+		{
+			string assetsFilePath = project.GetNuGetAssetsFilePath ();
+			return Task.FromResult (assetsFilePath);
+		}
+
+		public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync (DependencyGraphCacheContext context)
+		{
+			PackageSpec existingPackageSpec = GetExistingProjectPackageSpec (context);
+			if (existingPackageSpec != null) {
+				return new [] { existingPackageSpec };
+			}
+
+			PackageSpec packageSpec = await CreateProjectPackageSpec (context);
+
+			if (context != null) {
+				AddToCache (context, packageSpec);
+			}
+
+			return new [] { packageSpec };
+		}
+
+		PackageSpec GetExistingProjectPackageSpec (DependencyGraphCacheContext context)
+		{
+			PackageSpec packageSpec = null;
+			if (context != null) {
+				if (context.PackageSpecCache.TryGetValue (MSBuildProjectPath, out packageSpec)) {
+					return packageSpec;
+				}
+			}
+			return packageSpec;
+		}
+
+		async Task<PackageSpec> CreateProjectPackageSpec (DependencyGraphCacheContext context)
+		{
+			PackageSpec packageSpec = await Runtime.RunInMainThread (() => CreateProjectPackageSpec (project, context));
+			return packageSpec;
+		}
+
+		static PackageSpec CreateProjectPackageSpec (DotNetProject project, DependencyGraphCacheContext context)
+		{
+			PackageSpec packageSpec = PackageSpecCreator.CreatePackageSpec (project, context.Logger);
+			return packageSpec;
+		}
+
+		void AddToCache (DependencyGraphCacheContext context, PackageSpec projectPackageSpec)
+		{
+			if (IsMissingFromCache (context, projectPackageSpec)) {
+				context.PackageSpecCache.Add (
+					projectPackageSpec.RestoreMetadata.ProjectUniqueName,
+					projectPackageSpec);
+			}
+		}
+
+		bool IsMissingFromCache (
+			DependencyGraphCacheContext context,
+			PackageSpec packageSpec)
+		{
+			PackageSpec ignore;
+			return !context.PackageSpecCache.TryGetValue (
+				packageSpec.RestoreMetadata.ProjectUniqueName,
+				out ignore);
+		}
+
+		public override Task<bool> ExecuteInitScriptAsync (
+			PackageIdentity identity,
+			string packageInstallPath,
+			INuGetProjectContext projectContext,
+			bool throwOnFailure)
+		{
+			// Not supported. This gets called for every NuGet package
+			// even if they do not have an init.ps1 so do not report this.
+			return Task.FromResult (false);
+		}
+
+		public override Task PostProcessAsync (INuGetProjectContext nuGetProjectContext, CancellationToken token)
+		{
+			Runtime.RunInMainThread (() => {
+				DotNetProject.NotifyModified ("References");
+			});
+
+			packageManagementEvents.OnFileChanged (project.GetNuGetAssetsFilePath ());
+
+			return base.PostProcessAsync (nuGetProjectContext, token);
+		}
+
+		public void OnBeforeUninstall (IEnumerable<NuGetProjectAction> actions)
+		{
+		}
+
+		public void OnAfterExecuteActions (IEnumerable<NuGetProjectAction> actions)
+		{
+		}
+
+		public void NotifyProjectReferencesChanged ()
+		{
+			Runtime.AssertMainThread ();
+
+			DotNetProject.RefreshProjectBuilder ();
+			DotNetProject.NotifyModified ("References");
+		}
+
+		/// <summary>
+		/// Always returns true so the project is re-evaluated after a restore.
+		/// This ensures any imports in the generated .nuget.g.targets are
+		/// re-evaluated. Without this custom MSBuild targets used by a NuGet package
+		/// that was restored into the local NuGet package cache would not be available
+		/// until the solution is closed and re-opened. Also handles the project file
+		/// being edited by hand and a new package reference being added that has a
+		/// custom MSBuild target.
+		/// </summary>
+		public bool ProjectRequiresReloadAfterRestore ()
+		{
+			return true;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSpecCreator.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSpecCreator.cs
@@ -112,10 +112,13 @@ namespace MonoDevelop.PackageManagement
 				}
 
 				string targetFrameworks = properties.GetValue ("TargetFrameworks");
-				return MSBuildStringUtility.Split (targetFrameworks);
+				if (targetFrameworks != null) {
+					return MSBuildStringUtility.Split (targetFrameworks);
+				}
 			}
 
-			return new string[0];
+			var framework = NuGetFramework.Parse (project.TargetFrameworkMoniker.ToString ());
+			return new [] { framework.GetShortFolderName () };
 		}
 
 		static void AddProjectReferences (PackageSpec spec, IDotNetProject project, ILogger logger)


### PR DESCRIPTION
Non .NET Core Sdk style projects that use PackageReference in their
MSBuild project file are now supported. Previously the Solution
window would not show any packages for the project, would not allow
restoring, and would install new NuGet packages using a packages.config
file. Now if the project has a PackageReference the Packages folder
shows the installed packages and can be used to update or install
NuGet packages which will also create PackageReference MSBuild items.
If the project has no PackageReferences then by default a
packages.config file will be created. There is no UI option to opt-in
to using PackageReferences currently so the project file will need
to be edited to include at least one PackageReference before the
default behaviour of using a packages.config file is overridden.