### PR TITLE
Fixed 'Bug 56687 - Find references of method doesnt account for

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/HighlightUsagesExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/HighlightUsagesExtension.cs
@@ -47,6 +47,7 @@ using MonoDevelop.Ide.Editor.Extension;
 using MonoDevelop.Ide.FindInFiles;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Refactoring;
+using MonoDevelop.CSharp.Refactoring;
 
 namespace MonoDevelop.CSharp.Highlighting
 {
@@ -151,37 +152,39 @@ namespace MonoDevelop.CSharp.Highlighting
 
 			var doc = resolveResult.Document;
 			var documents = ImmutableHashSet.Create (doc); 
-			var symbol = resolveResult.Symbol;
-			foreach (var loc in symbol.Locations) {
-				if (loc.IsInSource && loc.SourceTree.FilePath == doc.FilePath)
+
+			foreach (var symbol in await CSharpFindReferencesProvider.GatherSymbols (resolveResult.Symbol, resolveResult.Document.Project.Solution, token)) {
+				foreach (var loc in symbol.Locations) {
+					if (loc.IsInSource && loc.SourceTree.FilePath == doc.FilePath)
+						result.Add (new MemberReference (symbol, doc.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length) {
+							ReferenceUsageType = ReferenceUsageType.Declaration
+						});
+				}
+
+				foreach (var mref in await SymbolFinder.FindReferencesAsync (symbol, DocumentContext.AnalysisDocument.Project.Solution, documents, token)) {
+					foreach (var loc in mref.Locations) {
+						Microsoft.CodeAnalysis.Text.TextSpan span = loc.Location.SourceSpan;
+						var root = loc.Location.SourceTree.GetRoot ();
+						var node = root.FindNode (loc.Location.SourceSpan);
+						var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
+						if (!trivia.IsKind (SyntaxKind.SingleLineDocumentationCommentTrivia)) {
+							span = node.Span;
+						}
+
+						if (span.Start != loc.Location.SourceSpan.Start) {
+							span = loc.Location.SourceSpan;
+						}
+						result.Add (new MemberReference (symbol, doc.FilePath, span.Start, span.Length) {
+							ReferenceUsageType = GetUsage (node)
+						});
+					}
+				}
+
+				foreach (var loc in await GetAdditionalReferencesAsync (doc, symbol, token)) {
 					result.Add (new MemberReference (symbol, doc.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length) {
-						ReferenceUsageType = ReferenceUsageType.Declaration	
-					});
-			}
-
-			foreach (var mref in await SymbolFinder.FindReferencesAsync (symbol, DocumentContext.AnalysisDocument.Project.Solution, documents, token)) {
-				foreach (var loc in mref.Locations) {
-					Microsoft.CodeAnalysis.Text.TextSpan span = loc.Location.SourceSpan;
-					var root = loc.Location.SourceTree.GetRoot ();
-					var node = root.FindNode (loc.Location.SourceSpan);
-					var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
-					if (!trivia.IsKind (SyntaxKind.SingleLineDocumentationCommentTrivia)) {
-						span = node.Span;
-					}
-
-					if (span.Start != loc.Location.SourceSpan.Start) {
-						span = loc.Location.SourceSpan;
-					}
-					result.Add (new MemberReference (symbol, doc.FilePath, span.Start, span.Length) {
-						ReferenceUsageType = GetUsage (node)
+						ReferenceUsageType = ReferenceUsageType.Write
 					});
 				}
-			}
-
-			foreach (var loc in await GetAdditionalReferencesAsync (doc, symbol, token)) {
-				result.Add (new MemberReference (symbol, doc.FilePath, loc.SourceSpan.Start, loc.SourceSpan.Length) {
-					ReferenceUsageType = ReferenceUsageType.Write
-				});
 			}
 
 			return result;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
@@ -212,53 +212,63 @@ namespace MonoDevelop.CSharp.Refactoring
 				var workspace = TypeSystemService.AllWorkspaces.FirstOrDefault (w => w.CurrentSolution == lookup.Solution) as MonoDevelopWorkspace;
 				if (workspace == null)
 					return Enumerable.Empty<SearchResult> ();
-
-				foreach (var loc in lookup.Symbol.Locations) {
-					if (token.IsCancellationRequested)
-						break;
-					
-					if (!loc.IsInSource)
-						continue;
-					var fileName = loc.SourceTree.FilePath;
-					var offset = loc.SourceSpan.Start;
-					string projectedName;
-					int projectedOffset;
-					if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-						fileName = projectedName;
-						offset = projectedOffset;
-					}
-					var sr = new MemberReference (lookup.Symbol, fileName, offset, loc.SourceSpan.Length);
-					sr.ReferenceUsageType = ReferenceUsageType.Declaration;
-					antiDuplicatesSet.Add (sr);
-					result.Add (sr);
-				}
-
-				foreach (var mref in await SymbolFinder.FindReferencesAsync (lookup.Symbol, lookup.Solution, token).ConfigureAwait (false)) {
-					foreach (var loc in mref.Locations) {
+				foreach (var sym in await GatherSymbols (lookup.Symbol, lookup.Solution, token)) {
+					foreach (var loc in sym.Locations) {
 						if (token.IsCancellationRequested)
 							break;
-						var fileName = loc.Document.FilePath;
-						var offset = loc.Location.SourceSpan.Start;
+
+						if (!loc.IsInSource)
+							continue;
+						var fileName = loc.SourceTree.FilePath;
+						var offset = loc.SourceSpan.Start;
 						string projectedName;
 						int projectedOffset;
 						if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
 							fileName = projectedName;
 							offset = projectedOffset;
 						}
-						var sr = new MemberReference (lookup.Symbol, fileName, offset, loc.Location.SourceSpan.Length);
+						var sr = new MemberReference (sym, fileName, offset, loc.SourceSpan.Length);
+						sr.ReferenceUsageType = ReferenceUsageType.Declaration;
+						antiDuplicatesSet.Add (sr);
+						result.Add (sr);
+					}
+
+					foreach (var mref in await SymbolFinder.FindReferencesAsync (sym, lookup.Solution, token).ConfigureAwait (false)) {
+						foreach (var loc in mref.Locations) {
+							if (token.IsCancellationRequested)
+								break;
+							var fileName = loc.Document.FilePath;
+							var offset = loc.Location.SourceSpan.Start;
+							string projectedName;
+							int projectedOffset;
+							if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
+								fileName = projectedName;
+								offset = projectedOffset;
+							}
+							var sr = new MemberReference (sym, fileName, offset, loc.Location.SourceSpan.Length);
 
 
-						if (antiDuplicatesSet.Add (sr)) {
-							var root = loc.Location.SourceTree.GetRoot ();
-							var node = root.FindNode (loc.Location.SourceSpan);
-							var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
-							sr.ReferenceUsageType = HighlightUsagesExtension.GetUsage (node);
-							result.Add (sr);
+							if (antiDuplicatesSet.Add (sr)) {
+								var root = loc.Location.SourceTree.GetRoot ();
+								var node = root.FindNode (loc.Location.SourceSpan);
+								var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
+								sr.ReferenceUsageType = HighlightUsagesExtension.GetUsage (node);
+								result.Add (sr);
+							}
 						}
 					}
 				}
 				return (IEnumerable<SearchResult>)result;
 			});
+		}
+
+		public static async Task<IEnumerable<ISymbol>> GatherSymbols (ISymbol symbol, Solution solution, CancellationToken token)
+		{
+			var result = new List<ISymbol> ();
+			result.Add (symbol);
+			foreach (var s in await SymbolFinder.FindImplementationsAsync (symbol, solution, null, token))
+				result.Add (s);
+			return result;
 		}
 
 		public override Task<IEnumerable<SearchResult>> FindAllReferences (string documentationCommentId, MonoDevelop.Projects.Project hintProject, CancellationToken token)
@@ -273,30 +283,32 @@ namespace MonoDevelop.CSharp.Refactoring
 				if (workspace == null)
 					return Enumerable.Empty<SearchResult> ();
 				foreach (var curSymbol in lookup.Symbol.ContainingType.GetMembers ().Where (m => m.Kind == lookup.Symbol.Kind && m.Name == lookup.Symbol.Name)) {
-					foreach (var simSym in SymbolFinder.FindSimilarSymbols (curSymbol, lookup.Compilation)) {
-						foreach (var loc in simSym.Locations) {
-							if (!loc.IsInSource)
-								continue;
-							var sr = new SearchResult (new FileProvider (loc.SourceTree.FilePath), loc.SourceSpan.Start, loc.SourceSpan.Length);
-							if (antiDuplicatesSet.Add (sr)) {
-								result.Add (sr);
-							}
-						}
-
-						foreach (var mref in await SymbolFinder.FindReferencesAsync (simSym, lookup.Solution).ConfigureAwait (false)) {
-							foreach (var loc in mref.Locations) {
-								var fileName = loc.Document.FilePath;
-								var offset = loc.Location.SourceSpan.Start;
-								string projectedName;
-								int projectedOffset;
-								if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-									fileName = projectedName;
-									offset = projectedOffset;
-								}
-
-								var sr = new SearchResult (new FileProvider (fileName), offset, loc.Location.SourceSpan.Length);
+					foreach (var sym in SymbolFinder.FindSimilarSymbols (curSymbol, lookup.Compilation)) {
+						foreach (var simSym in await GatherSymbols (sym, lookup.Solution, token)) {
+							foreach (var loc in simSym.Locations) {
+								if (!loc.IsInSource)
+									continue;
+								var sr = new SearchResult (new FileProvider (loc.SourceTree.FilePath), loc.SourceSpan.Start, loc.SourceSpan.Length);
 								if (antiDuplicatesSet.Add (sr)) {
 									result.Add (sr);
+								}
+							}
+
+							foreach (var mref in await SymbolFinder.FindReferencesAsync (simSym, lookup.Solution).ConfigureAwait (false)) {
+								foreach (var loc in mref.Locations) {
+									var fileName = loc.Document.FilePath;
+									var offset = loc.Location.SourceSpan.Start;
+									string projectedName;
+									int projectedOffset;
+									if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
+										fileName = projectedName;
+										offset = projectedOffset;
+									}
+
+									var sr = new SearchResult (new FileProvider (fileName), offset, loc.Location.SourceSpan.Length);
+									if (antiDuplicatesSet.Add (sr)) {
+										result.Add (sr);
+									}
 								}
 							}
 						}


### PR DESCRIPTION
implementations'

This is just a bandaid fix. The infrastructure seems to be implemented
in EditorFeatures. It's not reasonable that this isn't part of the
SymbolFinder core features. This implementaiton fixes the problem, but
once EditorFeatures is accessible for us we should just switch to
their find reference service.