### PR TITLE
[DotNetCore] Fix shared project re-evaluation and shared files displayed in Solution pad

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -541,11 +541,25 @@ namespace MonoDevelop.DotNetCore
 					return false;
 			}
 
+			if (IsFromSharedProject (buildItem))
+				return false;
+
 			// HACK: Remove any imported items that are not in the EvaluatedItems
 			// This may happen if a condition excludes the item. All items passed to the
 			// OnGetSupportsImportedItem are from the EvaluatedItemsIgnoringCondition
 			return Project.MSBuildProject.EvaluatedItems
 				.Any (item => item.IsImported && item.Name == buildItem.Name && item.Include == buildItem.Include);
+		}
+
+		/// <summary>
+		/// Checks that the project has the HasSharedItems property set to true and the SharedGUID
+		/// property in its global property group. Otherwise it is not considered to be a shared project.
+		/// </summary>
+		bool IsFromSharedProject (IMSBuildItemEvaluated buildItem)
+		{
+			var globalGroup = buildItem?.SourceItem?.ParentProject?.GetGlobalPropertyGroup ();
+			return globalGroup?.GetValue<bool> ("HasSharedItems") == true &&
+				globalGroup?.HasProperty ("SharedGUID") == true;
 		}
 
 		protected override ProjectRunConfiguration OnCreateRunConfiguration (string name)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -413,20 +413,35 @@ namespace MonoDevelop.DotNetCore
 			// project file is being saved.
 		}
 
+		/// <summary>
+		/// Shared projects can trigger a reference change during re-evaluation so do not
+		/// restore if the project is being re-evaluated. Otherwise this could cause the
+		/// restore to be run repeatedly.
+		/// </summary>
 		protected override void OnReferenceAddedToProject (ProjectReferenceEventArgs e)
 		{
 			base.OnReferenceAddedToProject (e);
 
-			if (!Project.Loading)
+			if (!IsLoadingOrReevaluating ())
 				RestoreNuGetPackages ();
 		}
 
+		/// <summary>
+		/// Shared projects can trigger a reference change during re-evaluation so do not
+		/// restore if the project is being re-evaluated. Otherwise this could cause the
+		/// restore to be run repeatedly.
+		/// </summary>
 		protected override void OnReferenceRemovedFromProject (ProjectReferenceEventArgs e)
 		{
 			base.OnReferenceRemovedFromProject (e);
 
-			if (!Project.Loading)
+			if (!IsLoadingOrReevaluating ())
 				RestoreNuGetPackages ();
+		}
+
+		bool IsLoadingOrReevaluating ()
+		{
+			return Project.Loading || Project.IsReevaluating;
 		}
 
 		void RestoreNuGetPackages ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -354,7 +354,7 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 			if (e.ProjectReference.ReferenceType == ReferenceType.Project && e.ProjectReference.Reference == Name) {
 				foreach (var f in Files) {
 					var pf = e.Project.GetProjectFile (f.FilePath);
-					if ((pf.Flags & ProjectItemFlags.DontPersist) != 0)
+					if (pf != null && (pf.Flags & ProjectItemFlags.DontPersist) != 0)
 						e.Project.Files.Remove (pf.FilePath);
 				}
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProjectMSBuildExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProjectMSBuildExtension.cs
@@ -47,14 +47,10 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 					projitemsFile = MSBuildProjectService.FromMSBuildPath (Project.ItemDirectory, projitemsFile);
 					projitemsFile = Path.Combine (Path.GetDirectoryName (msproject.FileName), projitemsFile);
 					if (File.Exists (projitemsFile)) {
-						using (MSBuildProject p = new MSBuildProject (msproject.EngineManager)) {
-							p.Load (projitemsFile);
-							Project.LoadProjectItems (p, ProjectItemFlags.Hidden | ProjectItemFlags.DontPersist, null);
-							var r = ProjectReference.CreateProjectReference (projitemsFile);
-							r.Flags = ProjectItemFlags.DontPersist;
-							r.SetItemsProjectPath (projitemsFile);
-							Project.References.Add (r);
-						}
+						var r = ProjectReference.CreateProjectReference (projitemsFile);
+						r.Flags = ProjectItemFlags.DontPersist;
+						r.SetItemsProjectPath (projitemsFile);
+						Project.References.Add (r);
 					}
 				}
 			}

--- a/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
@@ -472,6 +472,38 @@ namespace MonoDevelop.Projects
 
 			sol.Dispose ();
 		}
+
+		/// <summary>
+		/// Tests that re-evaluating a project that referenced a shared project does not throw a null reference
+		/// exception and the files are still available from both projects afterwards.
+		/// </summary>
+		[Test]
+		public async Task ReevaluateProjectReferencingSharedProject ()
+		{
+			string solFile = Util.GetSampleProject ("SharedProjectTest", "SharedProjectTest.sln");
+			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var pc1 = sol.FindProjectByName ("Console1");
+			Assert.IsNotNull (pc1);
+
+			var pcs = (SharedAssetsProject)sol.FindProjectByName ("Shared");
+			Assert.IsNotNull (pcs);
+
+			var sharedFile = pcs.ItemDirectory.Combine ("MyClass.cs");
+			var programFile = pc1.ItemDirectory.Combine ("Program.cs");
+
+			Assert.IsTrue (pc1.Files.GetFile (sharedFile) != null);
+			Assert.IsTrue (pcs.Files.GetFile (sharedFile) != null);
+			Assert.IsTrue (pc1.Files.GetFile (programFile) != null);
+
+			await pc1.ReevaluateProject (Util.GetMonitor ());
+
+			Assert.IsTrue (pc1.Files.GetFile (sharedFile) != null);
+			Assert.IsTrue (pcs.Files.GetFile (sharedFile) != null);
+			Assert.IsTrue (pc1.Files.GetFile (programFile) != null);
+
+			sol.Dispose ();
+		}
 	}
 }
 

--- a/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
@@ -504,6 +504,32 @@ namespace MonoDevelop.Projects
 
 			sol.Dispose ();
 		}
+
+		/// <summary>
+		/// Tests that files imported by Shared Assets projects are added as Hidden, DontPersist
+		/// files to the .NET Core project's Files collection.
+		/// </summary>
+		[Test]
+		public async Task DotNetCoreProjectReferencingSharedProject ()
+		{
+			string solFile = Util.GetSampleProject ("DotNetCoreSharedProjectTest", "DotNetCoreSharedProjectTest.sln");
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var dotNetCoreProject = sol.FindProjectByName ("DotNetCoreProject");
+			Assert.IsNotNull (dotNetCoreProject);
+
+			var sharedProject = (SharedAssetsProject)sol.FindProjectByName ("Shared");
+			Assert.IsNotNull (sharedProject);
+
+			var sharedFile = sharedProject.ItemDirectory.Combine ("MyClass.cs");
+
+			var file = dotNetCoreProject.Files.GetFile (sharedFile);
+
+			Assert.AreEqual (ProjectItemFlags.Hidden | ProjectItemFlags.DontPersist, file.Flags);
+			Assert.IsTrue (sharedProject.Files.GetFile (sharedFile) != null);
+
+			sol.Dispose ();
+		}
 	}
 }
 

--- a/main/tests/test-projects/DotNetCoreSharedProjectTest/DotNetCore/DotNetCoreProject.csproj
+++ b/main/tests/test-projects/DotNetCoreSharedProjectTest/DotNetCore/DotNetCoreProject.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+
+  <Import Project="..\Shared\Shared.projitems" Label="Shared" Condition="Exists('..\Shared\Shared.projitems')" />
+</Project>

--- a/main/tests/test-projects/DotNetCoreSharedProjectTest/DotNetCore/Program.cs
+++ b/main/tests/test-projects/DotNetCoreSharedProjectTest/DotNetCore/Program.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello World!");
+    }
+}

--- a/main/tests/test-projects/DotNetCoreSharedProjectTest/DotNetCoreSharedProjectTest.sln
+++ b/main/tests/test-projects/DotNetCoreSharedProjectTest/DotNetCoreSharedProjectTest.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCore", "DotNetCore\DotNetCoreProject.csproj", "{7A5198EC-20E7-4B49-9931-FBBCB58BDC27}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Shared", "Shared\Shared.shproj", "{551C9391-1E8F-47D3-9C80-6AE04DE1AEE3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7A5198EC-20E7-4B49-9931-FBBCB58BDC27}.Debug|x86.ActiveCfg = Debug|x86
+		{7A5198EC-20E7-4B49-9931-FBBCB58BDC27}.Debug|x86.Build.0 = Debug|x86
+		{7A5198EC-20E7-4B49-9931-FBBCB58BDC27}.Release|x86.ActiveCfg = Release|x86
+		{7A5198EC-20E7-4B49-9931-FBBCB58BDC27}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Console1\Console1.csproj
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreSharedProjectTest/Shared/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreSharedProjectTest/Shared/MyClass.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Shared
+{
+	public class MyClass
+	{
+		public MyClass ()
+		{
+		}
+	}
+}
+

--- a/main/tests/test-projects/DotNetCoreSharedProjectTest/Shared/Shared.projitems
+++ b/main/tests/test-projects/DotNetCoreSharedProjectTest/Shared/Shared.projitems
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{551C9391-1E8F-47D3-9C80-6AE04DE1AEE3}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>SharedNamespace</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)MyClass.cs" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreSharedProjectTest/Shared/Shared.shproj
+++ b/main/tests/test-projects/DotNetCoreSharedProjectTest/Shared/Shared.shproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{551C9391-1E8F-47D3-9C80-6AE04DE1AEE3}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Two fixes for shared projects:

 56144 - NetCore Projects show the files from a referenced Shared Project
 56147 - NRE restoring Shared Project in a NetCore app

Also removed some code calling Project.LoadProjectItems SharedAssetsProjectMSBuildExtension since it never seemed to add any files since the MSBuildProject loaded was not evaluated. The files are added later by other sections of code. The LoadProjectItems was being called during re-evaluation and clearing the Project.Files collection for the project referencing the shared project.