### PR TITLE
[Core] Fix error when adding new generic project to solution

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/GenericProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/GenericProject.cs
@@ -47,6 +47,7 @@ namespace MonoDevelop.Projects
 
 		protected override void OnInitializeFromTemplate (ProjectCreateInformation projectCreateInfo, XmlElement template)
 		{
+			base.OnInitializeFromTemplate (projectCreateInfo, template);
 			Configurations.Add (CreateConfiguration ("Default"));
 		}
 


### PR DESCRIPTION
Fixed bug #55783 - XS crashes when adding new project
https://bugzilla.xamarin.com/show_bug.cgi?id=55783

When adding a new generic project to an existing solution using the
New Project dialog an error dialog would be displayed saying that the
project does not have a file name and the save failed. The problem
was that the TemplateInitializationCallback was not called when
the GenericProject was initialized from the template so the filename
was not being set.