### PR TITLE
[Core] Fix project options cannot be opened for generic projects

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/GenericProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/GenericProject.cs
@@ -67,6 +67,11 @@ namespace MonoDevelop.Projects
 			base.OnWriteConfiguration (monitor, config, pset);
 			pset.SetValue ("OutputPath", config.OutputDirectory);
 		}
+
+		protected override ProjectFeatures OnGetSupportedFeatures ()
+		{
+			return ProjectFeatures.Build | ProjectFeatures.Configurations | ProjectFeatures.Execute;
+		}
 	}
 	
 	[ProjectModelDataItem]


### PR DESCRIPTION
On trying to open the project options dialog for a generic project
a null reference exception was thrown by the RunConfigurationPanel
since it could not find an run configuration editor for generic
projects. To avoid this the generic project now indicates it does
not support run configurations so the project options dialog can
be opened.