### PR TITLE
Fixed 'Bug 56650 - Many workspace errors logged while coding'

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -275,6 +275,7 @@ namespace MonoDevelop.Ide.Gui
 			IdeApp.ProjectOperations.CurrentProjectChanged += (s,a) => SetWorkbenchTitle ();
 
 			FileService.FileRemoved += CheckRemovedFile;
+			FileService.FileMoved += CheckRenamedFile;
 			FileService.FileRenamed += CheckRenamedFile;
 			
 //			TopMenu.Selected   += new CommandHandler(OnTopMenuSelected);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -745,7 +745,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		}
 
 		List<MonoDevelopSourceTextContainer> openDocuments = new List<MonoDevelopSourceTextContainer>();
-		internal void InformDocumentOpen (DocumentId documentId, ITextDocument editor)
+		internal void InformDocumentOpen (DocumentId documentId, TextEditor editor)
 		{
 			var document = InternalInformDocumentOpen (documentId, editor);
 			if (document as Document != null) {
@@ -755,13 +755,16 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		TextDocument InternalInformDocumentOpen (DocumentId documentId, ITextDocument editor)
+		TextDocument InternalInformDocumentOpen (DocumentId documentId, TextEditor editor)
 		{
-			TextDocument document = this.GetDocument (documentId) ?? this.GetAdditionalDocument (documentId);
+			var project = this.CurrentSolution.GetProject (documentId.ProjectId);
+			if (project == null)
+				return null;
+			TextDocument document = project.GetDocument (documentId) ?? project.GetAdditionalDocument (documentId);
 			if (document == null || openDocuments.Any (d => d.Id == documentId)) {
 				return document;
 			}
-			var monoDevelopSourceTextContainer = new MonoDevelopSourceTextContainer (documentId, editor);
+			var monoDevelopSourceTextContainer = new MonoDevelopSourceTextContainer (this, documentId, editor);
 			lock (openDocuments) {
 				openDocuments.Add (monoDevelopSourceTextContainer);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1293,8 +1293,12 @@ namespace MonoDevelop.Ide.TypeSystem
 				var projectId = kv.Key;
 				var docId = this.GetDocumentId (projectId, fileName);
 				if (docId != null) {
-					try { 
-						base.OnDocumentTextChanged (docId, newText, PreservationMode.PreserveIdentity);
+					try {
+						if (this.GetDocument (docId) != null) {
+							base.OnDocumentTextChanged (docId, newText, PreservationMode.PreserveIdentity);
+						} else if (this.GetAdditionalDocument (docId) != null) {
+							base.OnAdditionalDocumentTextChanged (docId, newText, PreservationMode.PreserveIdentity);
+						}
 					} catch (Exception e) {
 						LoggingService.LogWarning ("Roslyn error on text change", e);
 					}


### PR DESCRIPTION
Without a repro it's hard to tell why that happens. This patch should
ensure that no invalid document is open and that the analysis document
invalidates when the roslyn workspace closes the open document. The
source text container has now a check on invalid documents as well and
tries to reopen the document in that case. This should fix the issue.