### PR TITLE
[Ide] Improve performance of first folder expansion.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			if (project == null)
 				return;
 
-			ProjectFileCollection files;
+			List<ProjectFile> files;
 			List<string> folders;
 
 			GetFolderContent (project, path, out files, out folders);
@@ -76,11 +76,11 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			builder.AddChildren (folders.Select (f => new ProjectFolder (f, project, dataObject)));
 		}
 				
-		void GetFolderContent (Project project, string folder, out ProjectFileCollection files, out List<string> folders)
+		void GetFolderContent (Project project, string folder, out List<ProjectFile> files, out List<string> folders)
 		{
 			string folderPrefix = folder + Path.DirectorySeparatorChar;
 
-			files = new ProjectFileCollection ();
+			files = new List<ProjectFile> ();
 			folders = new List<string> ();
 			
 			foreach (ProjectFile file in project.Files)


### PR DESCRIPTION
WHenever we open a new folder, we calculate project paths to decide where the file ends up.
That said, the ProjectFileCollection is a bit heavy, as it does a lot more than just being a container for ProjectFile. It creates a tree of items, allocates a lot of data that we don't need, subscribes to change events. Addition of an item to a ProjectFileCollection is not O(1) either, its a recursive method which queries dictionaries based on how many path segments there are. The code just needs to check whether the path is a child of another path, so, since we do it in the GetFolderContent method, just use a simple List<ProjectFile>.
Expanding the icons folder from MonoDevelop.Ide is now ~instant, from 2-3s observed time.