### PR TITLE
Bug 55617 - Run->Debug Application doesn't support MultiProcessDebugging

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
@@ -65,9 +65,6 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation DebugApplication (this ProjectOperations opers, string executableFile, string args, string workingDir, IDictionary<string,string> envVars)
 		{
-			if (opers.CurrentRunOperation != null && !opers.CurrentRunOperation.IsCompleted)
-				return opers.CurrentRunOperation;
-
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileName (executableFile));
 
 			var oper = DebuggingService.Run (executableFile, args, workingDir, envVars, monitor.Console);
@@ -82,9 +79,6 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation AttachToProcess (this ProjectOperations opers, DebuggerEngine debugger, ProcessInfo proc)
 		{
-			if (opers.CurrentRunOperation != null && !opers.CurrentRunOperation.IsCompleted)
-				return opers.CurrentRunOperation;
-
 			var oper = DebuggingService.AttachToProcess (debugger, proc);
 
 			opers.AddRunOperation (oper);


### PR DESCRIPTION
This was missed when MultiDebugging support was introduced, same thing was done for other "start debug" calls e.g.: https://github.com/mono/monodevelop/commit/7826ec03c149c75ba943fd44a9f7d9bddfc3fd3b#diff-5d6c50c1e9217c288ff67babbbb8a9aeL49