### PR TITLE
[NuGetizer3000] Visual Studio on windows compatibility

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		[Test]
 		public async Task ConsoleProject_SaveProject_DoesNotAddExtraProperties ()
 		{
-			string solutionFileName = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-console.sln");
+			string solutionFileName = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-sdk-console.sln");
 			var solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = solution.GetAllProjects ().Single ();
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -74,9 +74,7 @@ namespace MonoDevelop.DotNetCore
 
 		bool IsDotNetCoreProject (DotNetProject project)
 		{
-			var properties = project.MSBuildProject.EvaluatedProperties;
-			return properties.HasProperty ("TargetFramework") ||
-				properties.HasProperty ("TargetFrameworks");
+			return project.MSBuildProject.Sdk != null;
 		}
 
 		protected override bool OnGetCanReferenceProject (DotNetProject targetProject, out string reason)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -74,7 +74,21 @@ namespace MonoDevelop.DotNetCore
 
 		bool IsDotNetCoreProject (DotNetProject project)
 		{
-			return project.MSBuildProject.Sdk != null;
+			return project.MSBuildProject.Sdk != null && HasSupportedFramework (project);
+		}
+
+		/// <summary>
+		/// Cannot check TargetFramework property since it may not be set.
+		/// Currently support .NET Core and .NET Standard.
+		/// </summary>
+		bool HasSupportedFramework (DotNetProject project)
+		{
+			string framework = project.MSBuildProject.EvaluatedProperties.GetValue ("TargetFrameworkIdentifier");
+			if (framework != null) {
+				return framework == ".NETCoreApp" || framework == ".NETStandard";
+			}
+
+			return false;
 		}
 
 		protected override bool OnGetCanReferenceProject (DotNetProject targetProject, out string reason)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.DotNetCore
 
 		protected override bool SupportsObject (WorkspaceObject item)
 		{
-			return base.SupportsObject (item) && IsDotNetCoreProject ((DotNetProject)item);
+			return base.SupportsObject (item) && IsSdkProject ((DotNetProject)item);
 		}
 
 		protected override void Initialize ()
@@ -72,23 +72,15 @@ namespace MonoDevelop.DotNetCore
 			return base.OnGetSupportsFramework (framework);
 		}
 
-		bool IsDotNetCoreProject (DotNetProject project)
-		{
-			return project.MSBuildProject.Sdk != null && HasSupportedFramework (project);
-		}
-
 		/// <summary>
-		/// Cannot check TargetFramework property since it may not be set.
-		/// Currently support .NET Core and .NET Standard.
+		/// Currently this project extension is enabled for all SDK style projects and
+		/// not just for .NET Core and .NET Standard projects. SDK project support
+		/// should be separated out from this extension so it can be enabled only for
+		/// .NET Core and .NET Standard projects.
 		/// </summary>
-		bool HasSupportedFramework (DotNetProject project)
+		bool IsSdkProject (DotNetProject project)
 		{
-			string framework = project.MSBuildProject.EvaluatedProperties.GetValue ("TargetFrameworkIdentifier");
-			if (framework != null) {
-				return framework == ".NETCoreApp" || framework == ".NETStandard";
-			}
-
-			return false;
+			return project.MSBuildProject.Sdk != null;
 		}
 
 		protected override bool OnGetCanReferenceProject (DotNetProject targetProject, out string reason)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -49,6 +49,11 @@ namespace MonoDevelop.PackageManagement
 		string projectName;
 		bool restoreRequired;
 
+		public DotNetCoreNuGetProject (DotNetProject project)
+			: this (project, project.GetDotNetCoreTargetFrameworks ())
+		{
+		}
+
 		public DotNetCoreNuGetProject (
 			DotNetProject project,
 			IEnumerable<string> targetFrameworks)
@@ -92,9 +97,8 @@ namespace MonoDevelop.PackageManagement
 
 		public static NuGetProject Create (DotNetProject project)
 		{
-			var targetFrameworks = project.GetDotNetCoreTargetFrameworks ();
-			if (targetFrameworks.Any ())
-				return new DotNetCoreNuGetProject (project, targetFrameworks);
+			if (project.MSBuildProject.Sdk != null)
+				return new DotNetCoreNuGetProject (project);
 
 			return null;
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -171,7 +171,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static bool IsDotNetCoreProject (this Project project)
 		{
-			return project.GetDotNetCoreTargetFrameworks ().Any ();
+			return project.MSBuildProject.Sdk != null;
 		}
 
 		public static bool HasPackageReferences (this DotNetProject project)

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkCrossPlatformLibraryProjectTemplateWizardPageWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkCrossPlatformLibraryProjectTemplateWizardPageWidget.cs
@@ -115,6 +115,10 @@ namespace MonoDevelop.Packaging.Gui
 
 		void NameTextChanged (object sender, EventArgs e)
 		{
+			// Use name as description by default.
+			if (wizardPage.LibraryName == wizardPage.Description)
+				descriptionTextBox.Text = nameTextBox.Text;
+
 			wizardPage.LibraryName = nameTextBox.Text;
 
 			if (wizardPage.HasLibraryNameError ()) {

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkPackagingProjectTemplateWizardPageWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkPackagingProjectTemplateWizardPageWidget.cs
@@ -101,6 +101,10 @@ namespace MonoDevelop.Packaging.Gui
 
 		void PackageIdTextBoxChanged (object sender, EventArgs e)
 		{
+			// Use id as description by default.
+			if (wizardPage.Id == wizardPage.Description)
+				packageDescriptionTextBox.Text = packageIdTextBox.Text;
+
 			wizardPage.Id = packageIdTextBox.Text;
 
 			if (wizardPage.HasIdError ()) {

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.csproj
@@ -91,7 +91,6 @@
     <Compile Include="MonoDevelop.Packaging\NuGetFilePropertyProvider.cs" />
     <Compile Include="MonoDevelop.Packaging\NuGetFileDescriptor.cs" />
     <Compile Include="MonoDevelop.Packaging\PackagingNuGetProject.cs" />
-    <Compile Include="MonoDevelop.Packaging\PackageReference.cs" />
     <Compile Include="MonoDevelop.Packaging\PackageReferenceCollection.cs" />
     <Compile Include="MonoDevelop.Packaging\AddPlatformImplementationHandler.cs" />
     <Compile Include="MonoDevelop.Packaging.Gui\AddPlatformImplementationDialog.cs" />
@@ -121,6 +120,7 @@
     </Compile>
     <Compile Include="MonoDevelop.Packaging.OptionPanels\ProjectNuGetBuildOptionsPanel.cs" />
     <Compile Include="MonoDevelop.Packaging\ProjectIsDotNetProjectOnlyCondition.cs" />
+    <Compile Include="MonoDevelop.Packaging\ProjectPackageReferenceExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.Packaging.Tests" />

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/DotNetProjectExtensions.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Packaging
 		public static void InstallBuildPackagingNuGetPackage (IEnumerable<Project> projects)
 		{
 			string packagesFolder = GetPackagesFolder ();
-			var packageReference = new PackageManagementPackageReference ("NuGet.Build.Packaging", "0.1.248");
+			var packageReference = new PackageManagementPackageReference ("NuGet.Build.Packaging", "0.1.276");
 
 			var packageReferences = new [] { packageReference };
 

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackageReferenceCollection.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackageReferenceCollection.cs
@@ -25,12 +25,13 @@
 // THE SOFTWARE.
 
 using System;
+using MonoDevelop.PackageManagement;
 using MonoDevelop.Projects;
 
 namespace MonoDevelop.Packaging
 {
 	[Serializable]
-	class PackageReferenceCollection : ProjectItemCollection<PackageReference>
+	class PackageReferenceCollection : ProjectItemCollection<ProjectPackageReference>
 	{
 	}
 }

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingNuGetProject.cs
@@ -74,7 +74,7 @@ namespace MonoDevelop.Packaging
 			return await Runtime.RunInMainThread (async () => {
 
 				// Check if this NuGet package is already installed and should be removed.
-				PackageReference existingPackageReference = project.FindPackageReference (packageIdentity);
+				ProjectPackageReference existingPackageReference = project.FindPackageReference (packageIdentity);
 				if (existingPackageReference != null) {
 					if (ShouldRemoveExistingPackageReference (existingPackageReference, packageIdentity)) {
 						project.PackageReferences.Remove (existingPackageReference);
@@ -94,9 +94,9 @@ namespace MonoDevelop.Packaging
 					GenerateNuGetBuildPackagingTargets (packageIdentity);
 				}
 
-				var packageReference = new PackageReference (packageIdentity);
+				var packageReference = ProjectPackageReference.Create (packageIdentity);
 				if (developmentDependency)
-					packageReference.PrivateAssets = "All";
+					packageReference.Metadata.SetValue ("PrivateAssets", "All");
 				project.PackageReferences.Add (packageReference);
 				await SaveProject ();
 				return true;
@@ -109,7 +109,7 @@ namespace MonoDevelop.Packaging
 			CancellationToken token)
 		{
 			return await Runtime.RunInMainThread (() => {
-				PackageReference packageReference = project.FindPackageReference (packageIdentity);
+				ProjectPackageReference packageReference = project.FindPackageReference (packageIdentity);
 				if (packageReference != null) {
 					project.PackageReferences.Remove (packageReference);
 					SaveProject ();
@@ -122,7 +122,7 @@ namespace MonoDevelop.Packaging
 		/// If the package version is already installed then there is no need to install the 
 		/// NuGet package.
 		/// </summary>
-		bool ShouldRemoveExistingPackageReference (PackageReference packageReference, PackageIdentity packageIdentity)
+		bool ShouldRemoveExistingPackageReference (ProjectPackageReference packageReference, PackageIdentity packageIdentity)
 		{
 			var existingPackageReference = packageReference.ToNuGetPackageReference ();
 			return !VersionComparer.Default.Equals (existingPackageReference.PackageIdentity.Version, packageIdentity.Version);

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
@@ -116,7 +116,7 @@ namespace MonoDevelop.Packaging
 			return true;
 		}
 
-		protected override bool OnGetCanExecute (MonoDevelop.Projects.ExecutionContext context, ConfigurationSelector configuration)
+		protected override bool OnGetCanExecute (Projects.ExecutionContext context, ConfigurationSelector configuration, SolutionItemRunConfiguration runConfiguration)
 		{
 			return false;
 		}

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
@@ -275,12 +275,12 @@ namespace MonoDevelop.Packaging
 			get { return packageReferences; }
 		}
 
-		public PackageReference FindPackageReference (PackageIdentity packageIdentity)
+		public ProjectPackageReference FindPackageReference (PackageIdentity packageIdentity)
 		{
 			return PackageReferences.FirstOrDefault (packageReference => IsMatch (packageReference, packageIdentity));
 		}
 
-		bool IsMatch (PackageReference packageReference, PackageIdentity packageIdentity)
+		bool IsMatch (ProjectPackageReference packageReference, PackageIdentity packageIdentity)
 		{
 			return String.Equals (packageReference.Include, packageIdentity.Id, StringComparison.OrdinalIgnoreCase);
 		}
@@ -297,12 +297,12 @@ namespace MonoDevelop.Packaging
 			referenceAssemblyFrameworks.AddRange (frameworks.Select (fx => new ReferenceAssemblyFramework (fx)));
 		}
 
-		PackageReference GetNuGetBuildPackagingPackageReference ()
+		ProjectPackageReference GetNuGetBuildPackagingPackageReference ()
 		{
 			return PackageReferences.FirstOrDefault (packageReference => IsNuGetBuildPackagingReference (packageReference));
 		}
 
-		bool IsNuGetBuildPackagingReference (PackageReference packageReference)
+		bool IsNuGetBuildPackagingReference (ProjectPackageReference packageReference)
 		{
 			return StringComparer.OrdinalIgnoreCase.Equals (packageReference.Include, "NuGet.Build.Packaging");
 		}

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
@@ -113,18 +113,7 @@ namespace MonoDevelop.Packaging
 
 		protected override bool OnSupportsFramework (TargetFramework framework)
 		{
-			bool result = base.OnSupportsFramework (framework);
-			if (result)
-				return result;
-
-			if (framework.Id.Identifier == ".NETFramework") {
-				Version frameworkVersion = null;
-				if (System.Version.TryParse (framework.Id.Version, out frameworkVersion)) {
-					return frameworkVersion.Major >= 4 && frameworkVersion.Minor >= 5;
-				}
-			}
-
-			return false;
+			return true;
 		}
 
 		protected override bool OnGetCanExecute (MonoDevelop.Projects.ExecutionContext context, ConfigurationSelector configuration)

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingProject.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -324,7 +325,24 @@ namespace MonoDevelop.Packaging
 			if (packageIdentity == null)
 				return false;
 
-			return GlobalPackagesExtractor.IsMissing (solutionManager, packageIdentity);
+			if (GlobalPackagesExtractor.IsMissing (solutionManager, packageIdentity))
+				return true;
+
+			// This will trigger a restore if the generated MSBuild files are missing.
+			return !GeneratedNuGetMSBuildFilesExist ();
+		}
+
+		/// <summary>
+		/// Looks for generated .nuget.targets and .nuget.props files for the project.
+		/// </summary>
+		bool GeneratedNuGetMSBuildFilesExist ()
+		{
+			string targetsName = $"{Name}.nuget.targets";
+			string propsName = $"{Name}.nuget.props";
+			string targetsPath = Path.Combine (BaseDirectory, targetsName);
+			string propsPath = Path.Combine (BaseDirectory, propsName);
+
+			return File.Exists (targetsPath) && File.Exists (propsPath);
 		}
 
 		public async Task RestorePackagesAsync (

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/ProjectPackageReferenceExtensions.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/ProjectPackageReferenceExtensions.cs
@@ -1,10 +1,10 @@
 ﻿//
-// PackageReference.cs
+// ProjectPackageReferenceExtensions.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,38 +24,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using MonoDevelop.Core.Serialization;
-using MonoDevelop.Projects;
+using MonoDevelop.PackageManagement;
+using NuGet.Packaging;
 using NuGet.Frameworks;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
 
 namespace MonoDevelop.Packaging
 {
-	[ExportProjectItemType ("PackageReference")]
-	class PackageReference : ProjectItem
+	static class ProjectPackageReferenceExtensions
 	{
-		internal PackageReference (PackageIdentity packageIdentity)
+		internal static PackageReference ToNuGetPackageReference (this ProjectPackageReference packageReference)
 		{
-			Include = packageIdentity.Id;
-			Version = packageIdentity.Version.ToString ();
-		}
-
-		public PackageReference ()
-		{
-		}
-
-		[ItemProperty ("Version")]
-		public string Version { get; set; }
-
-		[ItemProperty ("PrivateAssets")]
-		public string PrivateAssets { get; set; }
-
-		internal NuGet.Packaging.PackageReference ToNuGetPackageReference ()
-		{
-			var identity = new PackageIdentity (Include, new NuGetVersion (Version));
-			return new NuGet.Packaging.PackageReference (identity, NuGetFramework.Parse ("any"));
+			var nugetPackageReference = packageReference.CreatePackageReference ();
+			return new PackageReference (nugetPackageReference.PackageIdentity, NuGetFramework.Parse ("any"));
 		}
 	}
 }
-

--- a/main/src/addins/MonoDevelop.Packaging/PostBuild.proj
+++ b/main/src/addins/MonoDevelop.Packaging/PostBuild.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);_MyPostBuildTarget</PrepareForRunDependsOn>
-    <_BuildPackagingVersion>0.1.248</_BuildPackagingVersion>
+    <_BuildPackagingVersion>0.1.276</_BuildPackagingVersion>
   </PropertyGroup>
   <ItemGroup>
     <_MyNuGetPackage Include="$(MSBuildProjectDirectory)\..\..\..\packages\NuGet.Build.Packaging.$(_BuildPackagingVersion)\NuGet.Build.Packaging.$(_BuildPackagingVersion).nupkg" />

--- a/main/src/addins/MonoDevelop.Packaging/Templates/CrossPlatformLibrary.xpt.xml
+++ b/main/src/addins/MonoDevelop.Packaging/Templates/CrossPlatformLibrary.xpt.xml
@@ -29,7 +29,7 @@
 				DefaultNamespace="${ProjectName}"
 				HideGettingStarted="true" />
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.248" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
 			</Packages>
 			<Files>
 				<FileTemplateReference TemplateID="EmptyClass" name="MyClass.cs" />
@@ -50,7 +50,7 @@
 				<Reference type="Project" refto="${ProjectName}.Shared" />
 			</References>
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.248" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
 			</Packages>
 			<Files>
 				<FileTemplateReference TemplateID="CSharpAssemblyInfo" name="AssemblyInfo.cs" />
@@ -67,7 +67,7 @@
 				<Reference type="Project" refto="${ProjectName}.Shared" />
 			</References>
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.248" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
 			</Packages>
 			<Files>
 				<FileTemplateReference TemplateID="CSharpAssemblyInfo" name="AssemblyInfo.cs" />
@@ -77,7 +77,7 @@
 		<Project name="${ProjectName}.NuGet" directory="${ProjectName}.NuGet" type="NuGetPackaging" if="CreateNuGetProject">
 			<Options TargetFrameworkVersion="4.5" DefaultNamespace="${ProjectName}" HideGettingStarted="true" />
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.248" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
 			</Packages>
 			<References>
 				<Reference type="Project" refto="${ProjectName}.Android" if="CreateAndroidProject" />

--- a/main/src/addins/MonoDevelop.Packaging/Templates/PackagingProject.xpt.xml
+++ b/main/src/addins/MonoDevelop.Packaging/Templates/PackagingProject.xpt.xml
@@ -18,7 +18,7 @@
 		<Project name="${ProjectName}" directory="." type="NuGetPackaging">
 			<Options TargetFrameworkVersion="4.5" />
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.248" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
 			</Packages>
 			<Files>
 				<File name="readme.txt"><![CDATA[

--- a/main/src/addins/MonoDevelop.Packaging/packages.config
+++ b/main/src/addins/MonoDevelop.Packaging/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.Build.Packaging" version="0.1.248" targetFramework="net45" />
+  <package id="NuGet.Build.Packaging" version="0.1.276" targetFramework="net45" />
 </packages>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -705,6 +705,7 @@
     <Compile Include="MonoDevelop.Projects\MSBuildLogger.cs" />
     <Compile Include="MonoDevelop.Projects.Extensions\ImportSearchPathExtensionNode.cs" />
     <Compile Include="MonoDevelop.Projects.Extensions\AppliesToCondition.cs" />
+    <Compile Include="MonoDevelop.Projects\ProjectConfigurationItem.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfigurationItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConfigurationItem.cs
@@ -1,0 +1,44 @@
+﻿//
+// ProjectConfigurationItem.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace MonoDevelop.Projects
+{
+	// <ItemGroup Label="ProjectConfigurations">
+	//   <ProjectConfiguration Include="Debug|AnyCPU">
+	//     <Configuration>Debug</Configuration>
+	//     <Platform>AnyCPU</Platform>
+	//   </ProjectConfiguration>
+	//   <ProjectConfiguration Include="Release|AnyCPU">
+	//     <Configuration>Release</Configuration>
+	//     <Platform>AnyCPU</Platform>
+	//   </ProjectConfiguration>
+	// </ItemGroup>
+
+	[ExportProjectItemType ("ProjectConfiguration")]
+	class ProjectConfigurationItem : ProjectItem
+	{
+	}
+}


### PR DESCRIPTION
Fixes several NuGetizer 3000 bugs including:

 1. 56701 - Windows created nuspec can not be loaded on a mac
 2. 56706 - Can not create a nuget package with Standard net libraries
 3. 52657 - Creating a new Multiplatform Library requires a
description
 4. Packages folder empty on re-opening NuGet packaging project
 5. Fix Dependencies folder being displayed if latest NuGet.Build.Packaging 0.1.276 NuGet package is installed.
 6. Create MSBuild targets during restore for NuGet packaging project if they are missing.
 7. Update to latest stable NuGet.Build.Packaging 0.1.276 in project templates.