### PR TITLE
Fix msbuild evaluation issue

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -40,6 +40,7 @@ using System.Globalization;
 using Microsoft.Build.Evaluation;
 using System.Web.UI.WebControls;
 using MonoDevelop.Projects.Extensions;
+using System.Collections;
 
 namespace MonoDevelop.Projects.MSBuild
 {
@@ -541,6 +542,8 @@ namespace MonoDevelop.Projects.MSBuild
 			return ob != null ? Convert.ToString (ob, CultureInfo.InvariantCulture) : string.Empty;
 		}
 
+		static char [] dotOrBracket = { '.', '[' };
+
 		bool EvaluateProperty (string prop, bool ignorePropsWithTransforms, out object val, out bool needsItemEvaluation)
 		{
 			needsItemEvaluation = false;
@@ -559,12 +562,8 @@ namespace MonoDevelop.Projects.MSBuild
 				return EvaluateMember (type, null, prop, i, out val);
 			}
 
-			int n = prop.IndexOf ('[');
-			if (n > 0) {
-				return EvaluateStringAtIndex (prop, n, out val);
-			}
+			int n = prop.IndexOfAny (dotOrBracket);
 
-			n = prop.IndexOf ('.');
 			if (n == -1) {
 				needsItemEvaluation |= (!ignorePropsWithTransforms && propertiesWithTransforms.Contains (prop));
 				val = GetPropertyValue (prop) ?? string.Empty;
@@ -572,8 +571,23 @@ namespace MonoDevelop.Projects.MSBuild
 			} else {
 				var pn = prop.Substring (0, n);
 				val = GetPropertyValue (pn) ?? string.Empty;
-				return EvaluateMember (typeof(string), val, prop, n + 1, out val);
+				return EvaluateMemberOrIndexer (typeof (string), val, prop, n, out val);
 			}
+		}
+
+		bool EvaluateMemberOrIndexer (Type type, object instance, string str, int i, out object val)
+		{
+			// Position in string is either a '.' or a '['.
+
+			val = null;
+			if (i >= str.Length)
+				return false;
+			if (str [i] == '.') {
+				return EvaluateMember (type, instance, str, i + 1, out val);
+			} else if (str [i] == '[') {
+				return EvaluateIndexer (type, instance, str, i, out val);
+			}
+			return false;
 		}
 
 		internal bool EvaluateMember (Type type, object instance, string str, int i, out object val)
@@ -620,11 +634,37 @@ namespace MonoDevelop.Projects.MSBuild
 					return false;
 				}
 			}
-			if (j < str.Length && str[j] == '.') {
+			if (j < str.Length) {
 				// Chained member invocation
 				if (val == null)
 					return false;
-				return EvaluateMember (val.GetType (), val, str, j + 1, out val);
+				return EvaluateMemberOrIndexer (val.GetType (), val, str, j, out val);
+			}
+			return true;
+		}
+
+		bool EvaluateIndexer (Type type, object instance, string str, int i, out object val)
+		{
+			val = null;
+			object [] parameters;
+			i++;
+			if (!EvaluateParameters (str, ref i, out parameters))
+				return false;
+			if (parameters.Length != 1)
+				return false;
+			
+			var index = Convert.ToInt32 (parameters [0]);
+			if (instance is string) {
+				val = ((string)instance) [index];
+			}
+			else if (instance is IList array) {
+				val = array[index];
+			} else
+				return false;
+
+			if (++i < str.Length) {
+				// Chained member invocation
+				return EvaluateMemberOrIndexer (val.GetType (), val, str, i, out val);
 			}
 			return true;
 		}
@@ -696,7 +736,7 @@ namespace MonoDevelop.Projects.MSBuild
 			return true;
 		}
 
-		static char[] parameterCloseChars = new[] { ',', ')' };
+		static char[] parameterCloseChars = new[] { ',', ')', ']' };
 		internal bool EvaluateParameters (string str, ref int i, out object[] parameters)
 		{
 			parameters = null;
@@ -706,10 +746,11 @@ namespace MonoDevelop.Projects.MSBuild
 				var j = FindClosingChar (str, i, parameterCloseChars);
 				if (j == -1)
 					return false;
-				
+
+				var foundListEnd = str [j] == ')' || str [j] == ']';
 				var arg = str.Substring (i, j - i).Trim ();
 
-				if (arg.Length == 0 && str [j] == ')' && list.Count == 0) {
+				if (arg.Length == 0 && foundListEnd && list.Count == 0) {
 					// Empty parameters list
 					parameters = new object [0];
 					i = j;
@@ -722,7 +763,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 				list.Add (Evaluate (arg));
 
-				if (str [j] == ')') {
+				if (foundListEnd) {
 					// End of parameters list
 					parameters = list.ToArray ();
 					i = j;
@@ -858,31 +899,6 @@ namespace MonoDevelop.Projects.MSBuild
 				flags |= BindingFlags.NonPublic;
 			
 			return type.GetMember (memberName, flags | BindingFlags.Public | BindingFlags.IgnoreCase);
-		}
-
-		bool EvaluateStringAtIndex (string prop, int i, out object val)
-		{
-			val = null;
-
-			int j = prop.IndexOf (']');
-			if (j == -1)
-				return false;
-
-			if (j < prop.Length - 1 || j - i < 2)
-				return false;
-
-			string indexText = prop.Substring (i + 1, j - (i + 1));
-			int index = -1;
-			if (!int.TryParse (indexText, out index))
-				return false;
-
-			prop = prop.Substring (0, i);
-			string propertyValue = GetPropertyValue (prop) ?? string.Empty;
-			if (propertyValue.Length <= index)
-				return false;
-
-			val = propertyValue.Substring (index, 1);
-			return true;
 		}
 
 		static Tuple<Type, string []> [] supportedTypeMembers = {

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -391,6 +391,9 @@ namespace MonoDevelop.Projects
 			var dir = System.IO.Path.GetFullPath (System.IO.Path.Combine (System.IO.Path.GetDirectoryName (p.FileName), "foo"));
 			Assert.AreEqual (dir, p.EvaluatedProperties.GetValue ("FullPath"));
 
+			Assert.AreEqual ("00065535.0", p.EvaluatedProperties.GetValue ("DoubleNumber"));
+			Assert.AreEqual ("56735", p.EvaluatedProperties.GetValue ("DoubleNumberComplex"));
+
 			p.Dispose ();
 		}
 

--- a/main/tests/test-projects/msbuild-tests/functions.csproj
+++ b/main/tests/test-projects/msbuild-tests/functions.csproj
@@ -42,6 +42,8 @@
 	<Prefix>Post</Prefix>
 	<PostFiles>@(File)</PostFiles>
 	<P1>BBB</P1>
+	<DoubleNumber>00065535.0</DoubleNumber>
+	<DoubleNumberComplex>$([MSBuild]::Subtract($(DoubleNumber.Split('.')[0].Substring(3).Trim()), 8800))</DoubleNumberComplex>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>


### PR DESCRIPTION
Evaluate indexers for any expression result, not only for properties.
Fixes bug #55516 - Project evaluation fails to evaluate property in roslyn.