### PR TITLE
[NuGet] Fix build

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -191,6 +191,11 @@ namespace MonoDevelop.PackageManagement
 			return Task.FromResult (assetsFilePath);
 		}
 
+		public override Task<string> GetAssetsFilePathOrNullAsync ()
+		{
+			return GetAssetsFilePathAsync ();
+		}
+
 		public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync (DependencyGraphCacheContext context)
 		{
 			PackageSpec existingPackageSpec = GetExistingProjectPackageSpec (context);


### PR DESCRIPTION
Added missing GetAssetsFilePathOrNullAsync which is a new required
method for BuildIntegratedNuGetProject derived classes in NuGet 4.3.