### PR TITLE
[Templates] Allow for project references to be valid too.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/HasReferenceFileTemplateCondition.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/HasReferenceFileTemplateCondition.cs
@@ -44,7 +44,7 @@ namespace MonoDevelop.Ide.Templates
 		public override bool ShouldEnableFor (Project proj, string projectPath)
 		{
 			if (proj is DotNetProject dnp) {
-				return dnp.References.Where (x => x.ReferenceType != ReferenceType.Project).Any (x => {
+				return dnp.References.Any (x => {
 					if (x.StoredReference.Length < reference.Length)
 						return false;
 


### PR DESCRIPTION
Bug 56093 - [Forms] Templates don't appear if there's a project reference with Xamarin.Forms