### PR TITLE
Fixed 'Bug 55398 - Replace in Files within Current Document gives

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -75,7 +75,9 @@ namespace MonoDevelop.Ide.FindInFiles
 		public override IEnumerable<FileProvider> GetFiles (ProgressMonitor monitor, FilterOptions filterOptions)
 		{
 			monitor.Log.WriteLine (GettextCatalog.GetString ("Looking in '{0}'", IdeApp.Workbench.ActiveDocument.FileName));
-			yield return new FileProvider(IdeApp.Workbench.ActiveDocument.FileName);
+			var doc = IdeApp.Workbench.ActiveDocument;
+			if (doc.Editor != null)
+				yield return new OpenFileProvider (doc.Editor, doc.Project);
 		}
 
 		public override string GetDescription(FilterOptions filterOptions, string pattern, string replacePattern)
@@ -100,8 +102,11 @@ namespace MonoDevelop.Ide.FindInFiles
 
 		public override IEnumerable<FileProvider> GetFiles (ProgressMonitor monitor, FilterOptions filterOptions)
 		{
-			var selection = IdeApp.Workbench.ActiveDocument.Editor.SelectionRange;
-			yield return new FileProvider(IdeApp.Workbench.ActiveDocument.FileName, null, selection.Offset, selection.EndOffset);
+			var doc = IdeApp.Workbench.ActiveDocument;
+			if (doc.Editor != null) {
+				var selection = doc.Editor.SelectionRange;
+				yield return new OpenFileProvider (doc.Editor, doc.Project, selection.Offset, selection.EndOffset);
+			}
 		}
 
 		public override string GetDescription(FilterOptions filterOptions, string pattern, string replacePattern)
@@ -252,8 +257,8 @@ namespace MonoDevelop.Ide.FindInFiles
 		{
 			foreach (Document document in IdeApp.Workbench.Documents) {
 				monitor.Log.WriteLine (GettextCatalog.GetString ("Looking in '{0}'", document.FileName));
-				if (!string.IsNullOrEmpty (document.FileName) && filterOptions.NameMatches (document.FileName))
-					yield return new FileProvider (document.FileName);
+				if (document.Editor != null && filterOptions.NameMatches (document.FileName))
+					yield return new OpenFileProvider (document.Editor, document.Project);
 			}
 		}
 


### PR DESCRIPTION
Value cannot be null error'

Not exactly sure why document.FileName was null. I would've guessed it
was a new empty unsaved file use case - but the screenshots doesn't
look like so. Anyways in the search in open documents use case it's
not needed to look at the file name at all - so that should fix that
issue. But I hadn't any use case for that.