### PR TITLE
Fixed 'Bug 56890 - Rename a XAML type doesn't rename the file.'

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
@@ -36,6 +36,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis;
 using System.Threading.Tasks;
+using RefactoringEssentials;
 
 namespace MonoDevelop.Refactoring.Rename
 {
@@ -112,9 +113,15 @@ namespace MonoDevelop.Refactoring.Rename
 				title = GettextCatalog.GetString ("Rename Item");
 			}
 
-
 			Init (title, symbol.Name, async prop => { return await rename.PerformChangesAsync (symbol, prop); });
-
+			var loc = symbol.Locations.FirstOrDefault ();
+			if (loc.IsInSource) {
+				if (loc.SourceTree == null || 
+				    !System.IO.File.Exists (loc.SourceTree.FilePath) ||
+				    GeneratedCodeRecognition.IsFileNameForGeneratedCode (loc.SourceTree.FilePath)) {
+					renameFileFlag.Visible = false;
+				}
+			}
 		}
 
 		void Init (string title, string currenName, Func<RenameRefactoring.RenameProperties, Task<IList<Change>>> rename)

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
@@ -114,15 +114,25 @@ namespace MonoDevelop.Refactoring.Rename
 			}
 
 			Init (title, symbol.Name, async prop => { return await rename.PerformChangesAsync (symbol, prop); });
-			var loc = symbol.Locations.FirstOrDefault ();
-			if (loc.IsInSource) {
-				if (loc.SourceTree == null || 
-				    !System.IO.File.Exists (loc.SourceTree.FilePath) ||
-				    GeneratedCodeRecognition.IsFileNameForGeneratedCode (loc.SourceTree.FilePath)) {
-					renameFileFlag.Visible = false;
+
+			renameFileFlag.Visible = false;
+
+			foreach (var loc in symbol.Locations) {
+				if (loc.IsInSource) {
+					if (loc.SourceTree == null ||
+						!System.IO.File.Exists (loc.SourceTree.FilePath) ||
+						GeneratedCodeRecognition.IsFileNameForGeneratedCode (loc.SourceTree.FilePath)) {
+						continue;
+					} 
+					var oldName = System.IO.Path.GetFileNameWithoutExtension (loc.SourceTree.FilePath);
+					if (RenameRefactoring.IsCompatibleForRenaming(oldName, symbol.Name)) {
+						renameFileFlag.Visible = true;
+						break;
+					}
 				}
 			}
 		}
+
 
 		void Init (string title, string currenName, Func<RenameRefactoring.RenameProperties, Task<IList<Change>>> rename)
 		{

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
@@ -219,7 +219,7 @@ namespace MonoDevelop.Refactoring.Rename
 					var newName = properties.NewName;
 					if (string.IsNullOrEmpty (oldFileName) || string.IsNullOrEmpty (newName))
 						continue;
-					if (string.Equals (oldFileName, newName, StringComparison.OrdinalIgnoreCase) || oldFileName.EndsWith ("." + newName, StringComparison.OrdinalIgnoreCase))
+					if (IsCompatibleForRenaming (oldFileName, newName))
 						continue;
 					int idx = oldFileName.IndexOf (type.Name, StringComparison.Ordinal);
 					if (idx >= 0) {
@@ -237,6 +237,11 @@ namespace MonoDevelop.Refactoring.Rename
 				}
 			}
 			return changes;
+		}
+
+		internal static bool IsCompatibleForRenaming (string oldName, string newName)
+		{
+			return string.Equals (oldName, newName, StringComparison.OrdinalIgnoreCase) || oldName.EndsWith ("." + newName, StringComparison.OrdinalIgnoreCase);
 		}
 
 		static void FilterDuplicateLinkedDocs (Solution newSolution, List<DocumentId> documents)


### PR DESCRIPTION
Fix is to disable that option in non source code case. Renaming in generated code is complex in general case.