### PR TITLE
[C#] Fix NRE in AutoInsert bracket handler.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/CSharpAutoInsertBracketHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/CSharpAutoInsertBracketHandler.cs
@@ -71,8 +71,12 @@ namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 				return true;
 			}
 
+			var analysisDoc = ctx.AnalysisDocument;
+			if (analysisDoc == null)
+				return false;
+			
 			// check that the user is not typing in a string literal or comment
-			var tree = ctx.AnalysisDocument.GetSyntaxTreeAsync (cancellationToken).Result;
+			var tree = analysisDoc.GetSyntaxTreeAsync (cancellationToken).Result;
 
 			return !tree.IsInNonUserCode (position, cancellationToken);
 		}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.UnitTests/CSharpNUnitSourceCodeLocationFinder.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.UnitTests/CSharpNUnitSourceCodeLocationFinder.cs
@@ -42,21 +42,17 @@ namespace MonoDevelop.CSharp.UnitTests
 			if (cls == null)
 				return null;
 			if (cls.Name != testName) {
-				foreach (var met in cls.GetMembers ().OfType<IMethodSymbol> ()) {
-					if (met.Name == testName) {
-						var loc = met.Locations.FirstOrDefault (l => l.IsInSource);
-						return ConvertToSourceCodeLocation (loc);
-					}
+				foreach (var met in cls.GetMembers (testName).OfType<IMethodSymbol> ()) {
+					var loc = met.Locations.FirstOrDefault (l => l.IsInSource);
+					return ConvertToSourceCodeLocation (loc);
 				}
 
 				int idx = testName != null ? testName.IndexOf ('(') : -1;
 				if (idx > 0) {
 					testName = testName.Substring (0, idx);
-					foreach (var met in cls.GetMembers ().OfType<IMethodSymbol> ()) {
-						if (met.Name == testName){
-							var loc = met.Locations.FirstOrDefault (l => l.IsInSource);
-							return ConvertToSourceCodeLocation (loc);
-						}
+					foreach (var met in cls.GetMembers (testName).OfType<IMethodSymbol> ()) {
+						var loc = met.Locations.FirstOrDefault (l => l.IsInSource);
+						return ConvertToSourceCodeLocation (loc);
 					}
 				}
 			}


### PR DESCRIPTION
This happened while editing a file that was not set with BuildAction=Compile.