### PR TITLE
Fixed problem with Cmd+Shift+F not always working

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs
@@ -605,15 +605,20 @@ namespace MonoDevelop.Components
 
 		public static Gdk.EventKey CreateKeyEvent (uint keyval, Gdk.ModifierType state, Gdk.EventType eventType, Gdk.Window win)
 		{
-			return CreateKeyEvent (keyval, -1, state, eventType, win);
+			return CreateKeyEvent (keyval, -1, state, eventType, win, null);
 		}
 
 		public static Gdk.EventKey CreateKeyEventFromKeyCode (ushort keyCode, Gdk.ModifierType state, Gdk.EventType eventType, Gdk.Window win)
 		{
-			return CreateKeyEvent (0, keyCode, state, eventType, win);
+			return CreateKeyEvent (0, keyCode, state, eventType, win, null);
 		}
 
-		static Gdk.EventKey CreateKeyEvent (uint keyval, int keyCode, Gdk.ModifierType state, Gdk.EventType eventType, Gdk.Window win)
+		public static Gdk.EventKey CreateKeyEventFromKeyCode (ushort keyCode, Gdk.ModifierType state, Gdk.EventType eventType, Gdk.Window win, uint time)
+		{
+			return CreateKeyEvent (0, keyCode, state, eventType, win, time);
+		}
+
+		static Gdk.EventKey CreateKeyEvent (uint keyval, int keyCode, Gdk.ModifierType state, Gdk.EventType eventType, Gdk.Window win, uint? time)
 		{
 			int effectiveGroup, level;
 			Gdk.ModifierType cmods;
@@ -633,7 +638,7 @@ namespace MonoDevelop.Components
 				group = (byte)keyms [0].Group,
 				hardware_keycode = keyCode == -1 ? (ushort)keyms [0].Keycode : (ushort)keyCode,
 				length = 0,
-				time = Gtk.Global.CurrentEventTime
+				time = time ?? Gtk.Global.CurrentEventTime
 			};
 
 			IntPtr ptr = GLib.Marshaller.StructureToPtrAlloc (nativeEvent); 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
@@ -133,7 +133,7 @@ namespace MonoDevelop.Components.Mac
 				state |= Gdk.ModifierType.Mod1Mask;
 
 			var w = GetGtkWindow (ev.Window);
-			return GtkUtil.CreateKeyEventFromKeyCode (ev.KeyCode, state, Gdk.EventType.KeyPress, w != null ? w.GdkWindow : null);
+			return GtkUtil.CreateKeyEventFromKeyCode (ev.KeyCode, state, Gdk.EventType.KeyPress, w != null ? w.GdkWindow : null, (uint)(ev.Timestamp * 1000));
 		}
 
 


### PR DESCRIPTION
Problem was that Gtk.Global.CurrentEventTime is returning 0(at least on my computer) and throttling logic doesn’t like that, hence it ignores command