### PR TITLE
[A11y] Make the language selector accessible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -70,6 +70,7 @@ namespace MonoDevelop.Ide.Projects
 		GtkProjectConfigurationWidget projectConfigurationWidget;
 		GtkTemplateCellRenderer templateTextRenderer;
 		GtkTemplateCategoryCellRenderer categoryTextRenderer;
+		LanguageCellRenderer languageCellRenderer;
 
 		static GtkNewProjectDialogBackend ()
 		{
@@ -359,6 +360,11 @@ namespace MonoDevelop.Ide.Projects
 
 			column.SetCellDataFunc (templateTextRenderer, SetTemplateTextCellData);
 
+			languageCellRenderer = new LanguageCellRenderer ();
+			languageCellRenderer.CellBackgroundGdk = templateListBackgroundColor;
+
+			column.PackEnd (languageCellRenderer, false);
+			column.SetCellDataFunc (languageCellRenderer, SetLanguageCellData);
 			return column;
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Ide.Projects
 		public void RegisterController (INewProjectDialogController controller)
 		{
 			this.controller = controller;
-			templateTextRenderer.SelectedLanguage = controller.SelectedLanguage;
+			languageCellRenderer.SelectedLanguage = controller.SelectedLanguage;
 			topBannerLabel.Text = controller.BannerText;
 
 			LoadTemplates ();
@@ -114,6 +114,13 @@ namespace MonoDevelop.Ide.Projects
 			templateTextRenderer.TemplateCategory = model.GetValue (it, TemplateNameColumn) as string;
 		}
 
+		static void SetLanguageCellData (TreeViewColumn col, CellRenderer renderer, TreeModel model, TreeIter it)
+		{
+			var template = (SolutionTemplate)model.GetValue (it, TemplateColumn);
+			var languageRenderer = (LanguageCellRenderer)renderer;
+			languageRenderer.Template = template;
+		}
+
 		void HandlePopup (SolutionTemplate template, uint eventTime)
 		{
 			if (popupMenu == null) {
@@ -126,7 +133,7 @@ namespace MonoDevelop.Ide.Projects
 			popupMenu.ShowAll ();
 
 			MenuPositionFunc posFunc = (Menu m, out int x, out int y, out bool pushIn) => {
-				Gdk.Rectangle rect = templateTextRenderer.GetLanguageRect ();
+				Gdk.Rectangle rect = languageCellRenderer.GetLanguageRect ();
 				Gdk.Rectangle screenRect = GtkUtil.ToScreenCoordinates (templatesTreeView, templatesTreeView.GdkWindow, rect);
 				x = screenRect.X;
 				y = screenRect.Bottom;
@@ -143,7 +150,7 @@ namespace MonoDevelop.Ide.Projects
 				return;
 			}
 
-			if (templateTextRenderer.IsLanguageButtonPressed (args.Event)) {
+			if (languageCellRenderer.IsLanguageButtonPressed (args.Event)) {
 				HandlePopup (template, args.Event.Time);
 			}
 		}
@@ -170,7 +177,7 @@ namespace MonoDevelop.Ide.Projects
 			foreach (string language in template.AvailableLanguages.OrderBy (item => item)) {
 				var menuItem = new MenuItem (language);
 				menuItem.Activated += (o, e) => {
-					templateTextRenderer.SelectedLanguage = language;
+					languageCellRenderer.SelectedLanguage = language;
 					controller.SelectedLanguage = language;
 					templatesTreeView.QueueDraw ();
 					ShowSelectedTemplate ();
@@ -326,6 +333,7 @@ namespace MonoDevelop.Ide.Projects
 		void ShowTemplatesForCategory (TemplateCategory category)
 		{
 			templateTextRenderer.RenderRecentTemplate = false;
+			languageCellRenderer.RenderRecentTemplate = false;
 			foreach (TemplateCategory subCategory in category.Categories) {
 				templatesListStore.AppendValues (
 					MarkupTopLevelCategoryName (subCategory.Name),
@@ -346,6 +354,7 @@ namespace MonoDevelop.Ide.Projects
 		void ShowRecentTemplates ()
 		{
 			templateTextRenderer.RenderRecentTemplate = true;
+			languageCellRenderer.RenderRecentTemplate = true;
 			templatesListStore.AppendValues (
 				MarkupTopLevelCategoryName (Core.GettextCatalog.GetString ("Recently used templates")),
 				null,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
@@ -1,0 +1,233 @@
+﻿//
+// LanguageCellRenderer.cs
+//
+// Author:
+//       iain <>
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using Gdk;
+using Gtk;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Gui;
+using MonoDevelop.Ide.Templates;
+
+namespace MonoDevelop.Ide.Projects
+{
+	public class LanguageCellRenderer : CellRendererText
+	{
+		Rectangle languageRect;
+		int dropdownTriangleWidth = 8;
+		int dropdownTriangleHeight = 5;
+		const int dropdownTriangleRightHandPadding = 8;
+		const int languageRightHandPadding = 4;
+		const int languageLeftHandPadding = 9;
+
+		int minLanguageRectWidth;
+
+		public SolutionTemplate Template { get; set; }
+		string selectedLanguage;
+		public string SelectedLanguage { 
+			get {
+				return selectedLanguage;
+			}
+			set {
+				selectedLanguage = value;
+				Text = value;
+			}
+		}
+		public bool RenderRecentTemplate { get; set; }
+
+		int textWidth = 0;
+
+		public LanguageCellRenderer ()
+		{
+			minLanguageRectWidth = languageLeftHandPadding +
+				dropdownTriangleWidth +
+				dropdownTriangleRightHandPadding +
+				languageRightHandPadding + 10;
+		}
+
+		public Rectangle GetLanguageRect ()
+		{
+			return languageRect;
+		}
+
+		public override void GetSize (Widget widget, ref Rectangle cell_area, out int x_offset, out int y_offset, out int width, out int height)
+		{
+			base.GetSize (widget, ref cell_area, out x_offset, out y_offset, out width, out height);
+
+			int languageRectangleWidth = textWidth + languageLeftHandPadding;
+			if (TemplateHasMultipleLanguages ()) {
+				languageRectangleWidth += languageRightHandPadding + dropdownTriangleWidth + dropdownTriangleRightHandPadding;
+			} else {
+				languageRectangleWidth += languageLeftHandPadding;
+				languageRectangleWidth = Math.Max (languageRectangleWidth, minLanguageRectWidth);
+			}
+
+			width = languageRectangleWidth;
+		}
+
+		protected override void Render (Gdk.Drawable window, Widget widget, Gdk.Rectangle background_area, Gdk.Rectangle cell_area, Gdk.Rectangle expose_area, CellRendererState flags)
+		{
+			if (Template == null) {
+				return;
+			}
+
+			if (!Template.AvailableLanguages.Any () || !IsTemplateRowSelected (widget, flags)) {
+				return;
+			}
+
+			using (var ctx = CairoHelper.Create (window)) {
+				using (var layout = new Pango.Layout (widget.PangoContext)) {
+					int textHeight = 0;
+
+					SetMarkup (layout, GetSelectedLanguage ());
+					layout.GetPixelSize (out textWidth, out textHeight);
+
+					languageRect = GetLanguageButtonRectangle (window, widget, cell_area, textHeight, textWidth);
+
+					StateType state = StateType.Normal;
+					if (!RenderRecentTemplate) {
+						RoundBorder (ctx, languageRect.X, languageRect.Y, languageRect.Width, languageRect.Height);
+						SetSourceColor (ctx, Styles.NewProjectDialog.TemplateLanguageButtonBackground.ToCairoColor ());
+						ctx.Fill ();
+					} else {
+						state = GetState (widget, flags);
+					}
+
+					int tw = TemplateHasMultipleLanguages () ? textWidth + dropdownTriangleWidth + 2 : textWidth;
+					int languageTextX = languageRect.X + ((languageRect.Width - tw) / 2);
+					int languageTextY = languageRect.Y + (languageRect.Height - textHeight) / 2;
+
+					window.DrawLayout (widget.Style.TextGC (state), languageTextX, languageTextY, layout);
+
+					if (TemplateHasMultipleLanguages ()) {
+						int triangleX = languageTextX + textWidth + languageRightHandPadding;
+						int triangleY = languageRect.Y + (languageRect.Height - dropdownTriangleHeight) / 2;
+						DrawTriangle (ctx, triangleX, triangleY);
+					}
+				}
+			}
+		}
+
+		void DrawTriangle (Cairo.Context ctx, int x, int y)
+		{
+			int width = dropdownTriangleWidth;
+			int height = dropdownTriangleHeight;
+
+			SetSourceColor (ctx, Styles.NewProjectDialog.TemplateLanguageButtonTriangle.ToCairoColor ());
+			ctx.MoveTo (x, y);
+			ctx.LineTo (x + width, y);
+			ctx.LineTo (x + (width / 2), y + height);
+			ctx.LineTo (x, y);
+			ctx.Fill ();
+		}
+
+		Rectangle GetLanguageButtonRectangle (Drawable window, Widget widget, Rectangle cell_area, int textHeight, int textWidth)
+		{
+			int languageRectangleHeight = cell_area.Height - 8;
+			int languageRectangleWidth = textWidth + languageLeftHandPadding;
+			if (TemplateHasMultipleLanguages ()) {
+				languageRectangleWidth += languageRightHandPadding + dropdownTriangleWidth + dropdownTriangleRightHandPadding;
+			} else {
+				languageRectangleWidth += languageLeftHandPadding;
+				languageRectangleWidth = Math.Max (languageRectangleWidth, minLanguageRectWidth);
+			}
+
+			var dy = (cell_area.Height - languageRectangleHeight) / 2 - 1;
+			var y = cell_area.Y + dy;
+			//var x = widget.Allocation.Width - languageRectangleWidth - (int)Xpad;
+			var x = cell_area.X;
+
+			return new Rectangle (x, y, languageRectangleWidth, languageRectangleHeight);
+		}
+
+		internal bool IsLanguageButtonPressed (EventButton button)
+		{
+			return !RenderRecentTemplate && languageRect.Contains ((int)button.X, (int)button.Y);
+		}
+
+		void SetMarkup (Pango.Layout layout, string text)
+		{
+			string markup = "<span size='smaller'>" + text + "</span>";
+			layout.SetMarkup (markup);
+		}
+
+		static bool IsTemplateRowSelected (Widget widget, CellRendererState flags)
+		{
+			StateType stateType = GetState (widget, flags);
+			return (stateType == StateType.Selected) || (stateType == StateType.Active);
+		}
+
+		bool TemplateHasMultipleLanguages ()
+		{
+			return !RenderRecentTemplate && Template.AvailableLanguages.Count > 1;
+		}
+
+		static StateType GetState (Widget widget, CellRendererState flags)
+		{
+			StateType stateType = StateType.Normal;
+			if ((flags & CellRendererState.Prelit) != 0)
+				stateType = StateType.Prelight;
+			if ((flags & CellRendererState.Focused) != 0)
+				stateType = StateType.Normal;
+			if ((flags & CellRendererState.Insensitive) != 0)
+				stateType = StateType.Insensitive;
+			if ((flags & CellRendererState.Selected) != 0)
+				stateType = widget.HasFocus ? StateType.Selected : StateType.Active;
+			return stateType;
+		}
+
+		string GetSelectedLanguage ()
+		{
+			if (!Template.AvailableLanguages.Any ())
+				return String.Empty;
+			else if (RenderRecentTemplate)
+				return Template.Language;
+			else if (Template.AvailableLanguages.Contains (SelectedLanguage))
+				return SelectedLanguage;
+
+			return Template.AvailableLanguages.First ();
+		}
+
+		// Taken from MonoDevelop.Components.SearchEntry.
+		static void RoundBorder (Cairo.Context ctx, double x, double y, double w, double h)
+		{
+			double r = h / 2;
+			ctx.Arc (x + r, y + r, r, Math.PI / 2, Math.PI + Math.PI / 2);
+			ctx.LineTo (x + w - r, y);
+
+			ctx.Arc (x + w - r, y + r, r, Math.PI + Math.PI / 2, Math.PI + Math.PI + Math.PI / 2);
+
+			ctx.LineTo (x + r, y + h);
+
+			ctx.ClosePath ();
+		}
+
+		// Taken from Mono.TextEditor.HelperMethods.
+		public static void SetSourceColor (Cairo.Context cr, Cairo.Color color)
+		{
+			cr.SetSourceRGBA (color.R, color.G, color.B, color.A);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9419,6 +9419,7 @@
     <Compile Include="MonoDevelop.Ide.Codons\TemplateExtensionNode.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\HasReferenceFileTemplateCondition.cs" />
     <Compile Include="MonoDevelop.Ide.Editor.Highlighting\RoslynClassificationHighlighting.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\LanguageCellRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
@@ -9459,7 +9460,7 @@
     <None Include="MonoDevelop.Ide.Editor.Highlighting\VSCodeImport\objective-c\language-configuration.json" />
     <None Include="MonoDevelop.Ide.Editor.Highlighting\VSCodeImport\objective-c\package.json" />
   </ItemGroup>
-  <Import Project="..\..\core\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Def.projitems" Label="Shared" Condition="Exists('..\..\core\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Def.projitems')" />
+  <Import Project="..\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Def.projitems" Label="Shared" Condition="Exists('..\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Def.projitems')" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Components.MainToolbar\Theme\" />
     <Folder Include="MonoDevelop.Components\Xwt\" />


### PR DESCRIPTION
By splitting the language selector into its own cell we can make it accessible.

Fixes BXC #53729