### PR TITLE
[Ide] Fix generated code for resx files in .NET Core projects

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
@@ -69,6 +69,11 @@ namespace MonoDevelop.Ide.CustomTools
 					break;
 				}
 			});
+
+			// Allow CustomToolService to be used when running unit tests that do not initialize the workspace.
+			if (IdeApp.Workspace == null)
+				return;
+
 			IdeApp.Workspace.FileChangedInProject += delegate (object sender, ProjectFileEventArgs args) {
 				foreach (ProjectFileEventInfo e in args)
 					Update (e.ProjectFile, e.Project, false);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/ResXFileCodeGenerator.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/ResXFileCodeGenerator.cs
@@ -130,6 +130,13 @@ namespace MonoDevelop.Ide.CustomTools
 
 		static bool TargetsPcl2Framework (DotNetProject dnp)
 		{
+			// .NET Core 1.x and .NET Standard 1.x projects also need to be treated as though they target
+			// the PCL 2 framework so GetTypeInfo is used in the generated code. .NET Core 2.0 and
+			// .NET Standard 2.0 do not need to use GetTypeInfo.
+			string framework = dnp.TargetFramework.Id.Identifier;
+			if (framework == ".NETCoreApp" || framework == ".NETStandard")
+				return dnp.TargetFramework.Id.Version.StartsWith ("1.", StringComparison.Ordinal);
+
 			if (dnp.TargetFramework.Id.Identifier != TargetFrameworkMoniker.ID_PORTABLE)
 				return false;
 			var asms = dnp.AssemblyContext.GetAssemblies (dnp.TargetFramework);

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -32,6 +32,7 @@ using NUnit.Framework;
 using UnitTests;
 using MonoDevelop.CSharp.Project;
 using MonoDevelop.Core;
+using MonoDevelop.Ide.CustomTools;
 using MonoDevelop.Ide.Projects;
 using System.Linq;
 using MonoDevelop.Projects.MSBuild;
@@ -2634,6 +2635,54 @@ namespace MonoDevelop.Projects
 
 			Assert.That (capabilities, Contains.Item ("TestCapabilityNetStandard"));
 			Assert.That (capabilities, Has.None.EqualTo ("TestCapabilityNetCoreApp"));
+
+			sol.Dispose ();
+		}
+
+		/// <summary>
+		/// Tests that files generated from .resx files for .NET Core and .NET Standard
+		/// projects use "typeof(Resources).GetTypeInfo().Assembly" instead of
+		/// "typeof(Resources).Assembly". Without the GetTypeInfo the project will not
+		/// compile with NET Core below version 2.0
+		/// </summary>
+		[Test]
+		[TestCase ("DotNetCoreProject")]
+		[TestCase ("NetStandardProject")]
+		[Platform (Exclude = "Win")]
+		public async Task BuildDotNetCoreProjectAfterGeneratingResources (string projectName)
+		{
+			FilePath solFile = Util.GetSampleProject ("DotNetCoreResources", "DotNetCoreResources.sln");
+
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (DotNetProject)sol.Items.FirstOrDefault (item => item.Name == projectName);
+			p.RequiresMicrosoftBuild = true;
+
+			var resourceFile = p.Files.FirstOrDefault (f => f.FilePath.FileName == "Resources.resx");
+
+			var customToolResult = new SingleFileCustomToolResult ();
+			await ResXFileCodeGenerator.GenerateFile (resourceFile, customToolResult, true);
+			Assert.IsTrue (customToolResult.Success);
+
+			// Running a restore for a .NET Core project can take a long time if
+			// no packages are cached. So instead we just check the generated resource file.
+			//var res = await p.RunTarget (Util.GetMonitor (), "Restore", ConfigurationSelector.Default);
+			//Assert.AreEqual (0, res.BuildResult.Errors.Count);
+
+			//res = await p.RunTarget (Util.GetMonitor (), "Build", ConfigurationSelector.Default);
+			//Assert.AreEqual (0, res.BuildResult.Errors.Count);
+
+			var generatedResourceFile = resourceFile.FilePath.ChangeExtension (".Designer.cs");
+
+			bool foundLine = false;
+			foreach (string line in File.ReadAllLines (generatedResourceFile)) {
+				if (line.Contains ("typeof")) {
+					string lineWithoutSpaces = line.Replace (" ", "");
+					foundLine = lineWithoutSpaces.EndsWith ("typeof(Resources).GetTypeInfo().Assembly);", StringComparison.Ordinal);
+					break;
+				}
+			}
+
+			Assert.IsTrue (foundLine);
 
 			sol.Dispose ();
 		}

--- a/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/DotNetCoreProject.csproj
+++ b/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/DotNetCoreProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/Program.cs
+++ b/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/Program.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello World!");
+    }
+}

--- a/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/Resources.Designer.cs
+++ b/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/Resources.Designer.cs
@@ -1,0 +1,1 @@
+﻿To be generated

--- a/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/Resources.resx
+++ b/main/tests/test-projects/DotNetCoreResources/DotNetCoreProject/Resources.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="test">
+		<value>netcoreapp-resource-value</value>
+	</data>
+</root>

--- a/main/tests/test-projects/DotNetCoreResources/DotNetCoreResources.sln
+++ b/main/tests/test-projects/DotNetCoreResources/DotNetCoreResources.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCoreProject", "DotNetCoreProject\DotNetCoreProject.csproj", "{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandardProject", "NetStandardProject\NetStandardProject.csproj", "{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2EDB2FE-F9C2-4E1E-BCFA-1A310EA33E45}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreResources/NetStandardProject/Class1.cs
+++ b/main/tests/test-projects/DotNetCoreResources/NetStandardProject/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace DotNetCoreNetStandardProject
+{
+    public class Class1
+    {
+    }
+}

--- a/main/tests/test-projects/DotNetCoreResources/NetStandardProject/NetStandardProject.csproj
+++ b/main/tests/test-projects/DotNetCoreResources/NetStandardProject/NetStandardProject.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreResources/NetStandardProject/Resources.Designer.cs
+++ b/main/tests/test-projects/DotNetCoreResources/NetStandardProject/Resources.Designer.cs
@@ -1,0 +1,1 @@
+﻿To be generated

--- a/main/tests/test-projects/DotNetCoreResources/NetStandardProject/Resources.resx
+++ b/main/tests/test-projects/DotNetCoreResources/NetStandardProject/Resources.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="test">
+		<value>netstandard-resource-value</value>
+	</data>
+</root>


### PR DESCRIPTION
Fixed bug [#56519](https://bugzilla.xamarin.com/show_bug.cgi?id=56519) - ResX files produced for .NET Core generate code that does not compile

Projects that target .NET Core App 1.x or .NET Standard 1.x cannot
compile code that uses "typeof(Resources).Assembly" which was
generated by the ResXFileCodeGenerator. Now if these target frameworks
are used by the project then the code generated uses
"typeof(Resources).GetTypeInfo().Assembly" which is supported.
.NET Core 2.0 and .NET Standard 2.0 do not require the use of
GetTypeInfo.

As implemented, the ResXFileCodeGenerator knows about the .NETCoreApp and .NETStandard target frameworks. So not sure if this is the best place for the logic. It currently has a special case for the .NETPortable target framework.
