### PR TITLE
[Core] Fix bad merge conflict resolution in 11206a0039385143de65594f9…

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -430,7 +430,7 @@ namespace MonoDevelop.Core.Assemblies
 				}
 				foreach (var r in assembly.MainModule.AssemblyReferences) {
 					// Don't compare the version number since it may change depending on the version of .net standard
-					if (r.FullName.Equals ("System.Runtime")) {
+					if (r.Name.Equals ("System.Runtime")) {
 						referenceDict [fileName] = true; ;
 						return true;
 					}

--- a/main/tests/UnitTests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -1,0 +1,67 @@
+﻿//
+// SystemAssemblyServiceTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2017 2017
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Core.Assemblies
+{
+	[TestFixture]
+	public class SystemAssemblyServiceTests
+	{
+		[TestCase(true, "System.Collections.Immutable.dll")]
+		[TestCase(false, "MonoDevelop.Core.dll")]
+		public void ImmutableCollectionsContainReferenceToSystemRuntime (bool withSystemRuntime, string relativeDllPath)
+		{
+			var result = SystemAssemblyService.ContainsReferenceToSystemRuntime(relativeDllPath);
+			Assert.That(result, Is.EqualTo(withSystemRuntime));
+		}
+
+		[TestCase(true, "System.Collections.Immutable.dll")]
+		[TestCase(false, "MonoDevelop.Core.dll")]
+		public async Task ImmutableCollectionsContainReferenceToSystemRuntimeAsync (bool withSystemRuntime, string relativeDllPath)
+		{
+			var result = await SystemAssemblyService.ContainsReferenceToSystemRuntimeAsync(relativeDllPath);
+			Assert.That(result, Is.EqualTo(withSystemRuntime));
+		}
+
+		[Test]
+		public void CheckReferencesAreOk()
+		{
+			var names = new[] {
+				"mscorlib",
+				"System.Core",
+				"System"
+			};
+
+			var references = SystemAssemblyService.GetAssemblyReferences("Mono.Cecil.dll");
+			Assert.That(references, Is.EquivalentTo(names));
+		}
+	}
+}

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -305,6 +305,7 @@
     <Compile Include="MonoDevelop.Ide\TypeSystemServiceTests.cs" />
     <Compile Include="MonoDevelop.Projects\MSBuildSearchPathTests.cs" />
     <Compile Include="MonoDevelop.Projects\SdkVersionTests.cs" />
+    <Compile Include="MonoDevelop.Core.Assemblies\SystemAssemblyServiceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
@@ -330,6 +331,7 @@
     <Folder Include="MonoDevelop.Ide.Editor\Tests\" />
     <Folder Include="MonoDevelop.Ide.Editor\Commands\" />
     <Folder Include="MonoDevelop.Components.PropertyGrid\" />
+    <Folder Include="MonoDevelop.Core.Assemblies\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
…01dafbfc2426f30

It contained a mix of 6f06eaed471f4a41e40adb24328615de8afc7c97 and the previous version.

@slluis would adding a test that tests this on a project which references System.Collections.Immutable from .NET 4.5 after its built be ok?