### PR TITLE
[Core] Fix new resx file not added as Update item in Sdk projects

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3345,6 +3345,9 @@ namespace MonoDevelop.Projects
 								einfo.Action = ExpandedItemAction.AddUpdateItem;
 								items.Modified = true;
 								return;
+							} else if (buildItem == null) {
+								buildItem = new MSBuildItem (item.ItemName) { Update = item.Include };
+								msproject.AddItem (buildItem);
 							}
 						}
 					} else if (item.IsFromWildcardItem && item.ItemName != item.WildcardItem.Name) {

--- a/main/tests/test-projects/msbuild-glob-tests/glob-test-saved3.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-test-saved3.csproj
@@ -33,7 +33,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="**\\*.cs" Exclude="*9.cs" />
-    <Compile Include="c1bis.cs">
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="c1bis.cs">
       <foo>bar</foo>
     </Compile>
   </ItemGroup>


### PR DESCRIPTION
Fixed bug #56957 - Adding new resource file causes duplicate file
build error
https://bugzilla.xamarin.com/show_bug.cgi?id=56957

Adding a new Resources file to a .NET Core project would add the
.resx file and the .Designer.cs file as an Include instead of an
Update item:

```
  <ItemGroup>
    <EmbeddedResource Include="Resources.resx">
      <Generator>ResXFileCodeGenerator</Generator>
      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
    </EmbeddedResource>
  </ItemGroup>
  <ItemGroup>
    <Compile Include="Resources.Designer.cs">
      <DependentUpon>Resources.resx</DependentUpon>
    </Compile>
  </ItemGroup>
```
This then caused the build to fail since these files are part of
existing wildcard globs and should instead be Update items. This
problem affected new files that have extra metadata when they are
added to the project and then the project is saved.