### PR TITLE
Fixed version parsing of newer versions of Mono runtime in debugger unit tests

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.MonoDevelop.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.MonoDevelop.cs
@@ -70,9 +70,11 @@ namespace Mono.Debugging.Tests
 							if (string.IsNullOrWhiteSpace (o.Version) || o.Version == "Unknown")
 								return new Version (0, 0, 0, 0);
 							int indexOfBeforeDetails = o.Version.IndexOf (" (", StringComparison.Ordinal);
-							if (indexOfBeforeDetails == -1)
-								return new Version (0, 0, 0, 0);
-							string hopefullyVersion = o.Version.Remove (indexOfBeforeDetails);
+							string hopefullyVersion;
+							if (indexOfBeforeDetails != -1)
+								hopefullyVersion = o.Version.Remove (indexOfBeforeDetails);
+							else
+								hopefullyVersion = o.Version;
 							Version version;
 							if (Version.TryParse (hopefullyVersion, out version)) {
 								return version;


### PR DESCRIPTION
In past version had `4.8 (something)` now it's just `5.0`