### PR TITLE
[DotNetCore] Fix null ref in About dialog

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.DotNetCore
 
 			MSBuildSDKsPath = sdkPaths.MSBuildSDKsPath;
 			IsInstalled = !string.IsNullOrEmpty (MSBuildSDKsPath);
-			Versions = sdkPaths.SdkVersions;
+			Versions = sdkPaths.SdkVersions ?? new DotNetCoreVersion [0];
 
 			if (IsInstalled)
 				GetPreviewNetStandard20LibraryVersion ();


### PR DESCRIPTION
Fixed bug #56999 - Show details dialog is not displaying detailed
build information
https://bugzilla.xamarin.com/show_bug.cgi?id=56999

.NET Core sdk not being installed would result in the
DotNetCoreSdk.Versions being null which caused an exception in the
About dialog when trying to list the sdk versions installed.