### PR TITLE
[NuGet] Import NuGet.Frameworks.dll

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -5,6 +5,7 @@
 		<Import assembly="Microsoft.Web.XmlTransform.dll" />
 		<Import assembly="NuGet.Packaging.Core.Types.dll" />
 		<Import assembly="NuGet.Packaging.dll" />
+		<Import assembly="NuGet.Frameworks.dll" />
 	</Runtime>
 
 	<Extension path = "/MonoDevelop/Ide/Commands">


### PR DESCRIPTION
This avoids having duplicate NuGet.Frameworks.dll if this assembly
is required by another addin that depends on the NuGet addin.