### PR TITLE
[Mac] Fix ExecutionTarget icon theme

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -581,7 +581,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				Xwt.Drawing.Image baseIcon = ImageService.GetIcon (ActiveRuntime.Image, Gtk.IconSize.Menu);
 
 				string [] styles, disabledStyles;
-				if (NSUserDefaults.StandardUserDefaults.StringForKey ("AppleInterfaceStyle") == "Dark") {
+				if (IdeApp.Preferences.UserInterfaceTheme == Theme.Dark) {
 					styles = new [] { "dark" };
 					disabledStyles = new [] { "dark", "disabled" };
 				} else {


### PR DESCRIPTION
The main toolbar SelectorView icons must match the IDE theme and not the OS interface style.