### PR TITLE
[NuGet] Add file template condition for packages

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -165,4 +165,10 @@
 	<Extension path="/MonoDevelop/Core/SystemInformation"> 
 		<Class class="MonoDevelop.PackageManagement.NuGetSystemInformation" /> 
 	</Extension>
+
+	<Extension path="/MonoDevelop/Ide/FileTemplateConditionTypes">
+		<FileTemplateConditionType
+			name="HasPackageOrReference"
+			class="MonoDevelop.PackageManagement.HasNuGetPackageOrReferenceFileTemplateCondition" />
+	</Extension>
 </ExtensionModel>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -417,6 +417,7 @@
     <Compile Include="NuGet.CommandLine\SettingsCredentialProvider.cs" />
     <Compile Include="MonoDevelop.PackageManagement\UninstallNuGetPackagesAction.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageReferenceNuGetProject.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\HasNuGetPackageOrReferenceFileTemplateCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/HasNuGetPackageOrReferenceFileTemplateCondition.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/HasNuGetPackageOrReferenceFileTemplateCondition.cs
@@ -1,0 +1,75 @@
+﻿//
+// HasNuGetPackageOrReference.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Xml;
+using MonoDevelop.Ide.Templates;
+using MonoDevelop.Projects;
+using MonoDevelop.Projects.SharedAssetsProjects;
+
+namespace MonoDevelop.PackageManagement
+{
+	/// <summary>
+	/// Allows a file template to be enabled if a project has a particular assembly reference
+	/// or has a NuGet package reference. Using a NuGet package id is required for projects
+	/// that do not use a packages.config file, but instead use a project.json file or
+	/// PackageReference MSBuild items, since these projects do not have explicit references
+	/// to assemblies in the NuGet packages being used.
+	/// </summary>
+	class HasNuGetPackageOrReferenceFileTemplateCondition : HasReferenceFileTemplateCondition
+	{
+		string packageId;
+
+		public override void Load (XmlElement element)
+		{
+			base.Load (element);
+
+			packageId = element.GetAttribute ("PackageId");
+			if (string.IsNullOrWhiteSpace (packageId))
+				throw new InvalidOperationException ("Invalid value for PackageId condition in template.");
+		}
+
+		public override bool ShouldEnableFor (Project proj, string projectPath)
+		{
+			if (base.ShouldEnableFor (proj, projectPath))
+				return true;
+
+			// No need to explicitly check a shared project since base.ShouldEnableFor will call
+			// this method again for each project reference.
+			if (proj is DotNetProject dotNetProject) {
+				return HasPackageInstalled (dotNetProject);
+			}
+			return false;
+		}
+
+		bool HasPackageInstalled (DotNetProject project)
+		{
+			return PackageManagementServices.ProjectOperations.GetInstalledPackages (project)
+				.Any (packageReference => StringComparer.OrdinalIgnoreCase.Equals (packageId, packageReference.Id));
+		}
+	}
+}


### PR DESCRIPTION
A file template can now specify that it should be enable if the project
has a specific reference or has a particular NuGet package installed.
Whilst a reference will work for project's that use a packages.config
file if the project uses a project.json file or uses PackageReferences
then just checking the references will not find any matches. By
allowing a file template to specify a package id then projects that
do not have an explicit reference to a particular assembly, due to not
using a packages.config file, can now have file templates enabled or
disabled.

<HasPackageOrReference PackageId="Xamarin.Forms" Assembly="Xamarin.Forms" />