### PR TITLE
[Ide] Fix Remove item not added

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -1060,8 +1060,10 @@ namespace MonoDevelop.Projects.MSBuild
 				g.RemoveItem (item);
 				if (removeEmptyParentGroup && !g.Items.Any ()) {
 					Remove (g);
-					if (bestGroups != null)
-						bestGroups.Remove (item.Name);
+					if (bestGroups != null) {
+						string groupId = GetBestGroupId (item);
+						bestGroups.Remove (groupId);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixed bug #55560 - Setting Build Action to None for C# file is ignored
https://bugzilla.xamarin.com/show_bug.cgi?id=55560

Creating a .NET Core console project, then changing the build action
on a C# file to None, back to Compile and then back to None again
would result in the Remove item not being added to the project file.
So the project file would end up having:

```
  <ItemGroup>
    <None Include="Program.cs" />
  </ItemGroup>
```
When it should have had:

```
  <ItemGroup>
    <Compile Remove="Program.cs" />
  </ItemGroup>
  <ItemGroup>
    <None Include="Program.cs" />
  </ItemGroup>
```

The problem was that when the Compile Remove item was removed when
switching the build action back to Compile the associated best item
group was not removed since the wrong group id was used. Then when
the new Compile Remove item was added back again on changing the
build action back to None it was added to a item group that did not
belong to the MSBuildProject instead of creating a new item group.