### PR TITLE
[MicrosoftTemplateEngine] Get default parameters from ITemplateInfo

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
@@ -68,10 +68,12 @@ namespace MonoDevelop.Ide.Templates
 			var parameters = new List<string> ();
 			var cacheParameters = templateInfo.CacheParameters.Where (m => !string.IsNullOrEmpty (m.Value.DefaultValue));
 
+			if (!cacheParameters.Any ())
+				return defaultParameters;
+
 			if (!string.IsNullOrEmpty (defaultParameters)) {
 				priorityParameters = TemplateParameter.CreateParameters (defaultParameters).ToList ();
-				if (cacheParameters.Any ())
-					defaultParameters += ",";
+				defaultParameters += ",";
 			}
 
 			foreach (var p in cacheParameters) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
@@ -28,6 +28,7 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Settings;
 using System.Linq;
 using MonoDevelop.Ide.Codons;
+using System.Collections.Generic;
 
 namespace MonoDevelop.Ide.Templates
 {
@@ -53,12 +54,32 @@ namespace MonoDevelop.Ide.Templates
 			//ProjectFileExtension = template.FileExtension;
 			Wizard = template.Wizard;
 			SupportedParameters = template.SupportedParameters;
-			DefaultParameters = template.DefaultParameters;
+			DefaultParameters = MergeDefaultParameters (template.DefaultParameters);
 			ImageId = template.ImageId;
 			//ImageFile = template.ImageFile;
 			//Visibility = GetVisibility (template.Visibility);
 
 			//HasProjects = (template.SolutionDescriptor.EntryDescriptors.Length > 0);
+		}
+
+		string MergeDefaultParameters (string defaultParameters)
+		{
+			List<TemplateParameter> priorityParameters = null;
+			var parameters = new List<string> ();
+			var cacheParameters = templateInfo.CacheParameters.Where (m => !string.IsNullOrEmpty (m.Value.DefaultValue));
+
+			if (!string.IsNullOrEmpty (defaultParameters)) {
+				priorityParameters = TemplateParameter.CreateParameters (defaultParameters).ToList ();
+				if (cacheParameters.Any ())
+					defaultParameters += ",";
+			}
+
+			foreach (var p in cacheParameters) {
+				if (priorityParameters != null && !priorityParameters.Exists (t => t.Name == p.Key))
+					parameters.Add ($"{p.Key}={p.Value.DefaultValue}");
+			}
+
+			return defaultParameters += string.Join (",", parameters);
 		}
 	}
 }


### PR DESCRIPTION
With the new template engine, parameters can have default values:

```
"symbols": {
    "MinimumOSVersion": {
      "type": "parameter",
      "description": "Overrides the Info.plist's MinimumOSVersion",
      "replaces": "$MinimumOSVersion",
      "datatype": "string",
      "defaultValue": "8.0"
    }
}
```

Therefore we need to combine those "DefaultParameters" values with the ones set by the ExtensionNode.