### PR TITLE
[DotNetCore] Remove .NET Core 2.0 workarounds

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -51,42 +51,6 @@ namespace MonoDevelop.DotNetCore
 		public DotNetCoreProjectExtension ()
 		{
 			DotNetCoreProjectReloadMonitor.Initialize ();
-			PackageManagement.MSBuildProjectExtensions.ModifyImportedPackageReference = ModifyImportedPackageReference;
-		}
-
-		/// <summary>
-		/// HACK: Ensure NuGet packages can be restored for .NET Core 2.0 projects if
-		/// a preview version of .NET Core 2.0 is installed by mapping the Microsoft.NETCore.App
-		/// 2.0 package reference to the installed preview version. When MSBuild supports this
-		/// with the sdk resolver this code can be removed.
-		///
-		/// Also ensure NuGet packages are restored for .NET Standard 2.0 projects correctly.
-		/// By default the NETStandard.Library version 1.6.1 is used which is taken from the
-		/// SDK files included with Mono's MSBuild. Now the preview version of the
-		/// NETStandard.Library is used instead. The version used is taken from the
-		/// BundledNETStandardPackageVersion property from the Microsoft.NETCoreSdk.BundledVersions.props
-		/// file. This version is different to the preview version of the Microsoft.NETCore.App
-		/// package reference.
-		/// </summary>
-		static void ModifyImportedPackageReference (ProjectPackageReference packageReference, DotNetProject project)
-		{
-			if (packageReference.Include == "Microsoft.NETCore.App") {
-				string version = packageReference.Metadata.GetValue ("Version");
-				if (version == "2.0") {
-					string previewVersion = DotNetCoreRuntime.PreviewNetCore20AppVersion;
-					if (previewVersion != null)
-						packageReference.Metadata.SetValue ("Version", previewVersion);
-				}
-			} else if (project.TargetFramework.IsNetStandard20 ()) {
-				if (packageReference.Include == "NETStandard.Library") {
-					string version = packageReference.Metadata.GetValue ("Version");
-					if (version != null && version.StartsWith ("1.", StringComparison.Ordinal)) {
-						string previewVersion = DotNetCoreSdk.PreviewNetStandard20LibraryVersion;
-						if (previewVersion != null)
-							packageReference.Metadata.SetValue ("Version", previewVersion);
-					}
-				}
-			}
 		}
 
 		protected override bool SupportsObject (WorkspaceObject item)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
 using System.Linq;
 using MonoDevelop.Core;
 
@@ -42,8 +41,6 @@ namespace MonoDevelop.DotNetCore
 				.OrderByDescending (version => version)
 				.ToArray ();
 
-			GetPreviewNetCore20AppVersion ();
-
 			if (!IsInstalled)
 				LoggingService.LogInfo (".NET Core runtime not found.");
 		}
@@ -57,21 +54,6 @@ namespace MonoDevelop.DotNetCore
 		}
 
 		internal static DotNetCoreVersion[] Versions { get; private set; }
-
-		internal static string PreviewNetCore20AppVersion { get; private set; }
-
-		static void GetPreviewNetCore20AppVersion ()
-		{
-			var latestInstalledVersion = Versions.FirstOrDefault ();
-			if (latestInstalledVersion == null)
-				return;
-
-			if (latestInstalledVersion.Major == 2 &&
-			    latestInstalledVersion.Minor == 0 &&
-			    latestInstalledVersion.IsPrerelease) {
-				PreviewNetCore20AppVersion = latestInstalledVersion.OriginalString;
-			}
-		}
 
 		internal static bool IsNetCore1xInstalled ()
 		{

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -24,10 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Linq;
-using System.IO;
-using System.Xml;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.DotNetCore
@@ -42,9 +38,6 @@ namespace MonoDevelop.DotNetCore
 			MSBuildSDKsPath = sdkPaths.MSBuildSDKsPath;
 			IsInstalled = !string.IsNullOrEmpty (MSBuildSDKsPath);
 			Versions = sdkPaths.SdkVersions ?? new DotNetCoreVersion [0];
-
-			if (IsInstalled)
-				GetPreviewNetStandard20LibraryVersion ();
 
 			if (!IsInstalled)
 				LoggingService.LogInfo (".NET Core SDK not found.");
@@ -66,46 +59,6 @@ namespace MonoDevelop.DotNetCore
 			sdkPaths.FindSdkPaths (sdk);
 
 			return sdkPaths;
-		}
-
-		internal static string PreviewNetStandard20LibraryVersion { get; private set; }
-
-		static void GetPreviewNetStandard20LibraryVersion ()
-		{
-			var latestInstalledVersion = Versions.FirstOrDefault ();
-			if (latestInstalledVersion == null)
-				return;
-
-			if (latestInstalledVersion.Major == 2 &&
-			    latestInstalledVersion.Minor == 0 &&
-			    latestInstalledVersion.IsPrerelease) {
-				PreviewNetStandard20LibraryVersion = ReadBundledNETStandardPackageVersion ();
-			}
-		}
-
-		static string ReadBundledNETStandardPackageVersion ()
-		{
-			string sdkRoot = Path.GetDirectoryName (MSBuildSDKsPath);
-			string fileName = Path.Combine (sdkRoot, "Microsoft.NETCoreSdk.BundledVersions.props");
-
-			try {
-				if (!File.Exists (fileName))
-					return null;
-
-				using (var reader = XmlReader.Create (fileName)) {
-					while (reader.Read ()) {
-						switch (reader.NodeType) {
-						case XmlNodeType.Element:
-							if (reader.LocalName == "BundledNETStandardPackageVersion")
-								return reader.ReadElementContentAsString ();
-							break;
-						}
-					}
-				}
-			} catch (Exception ex) {
-				LoggingService.LogError (string.Format ("Unable to read '{0}'", fileName), ex);
-			}
-			return null;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
@@ -273,51 +273,5 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("dotnet5.6", runtimeGraph.Supports["dotnet5.6"].Name);
 			Assert.AreEqual ("portable-net45+win8", runtimeGraph.Supports["portable-net45+win8"].Name);
 		}
-
-		/// <summary>
-		/// Tests that workaround for netcoreapp2.0 and netstandard2.0 projects where
-		/// PackageTargetFallback for net461 is added. This should be added by the SDK
-		/// imports but currently that requires a sdk resolver to be used.
-		/// </summary>
-		[TestCase ("netcoreapp2.0", ".NETCoreApp,Version=v2.0")]
-		[TestCase ("netstandard2.0", ".NETStandard,Version=v2.0")]
-		public void CreatePackageSpec_NetCore20PackageTargetFallback_Net461ImportsAddedToTargetFramework (
-			string shortTargetFramework,
-			string fullTargetFramework)
-		{
-			CreateProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
-			AddTargetFramework (shortTargetFramework);
-			CreatePackageSpec ();
-
-			var targetFramework = spec.TargetFrameworks.Single ();
-			var fallbackFramework = targetFramework.FrameworkName as FallbackFramework;
-			Assert.AreEqual (1, targetFramework.Imports.Count);
-			Assert.AreEqual ("net461", targetFramework.Imports[0].GetShortFolderName ());
-			Assert.IsNotNull (fallbackFramework);
-			Assert.AreEqual (fullTargetFramework, targetFramework.FrameworkName.ToString ());
-			Assert.AreEqual (1, fallbackFramework.Fallback.Count);
-			Assert.AreEqual ("net461", fallbackFramework.Fallback[0].GetShortFolderName ());
-		}
-
-		/// <summary>
-		/// Tests that workaround for netcoreapp2.0 and netstandard2.0 projects where
-		/// PackageTargetFallback for net461 is not added for 1.x target frameworks.
-		/// </summary>
-		[TestCase ("netcoreapp1.1", ".NETCoreApp,Version=v1.1")]
-		[TestCase ("netstandard1.1", ".NETStandard,Version=v1.1")]
-		public void CreatePackageSpec_NetCore1xPackageTargetFallback_NoImportsAddedToTargetFramework (
-			string shortTargetFramework,
-			string fullTargetFramework)
-		{
-			CreateProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
-			AddTargetFramework (shortTargetFramework);
-			CreatePackageSpec ();
-
-			var targetFramework = spec.TargetFrameworks.Single ();
-			var fallbackFramework = targetFramework.FrameworkName as FallbackFramework;
-			Assert.AreEqual (0, targetFramework.Imports.Count);
-			Assert.IsNull (fallbackFramework);
-			Assert.AreEqual (fullTargetFramework, targetFramework.FrameworkName.ToString ());
-		}
 	}
 }


### PR DESCRIPTION
These workarounds are no longer needed now that the installed .NET Core sdk is now resolved.