### PR TITLE
Avoid assembly load failure on Windows.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -496,9 +496,9 @@ namespace MonoDevelop.Core
 		/// This is necessary on Windows because without it, even though the assemblies are already loaded
 		/// the CLR will still throw FileNotFoundException (unable to load assembly).
 		/// </summary>
-		private static System.Reflection.Assembly CurrentDomain_AssemblyResolve (object sender, ResolveEventArgs args)
+		static System.Reflection.Assembly CurrentDomain_AssemblyResolve (object sender, ResolveEventArgs args)
 		{
-			if (args.Name.StartsWith ("Microsoft.Build", StringComparison.OrdinalIgnoreCase)) {
+			if (args.Name != null && args.Name.StartsWith ("Microsoft.Build", StringComparison.OrdinalIgnoreCase)) {
 				foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies ()) {
 					if (string.Equals (assembly.FullName, args.Name, StringComparison.OrdinalIgnoreCase)) {
 						return assembly;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -486,6 +486,27 @@ namespace MonoDevelop.Core
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.dll"));
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Framework.dll"));
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Utilities.Core.dll"));
+
+			if (Type.GetType ("Mono.Runtime") == null) {
+				AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+			}
+		}
+
+		/// <summary>
+		/// This is necessary on Windows because without it, even though the assemblies are already loaded
+		/// the CLR will still throw FileNotFoundException (unable to load assembly).
+		/// </summary>
+		private static System.Reflection.Assembly CurrentDomain_AssemblyResolve (object sender, ResolveEventArgs args)
+		{
+			if (args.Name.StartsWith ("Microsoft.Build", StringComparison.OrdinalIgnoreCase)) {
+				foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies ()) {
+					if (string.Equals (assembly.FullName, args.Name, StringComparison.OrdinalIgnoreCase)) {
+						return assembly;
+					}
+				}
+			}
+
+			return null;
 		}
 	}
 	


### PR DESCRIPTION
For some reason even though we call Assembly.Load from the codebase, it still doesn't seem to get promoted from LoadFrom to the Load context.

A solution is to use AssemblyResolve event and just resolve to the assembly that's already loaded.