### PR TITLE
Add a preventative workaround for an incoming MSBuild regression

### DIFF
--- a/main/MonoDevelop.props
+++ b/main/MonoDevelop.props
@@ -5,6 +5,9 @@
 		<CustomBeforeMicrosoftCommonTargets>$(MonoDevelopRootDir)\msbuild\MonoDevelop.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
 		<CustomAfterMicrosoftCommonTargets>$(MonoDevelopRootDir)\msbuild\MonoDevelop.AfterCommon.targets</CustomAfterMicrosoftCommonTargets>
 		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+		<!-- temporary workaround for https://github.com/Microsoft/msbuild/issues/2165 -->
+		<CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
 	</PropertyGroup>
 	<!-- import common targets if they were not imported already by an MSBuild Sdk -->
 	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(MicrosoftCommonPropsHasBeenImported)' != 'true'" />


### PR DESCRIPTION
MSBuild 15.3 will be briefly broken, see details here:
https://github.com/Microsoft/msbuild/issues/2165

It is not yet public and will be fixed soon, but we're already starting to hit the problem as we upgrade. To temporarily work around this until everybody upgrades the MSBuild that fixes the issue this is a simple workaround with no other side effects.