### PR TITLE
Fixed 'Bug 57155 - Visual Studio for Mac crashing when adding snippet

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplate.cs
@@ -469,6 +469,7 @@ namespace MonoDevelop.Ide.CodeTemplates
 				Editor = editor,
 				//ParsedDocument = context.ParsedDocument != null ? context.ParsedDocument.ParsedFile : null,
 				InsertPosition = data.CaretLocation,
+				InsertOffset = data.CaretOffset,
 				LineIndent = data.GetLineIndent (data.CaretLocation.Line),
 				TemplateCode = Code
 			};

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs
@@ -61,6 +61,8 @@ namespace MonoDevelop.Ide.CodeTemplates
 			get;
 			set;
 		}
+
+		public int InsertOffset { get; set; }
 		
 		public string SelectedText {
 			get;
@@ -251,7 +253,7 @@ namespace MonoDevelop.Ide.CodeTemplates
 			var metadataName = string.IsNullOrEmpty (ns) ? name : ns + "." + name;
 			var type = compilation.Compilation.GetTypeByMetadataName (metadataName);
 			if (type != null) {
-				var minimalName = type.ToMinimalDisplayString (compilation, CurrentContext.Editor.CaretOffset);
+				var minimalName = type.ToMinimalDisplayString (compilation, CurrentContext.InsertOffset);
 				return string.IsNullOrEmpty (member) ? minimalName :  minimalName + "." + member;
 			}
 			return fullTypeName.Replace ("#", ".");


### PR DESCRIPTION
from toolbox'

The offset wasn't correct in the old semantic model. So using the
insertion offset fixes that crash.