### PR TITLE
Make main UI keyboard accessible

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
@@ -43,6 +43,7 @@ using System.Threading;
 using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Editor.Highlighting;
+using MonoDevelop.Ide.Gui;
 
 namespace MonoDevelop.SourceEditor.QuickTasks
 {
@@ -109,6 +110,12 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			private set;
 		}
 
+		// These caches are updated when the bar is redrawn
+		internal int taskIterator = 0;
+		internal int usageIterator = 0;
+		internal List<QuickTask> taskCache;
+		internal List<Usage> usageCache;
+
 		public IEnumerable<QuickTask> AllTasks {
 			get {
 				return parentStrip.AllTasks;
@@ -156,6 +163,8 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			fadeOutStage.Iteration += (sender, e) => QueueDraw ();
 
 			fadeInStage.UpdateFrequency = fadeOutStage.UpdateFrequency = 10;
+
+			CanFocus = true;
 		}
 
 		void HandleHighlightSearchPatternChanged (object sender, EventArgs e)
@@ -249,6 +258,35 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 		internal Mono.TextEditor.CodeSegmentPreviewWindow previewWindow;
 
+		bool ShowPreview (double y)
+		{
+			int line = YToLine (y);
+
+			line = Math.Max (1, line - 2);
+			int lastLine = Math.Min (TextEditor.LineCount, line + 5);
+			var start = TextEditor.GetLine (line);
+			var end = TextEditor.GetLine (lastLine);
+			if (start == null || end == null) {
+				return false;
+			}
+			var showSegment = new TextSegment (start.Offset, end.Offset + end.Length - start.Offset);
+
+			if (previewWindow != null) {
+				previewWindow.SetSegment (showSegment, false);
+				PositionPreviewWindow ((int)y);
+			} else {
+				var popup = new PreviewPopup (this, showSegment, TextEditor.Allocation.Width * 4 / 7, (int)y);
+				previewPopupTimeout = GLib.Timeout.Add (450, new GLib.TimeoutHandler (popup.Run));
+			}
+			return true;
+		}
+
+		void HidePreview ()
+		{
+			RemovePreviewPopupTimeout ();
+			DestroyPreviewWindow ();
+		}
+
 		protected override bool OnMotionNotifyEvent (EventMotion evnt)
 		{
 			RemovePreviewPopupTimeout ();
@@ -263,27 +301,11 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			const ModifierType buttonMask = ModifierType.Button1Mask | ModifierType.Button2Mask |
 				ModifierType.Button3Mask | ModifierType.Button4Mask | ModifierType.Button5Mask;
 			if ((evnt.State & ModifierType.ShiftMask) == ModifierType.ShiftMask) {
-				int line = YToLine (evnt.Y);
-
-				line = Math.Max (1, line - 2);
-				int lastLine = Math.Min (TextEditor.LineCount, line + 5);
-				var start = TextEditor.GetLine (line);
-				var end = TextEditor.GetLine (lastLine);
-				if (start == null || end == null) {
+				if (!ShowPreview (evnt.Y)) {
 					return base.OnMotionNotifyEvent (evnt);
 				}
-				var showSegment = new TextSegment (start.Offset, end.Offset + end.Length - start.Offset);
-
-				if (previewWindow != null) {
-					previewWindow.SetSegment (showSegment, false);
-					PositionPreviewWindow ((int)evnt.Y);
-				} else {
-					var popup = new PreviewPopup (this, showSegment, TextEditor.Allocation.Width * 4 / 7, (int)evnt.Y);
-					previewPopupTimeout = GLib.Timeout.Add (450, new GLib.TimeoutHandler (popup.Run));
-				}
 			} else {
-				RemovePreviewPopupTimeout ();
-				DestroyPreviewWindow ();
+				HidePreview ();
 			}
 			return base.OnMotionNotifyEvent (evnt);
 		}
@@ -722,13 +744,17 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			if (allUsages.MoveNext ()) {
 				var usage = allUsages.Current;
 				int y = (int)GetYPosition (TextEditor.OffsetToLineNumber (usage.Offset));
-				if (lineCache [0].Contains (y))
+				bool isFocusedUsage = (HasFocus && currentFocus == FocusWidget.Usages && usageIterator == focusedUsageIndex);
+
+				if (lineCache [0].Contains (y) && !isFocusedUsage)
 					return;
-				lineCache[0].Add (y);
+				lineCache [0].Add (y);
 				var usageColor = (Cairo.Color)SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.Foreground);
 				usageColor.A = 0.4;
 				HslColor color;
-				if ((usage.UsageType & MonoDevelop.Ide.FindInFiles.ReferenceUsageType.Declaration) != 0) {
+				if (isFocusedUsage) {
+					color = Styles.FocusColor.ToCairoColor ();
+				} else if ((usage.UsageType & MonoDevelop.Ide.FindInFiles.ReferenceUsageType.Declaration) != 0) {
 					color = SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.ChangingUsagesRectangle);
 					if (color.Alpha == 0.0)
 						color = SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.UsagesRectangle);
@@ -749,19 +775,33 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 				cr.LineTo (0, y - 3);
 				cr.ClosePath ();
 				cr.Fill ();
+
+				usageCache.Add (usage);
+				usageIterator++;
 			} else if (allTasks.MoveNext ()) {
 				var task = allTasks.Current;
 				int y = (int)GetYPosition (TextEditor.OffsetToLineNumber (task.Location));
-				if (!lineCache[1].Contains (y) && task.Severity != DiagnosticSeverity.Hidden) {
-					lineCache[1].Add (y);
-					cr.SetSourceColor (GetBarColor (task.Severity));
+				bool isFocusedTask = (HasFocus && currentFocus == FocusWidget.Tasks && taskIterator == focusedTaskIndex);
+				if ((!lineCache [1].Contains (y) && task.Severity != DiagnosticSeverity.Hidden) || isFocusedTask) {
+					lineCache [1].Add (y);
+					Cairo.Color color;
+					if (HasFocus && currentFocus == FocusWidget.Tasks && taskIterator == focusedTaskIndex) {
+						color = Styles.FocusColor.ToCairoColor ();
+					} else {
+						color = GetBarColor (task.Severity);
+					}
+					cr.SetSourceColor (color);
 					cr.Rectangle (1, y - 1, Allocation.Width - 1, 2);
 					cr.Fill ();
 				}
+
 				if (task.Severity == DiagnosticSeverity.Error)
 					severity = DiagnosticSeverity.Error;
 				else if (task.Severity == DiagnosticSeverity.Warning && severity != DiagnosticSeverity.Error)
 					severity = DiagnosticSeverity.Warning;
+
+				taskCache.Add (task);
+				taskIterator++;
 			} else {
 				nextStep = true;
 			}
@@ -884,6 +924,8 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 				return true;
 
 			using (Cairo.Context cr = Gdk.CairoHelper.Create (e.Window)) {
+
+				cr.Save ();
 				var allocation = Allocation;
 				var displayScale = Core.Platform.IsMac ? GtkWorkarounds.GetScaleFactor (this) : 1.0;
 				cr.Scale (1 / displayScale, 1 / displayScale);
@@ -892,9 +934,9 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 					cr.Paint ();
 				} else {
 					CachedDraw (cr,
-					            ref backgroundSurface,
-					            allocation,
-					            draw: (c, o) => DrawBackground (c, allocation), forceScale: displayScale);
+								ref backgroundSurface,
+								allocation,
+								draw: (c, o) => DrawBackground (c, allocation), forceScale: displayScale);
 				}
 				if (TextEditor == null)
 					return true;
@@ -903,9 +945,30 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 				if (QuickTaskStrip.MergeScrollBarAndQuickTasks)
 					DrawBar (cr);
+
+				cr.Restore ();
+
+				if (HasFocus) {
+					switch (currentFocus) {
+					case FocusWidget.Indicator:
+						cr.LineWidth = 1.0;
+
+						cr.SetSourceColor (Styles.FocusColor.ToCairoColor ());
+						cr.Rectangle (1, 1, Allocation.Width - 2, Allocation.Width - 2);
+						cr.SetDash (new double [] { 1, 1 }, 0.5);
+						cr.Stroke ();
+						break;
+
+					case FocusWidget.Tasks:
+						break;
+
+					case FocusWidget.Usages:
+						break;
+					}
+				}
 			}
 
-			return true;
+			return false;
 		}
 
 		CancellationTokenSource src;
@@ -975,6 +1038,11 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 					var displayScale = Core.Platform.IsMac ? GtkWorkarounds.GetScaleFactor (mode) : 1.0;
 					mode.DrawBackground (cr, allocation);
 					drawingStep++;
+
+					mode.taskIterator = 0;
+					mode.usageIterator = 0;
+					mode.taskCache = new List<QuickTask> ();
+					mode.usageCache = new List<Usage> ();
 					return true;
 				case 1:
 					for (int i = 0; i < 10 && !nextStep; i++) {
@@ -1113,6 +1181,221 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			DestroyIndicatorSurface ();
 
 			DrawIndicatorSurface (0);
+		}
+
+		protected override bool OnFocusInEvent (EventFocus evnt)
+		{
+			QueueDraw ();
+			return base.OnFocusInEvent (evnt);
+		}
+
+		protected override bool OnFocusOutEvent (EventFocus evnt)
+		{
+			QueueDraw ();
+			currentFocus = FocusWidget.None;
+			return base.OnFocusOutEvent (evnt);
+		}
+
+		enum FocusWidget
+		{
+			None,
+			Indicator,
+			Tasks,
+			Usages,
+		};
+		FocusWidget currentFocus = FocusWidget.None;
+		int focusedUsageIndex = -1;
+		int focusedTaskIndex = -1;
+
+		bool FocusNextTaskOrUsage (DirectionType direction)
+		{
+			if (direction == DirectionType.Down) {
+				if (currentFocus == FocusWidget.Tasks) {
+					focusedTaskIndex++;
+					if (focusedTaskIndex >= taskCache.Count) {
+						focusedTaskIndex = taskCache.Count - 1;
+					}
+				} else if (currentFocus == FocusWidget.Usages) {
+					focusedUsageIndex++;
+					if (focusedUsageIndex >= usageCache.Count) {
+						focusedUsageIndex = usageCache.Count - 1;
+					}
+				}
+			} else if (direction == DirectionType.Up) {
+				if (currentFocus == FocusWidget.Tasks) {
+					focusedTaskIndex--;
+					if (focusedTaskIndex < 0) {
+						focusedTaskIndex = 0;
+					}
+				} else if (currentFocus == FocusWidget.Usages) {
+					focusedUsageIndex--;
+					if (focusedUsageIndex < 0) {
+						focusedUsageIndex = 0;
+					}
+				}
+			}
+
+			return true;
+		}
+
+		bool FocusNextArea (DirectionType direction)
+		{
+			var hasUsages = usageCache.Count > 0;
+			var hasTasks = taskCache.Count > 0;
+
+			switch (currentFocus) {
+			case FocusWidget.None:
+				if (direction == DirectionType.TabForward) {
+					currentFocus = FocusWidget.Indicator;
+				} else if (direction == DirectionType.TabBackward) {
+					if (hasUsages) {
+						focusedUsageIndex = usageCache.Count - 1;
+						currentFocus = FocusWidget.Usages;
+					} else if (hasTasks) {
+						focusedTaskIndex = taskCache.Count - 1;
+						currentFocus = FocusWidget.Tasks;
+					} else {
+						currentFocus = FocusWidget.Indicator;
+					}
+				}
+				break;
+
+			case FocusWidget.Indicator:
+				if (direction == DirectionType.TabForward) {
+					if (hasTasks) {
+						focusedTaskIndex = 0;
+						currentFocus = FocusWidget.Tasks;
+					} else if (hasUsages) {
+						focusedUsageIndex = 0;
+						currentFocus = FocusWidget.Usages;
+					} else {
+						currentFocus = FocusWidget.None;
+					}
+				} else if (direction == DirectionType.TabBackward) {
+					currentFocus = FocusWidget.None;
+				}
+				break;
+
+			case FocusWidget.Tasks:
+				if (direction == DirectionType.TabForward) {
+					if (hasUsages) {
+						focusedUsageIndex = 0;
+						currentFocus = FocusWidget.Usages;
+					} else {
+						currentFocus = FocusWidget.None;
+					}
+				} else if (direction == DirectionType.TabBackward) {
+					currentFocus = FocusWidget.Indicator;
+				}
+				break;
+
+			case FocusWidget.Usages:
+				if (direction == DirectionType.TabForward) {
+					currentFocus = FocusWidget.None;
+				} else if (direction == DirectionType.TabBackward) {
+					if (hasTasks) {
+						focusedTaskIndex = 0;
+						currentFocus = FocusWidget.Tasks;
+					} else {
+						currentFocus = FocusWidget.Indicator;
+					}
+				}
+
+				break;
+			}
+
+			return (currentFocus != FocusWidget.None);
+		}
+
+		protected override bool OnFocused (DirectionType direction)
+		{
+			bool ret = true;
+
+			switch (direction) {
+			case DirectionType.TabForward:
+			case DirectionType.TabBackward:
+				ret = FocusNextArea (direction);
+				break;
+			case DirectionType.Left:
+			case DirectionType.Right:
+				ret = false;
+				break;
+
+			case DirectionType.Up:
+			case DirectionType.Down:
+				if (currentFocus == FocusWidget.None) {
+					ret = false;
+					break;
+				} else if (currentFocus == FocusWidget.Indicator) {
+					// Up from the indicator moves the focus out of the widget
+					if (direction == DirectionType.Up) {
+						ret = false;
+						break;
+					} else {
+						// Focus either the tasks or usages if they are available
+						ret = FocusNextArea (DirectionType.TabForward);
+						break;
+					}
+				}
+
+				ret = FocusNextTaskOrUsage (direction);
+				break;
+			}
+
+			if (ret) {
+				GrabFocus ();
+
+				double y = -1;
+				if (currentFocus == FocusWidget.Tasks) {
+					var t = taskCache [focusedTaskIndex];
+					parentStrip.GotoTask (t, false);
+					y = GetYPosition (TextEditor.OffsetToLineNumber (t.Location));
+				} else if (currentFocus == FocusWidget.Usages) {
+					var u = usageCache [focusedUsageIndex];
+					parentStrip.GotoUsage (u, false);
+					y = (int)GetYPosition (TextEditor.OffsetToLineNumber (u.Offset));
+				}
+
+				if (y > -1) {
+					ShowPreview (y);
+				}
+			} else {
+				currentFocus = FocusWidget.None;
+				HidePreview ();
+			}
+
+			if (currentFocus == FocusWidget.None || currentFocus == FocusWidget.Indicator) {
+				HidePreview ();
+				QueueDraw ();
+			} else {
+				DrawIndicatorSurface (10);
+			}
+			return ret;
+		}
+
+		protected override void OnActivate ()
+		{
+			HidePreview ();
+
+			if (currentFocus == FocusWidget.Tasks) {
+				var t = taskCache [focusedTaskIndex];
+				parentStrip.GotoTask (t, true);
+			} else if (currentFocus == FocusWidget.Usages) {
+				var u = usageCache [focusedUsageIndex];
+				parentStrip.GotoUsage (u, false);
+			} else if (currentFocus == FocusWidget.Indicator) {
+				parentStrip.GotoTask (parentStrip.SearchNextTask (GetHoverMode ()));
+			}
+			base.OnActivate ();
+		}
+
+		protected override bool OnKeyPressEvent (EventKey evnt)
+		{
+			if (evnt.Key == Gdk.Key.Escape) {
+				HidePreview ();
+				return true;
+			}
+			return base.OnKeyPressEvent (evnt);
 		}
 
 #region Accessibility

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskStrip.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskStrip.cs
@@ -231,11 +231,16 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 		public event EventHandler TaskProviderUpdated;
 
-		void PerformShowMenu (object sender, EventArgs e)
+		internal void ShowMenu ()
 		{
 			int x, y;
 			TranslateCoordinates (Toplevel, 0, 0, out x, out y);
 			IdeApp.CommandService.ShowContextMenu (this, x, y, IdeApp.CommandService.CreateCommandEntrySet ("/MonoDevelop/SourceEditor2/ContextMenu/Scrollbar"), this);
+		}
+
+		void PerformShowMenu (object sender, EventArgs e)
+		{
+			ShowMenu (); 
 		}
 
 		protected override bool OnButtonPressEvent (EventButton evnt)
@@ -342,28 +347,31 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			return firstTask;
 		}
 
-		internal void GotoTask (QuickTask quickTask)
+		internal void GotoTask (QuickTask quickTask, bool grabFocus = true)
 		{
 			if (quickTask == null)
 				return;
 
-			GotoLocation (quickTask.Location);
+			GotoLocation (quickTask.Location, grabFocus);
 		}
 
-		void GotoLocation (int location)
+		void GotoLocation (int location, bool grabFocus = true)
 		{
 			TextEditor.Caret.Offset = location;
 			TextEditor.CenterToCaret ();
 			TextEditor.StartCaretPulseAnimation ();
-			TextEditor.GrabFocus ();
+
+			if (grabFocus) {
+				TextEditor.GrabFocus ();
+			}
 		}
 
-		internal void GotoUsage (Usage usage)
+		internal void GotoUsage (Usage usage, bool grabFocus = true)
 		{
 			if (usage == null)
 				return;
 
-			GotoLocation (usage.Offset);
+			GotoLocation (usage.Offset, grabFocus);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
@@ -415,8 +415,6 @@ namespace MonoDevelop.SourceEditor
 			
 			textEditorData = textEditor.GetTextEditorData ();
 			textEditorData.EditModeChanged += TextEditorData_EditModeChanged;
-
-			ResetFocusChain ();
 			
 			UpdateLineCol ();
 			//			this.IsClassBrowserVisible = this.widget.TextEditor.Options.EnableQuickFinder;
@@ -473,20 +471,7 @@ namespace MonoDevelop.SourceEditor
 		{
 			this.UpdateLineCol ();
 		}
-		
-		void ResetFocusChain ()
-		{
-			List<Widget> focusChain = new List<Widget> ();
-			focusChain.Add (this.textEditor.TextArea);
-			if (this.searchAndReplaceWidget != null) {
-				focusChain.Add (this.searchAndReplaceWidget);
-			}
-			if (this.gotoLineNumberWidget != null) {
-				focusChain.Add (this.gotoLineNumberWidget);
-			}
-			vbox.FocusChain = focusChain.ToArray ();
-		}
-		
+
 		public void Dispose ()
 		{
 			if (IdeApp.CommandService != null)
@@ -1131,8 +1116,6 @@ namespace MonoDevelop.SourceEditor
 			if (this.splittedTextEditor != null) 
 				this.splittedTextEditor.HighlightSearchPattern = false;
 			
-			if (!isDisposed)
-				ResetFocusChain ();
 			return result;
 		}
 		
@@ -1211,8 +1194,6 @@ namespace MonoDevelop.SourceEditor
 					this.splittedTextEditor.HighlightSearchPattern = true;
 					this.splittedTextEditor.TextViewMargin.RefreshSearchMarker ();
 				}
-				ResetFocusChain ();
-
 			} else {
 				if (TextEditor.IsSomethingSelected) {
 					searchAndReplaceWidget.SetSearchPattern ();
@@ -1245,8 +1226,6 @@ namespace MonoDevelop.SourceEditor
 				gotoLineNumberWidget.Destroyed += (sender, e) => RemoveSearchWidget ();
 				gotoLineNumberWidgetFrame.ShowAll ();
 				TextEditor.AddAnimatedWidget (gotoLineNumberWidgetFrame, ANIMATION_DURATION, Mono.TextEditor.Theatrics.Easing.ExponentialInOut, Mono.TextEditor.Theatrics.Blocking.Downstage, this.TextEditor.Allocation.Width - 400, -gotoLineNumberWidget.Allocation.Height);
-				
-				ResetFocusChain ();
 			}
 			
 			gotoLineNumberWidget.Focus ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBarItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBarItem.cs
@@ -142,6 +142,7 @@ namespace MonoDevelop.Components.Docking
 			this.size = size;
 			this.bar = bar;
 			this.it = it;
+			CanFocus = true;
 			VisibleWindow = false;
 			UpdateTab ();
 			lastFrameSize = bar.Frame.Allocation.Size;
@@ -527,7 +528,28 @@ namespace MonoDevelop.Components.Docking
 				}
 				context.Fill ();
 			}
+
+			if (HasFocus) {
+				Gtk.Style.PaintFocus (Style, GdkWindow, State, Allocation, this, "button", Allocation.X + 2, Allocation.Y + 2, Allocation.Width - 4, Allocation.Height - 4);
+			}
 			return base.OnExposeEvent (evnt);
+		}
+
+		protected override bool OnFocusInEvent (Gdk.EventFocus evnt)
+		{
+			QueueDraw ();
+			return base.OnFocusInEvent (evnt);
+		}
+
+		protected override bool OnFocusOutEvent (Gdk.EventFocus evnt)
+		{
+			QueueDraw ();
+			return base.OnFocusOutEvent (evnt);
+		}
+
+		protected override void OnActivate ()
+		{
+			AutoShow ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -1147,6 +1147,17 @@ namespace MonoDevelop.Components.Docking
 		{
 			return new Cairo.Color (color.Red / (double) ushort.MaxValue, color.Green / (double) ushort.MaxValue, color.Blue / (double) ushort.MaxValue);
 		}
+
+		protected override bool OnFocused (DirectionType direction)
+		{
+			// If there's an overlay widget, that's all we can focus
+			if (overlayWidget != null && overlayWidget.Visible) {
+				overlayWidget.ChildFocus (direction);
+				return true;
+			}
+
+			return base.OnFocused (direction);
+		}
 	}
 
 	public class DockStyle

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
@@ -515,7 +515,8 @@ namespace MonoDevelop.Components.Docking
 			return false;
 		}
 
-		FocusWidget GetNextWidgetToFocus (FocusWidget widget, DirectionType direction) {
+		FocusWidget GetNextWidgetToFocus (FocusWidget widget, DirectionType direction)
+		{
 			FocusWidget nextSite;
 
 			switch (widget) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItemTitleTab.cs
@@ -25,7 +25,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using Gtk; 
+using Gtk;
 
 using System;
 using MonoDevelop.Ide.Gui;
@@ -38,8 +38,8 @@ using MonoDevelop.Ide.Fonts;
 
 namespace MonoDevelop.Components.Docking
 {
-	
-	class DockItemTitleTab: Gtk.EventBox
+
+	class DockItemTitleTab : Gtk.EventBox
 	{
 		static Xwt.Drawing.Image dockTabActiveBackImage = Xwt.Drawing.Image.FromResource ("padbar-active.9.png");
 		static Xwt.Drawing.Image dockTabBackImage = Xwt.Drawing.Image.FromResource ("padbar-inactive.9.png");
@@ -60,6 +60,7 @@ namespace MonoDevelop.Components.Docking
 		DockItem item;
 		bool allowPlaceholderDocking;
 		bool mouseOver;
+		Widget currentFocus = null; // Currently focused child
 
 		IDisposable subscribedLeaveEvent;
 
@@ -71,6 +72,8 @@ namespace MonoDevelop.Components.Docking
 
 		static readonly Xwt.WidgetSpacing TabPadding;
 		static readonly Xwt.WidgetSpacing TabActivePadding;
+
+		internal event EventHandler<EventArgs> TabPressed;
 
 		static DockItemTitleTab ()
 		{
@@ -95,7 +98,7 @@ namespace MonoDevelop.Components.Docking
 				tabActiveBackImage9 = dockTabActiveBackImage as Xwt.Drawing.NinePatchImage;
 			TabActivePadding = tabActiveBackImage9.Padding;
 		}
-		
+
 		public DockItemTitleTab (DockItem item, DockFrame frame)
 		{
 			var actionHandler = new ActionDelegate (this);
@@ -105,6 +108,7 @@ namespace MonoDevelop.Components.Docking
 			Accessible.SetRole (AtkCocoa.Roles.AXGroup, "pad header");
 			Accessible.SetSubRole ("XAPadHeader");
 
+			CanFocus = true;
 			this.item = item;
 			this.frame = frame;
 			this.VisibleWindow = false;
@@ -195,7 +199,7 @@ namespace MonoDevelop.Components.Docking
 				tabIcon.Accessible.SetShouldIgnore (true);
 				tabIcon.Show ();
 				box.PackStart (tabIcon, false, false, 3);
-				
+
 				labelWidget = new ExtendedLabel (label);
 				// Ignore the label because the title tab already contains its name
 				labelWidget.Accessible.SetShouldIgnore (true);
@@ -210,7 +214,7 @@ namespace MonoDevelop.Components.Docking
 				btnDock = new ImageButton ();
 				btnDock.Image = pixAutoHide;
 				btnDock.TooltipText = GettextCatalog.GetString ("Auto Hide");
-				btnDock.CanFocus = false;
+				btnDock.CanFocus = true;
 				//			btnDock.WidthRequest = btnDock.HeightRequest = 17;
 				btnDock.Clicked += OnClickDock;
 				btnDock.ButtonPressEvent += (o, args) => args.RetVal = true;
@@ -220,7 +224,7 @@ namespace MonoDevelop.Components.Docking
 				btnClose = new ImageButton ();
 				btnClose.Image = pixClose;
 				btnClose.TooltipText = GettextCatalog.GetString ("Close");
-				btnClose.CanFocus = false;
+				btnClose.CanFocus = true;
 				//			btnClose.WidthRequest = btnClose.HeightRequest = 17;
 				btnClose.WidthRequest = btnDock.SizeRequest ().Width;
 				btnClose.Clicked += delegate {
@@ -250,8 +254,7 @@ namespace MonoDevelop.Components.Docking
 				btnClose.Name = string.Format ("btnClose_{0}", labelNoSpaces ?? string.Empty);
 				realLabel = GettextCatalog.GetString ("Close {0}", label);
 				realHelp = GettextCatalog.GetString ("Close the {0} pad", label);
-			}
-			else {
+			} else {
 				labelWidget.Parent.Hide ();
 				realLabel = GettextCatalog.GetString ("Close pad");
 				realHelp = GettextCatalog.GetString ("Close the pad");
@@ -266,7 +269,7 @@ namespace MonoDevelop.Components.Docking
 				Accessible.SetTitle (label);
 				Accessible.SetLabel (label);
 			}
-			
+
 			// Get the required size before setting the ellipsize property, since ellipsized labels
 			// have a width request of 0
 			box.ShowAll ();
@@ -320,7 +323,7 @@ namespace MonoDevelop.Components.Docking
 		public int MinWidth {
 			get { return minWidth; }
 		}
-		
+
 		public bool Active {
 			get {
 				return active;
@@ -341,7 +344,7 @@ namespace MonoDevelop.Components.Docking
 				return page;
 			}
 		}
-		
+
 		public void UpdateBehavior ()
 		{
 			if (btnClose == null)
@@ -349,7 +352,7 @@ namespace MonoDevelop.Components.Docking
 
 			btnClose.Visible = (item.Behavior & DockItemBehavior.CantClose) == 0;
 			btnDock.Visible = (item.Behavior & DockItemBehavior.CantAutoHide) == 0;
-			
+
 			if (active || mouseOver) {
 				if (btnClose.Image == null)
 					btnClose.Image = pixClose;
@@ -371,6 +374,13 @@ namespace MonoDevelop.Components.Docking
 		bool tabPressed, tabActivated;
 		double pressX, pressY;
 
+		protected override void OnActivate ()
+		{
+			TabPressed?.Invoke (this, EventArgs.Empty);
+
+			base.OnActivate ();
+		}
+
 		protected override bool OnButtonPressEvent (Gdk.EventButton evnt)
 		{
 			if (evnt.TriggersContextMenu ()) {
@@ -381,6 +391,7 @@ namespace MonoDevelop.Components.Docking
 					tabPressed = true;
 					pressX = evnt.X;
 					pressY = evnt.Y;
+					TabPressed?.Invoke (this, EventArgs.Empty);
 				} else if (evnt.Type == Gdk.EventType.TwoButtonPress) {
 					tabActivated = true;
 				}
@@ -398,8 +409,7 @@ namespace MonoDevelop.Components.Docking
 					else
 						item.Status = DockItemStatus.AutoHide;
 				}
-			}
-			else if (!evnt.TriggersContextMenu () && evnt.Button == 1) {
+			} else if (!evnt.TriggersContextMenu () && evnt.Button == 1) {
 				frame.DockInPlaceholder (item);
 				frame.HidePlaceholder ();
 				if (GdkWindow != null)
@@ -411,15 +421,25 @@ namespace MonoDevelop.Components.Docking
 			return base.OnButtonReleaseEvent (evnt);
 		}
 
+		protected override bool OnFocusInEvent (Gdk.EventFocus evnt)
+		{
+			mouseOver = true;
+			UpdateBehavior ();
+			return base.OnFocusInEvent (evnt);
+		}
+
+		protected override bool OnFocusOutEvent (Gdk.EventFocus evnt)
+		{
+			if (currentFocus == null) {
+				mouseOver = false;
+				UpdateBehavior ();
+			}
+			return base.OnFocusOutEvent (evnt);
+		}
+
 		void HandlePress (object sender, EventArgs args)
 		{
-			// FIXME: How to support double click?
-			frame.DockInPlaceholder (item);
-			frame.HidePlaceholder ();
-			if (GdkWindow != null)
-				GdkWindow.Cursor = null;
-			frame.Toplevel.KeyPressEvent -= HeaderKeyPress;
-			frame.Toplevel.KeyReleaseEvent -= HeaderKeyRelease;
+			TabPressed?.Invoke (this, EventArgs.Empty);
 		}
 
 		void HandleShowMenu (object sender, EventArgs args)
@@ -453,6 +473,163 @@ namespace MonoDevelop.Components.Docking
 		{
 			mouseOver = false;
 			UpdateBehavior ();
+		}
+
+		enum FocusWidget
+		{
+			None,
+			Widget,
+			DockButton,
+			CloseButton
+		};
+
+		bool FocusCurrentWidget (DirectionType direction)
+		{
+			if (currentFocus == null) {
+				return false;
+			}
+
+			return currentFocus.ChildFocus (direction);
+		}
+
+		bool MoveFocusToWidget (FocusWidget widget, DirectionType direction)
+		{
+			switch (widget) {
+			case FocusWidget.Widget:
+				GrabFocus ();
+				currentFocus = null;
+				return true;
+
+			case FocusWidget.DockButton:
+				currentFocus = btnDock;
+				return btnDock.ChildFocus (direction);
+
+			case FocusWidget.CloseButton:
+				currentFocus = btnClose;
+				return btnClose.ChildFocus (direction);
+
+			case FocusWidget.None:
+				break;
+			}
+
+			return false;
+		}
+
+		FocusWidget GetNextWidgetToFocus (FocusWidget widget, DirectionType direction) {
+			FocusWidget nextSite;
+
+			switch (widget) {
+			case FocusWidget.CloseButton:
+				switch (direction) {
+				case DirectionType.TabForward:
+				case DirectionType.Right:
+				case DirectionType.Down:
+					return FocusWidget.None;
+
+				case DirectionType.TabBackward:
+				case DirectionType.Left:
+				case DirectionType.Up:
+					if (btnDock.Image != null) {
+						nextSite = FocusWidget.DockButton;
+					} else {
+						nextSite = FocusWidget.Widget;
+					}
+					return nextSite;
+				}
+
+				break;
+
+			case FocusWidget.DockButton:
+				switch (direction) {
+				case DirectionType.TabForward:
+				case DirectionType.Right:
+				case DirectionType.Down:
+					return btnClose.Image == null ? FocusWidget.None : FocusWidget.CloseButton;
+
+				case DirectionType.TabBackward:
+				case DirectionType.Left:
+				case DirectionType.Up:
+					return FocusWidget.Widget;
+				}
+
+				break;
+
+			case FocusWidget.Widget:
+				switch (direction) {
+				case DirectionType.TabForward:
+				case DirectionType.Right:
+				case DirectionType.Down:
+					if (btnDock.Image != null) {
+						nextSite = FocusWidget.DockButton;
+					} else if (btnClose.Image != null) {
+						nextSite = FocusWidget.CloseButton;
+					} else {
+						nextSite = FocusWidget.None;
+					}
+					return nextSite;
+
+				case DirectionType.TabBackward:
+				case DirectionType.Left:
+				case DirectionType.Up:
+					return FocusWidget.None;
+				}
+
+				break;
+			case FocusWidget.None:
+				switch (direction) {
+				case DirectionType.TabForward:
+				case DirectionType.Right:
+				case DirectionType.Down:
+					return FocusWidget.Widget;
+
+				case DirectionType.TabBackward:
+				case DirectionType.Left:
+				case DirectionType.Up:
+					if (btnClose.Image != null) {
+						nextSite = FocusWidget.CloseButton;
+					} else if (btnDock.Image != null) {
+						nextSite = FocusWidget.DockButton;
+					} else {
+						nextSite = FocusWidget.Widget;
+					}
+					return nextSite;
+				}
+
+				break;
+			}
+
+			return FocusWidget.None;
+		}
+
+		protected override bool OnFocused (DirectionType direction)
+		{
+			if (!FocusCurrentWidget (direction)) {
+				FocusWidget focus = FocusWidget.None;
+
+				if (currentFocus == btnClose) {
+					focus = FocusWidget.CloseButton;
+				} else if (currentFocus == btnDock) {
+					focus = FocusWidget.DockButton;
+				} else if (IsFocus) {
+					focus = FocusWidget.Widget;
+				}
+
+				while ((focus = GetNextWidgetToFocus (focus, direction)) != FocusWidget.None) {
+					if (MoveFocusToWidget (focus, direction)) {
+						return true;
+					}
+				}
+
+				// Clean up the icons because OnFocusOutEvent has already been called
+				// so we need the icons to hide again
+				mouseOver = false;
+				UpdateBehavior ();
+
+				currentFocus = null;
+				return false;
+			}
+
+			return true;
 		}
 
 		[GLib.ConnectBeforeAttribute]
@@ -527,6 +704,12 @@ namespace MonoDevelop.Components.Docking
 				DrawAsBrowser (evnt);
 			else
 				DrawNormal (evnt);
+
+			if (HasFocus) {
+				var alloc = labelWidget.Allocation;
+				Gtk.Style.PaintFocus (Style, GdkWindow, State, alloc, this, "label",
+				                      alloc.X, alloc.Y, alloc.Width, alloc.Height);
+			}
 			return base.OnExposeEvent (evnt);
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/TabStrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/TabStrip.cs
@@ -94,7 +94,7 @@ namespace MonoDevelop.Components.Docking
 				tab.Page.Hide ();
 			}
 			
-			tab.ButtonPressEvent += OnTabPress;
+			tab.TabPressed += OnTabPress;
 			UpdateAccessibilityTabs ();
 		}
 
@@ -198,13 +198,12 @@ namespace MonoDevelop.Components.Docking
 				box.Remove (w);
 		}
 		
-		void OnTabPress (object s, Gtk.ButtonPressEventArgs args)
+		void OnTabPress (object s, EventArgs args)
 		{
 			CurrentTab = Array.IndexOf (box.Children, s);
 			DockItemTitleTab t = (DockItemTitleTab) s;
 			DockItem.SetFocus (t.Page);
 			QueueDraw ();
-			args.RetVal = true;
 		}
 
 		protected override void OnSizeAllocated (Gdk.Rectangle allocation)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageButton.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageButton.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using Gdk;
 using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide;
 
@@ -98,6 +99,16 @@ namespace MonoDevelop.Components
 			}
 		}
 
+		protected override bool OnExposeEvent (Gdk.EventExpose evnt)
+		{
+			if (HasFocus && image != null) {
+				Gtk.Style.PaintFocus (Style, GdkWindow, State, Allocation, this, "button",
+				                      Allocation.X, Allocation.Y, Allocation.Width, Allocation.Height);
+			}
+
+			return base.OnExposeEvent (evnt);
+		}
+
 		protected override bool OnEnterNotifyEvent (Gdk.EventCrossing evnt)
 		{
 			hover = true;
@@ -128,6 +139,39 @@ namespace MonoDevelop.Components
 				return true;
 			}
 			return base.OnButtonReleaseEvent (evnt);
+		}
+
+		protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
+		{
+			pressed = image != null;
+			return base.OnKeyPressEvent (evnt);
+		}
+
+		protected override bool OnKeyReleaseEvent (Gdk.EventKey evnt)
+		{
+			if (pressed && evnt.Key == Gdk.Key.space) {
+				LoadImage ();
+				Clicked?.Invoke (this, EventArgs.Empty);
+				return true;
+			}
+
+			return base.OnKeyReleaseEvent (evnt);
+		}
+
+		protected override bool OnFocusInEvent (Gdk.EventFocus evnt)
+		{
+			hover = true;
+			LoadImage ();
+			QueueDraw ();
+			return base.OnFocusInEvent (evnt);
+		}
+
+		protected override bool OnFocusOutEvent (Gdk.EventFocus evnt)
+		{
+			hover = false;
+			LoadImage ();
+			QueueDraw ();
+			return base.OnFocusOutEvent (evnt);
 		}
 
 		void HandlePress (object o, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -341,7 +341,6 @@ namespace MonoDevelop.Components
 						DrawButtonBorder (ctx, x - padding, itemWidth + padding + padding);
 
 					if (index == focusedPathIndex) {
-						Console.WriteLine ($"Found {index}");
 						focusRect = new Gdk.Rectangle (x - padding, 0, itemWidth + (padding * 2) ,0);
 					}
 					int textOffset = 0;
@@ -407,7 +406,6 @@ namespace MonoDevelop.Components
 						DrawButtonBorder (ctx, x - padding, itemWidth + padding + padding);
 
 					if (index == focusedPathIndex) {
-						Console.WriteLine ($"Found right {index}");
 						focusRect = new Gdk.Rectangle (x - padding, 0, itemWidth + (padding * 2), 0);
 					}
 
@@ -603,12 +601,14 @@ namespace MonoDevelop.Components
 				menuWidget = null;
 			}
 
-			var window = Toplevel as Gtk.Window;
-			if (window != null) {
-				// Present the window because on macOS the main window remains unfocused otherwise.
-				window.Present ();
+			if (alreadyHaveFocus) {
+				var window = Toplevel as Gtk.Window;
+				if (window != null) {
+					// Present the window because on macOS the main window remains unfocused otherwise.
+					window.Present ();
+				}
+				GrabFocus ();
 			}
-			GrabFocus ();
 		}
 		
 		public int GetHoverXPosition (out int w)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -850,11 +850,9 @@ namespace MonoDevelop.Components
 			}
 
 			if (ret) {
-				alreadyHaveFocus = true;
 				GrabFocus ();
-			} else {
-				alreadyHaveFocus = false;
 			}
+			alreadyHaveFocus = ret;
 			QueueDraw ();
 			return ret;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -184,6 +184,8 @@ namespace MonoDevelop.Components
 			Accessible.SetLabel (GettextCatalog.GetString ("Breadcrumb Bar"));
 			Accessible.Description = GettextCatalog.GetString ("Jump to definitions in the current file");
 
+			CanFocus = true;
+
 			this.Events =  EventMask.ExposureMask | 
 				           EventMask.EnterNotifyMask |
 				           EventMask.LeaveNotifyMask |
@@ -304,7 +306,10 @@ namespace MonoDevelop.Components
 
 		protected override bool OnExposeEvent (EventExpose evnt)
 		{
+			Gdk.Rectangle focusRect = new Gdk.Rectangle (0, 0, 0, 0);
+
 			using (var ctx = Gdk.CairoHelper.Create (GdkWindow)) {
+				int index = 0;
 				ctx.Rectangle (0, 0, Allocation.Width, Allocation.Height);
 				ctx.SetSourceColor (Styles.BreadcrumbBackgroundColor.ToCairoColor ());
 				ctx.Fill ();
@@ -322,7 +327,7 @@ namespace MonoDevelop.Components
 				int textTopPadding = topPadding + (height - textHeight) / 2;
 				int xpos = leftPadding, ypos = topPadding;
 
-				for (int i = 0; i < leftPath.Length; i++) {
+				for (int i = 0; i < leftPath.Length; i++, index++) {
 					bool last = i == leftPath.Length - 1;
 
 					// Reduce the item size when required
@@ -335,6 +340,10 @@ namespace MonoDevelop.Components
 					if (hoverIndex >= 0 && hoverIndex < Path.Length && leftPath [i] == Path [hoverIndex] && (menuVisible || pressed || hovering))
 						DrawButtonBorder (ctx, x - padding, itemWidth + padding + padding);
 
+					if (index == focusedPathIndex) {
+						Console.WriteLine ($"Found {index}");
+						focusRect = new Gdk.Rectangle (x - padding, 0, itemWidth + (padding * 2) ,0);
+					}
 					int textOffset = 0;
 					if (leftPath [i].DarkIcon != null) {
 						int iy = (height - (int)leftPath [i].DarkIcon.Height) / 2 + topPadding;
@@ -382,7 +391,7 @@ namespace MonoDevelop.Components
 				}
 				
 				int xposRight = Allocation.Width - rightPadding;
-				for (int i = 0; i < rightPath.Length; i++) {
+				for (int i = 0; i < rightPath.Length; i++, index++) {
 					//				bool last = i == rightPath.Length - 1;
 
 					// Reduce the item size when required
@@ -396,7 +405,12 @@ namespace MonoDevelop.Components
 
 					if (hoverIndex >= 0 && hoverIndex < Path.Length && rightPath [i] == Path [hoverIndex] && (menuVisible || pressed || hovering))
 						DrawButtonBorder (ctx, x - padding, itemWidth + padding + padding);
-					
+
+					if (index == focusedPathIndex) {
+						Console.WriteLine ($"Found right {index}");
+						focusRect = new Gdk.Rectangle (x - padding, 0, itemWidth + (padding * 2), 0);
+					}
+
 					int textOffset = 0;
 					if (rightPath [i].DarkIcon != null) {
 						ctx.DrawImage (this, rightPath [i].DarkIcon, x, ypos);
@@ -436,8 +450,14 @@ namespace MonoDevelop.Components
 				ctx.SetSourceColor (Styles.BreadcrumbBottomBorderColor.ToCairoColor ());
 				ctx.LineWidth = 1;
 				ctx.Stroke ();
-			}
 
+				if (HasFocus) {
+					int focusY = topPadding - buttonPadding;
+					int focusHeight = Allocation.Height - topPadding - bottomPadding + buttonPadding * 2;
+
+					Gtk.Style.PaintFocus (Style, GdkWindow, State, Allocation, this, "label", focusRect.X, focusY, focusRect.Width, focusHeight);
+				}
+			}
 			return true;
 		}
 
@@ -517,12 +537,10 @@ namespace MonoDevelop.Components
 				idx++;
 			}
 
-			Console.WriteLine ($"path item: {idx}");
 			if (idx == Path.Length) {
 				return;
 			}
 
-			Console.WriteLine ("Showing menu");
 			ShowMenu ();
 		}
 
@@ -584,6 +602,13 @@ namespace MonoDevelop.Components
 				menuWidget.Destroy ();
 				menuWidget = null;
 			}
+
+			var window = Toplevel as Gtk.Window;
+			if (window != null) {
+				// Present the window because on macOS the main window remains unfocused otherwise.
+				window.Present ();
+			}
+			GrabFocus ();
 		}
 		
 		public int GetHoverXPosition (out int w)
@@ -788,6 +813,62 @@ namespace MonoDevelop.Components
 			styleButton.Destroy ();
 			KillLayout ();
 			this.boldAtts.Dispose ();
+		}
+
+		int focusedPathIndex = -1;
+		bool alreadyHaveFocus = false;
+		protected override bool OnFocused (DirectionType direction)
+		{
+			bool ret = true;
+
+			switch (direction) {
+			case DirectionType.TabForward:
+			case DirectionType.Right:
+				if (!alreadyHaveFocus) {
+					focusedPathIndex = 0;
+				} else {
+					focusedPathIndex++;
+
+					if (focusedPathIndex >= leftPath.Length + rightPath.Length) {
+						ret = false;
+					}
+				}
+				break;
+
+			case DirectionType.TabBackward:
+			case DirectionType.Left:
+				if (!alreadyHaveFocus) {
+					focusedPathIndex = leftPath.Length + rightPath.Length - 1;
+				} else {
+					focusedPathIndex--;
+
+					if (focusedPathIndex < 0) {
+						ret = false;
+					}
+				}
+				break;
+			}
+
+			if (ret) {
+				alreadyHaveFocus = true;
+				GrabFocus ();
+			} else {
+				alreadyHaveFocus = false;
+			}
+			QueueDraw ();
+			return ret;
+		}
+
+		protected override void OnActivate ()
+		{
+			if (focusedPathIndex < 0) {
+				return;
+			}
+
+			hoverIndex = focusedPathIndex;
+			pressHoverIndex = focusedPathIndex;
+
+			ShowMenu ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -1523,7 +1523,6 @@ namespace MonoDevelop.Ide.Gui
 				window.ToggleFullViewMode ();
 			};
 			TabsReordered += window.OnTabsReordered;
-			CanFocus = true;
 			
 			DoPopupMenu = window.ShowPopup;
 			Events |= Gdk.EventMask.FocusChangeMask | Gdk.EventMask.KeyPressMask;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -52,6 +52,8 @@ namespace MonoDevelop.Ide.Gui
 		public static Color SecondaryTextColor { get; internal set; }
 		public static Color SecondarySelectionTextColor { get; internal set; }
 
+		public static Color FocusColor { get; internal set; }
+
 		public static Color ErrorForegroundColor { get; internal set; }
 		public static Color WarningForegroundColor { get; internal set; }
 		public static Color InformationForegroundColor { get; internal set; }
@@ -463,6 +465,7 @@ namespace MonoDevelop.Ide.Gui
 			DockBarPrelightColor = Color.FromName ("#eeeeee");
 			BrowserPadBackground = Color.FromName ("#ebedf0");
 			PropertyPadDividerColor = Color.FromName ("#efefef");
+			FocusColor = Color.FromName ("#4b4b4b");
 
 			// these colors need to match colors from status icons
 			InformationBoxBackgroundColor = StatusInformationBackgroundColor;
@@ -579,6 +582,7 @@ namespace MonoDevelop.Ide.Gui
 			DockBarPrelightColor = Color.FromName ("#666666");
 			BrowserPadBackground = Color.FromName ("#484b55");
 			PropertyPadDividerColor = SeparatorColor;
+			FocusColor = Color.FromName ("#f2f2f4");
 
 			// these colors need to match colors from status icons
 			InformationBoxBackgroundColor = StatusInformationBackgroundColor;


### PR DESCRIPTION
Make the main UI navigable by the tab key.
Obviously you can't tab out of the main text editor though, but it seems like that's not a thing that can be done on native macOS anyway.