### PR TITLE
[Ide] Fix KeyBindingSet compare with parent

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingSet.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingSet.cs
@@ -100,7 +100,7 @@ namespace MonoDevelop.Components.Commands
 
 		public bool Equals (KeyBindingSet other)
 		{
-			if (bindings.Count != other.bindings.Count)
+			if (parent != other && bindings.Count != other.bindings.Count)
 				return false;
 			foreach (KeyValuePair<string, string> binding in bindings) {
 				string accel;


### PR DESCRIPTION
If KeyBindingSet is being compared to its parent,
only the key bindings defined by the child need
to be compared. Other bindings are inherited and
equal for both.

(fixes bug #57111)