### PR TITLE
[F#] Add target frameworks and don't reference mscorlib.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/CompilerArguments.fs
@@ -55,39 +55,6 @@ type CompilerArgumentsTests() =
             | _ -> Assert.Fail(sprintf "Too many references returned %A" testPaths)
         }
 
-    member private x.``Run Only FSharp.Core referenced``(assemblyName) =
-        async {
-            use! testProject = createFSharpProject()
-            let assemblyName = match assemblyName with Fqn a -> fromFqn a | File a -> a
-            let reference = testProject.AddReference assemblyName
-            let references = 
-                CompilerArguments.generateReferences(testProject,
-                                                     testProject.ReferencedAssemblies,
-                                                     Some (FSharpCompilerVersion.FSharp_3_1),
-                                                     FSharpTargetFramework.NET_4_5,
-                                                     ConfigurationSelector.Default,
-                                                     false)
-
-            references.Length |> should equal 3
-
-            //find the mscorlib inside the FSharp.Core ref
-            let mscorlibContained =
-                let assemblyDef = Mono.Cecil.AssemblyDefinition.ReadAssembly(reference.HintPath.ToString())
-                match assemblyDef.MainModule.AssemblyReferences |> Seq.tryFind (fun name -> name.Name = "mscorlib") with
-                |Some name ->
-                    let resolved = assemblyDef.MainModule.AssemblyResolver.Resolve(name)
-                    Some(Path.neutralise resolved.MainModule.FullyQualifiedName)
-                | None -> None
-
-            //find the mscorlib from the returned references (removing unwanted chars "" / \ etc)
-            let mscorlibReferenced =
-                references
-                |> List.tryFind (fun ref -> ref.Contains("mscorlib"))
-                |> Option.map (fun r -> Path.neutralise (r.Replace("-r:", "")))
-
-            mscorlibContained |> should equal mscorlibReferenced
-        }
-
     [<TestCase(TestPlatform.OSX,"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/mscorlib.dll")>]
     [<TestCase(TestPlatform.Linux,"/usr/lib/mono/4.5/mscorlib.dll")>]
     [<TestCase(TestPlatform.OSX,"mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" )>]
@@ -106,24 +73,6 @@ type CompilerArgumentsTests() =
             | _ -> ()
         } |> toTask
 
-    //[<TestCase(TestPlatform.Windows,"FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")>]  
-    [<TestCase(TestPlatform.OSX,"FSharp.Core, Version=4.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")>]  
-    [<TestCase(TestPlatform.OSX, "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/gac/FSharp.Core/4.4.1.0__b03f5f7f11d50a3a/FSharp.Core.dll")>]
-    [<TestCase(TestPlatform.Linux, "/usr/lib/mono/gac/FSharp.Core/4.4.1.0__b03f5f7f11d50a3a/FSharp.Core.dll")>] 
-    [<TestCase(TestPlatform.OSX, "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5/FSharp.Core.dll")>]
-    [<Test;AsyncStateMachine(typeof<Task>)>]
-    member x.``Only FSharp.Core referenced`` (platform: TestPlatform, assemblyName:string) =
-        async {
-            match platform with
-            | TestPlatform.Linux when Platform.IsLinux ->
-                do! x.``Run Only FSharp.Core referenced``(assemblyName)
-            | TestPlatform.OSX when Platform.IsMac ->
-                do! x.``Run Only FSharp.Core referenced``(assemblyName)
-            | TestPlatform.Windows when Platform.IsWindows -> 
-                do! x.``Run Only FSharp.Core referenced``(assemblyName)
-            | _ -> ()
-        } |> toTask
-    
     [<Test;AsyncStateMachine(typeof<Task>)>]
     member x.``Explicit FSharp.Core and mscorlib referenced``() =
         async {

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -34,7 +34,10 @@ module CompilerArguments =
       elif targetFramework = TargetFrameworkMoniker.NET_2_0 then FSharpTargetFramework.NET_2_0
       elif targetFramework = TargetFrameworkMoniker.NET_4_0 then FSharpTargetFramework.NET_4_0
       elif targetFramework = TargetFrameworkMoniker.NET_4_5 then FSharpTargetFramework.NET_4_5
-      else FSharpTargetFramework.NET_4_5
+      elif targetFramework = TargetFrameworkMoniker.NET_4_6 then FSharpTargetFramework.NET_4_6
+      elif targetFramework = TargetFrameworkMoniker.NET_4_6_1 then FSharpTargetFramework.NET_4_6_1
+      elif targetFramework = TargetFrameworkMoniker.NET_4_6_2 then FSharpTargetFramework.NET_4_6_2
+      else FSharpTargetFramework.NET_4_6_2
 
   module Project =
       ///Use the IdeApp.Workspace active configuration failing back to proj.DefaultConfiguration then ConfigurationSelector.Default
@@ -270,28 +273,17 @@ module CompilerArguments =
         // If 'mscorlib.dll' or 'FSharp.Core.dll' is not in the set of references, we try to resolve and add them.
         match find "FSharp.Core", find "mscorlib", Project.isDotNetCoreProject project with
         | None, Some mscorlib, false ->
-            // if mscorlib is founbd without FSharp.Core yield fsharp.core in the same base dir as mscorlib
+            // if mscorlib is found without FSharp.Core yield fsharp.core in the same base dir as mscorlib
             // falling back to one of the default directories
             let extraPath = Some (Path.GetDirectoryName (mscorlib))
             match ReferenceResolution.tryGetDefaultReference langVersion targetFramework "FSharp.Core" extraPath with
             | Some ref -> yield "-r:" + wrapf(ref)
             | None -> LoggingService.LogWarning(resolutionFailedMessage "FSharp.Core")
-
-        | Some fsharpCore, None, false ->
-            // If FSharp.Core is found without mscorlib yield an mscorlib thats referenced from FSharp.core
-            match ReferenceResolution.tryGetReferenceFromAssembly fsharpCore "mscorlib" with
-            | Some resolved -> yield "-r:" + wrapf(resolved)
-            | None -> LoggingService.LogWarning(resolutionFailedMessage "mscorlib")
-
         | None, None, false ->
-            // If neither are found yield the default fsharp.core and mscorlib
+            // If neither are found yield the default fsharp.core
             match ReferenceResolution.tryGetDefaultReference langVersion targetFramework "FSharp.Core" None with
             | Some ref -> yield "-r:" + wrapf(ref)
             | None -> LoggingService.LogWarning(resolutionFailedMessage "FSharp.Core")
-
-            match ReferenceResolution.tryGetDefaultReference langVersion targetFramework "mscorlib" None with
-            | Some ref -> yield "-r:" + wrapf(ref)
-            | None -> LoggingService.LogWarning(resolutionFailedMessage "mscorlib")
         | _ -> () // found them both, no action needed
 
         for file in projectReferences do

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerLocationUtils.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerLocationUtils.fs
@@ -29,6 +29,12 @@ type FSharpTargetFramework =
     | NET_3_5
     | NET_4_0
     | NET_4_5
+    | NET_4_5_1
+    | NET_4_5_2
+    | NET_4_6
+    | NET_4_6_1
+    | NET_4_6_2
+    | NET_4_7
 
 type FSharpCompilerVersion =
     // F# 2.0
@@ -336,6 +342,12 @@ module FSharpEnvironment =
                     | NET_2_0 | NET_3_0 | NET_3_5 -> "2.0"
                     | NET_4_0 -> "4.0"
                     | NET_4_5 -> "4.5"
+                    | NET_4_5_1 -> "4.5.1"
+                    | NET_4_5_2 -> "4.5.2"
+                    | NET_4_6 -> "4.6"
+                    | NET_4_6_1 -> "4.6.1"
+                    | NET_4_6_2 -> "4.6.2"
+                    | NET_4_7 -> "4.7"
 
                 let safeExists f = (try File.Exists(f) with _ -> false)
                 let result =


### PR DESCRIPTION
Fixes unit tests. msbuild doesn't reference mscorlib by default, so the IDE
shouldn't either