### PR TITLE
[NuGet] Fix credential dialog shown multiple times on opening solution 

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
@@ -87,6 +87,7 @@ namespace MonoDevelop.PackageManagement.Commands
 		void LastWorkspaceItemClosed (object sender, EventArgs e)
 		{
 			ClearUpdatedPackages ();
+			PackageManagementCredentialService.Reset ();
 		}
 
 		async Task RestoreAndCheckForUpdates (Solution solution)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialogRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialogRunner.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.PackageManagement
 		public void Run (string initialSearch = null)
 		{
 			try {
+				PackageManagementCredentialService.Reset ();
 				bool configurePackageSources = false;
 				do {
 					using (AddPackagesDialog dialog = CreateDialog (initialSearch)) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeUpdatedPackagesInWorkspace.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeUpdatedPackagesInWorkspace.cs
@@ -27,6 +27,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
@@ -64,6 +65,10 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		}
 
 		public void CheckForUpdates (ISolution solution)
+		{
+		}
+
+		public void CheckForUpdates (ISolution solution, ISourceRepositoryProvider sourceRepositoryProvider)
 		{
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableCheckForNuGetPackageUpdatesTaskRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableCheckForNuGetPackageUpdatesTaskRunner.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
@@ -65,9 +66,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public Task CheckForUpdatesTask;
 		public Action AfterCheckForUpdatesAction = () => { };
 
-		protected override Task CheckForUpdates (IEnumerable<IDotNetProject> projects)
+		protected override Task CheckForUpdates (
+			IEnumerable<IDotNetProject> projects,
+			ISourceRepositoryProvider sourceRepositoryProvider)
 		{
-			CheckForUpdatesTask = base.CheckForUpdates (projects);
+			CheckForUpdatesTask = base.CheckForUpdates (projects, sourceRepositoryProvider);
 			AfterCheckForUpdatesAction ();
 			return CheckForUpdatesTask;
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundPackageActionRunner.cs
@@ -109,6 +109,7 @@ namespace MonoDevelop.PackageManagement
 
 			List<IPackageAction> actionsList = actions.ToList ();
 			BackgroundDispatch (() => {
+				PackageManagementCredentialService.Reset ();
 				TryRunActionsWithProgressMonitor (progressMessage, actionsList, taskCompletionSource, clearConsole);
 				actionsList = null;
 				progressMessage = null;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IUpdatedNuGetPackagesInWorkspace.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IUpdatedNuGetPackagesInWorkspace.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using NuGet.Protocol.Core.Types;
+
 namespace MonoDevelop.PackageManagement
 {
 	internal interface IUpdatedNuGetPackagesInWorkspace
@@ -31,6 +33,7 @@ namespace MonoDevelop.PackageManagement
 		void Clear ();
 		void Clear (ISolution solution);
 		void CheckForUpdates (ISolution solution);
+		void CheckForUpdates (ISolution solution, ISourceRepositoryProvider sourceRepositoryProvider);
 		UpdatedNuGetPackagesInProject GetUpdatedPackages (IDotNetProject project);
 		bool AnyUpdates ();
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
@@ -75,7 +75,7 @@ namespace MonoDevelop.PackageManagement
 		/// <summary>
 		/// The credential service puts itself in a retry mode if a credential provider
 		/// is checked. This results in credentials stored in the key chain being ignored
-		/// and a dialog asking for credentials will be shown. it. This method will clear
+		/// and a dialog asking for credentials will be shown. This method will clear
 		/// the retry cache so credentials stored in the key chain will be re-used and a
 		/// dialog prompt will not be displayed unless the credentials are invalid. This
 		/// should be called before a user triggered action such as opening the Add

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using MonoDevelop.Core;
 using NuGet.CommandLine;
 using NuGet.Credentials;
+using NuGet.Protocol;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -69,6 +70,26 @@ namespace MonoDevelop.PackageManagement
 			var settings = SettingsLoader.LoadDefaultSettings ();
 			var packageSourceProvider = new MonoDevelopPackageSourceProvider (settings);
 			return new SettingsCredentialProvider (packageSourceProvider);
+		}
+
+		/// <summary>
+		/// The credential service puts itself in a retry mode if a credential provider
+		/// is checked. This results in credentials stored in the key chain being ignored
+		/// and a dialog asking for credentials will be shown. it. This method will clear
+		/// the retry cache so credentials stored in the key chain will be re-used and a
+		/// dialog prompt will not be displayed unless the credentials are invalid. This
+		/// should be called before a user triggered action such as opening the Add
+		/// Packages dialog, restoring a project's packages, or updating a package.
+		/// </summary>
+		public static void Reset ()
+		{
+			try {
+				var credentialService = HttpHandlerResourceV3.CredentialService as CredentialService;
+				if (credentialService != null)
+					credentialService.Reset ();
+			} catch (Exception ex) {
+				LoggingService.LogError ("Failed to reset PackageManagementCredentialService.", ex);
+			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
@@ -47,6 +47,7 @@ namespace MonoDevelop.PackageManagement
 		IMonoDevelopSolutionManager solutionManager;
 		IPackageManagementEvents packageManagementEvents;
 		Solution solution;
+		ISourceRepositoryProvider sourceRepositoryProvider;
 		List<NuGetProject> nugetProjects;
 		List<BuildIntegratedNuGetProject> buildIntegratedProjectsToBeRestored;
 		List<INuGetAwareProject> nugetAwareProjectsToBeRestored;
@@ -61,16 +62,23 @@ namespace MonoDevelop.PackageManagement
 			solutionManager.ClearProjectCache ();
 			nugetProjects = solutionManager.GetNuGetProjects ().ToList ();
 
+			// Use the same source repository provider for all restores and updates to prevent
+			// the credential dialog from being displayed for each restore and updates.
+			sourceRepositoryProvider = solutionManager.CreateSourceRepositoryProvider ();
+
 			if (AnyProjectsUsingPackagesConfig ()) {
 				restoreManager = new PackageRestoreManager (
-					solutionManager.CreateSourceRepositoryProvider (),
+					sourceRepositoryProvider,
 					solutionManager.Settings,
 					solutionManager
 				);
 			}
 
 			if (AnyDotNetCoreProjectsOrProjectsUsingProjectJson ()) {
-				buildIntegratedRestorer = new MonoDevelopBuildIntegratedRestorer (solutionManager);
+				buildIntegratedRestorer = new MonoDevelopBuildIntegratedRestorer (
+					solutionManager,
+					sourceRepositoryProvider,
+					solutionManager.Settings);
 			}
 
 			if (AnyNuGetAwareProjects ()) {
@@ -149,7 +157,7 @@ namespace MonoDevelop.PackageManagement
 		void CheckForUpdates ()
 		{
 			try {
-				PackageManagementServices.UpdatedPackagesInWorkspace.CheckForUpdates (new SolutionProxy (solution));
+				PackageManagementServices.UpdatedPackagesInWorkspace.CheckForUpdates (new SolutionProxy (solution), sourceRepositoryProvider);
 			} catch (Exception ex) {
 				LoggingService.LogError ("Check for NuGet package updates error.", ex);
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesInWorkspace.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesInWorkspace.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MonoDevelop.Core;
+using NuGet.Protocol.Core.Types;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -65,6 +66,11 @@ namespace MonoDevelop.PackageManagement
 
 		public void CheckForUpdates (ISolution solution)
 		{
+			CheckForUpdates (solution, null);
+		}
+
+		public void CheckForUpdates (ISolution solution, ISourceRepositoryProvider sourceRepositoryProvider)
+		{
 			GuiDispatch (() => {
 
 				if (taskRunner.IsRunning) {
@@ -72,7 +78,7 @@ namespace MonoDevelop.PackageManagement
 					return;
 				}
 
-				taskRunner.Start (GetProjects (solution));
+				taskRunner.Start (GetProjects (solution), sourceRepositoryProvider);
 			});
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesProvider.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesProvider.cs
@@ -49,14 +49,13 @@ namespace MonoDevelop.PackageManagement
 
 		public UpdatedNuGetPackagesProvider (
 			IDotNetProject dotNetProject,
-			IMonoDevelopSolutionManager solutionManager,
+			ISourceRepositoryProvider sourceRepositoryProvider,
 			NuGetProject project,
 			CancellationToken cancellationToken = default(CancellationToken))
 		{
 			this.dotNetProject = dotNetProject;
 			this.project = project;
 
-			var sourceRepositoryProvider = solutionManager.CreateSourceRepositoryProvider ();
 			this.sourceRepositories = sourceRepositoryProvider.GetRepositories ().ToList ();
 
 			this.cancellationToken = cancellationToken;

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.Credentials/CredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.Credentials/CredentialService.cs
@@ -182,5 +182,14 @@ namespace NuGet.Credentials
 		{
 			return $"{provider.Id}_{type == CredentialRequestType.Proxy}_{uri}";
 		}
+
+		/// <summary>
+		/// Clears the retry cache so credentials will be tried again from the key chain
+		/// instead of defaulting to showing the credential dialog.
+		/// </summary>
+		public void Reset ()
+		{
+			_retryCache.Clear ();
+		}
 	}
 }


### PR DESCRIPTION
Fixed bug #56674 - VS for Mac constantly prompting for MyGet
credentials
https://bugzilla.xamarin.com/show_bug.cgi?id=56674

With check for updates enabled, multiple projects in the solution,
and a package source that was missing or had invalid credentials,
on opening the solution the credential dialog would display multiple
times even if the correct username and password was entered or the
dialog was cancelled. The dialog was being displayed for each
project and the credential information was not being re-used.

To fix this the NuGet SourceRepositories are re-used when checking
for updates and also when restoring the projects when the solution
is first opened. Any valid credentials entered will be re-used
when checking the remaining projects. If the credential dialog is
cancelled then the dialog is no longer displayed again whilst
checking for updates.