### PR TITLE
[Ide] Fix null reference exception in New Project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
@@ -33,7 +33,7 @@ using MonoDevelop.Ide.Templates;
 
 namespace MonoDevelop.Ide.Projects
 {
-	public class LanguageCellRenderer : CellRendererText
+	class LanguageCellRenderer : CellRendererText
 	{
 		Rectangle languageRect;
 		int dropdownTriangleWidth = 8;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
@@ -181,7 +181,7 @@ namespace MonoDevelop.Ide.Projects
 
 		bool TemplateHasMultipleLanguages ()
 		{
-			return !RenderRecentTemplate && Template.AvailableLanguages.Count > 1;
+			return !RenderRecentTemplate && Template != null && Template.AvailableLanguages.Count > 1;
 		}
 
 		static StateType GetState (Widget widget, CellRendererState flags)


### PR DESCRIPTION
Selecting a different category in the New Project dialog would
throw a null reference exception in the language cell renderer due
to the template not being available initially.

Also wondering if we should make LanguageCellRenderer class non-public on master and on the d15-3 branch. It is only used by the New Project dialog.