### PR TITLE
[Connected Services] Invoke the code actions on the UI thread.

### DIFF
--- a/main/src/addins/MonoDevelop.ConnectedServices/CodeDependency.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/CodeDependency.cs
@@ -98,7 +98,9 @@ namespace MonoDevelop.ConnectedServices
 
 					this.InitLookupTypes (token, this.lookupTypes.Keys.ToArray ());
 
-					var result = await this.AddCodeToProject (token).ConfigureAwait (false);
+					var result = await Runtime.RunInMainThread<bool> (
+						() => this.AddCodeToProject (token)
+					);
 
 					LoggingService.LogInfo (result ? "Code dependency added." : "Code dependency was not added.");
 					return result;


### PR DESCRIPTION
Fixes the following exception

WARNING [2017-06-05 10:55:13Z]: Operation not supported in background thread. Location:   at System.Environment.get_StackTrace () [0x00000] in /private/tmp/source-mono-2017-04/bockbuild-2017-04/profiles/mono-mac-xamarin/build-root/mono-x64/mcs/class/corlib/System/Environment.cs:316
  at MonoDevelop.Core.Runtime.CheckMainThread () [0x00014] in /Users/builder/data/lanes/4989/8d2d1180/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs:445
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace.TryApplyChanges (Microsoft.CodeAnalysis.Solution newSolution, Microsoft.CodeAnalysis.Shared.Utilities.IProgressTracker progressTracker) [0x00000] in /Users/builder/data/lanes/4989/8d2d1180/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs:1115
  at Microsoft.CodeAnalysis.Workspace.TryApplyChanges (Microsoft.CodeAnalysis.Solution newSolution) [0x00000] in <62ecf748d8c54ce99002ae42d41637ec>:0
  at MonoDevelop.ConnectedServices.CodeDependency.UpdateMethodWithCodeDependency (Microsoft.CodeAnalysis.Location methodRegion) [0x0010d] in /Users/builder/data/lanes/4989/8d2d1180/source/monodevelop/main/src/addins/MonoDevelop.ConnectedServices/CodeDependency.cs:211
...