### PR TITLE
Binding redirect for S.R.IS.RI to 4.0.1.0

### DIFF
--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -37,10 +37,9 @@
 				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.3.0" />
 			</dependentAssembly>
-			<!-- HACK: workaround Mono 4.8.0 having wrong assembly version for System.Runtime.InteropServices.RuntimeInformation -->
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.0.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />


### PR DESCRIPTION
This is the version that we actually depend on using NuGet (4.3.0) and deploy to output folder.