### PR TITLE
[Ide] Don't bind Page+Up Page+Down keys by default

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -1000,9 +1000,9 @@
 			_label = "Scroll line down"
 			shortcut = "Control|Down" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageUp"
-			_label = "Scroll page up" macShortcut="Page_Up" />
+			_label = "Scroll page up" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageDown"
-			_label = "Scroll page down" macShortcut="Page_Down"/>
+			_label = "Scroll page down" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ScrollTop"
 			_label = "Scroll to top"/>
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ScrollBottom"

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
@@ -116,8 +116,8 @@
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.PulseCaret" shortcut="" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollLineDown" shortcut="Meta+Down" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollLineUp" shortcut="Meta+Up" />
-    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageDown" shortcut="Page_Down Meta+Page_Down" />
-    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageUp" shortcut="Page_Up Meta+Page_Up" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageDown" shortcut="Meta+Page_Down" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageUp" shortcut="Meta+Page_Up" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveEnd" shortcut="Shift+End" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveHome" shortcut="Shift+Home" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextWord" shortcut="Meta+Shift+Right" />

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
@@ -116,8 +116,8 @@
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.PulseCaret" shortcut="" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollLineDown" shortcut="Control+Down" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollLineUp" shortcut="Control+Up" />
-    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageDown" shortcut="Page_Down Control+Page_Down" />
-    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageUp" shortcut="Page_Up Control+Page_Up" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageDown" shortcut="Control+Page_Down" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ScrollPageUp" shortcut="Control+Page_Up" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveEnd" shortcut="Shift+End" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveHome" shortcut="Shift+Home" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextWord" shortcut="Control+Shift+Right" />


### PR DESCRIPTION
This makes the Page+Up/Page+Down keys less discoverable, but its the only way to resolve the conflict between the command manager and default Gtk key handler inside the text editor without bigger command system design changes.

(fixes bug #55143)