### PR TITLE
Bug 57223 - Debugger does not disconnect from mac apps properly

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/ProcessManager.cs
+++ b/main/src/addins/MacPlatform/MacInterop/ProcessManager.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.MacInterop
 			if (runningApp == null)
 				return false;
 
-			return runningApp.Terminate ();
+			return runningApp.ForceTerminate ();
 		}
 
 		public static bool IsRunning (int pid)


### PR DESCRIPTION
This fixes only part when mono/app fails to close itself and IDE needs to force close it, underlying problem still needs to be fixed by XM/Mono.