### PR TITLE
[A11y] Add a Restart panel and make it accessible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/RestartPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/RestartPanel.cs
@@ -1,0 +1,66 @@
+﻿//
+// RestartPanel.cs
+//
+// Author:
+//       iain <>
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+using Gtk;
+using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Components
+{
+	public class RestartPanel : Table
+	{
+		public event EventHandler<EventArgs> RestartRequested;
+
+		public RestartPanel () : base (2, 3, false)
+		{
+			RowSpacing = 6;
+			ColumnSpacing = 6;
+
+			var btnRestart = new Button () {
+				Label = GettextCatalog.GetString ("Restart {0}", BrandingService.ApplicationName),
+				CanFocus = true, UseUnderline = true
+			};
+			Attach (btnRestart, 1, 2, 1, 2, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
+
+			var imageRestart = new ImageView ("md-information", IconSize.Menu);
+			Attach (imageRestart, 0, 1, 0, 1, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
+
+			var labelRestart = new Label (GettextCatalog.GetString ("These preferences will take effect next time you start {0}", BrandingService.ApplicationName));
+			Attach (labelRestart, 1, 3, 0, 1, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
+
+			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", null,
+			                                               GettextCatalog.GetString ("A restart is required before these changes take effect"));
+			imageRestart.SetAccessibilityLabelRelationship (labelRestart);
+
+
+			btnRestart.Clicked += (sender, e) => {
+				RestartRequested?.Invoke (this, EventArgs.Empty);
+
+			};
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/IDEStyleOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/IDEStyleOptionsPanel.cs
@@ -32,6 +32,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components.Commands;
@@ -86,6 +87,10 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 		{
 			this.Build();
 			Load ();
+
+			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", null,
+			                                               GettextCatalog.GetString ("A restart is required before these changes take effect"));
+			imageRestart.SetAccessibilityLabelRelationship (labelRestart);
 		}
 
 		void Load ()
@@ -114,6 +119,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			comboTheme.Active = sel;
 			comboTheme.Changed += ComboThemeChanged;
 			tableRestart.Visible = separatorRestart.Visible = false;
+
 			labelRestart.LabelProp = GettextCatalog.GetString ("These preferences will take effect next time you start {0}", BrandingService.ApplicationName);
 			btnRestart.Label = GettextCatalog.GetString ("Restart {0}", BrandingService.ApplicationName);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/SdkLocationPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/SdkLocationPanel.cs
@@ -27,6 +27,7 @@
 using System;
 using Gtk;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 
@@ -129,28 +130,13 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			if (panel.RequiresRestart) {
 				PackStart (new HSeparator (), false, false, 0);
 
-				var tableRestart = new Table (2, 3, false) {
-					RowSpacing = 6, ColumnSpacing = 6
-				};
-
-				var btnRestart = new Button () {
-					Label = GettextCatalog.GetString ("Restart {0}", BrandingService.ApplicationName),
-					CanFocus = true, UseUnderline = true
-				};
-				tableRestart.Attach (btnRestart, 1, 2, 1, 2, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
-
-				var imageRestart = new ImageView ("md-information", IconSize.Menu);
-				tableRestart.Attach (imageRestart, 0, 1, 0, 1, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
-
-				var labelRestart = new Label (GettextCatalog.GetString ("These preferences will take effect next time you start {0}", BrandingService.ApplicationName));
-				tableRestart.Attach (labelRestart, 1, 3, 0, 1, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
-
-				PackStart (tableRestart, false, false, 0);
-
-				btnRestart.Clicked += (sender, e) => {
+				var tableRestart = new RestartPanel ();
+				tableRestart.RestartRequested += (sender, e) => {
 					ApplyChanges ();
 					IdeApp.Restart (true);
 				};
+
+				PackStart (tableRestart, false, false, 0);
 			}
 
 			ShowAll ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9413,6 +9413,7 @@
     <Compile Include="MonoDevelop.Ide.Editor.Highlighting\RoslynClassificationHighlighting.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\LanguageCellRenderer.cs" />
     <Compile Include="MonoDevelop.Components\Mac\MacLeakHelpers.cs" />
+    <Compile Include="MonoDevelop.Components\RestartPanel.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
Split the Restart panel out into a separate widget, make it accessible.

Fixes BXC #53523