### PR TITLE
[DotNetCore] Fix ASP.NET Core project build error with old SDK

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -146,6 +146,7 @@
     <Compile Include="gtk-gui\generated.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Gui\GtkDotNetCoreProjectTemplateWizardPageWidget.cs" />
     <Compile Include="gtk-gui\MonoDevelop.DotNetCore.Gui.GtkDotNetCoreProjectTemplateWizardPageWidget.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\MSBuildSdksPathGlobalPropertyProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdksPathGlobalPropertyProvider.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MSBuildSdksPathGlobalPropertyProvider.cs
@@ -1,0 +1,82 @@
+﻿//
+// MSBuildSdksPathGlobalPropertyProvider.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using MonoDevelop.Projects.MSBuild;
+using System.Linq;
+
+namespace MonoDevelop.DotNetCore
+{
+	/// <summary>
+	/// Defines the MSBuildSDKsPath global property which is used by the Microsoft.NET.Sdk.Web
+	/// MSBuild targets when importing the core Sdk.props. This property is not needed for
+	/// .NET Core 1.0.4 SDK or above. The Microsoft.NET.Sdk.Web MSBuild targets in .NET Core
+	/// 1.0.4 SDK do not use the MSBuildSDKsPath property when importing other targets but
+	/// older SDKs do.
+	///
+	/// If the installed .NET Core SDK is older than 1.0.4 then the MSBuildSDKsPath global
+	/// property is set. If the .NET Core SDK is not installed then the MSBuildSDKsPath
+	/// global property is set if the .NET Core SDKs are shipped with Mono. The
+	/// Microsoft.NET.Sdk.Web MSBuild targets that ship with Mono are from an older .NET
+	/// Core SDK version which uses the MSBuildSDKsPath property to import other targets.
+	/// </summary>
+	class MSBuildSdksPathGlobalPropertyProvider : IMSBuildGlobalPropertyProvider
+	{
+		static DotNetCoreVersion minimumVersion = DotNetCoreVersion.Parse ("1.0.4");
+		Dictionary<string, string> properties;
+
+		#pragma warning disable 67
+		public event EventHandler GlobalPropertiesChanged;
+		#pragma warning restore 67
+
+		public IDictionary<string, string> GetGlobalProperties ()
+		{
+			if (properties == null) {
+				properties = new Dictionary<string, string> ();
+
+				string sdksPath = GetMSBuildSDKsPath ();
+				if (sdksPath != null)
+					properties.Add ("MSBuildSDKsPath", sdksPath);
+			}
+			return properties;
+		}
+
+		string GetMSBuildSDKsPath ()
+		{
+			if (DotNetCoreSdk.IsInstalled) {
+				var latestVersion = DotNetCoreSdk.Versions.FirstOrDefault ();
+				if (latestVersion != null && latestVersion < minimumVersion) {
+					return DotNetCoreSdk.MSBuildSDKsPath;
+				}
+			} else if (MSBuildSdks.Installed) {
+				return MSBuildSdks.MSBuildSDKsPath;
+			}
+
+			return null;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -546,4 +546,10 @@
 		<StockIcon stockid="md-netcore-test-project" resource="project-netcore-test-32.png" size="Dnd" />
 		<StockIcon stockid="md-crossplatform-library-project" resource="project-crossplatform-library-32.png" size="Dnd" />
 	</Extension>
+
+	<Extension path="/MonoDevelop/ProjectModel/MSBuildGlobalPropertyProviders">
+		<Type
+			id="DotNetCoreMSBuildSdksPathPropertyProvider"
+			class="MonoDevelop.DotNetCore.MSBuildSdksPathGlobalPropertyProvider" />
+	</Extension>
 </ExtensionModel>


### PR DESCRIPTION
Fixed bug #57195 - Xamarin.Forms with ASP.NET Mobile Backend does not
build
https://bugzilla.xamarin.com/show_bug.cgi?id=57195

Building an ASP.NET Core project when .NET Core SDK 1.0.3 or lower
was installed, or if no .NET Core SDK was installed, would result in
the build failing with the error:

error MSB4057: The target "Build" does not exist in the project.

With .NET Core SDK 1.0.4 or later installed this build error does not
occur. The problem is that with older .NET Core SDKs the ASP.NET Core
project uses the Microsoft.Web.Sdk.Web MSBuild imports. The older
Microsoft.Web.Sdk.Web  imports use the MSBuildSdksPath property when
importing other MSBuild targets files. This is not defined and results
in nothing being imported and so the build targets are not available.
To fix this the MSBuildSDKsPath property is defined globally if an
old .NET Core sdk is installed, or if no .NET Core SDK is installed.

This will need fixing in the d15-3 branch too.