### PR TITLE
[F#] Fix tooltip position for namespaces

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -41,6 +41,7 @@ module Symbols =
 
         let startOffset = doc.LocationToOffset(start.Line, start.Column+1)
         let endOffset = doc.LocationToOffset(finish.Line, finish.Column+1)
+        let startOffset = if startOffset = endOffset then endOffset-lastIdent.Length else startOffset
         MonoDevelop.Core.Text.TextSegment.FromBounds(startOffset, endOffset)
 
     let getEditorDataForFileName (fileName:string) =


### PR DESCRIPTION
This is a workaround for a bug in FCS. The compiler is returning the
same location for both start and end of the namespace name, which
resulted in a zero width tooltip.