### PR TITLE
[TextEditor] Don't modify root window background

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -780,7 +780,7 @@ namespace Mono.TextEditor
 				settingWidgetBg = true; //prevent infinite recusion
 
 				Widget parent = this;
-				while (parent.Parent != null && !(parent is ScrolledWindow)) {
+				while (parent != null && !(parent is ScrolledWindow)) {
 					parent = parent.Parent;
 				}
 


### PR DESCRIPTION
Don't modify the background of the root window, if
the text editor is not inside a ScrolledWindow.

(fixes bug #43049)