### PR TITLE
[TextEditor] Properly copy the TextEditorOptions color style

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
@@ -589,7 +589,7 @@ namespace Mono.TextEditor
 			indentStyle = other.IndentStyle;
 			fontName = other.FontName;
 			enableSyntaxHighlighting = other.EnableSyntaxHighlighting;
-			colorStyle = other.colorStyle;
+			colorStyle = other.EditorThemeName;
 			overrideDocumentEolMarker = other.OverrideDocumentEolMarker;
 			defaultEolMarker = other.DefaultEolMarker;
 			enableAnimations = other.EnableAnimations;


### PR DESCRIPTION
When copying a TextEditorOptions derivate which overrides `TextEditorOptions.EditorThemeName`, always use the overriden style name, since the internal `colorStyle` could be wrong.

This also fixes the wrong Diff View theme (alsways default `Light`).