### PR TITLE
[Ide] Fix file templates not translated

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewFileDialog.cs
@@ -404,8 +404,8 @@ namespace MonoDevelop.Ide.Projects
 			FileTemplate template = iconView.CurrentlySelected != null ? iconView.CurrentlySelected.Template : null;
 			
 			if (template != null) {
-				labelTemplateTitle.Markup = "<b>" + GettextCatalog.GetString (template.Name) + "</b>";
-				infoLabel.Text = GettextCatalog.GetString (template.Description);
+				labelTemplateTitle.Markup = "<b>" + template.Name + "</b>";
+				infoLabel.Text = template.Description;
 				
 				string filename = GetFileNameFromEntry ();
 				string name = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Ide.Templates
 			fileTemplate.LastModified = xmlDocument.DocumentElement.GetAttribute ("LastModified");
 
 			if (xmlNodeConfig ["_Name"] != null) {
-				fileTemplate.Name = xmlNodeConfig ["_Name"].InnerText;
+				fileTemplate.Name = addin.Localizer.GetString (xmlNodeConfig ["_Name"].InnerText);
 			} else {
 				throw new InvalidOperationException (string.Format ("Missing element '_Name' in file template: {0}", templateId));
 			}
@@ -140,7 +140,7 @@ namespace MonoDevelop.Ide.Templates
 			}
 
 			if (xmlNodeConfig ["_Description"] != null) {
-				fileTemplate.Description = xmlNodeConfig ["_Description"].InnerText;
+				fileTemplate.Description = addin.Localizer.GetString (xmlNodeConfig ["_Description"].InnerText);
 			}
 
 			if (xmlNodeConfig ["Icon"] != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Ide.Templates
 			fileTemplate.LastModified = xmlDocument.DocumentElement.GetAttribute ("LastModified");
 
 			if (xmlNodeConfig ["_Name"] != null) {
-				fileTemplate.Name = addin.Localizer.GetString (xmlNodeConfig ["_Name"].InnerText);
+				fileTemplate.Name = Localize (addin, xmlNodeConfig ["_Name"].InnerText);
 			} else {
 				throw new InvalidOperationException (string.Format ("Missing element '_Name' in file template: {0}", templateId));
 			}
@@ -140,7 +140,7 @@ namespace MonoDevelop.Ide.Templates
 			}
 
 			if (xmlNodeConfig ["_Description"] != null) {
-				fileTemplate.Description = addin.Localizer.GetString (xmlNodeConfig ["_Description"].InnerText);
+				fileTemplate.Description = Localize (addin, xmlNodeConfig ["_Description"].InnerText);
 			}
 
 			if (xmlNodeConfig ["Icon"] != null) {
@@ -450,6 +450,17 @@ namespace MonoDevelop.Ide.Templates
 					list.Remove ("*");
 				}
 			}
+		}
+
+		/// <summary>
+		/// The addin may be null if the file template is loaded by a unit test.
+		/// </summary>
+		static string Localize (RuntimeAddin addin, string s)
+		{
+			if (addin != null)
+				return addin.Localizer.GetString (s);
+
+			return GettextCatalog.GetString (s);
 		}
 	}
 }


### PR DESCRIPTION
Fixed bug #53635 - Many "New file" dialogs/strings are unlocalized.
https://bugzilla.xamarin.com/show_bug.cgi?id=53635

File templates that require a custom localizer were not translated
since Gettextcatalog.GetString was always used.

Requires [md-addins change](https://github.com/xamarin/md-addins/pull/2077) before this will translate the file templates.