### PR TITLE
[Ide] Fix project template categories not added to translations

### DIFF
--- a/main/src/addins/MonoDevelop.AzureFunctions/Properties/Manifest.addin.xml
+++ b/main/src/addins/MonoDevelop.AzureFunctions/Properties/Manifest.addin.xml
@@ -1,8 +1,8 @@
 ﻿<ExtensionModel>
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateCategories">
-		<Category id="cloud" name="Cloud" insertafter="netcore">
-			<Category id="general" name="General">
-				<Category id="general" name="General" />
+		<Category id="cloud" _name="Cloud" insertafter="netcore">
+			<Category id="general" _name="General">
+				<Category id="general" _name="General" />
 			</Category>
 		</Category>
 	</Extension>

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -8,16 +8,16 @@
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateCategories">
-		<Category id="netcore" name=".NET Core" icon="md-platform-netcore" insertbefore="other">
-			<Category id="app" name="App">
-				<Category id="general" name="General" />
-				<Category id="aspnet" name="ASP.NET Core" />
+		<Category id="netcore" _name=".NET Core" icon="md-platform-netcore" insertbefore="other">
+			<Category id="app" _name="App">
+				<Category id="general" _name="General" />
+				<Category id="aspnet" _name="ASP.NET Core" />
 			</Category>
-			<Category id="library" name="Library">
-				<Category id="general" name="General" />
+			<Category id="library" _name="Library">
+				<Category id="general" _name="General" />
 			</Category>
-			<Category id="test" name="Tests">
-				<Category id="general" name="General" />
+			<Category id="test" _name="Tests">
+				<Category id="general" _name="General" />
 			</Category>
 		</Category>
 	</Extension>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Templates.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Templates.addin.xml
@@ -114,20 +114,20 @@
 </Extension>
 
 <Extension path="/MonoDevelop/Ide/ProjectTemplateCategories">
-	<Category id="multiplat" name="Multiplatform" icon="md-platform-crossplatform">
-			<Category id="library" name="Library">
-				<Category id="general" name="General" mappedCategories="crossplat/library/general" />
+	<Category id="multiplat" _name="Multiplatform" icon="md-platform-crossplatform">
+			<Category id="library" _name="Library">
+				<Category id="general" _name="General" mappedCategories="crossplat/library/general" />
 			</Category>
 		</Category>
-	<Category id="other" name="Other" icon="md-platform-other">
-		<Category id="net" name=".NET">
-			<Category id="general" name="General" mappedCategories="C#" />
-			<Category id="aspnet" name="ASP.NET" mappedCategories="C#/ASP.NET" />
+	<Category id="other" _name="Other" icon="md-platform-other">
+		<Category id="net" _name=".NET">
+			<Category id="general" _name="General" mappedCategories="C#" />
+			<Category id="aspnet" _name="ASP.NET" mappedCategories="C#/ASP.NET" />
 		</Category>
-		<Category id="misc" name="Miscellaneous">
-			<Category id="generic" name="Generic" />
-			<Category id="c" name="C/C++" />
-			<Category id="general" name="General" default="true" />
+		<Category id="misc" _name="Miscellaneous">
+			<Category id="generic" _name="Generic" />
+			<Category id="c" _name="C/C++" />
+			<Category id="general" _name="General" default="true" />
 		</Category>
 	</Category>
 </Extension>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Codons/TemplateCategoryCodon.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Codons/TemplateCategoryCodon.cs
@@ -27,6 +27,7 @@
 using Mono.Addins;
 using MonoDevelop.Ide.Templates;
 using MonoDevelop.Core;
+using System;
 using System.Linq;
 
 namespace MonoDevelop.Ide.Codons
@@ -34,8 +35,12 @@ namespace MonoDevelop.Ide.Codons
 	[ExtensionNode (Description="A template category.")]
 	internal class TemplateCategoryCodon : ExtensionNode
 	{
+		[ObsoleteAttribute ("This is ignored when generating translations.")]
 		[NodeAttribute ("name", "Name of the category.", Localizable=true)]
 		string name;
+
+		[NodeAttribute ("_name", "Name of the category.", Localizable=true)]
+		string _name;
 
 		[NodeAttribute("icon", "Icon for the category.")]
 		string icon;
@@ -48,7 +53,7 @@ namespace MonoDevelop.Ide.Codons
 
 		public TemplateCategory ToTemplateCategory ()
 		{
-			var category = new TemplateCategory (Id, name, icon);
+			var category = new TemplateCategory (Id, _name ?? name, icon);
 			category.MappedCategories = mappedCategories;
 			category.IsDefault = IsDefaultCategory ();
 


### PR DESCRIPTION
The project template categories were defined in the .addin.xml file
using an attribute without an underscore so they were not added
to the translations. The project template categories now use _name
for the category name so they are added to the translations. To
maintain backwards compatibility the name attribute without the
underscore is still supported.

    <Category id="library" _name="Library">