### PR TITLE
Remote process crash instrumented

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace MonoDevelop.Core.Execution
 {
@@ -42,7 +44,7 @@ namespace MonoDevelop.Core.Execution
 		// Time this connection will wait for the process to connect back
 		const int ProcessInitializationTimeout = 15000;
 
-		#if DEBUG_MESSAGES
+		#if !DEBUG_MESSAGES
 		internal static bool DebugMode = true;
 		#else
 		internal static bool DebugMode = false;
@@ -95,6 +97,7 @@ namespace MonoDevelop.Core.Execution
 
 		void SetStatus (ConnectionStatus s, string message, Exception e = null)
 		{
+			Log ($"status={s} message={message} exception={e?.Message}");
 			status = s;
 			StatusMessage = message;
 			StatusException = e;
@@ -127,6 +130,7 @@ namespace MonoDevelop.Core.Execution
 
 		public void Dispose ()
 		{
+			Log ();
 			Disconnect ().Ignore ();
 		}
 
@@ -160,6 +164,7 @@ namespace MonoDevelop.Core.Execution
 
 		public async Task Disconnect ()
 		{
+			Log ();
 			StopPinger ();
 		
 			if (process == null)
@@ -168,10 +173,13 @@ namespace MonoDevelop.Core.Execution
 			try {
 				// Send a stop message to try a graceful stop. Don't wait more than 2s for a response
 				var timeout = Task.Delay (2000);
+				Log ("await Stop Process timeout 2000");
 				if (await Task.WhenAny (SendMessage (new BinaryMessage ("Stop", "Process")), timeout) != timeout) {
 					// Wait for at most two seconds for the process to end
 					timeout = Task.Delay (4000);
+					Log ("await Process Exit timeout 4000");
 					if (await Task.WhenAny (process.Task, timeout) != timeout)
+						Log ("All done!");
 						return; // All done!
 				}
 			} catch {
@@ -187,11 +195,14 @@ namespace MonoDevelop.Core.Execution
 			} catch {
 				// Ignore
 			}
+
+			Log ("await Process.Task");
 			await process.Task;
 		}
 
 		public async Task Connect ()
 		{
+			Log ();
 			initializationDone = false;
 			AbortPendingMessages ();
 			if (listener != null && !disposed) {
@@ -199,6 +210,7 @@ namespace MonoDevelop.Core.Execution
 				await Disconnect ();
 			}
 			await StartConnecting ();
+			Log ("Connect done");
 		}
 
 		Task StartConnecting ()
@@ -224,16 +236,20 @@ namespace MonoDevelop.Core.Execution
 
 				processConnectedEvent = new TaskCompletionSource<bool> ();
 
+				Log ("BeginAcceptTcpClient");
 				listener.BeginAcceptTcpClient (OnConnected, listener);
 
 				await InitializeRemoteProcessAsync (token).ConfigureAwait (false);
+				Log ("done");
 			} catch (Exception ex) {
+				Log (ex);
 				HandleRemoteConnectException (ex, token);
 			}
 		}
 
 		async Task InitializeRemoteProcessAsync (CancellationToken token)
 		{
+			Log ();
 			try {
 				await StartRemoteProcess ().ConfigureAwait (false);
 
@@ -243,9 +259,14 @@ namespace MonoDevelop.Core.Execution
 					throw new Exception ("Could not start process");
 				
 				var timeout = Task.Delay (ProcessInitializationTimeout, token).ContinueWith (t => {
-					if (t.IsCanceled)
+					if (t.IsCanceled) {
+						Log ("t.IsCanceled; return");
 						return;
-					processConnectedEvent.TrySetException (new Exception ("Could not start process"));
+					}
+
+					if (processConnectedEvent.TrySetException (new Exception ("Could not start process"))) {
+						Log ("TrySetException Could not start process");
+					}
 				});
 
 				await Task.WhenAny (timeout, processConnectedEvent.Task).ConfigureAwait (false);
@@ -266,12 +287,14 @@ namespace MonoDevelop.Core.Execution
 				initializationDone = true;
 			
 			} catch (Exception ex) {
+				Log (ex.Message);
 				HandleRemoteConnectException (ex, token);
 			}
 		}
 
 		void HandleRemoteConnectException (Exception ex, CancellationToken token)
 		{
+			Log (ex.Message);
 			LoggingService.LogError ("Connection failed", ex);
 			token.ThrowIfCancellationRequested ();
 			StopRemoteProcess ();
@@ -281,6 +304,7 @@ namespace MonoDevelop.Core.Execution
 		Task StartRemoteProcess ()
 		{
 			return Task.Run (() => {
+				Log ();
 				var cmd = Runtime.ProcessService.CreateCommand (exePath);
 				cmd.Arguments = ((IPEndPoint)listener.LocalEndpoint).Port + " " + DebugMode;
 
@@ -296,6 +320,8 @@ namespace MonoDevelop.Core.Execution
 		bool stopping;
 		void ProcessExited ()
 		{
+			Log ();
+
 			// any exception bubbling up from here would crash the process
 			try {
 				// somehow capture that the process has exited
@@ -303,7 +329,8 @@ namespace MonoDevelop.Core.Execution
 				if (!stopping)
 					AbortConnection (isAsync: true);
 			}
-			catch {
+			catch (Exception ex) {
+				Log ("Caught " + ex.Message);
 			}
 		}
 
@@ -315,7 +342,9 @@ namespace MonoDevelop.Core.Execution
 		public Task<BinaryMessage> SendMessage (BinaryMessage message)
 		{
 			// do not attempt to send new messages if the process has already exited
+			Log (message.ToString ());
 			if (process == null || process.IsCompleted) {
+				Log ("Process not running, not sending message");
 				return Task.FromException<BinaryMessage> (new Exception ("Process not running"));
 			}
 
@@ -331,6 +360,7 @@ namespace MonoDevelop.Core.Execution
 
 		public void PostMessage (BinaryMessage message)
 		{
+			Log ();
 			message.ReadCustomData ();
 			var interceptor = Interceptor;
 			if (interceptor != null && !interceptor.PreProcessMessage (message))
@@ -341,28 +371,36 @@ namespace MonoDevelop.Core.Execution
 
 		public void FlushMessages (string target)
 		{
+			Log (target);
 			var msg = new BinaryMessage ("FlushMessages", target);
 			SendMessage (msg);
 		}
 
 		void PostMessage (BinaryMessage message, TaskCompletionSource<BinaryMessage> cs, bool checkInitialized)
 		{
-			if (checkInitialized && !initializationDone)
+			if (checkInitialized && !initializationDone) {
+				Log ($"Not connected, checkInitialized={checkInitialized} initializationDone={initializationDone}");
 				throw new RemoteProcessException ("Not connected");
+			}
 
 			if (cs != null) {
+				Log ("Before lock messageWaiters");
 				lock (messageWaiters) {
+					Log ("In messageWaiters");
 					messageWaiters [message.Id] = new MessageRequest {
 						Request = message,
 						TaskSource = cs
 					};
+					Log ($"messageWaiters[{message.Id}] assigned");
 				}
 			}
 
 			lock (messageQueue) {
+				Log ("In lock messageQueue");
 				messageQueue.Add (message);
 				if (!senderRunning) {
 					senderRunning = true;
+					Log ("Setting senderRunning to true");
 					ThreadPool.QueueUserWorkItem (delegate {
 						SendMessages ();
 					});
@@ -374,25 +412,32 @@ namespace MonoDevelop.Core.Execution
 
 		void SendMessages ()
 		{
+			Log ();
 			while (true) {
 				List<BinaryMessage> queueCopy;
 				lock (messageQueue) {
 					if (messageQueue.Count == 0) {
+						Log ("senderRunning = false");
 						senderRunning = false;
 						return;
 					}
 					queueCopy = new List<BinaryMessage> (messageQueue);
 					messageQueue.Clear ();
+					Log ("Cleared messageQueue");
 				}
 				foreach (var m in queueCopy)
 					PostMessageInternal (m);
+				Log ("Done SendMessages loop");
 			}
 		}
 
 		void PostMessageInternal (BinaryMessage message)
 		{
+			Log ($"{message.Id} {message.Name}");
+
 			if ((status != ConnectionStatus.Connected || disposed) && !message.BypassConnection) {
 				ProcessResponse (message.CreateErrorResponse ("Connection is closed"));
+				Log ($"Connection is closed, status={status} disposed={disposed}");
 				return;
 			}
 
@@ -400,6 +445,7 @@ namespace MonoDevelop.Core.Execution
 				if (DebugMode)
 					message.SentTime = DateTime.Now;
 
+				Log ("Sending message");
 				// Now send the message. This one will need a response
 
 				if (DebugMode)
@@ -411,9 +457,12 @@ namespace MonoDevelop.Core.Execution
 				connectionStream.Flush ();
 			}	
 			catch (Exception ex){
+				Log (ex);
 				if (connection == null || (!connection.Connected && status == ConnectionStatus.Connected)) {
+					Log ("PostMessageInteral calling AbortConnection");
 					AbortConnection ("Disconnected from remote process due to a communication error", isAsync: true);
 				} else
+					Log ("Calling ProcessResponse");
 					ProcessResponse (message.CreateErrorResponse (ex.ToString ()));
 			}
 		}
@@ -422,16 +471,23 @@ namespace MonoDevelop.Core.Execution
 		{
 			public BinaryMessage Request;
 			public TaskCompletionSource<BinaryMessage> TaskSource;
+
+			public override string ToString ()
+			{
+				return $"Request Id={Request.Id} Name={Request.Name}";
+			}
 		}
 
 		Dictionary<int, MessageRequest> messageWaiters = new Dictionary<int, MessageRequest> ();
 
 		void AbortConnection (string message = null, bool isAsync = false)
 		{
+			Log ($"message={message} isAsync={isAsync}");
 			if (message == null)
 				message = "Disconnected from remote process";
 			AbortPendingMessages ();
 			disposed = true;
+			Log ("processConnectedEvent TrySetResult true");
 			processConnectedEvent.TrySetResult (true);
 			if (isAsync)
 				PostSetStatus (ConnectionStatus.Disconnected, message);
@@ -441,22 +497,36 @@ namespace MonoDevelop.Core.Execution
 
 		void AbortPendingMessages ()
 		{
+			Log ();
 			lock (messageWaiters) {
+				Log ("In lock messageWaiters");
 				// capture the original values because they can change while we're enumerating
 				var originalValues = messageWaiters.Values.ToArray ();
-				foreach (var m in originalValues)
+				foreach (var m in originalValues) {
+					Log ("Original value: " + m.ToString ());
+				}
+
+				foreach (var m in originalValues) {
+					Log ($"Inside foreach for {m}");
 					NotifyResponse (m, m.Request.CreateErrorResponse ("Connection closed"));
+					Log ("After loop body for {m}");
+				}
+				Log ("After foreach");
 				messageWaiters.Clear ();
 				messageQueue.Clear ();
 			}
+
+			Log ("AbortPendingMessages done");
 		}
 
 		void StopPinger ()
 		{
+			Log ();
 			if (pinger != null) {
 				// not sure but it seems that if multiple places call StopPinger we should lock here
 				lock (pingerLock) {
 					if (pinger != null) {
+						Log ("Disposing pinger");
 						pinger.Dispose ();
 						pinger = null;
 					}
@@ -466,7 +536,8 @@ namespace MonoDevelop.Core.Execution
 
 		void StopRemoteProcess (bool isAsync = false)
 		{
-			if (process != null)
+			Log ("isAsync=" + isAsync);
+			if (process != null && !process.IsCompleted)
 				stopping = true;
 
 			if (stopping) {
@@ -490,6 +561,7 @@ namespace MonoDevelop.Core.Execution
 			}
 
 			if (stopping) {
+				Log ("process.Cancel()");
 				process.Cancel ();
 			}
 		}
@@ -503,9 +575,11 @@ namespace MonoDevelop.Core.Execution
 				try {
 					connection = listener.EndAcceptTcpClient (res);
 					connectionStream = connection.GetStream ();
+					Log ("Creating pinger");
 					pinger = new Timer (PingConnection, null, PingPeriod, PingPeriod);
 				} catch (Exception ex) {
 					LoggingService.LogError ("Connection to layout renderer failed", ex);
+					Log (ex.Message);
 					PostSetStatus (ConnectionStatus.ConnectionFailed, "Connection to layout renderer failed");
 					return;
 				}
@@ -524,9 +598,11 @@ namespace MonoDevelop.Core.Execution
 				byte type;
 
 				try {
+					Log ("connectionStream.ReadAsync");
 					int nr = await connectionStream.ReadAsync (buffer, 0, 1, mainCancelSource.Token).ConfigureAwait (false);
 					if (nr == 0) {
 						// Connection closed. Remote process should die by itself.
+						Log ("nr == 0");
 						return;
 					}
 					type = buffer [0];
@@ -535,11 +611,13 @@ namespace MonoDevelop.Core.Execution
 					if (disposed)
 						return;
 					LoggingService.LogError ("ReadMessage failed", ex);
+					Log (ex.Message);
 					StopRemoteProcess (isAsync: true);
 					PostSetStatus (ConnectionStatus.ConnectionFailed, "Connection to remote process failed.");
 					return;
 				}
 
+				Log ("Calling HandleMessage id=" + msg.Id);
 				HandleMessage (msg, type);
 			}
 		}
@@ -547,20 +625,24 @@ namespace MonoDevelop.Core.Execution
 		async void HandleMessage (BinaryMessage msg, byte type)
 		{
 			var t = Task.Run (() => {
+				Log ("Task start");
 				msg = LoadMessageData (msg);
 				if (type == 0)
 					ProcessResponse (msg);
 				else
 					ProcessRemoteMessage (msg);
+				Log ("Task end");
 			});
 
 			try {
 				lock (pendingMessageTasks)
 					pendingMessageTasks.Add (t);
 
+				Log ("await t");
 				await t.ConfigureAwait (false);
 			} catch (Exception e) {
 				LoggingService.LogError ("RemoteProcessConnection.HandleMessage failed", e);
+				Log (e.Message);
 			} finally {
 				lock (pendingMessageTasks)
 					pendingMessageTasks.Remove (t);
@@ -571,12 +653,15 @@ namespace MonoDevelop.Core.Execution
 
 		public Task ProcessPendingMessages ()
 		{
-			lock (pendingMessageTasks)
+			lock (pendingMessageTasks) {
+				Log ();
 				return Task.WhenAll (pendingMessageTasks.ToArray ());
+			}
 		}
 
 		BinaryMessage LoadMessageData (BinaryMessage msg)
 		{
+			Log ();
 			Type type;
 			if (messageTypes.TryGetValue (msg.Name, out type)) {
 				var res = (BinaryMessage)Activator.CreateInstance (type);
@@ -588,11 +673,15 @@ namespace MonoDevelop.Core.Execution
 
 		void ProcessResponse (BinaryMessage msg)
 		{
+			Log ();
+
 			DateTime respTime = DateTime.Now;
 			MessageRequest req;
 
 			lock (messageWaiters) {
+				Log ("In lock messageWaiters");
 				if (messageWaiters.TryGetValue (msg.Id, out req)) {
+					Log ("Remove " + msg.Id);
 					messageWaiters.Remove (msg.Id);
 					try {
 						var rt = req.Request.GetResponseType ();
@@ -602,6 +691,7 @@ namespace MonoDevelop.Core.Execution
 							msg = resp;
 						}
 					} catch (Exception ex) {
+						Log (ex);
 						msg = msg.CreateErrorResponse (ex.ToString ());
 					}
 
@@ -610,8 +700,11 @@ namespace MonoDevelop.Core.Execution
 						LogMessage (MessageType.Response, msg, time);
 					}
 
+					Log ($"{msg}");
+
 				} else if (DebugMode) {
 					req = null;
+					Log ("req = null " + msg);
 					LogMessage (MessageType.Response, msg, -1);
 				}
 			}
@@ -623,43 +716,54 @@ namespace MonoDevelop.Core.Execution
 
 		void NotifyResponse (MessageRequest req, BinaryMessage res)
 		{
+			Log ($"req={req} res={res}");
+
 			if (disposed || res == null) {
+				Log ($"disposed={disposed}");
 				req.TaskSource.SetException (new Exception ("Connection closed"));
 			}
 			else if (res.Name == "Error") {
+				Log ("res.Name = Error");
 				string msg = res.GetArgument<string> ("Message");
 				if (res.GetArgument<bool> ("IsInternal") && !string.IsNullOrEmpty (msg)) {
 					msg = "The operation failed due to an internal error: " + msg + ".";
 				}
 
 				// if someone else had already set the exception, don't crash
+				Log ("req.TaskSource.TrySetException: " + msg);
 				req.TaskSource.TrySetException (new RemoteProcessException (msg) { ExtendedDetails = res.GetArgument<string> ("Log") });
 			} else {
+				Log ("req.TaskSource.SetResult");
 				req.TaskSource.SetResult (res);
 			}
 		}
 
 		void ProcessRemoteMessage (BinaryMessage msg)
 		{
+			Log ("id=" + msg.Id.ToString ());
 			if (DebugMode)
 				LogMessage (MessageType.Message, msg);
 
 			if (msg.Name == "Connect") {
+				Log ("processConnectedEvent.TrySetResult(true)");
 				processConnectedEvent.TrySetResult (true);
 				return;
 			}
 
 			if (MessageReceived != null) {
 				Runtime.RunInMainThread (delegate {
+					Log ("MessageReceived?.Invoke");
 					MessageReceived?.Invoke (null, new MessageEventArgs () { Message = msg });
 				});
 			}
 
 			try {
+				Log ("Before foreach listeners");
 				foreach (var li in listeners) {
 					li.ProcessMessage (msg);
 				}
 			} catch (Exception ex) {
+				Log (ex);
 				LoggingService.LogError ("Exception in message invocation: " + msg, ex);
 			}
 		}
@@ -670,27 +774,30 @@ namespace MonoDevelop.Core.Execution
 
 		void LogMessage (MessageType type, BinaryMessage msg, int time = -1)
 		{
-			Console.Write ("[" + (Environment.TickCount - tickBase) + "] ");
+			Log ("[" + (Environment.TickCount - tickBase) + "] ");
 
 			if (type == MessageType.Request)
-				Console.WriteLine ("[CLIENT] XS >> RP " + msg);
+				Log ("[CLIENT] XS >> RP " + msg);
 			else if (type == MessageType.Response) {
 				if (time != -1)
-					Console.WriteLine ("[CLIENT] XS << RP " + time + "ms " + msg);
+					Log ("[CLIENT] XS << RP " + time + "ms " + msg);
 				else
-					Console.WriteLine ("[CLIENT] XS << RP " + msg);
+					Log ("[CLIENT] XS << RP " + msg);
 			}
 			else
-				Console.WriteLine ("[CLIENT] XS <- RP " + msg);
+				Log ("[CLIENT] XS <- RP " + msg);
 		}
 
 		void PingConnection (object state)
 		{
+			Log ();
 			bool lockTaken = false;
 			try {
 				Monitor.TryEnter (pingerLock, ref lockTaken);
-				if (!lockTaken)
+				if (!lockTaken) {
+					Log ("lockTaken=false");
 					return;
+				}
 
 				// only attempt to ping if the process is still there
 				if (pinger != null) {
@@ -699,11 +806,26 @@ namespace MonoDevelop.Core.Execution
 				}
 
 			} catch (Exception ex) {
+				Log (ex);
 				LoggingService.LogError ("Connection ping failed", ex);
 			} finally {
 				if (lockTaken)
 					Monitor.Exit (pingerLock);
 			}
+		}
+
+		private static object logLock = new object ();
+		private static readonly string logFilePath = @"C:\temp\md\" + Process.GetCurrentProcess ().Id.ToString () + ".txt";
+		public static void Log (string s = "", [CallerMemberName] string memberName = "", [CallerLineNumber] int lineNumber = 0)
+		{
+			lock (logLock) {
+				File.AppendAllText (logFilePath, $"{DateTime.Now.ToString ("HH:mm:ss.fff")} [thread: {Thread.CurrentThread.ManagedThreadId.ToString ().PadLeft (2, ' ')}]: {memberName} (line {lineNumber}): " + s + Environment.NewLine);
+			}
+		}
+
+		public static void Log (Exception ex, [CallerMemberName] string memberName = "", [CallerLineNumber] int lineNumber = 0)
+		{
+			Log ("Exception: " + ex.Message, memberName, lineNumber);
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
@@ -81,7 +81,7 @@ namespace MonoDevelop.Core.Execution
 		public bool IsReachable {
 			get {
 				var s = status;
-				return s != ConnectionStatus.ConnectionFailed && s != ConnectionStatus.Disconnected;
+				return process != null && s != ConnectionStatus.ConnectionFailed && s != ConnectionStatus.Disconnected;
 			}
 		}
 
@@ -298,6 +298,8 @@ namespace MonoDevelop.Core.Execution
 		{
 			// any exception bubbling up from here would crash the process
 			try {
+				// somehow capture that the process has exited
+				process = null;
 				if (!stopping)
 					AbortConnection (isAsync: true);
 			}
@@ -312,6 +314,11 @@ namespace MonoDevelop.Core.Execution
 
 		public Task<BinaryMessage> SendMessage (BinaryMessage message)
 		{
+			// do not attempt to send new messages if the process has already exited
+			if (process == null || process.IsCompleted) {
+				return Task.FromException<BinaryMessage> (new Exception ("Process not running"));
+			}
+
 			message.ReadCustomData ();
 			var interceptor = Interceptor;
 			if (interceptor != null && !interceptor.PreProcessMessage (message))
@@ -447,8 +454,13 @@ namespace MonoDevelop.Core.Execution
 		void StopPinger ()
 		{
 			if (pinger != null) {
-				pinger.Dispose ();
-				pinger = null;
+				// not sure but it seems that if multiple places call StopPinger we should lock here
+				lock (pingerLock) {
+					if (pinger != null) {
+						pinger.Dispose ();
+						pinger = null;
+					}
+				}
 			}
 		}
 
@@ -457,7 +469,11 @@ namespace MonoDevelop.Core.Execution
 			if (process != null)
 				stopping = true;
 
-			AbortConnection (isAsync: isAsync);
+			if (stopping) {
+				// only abort connection if the process is still there
+				AbortConnection (isAsync: isAsync);
+			}
+
 			StopPinger ();
 
 			if (listener != null) {
@@ -472,7 +488,10 @@ namespace MonoDevelop.Core.Execution
 				connection.Close ();
 				connection = null;
 			}
-			process.Cancel ();
+
+			if (stopping) {
+				process.Cancel ();
+			}
 		}
 
 		void OnConnected (IAsyncResult res)
@@ -672,8 +691,13 @@ namespace MonoDevelop.Core.Execution
 				Monitor.TryEnter (pingerLock, ref lockTaken);
 				if (!lockTaken)
 					return;
-				var msg = new BinaryMessage ("Ping", "Process");
-				SendMessage (msg);
+
+				// only attempt to ping if the process is still there
+				if (pinger != null) {
+					var msg = new BinaryMessage ("Ping", "Process");
+					SendMessage (msg);
+				}
+
 			} catch (Exception ex) {
 				LoggingService.LogError ("Connection ping failed", ex);
 			} finally {


### PR DESCRIPTION
@slluis I've found that instrumenting the RemoteProcessConnection.cs like this really helps to debug and investigate what's going on.

Of course this is just for debugging, do not merge.