### PR TITLE
Changes needed to build MD on Windows

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -90,7 +90,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
-    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Windows_NT'">$(MSBuildToolsPath)\</MSBuild_OSS_BinDir>
+    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Windows_NT'">C:\MSBuild\bin\Bootstrap\MSBuild\15.0\Bin\</MSBuild_OSS_BinDir>
     <!-- when building with xbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/xbuild/*/bin`
 	 when building with msbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/msbuild/*/bin`
 	 Prefer referencing msbuild 15.* assemblies over 14.1 . At runtime, we use correct one anyway

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Runtime.cs
 //
 // Author:
@@ -483,6 +483,7 @@ namespace MonoDevelop.Core
 		{
 			// Explicitly load the msbuild libraries since they are not installed in the GAC
 			var path = systemAssemblyService.CurrentRuntime.GetMSBuildBinPath ("15.0");
+			path = @"C:\MSBuild\bin\Bootstrap\MSBuild\15.0\Bin";
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.dll"));
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Framework.dll"));
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Utilities.Core.dll"));

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.MSBuildResolver/MonoDevelop.MSBuildResolver.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.MSBuildResolver/MonoDevelop.MSBuildResolver.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>MonoDevelop.MSBuildResolver</RootNamespace>
     <AssemblyName>MonoDevelop.MSBuildResolver</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Windows_NT'">$(MSBuildToolsPath)\</MSBuild_OSS_BinDir>
+    <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Windows_NT'">C:\MSBuild\bin\Bootstrap\MSBuild\15.0\bin\</MSBuild_OSS_BinDir>
     <!-- when building with xbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/xbuild/*/bin`
 	 when building with msbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/msbuild/*/bin`
 	 Prefer referencing msbuild 15.* assemblies over 14.1 . At runtime, we use correct one anyway


### PR DESCRIPTION
This demonstrates a workaround of how to build Monodevelop on Windows.

The problem right now is we took a dependency on SdkResolver APIs that will only appear in MSBuild 15.3. Since the chances are the majority don't have the preview of VS 2017 Update 3 with these changes installed, the MD build will fail.

These three changes make it work again. Important: for this to work you need to:

 1. C:\\> `git clone https://github.com/Microsoft/MSBuild`
 2. C:\\> `cd MSBuild`
 3. C:\MSBuild> `cibuild --Scope Compile`