### PR TITLE
[d15-3][Gettext] Do not include CDATA tags in translations

### DIFF
--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.addin.xml
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.addin.xml
@@ -112,7 +112,7 @@
 		</XmlRegexScanner>
 		<XmlRegexScanner extension="xml" mimeType="application/xml">
 			<Include regex='\s_[-A-Za-z0-9._:]+\s*=\s*"([^"]+)"' escapeMode="Xml" />
-			<Include regex="&lt;_[^&gt;]+&gt;((?:.|\n)*?)&lt;/_[^&gt;]+&gt;" escapeMode="Xml" />
+			<Include regex="&lt;_[^&gt;]+&gt;(?:&lt;!\[CDATA\[)?((?:.|\n)*?)(?:\]\]&gt;)?&lt;/_[^&gt;]+&gt;" escapeMode="Xml" />
 		</XmlRegexScanner>
 		<RegexScanner extension="vb">
 			<Exclude regex='".*?[^"]"(?!")' />   <!-- Strings-->


### PR DESCRIPTION
CDATA tags that were inside translatable xml elements were included
in the extracted translation text when the files are scanned. The
CDATA tags themselves should not be displayed to the user so they are
now excluded with the regular expression. CDATA tags are used in
the project templates and were not translated since the text being
passed to the translation catalog would not include these tags and
would not find a match.