### PR TITLE
Fixed 'Bug 57392 - ctor code snippet is producing an nameless

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/ExpansionObject.cs
@@ -38,6 +38,7 @@ using System.Linq;
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide.Editor.Extension;
 using System.Web.SessionState;
+using System.Threading;
 
 namespace MonoDevelop.Ide.CodeTemplates
 {
@@ -50,10 +51,7 @@ namespace MonoDevelop.Ide.CodeTemplates
 		
 		public SemanticModel Compilation {
 			get {
-				var analysisDocument = DocumentContext.ParsedDocument;
-				if (analysisDocument == null)
-					return null;
-				return analysisDocument.GetAst<SemanticModel> ();
+				return DocumentContext.AnalysisDocument.GetSemanticModelAsync (default (CancellationToken)).WaitAndGetResult (default (CancellationToken));
 			}
 		}
 


### PR DESCRIPTION
constructor'

We should consider replacing our code template system with the VS.NET
one or rework the system.