### PR TITLE
[F#] Simplify Task usage

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Shared/Extensions.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Shared/Extensions.fs
@@ -1,6 +1,7 @@
 ﻿namespace MonoDevelop.FSharp.Shared
 open System
 open System.Text
+open System.Threading.Tasks
 open System.IO
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open ExtCore
@@ -240,3 +241,16 @@ module AsyncChoiceCE =
 module Async =
     let inline startAsPlainTask (work : Async<unit>) =
         System.Threading.Tasks.Task.Factory.StartNew(fun () -> work |> Async.RunSynchronously)
+
+    let inline awaitPlainTask (task: Task) = 
+        let continuation (t : Task) : unit =
+            if t.IsFaulted then raise t.Exception
+        task.ContinueWith continuation |> Async.AwaitTask
+
+[<AutoOpen>]
+module AsyncTaskBind =
+    type Microsoft.FSharp.Control.AsyncBuilder with
+        member x.Bind(computation:Task<'T>, binder:'T -> Async<'R>) =  x.Bind(Async.AwaitTask computation, binder)
+        member x.ReturnFrom(computation:Task<'T>) = x.ReturnFrom(Async.AwaitTask computation)
+        member x.Bind(computation:Task, binder:unit -> Async<unit>) =  x.Bind(Async.awaitPlainTask computation, binder)
+        member x.ReturnFrom(computation:Task) = x.ReturnFrom(Async.awaitPlainTask computation)

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/CompilerArguments.fs
@@ -29,8 +29,7 @@ type CompilerArgumentsTests() =
             let testProject = Services.ProjectService.CreateDotNetProject ("F#") :?> FSharpProject
             testProject.FileName <- Path.GetTempFileName() |> FilePath
 
-
-            let! _ = testProject.SaveAsync monitor |> Async.AwaitTask
+            do! testProject.SaveAsync monitor |> Async.awaitPlainTask
             do! testProject.ReevaluateProject(monitor)
             return testProject
         }

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
@@ -100,8 +100,8 @@ type ``Template tests``() =
             let projects = sln.Items |> Seq.filter(fun i -> i :? DotNetProject) |> Seq.cast<DotNetProject> |> List.ofSeq
 
 
-            do! NuGetPackageInstaller.InstallPackages (sln, projectTemplate.PackageReferencesForCreatedProjects) |> Async.AwaitTask
-            do! sln.SaveAsync(monitor) |> Async.AwaitTask
+            do! NuGetPackageInstaller.InstallPackages (sln, projectTemplate.PackageReferencesForCreatedProjects)
+            do! sln.SaveAsync(monitor)
 
             let getErrorsForProject (projects: DotNetProject list) =
                 asyncSeq {

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -280,10 +280,9 @@ type FSharpProject() as self =
         let task = base.OnReevaluateProject (e)
 
         async {
-            do! task |> Async.AwaitTask
-
+            do! task
             MDLanguageService.invalidateProjectFile self.FileName
-            let! refs = x.GetReferencedAssemblies (CompilerArguments.getConfig()) |> Async.AwaitTask
+            let! refs = x.GetReferencedAssemblies (CompilerArguments.getConfig())
             referencedAssemblies <- Some refs
         }
 

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
@@ -172,7 +172,6 @@ module Refactoring =
         async {
             do! Async.SwitchToContext(Runtime.MainSynchronizationContext)
             let! jumped = RefactoringService.TryJumpToDeclarationAsync(symbol.XmlDocSig, ctx.Project)
-                          |> Async.AwaitTask
 
             if not jumped then
                 match symbol.Assembly.FileName with

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -326,7 +326,8 @@ module CompilerArguments =
        yield "--out:" + project.GetOutputFileName(configSelector).ToString()
        if Project.isPortable project || Project.isDotNetCoreProject project then
            yield "--targetprofile:netcore"
-       yield "--platform:" + fsconfig.PlatformTarget
+       if not (String.IsNullOrWhiteSpace fsconfig.PlatformTarget) then
+           yield "--platform:" + fsconfig.PlatformTarget
        yield "--fullpaths"
        yield "--flaterrors"
        for symbol in defines do yield "--define:" + symbol

--- a/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/Program.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/Program.fs
@@ -74,13 +74,13 @@ module CompletionServer =
 
         let writeOutput (s:string) =
             async {
-                do! outStream.WriteLineAsync s |> Async.AwaitTask
+                do! outStream.WriteLineAsync s
             }
 
         let writeData commandType obj =
             async {
                 let json = JsonConvert.SerializeObject obj
-                do! Console.Error.WriteLineAsync (commandType + " " + json) |> Async.AwaitTask
+                do! Console.Error.WriteLineAsync (commandType + " " + json)
             }
 
         let renderImage (image:Image) =
@@ -110,7 +110,7 @@ module CompletionServer =
 
             let parseInput() =
                 async {
-                    let! command = inStream.ReadLineAsync() |> Async.AwaitTask
+                    let! command = inStream.ReadLineAsync()
 
                     match command with
                     | Input input ->

--- a/main/external/fsharpbinding/paket.lock
+++ b/main/external/fsharpbinding/paket.lock
@@ -8,7 +8,7 @@ NUGET
     FSharp.Compiler.CodeDom (0.9.2)
     FSharp.Compiler.Service (11.0.10)
       System.Collections.Immutable (>= 1.2)
-      System.Reflection.Metadata (>= 1.4.1-beta-24227-04)
+      System.Reflection.Metadata (>= 1.4.2)
     FSharp.Core (4.1.0.2)
       System.ValueTuple (>= 4.3)
     Mono.Cecil (0.9.6.4)


### PR DESCRIPTION
Simplify Task usage by allowing async to bind and return `Task` or `Task<T>`