### PR TITLE
[D15.3][Git] Fix misleading exception being thrown on declining auth prompt

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -179,9 +179,10 @@ namespace MonoDevelop.VersionControl.Git
 						PasswordService.AddWebUserNameAndPassword (uri, upcred.Username, upcred.Password);
 					}
 				}
+				return cred;
 			}
 
-			return cred;
+			throw new VersionControlException (GettextCatalog.GetString ("Operation cancelled by the user"));
 		}
 
 		static bool KeyHasPassphrase (string key)


### PR DESCRIPTION
Bug 56534 - Update git repo on VSTS fails with "null username or password"