### PR TITLE
Add accessibility attributes to the preferences dialog

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CodeGenerationPanel.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CodeGenerationPanel.cs
@@ -58,37 +58,32 @@ namespace MonoDevelop.CSharp.Project
 
 		void SetupAccessibility ()
 		{
-			generateOverflowChecksCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.OverflowChecks", null, 
+			generateOverflowChecksCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.OverflowChecks", "", 
 			                                                                    GettextCatalog.GetString ("Check this to enable overflow checking"));
-			enableOptimizationCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.Optimizations", null,
+			enableOptimizationCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.Optimizations", "",
 			                                                                GettextCatalog.GetString ("Check this to enable optimizations"));
-			generateXmlOutputCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.XmlDoc", null,
+			generateXmlOutputCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.XmlDoc", "",
 			                                                               GettextCatalog.GetString ("Check this to generate XML documentation"));
 			xmlDocsEntry.EntryAccessible.Name = "CompilerOptions.XmlEntry";
 			xmlDocsEntry.EntryAccessible.SetLabel (GettextCatalog.GetString ("XML Filename"));
 			xmlDocsEntry.EntryAccessible.Description = GettextCatalog.GetString ("Enter the filename for the generated XML documentation");
 
-			comboDebug.SetCommonAccessibilityAttributes ("CompilerOptions.DebugCombo", GettextCatalog.GetString ("Debug Information"),
+			comboDebug.SetCommonAccessibilityAttributes ("CompilerOptions.DebugCombo", label2,
 			                                             GettextCatalog.GetString ("Select the level of debugging information to be generated"));
-			comboDebug.SetAccessibilityLabelRelationship (label2);
 
-			symbolsEntry.SetCommonAccessibilityAttributes ("CompilerOptions.SymbolsEntry", GettextCatalog.GetString ("Define Symbols"),
+			symbolsEntry.SetCommonAccessibilityAttributes ("CompilerOptions.SymbolsEntry", label87,
 			                                               GettextCatalog.GetString ("Enter the symbols the compiler should define"));
-			symbolsEntry.SetAccessibilityLabelRelationship (label87);
 
-			comboPlatforms.SetCommonAccessibilityAttributes ("CompilerOptions.Platforms", GettextCatalog.GetString ("Platform Target"),
+			comboPlatforms.SetCommonAccessibilityAttributes ("CompilerOptions.Platforms", label1,
 			                                                 GettextCatalog.GetString ("Select the platform to target"));
-			comboPlatforms.SetAccessibilityLabelRelationship (label1);
 
-			warningLevelSpinButton.SetCommonAccessibilityAttributes ("CompilerOptions.WarningsLevel", GettextCatalog.GetString ("Warning Level"),
+			warningLevelSpinButton.SetCommonAccessibilityAttributes ("CompilerOptions.WarningsLevel", label85,
 			                                                         GettextCatalog.GetString ("Select the warning level to use"));
-			warningLevelSpinButton.SetAccessibilityLabelRelationship (label85);
 
-			ignoreWarningsEntry.SetCommonAccessibilityAttributes ("CompilerOptions.IgnoreWarnings", GettextCatalog.GetString ("Ignore Warnings"),
+			ignoreWarningsEntry.SetCommonAccessibilityAttributes ("CompilerOptions.IgnoreWarnings", label86,
 			                                                      GettextCatalog.GetString ("Enter the warning numbers separated by a comma that the compile should ignore"));
-			ignoreWarningsEntry.SetAccessibilityLabelRelationship (label86);
 
-			warningsAsErrorsCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.WarningsAsErrors", null,
+			warningsAsErrorsCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.WarningsAsErrors", "",
 			                                                              GettextCatalog.GetString ("Check to treat warnings as errors"));
 		}
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
@@ -131,32 +131,25 @@ namespace MonoDevelop.CSharp.Project
 
 		void SetupAccessibility ()
 		{
-			compileTargetCombo.SetCommonAccessibilityAttributes ("CodeGeneration.CompileTarget",
-			                                                     GettextCatalog.GetString ("Compile Target"),
+			compileTargetCombo.SetCommonAccessibilityAttributes ("CodeGeneration.CompileTarget", label86,
 			                                                     GettextCatalog.GetString ("Select the compile target for the code generation"));
-			compileTargetCombo.SetAccessibilityLabelRelationship (label86);
 
-			mainClassEntry.SetCommonAccessibilityAttributes ("CodeGeneration.MainClass",
-			                                                 GettextCatalog.GetString ("Main Class"),
+			mainClassEntry.SetCommonAccessibilityAttributes ("CodeGeneration.MainClass", label88,
 			                                                 GettextCatalog.GetString ("Enter the main class for the code generation"));
-			mainClassEntry.SetAccessibilityLabelRelationship (label88);
 
-			iconEntry.SetEntryAccessibilityAttributes ("CodeGeneration.WinIcon", GettextCatalog.GetString ("Win32 Icon"),
+			iconEntry.SetEntryAccessibilityAttributes ("CodeGeneration.WinIcon", "",
 			                                           GettextCatalog.GetString ("Enter the file to use as the icon on Windows"));
 			iconEntry.SetAccessibilityLabelRelationship (label3);
 
-			codepageEntry.SetCommonAccessibilityAttributes ("CodeGeneration.CodePage", GettextCatalog.GetString ("Compiler Code Page"),
+			codepageEntry.SetCommonAccessibilityAttributes ("CodeGeneration.CodePage", label1,
 			                                                GettextCatalog.GetString ("Select the compiler code page"));
-			codepageEntry.SetAccessibilityLabelRelationship (label1);
 
-			noStdLibCheckButton.SetCommonAccessibilityAttributes ("CodeGeneration.NoStdLib", null, GettextCatalog.GetString ("Whether or not to include a reference to mscorlib.dll"));
+			noStdLibCheckButton.SetCommonAccessibilityAttributes ("CodeGeneration.NoStdLib", "", GettextCatalog.GetString ("Whether or not to include a reference to mscorlib.dll"));
 
-			langVerCombo.SetCommonAccessibilityAttributes ("CodeGeneration.LanguageVersion",
-			                                               GettextCatalog.GetString ("C# Language Version"),
+			langVerCombo.SetCommonAccessibilityAttributes ("CodeGeneration.LanguageVersion", label2,
 			                                               GettextCatalog.GetString ("Select the version of C# to use"));
-			langVerCombo.SetAccessibilityLabelRelationship (label2);
 
-			allowUnsafeCodeCheckButton.SetCommonAccessibilityAttributes ("CodeGeneration.AllowUnsafe", null,
+			allowUnsafeCodeCheckButton.SetCommonAccessibilityAttributes ("CodeGeneration.AllowUnsafe", "",
 			                                                             GettextCatalog.GetString ("Check to allow 'unsafe' code"));
 		}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugApplicationDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugApplicationDialog.cs
@@ -42,23 +42,21 @@ namespace MonoDevelop.Debugger
 
 		void SetupAccessibility ()
 		{
-			fileEntry.EntryAccessible.SetCommonAttributes ("DebugApplicationDialog.FileEntry", null,
+			fileEntry.EntryAccessible.SetCommonAttributes ("DebugApplicationDialog.FileEntry", "",
 			                                               GettextCatalog.GetString ("Select the file to debug"));
 			fileEntry.EntryAccessible.SetTitleUIElement (label7.Accessible);
 			label7.Accessible.SetTitleFor (fileEntry.EntryAccessible);
 
-			folderEntry.EntryAccessible.SetCommonAttributes ("DebugApplicationDialog.FolderEntry", null,
+			folderEntry.EntryAccessible.SetCommonAttributes ("DebugApplicationDialog.FolderEntry", "",
 			                                                 GettextCatalog.GetString ("Select the working directory for execution"));
 			folderEntry.EntryAccessible.SetTitleUIElement (label9.Accessible);
 			label9.Accessible.SetTitleFor (folderEntry.EntryAccessible);
 
-			argsEntry.SetCommonAccessibilityAttributes ("DebugApplicationDialog.ArgumentsEntry", null,
+			argsEntry.SetCommonAccessibilityAttributes ("DebugApplicationDialog.ArgumentsEntry", label8,
 			                                            GettextCatalog.GetString ("Enter arguments to be passed to the executable"));
-			argsEntry.SetAccessibilityLabelRelationship (label8);
 
-			envVarList.SetCommonAccessibilityAttributes ("DebugApplicationDialog.EnvironmentList", null,
+			envVarList.SetCommonAccessibilityAttributes ("DebugApplicationDialog.EnvironmentList", label6,
 			                                             GettextCatalog.GetString ("Enter any environment variables that need to be set before execution"));
-			envVarList.SetAccessibilityLabelRelationship (label6);
 
 			buttonCancel.Accessible.SetLabel (GettextCatalog.GetString ("Cancel"));
 			buttonOk.Accessible.SetLabel (GettextCatalog.GetString ("Ok"));

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerOptionsPanelWidget.cs
@@ -27,6 +27,7 @@
 using System;
 using Mono.Debugging.Client;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.Gui.Dialogs;
 using Xwt;
 using MonoDevelop.Core;
@@ -62,6 +63,7 @@ namespace MonoDevelop.Debugger
 		CheckBox checkGroupStatic;
 		SpinButton spinTimeout;
 		CheckBox enableLogging;
+		Label evalLabel;
 
 		void Build ()
 		{
@@ -82,7 +84,8 @@ namespace MonoDevelop.Debugger
 			checkGroupStatic = new CheckBox (GettextCatalog.GetString ("Group static members"));
 			PackStart (checkGroupStatic);
 			var evalBox = new HBox ();
-			evalBox.PackStart (new Label (GettextCatalog.GetString ("Evaluation Timeout:")));
+			evalLabel = new Label (GettextCatalog.GetString ("Evaluation Timeout:"));
+			evalBox.PackStart (evalLabel);
 			spinTimeout = new SpinButton ();
 			spinTimeout.ClimbRate = 100;
 			spinTimeout.Digits = 0;
@@ -99,6 +102,30 @@ namespace MonoDevelop.Debugger
 			});
 			enableLogging = new CheckBox (GettextCatalog.GetString ("Enable diagnostic logging", BrandingService.ApplicationName));
 			PackStart (enableLogging);
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			checkProjectCodeOnly.SetCommonAccessibilityAttributes ("DebuggerPanel.projectCodeOnly", "",
+			                                                       GettextCatalog.GetString ("Check to only debug the project code and not step into framework code"));
+			checkStepOverPropertiesAndOperators.SetCommonAccessibilityAttributes ("DebuggerPanel.stepOverProperties", "",
+			                                                                      GettextCatalog.GetString ("Check to step over properties and operators"));
+			checkAllowEval.SetCommonAccessibilityAttributes ("DebuggerPanel.allowEval", "",
+			                                                 GettextCatalog.GetString ("Check to allow implicit property evaluation and method invocation"));
+			checkAllowToString.SetCommonAccessibilityAttributes ("DebuggerPanel.allowToString", "",
+			                                                     GettextCatalog.GetString ("Check to call string-conversion functions on objects in the Variables windows"));
+			checkShowBaseGroup.SetCommonAccessibilityAttributes ("DebuggerPanel.showBaseGroup", "",
+			                                                     GettextCatalog.GetString ("Check to show inherited class members in a base class group"));
+			checkGroupPrivate.SetCommonAccessibilityAttributes ("DebuggerPanel.groupPrivate", "",
+			                                                    GettextCatalog.GetString ("Check to group non-public members in the Variables windows"));
+			checkGroupStatic.SetCommonAccessibilityAttributes ("DebuggerPanel.groupStatic", "",
+			                                                   GettextCatalog.GetString ("Check to group static members in the Variables windows"));
+			spinTimeout.SetCommonAccessibilityAttributes ("DebuggerPanel.timeout", evalLabel,
+			                                              GettextCatalog.GetString ("Set the length of time the evaluation will wait before giving up"));
+			enableLogging.SetCommonAccessibilityAttributes ("DebuggerPanel.enableLogging", "",
+			                                                GettextCatalog.GetString ("Check to enable some diagnostic logging"));
 		}
 
 		public DebuggerOptionsPanelWidget ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackageSourceDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackageSourceDialog.UI.cs
@@ -26,6 +26,7 @@
 
 using System;
 using MonoDevelop.Core;
+using MonoDevelop.Components.AtkCocoaHelper;
 using Xwt;
 
 namespace MonoDevelop.PackageManagement
@@ -47,10 +48,12 @@ namespace MonoDevelop.PackageManagement
 			int labelWidth = 80;
 
 			var mainVBox = new VBox ();
+			mainVBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			Content = mainVBox;
 
 			// Package source name.
 			var packageSourceNameHBox = new HBox ();
+			packageSourceNameHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			mainVBox.PackStart (packageSourceNameHBox);
 
 			var packageSourceNameLabel = new Label ();
@@ -60,10 +63,13 @@ namespace MonoDevelop.PackageManagement
 			packageSourceNameHBox.PackStart (packageSourceNameLabel);
 
 			packageSourceNameTextEntry = new TextEntry ();
+			packageSourceNameTextEntry.SetCommonAccessibilityAttributes ("PackageSourceDialog.name", packageSourceNameLabel,
+			                                                             GettextCatalog.GetString ("Enter the name for this package source"));
 			packageSourceNameHBox.PackEnd (packageSourceNameTextEntry, true);
 
 			// Package source URL.
 			var packageSourceUrlHBox = new HBox ();
+			packageSourceUrlHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			mainVBox.PackStart (packageSourceUrlHBox);
 
 			var packageSourceUrlLabel = new Label ();
@@ -73,6 +79,8 @@ namespace MonoDevelop.PackageManagement
 			packageSourceUrlHBox.PackStart (packageSourceUrlLabel);
 
 			packageSourceUrlTextEntry = new TextEntry ();
+			packageSourceUrlTextEntry.SetCommonAccessibilityAttributes ("PackageSourceDialog.url", packageSourceUrlLabel,
+			                                                            GettextCatalog.GetString ("Enter the URL for this package source"));
 			packageSourceUrlTextEntry.PlaceholderText = GettextCatalog.GetString ("URL or folder");
 			packageSourceUrlHBox.PackStart (packageSourceUrlTextEntry, true);
 
@@ -82,6 +90,7 @@ namespace MonoDevelop.PackageManagement
 
 			// Package source username.
 			var packageSourceUserNameHBox = new HBox ();
+			packageSourceUserNameHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			mainVBox.PackStart (packageSourceUserNameHBox);
 
 			var packageSourceUserNameLabel = new Label ();
@@ -91,11 +100,14 @@ namespace MonoDevelop.PackageManagement
 			packageSourceUserNameHBox.PackStart (packageSourceUserNameLabel);
 
 			packageSourceUserNameTextEntry = new TextEntry ();
+			packageSourceUserNameTextEntry.SetCommonAccessibilityAttributes ("PackageSourceDialog.username", packageSourceUserNameLabel,
+			                                                                 GettextCatalog.GetString ("Enter the username (if required) for this package source"));
 			packageSourceUserNameTextEntry.PlaceholderText = GettextCatalog.GetString ("Private sources only");
 			packageSourceUserNameHBox.PackEnd (packageSourceUserNameTextEntry, true);
 
 			// Package source password.
 			var packageSourcePasswordHBox = new HBox ();
+			packageSourcePasswordHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			mainVBox.PackStart (packageSourcePasswordHBox);
 
 			var packageSourcePasswordLabel = new Label ();
@@ -105,6 +117,8 @@ namespace MonoDevelop.PackageManagement
 			packageSourcePasswordHBox.PackStart (packageSourcePasswordLabel);
 
 			packageSourcePasswordTextEntry = new PasswordEntry ();
+			packageSourcePasswordTextEntry.SetCommonAccessibilityAttributes ("PackageSourceDialog.password", packageSourcePasswordLabel,
+			                                                                 GettextCatalog.GetString ("Enter the password (if required) for this package source"));
 			packageSourcePasswordTextEntry.PlaceholderText = GettextCatalog.GetString ("Private sources only");
 			packageSourcePasswordHBox.PackEnd (packageSourcePasswordTextEntry, true);
 

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkProjectNuGetBuildOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkProjectNuGetBuildOptionsPanelWidget.cs
@@ -46,7 +46,7 @@ namespace MonoDevelop.Packaging.Gui
 
 		void SetupAccessibility ()
 		{
-			packOnBuildButton.SetCommonAccessibilityAttributes ("NugetBuildOptionsPanel.PackOnBuild", null,
+			packOnBuildButton.SetCommonAccessibilityAttributes ("NugetBuildOptionsPanel.PackOnBuild", "",
 			                                                    GettextCatalog.GetString ("Check to create a NuGet package when building"));
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/BehaviorPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/BehaviorPanel.cs
@@ -25,6 +25,7 @@
 
 using System;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 using Mono.TextEditor;
@@ -46,8 +47,36 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			controlLeftRightCombobox.InsertText (1, GettextCatalog.GetString ("Windows"));
 			
 			autoInsertBraceCheckbutton.Toggled += HandleAutoInsertBraceCheckbuttonToggled;
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			tabAsReindentCheckbutton.SetCommonAccessibilityAttributes ("BehaviorPanel.tabsAsReindent", "",
+			                                                           GettextCatalog.GetString ("Check to use the Tab key as a reindent command"));
+			smartBackspaceCheckbutton.SetCommonAccessibilityAttributes ("BehaviorPanel.smartBackspace", "",
+			                                                            GettextCatalog.GetString ("Check to make Backspace remove indentation"));
+			autoInsertBraceCheckbutton.SetCommonAccessibilityAttributes ("BehaviorPanel.autoInsertBrace", "",
+			                                                             GettextCatalog.GetString ("Check to automatically insert braces"));
+			smartSemicolonPlaceCheckbutton.SetCommonAccessibilityAttributes ("BehaviorPanel.smartSemicolon", "",
+			                                                                 GettextCatalog.GetString ("Check to use smart semicolon placement"));
+			checkbuttonFormatOnSave.SetCommonAccessibilityAttributes ("BehaviorPanel.formatOnSave", "",
+			                                                          GettextCatalog.GetString ("Check to reformat the document when saving"));
+			checkbuttonOnTheFlyFormatting.SetCommonAccessibilityAttributes ("BehaviorPanel.formatOnFly", "",
+			                                                                GettextCatalog.GetString ("Check to reformat the document while typing"));
+			checkbuttonAutoSetSearchPatternCasing.SetCommonAccessibilityAttributes ("BehaviorPanel.autoSearchPattern", "",
+			                                                                        GettextCatalog.GetString ("Check to automatically set the search pattern case sensitivity"));
+			checkbuttonEnableSelectionSurrounding.SetCommonAccessibilityAttributes ("BehaviorPanel.enableSelectionSurrounding", "",
+			                                                                        GettextCatalog.GetString ("Check to enable selection surrounding keys"));
+			checkbuttonGenerateFormattingUndoStep.SetCommonAccessibilityAttributes ("BehaviorPanel.generateFormattingUndo", "",
+			                                                                        GettextCatalog.GetString ("Check to add undo step for formatting changes"));
+			indentationCombobox.SetCommonAccessibilityAttributes ("BehaviorPanel.indentation", label1,
+			                                                      GettextCatalog.GetString ("Select the indentation mode"));
+			controlLeftRightCombobox.SetCommonAccessibilityAttributes ("BehaviorPanel.wordBreakMode", label2,
+			                                                           GettextCatalog.GetString ("Select the word break mode"));
+		}
+
 		public virtual Control CreatePanelWidget ()
 		{
 			//			this.autoInsertTemplateCheckbutton.Active  = DefaultSourceEditorOptions.Options.AutoInsertTemplates;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/GeneralOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/GeneralOptionsPanel.cs
@@ -26,6 +26,7 @@
 using System;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Content;
 using MonoDevelop.Ide.Editor; 
@@ -42,6 +43,20 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.comboboxLineEndings.AppendText (GettextCatalog.GetString ("Leave line endings as is"));
 			this.comboboxLineEndings.AppendText (GettextCatalog.GetString ("Always convert line endings"));
 			this.comboboxLineEndings.Active = (int)DefaultSourceEditorOptions.Instance.LineEndingConversion;
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			comboboxLineEndings.SetCommonAccessibilityAttributes ("SourceEditorGeneral.lineEndings", label1,
+			                                                      GettextCatalog.GetString ("Select how to handle line ending conversions"));
+			foldingCheckbutton.SetCommonAccessibilityAttributes ("SourceEditorGeneral.folding", "",
+			                                                     GettextCatalog.GetString ("Check to enable line folding"));
+			foldregionsCheckbutton.SetCommonAccessibilityAttributes ("SourceEditorGeneral.regions", "",
+			                                                         GettextCatalog.GetString ("Check to fold regions by default"));
+			foldCommentsCheckbutton.SetCommonAccessibilityAttributes ("SourceEditorGeneral.commens", "",
+			                                                          GettextCatalog.GetString ("Check to fold comments by default"));
 		}
 
 		public virtual Control CreatePanelWidget ()

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/MarkerPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/MarkerPanel.cs
@@ -26,6 +26,7 @@
 using System;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide;
@@ -69,6 +70,37 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			showWhitespaces = DefaultSourceEditorOptions.Instance.ShowWhitespaces;
 			includeWhitespaces = DefaultSourceEditorOptions.Instance.IncludeWhitespaces;
 			enableQuickDiff = DefaultSourceEditorOptions.Instance.EnableQuickDiff;
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			checkbuttonTabs.SetCommonAccessibilityAttributes ("MarkerPanel.tabs", "",
+			                                                  GettextCatalog.GetString ("Check to show tabs when showing invisible characters"));
+			checkbuttonSpaces.SetCommonAccessibilityAttributes ("MarkerPanel.spaces", "",
+			                                                    GettextCatalog.GetString ("Check to show spaces when showing invisible characters"));
+			checkbuttonLineEndings.SetCommonAccessibilityAttributes ("MarkerPanel.lineEndings", "",
+			                                                         GettextCatalog.GetString ("Check to show line endings when showing invisible characters"));
+			showRulerCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.showRuler", "",
+			                                                       GettextCatalog.GetString ("Check to show the column ruler"));
+			showLineNumbersCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.showLineNumbers", "",
+			                                                             GettextCatalog.GetString ("Check to show line numbers"));
+			highlightCurrentLineCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.highlightCurrentLine", "",
+			                                                                  GettextCatalog.GetString ("Check to highlight to current line"));
+			highlightMatchingBracketCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.highlightMatching", "",
+			                                                                      GettextCatalog.GetString ("Check to highlight the matching bracket"));
+			enableHighlightUsagesCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.highlightUsages", "",
+			                                                                   GettextCatalog.GetString ("Check to highlight identifier references"));
+			enableAnimationCheckbutton1.SetCommonAccessibilityAttributes ("MarkerPanel.enableAnim", "",
+			                                                              GettextCatalog.GetString ("Check to enable animations in the text editor"));
+			enableQuickDiffCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.quickDiff", "",
+			                                                             GettextCatalog.GetString ("Check to highlight changed line"));
+			drawIndentMarkersCheckbutton.SetCommonAccessibilityAttributes ("MarkerPanel.drawIndent", "",
+			                                                               GettextCatalog.GetString ("Check to draw indentation markers"));
+
+			showWhitespacesCombobox.SetCommonAccessibilityAttributes ("MarkerPanel.showWhitespace", label1,
+			                                                          GettextCatalog.GetString ("Select when to show invisible characters"));
 		}
 		
 		public virtual Control CreatePanelWidget ()

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/CommitMessageStylePanelWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/CommitMessageStylePanelWidget.cs
@@ -59,26 +59,24 @@ namespace MonoDevelop.VersionControl
 			                                              GettextCatalog.GetString ("Enter the commit message header"));
 			entryHeader.SetAccessibilityLabelRelationship (label4);
 
-			checkUseBullets.SetCommonAccessibilityAttributes ("CommitMessageStyle.UseBullets", null,
+			checkUseBullets.SetCommonAccessibilityAttributes ("CommitMessageStyle.UseBullets", "",
 			                                                  GettextCatalog.GetString ("Check to use bullets for each entry"));
-			checkIndentEntries.SetCommonAccessibilityAttributes ("CommitMessageStyle.IndentEntries", null,
+			checkIndentEntries.SetCommonAccessibilityAttributes ("CommitMessageStyle.IndentEntries", "",
 			                                                     GettextCatalog.GetString ("Check to indent each entry"));
-			checkIndent.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckIndent", null,
+			checkIndent.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckIndent", "",
 			                                              GettextCatalog.GetString ("Check to align the message text"));
-			checkLineSep.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckLineSep", null,
+			checkLineSep.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckLineSep", "",
 			                                               GettextCatalog.GetString ("Check to add a blank line between messages"));
-			checkOneLinePerFile.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckOneLine", null,
+			checkOneLinePerFile.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckOneLine", "",
 			                                                      GettextCatalog.GetString ("Check to add one line per file changed"));
-			checkMsgInNewLine.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckMsgNewLine", null,
+			checkMsgInNewLine.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckMsgNewLine", "",
 			                                                    GettextCatalog.GetString ("Check to keep the file name and messages on separate lines"));
-			checkIncludeDirs.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckIncludeDirs", null,
+			checkIncludeDirs.SetCommonAccessibilityAttributes ("CommitMessageStyle.CheckIncludeDirs", "",
 			                                                   GettextCatalog.GetString ("Check to include file directories"));
-			checkWrap.SetCommonAccessibilityAttributes ("CommitMessageStyle.Wrap", null,
+			checkWrap.SetCommonAccessibilityAttributes ("CommitMessageStyle.Wrap", "",
 			                                            GettextCatalog.GetString ("Check to wrap the lines at 60 characters"));
-			textview.SetCommonAccessibilityAttributes ("CommitMessagesStyle.Preview",
-			                                           GettextCatalog.GetString ("Preview"),
+			textview.SetCommonAccessibilityAttributes ("CommitMessagesStyle.Preview", label9,
 			                                           GettextCatalog.GetString ("A preview of the settings above"));
-			textview.SetAccessibilityLabelRelationship (label9);
 		}
 
 		public void Load (CommitMessageFormat format, AuthorInformation uinfo)

--- a/main/src/addins/Xml/Editor/XmlEditorOptionsPanelWidget.cs
+++ b/main/src/addins/Xml/Editor/XmlEditorOptionsPanelWidget.cs
@@ -28,6 +28,7 @@
 
 using Gtk;
 using MonoDevelop.Core;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.Xml.Editor
 {
@@ -40,7 +41,11 @@ namespace MonoDevelop.Xml.Editor
 			Spacing = 6;
 
 			autoCompleteElementsCheck = new CheckButton (GettextCatalog.GetString ("Automatically insert closing tags"));
+			autoCompleteElementsCheck.SetCommonAccessibilityAttributes ("XmlOptionsPanel.autoComplete", "",
+			                                                            GettextCatalog.GetString ("Check to enable automatic close tag insertion"));
 			autoAddPunctuationCheck = new CheckButton (GettextCatalog.GetString ("Automatically insert punctuation (=\"\", />, etc.)"));
+			autoAddPunctuationCheck.SetCommonAccessibilityAttributes ("XmlOptionsPanel.autoAdd", "",
+			                                                          GettextCatalog.GetString ("Check to enable automatic punctuation insertion"));
 			showSchemaAnnotationCheck = new CheckButton (GettextCatalog.GetString ("Show schema annotation"));
 
 			PackStart (autoCompleteElementsCheck, false, false, 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelper.cs
@@ -43,18 +43,56 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			if (!string.IsNullOrEmpty (name)) {
 				o.Name = name;
 			}
-			if (!string.IsNullOrEmpty (name)) {
+			if (!string.IsNullOrEmpty (help)) {
 				o.Description = help;
 			}
-			if (!string.IsNullOrEmpty (name)) {
+			if (!string.IsNullOrEmpty (label)) {
 				o.SetLabel (label);
 			}
+		}
+
+		public static void SetCommonAttributes (this Xwt.Accessibility.Accessible o, string name, string label, string help)
+		{
+			if (!string.IsNullOrEmpty (name)) {
+				o.Identifier = name;
+			}
+
+			if (!string.IsNullOrEmpty (label)) {
+				o.Label = label;
+			}
+
+			if (!string.IsNullOrEmpty (help)) {
+				o.Description = help;
+			}
+		}
+
+		public static void SetCommonAccessibilityAttributes (this Xwt.Widget w, string name, Xwt.Widget label, string help)
+		{
+			w.Accessible.SetCommonAttributes (name, null, help);
+			if (label != null) {
+				// FIXME Add relationship to Xwt
+			}
+		}
+
+		public static void SetCommonAccessibilityAttributes (this Xwt.Widget w, string name, string label, string help)
+		{
+			w.Accessible.SetCommonAttributes (name, label, help);
 		}
 
 		public static void SetCommonAccessibilityAttributes (this Gtk.Widget w, string name, string label, string help)
 		{
 			var accessible = w.Accessible;
 			accessible.SetCommonAttributes (name, label, help);
+		}
+
+		public static void SetCommonAccessibilityAttributes (this Gtk.Widget w, string name, Gtk.Widget label, string help)
+		{
+			var accessible = w.Accessible;
+			accessible.SetCommonAttributes (name, null, help);
+
+			if (label != null) {
+				w.SetAccessibilityLabelRelationship (label);
+			}
 		}
 
 		public static void SetAccessibilityLabelRelationship (this Gtk.Widget w, Gtk.Widget label)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelper.cs
@@ -127,6 +127,7 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			AXColumn,
 			AXGroup,
 			AXImage,
+			AXLink,
 			AXMenuButton,
 			AXPopUpButton,
 			AXRadioButton,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/FolderListSelector.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/FolderListSelector.cs
@@ -57,13 +57,13 @@ namespace MonoDevelop.Components
 
 		void SetupAccessibility ()
 		{
-			buttonAdd.SetCommonAccessibilityAttributes ("FolderListSelector.add", null,
+			buttonAdd.SetCommonAccessibilityAttributes ("FolderListSelector.add", "",
 			                                            GettextCatalog.GetString ("Add the folder to the list"));
-			buttonRemove.SetCommonAccessibilityAttributes ("FolderListSelector.remove", null,
+			buttonRemove.SetCommonAccessibilityAttributes ("FolderListSelector.remove", "",
 			                                               GettextCatalog.GetString ("Remove the selected folder from the list"));
-			buttonUp.SetCommonAccessibilityAttributes ("FolderListSelector.up", null,
+			buttonUp.SetCommonAccessibilityAttributes ("FolderListSelector.up", "",
 			                                           GettextCatalog.GetString ("Move the selected folder up the list"));
-			buttonDown.SetCommonAccessibilityAttributes ("FolderListSelector.down", null,
+			buttonDown.SetCommonAccessibilityAttributes ("FolderListSelector.down", "",
 			                                             GettextCatalog.GetString ("Move the selected folder down the list"));
 			dirList.SetCommonAccessibilityAttributes ("FolderListSelector.dirList", GettextCatalog.GetString ("Folder List"),
 			                                          GettextCatalog.GetString ("The list of folders"));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/FolderListSelector.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/FolderListSelector.cs
@@ -26,7 +26,10 @@
 
 using System;
 using System.Collections.Generic;
+
+using MonoDevelop.Components.AtkCocoaHelper;
 using Gtk;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components
 {
@@ -48,8 +51,24 @@ namespace MonoDevelop.Components
 				UpdateStatus ();
 			};
 			UpdateStatus ();
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			buttonAdd.SetCommonAccessibilityAttributes ("FolderListSelector.add", null,
+			                                            GettextCatalog.GetString ("Add the folder to the list"));
+			buttonRemove.SetCommonAccessibilityAttributes ("FolderListSelector.remove", null,
+			                                               GettextCatalog.GetString ("Remove the selected folder from the list"));
+			buttonUp.SetCommonAccessibilityAttributes ("FolderListSelector.up", null,
+			                                           GettextCatalog.GetString ("Move the selected folder up the list"));
+			buttonDown.SetCommonAccessibilityAttributes ("FolderListSelector.down", null,
+			                                             GettextCatalog.GetString ("Move the selected folder down the list"));
+			dirList.SetCommonAccessibilityAttributes ("FolderListSelector.dirList", GettextCatalog.GetString ("Folder List"),
+			                                          GettextCatalog.GetString ("The list of folders"));
+		}
+
 		public List<string> Directories {
 			get {
 				return directories;
@@ -159,6 +178,12 @@ namespace MonoDevelop.Components
 			directories [i - 1] = dir;
 			directories [i] = prevDir;
 			FocusRow (it);
+		}
+
+		internal Atk.Object EntryAccessible {
+			get {
+				return folderentry.EntryAccessible;
+			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/RestartPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/RestartPanel.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Components
 			var labelRestart = new Label (GettextCatalog.GetString ("These preferences will take effect next time you start {0}", BrandingService.ApplicationName));
 			Attach (labelRestart, 1, 3, 0, 1, AttachOptions.Fill, AttachOptions.Fill, 0, 0);
 
-			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", null,
+			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", "",
 			                                               GettextCatalog.GetString ("A restart is required before these changes take effect"));
 			imageRestart.SetAccessibilityLabelRelationship (labelRestart);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
@@ -138,6 +138,8 @@ namespace MonoDevelop.Components
 
 			NoShowAll = true;
 			GtkWorkarounds.SetTransparentBgHint (this, true);
+
+			Accessible.SetShouldIgnore (true);
 		}
 
 		public Xwt.Drawing.Image FilterButtonPixbuf {
@@ -161,6 +163,7 @@ namespace MonoDevelop.Components
 			entry = new FramelessEntry (this);
 			entry.UseNativeContextMenus ();
 			entry.Accessible.SetSubRole ("AXSearchField");
+			entry.Accessible.SetLabel (GettextCatalog.GetString ("Search"));
 
 			filter_button = new HoverImageButton (IconSize.Menu, "md-searchbox-search");
 			filter_button.Accessible.SetRole (AtkCocoa.Roles.AXMenuButton);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/CustomExecutionModeWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/CustomExecutionModeWidget.cs
@@ -46,13 +46,11 @@ namespace MonoDevelop.Ide.Execution
 			folderEntry.EntryAccessible.SetTitleUIElement (label2.Accessible);
 			label2.Accessible.SetTitleFor (folderEntry.EntryAccessible);
 
-			entryArgs.SetCommonAccessibilityAttributes ("CustomExecutionMode.Arguments", null,
+			entryArgs.SetCommonAccessibilityAttributes ("CustomExecutionMode.Arguments", label4,
 			                                            GettextCatalog.GetString ("Enter any custom arguments to be passed to the executable"));
-			entryArgs.SetAccessibilityLabelRelationship (label4);
 
-			envVarList.SetCommonAccessibilityAttributes ("CustomExecutionMode.Variables", null,
+			envVarList.SetCommonAccessibilityAttributes ("CustomExecutionMode.Variables", label3,
 			                                             GettextCatalog.GetString ("Enter any custom environment variables"));
-			envVarList.SetAccessibilityLabelRelationship (label3);
 		}
 		
 		#region IExecutionModeEditor implementation

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using Gtk;
 
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.ExternalTools;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
@@ -135,8 +136,47 @@ namespace MonoDevelop.Ide.ExternalTools
 			defaultKeyTextBox.KeyReleaseEvent += OnDefaultKeyEntryKeyRelease;
 
 			SelectionChanged (this, EventArgs.Empty);
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			addButton.SetCommonAccessibilityAttributes ("ExternalTools.Add", null,
+			                                            GettextCatalog.GetString ("Click to add a new external tool"));
+			removeButton.SetCommonAccessibilityAttributes ("ExternalTools.Remove", null,
+			                                               GettextCatalog.GetString ("Click to remove an external tool from the list"));
+			moveUpButton.SetCommonAccessibilityAttributes ("ExternalTools.Up", null,
+			                                               GettextCatalog.GetString ("Click to move the selected tool up the list"));
+			moveDownButton.SetCommonAccessibilityAttributes ("ExternalTools.Down", null,
+			                                                 GettextCatalog.GetString ("Click to move the selected tool down the list"));
+			titleTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Title", null,
+			                                               GettextCatalog.GetString ("Enter the title for this command"));
+			titleTextBox.SetAccessibilityLabelRelationship (titleLabel);
+			browseButton.Accessible.SetCommonAttributes ("ExternalTools.Command", null,
+			                                             GettextCatalog.GetString ("Enter or select the path for the external command"));
+			browseButton.Accessible.SetTitleUIElement (commandLabel.Accessible);
+			argumentTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Arguments", null,
+			                                                  GettextCatalog.GetString ("Enter the arguments for the external command"));
+			argumentTextBox.SetAccessibilityLabelRelationship (argumentLabel);
+			tagSelectorArgs.ButtonAccessible.SetCommonAttributes ("ExternalTools.tagSelectorArgs", GettextCatalog.GetString ("Argument Tags"),
+				                                                  GettextCatalog.GetString ("Select tags to add to the arguments"));
+			workingDirTextBox.SetCommonAccessibilityAttributes ("ExternalTools.workingDir", null,
+			                                                    GettextCatalog.GetString ("Enter the working directory for this command"));
+			workingDirTextBox.SetAccessibilityLabelRelationship (workingDirLabel);
+			tagSelectorPath.ButtonAccessible.SetCommonAttributes ("ExternalTools.tagSelectorPath", GettextCatalog.GetString ("Working Directory Tags"),
+				                                                  GettextCatalog.GetString ("Select tags to add to the working directory"));
+			defaultKeyTextBox.SetCommonAccessibilityAttributes ("ExternalTools.defaultKey", null,
+			                                                    GettextCatalog.GetString ("Enter the default key binding for this command"));
+			defaultKeyTextBox.SetAccessibilityLabelRelationship (defaultKeyLabel);
+			promptArgsCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.promptArgs", null,
+			                                                     GettextCatalog.GetString ("Check to prompt for arguments when running the command"));
+			saveCurrentFileCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.saveCurrentFile", null,
+			                                                          GettextCatalog.GetString ("Check to save the current file before running the command"));
+			useOutputPadCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.useExternalPad", null,
+			                                                       GettextCatalog.GetString ("Check to display the commands output in the Output Pad"));
+		}
+
 		void MoveUpButtonClicked (object sender, EventArgs e)
 		{
 			if (toolListBox.Selection.CountSelectedRows () == 1) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
@@ -142,38 +142,35 @@ namespace MonoDevelop.Ide.ExternalTools
 
 		void SetupAccessibility ()
 		{
-			addButton.SetCommonAccessibilityAttributes ("ExternalTools.Add", null,
+			addButton.SetCommonAccessibilityAttributes ("ExternalTools.Add", "",
 			                                            GettextCatalog.GetString ("Click to add a new external tool"));
-			removeButton.SetCommonAccessibilityAttributes ("ExternalTools.Remove", null,
+			removeButton.SetCommonAccessibilityAttributes ("ExternalTools.Remove", "",
 			                                               GettextCatalog.GetString ("Click to remove an external tool from the list"));
-			moveUpButton.SetCommonAccessibilityAttributes ("ExternalTools.Up", null,
+			moveUpButton.SetCommonAccessibilityAttributes ("ExternalTools.Up", "",
 			                                               GettextCatalog.GetString ("Click to move the selected tool up the list"));
-			moveDownButton.SetCommonAccessibilityAttributes ("ExternalTools.Down", null,
+			moveDownButton.SetCommonAccessibilityAttributes ("ExternalTools.Down", "",
 			                                                 GettextCatalog.GetString ("Click to move the selected tool down the list"));
-			titleTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Title", null,
+			titleTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Title", titleLabel,
 			                                               GettextCatalog.GetString ("Enter the title for this command"));
-			titleTextBox.SetAccessibilityLabelRelationship (titleLabel);
 			browseButton.Accessible.SetCommonAttributes ("ExternalTools.Command", null,
 			                                             GettextCatalog.GetString ("Enter or select the path for the external command"));
 			browseButton.Accessible.SetTitleUIElement (commandLabel.Accessible);
-			argumentTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Arguments", null,
+			argumentTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Arguments", "",
 			                                                  GettextCatalog.GetString ("Enter the arguments for the external command"));
 			argumentTextBox.SetAccessibilityLabelRelationship (argumentLabel);
 			tagSelectorArgs.ButtonAccessible.SetCommonAttributes ("ExternalTools.tagSelectorArgs", GettextCatalog.GetString ("Argument Tags"),
 				                                                  GettextCatalog.GetString ("Select tags to add to the arguments"));
-			workingDirTextBox.SetCommonAccessibilityAttributes ("ExternalTools.workingDir", null,
+			workingDirTextBox.SetCommonAccessibilityAttributes ("ExternalTools.workingDir", workingDirLabel,
 			                                                    GettextCatalog.GetString ("Enter the working directory for this command"));
-			workingDirTextBox.SetAccessibilityLabelRelationship (workingDirLabel);
 			tagSelectorPath.ButtonAccessible.SetCommonAttributes ("ExternalTools.tagSelectorPath", GettextCatalog.GetString ("Working Directory Tags"),
 				                                                  GettextCatalog.GetString ("Select tags to add to the working directory"));
-			defaultKeyTextBox.SetCommonAccessibilityAttributes ("ExternalTools.defaultKey", null,
+			defaultKeyTextBox.SetCommonAccessibilityAttributes ("ExternalTools.defaultKey", defaultKeyLabel,
 			                                                    GettextCatalog.GetString ("Enter the default key binding for this command"));
-			defaultKeyTextBox.SetAccessibilityLabelRelationship (defaultKeyLabel);
-			promptArgsCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.promptArgs", null,
+			promptArgsCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.promptArgs", "",
 			                                                     GettextCatalog.GetString ("Check to prompt for arguments when running the command"));
-			saveCurrentFileCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.saveCurrentFile", null,
+			saveCurrentFileCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.saveCurrentFile", "",
 			                                                          GettextCatalog.GetString ("Check to save the current file before running the command"));
-			useOutputPadCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.useExternalPad", null,
+			useOutputPadCheckBox.SetCommonAccessibilityAttributes ("ExternalTools.useExternalPad", "",
 			                                                       GettextCatalog.GetString ("Check to display the commands output in the Output Pad"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/MimeTypePolicyOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/MimeTypePolicyOptionsPanel.cs
@@ -278,7 +278,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 				}
 			};
 
-			defaultSettingsButton.SetCommonAccessibilityAttributes ("MimePanel.DefaultCheckbox", null,
+			defaultSettingsButton.SetCommonAccessibilityAttributes ("MimePanel.DefaultCheckbox", "",
 			                                                        GettextCatalog.GetString ("Check to use the default settings from '{0}'", baseType));
 			defaultSettingsButton.Accessible.AddLinkedUIElement (panelWidget.Accessible);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/AssemblyFoldersPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/AssemblyFoldersPanel.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 
@@ -55,6 +56,16 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.Build ();
 			label1.LabelProp = MonoDevelop.Core.BrandingService.BrandApplicationName (label1.LabelProp);
 			selector.Directories = new List<string> (Runtime.SystemAssemblyService.UserAssemblyContext.Directories);
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			selector.EntryAccessible.SetCommonAttributes (null, null,
+			                                              GettextCatalog.GetString ("Enter a folder to search for assemblies and packages"));
+			selector.EntryAccessible.SetTitleUIElement (label1.Accessible);
+			label1.Accessible.SetTitleFor (selector.EntryAccessible);
 		}
 		
 		public void Store ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/AuthorInformationPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/AuthorInformationPanel.cs
@@ -28,9 +28,11 @@
 
 using System;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Projects;
 using MonoDevelop.Ide.Projects;
 using MonoDevelop.Ide.Gui.Dialogs;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Gui.OptionPanels
 {
@@ -74,8 +76,31 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.info = info;
 			checkCustom.Active = (info != null);
 			UseDefaultToggled (this, EventArgs.Empty);
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			nameEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.nameEntry", "",
+			                                            GettextCatalog.GetString ("Enter the author name"));
+			nameEntry.SetAccessibilityLabelRelationship (label2);
+
+			emailEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.emailEntry", "",
+			                                             GettextCatalog.GetString ("Enter the author's email address"));
+			emailEntry.SetAccessibilityLabelRelationship (label4);
+
+			copyrightEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.copyrightEntry", "",
+			                                                 GettextCatalog.GetString ("Enter the copyright statement"));
+			copyrightEntry.SetAccessibilityLabelRelationship (label3);
+			companyEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.companyEntry", "",
+			                                               GettextCatalog.GetString ("Enter the company name"));
+			companyEntry.SetAccessibilityLabelRelationship (label5);
+			trademarkEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.trademarkEntry", "",
+			                                                 GettextCatalog.GetString ("Enter the trademark statement"));
+			trademarkEntry.SetAccessibilityLabelRelationship (label6);
+		}
+
 		public AuthorInformation Get ()
 		{
 			return checkCustom.Active? new AuthorInformation (nameEntry.Text, emailEntry.Text, copyrightEntry.Text, companyEntry.Text, trademarkEntry.Text) : null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildMessagePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildMessagePanel.cs
@@ -26,6 +26,7 @@
 
 using System;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 
@@ -83,8 +84,24 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			comboboxMessageBubbles.AppendText (GettextCatalog.GetString ("For Errors and Warnings"));
 			comboboxMessageBubbles.Active = (int)IdeApp.Preferences.ShowMessageBubbles.Value;
 			this.QueueResize ();
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			comboboxJumpToFirst.SetCommonAccessibilityAttributes ("BuildMessagePanel.jumpToFirst", null,
+			                                                      GettextCatalog.GetString ("Select which type of result to jump to after build completes"));
+			comboboxJumpToFirst.SetAccessibilityLabelRelationship (label6);
+
+			comboboxErrorPadAfter.SetCommonAccessibilityAttributes ("BuildMessagePanel.errorPadAfter", null,
+			                                                        GettextCatalog.GetString ("Select when to show the Error Pad"));
+			comboboxErrorPadAfter.SetAccessibilityLabelRelationship (label3);
+
+			comboboxMessageBubbles.SetCommonAccessibilityAttributes ("BuildMessagePanel.messageBubbles", null,
+			                                                         GettextCatalog.GetString ("Select when to show message bubbles"));
+			comboboxMessageBubbles.SetAccessibilityLabelRelationship (label5);
+		}
 		public void Store ()
 		{
 			IdeApp.Preferences.JumpToFirstErrorOrWarning.Value = (JumpToFirst)comboboxJumpToFirst.Active;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildMessagePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildMessagePanel.cs
@@ -90,17 +90,14 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		void SetupAccessibility ()
 		{
-			comboboxJumpToFirst.SetCommonAccessibilityAttributes ("BuildMessagePanel.jumpToFirst", null,
+			comboboxJumpToFirst.SetCommonAccessibilityAttributes ("BuildMessagePanel.jumpToFirst", label6,
 			                                                      GettextCatalog.GetString ("Select which type of result to jump to after build completes"));
-			comboboxJumpToFirst.SetAccessibilityLabelRelationship (label6);
 
-			comboboxErrorPadAfter.SetCommonAccessibilityAttributes ("BuildMessagePanel.errorPadAfter", null,
+			comboboxErrorPadAfter.SetCommonAccessibilityAttributes ("BuildMessagePanel.errorPadAfter", label3,
 			                                                        GettextCatalog.GetString ("Select when to show the Error Pad"));
-			comboboxErrorPadAfter.SetAccessibilityLabelRelationship (label3);
 
-			comboboxMessageBubbles.SetCommonAccessibilityAttributes ("BuildMessagePanel.messageBubbles", null,
+			comboboxMessageBubbles.SetCommonAccessibilityAttributes ("BuildMessagePanel.messageBubbles", label5,
 			                                                         GettextCatalog.GetString ("Select when to show message bubbles"));
-			comboboxMessageBubbles.SetAccessibilityLabelRelationship (label5);
 		}
 		public void Store ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
@@ -71,27 +71,26 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		void SetupAccessibility ()
 		{
-			buildBeforeRunCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildBeforeRun", null,
+			buildBeforeRunCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildBeforeRun", "",
 			                                                         GettextCatalog.GetString ("Check to build the solution before running"));
-			runWithWarningsCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.runWithWarnings", null,
+			runWithWarningsCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.runWithWarnings", "",
 			                                                          GettextCatalog.GetString ("Check to run the solution even if the build had warnings"));
-			buildBeforeTestCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildBeforeTest", null,
+			buildBeforeTestCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildBeforeTest", "",
 			                                                          GettextCatalog.GetString ("Check to build the solution before running tests"));
-			buildWithMSBuildCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildWithMSBuild", null,
+			buildWithMSBuildCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildWithMSBuild", "",
 			                                                           GettextCatalog.GetString ("Check to use MSBuild to build the solution"));
-			parallelBuildCheckbox.SetCommonAccessibilityAttributes ("BuildPanel.parallelBuild", null,
+			parallelBuildCheckbox.SetCommonAccessibilityAttributes ("BuildPanel.parallelBuild", "",
 			                                                        GettextCatalog.GetString ("Check to enable parallel building"));
 
-			saveChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.saveChanges", null,
+			saveChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.saveChanges", "",
 			                                                         GettextCatalog.GetString ("Check to save changes before building"));
-			noSaveRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.noSave", null,
+			noSaveRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.noSave", "",
 			                                                    GettextCatalog.GetString ("Check to not save changes before building"));
-			promptChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.promptSave", null,
+			promptChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.promptSave", "",
 			                                                           GettextCatalog.GetString ("Check to be prompted to save changes before building"));
 
-			verbosityCombo.SetCommonAccessibilityAttributes ("BuildPanel.verbosity", null,
+			verbosityCombo.SetCommonAccessibilityAttributes ("BuildPanel.verbosity", label1,
 			                                                 GettextCatalog.GetString ("Select the verbosity level of the build"));
-			verbosityCombo.SetAccessibilityLabelRelationship (label1);
 		}
 		
 		public void Store ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
@@ -29,6 +29,7 @@
 using System;
 using MonoDevelop.Core;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Projects.MSBuild;
 
@@ -64,6 +65,33 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			buildBeforeTestCheckBox.Active = IdeApp.Preferences.BuildBeforeRunningTests;
 			buildWithMSBuildCheckBox.Active = Runtime.Preferences.BuildWithMSBuild;
 			parallelBuildCheckbox.Active = MonoDevelop.Core.Runtime.Preferences.ParallelBuild.Value;
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			buildBeforeRunCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildBeforeRun", null,
+			                                                         GettextCatalog.GetString ("Check to build the solution before running"));
+			runWithWarningsCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.runWithWarnings", null,
+			                                                          GettextCatalog.GetString ("Check to run the solution even if the build had warnings"));
+			buildBeforeTestCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildBeforeTest", null,
+			                                                          GettextCatalog.GetString ("Check to build the solution before running tests"));
+			buildWithMSBuildCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildWithMSBuild", null,
+			                                                           GettextCatalog.GetString ("Check to use MSBuild to build the solution"));
+			parallelBuildCheckbox.SetCommonAccessibilityAttributes ("BuildPanel.parallelBuild", null,
+			                                                        GettextCatalog.GetString ("Check to enable parallel building"));
+
+			saveChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.saveChanges", null,
+			                                                         GettextCatalog.GetString ("Check to save changes before building"));
+			noSaveRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.noSave", null,
+			                                                    GettextCatalog.GetString ("Check to not save changes before building"));
+			promptChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.promptSave", null,
+			                                                           GettextCatalog.GetString ("Check to be prompted to save changes before building"));
+
+			verbosityCombo.SetCommonAccessibilityAttributes ("BuildPanel.verbosity", null,
+			                                                 GettextCatalog.GetString ("Select the verbosity level of the build"));
+			verbosityCombo.SetAccessibilityLabelRelationship (label1);
 		}
 		
 		public void Store ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/GlobalAuthorInformationPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/GlobalAuthorInformationPanel.cs
@@ -28,6 +28,7 @@
 
 using System;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Projects;
@@ -61,8 +62,33 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			copyrightEntry.Text = AuthorInformation.Default.Copyright ?? "";
 			companyEntry.Text = AuthorInformation.Default.Company ?? "";
 			trademarkEntry.Text = AuthorInformation.Default.Trademark ?? "";
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			nameEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.nameEntry", "",
+														GettextCatalog.GetString ("Enter the author name"));
+			nameEntry.SetAccessibilityLabelRelationship (label2);
+
+			emailEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.emailEntry", "",
+														 GettextCatalog.GetString ("Enter the author's email address"));
+			emailEntry.SetAccessibilityLabelRelationship (label4);
+
+			copyrightEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.copyrightEntry", "",
+															 GettextCatalog.GetString ("Enter the copyright statement"));
+			copyrightEntry.SetAccessibilityLabelRelationship (label3);
+
+			companyEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.companyEntry", "",
+														   GettextCatalog.GetString ("Enter the company name"));
+			companyEntry.SetAccessibilityLabelRelationship (label5);
+
+			trademarkEntry.SetCommonAccessibilityAttributes ("AuthorInformationPanel.trademarkEntry", "",
+															 GettextCatalog.GetString ("Enter the trademark statement"));
+			trademarkEntry.SetAccessibilityLabelRelationship (label6);
+		}
+
 		public void Save ()
 		{
 			Runtime.Preferences.AuthorName.Value = nameEntry.Text;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/IDEStyleOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/IDEStyleOptionsPanel.cs
@@ -88,17 +88,14 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.Build();
 			Load ();
 
-			comboTheme.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.Theme", null,
+			comboTheme.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.Theme", labelTheme,
 			                                             GettextCatalog.GetString ("Select the user interface theme"));
-			comboTheme.SetAccessibilityLabelRelationship (labelTheme);
 
-			comboLanguage.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.Language", null,
+			comboLanguage.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.Language", label2,
 			                                                GettextCatalog.GetString ("Select the user interface language"));
-			comboLanguage.SetAccessibilityLabelRelationship (label2);
 
-			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", null,
+			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", labelRestart,
 			                                               GettextCatalog.GetString ("A restart is required before these changes take effect"));
-			imageRestart.SetAccessibilityLabelRelationship (labelRestart);
 		}
 
 		void Load ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/IDEStyleOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/IDEStyleOptionsPanel.cs
@@ -88,6 +88,14 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.Build();
 			Load ();
 
+			comboTheme.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.Theme", null,
+			                                             GettextCatalog.GetString ("Select the user interface theme"));
+			comboTheme.SetAccessibilityLabelRelationship (labelTheme);
+
+			comboLanguage.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.Language", null,
+			                                                GettextCatalog.GetString ("Select the user interface language"));
+			comboLanguage.SetAccessibilityLabelRelationship (label2);
+
 			imageRestart.SetCommonAccessibilityAttributes ("IDEStyleOptionsPanel.RestartImage", null,
 			                                               GettextCatalog.GetString ("A restart is required before these changes take effect"));
 			imageRestart.SetAccessibilityLabelRelationship (labelRestart);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
@@ -168,13 +168,12 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			searchEntry.Entry.SetCommonAccessibilityAttributes ("KeyBindingsPanel.searchEntry", GettextCatalog.GetString ("Search"),
 																GettextCatalog.GetString ("Enter a search term to find it in the keybindings list"));
 
-			accelEntry.SetCommonAccessibilityAttributes ("KeyBindingsPanel.accelEntry", null,
+			accelEntry.SetCommonAccessibilityAttributes ("KeyBindingsPanel.accelEntry", labelEditBinding,
 			                                             GettextCatalog.GetString ("Enter the keybinding for this command"));
-			accelEntry.SetAccessibilityLabelRelationship (labelEditBinding);
 
-			addButton.SetCommonAccessibilityAttributes ("KeyBindingsPanel.addButton", null,
+			addButton.SetCommonAccessibilityAttributes ("KeyBindingsPanel.addButton", "",
 			                                            GettextCatalog.GetString ("Add a new binding for this command"));
-			updateButton.SetCommonAccessibilityAttributes ("KeyBindingsPanel.updateButton", null,
+			updateButton.SetCommonAccessibilityAttributes ("KeyBindingsPanel.updateButton", "",
 			                                               GettextCatalog.GetString ("Update the binding for this command"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/KeyBindingsPanel.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components.Commands;
 using Gtk;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.Ide.Gui.OptionPanels
 {
@@ -154,6 +155,27 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			//HACK: workaround for MD Bug 608021: Stetic loses values assigned to "new" properties of custom widget
 			conflicButton.Label = GettextCatalog.GetString ("_View Conflicts");
 			conflicButton.UseUnderline = true;
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			schemeCombo.Accessible.Name = "KeyBindingsPanel.schemeCombo";
+			schemeCombo.Accessible.Description = GettextCatalog.GetString ("Select a predefined keybindings scheme");
+			schemeCombo.SetAccessibilityLabelRelationship (labelScheme);
+
+			searchEntry.Entry.SetCommonAccessibilityAttributes ("KeyBindingsPanel.searchEntry", GettextCatalog.GetString ("Search"),
+																GettextCatalog.GetString ("Enter a search term to find it in the keybindings list"));
+
+			accelEntry.SetCommonAccessibilityAttributes ("KeyBindingsPanel.accelEntry", null,
+			                                             GettextCatalog.GetString ("Enter the keybinding for this command"));
+			accelEntry.SetAccessibilityLabelRelationship (labelEditBinding);
+
+			addButton.SetCommonAccessibilityAttributes ("KeyBindingsPanel.addButton", null,
+			                                            GettextCatalog.GetString ("Add a new binding for this command"));
+			updateButton.SetCommonAccessibilityAttributes ("KeyBindingsPanel.updateButton", null,
+			                                               GettextCatalog.GetString ("Update the binding for this command"));
 		}
 
 		void Refilter ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/LoadSavePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/LoadSavePanel.cs
@@ -88,16 +88,16 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		void SetupAccessibility ()
 		{
-			folderEntry.EntryAccessible.SetCommonAttributes ("LoadSavePanel.folderEntry", null,
+			folderEntry.EntryAccessible.SetCommonAttributes ("LoadSavePanel.folderEntry", "",
 			                                                 GettextCatalog.GetString ("Enter the default path for the solution"));
 			folderEntry.EntryAccessible.SetTitleUIElement (locationLabel.Accessible);
 			locationLabel.Accessible.SetTitleFor (folderEntry.EntryAccessible);
 
-			loadUserDataCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.loadUserData", null,
+			loadUserDataCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.loadUserData", "",
 			                                                          GettextCatalog.GetString ("Check to load the user specific settings with the solution"));
-			loadPrevProjectCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.loadPrevious", null,
+			loadPrevProjectCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.loadPrevious", "",
 			                                                             GettextCatalog.GetString ("Check to load the previous solution when starting the application"));
-			createBackupCopyCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.createBackup", null,
+			createBackupCopyCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.createBackup", "",
 			                                                              GettextCatalog.GetString ("Check to always create a backup copy"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/LoadSavePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/LoadSavePanel.cs
@@ -37,6 +37,7 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Projects;
 
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 #pragma warning disable 612
 
@@ -81,8 +82,25 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			loadUserDataCheckButton.Active = IdeApp.Preferences.LoadDocumentUserProperties;
 			createBackupCopyCheckButton.Active = IdeApp.Preferences.CreateFileBackupCopies;
 			loadPrevProjectCheckButton.Active = IdeApp.Preferences.LoadPrevSolutionOnStartup.Value;
+
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			folderEntry.EntryAccessible.SetCommonAttributes ("LoadSavePanel.folderEntry", null,
+			                                                 GettextCatalog.GetString ("Enter the default path for the solution"));
+			folderEntry.EntryAccessible.SetTitleUIElement (locationLabel.Accessible);
+			locationLabel.Accessible.SetTitleFor (folderEntry.EntryAccessible);
+
+			loadUserDataCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.loadUserData", null,
+			                                                          GettextCatalog.GetString ("Check to load the user specific settings with the solution"));
+			loadPrevProjectCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.loadPrevious", null,
+			                                                             GettextCatalog.GetString ("Check to load the previous solution when starting the application"));
+			createBackupCopyCheckButton.SetCommonAccessibilityAttributes ("LoadSavePanel.createBackup", null,
+			                                                              GettextCatalog.GetString ("Check to always create a backup copy"));
+		}
+
 		public bool ValidateChanges ()
 		{
 			// check for correct settings

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/MonoRuntimePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/MonoRuntimePanel.cs
@@ -34,6 +34,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Core.Assemblies;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.Ide.Gui.OptionPanels
 {
@@ -94,6 +95,20 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			
 			tree.Selection.Changed += HandleChanged;
 			UpdateButtons ();
+
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			tree.SetCommonAccessibilityAttributes ("MonoRuntimePanel.tree", GettextCatalog.GetString ("Available Runtimes"),
+			                                       GettextCatalog.GetString ("A list of available runtimes"));
+			buttonAdd.SetCommonAccessibilityAttributes ("MonoRuntimePanel.add", null,
+			                                            GettextCatalog.GetString ("Click to install a new runtime"));
+			buttonRemove.SetCommonAccessibilityAttributes ("MonoRuntimePanel.remove", null,
+			                                               GettextCatalog.GetString ("Click to remove the currently selected runtime"));
+			buttonDefault.SetCommonAccessibilityAttributes ("MonoRuntimePanel.default", null,
+			                                                GettextCatalog.GetString ("Click to set the currently selected runtime as default"));
 		}
 
 		void HandleChanged(object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/MonoRuntimePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/MonoRuntimePanel.cs
@@ -103,11 +103,11 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 		{
 			tree.SetCommonAccessibilityAttributes ("MonoRuntimePanel.tree", GettextCatalog.GetString ("Available Runtimes"),
 			                                       GettextCatalog.GetString ("A list of available runtimes"));
-			buttonAdd.SetCommonAccessibilityAttributes ("MonoRuntimePanel.add", null,
+			buttonAdd.SetCommonAccessibilityAttributes ("MonoRuntimePanel.add", "",
 			                                            GettextCatalog.GetString ("Click to install a new runtime"));
-			buttonRemove.SetCommonAccessibilityAttributes ("MonoRuntimePanel.remove", null,
+			buttonRemove.SetCommonAccessibilityAttributes ("MonoRuntimePanel.remove", "",
 			                                               GettextCatalog.GetString ("Click to remove the currently selected runtime"));
-			buttonDefault.SetCommonAccessibilityAttributes ("MonoRuntimePanel.default", null,
+			buttonDefault.SetCommonAccessibilityAttributes ("MonoRuntimePanel.default", "",
 			                                                GettextCatalog.GetString ("Click to set the currently selected runtime as default"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TasksOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TasksOptionsPanel.cs
@@ -33,6 +33,7 @@ using System.Text;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.Tasks;
 using Gtk;
 
@@ -69,6 +70,41 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			entryToken.Changed += new EventHandler (Validate);
 
 			Styles.Changed += HandleUserInterfaceThemeChanged;
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			comboPriority.SetCommonAccessibilityAttributes ("TasksPanel.priorityCombo", null,
+			                                                GettextCatalog.GetString ("Select the priority for this token"));
+			comboPriority.SetAccessibilityLabelRelationship (label113);
+
+			entryToken.SetCommonAccessibilityAttributes ("TasksPanel.tokenEntry", null,
+			                                             GettextCatalog.GetString ("Enter a word to detect as a token"));
+			entryToken.SetAccessibilityLabelRelationship (label112);
+
+			tokensTreeView.SetCommonAccessibilityAttributes ("TasksPanel.tokensList", null,
+			                                                 GettextCatalog.GetString ("A list of recognised tokens"));
+			tokensTreeView.SetAccessibilityLabelRelationship (labelTokens);
+
+			buttonAdd.SetCommonAccessibilityAttributes ("TasksPanel.addButton", null,
+			                                            GettextCatalog.GetString ("Add a new token"));
+			buttonChange.SetCommonAccessibilityAttributes ("TasksPanel.changeButton", null,
+			                                               GettextCatalog.GetString ("Edit the currently selected token"));
+			buttonRemove.SetCommonAccessibilityAttributes ("TasksPanel.removeButton", null,
+			                                               GettextCatalog.GetString ("Remove the currently selected token"));
+
+			colorbuttonLowPrio.SetCommonAccessibilityAttributes ("TasksPanel.lowColor", null,
+			                                                     GettextCatalog.GetString ("Select the foreground color for low priority tasks"));
+			colorbuttonLowPrio.SetAccessibilityLabelRelationship (label12);
+
+			colorbuttonHighPrio.SetCommonAccessibilityAttributes ("TasksPanel.hiColor", null,
+			                                                      GettextCatalog.GetString ("Select the foreground color for the high priority tasks"));
+			colorbuttonHighPrio.SetAccessibilityLabelRelationship (label10);
+
+			colorbuttonNormalPrio.SetCommonAccessibilityAttributes ("TasksPanel.normalColor", null,
+			                                                        GettextCatalog.GetString ("Select the foreground color for the normal priority tasks"));
+			colorbuttonNormalPrio.SetAccessibilityLabelRelationship (label11);
 		}
 		
 		void Validate (object sender, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TasksOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TasksOptionsPanel.cs
@@ -75,36 +75,30 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		void SetupAccessibility ()
 		{
-			comboPriority.SetCommonAccessibilityAttributes ("TasksPanel.priorityCombo", null,
+			comboPriority.SetCommonAccessibilityAttributes ("TasksPanel.priorityCombo", label113,
 			                                                GettextCatalog.GetString ("Select the priority for this token"));
-			comboPriority.SetAccessibilityLabelRelationship (label113);
 
-			entryToken.SetCommonAccessibilityAttributes ("TasksPanel.tokenEntry", null,
+			entryToken.SetCommonAccessibilityAttributes ("TasksPanel.tokenEntry", label112,
 			                                             GettextCatalog.GetString ("Enter a word to detect as a token"));
-			entryToken.SetAccessibilityLabelRelationship (label112);
 
-			tokensTreeView.SetCommonAccessibilityAttributes ("TasksPanel.tokensList", null,
+			tokensTreeView.SetCommonAccessibilityAttributes ("TasksPanel.tokensList", labelTokens,
 			                                                 GettextCatalog.GetString ("A list of recognised tokens"));
-			tokensTreeView.SetAccessibilityLabelRelationship (labelTokens);
 
-			buttonAdd.SetCommonAccessibilityAttributes ("TasksPanel.addButton", null,
+			buttonAdd.SetCommonAccessibilityAttributes ("TasksPanel.addButton", "",
 			                                            GettextCatalog.GetString ("Add a new token"));
-			buttonChange.SetCommonAccessibilityAttributes ("TasksPanel.changeButton", null,
+			buttonChange.SetCommonAccessibilityAttributes ("TasksPanel.changeButton", "",
 			                                               GettextCatalog.GetString ("Edit the currently selected token"));
-			buttonRemove.SetCommonAccessibilityAttributes ("TasksPanel.removeButton", null,
+			buttonRemove.SetCommonAccessibilityAttributes ("TasksPanel.removeButton", "",
 			                                               GettextCatalog.GetString ("Remove the currently selected token"));
 
-			colorbuttonLowPrio.SetCommonAccessibilityAttributes ("TasksPanel.lowColor", null,
+			colorbuttonLowPrio.SetCommonAccessibilityAttributes ("TasksPanel.lowColor", label12,
 			                                                     GettextCatalog.GetString ("Select the foreground color for low priority tasks"));
-			colorbuttonLowPrio.SetAccessibilityLabelRelationship (label12);
 
-			colorbuttonHighPrio.SetCommonAccessibilityAttributes ("TasksPanel.hiColor", null,
+			colorbuttonHighPrio.SetCommonAccessibilityAttributes ("TasksPanel.hiColor", label10,
 			                                                      GettextCatalog.GetString ("Select the foreground color for the high priority tasks"));
-			colorbuttonHighPrio.SetAccessibilityLabelRelationship (label10);
 
-			colorbuttonNormalPrio.SetCommonAccessibilityAttributes ("TasksPanel.normalColor", null,
+			colorbuttonNormalPrio.SetCommonAccessibilityAttributes ("TasksPanel.normalColor", label11,
 			                                                        GettextCatalog.GetString ("Select the foreground color for the normal priority tasks"));
-			colorbuttonNormalPrio.SetAccessibilityLabelRelationship (label11);
 		}
 		
 		void Validate (object sender, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TextStylePolicyPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TextStylePolicyPanel.cs
@@ -78,33 +78,26 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		void SetupAccessibility ()
 		{
-			columnWidthSpin.SetCommonAccessibilityAttributes ("Textpolicy.WidthSpinner",
-			                                                  GettextCatalog.GetString ("Desired File Width"),
+			columnWidthSpin.SetCommonAccessibilityAttributes ("Textpolicy.WidthSpinner", label1,
 			                                                  GettextCatalog.GetString ("The desired width of the file in columns"));
-			columnWidthSpin.SetAccessibilityLabelRelationship (label1);
 
-			lineEndingCombo.SetCommonAccessibilityAttributes ("Textpolicy.LineEndings",
-			                                                  GettextCatalog.GetString ("Line Endings"),
+			lineEndingCombo.SetCommonAccessibilityAttributes ("Textpolicy.LineEndings", label6,
 			                                                  GettextCatalog.GetString ("Select the type of line endings the file should have"));
-			lineEndingCombo.SetAccessibilityLabelRelationship (label6);
 
-			tabWidthSpin.SetCommonAccessibilityAttributes ("Textpolicy.TabWidth",
-			                                               GettextCatalog.GetString ("Tab Width"),
+			tabWidthSpin.SetCommonAccessibilityAttributes ("Textpolicy.TabWidth", label7,
 			                                               GettextCatalog.GetString ("Select the width of tab stops"));
-			tabWidthSpin.SetAccessibilityLabelRelationship (label7);
 
-			indentWidthSpin.SetCommonAccessibilityAttributes ("Textpolicy.IndentWidth",
-			                                                  GettextCatalog.GetString ("Indent Width"),
+			indentWidthSpin.SetCommonAccessibilityAttributes ("Textpolicy.IndentWidth", label9,
 			                                                  GettextCatalog.GetString ("Select the width of indents"));
-			indentWidthSpin.SetAccessibilityLabelRelationship (label9);
 
-			tabsToSpaceCheck.SetCommonAccessibilityAttributes ("Textpolicy.TabsToSpaces", null,
+			tabsToSpaceCheck.SetCommonAccessibilityAttributes ("Textpolicy.TabsToSpaces", "",
 			                                                   GettextCatalog.GetString ("Check to automatically convert tabs to spaces"));
-			tabsAfterNonTabsCheck.SetCommonAccessibilityAttributes ("Textpolicy.TabsAfterSpaces", null,
+			tabsAfterNonTabsCheck.SetCommonAccessibilityAttributes ("Textpolicy.TabsAfterSpaces", "",
 			                                                        GettextCatalog.GetString ("Check to allow tabs after non-tabs"));
-			removeTrailingWhitespaceCheck.SetCommonAccessibilityAttributes ("Textpolicy.TrailingWhitespace", null,
+			removeTrailingWhitespaceCheck.SetCommonAccessibilityAttributes ("Textpolicy.TrailingWhitespace", "",
 			                                                                GettextCatalog.GetString ("Check to automatically remove trailing whitespace from a line"));
 		}
+
 		protected virtual void UpdateState (object sender, System.EventArgs e)
 		{
 			panel.UpdateSelectedNamedPolicy ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/CommonAssemblySigningPreferences.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/CommonAssemblySigningPreferences.cs
@@ -50,7 +50,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 
 		void SetupAccessibility ()
 		{
-			signAssemblyCheckbutton.SetCommonAccessibilityAttributes ("SigningOptions.Sign", null,
+			signAssemblyCheckbutton.SetCommonAccessibilityAttributes ("SigningOptions.Sign", "",
 			                                                          GettextCatalog.GetString ("Check to enable assembly signing"));
 			strongNameFileEntry.EntryAccessible.Name = "SigningOptions.NameFile";
 			strongNameFileEntry.EntryAccessible.SetLabel (GettextCatalog.GetString ("Strong Name File"));
@@ -58,7 +58,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			strongNameFileEntry.EntryAccessible.SetTitleUIElement (strongNameFileLabel.Accessible);
 			strongNameFileLabel.Accessible.SetTitleFor (strongNameFileEntry.EntryAccessible);
 
-			delaySignCheckbutton.SetCommonAccessibilityAttributes ("SigningOptions.Delay", null,
+			delaySignCheckbutton.SetCommonAccessibilityAttributes ("SigningOptions.Delay", "",
 			                                                       GettextCatalog.GetString ("Delay signing the assembly"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/CustomCommandWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/CustomCommandWidget.cs
@@ -113,20 +113,17 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			comboType.SetCommonAccessibilityAttributes ("CustomCommands.OperationType",
 														GettextCatalog.GetString ("Select a project operation"),
 														GettextCatalog.GetString ("Select the type of project operation to add a custom command for"));
-			buttonRemove.SetCommonAccessibilityAttributes ("CustomCommands.Remove", null, GettextCatalog.GetString ("Click to remove this custom command"));
+			buttonRemove.SetCommonAccessibilityAttributes ("CustomCommands.Remove", "", GettextCatalog.GetString ("Click to remove this custom command"));
 
-			entryCommand.SetCommonAccessibilityAttributes ("CustomCommand.CommandEntry", GettextCatalog.GetString ("Command"),
+			entryCommand.SetCommonAccessibilityAttributes ("CustomCommand.CommandEntry", label3,
 			                                               GettextCatalog.GetString ("Enter the custom command"));
-			entryCommand.SetAccessibilityLabelRelationship (label3);
 			buttonBrowse.SetCommonAccessibilityAttributes ("CustomCommand.CommandBrowse", "", GettextCatalog.GetString ("Use a file selector to select a custom command"));
 
-			entryName.SetCommonAccessibilityAttributes ("CustomCommands.WorkingDirectory",
-			                                            GettextCatalog.GetString ("Working Directory"),
+			entryName.SetCommonAccessibilityAttributes ("CustomCommands.WorkingDirectory", label1,
 			                                            GettextCatalog.GetString ("Enter the directory for the command to execute in"));
-			entryName.SetAccessibilityLabelRelationship (label1);
 
-			checkExternalCons.SetCommonAccessibilityAttributes ("CustomCommands.RunOnExtConsole", null, GettextCatalog.GetString ("Check for the command to run on an external console"));
-			checkPauseCons.SetCommonAccessibilityAttributes ("CustomCommands.Pause", null, GettextCatalog.GetString ("Check to pause the console output"));
+			checkExternalCons.SetCommonAccessibilityAttributes ("CustomCommands.RunOnExtConsole", "", GettextCatalog.GetString ("Check for the command to run on an external console"));
+			checkPauseCons.SetCommonAccessibilityAttributes ("CustomCommands.Pause", "", GettextCatalog.GetString ("Check to pause the console output"));
 		}
 
 		public CustomCommand CustomCommand {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/GeneralProjectOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/GeneralProjectOptions.cs
@@ -101,7 +101,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			                                               GettextCatalog.GetString ("Enter the project version"));
 			label1.Accessible.SetTitleFor (entryVersion.Accessible);
 
-			checkSolutionVersion.SetCommonAccessibilityAttributes ("GeneralProjectOptions.SolutionVersion", null,
+			checkSolutionVersion.SetCommonAccessibilityAttributes ("GeneralProjectOptions.SolutionVersion", "",
 			                                                       GettextCatalog.GetString ("Check to use the same version as the solution"));
 
 			projectDescriptionTextView.Accessible.SetTitleUIElement (descriptionLabel.Accessible);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/NamespaceSynchronisationPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/NamespaceSynchronisationPanel.cs
@@ -174,15 +174,15 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 		void SetupAccessibility ()
 		{
 			checkAssociateNamespacesDirectories.SetCommonAccessibilityAttributes ("NamespaceOptions.AssociateNamespace",
-			                                                                      null,
+			                                                                      "",
 			                                                                      GettextCatalog.GetString ("Check to associate namespaces with directory names"));
-			checkDefaultAsRoot.SetCommonAccessibilityAttributes ("NamespaceOptions.DefaultRoot", null,
+			checkDefaultAsRoot.SetCommonAccessibilityAttributes ("NamespaceOptions.DefaultRoot", "",
 			                                                     GettextCatalog.GetString ("Check to use the default namespace as the root of all namespaces"));
-			radioFlat.SetCommonAccessibilityAttributes ("NamespaceOptions.Flat", null,
+			radioFlat.SetCommonAccessibilityAttributes ("NamespaceOptions.Flat", "",
 			                                            GettextCatalog.GetString ("Check to use a flat folder structure"));
-			radioHierarch.SetCommonAccessibilityAttributes ("NamespaceOptions.Hierarchy", null,
+			radioHierarch.SetCommonAccessibilityAttributes ("NamespaceOptions.Hierarchy", "",
 			                                                GettextCatalog.GetString ("Check to use a hierarchical folder structure"));
-			checkVSStyleResourceNames.SetCommonAccessibilityAttributes ("NamespaceOptions.VSNames", null,
+			checkVSStyleResourceNames.SetCommonAccessibilityAttributes ("NamespaceOptions.VSNames", "",
 			                                                            GettextCatalog.GetString ("Check to use Visual Studio style resource names"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewConfigurationDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewConfigurationDialog.cs
@@ -66,19 +66,14 @@ namespace MonoDevelop.Ide.Projects
 
 		void SetupAccessibility ()
 		{
-			comboName.SetCommonAccessibilityAttributes ("NewConfiguration.Name",
-			                                            GettextCatalog.GetString ("Name"),
+			comboName.SetCommonAccessibilityAttributes ("NewConfiguration.Name", label1,
 			                                            GettextCatalog.GetString ("Select or enter the name of the new configuration"));
-			comboName.Accessible.SetTitleUIElement (label1.Accessible);
-			label1.Accessible.SetTitleFor (comboName.Accessible);
 
 			comboPlatform.SetCommonAccessibilityAttributes ("NewConfiguration.Platform",
-			                                                GettextCatalog.GetString ("Platform"),
+			                                                label2,
 			                                                GettextCatalog.GetString ("Select or enter the platform for the new configuration"));
-			comboPlatform.Accessible.SetTitleUIElement (label2.Accessible);
-			label2.Accessible.SetTitleFor (comboPlatform.Accessible);
 
-			createChildrenCheck.SetCommonAccessibilityAttributes ("NewConfiguration.CreateCheck", null,
+			createChildrenCheck.SetCommonAccessibilityAttributes ("NewConfiguration.CreateCheck", "",
 			                                                      GettextCatalog.GetString ("Check to create configurations for all the solution items"));
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.StandardHeader/StandardHeaderPolicyPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.StandardHeader/StandardHeaderPolicyPanel.cs
@@ -116,7 +116,7 @@ namespace MonoDevelop.Ide.StandardHeader
 			treeviewTemplates.SetCommonAccessibilityAttributes ("StandardHeaderPanel.TemplateTree",
 			                                                    GettextCatalog.GetString ("Templates"),
 			                                                    GettextCatalog.GetString ("Select a template to be inserted into the header text"));
-			includeAutoCheck.SetCommonAccessibilityAttributes ("StandardHeaderPanel.AutoCheck", null,
+			includeAutoCheck.SetCommonAccessibilityAttributes ("StandardHeaderPanel.AutoCheck", "",
 			                                                   GettextCatalog.GetString ("Check to include the standard header in newly created files"));
 		}
 		void TreeviewTemplates_RowActivated (object o, Gtk.RowActivatedArgs args)


### PR DESCRIPTION
This adds accessibility attributes to the preferences panels and their dialogs, except for the code formatting panes and the F# settings.

Help descriptions are missing from some panes that are only checkboxes, but the checkbox's labels are usually descriptive enough to not need them.