### PR TITLE
Fix badly formatted nowarn

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -319,6 +319,9 @@ module CompilerArguments =
   let generateCompilerOptions (project:DotNetProject, projectAssemblyReferences: AssemblyReference seq, fsconfig:FSharpCompilerParameters, reqLangVersion, targetFramework, configSelector, shouldWrap) =
     let dashr = generateReferences (project, projectAssemblyReferences, reqLangVersion, targetFramework, configSelector, shouldWrap) |> Array.ofSeq
 
+    let splitByChars (chars: char array) (s:string) =
+        s.Split(chars, StringSplitOptions.RemoveEmptyEntries)
+
     let defines = fsconfig.GetDefineSymbols()
     [
        yield "--simpleresolution"
@@ -342,9 +345,10 @@ module CompilerArguments =
        yield if fsconfig.TreatWarningsAsErrors then "--warnaserror+" else "--warnaserror-"
        yield sprintf "--warn:%d" fsconfig.WarningLevel
        if not (String.IsNullOrWhiteSpace fsconfig.NoWarn) then
-           yield "--nowarn:" + fsconfig.NoWarn
+           for arg in fsconfig.NoWarn |> splitByChars [|';'; ','|] do
+               yield "--nowarn:" + arg
        // TODO: This currently ignores escaping using "..."
-       for arg in fsconfig.OtherFlags.Split([| ' ' |], StringSplitOptions.RemoveEmptyEntries) do
+       for arg in fsconfig.OtherFlags |> splitByChars [|' '|] do
          yield arg
        yield! dashr
        yield! (getCompiledFiles project)]


### PR DESCRIPTION
Fixes the warning when  a badly formatted NoWarn compiler option such as `;1591` is received.
<img width="343" alt="screen shot 2017-06-15 at 12 09 50 pm" src="https://user-images.githubusercontent.com/667194/27179076-ee6c2b66-51c4-11e7-9c72-d918db1e6f2b.png">
