### PR TITLE
[Packaging] Fix description metadata not wrapping in project options

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/gtk-gui/MonoDevelop.Packaging.Gui.GtkNuGetPackageMetadataOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/gtk-gui/MonoDevelop.Packaging.Gui.GtkNuGetPackageMetadataOptionsPanelWidget.cs
@@ -168,7 +168,6 @@ namespace MonoDevelop.Packaging.Gui
 			// Container child generalTable.Gtk.Table+TableChild
 			this.packageDescriptionScrolledWindow = new global::Gtk.ScrolledWindow();
 			this.packageDescriptionScrolledWindow.Name = "packageDescriptionScrolledWindow";
-			this.packageDescriptionScrolledWindow.HscrollbarPolicy = ((global::Gtk.PolicyType)(2));
 			this.packageDescriptionScrolledWindow.ShadowType = ((global::Gtk.ShadowType)(1));
 			// Container child packageDescriptionScrolledWindow.Gtk.Container+ContainerChild
 			this.packageDescriptionTextView = new global::Gtk.TextView();

--- a/main/src/addins/MonoDevelop.Packaging/gtk-gui/gui.stetic
+++ b/main/src/addins/MonoDevelop.Packaging/gtk-gui/gui.stetic
@@ -449,7 +449,6 @@
             <child>
               <widget class="Gtk.ScrolledWindow" id="packageDescriptionScrolledWindow">
                 <property name="MemberName" />
-                <property name="HscrollbarPolicy">Never</property>
                 <property name="ShadowType">In</property>
                 <child>
                   <widget class="Gtk.TextView" id="packageDescriptionTextView">


### PR DESCRIPTION
Fixed bug #56918 - When typing a description in NuGet package Metadata
the UI keeps on growing
https://bugzilla.xamarin.com/show_bug.cgi?id=56918

In project options typing a long description for the NuGet package
metadata would cause the dialog to increase in width. The release
notes on the other tab does not have this problem. Setting the
scroll window's policy to never show the horizontal scrolllbars
seems to break the word wrapping. Leaving it as the default fixes
the wrapping so the dialog does not increase in width.