### PR TITLE
[Core] Fix null ref exception on creating a new project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetCompilerParameters.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetCompilerParameters.cs
@@ -35,7 +35,7 @@ namespace MonoDevelop.Projects
 	public abstract class DotNetCompilerParameters
 	{
 		public DotNetProject ParentProject {
-			get { return ParentConfiguration.ParentItem; }
+			get { return ParentConfiguration?.ParentItem; }
 		}
 
 		internal protected virtual void Read (IPropertySet pset)


### PR DESCRIPTION
Creating the configuration when creating a project would throw a null
reference exception since the CSharpCompilerParameters was trying to
notify its parent project that a property had changed but it was
not associated with a parent configuration.