### PR TITLE
[DotNetCore] Fix .NET Core library project targeting .NET standard

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
@@ -132,6 +132,24 @@ namespace MonoDevelop.DotNetCore.Templating
 						Parameters ["UseNetCore1x"] = "true";
 					}
 				}
+				ConfigureDefaultNetCoreAppFramework ();
+			}
+		}
+
+		/// <summary>
+		/// Framework needs to be specified for .NET Core library projects if only one runtime/sdk
+		/// is available. Otherwise .NETStandard will be used for the target framework of the project.
+		/// </summary>
+		void ConfigureDefaultNetCoreAppFramework ()
+		{
+			if (!IsSupportedParameter ("NetCoreLibrary"))
+				return;
+
+			var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
+			if (highestFramework != null) {
+				Parameters ["framework"] = highestFramework.Id.GetShortFrameworkName ();
+			} else {
+				Parameters ["framework"] = "netcoreapp1.1";
 			}
 		}
 	}

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -203,6 +203,7 @@
 			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.1.x.1.0.0-beta2-20170523-241.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
+			supportedParameters="NetCoreLibrary"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 			condition="UseNetCore1x=true"
 			category="netcore/library/general" />
@@ -217,6 +218,7 @@
 			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170523-241.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
+			supportedParameters="NetCoreLibrary"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 			condition="UseNetCore20=true"
 			category="netcore/library/general" />
@@ -229,7 +231,7 @@
 			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170523-241.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
-			supportedParameters="FSharpNetCoreLibrary"
+			supportedParameters="FSharpNetCoreLibrary;NetCoreLibrary"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 			condition="UseNetCore20=true"
 			category="netcore/library/general" />


### PR DESCRIPTION
Fixed bug #57591 - .NET Core Class Library targets .NET Standard
https://bugzilla.xamarin.com/show_bug.cgi?id=57591

When a single .NET Core app runtime was installed then the .NET
Core app class library project would use the default framework set
by the project template which is .NET Standard instead of .NET Core
App. This happens when the wizard is not displayed so the framework
is not set. Now the framework is set if the wizard page is not
displayed so the correct target framework is used in the created
class library project.