### PR TITLE
Enable VSMEF parallel to the old composition

### DIFF
--- a/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
+++ b/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
@@ -34,25 +34,12 @@ namespace Microsoft.VisualStudio.Platform
 
         public CompositionContainer CompositionContainer { get; }
 
-        public ITextBufferFactoryService2 TextBufferFactoryService { get; }
-
         PlatformCatalog()
         {
             var container = PlatformCatalog.CreateContainer();
             container.SatisfyImportsOnce(this);
 
             this.CompositionContainer = container;
-            this.TextBufferFactoryService = (ITextBufferFactoryService2)_textBufferFactoryService;
-
-            this.MimeToContentTypeRegistryService.LinkTypes("text/plain", this.ContentTypeRegistryService.GetContentType("text"));		  //HACK
-            this.MimeToContentTypeRegistryService.LinkTypes("text/x-csharp", this.ContentTypeRegistryService.GetContentType("csharp"));   //HACK
-
-            if (null != this.ContentTypeRegistryService.GetContentType("css"))
-            {
-                this.MimeToContentTypeRegistryService.LinkTypes("text/x-css", this.ContentTypeRegistryService.GetContentType("css"));   //HACK
-                this.MimeToContentTypeRegistryService.LinkTypes("text/x-html", this.ContentTypeRegistryService.GetContentType("htmlx"));   //HACK
-                this.MimeToContentTypeRegistryService.LinkTypes("text/x-json", this.ContentTypeRegistryService.GetContentType("JSON"));   //HACK
-            }
         }
 
         static CompositionContainer CreateContainer()
@@ -92,15 +79,12 @@ namespace Microsoft.VisualStudio.Platform
             return container;
         }
 
-        [Export]                                        //HACK
-        [Name("csharp")]                                //HACK
-        [BaseDefinition("code")]                        //HACK
-        public ContentTypeDefinition codeContentType;   //HACK
-
         [Import]
         internal ITextBufferFactoryService _textBufferFactoryService { get; private set; }
 
-        [Import]
+		public ITextBufferFactoryService2 TextBufferFactoryService => (ITextBufferFactoryService2)_textBufferFactoryService;
+
+		[Import]
         internal ITextDocumentFactoryService TextDocumentFactoryService { get; private set; }
 
         [Import]
@@ -152,9 +136,17 @@ namespace Microsoft.VisualStudio.Platform
     }
 
     [Export(typeof(IMimeToContentTypeRegistryService))]
-    public class MimeToContentTypeRegistryService : IMimeToContentTypeRegistryService
+    public class MimeToContentTypeRegistryService : IMimeToContentTypeRegistryService, IPartImportsSatisfiedNotification
     {
-        public string GetMimeType(IContentType type)
+		[Import]
+		IContentTypeRegistryService ContentTypeRegistryService { get; set; }
+
+		[Export]
+		[Name ("csharp")]
+		[BaseDefinition ("code")]
+		public ContentTypeDefinition codeContentType;
+
+		public string GetMimeType(IContentType type)
         {
             string mimeType;
             if (this.maps.Item2.TryGetValue(type, out mimeType))
@@ -193,10 +185,26 @@ namespace Microsoft.VisualStudio.Platform
 
                 oldMap = result;
             }
-
         }
 
-        Tuple<ImmutableDictionary<string, IContentType>, ImmutableDictionary<IContentType, string>> maps = Tuple.Create(ImmutableDictionary<string, IContentType>.Empty, ImmutableDictionary<IContentType, string>.Empty);
+		void LinkTypes (string mimeType, string contentType)
+		{
+			LinkTypes (mimeType, ContentTypeRegistryService.GetContentType (contentType));
+		}
+
+		void IPartImportsSatisfiedNotification.OnImportsSatisfied ()
+		{
+			LinkTypes ("text/plain", "text");
+			LinkTypes ("text/x-csharp", "csharp");
+
+			if (this.ContentTypeRegistryService.GetContentType ("css") != null) {
+				LinkTypes ("text/x-css", "css");
+				LinkTypes ("text/x-html", "htmlx");
+				LinkTypes ("text/x-json", "JSON");
+			}
+		}
+
+		Tuple<ImmutableDictionary<string, IContentType>, ImmutableDictionary<IContentType, string>> maps = Tuple.Create(ImmutableDictionary<string, IContentType>.Empty, ImmutableDictionary<IContentType, string>.Empty);
     }
 
     // Fold back into Text.Def.TextData.TextSnapshotToTextReader

--- a/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
+++ b/main/src/core/Mono.TextEditor.Platform/PlatformCatalog.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //  Licensed under the MIT License. See License.txt in the project root for license information.
 //
@@ -30,13 +30,13 @@ namespace Microsoft.VisualStudio.Platform
 {
     public class PlatformCatalog
     {
-        public static PlatformCatalog Instance = new PlatformCatalog();
+        public static readonly PlatformCatalog Instance = new PlatformCatalog();
 
         public CompositionContainer CompositionContainer { get; }
 
         public ITextBufferFactoryService2 TextBufferFactoryService { get; }
 
-        private PlatformCatalog()
+        PlatformCatalog()
         {
             var container = PlatformCatalog.CreateContainer();
             container.SatisfyImportsOnce(this);
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.Platform
             }
         }
 
-        private static CompositionContainer CreateContainer()
+        static CompositionContainer CreateContainer()
         {
             // TODO: Read these from manifest.addin.xml?
             AggregateCatalog catalog = new AggregateCatalog();
@@ -196,7 +196,7 @@ namespace Microsoft.VisualStudio.Platform
 
         }
 
-        private Tuple<ImmutableDictionary<string, IContentType>, ImmutableDictionary<IContentType, string>> maps = Tuple.Create(ImmutableDictionary<string, IContentType>.Empty, ImmutableDictionary<IContentType, string>.Empty);
+        Tuple<ImmutableDictionary<string, IContentType>, ImmutableDictionary<IContentType, string>> maps = Tuple.Create(ImmutableDictionary<string, IContentType>.Empty, ImmutableDictionary<IContentType, string>.Empty);
     }
 
     // Fold back into Text.Def.TextData.TextSnapshotToTextReader

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -255,6 +255,9 @@
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Features">
       <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Features.2.3.0-beta1\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Features.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures">
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.EditorFeatures.2.3.0-beta1\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
       <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.2.3.0-beta1\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
     </Reference>

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -7,6 +7,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.3.0-beta1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp.Features" version="2.3.0-beta1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.3.0-beta1" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.3.0-beta1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.3.0-beta1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Elfie" version="1.0.0-rc9" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Features" version="2.3.0-beta1" targetFramework="net461" />

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -234,7 +234,11 @@
 		<ExtensionNode name = "Assembly" type = "MonoDevelop.Core.AddIns.AssemblyExtensionNode" />
 	</ExtensionPoint>
 
-	<!-- Extensions -->
+	<ExtensionPoint path="/MonoDevelop/Ide/Composition">
+		<ExtensionNode name = "Assembly" type = "MonoDevelop.Core.AddIns.AssemblyExtensionNode" />
+	</ExtensionPoint>
+
+  <!-- Extensions -->
 	
 	<Extension path = "/MonoDevelop/Core/Applications">
 		<Application id = "gsetup"
@@ -394,4 +398,15 @@
 	<Extension path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
 		<Assembly file="Microsoft.VisualStudio.Text.Logic.dll"/>
 	</Extension>
+
+	<Extension path="/MonoDevelop/Ide/Composition">
+		<Assembly file="Microsoft.CodeAnalysis.Features.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.Workspaces.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.CSharp.Features.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.CSharp.Workspaces.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
+		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" />
+		<Assembly file="MonoDevelop.Ide.dll"/>
+	</Extension>
+
 </ExtensionModel>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -31,6 +31,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Composition;
 using Mono.Addins;
 using MonoDevelop.Core;
@@ -88,6 +90,8 @@ namespace MonoDevelop.Ide.Composition
 		public RuntimeComposition RuntimeComposition { get; private set; }
 		public IExportProviderFactory ExportProviderFactory { get; private set; }
 		public ExportProvider ExportProvider { get; private set; }
+		public HostServices HostServices { get; private set; }
+		public System.ComponentModel.Composition.Hosting.ExportProvider ExportProviderV1 { get; private set; }
 
 		internal CompositionManager ()
 		{
@@ -109,6 +113,7 @@ namespace MonoDevelop.Ide.Composition
 			var assemblies = new HashSet<Assembly> ();
 			ReadAssembliesFromAddins (assemblies, "/MonoDevelop/Ide/TypeService/PlatformMefHostServices");
 			ReadAssembliesFromAddins (assemblies, "/MonoDevelop/Ide/TypeService/MefHostServices");
+			ReadAssembliesFromAddins (assemblies, "/MonoDevelop/Ide/Composition");
 
 			// spawn discovery tasks in parallel for each assembly
 			var tasks = new List<Task<DiscoveredParts>> (assemblies.Count);
@@ -137,6 +142,8 @@ namespace MonoDevelop.Ide.Composition
 			RuntimeComposition = RuntimeComposition.CreateRuntimeComposition (configuration);
 			ExportProviderFactory = RuntimeComposition.CreateExportProviderFactory ();
 			ExportProvider = ExportProviderFactory.CreateExportProvider ();
+			HostServices = MefV1HostServices.Create (ExportProvider.AsExportProvider ());
+			ExportProviderV1 = NetFxAdapters.AsExportProvider (ExportProvider);
 		}
 
 		void ReadAssembliesFromAddins (HashSet<Assembly> assemblies, string extensionPath)

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -119,6 +119,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.CodeAnalysis.EditorFeatures.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
 			</dependentAssembly>


### PR DESCRIPTION
A set of fixes that enables the new VSMEF composition live side-by-side with the old compositions for now. This will allow the WebTools addin to target the new composition while everything else is unchanged.