### PR TITLE
[Ide] Allow shell PathBar and Toolbar to coexist

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Content/IPathedDocument.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Content/IPathedDocument.cs
@@ -39,6 +39,11 @@ namespace MonoDevelop.Ide.Gui.Content
 		
 		event EventHandler<DocumentPathChangedEventArgs> PathChanged;
 	}
+
+	public interface IPathedDocumentEx
+	{
+		bool AllowToolbarToCoExist { get; }
+	}
 	
 	public class DocumentPathChangedEventArgs : EventArgs
 	{


### PR DESCRIPTION
By making a document implement IPathedDocumentEx.CanCoexist, you can attach a stock pathbar and a toolbar.

Bug 40652 - PathBar is broken for the forms previewer

cc @garuma @alanmcgovern @chkn 

This is currently untested, but this would be the only option to fix this without breaking API.