### PR TITLE
[NuGet] Trim whitespace from new package source

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/RegisteredPackageSourcesViewModelTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/RegisteredPackageSourcesViewModelTests.cs
@@ -552,6 +552,26 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("abc", expectedViewModel.Name);
 			Assert.AreEqual ("http://url", expectedViewModel.Source);
 		}
+
+		[Test]
+		public void NewPackageSourceName_ChangedWithWhitespaceAtStartAndEnd_NewPackageSourceNameWhitespaceIsTrimmed ()
+		{
+			CreateViewModel ();
+			viewModel.Load ();
+			viewModel.NewPackageSourceName = "  Test  ";
+
+			Assert.AreEqual ("Test", viewModel.NewPackageSourceName);
+		}
+
+		[Test]
+		public void NewPackageSourceUrl_ChangedWithWhitespaceAtStartAndEnd_NewPackageSourceUrlWhitespaceIsTrimmed ()
+		{
+			CreateViewModel ();
+			viewModel.Load ();
+			viewModel.NewPackageSourceUrl  = " Test ";
+
+			Assert.AreEqual ("Test", viewModel.NewPackageSourceUrl);
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RegisteredPackageSourcesViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RegisteredPackageSourcesViewModel.cs
@@ -174,7 +174,7 @@ namespace MonoDevelop.PackageManagement
 		public string NewPackageSourceName {
 			get { return newPackageSource.Name; }
 			set {
-				newPackageSource.Name = value;
+				newPackageSource.Name = value?.Trim ();
 				OnPropertyChanged(viewModel => viewModel.NewPackageSourceName);
 			}
 		}
@@ -182,7 +182,7 @@ namespace MonoDevelop.PackageManagement
 		public string NewPackageSourceUrl {
 			get { return newPackageSource.Source; }
 			set {
-				newPackageSource.Source = value;
+				newPackageSource.Source = value?.Trim ();
 				OnPropertyChanged(viewModel => viewModel.NewPackageSourceUrl);
 			}
 		}


### PR DESCRIPTION
Fixed bug #57588 - Adding package source url with extra spaces should
be trimmed
https://bugzilla.xamarin.com/show_bug.cgi?id=57588

Copying and pasting NuGet package source url can sometimes copy extra
whitespace which can then result in restore errors such as:

Failed to verify the root directory of local source
' https://api.nuget.org/v3/index.json'.

The package source name and url entered are now trimmed. This also
matches Visual Studio on Windows behaviour.