### PR TITLE
[NuGet] Ignore ReferenceOutputAssembly false project refs for restore

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSpecCreatorTests.cs
@@ -71,10 +71,11 @@ namespace MonoDevelop.PackageManagement.Tests
 			project.PackageReferences.Add (packageReference);
 		}
 
-		FakeDotNetProject AddProjectReference (string projectName, string fileName, string include)
+		FakeDotNetProject AddProjectReference (string projectName, string fileName, string include, bool referenceOutputAssembly = true)
 		{
 			fileName = fileName.ToNativePath ();
 			var projectReference = ProjectReference.CreateCustomReference (ReferenceType.Project, include);
+			projectReference.ReferenceOutputAssembly = referenceOutputAssembly;
 			project.References.Add (projectReference);
 
 			var fakeOtherProject = new FakeDotNetProject (fileName);
@@ -272,6 +273,29 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual (2, runtimeGraph.Supports.Count);
 			Assert.AreEqual ("dotnet5.6", runtimeGraph.Supports["dotnet5.6"].Name);
 			Assert.AreEqual ("portable-net45+win8", runtimeGraph.Supports["portable-net45+win8"].Name);
+		}
+
+		[Test]
+		public void CreatePackageSpec_OneProjectReferenceWithReferenceAssemblyIsFalse_ProjectReferencedNotAddedToPackageSpec ()
+		{
+			CreateProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			AddTargetFramework ("netcoreapp1.0");
+			string referencedProjectFileName = @"d:\projects\MyProject\Lib\Lib.csproj".ToNativePath ();
+			string include = @"Lib\Lib.csproj".ToNativePath ();
+			var referencedProject = AddProjectReference ("Lib", referencedProjectFileName, include, referenceOutputAssembly: false);
+			solution.OnResolveProject = pr => {
+				if (pr.Include == include)
+					return referencedProject;
+				return null;
+			};
+			CreatePackageSpec ();
+
+			var targetFramework = spec.RestoreMetadata.TargetFrameworks.Single ();
+			Assert.AreEqual ("MyProject", spec.Name);
+			Assert.AreEqual ("MyProject", spec.RestoreMetadata.ProjectName);
+			Assert.AreEqual ("netcoreapp1.0", spec.RestoreMetadata.OriginalTargetFrameworks.Single ());
+			Assert.AreEqual (".NETCoreApp,Version=v1.0", targetFramework.FrameworkName.ToString ());
+			Assert.AreEqual (0, targetFramework.ProjectReferences.Count);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSpecCreator.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSpecCreator.cs
@@ -166,6 +166,9 @@ namespace MonoDevelop.PackageManagement
 			if (projectReference.ReferenceType != ReferenceType.Project)
 				return false;
 
+			if (!projectReference.ReferenceOutputAssembly)
+				return false;
+
 			if (projectReference.Include != null)
 				return !projectReference.Include.EndsWith (".shproj", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Project references that have ReferenceOutputAssembly set to false
should not be added to the project.assets.json file. This can cause
the restore to fail. For example, if a .NET Standard project has a
project reference to a .NET Core App project, but has the
ReferenceOutputAssembly set to false, then dotnet restore from the
command line works, but the restore would fail in the IDE. Now the
restore works when run by the IDE.