### PR TITLE
Fix quick fix menu load issue

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -289,8 +289,10 @@
 
 	<Extension path = "/MonoDevelop/SourceEditor2/ContextMenu/Editor">
 		<Condition id="FileType" mimeTypes="text/x-csharp">
-			<CommandItem id = "MonoDevelop.Refactoring.RefactoryCommands.QuickFixMenu"  insertafter="MonoDevelop.SourceEditor.SourceEditorCommands.MarkerOperations" insertbefore="MonoDevelop.Debugger.DebugCommands.ExpressionEvaluator"/>
-			<CommandItem id = "MonoDevelop.Refactoring.RefactoryCommands.CurrentRefactoryOperations" insertafter="MonoDevelop.SourceEditor.SourceEditorCommands.MarkerOperations" insertbefore="MonoDevelop.Debugger.DebugCommands.ExpressionEvaluator"/>
+			<ItemSet id = "MonoDevelop.Refactoring.RefactoryCommands.QuickFixMenu" _label = "Quick Fix" autohide = "true" insertafter="MonoDevelop.SourceEditor.SourceEditorCommands.MarkerOperations" insertbefore="MonoDevelop.Debugger.DebugCommands.ExpressionEvaluator">
+				<CommandItem id = "MonoDevelop.Refactoring.RefactoryCommands.QuickFixMenu" />
+			</ItemSet>
+			<CommandItem id = "MonoDevelop.Refactoring.RefactoryCommands.CurrentRefactoryOperations" />
 
 			<ItemSet id = "Navigate" _label = "Navigate">
 				<CommandItem id = "MonoDevelop.Refactoring.RefactoryCommands.FindAllReferences"/>


### PR DESCRIPTION
Changed the way the quick fix menu is shown. It used to be a command
that generated a submenu with the fixes. Now the quick fix menu is
defined as an item set that contains the quick fix command array.

This is a workaround to a Cocoa issue. When a submenu is made visible,
there seems to be no way to hide it, even when the item that defines
the submenu is removed. By changing the way the quick fix menu is
generated, that menu doesn't need to be closed and recreated, it is
just updated.

Fixes bug #57704