### PR TITLE
[Stetic] Fix InvalidCastException preventing editing

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/libsteticui/AssemblyResolver.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/libsteticui/AssemblyResolver.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Text;
@@ -40,7 +41,7 @@ namespace Stetic {
 
 	internal class AssemblyResolver : BaseAssemblyResolver {
 
-		Hashtable _assemblies;
+		Dictionary<string, AssemblyDefinition> _assemblies;
 		ApplicationBackend app;
 
 		public IDictionary AssemblyCache {
@@ -50,7 +51,7 @@ namespace Stetic {
 		public AssemblyResolver (ApplicationBackend app)
 		{
 			this.app = app;
-			_assemblies = new Hashtable ();
+			_assemblies = new Dictionary<string, AssemblyDefinition> ();
 		}
 
 		public StringCollection Directories = new StringCollection ();
@@ -62,8 +63,7 @@ namespace Stetic {
 	
 		public AssemblyDefinition Resolve (AssemblyNameReference name, string basePath)
 		{
-			AssemblyDefinition asm = (AssemblyDefinition) _assemblies [name.FullName];
-			if (asm == null) {
+			if (_assemblies.TryGetValue (name.FullName, out var asm)) {
 				if (app != null) {
 					string ares = app.ResolveAssembly (name.Name);
 					if (ares != null) {
@@ -85,7 +85,7 @@ namespace Stetic {
 		
 		public void ClearCache ()
 		{
-			foreach (AssemblyDefinition asm in _assemblies) {
+			foreach (AssemblyDefinition asm in _assemblies.Values) {
 				asm.Dispose ();
 			}
 			_assemblies.Clear ();


### PR DESCRIPTION
ERROR [2017-06-23 22:59:52Z]: The file '/Users/therzok/Work/md/monodevelop/main/external/mono-addins/Mono.Addins.Gui/Mono.Addins.Gui/AddinManagerDialog.cs' could not be opened.
System.InvalidCastException: Specified cast is not valid.
  at Stetic.AssemblyResolver.ClearCache () [0x0000e] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/AssemblyResolver.cs:88
  at Stetic.CecilWidgetLibrary.Flush () [0x0000e] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/CecilWidgetLibrary.cs:364
  at Stetic.Registry.EndChangeSet () [0x0002f] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libstetic/Registry.cs:44
  at Stetic.ApplicationBackend.LoadLibraries (Stetic.AssemblyResolver resolver, System.Collections.IEnumerable libraries) [0x00016] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/ApplicationBackend.cs:203
  at (wrapper remoting-invoke-with-check) Stetic.ApplicationBackend:LoadLibraries (Stetic.AssemblyResolver,System.Collections.IEnumerable)
  at Stetic.ProjectBackend.Read (System.Xml.XmlDocument doc) [0x00262] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/ProjectBackend.cs:364
  at Stetic.ProjectBackend.Load (System.String xmlFile, System.String fileName) [0x0001b] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/ProjectBackend.cs:305
  at Stetic.ProjectBackend.Load (System.String fileName) [0x00000] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/ProjectBackend.cs:296
  at (wrapper remoting-invoke-with-check) Stetic.ProjectBackend:Load (string)
  at Stetic.Project.get_ProjectBackend () [0x0004b] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/Project.cs:72
  at Stetic.Project.set_ImagesRootPath (System.String value) [0x00000] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/libsteticui/Project.cs:146
  at (wrapper remoting-invoke-with-check) Stetic.Project:set_ImagesRootPath (string)
  at MonoDevelop.GtkCore.GuiBuilder.GuiBuilderView.AttachWindow (MonoDevelop.GtkCore.GuiBuilder.GuiBuilderWindow window) [0x0001d] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderView.cs:86
  at MonoDevelop.GtkCore.GuiBuilder.GuiBuilderView..ctor (MonoDevelop.Ide.Gui.ViewContent content, MonoDevelop.GtkCore.GuiBuilder.GuiBuilderWindow window) [0x0005b] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderView.cs:79
  at MonoDevelop.GtkCore.GuiBuilder.GuiBuilderDisplayBinding.CreateContent (MonoDevelop.Core.FilePath fileName, System.String mimeType, MonoDevelop.Projects.Project ownerProject) [0x0003c] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderDisplayBinding.cs:80
  at MonoDevelop.Ide.Gui.LoadFileWrapper+<Invoke>d__8.MoveNext () [0x00053] in /Users/builder/data/lanes/432/5315887a/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs:1561