### PR TITLE
[d15-3][DotNetCore] Fix F# .NET Core 2.0 projects do not compile

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -48,6 +48,9 @@ namespace MonoDevelop.DotNetCore
 
 			if (!IsInstalled)
 				LoggingService.LogInfo (".NET Core SDK not found.");
+
+			if (IsInstalled)
+				SetFSharpShims ();
 		}
 
 		public static bool IsInstalled { get; private set; }
@@ -106,6 +109,27 @@ namespace MonoDevelop.DotNetCore
 				LoggingService.LogError (string.Format ("Unable to read '{0}'", fileName), ex);
 			}
 			return null;
+		}
+
+		/// <summary>
+		/// This is a workaround to allow F# .NET Core 2.0 projects to be evaluated properly and compile
+		/// without any errors. The better solution would be to ship the new Microsoft.FSharp.NetSdk.props
+		/// and .targets files with Mono so this workaround can be removed. Setting the FSharpPropsShim
+		/// and FSharpTargetsShim as environment variables allows the correct MSBuild imports to be used
+		/// when building and evaluating. Just setting a global MSBuild property would fix the Build target
+		/// not being found but the MSBuild project evaluation would not add the FSharp.Core PackageReference
+		/// to the project.assets.json file, also all .fs files were treated as None items instead of
+		/// Compile items.
+		/// </summary>
+		static void SetFSharpShims ()
+		{
+			var latestVersion = Versions.FirstOrDefault ();
+			if (latestVersion != null && latestVersion.Major == 2) {
+				FilePath directory = FilePath.Build (MSBuildSDKsPath, "..", "FSharp");
+
+				Environment.SetEnvironmentVariable ("FSharpPropsShim", directory.Combine ("Microsoft.FSharp.NetSdk.props").FullPath);
+				Environment.SetEnvironmentVariable ("FSharpTargetsShim", directory.Combine ("Microsoft.FSharp.NetSdk.targets").FullPath);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixed bug #57769 - F# .NET Core 2.0 projects do not compile
https://bugzilla.xamarin.com/show_bug.cgi?id=57769

F# .NET Core projects would fail to compile with an error about the
Build target being missing.

    MSB4057: The target "Build" does not exist in the project.

Also the FSharp.Core package reference was not added to the generated
project.assets.json file. This is an implicit reference added by the
.NET Core sdk MSBuild targets.

Until the Microsoft.FSharp.NetSdk.targets and .props files are
included in Mono a workaround has been added where the F# shim
properties are set as environment variables which allows the project
to be evaluated properly and the build to work.

    FSharpPropsShim=/usr/local/share/dotnet/sdk/2.0.0-preview2-006497/FSharp/Microsoft.FSharp.NetSdk.props
    FSharpTargetsShim=/usr/local/share/dotnet/sdk/2.0.0-preview2-006497/FSharp/Microsoft.FSharp.NetSdk.targets

The F# ASP.NET Core 2.0 MVC project does not seem to run due to a Razor compilation error on my machine. I see the same problem when creating a new project using just the .NET Core command line, building and running it.