### PR TITLE
[Core] Optimize MSBuild evaluation whitespace allocations.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/StringTable.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/StringTable.cs
@@ -462,7 +462,7 @@ namespace MonoDevelop.Core
         private string AddItem(string chars, int start, int len, int hashCode)
         {
             var text = chars.Substring(start, len);
-            AddCore(chars, hashCode);
+            AddCore(text, hashCode);
             return text;
         }
 


### PR DESCRIPTION
This reduces the number of duplicate strings from 40MB to 30MB. We now
avoid substringing and creating a lot of string junk and reusing simple
whitespace strings.

Also cache the first part of the string, as most of them are just
newlines