### PR TITLE
Fix offsets for base method tooltip. Fixes #57807

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TestTooltipProvider.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TestTooltipProvider.fs
@@ -1,6 +1,5 @@
 namespace MonoDevelopTests
 open System.Text.RegularExpressions
-open System.Threading
 open NUnit.Framework
 open FsUnit
 open MonoDevelop.FSharp.MonoDevelop
@@ -54,6 +53,19 @@ type TestTooltipProvider() =
         let segment = Symbols.getTextSegment editor symbolUse.Value col line
         segment.Offset |> should equal 5
         segment.EndOffset |> should equal 11
+
+    [<Test>]
+    member this.``Base method has correct segment``() =
+        let source =
+            """
+            type BaseType(int) = class end
+            type MyString() =
+                inherit BaseType(int)
+                let x = base.To$String() 
+            """
+        let line, col, symbolUse, editor = getSymbol source
+        let segment = Symbols.getTextSegment editor symbolUse.Value col line
+        segment.EndOffset - segment.Offset |> should equal 8
 
     [<Test>]
     member this.``Tooltip arrows are right aligned``() =

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -41,7 +41,11 @@ module Symbols =
 
         let startOffset = doc.LocationToOffset(start.Line, start.Column+1)
         let endOffset = doc.LocationToOffset(finish.Line, finish.Column+1)
-        let startOffset = if startOffset = endOffset then endOffset-lastIdent.Length else startOffset
+        let startOffset =
+            if startOffset = endOffset then 
+                endOffset-symbolUse.Symbol.DisplayName.Length
+            else
+                startOffset
         MonoDevelop.Core.Text.TextSegment.FromBounds(startOffset, endOffset)
 
     let getEditorDataForFileName (fileName:string) =


### PR DESCRIPTION
Fixes this tooltip issue where the tooltip appears in the wrong position when endOffset == offset

![](https://bugzilla.xamarin.com/attachment.cgi?id=23150)