### PR TITLE
[NuGet] Allow NuGet action to be cancelled on closing solution

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
@@ -25,14 +25,15 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
+using MonoDevelop.PackageManagement.Gui;
 using MonoDevelop.Projects;
 using NuGet.Common;
-using System.Collections.Generic;
 
 namespace MonoDevelop.PackageManagement.Commands
 {
@@ -131,8 +132,10 @@ namespace MonoDevelop.PackageManagement.Commands
 		{
 			try {
 				if (PackageManagementServices.BackgroundPackageActionRunner.IsRunning) {
-					MessageService.ShowMessage (GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being processed."));
-					e.Cancel = true;
+					using (var dialog = new SolutionClosingDialog ()) {
+						dialog.ShowWithParent ();
+						e.Cancel = dialog.KeepSolutionOpen;
+					}
 				}
 			} catch (Exception ex) {
 				LoggingService.LogError ("Error on unloading workspace item.", ex);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
@@ -31,7 +31,6 @@ using System.Threading.Tasks;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
-using MonoDevelop.PackageManagement.Gui;
 using MonoDevelop.Projects;
 using NuGet.Common;
 
@@ -131,12 +130,7 @@ namespace MonoDevelop.PackageManagement.Commands
 		void WorkspaceItemUnloading (object sender, ItemUnloadingEventArgs e)
 		{
 			try {
-				if (PackageManagementServices.BackgroundPackageActionRunner.IsRunning) {
-					using (var dialog = new SolutionClosingDialog ()) {
-						dialog.ShowWithParent ();
-						e.Cancel = dialog.KeepSolutionOpen;
-					}
-				}
+				e.Cancel = !PendingPackageActionsHandler.OnSolutionClosing ();
 			} catch (Exception ex) {
 				LoggingService.LogError ("Error on unloading workspace item.", ex);
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
@@ -31,13 +31,11 @@ namespace MonoDevelop.PackageManagement.Gui
 {
 	partial class SolutionClosingDialog : Dialog
 	{
-		Button yesButton;
+		DialogButton yesButton;
 		Spinner spinner;
 
 		void Build ()
 		{
-			Resizable = false;
-
 			var mainVBox = new VBox ();
 			mainVBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			Content = mainVBox;
@@ -63,28 +61,20 @@ namespace MonoDevelop.PackageManagement.Gui
 			spinner.Accessible.Description =  GettextCatalog.GetString ("Busy indicator shown whilst waiting stopping for NuGet package processing to stop");
 			spinner.Visible = false;
 
-			var bottomHBox = new HBox ();
-			bottomHBox.Margin = new WidgetSpacing (5, 10, 5, 0);
-			bottomHBox.Spacing = 10;
-			bottomHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
-			mainVBox.PackStart (bottomHBox);
+			var noButton = new DialogButton (Command.No);
+			yesButton = new DialogButton (Command.Yes);
+			Buttons.Add (noButton);
+			Buttons.Add (yesButton);
+		}
 
-			yesButton = new Button ();
-			yesButton.MinWidth = 120;
-			yesButton.MinHeight = 25;
-			yesButton.Label = GettextCatalog.GetString ("Yes");
-			yesButton.Accessible.Identifier = "yesButton";
-			yesButton.Accessible.Description = GettextCatalog.GetString ("Stops the current NuGet package processing");
-			bottomHBox.PackEnd (yesButton);
-
-			var noButton = new Button ();
-			noButton.MinWidth = 120;
-			noButton.MinHeight = 25;
-			noButton.Label = GettextCatalog.GetString ("No");
-			noButton.Accessible.Identifier = "noButton";
-			noButton.Accessible.Description = GettextCatalog.GetString ("Closes the dialog without stopping the NuGet package processing");
-			noButton.Clicked += (sender, e) => Close ();
-			bottomHBox.PackEnd (noButton);
+		/// <summary>
+		/// Do not immediately close the dialog if the Yes button is clicked.
+		/// The dialog will wait until the NuGet package action has stopped.
+		/// </summary>
+		protected override void OnCommandActivated (Command cmd)
+		{
+			if (cmd != Command.Yes)
+				base.OnCommandActivated (cmd);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
@@ -39,14 +39,17 @@ namespace MonoDevelop.PackageManagement.Gui
 			Resizable = false;
 
 			var mainVBox = new VBox ();
+			mainVBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			Content = mainVBox;
 
 			var label = new Label ();
 			label.Margin = new WidgetSpacing (10, 10, 10, 0);
 			label.Text = GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being processed.");
+
 			mainVBox.PackStart (label);
 
 			var middleHBox = new HBox ();
+			middleHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			mainVBox.PackStart (middleHBox);
 
 			var questionLabel = new Label ();
@@ -56,23 +59,30 @@ namespace MonoDevelop.PackageManagement.Gui
 
 			spinner = new Spinner ();
 			middleHBox.PackStart (spinner);
+			spinner.Accessible.Identifier = "busySpinner";
+			spinner.Accessible.Description =  GettextCatalog.GetString ("Busy indicator shown whilst waiting stopping for NuGet package processing to stop");
 			spinner.Visible = false;
 
 			var bottomHBox = new HBox ();
 			bottomHBox.Margin = new WidgetSpacing (5, 10, 5, 0);
 			bottomHBox.Spacing = 10;
+			bottomHBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			mainVBox.PackStart (bottomHBox);
 
 			yesButton = new Button ();
 			yesButton.MinWidth = 120;
 			yesButton.MinHeight = 25;
 			yesButton.Label = GettextCatalog.GetString ("Yes");
+			yesButton.Accessible.Identifier = "yesButton";
+			yesButton.Accessible.Description = GettextCatalog.GetString ("Stops the current NuGet package processing");
 			bottomHBox.PackEnd (yesButton);
 
 			var noButton = new Button ();
 			noButton.MinWidth = 120;
 			noButton.MinHeight = 25;
 			noButton.Label = GettextCatalog.GetString ("No");
+			noButton.Accessible.Identifier = "noButton";
+			noButton.Accessible.Description = GettextCatalog.GetString ("Closes the dialog without stopping the NuGet package processing");
 			noButton.Clicked += (sender, e) => Close ();
 			bottomHBox.PackEnd (noButton);
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
@@ -39,36 +39,39 @@ namespace MonoDevelop.PackageManagement.Gui
 			Resizable = false;
 
 			var mainVBox = new VBox ();
-			mainVBox.Margin = 14;
 			Content = mainVBox;
 
 			var label = new Label ();
+			label.Margin = new WidgetSpacing (10, 10, 10, 0);
 			label.Text = GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being processed.");
 			mainVBox.PackStart (label);
 
+			var middleHBox = new HBox ();
+			mainVBox.PackStart (middleHBox);
+
 			var questionLabel = new Label ();
-			questionLabel.Text = "Stop processing NuGet packages?";
-			mainVBox.PackStart (questionLabel);
+			questionLabel.Margin = 10;
+			questionLabel.Text = GettextCatalog.GetString ("Stop processing NuGet packages?");
+			middleHBox.PackStart (questionLabel);
 
 			spinner = new Spinner ();
-			mainVBox.PackStart (spinner);
+			middleHBox.PackStart (spinner);
 			spinner.Visible = false;
 
 			var bottomHBox = new HBox ();
-			bottomHBox.Margin = 0;
-			//bottomHBox.Margin = new WidgetSpacing (8, 5, 14, 10);
-			bottomHBox.Spacing = 5;
+			bottomHBox.Margin = new WidgetSpacing (5, 10, 5, 0);
+			bottomHBox.Spacing = 10;
 			mainVBox.PackStart (bottomHBox);
 
 			yesButton = new Button ();
-			//stopButton.MinWidth = 120;
-			//stopButton.MinHeight = 25;
+			yesButton.MinWidth = 120;
+			yesButton.MinHeight = 25;
 			yesButton.Label = GettextCatalog.GetString ("Yes");
 			bottomHBox.PackEnd (yesButton);
 
 			var noButton = new Button ();
-			//cancelButton.MinWidth = 120;
-			//cancelButton.MinHeight = 25;
+			noButton.MinWidth = 120;
+			noButton.MinHeight = 25;
 			noButton.Label = GettextCatalog.GetString ("No");
 			noButton.Clicked += (sender, e) => Close ();
 			bottomHBox.PackEnd (noButton);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
@@ -1,0 +1,77 @@
+﻿//
+// SolutionClosingDialog.UI.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Core;
+using Xwt;
+
+namespace MonoDevelop.PackageManagement.Gui
+{
+	partial class SolutionClosingDialog : Dialog
+	{
+		Button yesButton;
+		Spinner spinner;
+
+		void Build ()
+		{
+			Resizable = false;
+
+			var mainVBox = new VBox ();
+			mainVBox.Margin = 14;
+			Content = mainVBox;
+
+			var label = new Label ();
+			label.Text = GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being processed.");
+			mainVBox.PackStart (label);
+
+			var questionLabel = new Label ();
+			questionLabel.Text = "Stop processing NuGet packages?";
+			mainVBox.PackStart (questionLabel);
+
+			spinner = new Spinner ();
+			mainVBox.PackStart (spinner);
+			spinner.Visible = false;
+
+			var bottomHBox = new HBox ();
+			bottomHBox.Margin = 0;
+			//bottomHBox.Margin = new WidgetSpacing (8, 5, 14, 10);
+			bottomHBox.Spacing = 5;
+			mainVBox.PackStart (bottomHBox);
+
+			yesButton = new Button ();
+			//stopButton.MinWidth = 120;
+			//stopButton.MinHeight = 25;
+			yesButton.Label = GettextCatalog.GetString ("Yes");
+			bottomHBox.PackEnd (yesButton);
+
+			var noButton = new Button ();
+			//cancelButton.MinWidth = 120;
+			//cancelButton.MinHeight = 25;
+			noButton.Label = GettextCatalog.GetString ("No");
+			noButton.Clicked += (sender, e) => Close ();
+			bottomHBox.PackEnd (noButton);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.UI.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.PackageManagement.Gui
 		DialogButton yesButton;
 		Spinner spinner;
 
-		void Build ()
+		void Build (bool installing)
 		{
 			var mainVBox = new VBox ();
 			mainVBox.Accessible.Role = Xwt.Accessibility.Role.Filler;
@@ -42,7 +42,7 @@ namespace MonoDevelop.PackageManagement.Gui
 
 			var label = new Label ();
 			label.Margin = new WidgetSpacing (10, 10, 10, 0);
-			label.Text = GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being processed.");
+			label.Text = GetMainLabelText (installing);
 
 			mainVBox.PackStart (label);
 
@@ -52,7 +52,7 @@ namespace MonoDevelop.PackageManagement.Gui
 
 			var questionLabel = new Label ();
 			questionLabel.Margin = 10;
-			questionLabel.Text = GettextCatalog.GetString ("Stop processing NuGet packages?");
+			questionLabel.Text = GetQuestionLabelText (installing);
 			middleHBox.PackStart (questionLabel);
 
 			spinner = new Spinner ();
@@ -65,6 +65,22 @@ namespace MonoDevelop.PackageManagement.Gui
 			yesButton = new DialogButton (Command.Yes);
 			Buttons.Add (noButton);
 			Buttons.Add (yesButton);
+		}
+
+		static string GetMainLabelText (bool installing)
+		{
+			if (installing)
+				return GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being installed.");
+
+			return  GettextCatalog.GetString ("Unable to close the solution when NuGet packages are being uninstalled.");
+		}
+
+		static string GetQuestionLabelText (bool installing)
+		{
+			if (installing)
+				return GettextCatalog.GetString ("Stop installing NuGet packages?");
+
+			return GettextCatalog.GetString ("Stop uninstalling NuGet packages?");
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.cs
@@ -1,0 +1,95 @@
+﻿//
+// SolutionClosingDialog.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Xwt;
+
+namespace MonoDevelop.PackageManagement.Gui
+{
+	partial class SolutionClosingDialog
+	{
+		const int timeout = 250; // ms
+		IDisposable timer;
+
+		public SolutionClosingDialog ()
+		{
+			Build ();
+
+			yesButton.Clicked += StopButtonClicked;
+		}
+
+		public bool KeepSolutionOpen { get; private set; } = true;
+
+		void StopButtonClicked (object sender, EventArgs e)
+		{
+			yesButton.Sensitive = false;
+
+			CloseIfNotRunningNuGetActions ();
+
+			PackageManagementServices.BackgroundPackageActionRunner.Cancel ();
+
+			CloseIfNotRunningNuGetActions ();
+
+			spinner.Visible = true;
+			spinner.Animate = true;
+
+			timer = CreateTimer ();
+		}
+
+		int count; 
+
+		void CloseIfNotRunningNuGetActions ()
+		{
+			if (!PackageManagementServices.BackgroundPackageActionRunner.IsRunning) {
+			//++count;
+			//if (count > 10) {
+				KeepSolutionOpen = false;
+				Close ();
+			}
+		}
+
+		IDisposable CreateTimer ()
+		{
+			return Application.TimeoutInvoke (timeout, CheckNuGetActionsStillRunning);
+		}
+
+		bool CheckNuGetActionsStillRunning ()
+		{
+			CloseIfNotRunningNuGetActions ();
+			return true;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+
+			if (timer != null) {
+				timer.Dispose ();
+				timer = null;
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/SolutionClosingDialog.cs
@@ -59,13 +59,9 @@ namespace MonoDevelop.PackageManagement.Gui
 			timer = CreateTimer ();
 		}
 
-		int count; 
-
 		void CloseIfNotRunningNuGetActions ()
 		{
 			if (!PackageManagementServices.BackgroundPackageActionRunner.IsRunning) {
-			//++count;
-			//if (count > 10) {
 				KeepSolutionOpen = false;
 				Close ();
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeBackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeBackgroundPackageActionRunner.cs
@@ -87,6 +87,10 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			throw new NotImplementedException ();
 		}
 
+		public void Cancel ()
+		{
+		}
+
 		public ProgressMonitorStatusMessage ShowErrorProgressMessage;
 		public string ShowErrorMessage;
 		public Exception ShowErrorException;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeBackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeBackgroundPackageActionRunner.cs
@@ -91,6 +91,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		{
 		}
 
+		public PendingPackageActionsInformation GetPendingActionsInfo ()
+		{
+			throw new NotImplementedException ();
+		}
+
 		public ProgressMonitorStatusMessage ShowErrorProgressMessage;
 		public string ShowErrorMessage;
 		public Exception ShowErrorException;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageAction.cs
@@ -39,6 +39,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public string PackageId { get; set; }
 
+		public PackageActionType ActionType { get; set; }
+
 		public void Execute ()
 		{
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
@@ -102,6 +102,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			GetLatestVersionLogger = log;
 			GetLatestVersionCancellationToken = token;
 
+			token.ThrowIfCancellationRequested ();
+
 			var resolvedPackage = new ResolvedPackage (LatestVersion, true);
 			return Task.FromResult (resolvedPackage);
 		}
@@ -134,6 +136,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			PreviewInstallCancellationToken = token;
 
 			BeforePreviewInstallPackageAsyncAction ();
+
+			token.ThrowIfCancellationRequested ();
 
 			IEnumerable<NuGetProjectAction> actions = InstallActions.ToArray ();
 			return Task.FromResult (actions);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitor.cs
@@ -127,6 +127,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		{
 			CancellationTokenSource.Cancel ();
 		}
+
+		public void SetCancellationTokenSource (CancellationTokenSource cancellationTokenSource)
+		{
+			CancellationTokenSource = cancellationTokenSource;
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitor.cs
@@ -122,6 +122,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		}
 
 		public bool IsDisposed;
+
+		public void Cancel ()
+		{
+			CancellationTokenSource.Cancel ();
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitorFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitorFactory.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using MonoDevelop.Core;
+using System.Threading;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
@@ -41,8 +42,17 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public ProgressMonitor CreateProgressMonitor (string statusText, bool clearConsole)
 		{
+			return CreateProgressMonitor (statusText, clearConsole, null);
+		}
+
+		public ProgressMonitor CreateProgressMonitor (
+			string statusText,
+			bool clearConsole,
+			CancellationTokenSource cancellationTokenSource)
+		{
 			StatusText = statusText;
 			ClearConsole = clearConsole;
+			ProgressMonitor.SetCancellationTokenSource (cancellationTokenSource);
 			return ProgressMonitor;
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableBackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableBackgroundPackageActionRunner.cs
@@ -49,8 +49,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		void Init ()
 		{
-			CreateEventMonitorAction = (monitor, packageManagementEvents) => {
-				EventsMonitor = new TestablePackageManagementEventsMonitor (monitor, packageManagementEvents);
+			CreateEventMonitorAction = (monitor, packageManagementEvents, completionSource) => {
+				EventsMonitor = new TestablePackageManagementEventsMonitor (monitor, packageManagementEvents, completionSource);
 				return EventsMonitor;
 			};
 		}
@@ -81,6 +81,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public Func<ProgressMonitor,
 			IPackageManagementEvents,
+			TaskCompletionSource<bool>,
 			PackageManagementEventsMonitor> CreateEventMonitorAction;
 
 		protected override PackageManagementEventsMonitor CreateEventMonitor (
@@ -88,7 +89,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			IPackageManagementEvents packageManagementEvents,
 			TaskCompletionSource<bool> taskCompletionSource)
 		{
-			return CreateEventMonitorAction (monitor, packageManagementEvents);
+			return CreateEventMonitorAction (monitor, packageManagementEvents, taskCompletionSource);
 		}
 
 		public TestablePackageManagementEventsMonitor EventsMonitor;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestablePackageCompatibilityRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestablePackageCompatibilityRunner.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			ProgressMonitor monitor,
 			IPackageManagementEvents packageManagementEvents)
 		{
-			EventsMonitor = new TestablePackageManagementEventsMonitor (monitor, packageManagementEvents);
+			EventsMonitor = new TestablePackageManagementEventsMonitor (monitor, packageManagementEvents, null);
 			return EventsMonitor;
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestablePackageManagementEventsMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestablePackageManagementEventsMonitor.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
@@ -34,8 +35,9 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 	{
 		public TestablePackageManagementEventsMonitor (
 			ProgressMonitor progressMonitor,
-			IPackageManagementEvents packageManagementEvents)
-			: base (progressMonitor, packageManagementEvents)
+			IPackageManagementEvents packageManagementEvents,
+			TaskCompletionSource<bool> taskCompletionSource)
+			: base (progressMonitor, packageManagementEvents, taskCompletionSource)
 		{
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
@@ -165,6 +165,11 @@ namespace MonoDevelop.PackageManagement.Tests
 			packageManager.InstallActions.Add (projectAction);
 		}
 
+		void CancelCurrentAction ()
+		{
+			progressMonitorFactory.ProgressMonitor.Cancel ();
+		}
+
 		[Test]
 		public void Run_OneInstallActionAndOneUninstallActionAndRunNotCompleted_InstallActionMarkedAsPending ()
 		{
@@ -566,6 +571,27 @@ namespace MonoDevelop.PackageManagement.Tests
 			Run (clearConsole: false);
 
 			Assert.IsFalse (progressMonitorFactory.ClearConsole);
+		}
+
+		/// <summary>
+		/// Do not open the package console window after the package action is cancelled.
+		/// This is done when other exceptions occur during package processing since it is
+		/// done in the background and just showing an error in the status bar may not bring
+		/// the error enough attention. However if the user cancels the action there is no
+		/// need to show the package console after the install fails. This is also a workaround
+		/// to prevent any open dialogs from being closed when the package console window is
+		/// opened after the NuGet action is cancelled by the user.
+		/// </summary>
+		[Test]
+		public void Run_OneInstallActionThatIsCancelledByUser_PackageConsoleNotDisplayed ()
+		{
+			CreateRunner ();
+			AddInstallAction ();
+			RunWithoutBackgroundDispatch ();
+			CancelCurrentAction ();
+			runner.ExecuteBackgroundDispatch ();
+
+			Assert.IsFalse (runner.EventsMonitor.IsPackageConsoleShown);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
@@ -183,6 +183,14 @@ namespace MonoDevelop.PackageManagement.Tests
 			progressMonitorFactory.ProgressMonitor.Cancel ();
 		}
 
+		void AddRestoreAction ()
+		{
+			var action = new FakeNuGetPackageAction ();
+			action.ActionType = PackageActionType.Restore;
+
+			actions.Add (action);
+		}
+
 		[Test]
 		public void Run_OneInstallActionAndOneUninstallActionAndRunNotCompleted_InstallActionMarkedAsPending ()
 		{
@@ -762,6 +770,58 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsTrue (task2.IsCanceled);
 			Assert.IsTrue (task3.IsCanceled);
 			Assert.IsFalse (runner.IsRunning);
+		}
+
+		[Test]
+		public void GetPendingActionsInfo_InstallActionBeingRun_InstallPending ()
+		{
+			CreateRunner ();
+			AddInstallAction ();
+			RunWithoutBackgroundDispatch ();
+
+			var info = runner.GetPendingActionsInfo ();
+
+			Assert.IsTrue (info.IsInstallPending);
+		}
+
+		[Test]
+		public void GetPendingActionsInfo_UninstallActionBeingRun_UninstallPending ()
+		{
+			CreateRunner ();
+			AddUninstallAction ();
+			RunWithoutBackgroundDispatch ();
+
+			var info = runner.GetPendingActionsInfo ();
+
+			Assert.IsTrue (info.IsUninstallPending);
+		}
+
+		[Test]
+		public void GetPendingActionsInfo_RestoreActionBeingRun_RestorePending ()
+		{
+			CreateRunner ();
+			AddRestoreAction ();
+			RunWithoutBackgroundDispatch ();
+
+			var info = runner.GetPendingActionsInfo ();
+
+			Assert.IsTrue (info.IsRestorePending);
+		}
+
+		[Test]
+		public void GetPendingActionsInfo_InstallAndUninstallActions_InstallAndUninstallPending ()
+		{
+			CreateRunner ();
+			AddInstallAction ();
+			AddUninstallAction ();
+
+			RunWithoutBackgroundDispatch ();
+
+			var info = runner.GetPendingActionsInfo ();
+
+			Assert.IsTrue (info.IsInstallPending);
+			Assert.IsTrue (info.IsUninstallPending);
+			Assert.IsFalse (info.IsRestorePending);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -418,6 +418,10 @@
     <Compile Include="MonoDevelop.PackageManagement\UninstallNuGetPackagesAction.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageReferenceNuGetProject.cs" />
     <Compile Include="MonoDevelop.PackageManagement\HasNuGetPackageOrReferenceFileTemplateCondition.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Gui\SolutionClosingDialog.UI.cs">
+      <DependentUpon>SolutionClosingDialog.cs</DependentUpon>
+    </Compile>
+    <Compile Include="MonoDevelop.PackageManagement.Gui\SolutionClosingDialog.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -424,6 +424,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Gui\SolutionClosingDialog.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PendingPackageActionsInformation.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageActionType.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\PendingPackageActionsHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -422,6 +422,8 @@
       <DependentUpon>SolutionClosingDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="MonoDevelop.PackageManagement.Gui\SolutionClosingDialog.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\PendingPackageActionsInformation.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\PackageActionType.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/BackgroundPackageActionRunner.cs
@@ -167,7 +167,8 @@ namespace MonoDevelop.PackageManagement
 						eventMonitor.ReportResult (progressMessage);
 					} catch (Exception ex) {
 						RemoveInstallActions (installPackageActions);
-						eventMonitor.ReportError (progressMessage, ex);
+						bool showPackageConsole = !monitor.CancellationToken.IsCancellationRequested;
+						eventMonitor.ReportError (progressMessage, ex, showPackageConsole);
 					} finally {
 						monitor.EndTask ();
 						GuiDispatch (() => {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForUpdatedPackagesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForUpdatedPackagesAction.cs
@@ -54,6 +54,10 @@ namespace MonoDevelop.PackageManagement
 			return false;
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.None; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IBackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IBackgroundPackageActionRunner.cs
@@ -35,6 +35,7 @@ namespace MonoDevelop.PackageManagement
 	{
 		IEnumerable<IInstallNuGetPackageAction> PendingInstallActions { get; }
 		IEnumerable<IInstallNuGetPackageAction> PendingInstallActionsForProject (DotNetProject project);
+		PendingPackageActionsInformation GetPendingActionsInfo ();
 
 		void Run (ProgressMonitorStatusMessage progressMessage, IPackageAction action);
 		void Run (ProgressMonitorStatusMessage progressMessage, IPackageAction action, bool clearConsole);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IBackgroundPackageActionRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IBackgroundPackageActionRunner.cs
@@ -43,6 +43,8 @@ namespace MonoDevelop.PackageManagement
 		Task RunAsync (ProgressMonitorStatusMessage progressMessage, IEnumerable<IPackageAction> actions);
 		Task RunAsync (ProgressMonitorStatusMessage progressMessage, IEnumerable<IPackageAction> actions, bool clearConsole);
 
+		void Cancel ();
+
 		void ShowError (ProgressMonitorStatusMessage progressMessage, Exception exception);
 		void ShowError (ProgressMonitorStatusMessage progressMessage, string message);
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageAction.cs
@@ -35,5 +35,6 @@ namespace MonoDevelop.PackageManagement
 		void Execute ();
 		void Execute (CancellationToken cancellationToken);
 		bool HasPackageScriptsToRun();
+		PackageActionType ActionType { get; }
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageManagementProgressMonitorFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageManagementProgressMonitorFactory.cs
@@ -24,7 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
+using System.Threading;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.PackageManagement
@@ -33,6 +33,10 @@ namespace MonoDevelop.PackageManagement
 	{
 		ProgressMonitor CreateProgressMonitor (string statusText);
 		ProgressMonitor CreateProgressMonitor (string statusText, bool clearConsole);
+		ProgressMonitor CreateProgressMonitor (
+			string statusText,
+			bool clearConsole,
+			CancellationTokenSource cancellationTokenSource);
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/InstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/InstallNuGetPackageAction.cs
@@ -111,6 +111,10 @@ namespace MonoDevelop.PackageManagement
 		public bool PreserveLocalCopyReferences { get; set; }
 		public bool OpenReadmeFile { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Install; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageActionType.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageActionType.cs
@@ -1,0 +1,36 @@
+﻿//
+// PackageActionType.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace MonoDevelop.PackageManagement
+{
+	enum PackageActionType
+	{
+		None,
+		Install,
+		Uninstall,
+		Restore
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementBackgroundDispatcher.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementBackgroundDispatcher.cs
@@ -39,6 +39,7 @@ namespace MonoDevelop.PackageManagement
 		static Queue<Action> backgroundQueue = new Queue<Action> ();
 		static ManualResetEvent backgroundThreadWait = new ManualResetEvent (false);
 		static Thread backgroundThread;
+		static Action action;
 
 		public static void Initialize ()
 		{
@@ -53,7 +54,7 @@ namespace MonoDevelop.PackageManagement
 		static void RunDispatcher ()
 		{
 			while (true) {
-				Action action = null;
+				action = null;
 				bool wait = false;
 				lock (backgroundQueue) {
 					if (backgroundQueue.Count == 0) {
@@ -90,6 +91,18 @@ namespace MonoDevelop.PackageManagement
 				if (backgroundQueue.Count == 1)
 					backgroundThreadWait.Set ();
 			}
+		}
+
+		public static void Clear ()
+		{
+			lock (backgroundQueue) {
+				backgroundQueue.Clear ();
+			}
+		}
+
+		public static bool IsDispatching ()
+		{
+			return backgroundQueue.Count > 0 || action != null;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementEventsMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementEventsMonitor.cs
@@ -164,12 +164,13 @@ namespace MonoDevelop.PackageManagement
 			FileService.NotifyFilesChanged (files);
 		}
 
-		public void ReportError (ProgressMonitorStatusMessage progressMessage, Exception ex)
+		public void ReportError (ProgressMonitorStatusMessage progressMessage, Exception ex, bool showPackageConsole = true)
 		{
 			LoggingService.LogError (progressMessage.Error, ex);
 			progressMonitor.Log.WriteLine (GetErrorMessageForPackageConsole (ex));
 			progressMonitor.ReportError (progressMessage.Error, null);
-			ShowPackageConsole (progressMonitor);
+			if (showPackageConsole)
+				ShowPackageConsole (progressMonitor);
 			packageManagementEvents.OnPackageOperationError (ex);
 
 			if (taskCompletionSource != null) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitor.cs
@@ -46,7 +46,11 @@ namespace MonoDevelop.PackageManagement
 			get { return consoleMonitor.Console; }
 		}
 
-		public PackageManagementProgressMonitor (OutputProgressMonitor consoleMonitor, ProgressMonitor statusMonitor)
+		public PackageManagementProgressMonitor (
+			OutputProgressMonitor consoleMonitor,
+			ProgressMonitor statusMonitor,
+			CancellationTokenSource cancellationTokenSource)
+			: base (cancellationTokenSource)
 		{
 			AddFollowerMonitor (statusMonitor);
 			this.consoleMonitor = consoleMonitor;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitorFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitorFactory.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Core.Execution;
 using MonoDevelop.Ide.Gui.Pads;
 using System;
 using System.Linq;
+using System.Threading;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -42,6 +43,14 @@ namespace MonoDevelop.PackageManagement
 		}
 
 		public ProgressMonitor CreateProgressMonitor (string title, bool clearConsole)
+		{
+			return CreateProgressMonitor (title, clearConsole, null);
+		}
+
+		public ProgressMonitor CreateProgressMonitor (
+			string title,
+			bool clearConsole,
+			CancellationTokenSource cancellationTokenSource)
 		{
 			ConfigureConsoleClearing (clearConsole);
 
@@ -58,7 +67,7 @@ namespace MonoDevelop.PackageManagement
 				pad,
 				true);
 
-			return new PackageManagementProgressMonitor (consoleMonitor, statusMonitor);
+			return new PackageManagementProgressMonitor (consoleMonitor, statusMonitor, cancellationTokenSource);
 		}
 
 		OutputProgressMonitor CreatePackageConsoleOutputMonitor ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PendingPackageActionsInformation.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PendingPackageActionsInformation.cs
@@ -1,0 +1,58 @@
+﻿//
+// PendingPackageActionsInformation.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+
+namespace MonoDevelop.PackageManagement
+{
+	class PendingPackageActionsInformation
+	{
+		public bool IsInstallPending { get; private set; }
+		public bool IsUninstallPending { get; private set; }
+		public bool IsRestorePending { get; private set; }
+
+		public void Add (IEnumerable<IPackageAction> actions)
+		{
+			foreach (var action in actions)
+				Add (action);
+		}
+
+		public void Add (IPackageAction action)
+		{
+			switch (action.ActionType) {
+			case PackageActionType.Install:
+				IsInstallPending = true;
+				break;
+			case PackageActionType.Uninstall:
+				IsUninstallPending = true;
+				break;
+			case PackageActionType.Restore:
+				IsRestorePending = true;
+				break;
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ReinstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ReinstallNuGetPackageAction.cs
@@ -69,6 +69,10 @@ namespace MonoDevelop.PackageManagement
 		public string PackageId { get; set; }
 		public NuGetVersion Version { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Install; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
@@ -107,6 +107,10 @@ namespace MonoDevelop.PackageManagement
 			return nugetAwareProjects.Any ();
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Restore; }
+		}
+
 		public bool CheckForUpdatesAfterRestore { get; set; }
 
 		public async Task<bool> HasMissingPackages (CancellationToken cancellationToken = default(CancellationToken))

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndUninstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndUninstallNuGetPackageAction.cs
@@ -66,6 +66,10 @@ namespace MonoDevelop.PackageManagement
 		public string PackageId { get; set; }
 		public NuGetVersion Version { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Uninstall; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesAction.cs
@@ -98,6 +98,10 @@ namespace MonoDevelop.PackageManagement
 
 		public bool RestorePackagesConfigProjects { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Restore; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInDotNetCoreProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInDotNetCoreProject.cs
@@ -52,6 +52,10 @@ namespace MonoDevelop.PackageManagement
 
 		public bool ReloadProject { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Restore; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetAwareProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetAwareProjectAction.cs
@@ -49,6 +49,10 @@ namespace MonoDevelop.PackageManagement
 			);
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Restore; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
@@ -51,6 +51,10 @@ namespace MonoDevelop.PackageManagement
 			packageRestorer = new MonoDevelopBuildIntegratedRestorer (solutionManager);
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Restore; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInProjectAction.cs
@@ -60,6 +60,10 @@ namespace MonoDevelop.PackageManagement
 			);
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Restore; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UninstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UninstallNuGetPackageAction.cs
@@ -78,6 +78,10 @@ namespace MonoDevelop.PackageManagement
 		public bool RemoveDependencies { get; set; }
 		public bool IsErrorWhenPackageNotInstalled { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Uninstall; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UninstallNuGetPackagesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UninstallNuGetPackagesAction.cs
@@ -76,6 +76,10 @@ namespace MonoDevelop.PackageManagement
 			this.packageIds.AddRange (packageIds);
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Uninstall; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
@@ -89,6 +89,10 @@ namespace MonoDevelop.PackageManagement
 			projectName = dotNetProject.Name;
 		}
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Install; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateNuGetPackageAction.cs
@@ -80,6 +80,10 @@ namespace MonoDevelop.PackageManagement
 		public string PackageId { get; set; }
 		public bool IncludePrerelease { get; set; }
 
+		public PackageActionType ActionType {
+			get { return PackageActionType.Install; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);


### PR DESCRIPTION
Fixed bug #53795 - Failure to install blocks the IDE
https://bugzilla.xamarin.com/show_bug.cgi?id=53795

Previously when closing the solution or IDE when a NuGet package
action is still running a dialog would be displayed saying that the
solution cannot be closed until the NuGet operation was completed.
This was true with NuGet v2 but with NuGet v3 and above the NuGet
operations can be cancelled. So now the dialog allows the current
operation to be cancelled when the Yes button is clicked. If the
operation is taking a while a busy spinner image will be displayed in
the dialog until the dialog is closed or the operation is cancelled
and then the solution will be closed.

<img width="444" alt="installingnugetpackagesonclosesolution" src="https://user-images.githubusercontent.com/372361/27784955-f3964da2-5fd3-11e7-98f5-52b0fe114a71.png">

The above dialog is not shown if a only a NuGet restore is being run. In this case a request will be made to cancel the restore and the solution will be closed.