### PR TITLE
[DotNetCore] Show SDK information before dependencies are restored

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/PackageDependencyNode.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/PackageDependencyNode.cs
@@ -66,6 +66,18 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 			version = packageReference.Metadata.GetValue ("Version", string.Empty);
 		}
 
+		public PackageDependencyNode (
+			DependenciesNode dependenciesNode,
+			string name,
+			bool topLevel,
+			bool readOnly)
+		{
+			this.dependenciesNode = dependenciesNode;
+			this.name = name;
+			IsTopLevel = topLevel;
+			IsReadOnly = readOnly;
+		}
+
 		public static PackageDependencyNode Create (
 			DependenciesNode dependenciesNode,
 			string dependencyName,
@@ -111,6 +123,9 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 
 		public string GetSecondaryLabel ()
 		{
+			if (string.IsNullOrEmpty (version))
+				return string.Empty;
+
 			return string.Format ("({0})", version);
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/SdkDependenciesNode.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/SdkDependenciesNode.cs
@@ -78,5 +78,16 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 		{
 			return ParentNode.PackageDependencyCache.GetDependency (dependency);
 		}
+
+		/// <summary>
+		/// Returns a SDK node for the project whilst the package dependencies are still loading.
+		/// </summary>
+		public IEnumerable<PackageDependencyNode> GetDefaultNodes ()
+		{
+			if (Project.TargetFramework.IsNetCoreApp ())
+				yield return new PackageDependencyNode (ParentNode, "Microsoft.NETCore.App", true, true);
+			else if (Project.TargetFramework.IsNetStandard ())
+				yield return new PackageDependencyNode (ParentNode, "NETStandard.Library", true, true);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/SdkDependenciesNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/SdkDependenciesNodeBuilder.cs
@@ -62,6 +62,8 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 			var dependenciesNode = (SdkDependenciesNode)dataObject;
 			if (dependenciesNode.LoadedDependencies) {
 				AddLoadedDependencyNodes (treeBuilder, dependenciesNode);
+			} else {
+				treeBuilder.AddChildren (dependenciesNode.GetDefaultNodes ());
 			}
 		}
 
@@ -73,6 +75,10 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 			} else if (frameworkNodes.Any ()) {
 				var frameworkNode = frameworkNodes.First ();
 				treeBuilder.AddChildren (frameworkNode.GetDependencyNodes ());
+			} else {
+				// Projects sometimes return no dependencies from MSBuild initially so
+				// add the default nodes until the dependencies are updated.
+				treeBuilder.AddChildren (dependenciesNode.GetDefaultNodes ());
 			}
 		}
 


### PR DESCRIPTION
Fixed bug #56455 - Show SDK for project when not restored
https://bugzilla.xamarin.com/show_bug.cgi?id=56455

When a new .NET Core project is created the Dependencies - SDK folder
shows no items until the restore is completed. Now the SDK dependency
is shown (e.g. NETStandard.Library or Microsoft.NETCore.App) whilst
the dependencies are being restored and the updated information has
not yet been returned from MSBuild. This mirrors the behaviour of
Visual Studio on Windows.