### PR TITLE
Fix duplicate global preference section ids

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -114,7 +114,7 @@
 
 	<Extension path="/MonoDevelop/Ide/GlobalOptionsDialog">
 		<Section id="NuGetPackageManagement" _label="NuGet" insertafter="VersionControl">
-			<Section id="General" _label="General" fill="true" class="MonoDevelop.PackageManagement.Gui.PackageManagementOptionsPanel" icon="md-prefs-package" />
+			<Section id="NuGetGeneral" _label="General" fill="true" class="MonoDevelop.PackageManagement.Gui.PackageManagementOptionsPanel" icon="md-prefs-package" />
 			<Section id="PackageSources" _label="Sources" fill="true" class="MonoDevelop.PackageManagement.Gui.PackageSourcesOptionsPanel" icon="md-prefs-package-source" />
 		</Section>
 	</Extension>

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
@@ -27,7 +27,7 @@
 		<Section id="PerformanceDiagnostics"
 			_label="Performance Diagnostics"
 			insertafter="VersionControl">
-			<Section id="General"
+			<Section id="PerformanceDiagnosticsGeneral"
 				_label="General"
 				fill="true"
 				class="PerformanceDiagnosticsAddIn.GlobalOptionsPanel"


### PR DESCRIPTION
NuGet - General and Performance Diagnostics - General were using the same section id as Text Editor - General so the wrong preferences page was displayed on re-opening the global preferences dialog. The Text Editor - General section was previously always selected since it was the first matching section id.