### PR TITLE
[Ide] Fix language not displayed for recently used project templates

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
@@ -93,7 +93,7 @@ namespace MonoDevelop.Ide.Projects
 				return;
 			}
 
-			if (!Template.AvailableLanguages.Any () || !IsTemplateRowSelected (widget, flags)) {
+			if (!RenderRecentTemplate && (!Template.AvailableLanguages.Any () || !IsTemplateRowSelected (widget, flags))) {
 				return;
 			}
 


### PR DESCRIPTION
Fixed bug #57904 - Language not shown for all recently used projects
in New Project dialog
https://bugzilla.xamarin.com/show_bug.cgi?id=57904

In the New Project dialog the Recently used section would only show
the template language if the row was selected. Now every row shows
the language.