### PR TITLE
[Ide] Support not saving files when creating new project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -369,6 +369,12 @@ namespace MonoDevelop.Ide.Gui
 				if (result == AlertButton.Cancel)
 					return false;
 
+				if (result == AlertButton.CloseWithoutSave) {
+					doc.Window.ViewContent.DiscardChanges ();
+					await doc.Window.CloseWindow (true);
+					continue;
+				}
+
 				await doc.Save ();
 				if (doc.IsDirty) {
 					doc.Select ();
@@ -385,8 +391,8 @@ namespace MonoDevelop.Ide.Gui
 				(object)(doc.Window.ViewContent.IsUntitled
 					? doc.Window.ViewContent.UntitledName
 					: System.IO.Path.GetFileName (doc.Window.ViewContent.ContentName))),
-				"",
-				 AlertButton.Cancel, doc.Window.ViewContent.IsUntitled ? AlertButton.SaveAs : AlertButton.Save);
+				GettextCatalog.GetString ("If you don't save, all changes will be permanently lost."),
+				AlertButton.CloseWithoutSave, AlertButton.Cancel, doc.Window.ViewContent.IsUntitled ? AlertButton.SaveAs : AlertButton.Save);
 		}
 		
 		public void CloseAllDocuments (bool leaveActiveDocumentOpen)


### PR DESCRIPTION
Fixed bug #55351 - Dirty file interferes with creating new project
https://bugzilla.xamarin.com/show_bug.cgi?id=55351

With unsaved files open in the IDE, creating a new project would
show a dialog prompt asking to save changes. This dialog had two
buttons Cancel and Save (or Save As). Now the dialog also has a
Don't Save button which will discard the changes and close the unsaved
file. Also the dialog now has a message saying that not saving will
cause the changes to be permanently lost.