### PR TITLE
[WebReferences] Disable WCF option in dialog when unsupported

### DIFF
--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.Dialogs/WebReferenceDialog.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.Dialogs/WebReferenceDialog.cs
@@ -150,7 +150,7 @@ namespace MonoDevelop.WebReferences.Dialogs
 		#endregion
 		
 		#region Member Variables
-		const string homeUrl = "http://www.w3schools.com/xml/tempconvert.asmx";
+		const string homeUrl = "https://www.w3schools.com/xml/tempconvert.asmx?WSDL";
 		WebServiceDiscoveryResult selectedService;
 //		protected Gtk.Alignment frmBrowserAlign;
 		#endregion

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.Dialogs/WebReferenceDialog.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.Dialogs/WebReferenceDialog.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Gtk;
 
 using MonoDevelop.Core;
+using MonoDevelop.Core.Assemblies;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.WebBrowser;
 using MonoDevelop.WebReferences;
@@ -491,7 +492,15 @@ namespace MonoDevelop.WebReferences.Dialogs
 				btnOK.Sensitive = isWebService;
 				tlbNavigate.Visible = WebBrowserService.CanGetWebBrowser;
 				tbxReferenceName.Sensitive = isWebService;
-				comboModel.Sensitive = !project.IsPortableLibrary;
+				if (project.IsPortableLibrary)
+					comboModel.Sensitive = false;
+				else if (IsWcfSupported ())
+					comboModel.Sensitive = true;
+				else {
+					// Select web references instead of WCF.
+					comboModel.Active = 1;
+					comboModel.Sensitive = false;
+				}
 				break;
 
 			case DialogState.CreateConfig:
@@ -593,6 +602,15 @@ namespace MonoDevelop.WebReferences.Dialogs
 			default:
 				throw new InvalidOperationException ();
 			}
+		}
+
+		/// <summary>
+		/// PCL or projects that target .NET Framework are considered to support WCF.
+		/// </summary>
+		bool IsWcfSupported ()
+		{
+			return project.TargetFramework.Id.Identifier == TargetFrameworkMoniker.ID_NET_FRAMEWORK ||
+				project.IsPortableLibrary;
 		}
 
 		protected void OnBtnBackClicked (object sender, EventArgs e)


### PR DESCRIPTION
Fixed bug #57449 - Remove WCF 'Add a Reference' dialog
https://bugzilla.xamarin.com/show_bug.cgi?id=57449

The WCF option in the Web References dialog is enabled if the project
targets the .NET Framework. If the project targets a Xamarin mobile
framework then WCF cannot be selected, the combo box is disabled, and
instead the .NET 2.0 Web Services option is selected by default. The
logic for PCL projects is unchanged from before and WCF will selected
by default and the .NET 2.0 Web Services option cannot be selected.

Also updated the default url used in the dialog to one that works. Not sure if we should be using a default url, maybe no url, or just the last one used might be better. VS 2017 on Windows in its Service References dialog does not use a default and does not remember the last url entered.