### PR TITLE
Replace SharpZipLib package with JetBrains.SharpZipLib.Stripped

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -135,7 +135,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\..\..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170615.10\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -23,7 +23,7 @@
   <package id="Microsoft.VisualStudio.Text.UI" version="15.0.26201" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -167,7 +167,7 @@
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\..\..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170615.10\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable">
@@ -193,7 +193,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\..\..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170615.10\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\..\packages\System.Composition.AttributedModel.1.0.31\lib\netstandard1.0\System.Composition.AttributedModel.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.VisualStudio.Text.UI" version="15.0.26201" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -6,8 +6,8 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518" />
-				<bindingRedirect oldVersion="2.84.0.0-4.84.0.0" newVersion="0.86.0.518" />
+				<bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="1.0.6375.31400" />
+				<bindingRedirect oldVersion="2.84.0.0-4.84.0.0" newVersion="1.0.6375.31400" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
The bump is required to support ZIP files with
versions not supported by the old SharpZipLib 0.86