### PR TITLE
[Core] Expose shared cache methods to StringInternPool.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/StringInternPool.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/StringInternPool.cs
@@ -56,5 +56,20 @@ namespace MonoDevelop.Core
 		{
 			return table.Add (chars);
 		}
+
+		public static string AddShared (StringBuilder chars)
+		{
+			return StringTable.AddShared (chars);
+		}
+
+		public static string AddShared (string chars)
+		{
+			return StringTable.AddShared (chars);
+		}
+
+		public static string AddShared (string chars, int start, int len)
+		{
+			return StringTable.AddShared (chars, start, len);
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/StringTable.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/StringTable.cs
@@ -536,6 +536,33 @@ namespace MonoDevelop.Core
             return AddSharedSlow(hashCode, chars);
         }
 
+		internal static string AddShared (string chars)
+		{
+			var hashCode = Hash.GetFNVHashCode (chars);
+
+			string shared = FindSharedEntry (chars, hashCode);
+			if (shared != null) {
+				return shared;
+			}
+
+			AddSharedSlow (hashCode, chars);
+			return chars;
+		}
+
+		internal static string AddShared (string chars, int start, int len)
+		{
+			var hashCode = Hash.GetFNVHashCode (chars, start, len);
+
+			string shared = FindSharedEntry (chars, start, len, hashCode);
+			if (shared != null) {
+				return shared;
+			}
+
+			string text = chars.Substring (start, len);
+			AddSharedSlow (hashCode, text);
+			return text;
+		}
+
         private static string AddSharedSlow(int hashCode, StringBuilder builder)
         {
             string text = builder.ToString();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -933,8 +933,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		MSBuildItemEvaluated CreateEvaluatedItem (MSBuildEvaluationContext context, ProjectInfo pinfo, MSBuildProject project, MSBuildItem sourceItem, string include, string evaluatedFile = null, string recursiveDir = null)
 		{
-			lock (EngineManager.Pool)
-				include = EngineManager.Pool.Add (include);
+			include = StringInternPool.AddShared (include);
 
 			var it = new MSBuildItemEvaluated (project, sourceItem.Name, sourceItem.Include, include);
 			var md = new Dictionary<string,IMSBuildPropertyEvaluated> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngineManager.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngineManager.cs
@@ -34,8 +34,6 @@ namespace MonoDevelop.Projects.MSBuild
 		object localLock = new object ();
 		bool disposed;
 
-		internal Core.StringInternPool Pool { get; } = new Core.StringInternPool ();
-
 		public MSBuildEngine GetEngine (bool supportsMSBuild)
 		{
 /*			if (supportsMSBuild) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -458,9 +458,7 @@ namespace MonoDevelop.Projects.MSBuild
 				while (i != -1);
 
 				sb.Append (str, last, str.Length - last);
-				lock (project.Pool) {
-					return project.Pool.Add (sb);
-				}
+				return StringInternPool.AddShared (sb);
 			} finally {
 				evaluationSbs.Enqueue (sb);
 			}
@@ -500,15 +498,12 @@ namespace MonoDevelop.Projects.MSBuild
 			i += 2;
 			int j = FindClosingChar (str, i, ')');
 			if (j == -1) {
-				lock (project.Pool)
-					val = project.Pool.Add (str, start, str.Length - start);
+				val = StringInternPool.AddShared (str, start, str.Length - start);
 				i = str.Length;
 				return false;
 			}
 
-			string prop;
-			lock (project.Pool)
-				prop = project.Pool.Add (str, i, j - i).Trim ();
+			string prop = StringInternPool.AddShared (str, i, j - i).Trim ();
 			i = j + 1;
 
 			bool res = false;
@@ -532,9 +527,7 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 			if (!res)
-				lock (project.Pool) {
-					val = project.Pool.Add (str, start, j - start + 1);
-				}
+				val = StringInternPool.AddShared (str, start, j - start + 1);
 
 			return res;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -1104,8 +1104,6 @@ namespace MonoDevelop.Projects.MSBuild
 		internal Dictionary<string, string> GlobalProperties {
 			get { return globalProperties; }
 		}
-
-		internal StringInternPool Pool => engineManager.Pool;
 	}
 
 	static class XmlUtil

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildWhitespace.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildWhitespace.cs
@@ -203,9 +203,6 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		// PERF: Keep a global pool for whitespace in MSBuild.
-		// There are not many variations on a properly formatted project so the pool is small.
-		readonly static StringInternPool whitespacePool = new StringInternPool ();
 		public static object ConsumeUntilNewLine (ref object ws)
 		{
 			if (ws == null)
@@ -219,11 +216,8 @@ namespace MonoDevelop.Projects.MSBuild
 						if (n == s.Length - 1)
 							break; // Default case, consume the whole string
 						int len = n + 1;
-						string res;
-						lock (whitespacePool) {
-							res = whitespacePool.Add (s, 0, len);
-							ws = whitespacePool.Add (s, len, s.Length - len);
-						}
+						string res = StringInternPool.AddShared (s, 0, len);
+						ws = StringInternPool.AddShared (s, len, s.Length - len);
 						return res;
 					}
 				}
@@ -243,10 +237,7 @@ namespace MonoDevelop.Projects.MSBuild
 						return res;
 					}
 				}
-				string result;
-				lock (whitespacePool) {
-					result = whitespacePool.Add (sb);
-				}
+				string result = StringInternPool.AddShared (sb);
 				ws = null;
 				return result;
 			}


### PR DESCRIPTION
The normal instance methods are really good only for serial code. If parallel code uses it, it's better to use the thread safe global cache rather than the local cache.

Fixes some abnormal behaviour in unlucky scenario where lock contention in the bg
can reach 20s for evaluating Main.sln