### PR TITLE
[A11y] Fix the keyboard focus on the editor

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
@@ -236,6 +236,7 @@ namespace MonoDevelop.SourceEditor
 				scrolledBackground = new EventBox ();
 				scrolledBackground.Accessible.SetShouldIgnore (true);
 				scrolledWindow = new CompactScrolledWindow ();
+				scrolledWindow.CanFocus = false;
 				scrolledWindow.ButtonPressEvent += PrepareEvent;
 				scrolledWindow.Accessible.SetShouldIgnore (true);
 				scrolledBackground.Add (scrolledWindow);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -354,11 +354,42 @@ namespace MonoDevelop.Ide.Gui
 		static IEnumerable<Gtk.Widget> GetFocussableWidgets (Gtk.Widget widget)
 		{
 			var c = widget as Container;
-			if (widget.CanFocus)
+
+			if (widget.CanFocus) {
 				yield return widget;
+			}
+
 			if (c != null) {
-				foreach (var f in c.FocusChain.SelectMany (GetFocussableWidgets).Where (y => y != null))
+				foreach (var f in c.FocusChain.SelectMany (GetFocussableWidgets).Where (y => y != null)) {
 					yield return f;
+				}
+			}
+
+			if (c?.Children?.Length != 0) {
+				foreach (var f in c.Children) {
+					var container = f as Container;
+					if (container != null) {
+						foreach (var child in GetFocussableChildren (container)) {
+							yield return child;
+						}
+					}
+				}
+			}
+		}
+
+		static IEnumerable<Gtk.Widget> GetFocussableChildren (Gtk.Container container)
+		{
+			if (container.CanFocus) {
+				yield return container;
+			}
+
+			foreach (var f in container.Children) {
+				var c = f as Container;
+				if (c != null) {
+					foreach (var child in GetFocussableChildren (c)) {
+						yield return child;
+					}
+				}
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -585,7 +585,6 @@ namespace MonoDevelop.Ide.Gui
 
 							if (info.Options.HasFlag (OpenDocumentOptions.BringToFront)) {
 								doc.Select ();
-								doc.Window.SelectWindow ();
 								NavigationHistoryService.LogActiveDocument ();
 							}
 							return doc;


### PR DESCRIPTION
Now that the whole of the shell UI can be focused, lots of controls like to
steal the keyboard focus meaning that when we expect to be able to type in the
editor, we often can't. To fix this, when opening a new document, we have the
editor grab focus.