### PR TITLE
[d15-4][AspNet] Fix MVC project template html page character set

### DIFF
--- a/main/src/addins/AspNet/Templates/MvcCommon/_Layout.cshtml
+++ b/main/src/addins/AspNet/Templates/MvcCommon/_Layout.cshtml
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>@ViewBag.Title</title>
+    <meta charset="utf-8" />
 </head>
 <body>
 	@RenderBody()


### PR DESCRIPTION
Fixed bug #57640 - ASP.NET MVC default profile, showed Chinese will
be garbled
https://bugzilla.xamarin.com/show_bug.cgi?id=57640

Added a meta tag to the layout page specifying the character set to be
utf-8 which prevents the text from not being displayed correctly in
the browser. This matches the .NET Core MVC project templates and also
the non-.NET Core MVC project templates in Visual Studio.