### PR TITLE
15.3 - remove "Preview" from builds

### DIFF
--- a/version.config
+++ b/version.config
@@ -1,4 +1,4 @@
 Version=7.1
 Label=7.1 Preview
 CompatVersion=7.0
-IsPreview=true
+IsPreview=false

--- a/version.config
+++ b/version.config
@@ -1,4 +1,4 @@
 Version=7.1
-Label=7.1 Preview
+Label=7.1
 CompatVersion=7.0
 IsPreview=false


### PR DESCRIPTION
Now that we are finalising 15.3 builds, we can remove the preview branding.