### PR TITLE
Sign MonoDevelop.FSharp.Gui.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Gui/MonoDevelop.FSharp.Gui.csproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Gui/MonoDevelop.FSharp.Gui.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="..\..\..\MonoDevelop.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +12,8 @@
     <RootNamespace>MonoDevelop.FSharp.Gui</RootNamespace>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\msbuild\MonoDevelop-Public.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
This project wasn't signed and StrongNamer was invoked for this project causing a double-write (an occasional build race condition), also breaking build incrementality.