### PR TITLE
Adds a Diagnostics menu item to put a mark in the log.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -828,6 +828,9 @@
 	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTreeDelayed"
 			 defaultHandler = "MonoDevelop.Ide.Commands.DumpA11yTreeDelayedHandler"
 			 _label = "Dump Accessibility Tree (10s)" />
+	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.MarkLog"
+			 defaultHandler = "MonoDevelop.Ide.Commands.MarkLogHandler"
+			 _label = "Mark Log" />
 	</Category>
 
 	<!-- SearchCommands -->

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -288,6 +288,7 @@
 			<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpUITree" />
 			<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTree" />
 			<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.DumpA11yTreeDelayed" />
+			<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.MarkLog" />
 		</ItemSet>
 		<Condition id = "Platform" value = "!mac">
 			<SeparatorItem id = "SeparatorAbout" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/HelpCommands.cs
@@ -32,6 +32,7 @@ using System.Timers;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Commands
 {
@@ -175,5 +176,13 @@ namespace MonoDevelop.Ide.Commands
 			t.Start ();
 		}
 #endif
+	}
+
+	class MarkLogHandler : CommandHandler
+	{
+		protected override void Run ()
+		{
+			LoggingService.LogInfo ("\n\n--- --- --- --- MARK --- --- --- ---\n\n");
+		}
 	}
 }


### PR DESCRIPTION
Adding a mark in the log can be helpful to find a point in a busy log. Mark the
log before doing an action, and then it can be easier to work out when you
started the action