### PR TITLE
[policies] Fix NewLinesForBracesInTypes for Mono C# policy

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/policies/MonoCSharpPolicy.xml
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/policies/MonoCSharpPolicy.xml
@@ -32,7 +32,7 @@ THE SOFTWARE.
 	<IndentSwitchSection>False</IndentSwitchSection>
 	<IndentSwitchCaseSection>True</IndentSwitchCaseSection>
 	<LabelPositioning>OneLess</LabelPositioning>
-	<NewLinesForBracesInTypes>True</NewLinesForBracesInTypes>
+	<NewLinesForBracesInTypes>False</NewLinesForBracesInTypes>
 	<NewLinesForBracesInMethods>True</NewLinesForBracesInMethods>
 	<NewLinesForBracesInProperties>False</NewLinesForBracesInProperties>
 	<NewLinesForBracesInAccessors>False</NewLinesForBracesInAccessors>


### PR DESCRIPTION
According to the mono coding guidelines document: http://www.mono-project.com/community/contributing/coding-guidelines/#where-to-put-braces
(where to put braces in particular), "Classes and namespaces go like if statements, differently than methods".

good:

namespace N {
    class X {
        ...
    }
}

bad:

namespace N
{
    class X
    {
        ...
    }
}

So, to summarize:

Statement                      Brace position
Namespace                      same line
Type                           same line
Method (including ctor)        new line
Properties                     same line
Control blocks (if, for…)      same line
Anonymous types and methods    same line