### PR TITLE
Avoid copying some F# dependencies twice.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/MonoDevelop.FSharpInteractive.Service.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/MonoDevelop.FSharpInteractive.Service.fsproj
@@ -58,6 +58,7 @@
     <ProjectReference Include="..\MonoDevelop.FSharp.Shared\MonoDevelop.FSharp.Shared.fsproj">
       <Project>{AF5FEAD5-B50E-4F07-A274-32F23D5C504D}</Project>
       <Name>MonoDevelop.FSharp.Shared</Name>
+      <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -88,7 +89,7 @@
       <ItemGroup>
         <Reference Include="ExtCore">
           <HintPath>..\packages\ExtCore\lib\net45\ExtCore.dll</HintPath>
-          <Private>True</Private>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -104,7 +105,7 @@
         </Reference>
         <Reference Include="FSharp.Compiler.Service">
           <HintPath>..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>


### PR DESCRIPTION
The F# binding project already copies these files to the destination. Avoid copying them here so that we don't have a double-write.