### PR TITLE
Fix issue in FastCheckNeedsBuild

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -274,7 +274,7 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 			return ProjectFeatures.None;
 		}
 
-		protected override bool OnFastCheckNeedsBuild (ConfigurationSelector configuration)
+		protected override bool OnFastCheckNeedsBuild (ConfigurationSelector configuration, TargetEvaluationContext context)
 		{
 			return false;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/OperationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/OperationContext.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using MonoDevelop.Core.Execution;
 
 namespace MonoDevelop.Projects
 {
@@ -56,7 +57,13 @@ namespace MonoDevelop.Projects
 				customData = new Dictionary<object, object> (other.customData);
 			else
 				customData = null;
+			ExecutionTarget = other.ExecutionTarget;
 		}
+
+		/// <summary>
+		/// Execution target for which the operation is being executed
+		/// </summary>
+		public ExecutionTarget ExecutionTarget { get; set; }
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -85,6 +85,19 @@ namespace MonoDevelop.Projects
 			next.OnWriteRunConfiguration (monitor, config, properties);
 		}
 
+		/// <summary>
+		/// Called to initialize a TargetEvaluationContext instance required by RunTarget()
+		/// and other methods that invoke MSBuild targets
+		/// </summary>
+		/// <returns>The initialized evaluation context (it can be just the provided context)</returns>
+		/// <param name="target">The MSBuild target that is going to be invoked</param>
+		/// <param name="configuration">Build configuration</param>
+		/// <param name="context">Execution context</param>
+		internal protected virtual TargetEvaluationContext OnConfigureTargetEvaluationContext (string target, ConfigurationSelector configuration, TargetEvaluationContext context)
+		{
+			return next.OnConfigureTargetEvaluationContext (target, configuration, context);
+		}
+
 		internal protected virtual Task<TargetEvaluationResult> OnRunTarget (ProgressMonitor monitor, string target, ConfigurationSelector configuration, TargetEvaluationContext context)
 		{
 			return next.OnRunTarget (monitor, target, configuration, context);
@@ -218,9 +231,25 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		[Obsolete ("Use OnFastCheckNeedsBuild (ConfigurationSelector,TargetEvaluationContext)")]
 		internal protected virtual bool OnFastCheckNeedsBuild (ConfigurationSelector configuration)
 		{
 			return next.OnFastCheckNeedsBuild (configuration);
+		}
+
+		/// <summary>
+		/// Checks if this project needs to be built.
+		/// </summary>
+		/// <returns><c>true</c>, if the project is dirty and needs to be rebuilt, <c>false</c> otherwise.</returns>
+		/// <param name="configuration">Build configuration.</param>
+		/// <param name="context">Evaluation context.</param>
+		/// <remarks>
+		/// This method can be overriden to provide custom logic for checking if a project needs to be built, either
+		/// due to changes in the content or in the configuration.
+		/// </remarks>
+		internal protected virtual bool OnFastCheckNeedsBuild (ConfigurationSelector configuration, TargetEvaluationContext context)
+		{
+			return next.OnFastCheckNeedsBuild (configuration, context);
 		}
 
 		#endregion


### PR DESCRIPTION
The FastCheckNeedsBuild method now takes an OperationContext as argument.
This is necessary because when building a project, OperationContext can
contain custom msbuild properties that can have an effect on the build
(for example, a build can be specific to the target device currently selected
in the IDE).

OnFastCheckNeedsBuild now keeps track of the global msbuild properties
specified in the context, and uses them when checking for changes.