### PR TITLE
Update to StrongNamer 0.0.6 that supports better build incrementality.

### DIFF
--- a/main/external/fsharpbinding/paket.lock
+++ b/main/external/fsharpbinding/paket.lock
@@ -13,7 +13,7 @@ NUGET
       System.ValueTuple (>= 4.3)
     Mono.Cecil (0.9.6.4)
     Newtonsoft.Json (10.0.1)
-    StrongNamer (0.0.3)
+    StrongNamer (0.0.6)
     System.Collections.Immutable (1.3.1)
     System.Reflection.Metadata (1.4.2)
       System.Collections.Immutable (>= 1.3.1)


### PR DESCRIPTION
StrongNamer 0.0.6 has a fix that avoids rewriting a signed binary if it already exists and the Mvid matches.