### PR TITLE
SkipUnchangedFiles="true" when copying files in MSBuild.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -65,7 +65,7 @@
         <Version>4.3.0</Version>
       </NuGetPackage>
     </ItemGroup>
-    <Copy SourceFiles="..\packages\%(NuGetPackage.Name)\%(NuGetPackage.Name).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)/Packages" />
+    <Copy SourceFiles="..\packages\%(NuGetPackage.Name)\%(NuGetPackage.Name).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)/Packages" SkipUnchangedFiles="true" />
   </Target>
   <Target Name="AfterBuild">
   </Target>

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
@@ -175,6 +175,6 @@
          <Version>$(TemplatesVersion)</Version>
        </NuGetPackage>
      </ItemGroup>
-     <Copy SourceFiles="..\..\..\packages\%(NuGetPackage.Identity).%(NuGetPackage.Version)\%(NuGetPackage.Identity).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)\Templates" />
+     <Copy SourceFiles="..\..\..\packages\%(NuGetPackage.Identity).%(NuGetPackage.Version)\%(NuGetPackage.Identity).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)\Templates" SkipUnchangedFiles="true" />
    </Target>
 </Project>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -425,6 +425,6 @@
          <Version>$(TemplatesVersion)</Version>
        </NuGetPackage>
      </ItemGroup>
-     <Copy SourceFiles="..\..\..\packages\%(NuGetPackage.Identity).%(NuGetPackage.Version)\%(NuGetPackage.Identity).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)\Templates" />
+     <Copy SourceFiles="..\..\..\packages\%(NuGetPackage.Identity).%(NuGetPackage.Version)\%(NuGetPackage.Identity).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)\Templates" SkipUnchangedFiles="true" />
    </Target>
 </Project>

--- a/main/src/addins/MonoDevelop.Packaging/PostBuild.proj
+++ b/main/src/addins/MonoDevelop.Packaging/PostBuild.proj
@@ -7,6 +7,6 @@
     <_MyNuGetPackage Include="$(MSBuildProjectDirectory)\..\..\..\packages\NuGet.Build.Packaging.$(_BuildPackagingVersion)\NuGet.Build.Packaging.$(_BuildPackagingVersion).nupkg" />
   </ItemGroup>
   <Target Name="_MyPostBuildTarget">
-    <Copy SourceFiles="@(_MyNuGetPackage)" DestinationFolder="$(OutputPath)\packages" /> 
+    <Copy SourceFiles="@(_MyNuGetPackage)" DestinationFolder="$(OutputPath)\packages" SkipUnchangedFiles="true" /> 
   </Target>
 </Project>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9533,6 +9533,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy SourceFiles="@(Data)" DestinationFolder="..\..\..\build\data\%(Data.RelativeDir)" />
+    <Copy SourceFiles="@(Data)" DestinationFolder="..\..\..\build\data\%(Data.RelativeDir)" SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
This helps avoid unnecessary copy operations during the build.