### PR TITLE
Fixes BXC #53727

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewFileDialog.cs
@@ -173,12 +173,9 @@ namespace MonoDevelop.Ide.Projects
 
 			if (catView.Selection.GetSelected (out treeModel, out treeIter)) {
 				FillCategoryTemplates (treeIter);
-				catView.ExpandRow (treeModel.GetPath (treeIter), false);
 				UpdateOkStatus ();
 			}
 		}
-
-
 
 		void InitializeDialog (bool update)
 		{


### PR DESCRIPTION
Xamarin-Studio]Accessibility:MAS06:OSX:keyboard:Button got Expanding when tab through that.