### PR TITLE
Fixed 'Bug 57303 - Renaming makes the text unreadable while in dark

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextLinkEditMode.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextLinkEditMode.cs
@@ -219,12 +219,21 @@ namespace Mono.TextEditor
 				handler (this, e);
 		}
 
-		TextLink closedLink = null;
+		TextLink closedLink = null, currentSelectedLink = null;
 
 		void HandlePositionChanged (object sender, DocumentLocationEventArgs e)
 		{
 			int caretOffset = Editor.Caret.Offset - baseOffset;
 			TextLink link = links.Find (l => !l.PrimaryLink.IsInvalid () && l.PrimaryLink.Offset <= caretOffset && caretOffset <= l.PrimaryLink.EndOffset);
+
+			if (link != currentSelectedLink) {
+				foreach (var l in textLinkMarkers) {
+					Editor.Document.CommitLineUpdate (l.LineSegment);
+				}
+				currentSelectedLink = link;
+			}
+
+
 			if (link != null && link.Count > 0 && link.IsEditable) {
 				if (closedLink == link)
 					return;
@@ -277,6 +286,7 @@ namespace Mono.TextEditor
 			Editor.Document.CommitUpdateAll ();
 			this.undoDepth = Editor.Document.GetCurrentUndoDepth ();
 			ShowHelpWindow ();
+			currentSelectedLink = null;
 		}
 
 		public bool HasChangedText {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/GruvboxStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/GruvboxStyle.json
@@ -71,10 +71,10 @@
 		{ "name": "Debugger Current Line Marker", "color": "#69684c", "bordercolor": "#69684c" },
 		{ "name": "Debugger Stack Line Marker", "color": "#5c6b4d", "bordercolor": "#5c6b4d" },
 
-		{ "name": "Primary Link", "color": "foreground", "secondcolor": "#7f4a81" },
-		{ "name": "Primary Link(Highlighted)", "color": "foreground", "secondcolor": "#b167b3" },
-		{ "name": "Secondary Link", "color": "foreground", "secondcolor": "#262228" },
-		{ "name": "Secondary Link(Highlighted)", "color": "foreground", "secondcolor": "#4e4552" },
+		{ "name": "Primary Link", "color": "#7f4a81", "secondcolor": "#7f4a81" },
+		{ "name": "Primary Link(Highlighted)", "color": "#b167b3", "secondcolor": "#b167b3" },
+		{ "name": "Secondary Link", "color": "#262228", "secondcolor": "#262228" },
+		{ "name": "Secondary Link(Highlighted)", "color": "#4e4552", "secondcolor": "#4e4552" },
 
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/MonokaiStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/MonokaiStyle.json
@@ -79,10 +79,10 @@
 		{ "name": "Debugger Current Line Marker", "color": "#69684c", "bordercolor": "#69684c" },
 		{ "name": "Debugger Stack Line Marker", "color": "#618336", "bordercolor": "#618336" },
 
-		{ "name": "Primary Link", "color": "monokai-white", "secondcolor": "#7f4a81" },
-		{ "name": "Primary Link(Highlighted)", "color": "monokai-white", "secondcolor": "#b167b3" },
-		{ "name": "Secondary Link", "color": "monokai-white", "secondcolor": "#262228" },
-		{ "name": "Secondary Link(Highlighted)", "color": "monokai-white", "secondcolor": "#4e4552" },
+		{ "name": "Primary Link", "color": "#4f4a81", "secondcolor": "#4f4a81" },
+		{ "name": "Primary Link(Highlighted)", "color": "#4147b3", "secondcolor": "#4147b3" },
+		{ "name": "Secondary Link", "color": "#262228", "secondcolor": "#262228" },
+		{ "name": "Secondary Link(Highlighted)", "color": "#4e4552", "secondcolor": "#4e4552" },
 
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/NightshadeStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/NightshadeStyle.json
@@ -91,10 +91,10 @@
 		{ "name": "Debugger Current Line Marker", "color": "#69684c", "bordercolor": "#69684c" },
 		{ "name": "Debugger Stack Line Marker", "color": "#4a6429", "bordercolor": "#4a6429" },
 
-		{ "name": "Primary Link", "color": "chocolate1", "secondcolor": "chocolate3" },
-		{ "name": "Primary Link(Highlighted)", "color": "chocolate1", "secondcolor": "chocolate2" },
-		{ "name": "Secondary Link", "color": "white", "secondcolor": "aluminium6" },
-		{ "name": "Secondary Link(Highlighted)", "color": "aluminium1", "secondcolor": "aluminium5" },
+		{ "name": "Primary Link", "color": "chocolate3", "secondcolor": "chocolate3" },
+		{ "name": "Primary Link(Highlighted)", "color": "chocolate2", "secondcolor": "chocolate2" },
+		{ "name": "Secondary Link", "color": "aluminium6", "secondcolor": "aluminium6" },
+		{ "name": "Secondary Link(Highlighted)", "color": "aluminium5", "secondcolor": "aluminium5" },
 
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/OblivionStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/OblivionStyle.json
@@ -83,10 +83,10 @@
 		{ "name": "Debugger Current Line Marker", "color": "#69684c", "bordercolor": "#69684c" },
 		{ "name": "Debugger Stack Line Marker", "color": "#5f7247", "bordercolor": "#5f7247" },
 
-		{ "name": "Primary Link", "color": "chocolate1", "secondcolor": "chocolate3" },
-		{ "name": "Primary Link(Highlighted)", "color": "chocolate1", "secondcolor": "chocolate2" },
-		{ "name": "Secondary Link", "color": "white", "secondcolor": "aluminium6" },
-		{ "name": "Secondary Link(Highlighted)", "color": "aluminium1", "secondcolor": "aluminium5" },
+		{ "name": "Primary Link", "color": "chocolate3", "secondcolor": "chocolate3" },
+		{ "name": "Primary Link(Highlighted)", "color": "chocolate2", "secondcolor": "chocolate2" },
+		{ "name": "Secondary Link", "color": "aluminium6", "secondcolor": "aluminium6" },
+		{ "name": "Secondary Link(Highlighted)", "color": "aluminium5", "secondcolor": "aluminium5" },
 
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedDarkStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedDarkStyle.json
@@ -77,6 +77,11 @@
 		{ "name": "Debugger Current Line Marker", "color": "#69684c", "bordercolor": "#69684c" },
 		{ "name": "Debugger Stack Line Marker", "color": "#54653f", "bordercolor": "#54653f" },
 
+		{ "name": "Primary Link", "color": "base2", "secondcolor": "base2" },
+		{ "name": "Primary Link(Highlighted)", "color": "base2", "secondcolor": "base2" },
+		{ "name": "Secondary Link", "color": "base02", "secondcolor": "base02" },
+		{ "name": "Secondary Link(Highlighted)", "color": "base02", "secondcolor": "base02" },
+
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },
 		{ "name": "Message Bubble Error Counter", "color": "black", "secondcolor": "#e3a6a1" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedLightStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedLightStyle.json
@@ -68,6 +68,11 @@
 
 		{ "name": "Debugger Stack Line Marker", "color": "#c9e1a9", "bordercolor": "#c9e1a9" },
 
+  		{ "name": "Primary Link", "color": "base02", "secondcolor": "base02" },
+		{ "name": "Primary Link(Highlighted)", "color": "base02", "secondcolor": "base02" },
+		{ "name": "Secondary Link", "color": "base2", "secondcolor": "base2" },
+		{ "name": "Secondary Link(Highlighted)", "color": "base2", "secondcolor": "base2" },
+		
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },
 		{ "name": "Message Bubble Error Counter", "color": "black", "secondcolor": "#e3a6a1" },


### PR DESCRIPTION
mode'

Some highlighting styles were wrong in that highlighting case. Dark &
Light mode are well supported - but some of the lesser used ones
needed attention.
Fixed a minor drawing bug in text link mode as well.