### PR TITLE
[NuGet] Transitive assembly references not available until solution reloaded

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectReloadMonitor.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectReloadMonitor.cs
@@ -76,7 +76,7 @@ namespace MonoDevelop.DotNetCore
 		void OnDotNetCoreProjectReloaded (ProjectReloadedEventArgs e)
 		{
 			DotNetCoreProjectBuilderMaintainer.OnProjectReload (e);
-			RestorePackagesInProjectHandler.Run (e.NewProject.DotNetProject);
+			RestorePackagesInProjectHandler.Run (e.NewProject.DotNetProject, restoreTransitiveProjectReferences: true);
 		}
 
 		async void FileChanged (object sender, FileEventArgs e)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesInProjectHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesInProjectHandler.cs
@@ -45,23 +45,32 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		public static void Run (DotNetProject project)
 		{
+			Run (project, false);
+		}
+
+		public static void Run (DotNetProject project, bool restoreTransitiveProjectReferences)
+		{
 			try {
 				ProgressMonitorStatusMessage message = ProgressMonitorStatusMessageFactory.CreateRestoringPackagesInProjectMessage ();
-				IPackageAction action = CreateRestorePackagesAction (project);
+				IPackageAction action = CreateRestorePackagesAction (project, restoreTransitiveProjectReferences);
 				PackageManagementServices.BackgroundPackageActionRunner.Run (message, action);
 			} catch (Exception ex) {
 				ShowStatusBarError (ex);
 			}
 		}
 
-		static IPackageAction CreateRestorePackagesAction (DotNetProject project)
+		static IPackageAction CreateRestorePackagesAction (DotNetProject project, bool restoreTransitiveProjectReferences)
 		{
 			var solutionManager = PackageManagementServices.Workspace.GetSolutionManager (project.ParentSolution);
 			var nugetProject = solutionManager.GetNuGetProject (new DotNetProjectProxy (project));
 
 			var buildIntegratedProject = nugetProject as BuildIntegratedNuGetProject;
 			if (buildIntegratedProject != null) {
-				return new RestoreNuGetPackagesInNuGetIntegratedProject (project, buildIntegratedProject, solutionManager);
+				return new RestoreNuGetPackagesInNuGetIntegratedProject (
+					project,
+					buildIntegratedProject,
+					solutionManager,
+					restoreTransitiveProjectReferences);
 			}
 
 			var nugetAwareProject = project as INuGetAwareProject;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeMonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeMonoDevelopBuildIntegratedRestorer.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.ProjectManagement.Projects;
@@ -41,6 +42,16 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			CancellationToken cancellationToken)
 		{
 			ProjectRestored = project;
+			return Task.FromResult (0);
+		}
+
+		public List<BuildIntegratedNuGetProject> ProjectsRestored = new List<BuildIntegratedNuGetProject> ();
+
+		public Task RestorePackages (
+			IEnumerable<BuildIntegratedNuGetProject> projects,
+			CancellationToken cancellationToken)
+		{
+			ProjectsRestored.AddRange (projects);
 			return Task.FromResult (0);
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeMonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeMonoDevelopBuildIntegratedRestorer.cs
@@ -1,10 +1,10 @@
 ﻿//
-// TestableDotNetCoreNuGetProject.cs
+// FakeMonoDevelopBuildIntegratedRestorer.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,34 +24,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Threading;
 using System.Threading.Tasks;
-using MonoDevelop.Projects;
+using NuGet.ProjectManagement.Projects;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
-	class TestableDotNetCoreNuGetProject : DotNetCoreNuGetProject
+	class FakeMonoDevelopBuildIntegratedRestorer : IMonoDevelopBuildIntegratedRestorer
 	{
-		public TestableDotNetCoreNuGetProject (DotNetProject project)
-			: base (project, new [] { "netcoreapp1.0" })
-		{
-			BuildIntegratedRestorer = new FakeMonoDevelopBuildIntegratedRestorer ();
-		}
+		public bool LockFileChanged { get; set; }
 
-		public bool IsSaved { get; set; }
+		public BuildIntegratedNuGetProject ProjectRestored;
 
-		public override Task SaveProject ()
+		public Task RestorePackages (
+			BuildIntegratedNuGetProject project,
+			CancellationToken cancellationToken)
 		{
-			IsSaved = true;
+			ProjectRestored = project;
 			return Task.FromResult (0);
-		}
-
-		public FakeMonoDevelopBuildIntegratedRestorer BuildIntegratedRestorer;
-		public Solution SolutionUsedToCreateBuildIntegratedRestorer;
-
-		protected override IMonoDevelopBuildIntegratedRestorer CreateBuildIntegratedRestorer (Solution solution)
-		{
-			SolutionUsedToCreateBuildIntegratedRestorer = solution;
-			return BuildIntegratedRestorer;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProject.cs
@@ -107,7 +107,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			return Task.FromResult (0);
 		}
 
-		public void NotifyProjectReferencesChanged ()
+		public void NotifyProjectReferencesChanged (bool includeTransitiveProjectReferences)
 		{
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeSolutionManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeSolutionManager.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MonoDevelop.Projects;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.ProjectManagement;
@@ -113,13 +114,19 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			throw new NotImplementedException ();
 		}
 
-		public Dictionary<IDotNetProject, FakeNuGetProject> NuGetProjects = new Dictionary<IDotNetProject, FakeNuGetProject> ();
+		public Dictionary<IDotNetProject, NuGetProject> NuGetProjects = new Dictionary<IDotNetProject, NuGetProject> ();
+		public Dictionary<DotNetProject, NuGetProject> NuGetProjectsUsingDotNetProjects = new Dictionary<DotNetProject, NuGetProject> ();
 
 		public NuGetProject GetNuGetProject (IDotNetProject project)
 		{
-			FakeNuGetProject nugetProject = null;
+			NuGetProject nugetProject = null;
 			if (NuGetProjects.TryGetValue (project, out nugetProject))
 				return nugetProject;
+
+			if (project.DotNetProject != null) {
+				if (NuGetProjectsUsingDotNetProjects.TryGetValue (project.DotNetProject, out nugetProject))
+					return nugetProject;
+			}
 
 			return new FakeNuGetProject (project);
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -210,6 +210,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableUninstallNuGetPackagesAction.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\PackageReferenceNuGetProjectTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestablePackageReferenceNuGetProject.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeMonoDevelopBuildIntegratedRestorer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -211,6 +211,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\PackageReferenceNuGetProjectTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestablePackageReferenceNuGetProject.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeMonoDevelopBuildIntegratedRestorer.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\RestoreNuGetPackagesInNuGetIntegratedProjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
 using NUnit.Framework;
+using NuGet.PackageManagement;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -44,6 +45,7 @@ namespace MonoDevelop.PackageManagement.Tests
 		TestableDotNetCoreNuGetProject project;
 		FakeNuGetProjectContext context;
 		DependencyGraphCacheContext dependencyGraphCacheContext;
+		FakeMonoDevelopBuildIntegratedRestorer buildIntegratedRestorer;
 
 		void CreateNuGetProject (string projectName = "MyProject", string fileName = @"d:\projects\MyProject\MyProject.csproj")
 		{
@@ -52,6 +54,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			dotNetProject.Name = projectName;
 			dotNetProject.FileName = fileName.ToNativePath ();
 			project = new TestableDotNetCoreNuGetProject (dotNetProject);
+			buildIntegratedRestorer = project.BuildIntegratedRestorer;
 		}
 
 		void AddDotNetProjectPackageReference (string packageId, string version)
@@ -84,6 +87,12 @@ namespace MonoDevelop.PackageManagement.Tests
 		{
 			var specs = await project.GetPackageSpecsAsync (cacheContext);
 			return specs.Single ();
+		}
+
+		void OnAfterExecuteActions (string packageId, string version, NuGetProjectActionType actionType)
+		{
+			var action = new FakeNuGetProjectAction (packageId, version, actionType);
+			project.OnAfterExecuteActions (new [] { action });
 		}
 
 		[Test]
@@ -254,6 +263,134 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
 			Assert.IsTrue (packageReference.IsFloating ());
 			Assert.AreEqual ("2.6.0-*", packageReference.AllowedVersions.Float.ToString ());
+		}
+
+		[Test]
+		public async Task PostProcessAsync_ProjectAssetsFile_NotifyChangeInAssetsFile ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0");
+			dotNetProject.BaseIntermediateOutputPath = @"d:\projects\MyProject\obj".ToNativePath ();
+			string fileNameChanged = null;
+			PackageManagementServices.PackageManagementEvents.FileChanged += (sender, e) => {
+				fileNameChanged = e.Single ().FileName;
+			};
+
+			await project.PostProcessAsync (context, CancellationToken.None);
+
+			string expectedFileNameChanged = @"d:\projects\MyProject\obj\project.assets.json".ToNativePath ();
+			Assert.AreEqual (expectedFileNameChanged, fileNameChanged);
+		}
+
+		[Test]
+		public async Task PostProcessAsync_References_NotifyReferencesChangedEventFired ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0");
+			string modifiedHint = null;
+			dotNetProject.Modified += (sender, e) => {
+				modifiedHint = e.Single ().Hint;
+			};
+
+			await project.PostProcessAsync (context, CancellationToken.None);
+
+			Assert.AreEqual ("References", modifiedHint);
+		}
+
+		[Test]
+		public async Task PostProcessAsync_RestoreRunLockFileNotChanged_NotifyReferencesChangedEventFired ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0");
+			var solution = new Solution ();
+			solution.RootFolder.AddItem (dotNetProject);
+			string modifiedHint = null;
+			dotNetProject.Modified += (sender, e) => {
+				modifiedHint = e.Single ().Hint;
+			};
+			OnAfterExecuteActions ("NUnit", "2.6.3", NuGetProjectActionType.Install);
+
+			await project.PostProcessAsync (context, CancellationToken.None);
+
+			Assert.AreEqual (solution, project.SolutionUsedToCreateBuildIntegratedRestorer);
+			Assert.AreEqual (project, buildIntegratedRestorer.ProjectRestored);
+			Assert.AreEqual ("References", modifiedHint);
+		}
+
+		[Test]
+		public async Task PostProcessAsync_RestoreRunLockFileNotChanged_NotifyChangeInAssetsFile ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0");
+			dotNetProject.BaseIntermediateOutputPath = @"d:\projects\MyProject\obj".ToNativePath ();
+			string fileNameChanged = null;
+			PackageManagementServices.PackageManagementEvents.FileChanged += (sender, e) => {
+				fileNameChanged = e.Single ().FileName;
+			};
+			OnAfterExecuteActions ("NUnit", "2.6.3", NuGetProjectActionType.Install);
+
+			await project.PostProcessAsync (context, CancellationToken.None);
+
+			string expectedFileNameChanged = @"d:\projects\MyProject\obj\project.assets.json".ToNativePath ();
+			Assert.AreEqual (expectedFileNameChanged, fileNameChanged);
+			Assert.AreEqual (project, buildIntegratedRestorer.ProjectRestored);
+		}
+
+		/// <summary>
+		/// Build restorer would trigger the notification itself.
+		/// </summary>
+		[Test]
+		public async Task PostProcessAsync_RestoreRunLockFileChanged_NotifyReferencesChangedEventNotFired ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0");
+			string modifiedHint = null;
+			dotNetProject.Modified += (sender, e) => {
+				modifiedHint = e.Single ().Hint;
+			};
+			buildIntegratedRestorer.LockFileChanged = true;
+			OnAfterExecuteActions ("NUnit", "2.6.3", NuGetProjectActionType.Install);
+
+			await project.PostProcessAsync (context, CancellationToken.None);
+
+			Assert.AreEqual (project, buildIntegratedRestorer.ProjectRestored);
+			Assert.IsNull (modifiedHint);
+		}
+
+		/// <summary>
+		/// Build restorer would trigger the notification itself.
+		/// </summary>
+		[Test]
+		public async Task PostProcessAsync_RestoreRunLockFileChanged_NotifyChangeInAssetsFileIsNotMade ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.0");
+			dotNetProject.BaseIntermediateOutputPath = @"d:\projects\MyProject\obj".ToNativePath ();
+			string fileNameChanged = null;
+			PackageManagementServices.PackageManagementEvents.FileChanged += (sender, e) => {
+				fileNameChanged = e.Single ().FileName;
+			};
+			buildIntegratedRestorer.LockFileChanged = true;
+			OnAfterExecuteActions ("NUnit", "2.6.3", NuGetProjectActionType.Install);
+
+			await project.PostProcessAsync (context, CancellationToken.None);
+
+			Assert.IsNull (fileNameChanged);
+			Assert.AreEqual (project, buildIntegratedRestorer.ProjectRestored);
+		}
+
+		[Test]
+		public void NotifyProjectReferencesChanged_References_NotifyReferencesChangedEventFired ()
+		{
+			CreateNuGetProject ();
+			string modifiedHint = null;
+			dotNetProject.Modified += (sender, e) => {
+				modifiedHint = e.Single ().Hint;
+			};
+
+			project.NotifyProjectReferencesChanged ();
+
+			Assert.AreEqual ("References", modifiedHint);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetProjectExtensionsTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetProjectExtensionsTests.cs
@@ -283,7 +283,7 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
-		public void DotNetCoreNotifyReferencesChanged_TwoOneProjectReferencesChainToModifiedProject_NotifyReferencesChangedForAllProjects ()
+		public void DotNetCoreNotifyReferencesChanged_TwoProjectReferencesChainToModifiedProject_NotifyReferencesChangedForAllProjects ()
 		{
 			var dotNetProject = CreateDotNetCoreProject ();
 			AddParentSolution (dotNetProject);
@@ -317,7 +317,7 @@ namespace MonoDevelop.PackageManagement.Tests
 		/// Same as above but the projects are added to the solution in a different order.
 		/// </summary>
 		[Test]
-		public void DotNetCoreNotifyReferencesChanged_TwoOneProjectReferencesChainToModifiedProject_NotifyReferencesChangedForAllProjects2 ()
+		public void DotNetCoreNotifyReferencesChanged_TwoProjectReferencesChainToModifiedProject_NotifyReferencesChangedForAllProjects2 ()
 		{
 			var dotNetProject = CreateDotNetCoreProject ();
 			AddParentSolution (dotNetProject);
@@ -345,6 +345,44 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("References", modifiedHint);
 			Assert.AreEqual ("References", modifiedHintForReferencingProject1);
 			Assert.AreEqual ("References", modifiedHintForReferencingProject2);
+		}
+
+		[Test]
+		public void GetReferencingProjects_ThreeProjectsOneProjectReferencesModifiedProject_OneProjectReturned ()
+		{
+			var dotNetProject = CreateDotNetCoreProject ();
+			AddParentSolution (dotNetProject);
+			var referencedProject = CreateDotNetCoreProject ();
+			dotNetProject.ParentSolution.RootFolder.AddItem (referencedProject);
+			referencedProject.References.Add (ProjectReference.CreateProjectReference (dotNetProject));
+			var otherProject = CreateDotNetCoreProject ();
+			dotNetProject.ParentSolution.RootFolder.AddItem (otherProject);
+
+			var projects = dotNetProject.GetReferencingProjects ().ToList ();
+
+			Assert.AreEqual (1, projects.Count);
+			Assert.AreEqual (projects[0], referencedProject);
+		}
+
+		[Test]
+		public void GetReferencingProjects_TwoProjectReferencesChainToModifiedProject_NotifyReferencesChangedForAllProjects ()
+		{
+			var dotNetProject = CreateDotNetCoreProject ();
+			AddParentSolution (dotNetProject);
+			var referencingProject1 = CreateDotNetCoreProject ();
+			dotNetProject.ParentSolution.RootFolder.AddItem (referencingProject1);
+			referencingProject1.References.Add (ProjectReference.CreateProjectReference (dotNetProject));
+			var referencingProject2 = CreateDotNetCoreProject ();
+			dotNetProject.ParentSolution.RootFolder.AddItem (referencingProject2);
+			referencingProject2.References.Add (ProjectReference.CreateProjectReference (referencingProject1));
+			var otherProject = CreateDotNetCoreProject ();
+			dotNetProject.ParentSolution.RootFolder.AddItem (otherProject);
+
+			var projects = dotNetProject.GetReferencingProjects ().ToList ();
+
+			Assert.AreEqual (2, projects.Count);
+			Assert.That (projects, Contains.Item (referencingProject1));
+			Assert.That (projects, Contains.Item (referencingProject2));
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/RestoreNuGetPackagesInNuGetIntegratedProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/RestoreNuGetPackagesInNuGetIntegratedProjectTests.cs
@@ -1,0 +1,108 @@
+﻿//
+// RestoreNuGetPackagesInNuGetIntegratedProjectTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	class RestoreNuGetPackagesInNuGetIntegratedProjectTests
+	{
+		RestoreNuGetPackagesInNuGetIntegratedProject action;
+		DotNetProject dotNetProject;
+		FakeDotNetProject fakeDotNetProject;
+		TestableDotNetCoreNuGetProject nugetProject;
+		FakeMonoDevelopBuildIntegratedRestorer buildIntegratedRestorer;
+
+		void CreateAction ()
+		{
+			var solutionManager = new FakeSolutionManager ();
+			CreateNuGetProject ();
+			fakeDotNetProject = new FakeDotNetProject (dotNetProject.FileName);
+			fakeDotNetProject.DotNetProject = dotNetProject;
+
+			action = new RestoreNuGetPackagesInNuGetIntegratedProject (
+				fakeDotNetProject,
+				nugetProject,
+				solutionManager,
+				buildIntegratedRestorer);
+		}
+
+		void CreateNuGetProject (string projectName = "MyProject", string fileName = @"d:\projects\MyProject\MyProject.csproj")
+		{
+			var context = new FakeNuGetProjectContext ();
+			dotNetProject = CreateDotNetCoreProject (projectName, fileName);
+			var solution = new Solution ();
+			solution.RootFolder.AddItem (dotNetProject);
+			nugetProject = new TestableDotNetCoreNuGetProject (dotNetProject);
+			buildIntegratedRestorer = nugetProject.BuildIntegratedRestorer;
+		}
+
+		static DummyDotNetProject CreateDotNetCoreProject (string projectName = "MyProject", string fileName = @"d:\projects\MyProject\MyProject.csproj")
+		{
+			var project = new DummyDotNetProject ();
+			project.Name = projectName;
+			project.FileName = fileName.ToNativePath ();
+			return project;
+		}
+
+		[Test]
+		public void Execute_BuildIntegratedRestorer_PackagesRestoredForProject ()
+		{
+			CreateAction ();
+
+			action.Execute ();
+
+			Assert.AreEqual (nugetProject, buildIntegratedRestorer.ProjectRestored);
+		}
+
+		[Test]
+		public void Execute_Events_PackagesRestoredEventFired ()
+		{
+			CreateAction ();
+			bool packagesRestoredEventFired = false;
+			PackageManagementServices.PackageManagementEvents.PackagesRestored += (sender, e) => {
+				packagesRestoredEventFired = true;
+			};
+
+			action.Execute ();
+
+			Assert.IsTrue (packagesRestoredEventFired);
+		}
+
+		[Test]
+		public void Execute_ReferenceStatus_IsRefreshed ()
+		{
+			CreateAction ();
+
+			action.Execute ();
+
+			Assert.IsTrue (fakeDotNetProject.IsReferenceStatusRefreshed);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -425,6 +425,7 @@
     <Compile Include="MonoDevelop.PackageManagement\PendingPackageActionsInformation.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageActionType.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PendingPackageActionsHandler.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\IMonoDevelopBuildIntegratedRestorer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -281,7 +281,7 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			Runtime.RunInMainThread (() => {
-				DotNetProject.NotifyModified ("References");
+				DotNetProject.DotNetCoreNotifyReferencesChanged ();
 			});
 
 			packageManagementEvents.OnFileChanged (project.GetNuGetAssetsFilePath ());
@@ -303,7 +303,7 @@ namespace MonoDevelop.PackageManagement
 			if (!packageRestorer.LockFileChanged) {
 				// Need to refresh the references since the restore did not.
 				await Runtime.RunInMainThread (() => {
-					DotNetProject.NotifyModified ("References");
+					DotNetProject.DotNetCoreNotifyReferencesChanged ();
 					packageManagementEvents.OnFileChanged (project.GetNuGetAssetsFilePath ());
 				});
 			}
@@ -326,12 +326,16 @@ namespace MonoDevelop.PackageManagement
 			restoreRequired = actions.Any (action => action.NuGetProjectActionType == NuGetProjectActionType.Install);
 		}
 
-		public void NotifyProjectReferencesChanged ()
+		public void NotifyProjectReferencesChanged (bool includeTransitiveProjectReferences)
 		{
 			Runtime.AssertMainThread ();
 
 			DotNetProject.RefreshProjectBuilder ();
-			DotNetProject.NotifyModified ("References");
+
+			if (includeTransitiveProjectReferences)
+				DotNetProject.DotNetCoreNotifyReferencesChanged ();
+			else
+				DotNetProject.NotifyModified ("References");
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -292,8 +292,7 @@ namespace MonoDevelop.PackageManagement
 		async Task RestorePackages (INuGetProjectContext nuGetProjectContext, CancellationToken token)
 		{
 			var packageRestorer = await Runtime.RunInMainThread (() => {
-				var solutionManager = PackageManagementServices.Workspace.GetSolutionManager (project.ParentSolution);
-				return new MonoDevelopBuildIntegratedRestorer (solutionManager);
+				return CreateBuildIntegratedRestorer (project.ParentSolution);
 			});
 
 			var restoreTask = packageRestorer.RestorePackages (this, token);
@@ -310,6 +309,12 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			await base.PostProcessAsync (nuGetProjectContext, token);
+		}
+
+		protected virtual IMonoDevelopBuildIntegratedRestorer CreateBuildIntegratedRestorer (Solution solution)
+		{
+			var solutionManager = PackageManagementServices.Workspace.GetSolutionManager (project.ParentSolution);
+			return new MonoDevelopBuildIntegratedRestorer (solutionManager);
 		}
 
 		public void OnBeforeUninstall (IEnumerable<NuGetProjectAction> actions)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -254,7 +254,7 @@ namespace MonoDevelop.PackageManagement
 		public static IEnumerable<DotNetProject> GetReferencingProjects (this DotNetProject project)
 		{
 			var projects = new List<DotNetProject> ();
-			var traversedProjects = new Dictionary<string, bool> ();
+			var traversedProjects = new Dictionary<string, bool> (StringComparer.OrdinalIgnoreCase);
 			traversedProjects.Add (project.ItemId, true);
 
 			foreach (var currentProject in project.ParentSolution.GetAllDotNetProjects ()) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IBuildIntegratedNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IBuildIntegratedNuGetProject.cs
@@ -37,7 +37,13 @@ namespace MonoDevelop.PackageManagement
 		void OnBeforeUninstall (IEnumerable<NuGetProjectAction> actions);
 		void OnAfterExecuteActions (IEnumerable<NuGetProjectAction> actions);
 		Task PostProcessAsync (INuGetProjectContext nuGetProjectContext, CancellationToken token);
-		void NotifyProjectReferencesChanged ();
+
+		/// <summary>
+		/// Notifies the project references changed.
+		/// </summary>
+		/// <param name="includeTransitiveProjectReferences">If set to <c>true</c> also notify references
+		/// have changed in all projects that transitively reference this project.</param>
+		void NotifyProjectReferencesChanged (bool includeTransitiveProjectReferences);
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IMonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IMonoDevelopBuildIntegratedRestorer.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.ProjectManagement.Projects;
@@ -34,6 +35,10 @@ namespace MonoDevelop.PackageManagement
 	{
 		Task RestorePackages (
 			BuildIntegratedNuGetProject project,
+			CancellationToken cancellationToken);
+
+		Task RestorePackages (
+			IEnumerable<BuildIntegratedNuGetProject> projects,
 			CancellationToken cancellationToken);
 
 		bool LockFileChanged { get; }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IMonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IMonoDevelopBuildIntegratedRestorer.cs
@@ -1,10 +1,10 @@
 ﻿//
-// TestableDotNetCoreNuGetProject.cs
+// IMonoDevelopBuildIntegratedRestorer.cs
 //
 // Author:
 //       Matt Ward <matt.ward@xamarin.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,34 +24,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Threading;
 using System.Threading.Tasks;
-using MonoDevelop.Projects;
+using NuGet.ProjectManagement.Projects;
 
-namespace MonoDevelop.PackageManagement.Tests.Helpers
+namespace MonoDevelop.PackageManagement
 {
-	class TestableDotNetCoreNuGetProject : DotNetCoreNuGetProject
+	interface IMonoDevelopBuildIntegratedRestorer
 	{
-		public TestableDotNetCoreNuGetProject (DotNetProject project)
-			: base (project, new [] { "netcoreapp1.0" })
-		{
-			BuildIntegratedRestorer = new FakeMonoDevelopBuildIntegratedRestorer ();
-		}
+		Task RestorePackages (
+			BuildIntegratedNuGetProject project,
+			CancellationToken cancellationToken);
 
-		public bool IsSaved { get; set; }
-
-		public override Task SaveProject ()
-		{
-			IsSaved = true;
-			return Task.FromResult (0);
-		}
-
-		public FakeMonoDevelopBuildIntegratedRestorer BuildIntegratedRestorer;
-		public Solution SolutionUsedToCreateBuildIntegratedRestorer;
-
-		protected override IMonoDevelopBuildIntegratedRestorer CreateBuildIntegratedRestorer (Solution solution)
-		{
-			SolutionUsedToCreateBuildIntegratedRestorer = solution;
-			return BuildIntegratedRestorer;
-		}
+		bool LockFileChanged { get; }
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
@@ -44,7 +44,7 @@ using NuGet.Protocol.Core.Types;
 
 namespace MonoDevelop.PackageManagement
 {
-	internal class MonoDevelopBuildIntegratedRestorer
+	internal class MonoDevelopBuildIntegratedRestorer : IMonoDevelopBuildIntegratedRestorer
 	{
 		IPackageManagementEvents packageManagementEvents;
 		List<SourceRepository> sourceRepositories;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
@@ -99,7 +99,9 @@ namespace MonoDevelop.PackageManagement
 				await Runtime.RunInMainThread (() => {
 					FileService.NotifyFilesChanged (changedLocks);
 					foreach (var project in affectedProjects) {
-						NotifyProjectReferencesChanged (project);
+						// Restoring the entire solution so do not refresh references for
+						// transitive  project references since they should be refreshed anyway.
+						NotifyProjectReferencesChanged (project, includeTransitiveProjectReferences: false);
 					}
 				});
 			}
@@ -114,12 +116,17 @@ namespace MonoDevelop.PackageManagement
 			var changedLock = await RestorePackagesInternal (project, cancellationToken);
 
 			if (projectToReload != null) {
-				await ReloadProject (projectToReload, changedLock);
+				// Need to ensure transitive project references are refreshed if only the single
+				// project is reloaded since they will still be out of date.
+				await ReloadProject (projectToReload, changedLock, refreshTransitiveReferences: true);
 			} else if (changedLock != null) {
 				LockFileChanged = true;
 				await Runtime.RunInMainThread (() => {
 					FileService.NotifyFileChanged (changedLock);
-					NotifyProjectReferencesChanged (project);
+
+					// Restoring a single project so ensure references are refreshed for
+					// transitive project references.
+					NotifyProjectReferencesChanged (project, includeTransitiveProjectReferences: true);
 				});
 			}
 		}
@@ -153,11 +160,13 @@ namespace MonoDevelop.PackageManagement
 			return null;
 		}
 
-		static void NotifyProjectReferencesChanged (BuildIntegratedNuGetProject project)
+		static void NotifyProjectReferencesChanged (
+			BuildIntegratedNuGetProject project,
+			bool includeTransitiveProjectReferences)
 		{
 			var buildIntegratedProject = project as IBuildIntegratedNuGetProject;
 			if (buildIntegratedProject != null) {
-				buildIntegratedProject.NotifyProjectReferencesChanged ();
+				buildIntegratedProject.NotifyProjectReferencesChanged (includeTransitiveProjectReferences);
 			}
 		}
 
@@ -219,7 +228,7 @@ namespace MonoDevelop.PackageManagement
 			return null;
 		}
 
-		Task ReloadProject (DotNetProject projectToReload, string changedLock)
+		Task ReloadProject (DotNetProject projectToReload, string changedLock, bool refreshTransitiveReferences = false)
 		{
 			return Runtime.RunInMainThread (async () => {
 				if (changedLock != null) {
@@ -227,6 +236,9 @@ namespace MonoDevelop.PackageManagement
 					FileService.NotifyFileChanged (changedLock);
 				}
 				await projectToReload.ReevaluateProject (new ProgressMonitor ());
+
+				if (refreshTransitiveReferences)
+					projectToReload.DotNetCoreNotifyReferencesChanged (transitiveOnly: true);
 			});
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -284,7 +284,7 @@ namespace MonoDevelop.PackageManagement
 		{
 		}
 
-		public void NotifyProjectReferencesChanged ()
+		public void NotifyProjectReferencesChanged (bool includeTransitiveProjectReferences)
 		{
 			Runtime.AssertMainThread ();
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectJsonBuildIntegratedProjectSystem.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectJsonBuildIntegratedProjectSystem.cs
@@ -247,7 +247,7 @@ namespace MonoDevelop.PackageManagement
 			return excludedReferences;
 		}
 
-		public void NotifyProjectReferencesChanged ()
+		public void NotifyProjectReferencesChanged (bool includeTransitiveProjectReferences)
 		{
 			Runtime.AssertMainThread ();
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
@@ -39,16 +41,19 @@ namespace MonoDevelop.PackageManagement
 		IMonoDevelopSolutionManager solutionManager;
 		IMonoDevelopBuildIntegratedRestorer packageRestorer;
 		IPackageManagementEvents packageManagementEvents;
+		List<BuildIntegratedNuGetProject> referencingProjects;
 
 		public RestoreNuGetPackagesInNuGetIntegratedProject (
 			DotNetProject project,
 			BuildIntegratedNuGetProject nugetProject,
-			IMonoDevelopSolutionManager solutionManager)
+			IMonoDevelopSolutionManager solutionManager,
+			bool restoreTransitiveProjectReferences = false)
 			: this (
 				new DotNetProjectProxy (project),
 				nugetProject,
 				solutionManager,
-				new MonoDevelopBuildIntegratedRestorer (solutionManager))
+				new MonoDevelopBuildIntegratedRestorer (solutionManager),
+				restoreTransitiveProjectReferences)
 		{
 		}
 
@@ -56,13 +61,17 @@ namespace MonoDevelop.PackageManagement
 			IDotNetProject project,
 			BuildIntegratedNuGetProject nugetProject,
 			IMonoDevelopSolutionManager solutionManager,
-			IMonoDevelopBuildIntegratedRestorer packageRestorer)
+			IMonoDevelopBuildIntegratedRestorer packageRestorer,
+			bool restoreTransitiveProjectReferences)
 		{
 			this.project = project;
 			this.nugetProject = nugetProject;
 			this.solutionManager = solutionManager;
 			this.packageRestorer = packageRestorer;
 			packageManagementEvents = PackageManagementServices.PackageManagementEvents;
+
+			if (restoreTransitiveProjectReferences)
+				IncludeTransitiveProjectReferences ();
 		}
 
 		public PackageActionType ActionType {
@@ -89,11 +98,43 @@ namespace MonoDevelop.PackageManagement
 
 		async Task ExecuteAsync (CancellationToken cancellationToken)
 		{
-			await packageRestorer.RestorePackages (nugetProject, cancellationToken);
+			if (referencingProjects == null)
+				await packageRestorer.RestorePackages (nugetProject, cancellationToken);
+			else
+				await RestoreMultiplePackages (cancellationToken);
 
 			await Runtime.RunInMainThread (() => project.RefreshReferenceStatus ());
 
 			packageManagementEvents.OnPackagesRestored ();
+		}
+
+		/// <summary>
+		/// Execute will restore packages for all projects that transitively reference the project
+		/// passed to the constructor of this restore action if this method is passed.
+		/// </summary>
+		void IncludeTransitiveProjectReferences ()
+		{
+			var projects = project.DotNetProject.GetReferencingProjects ();
+			if (!projects.Any ())
+				return;
+
+			referencingProjects = new List<BuildIntegratedNuGetProject> ();
+			foreach (var referencingProject in projects) {
+				var projectProxy = new DotNetProjectProxy (referencingProject);
+				var currentNuGetProject = solutionManager.GetNuGetProject (projectProxy) as BuildIntegratedNuGetProject;
+				if (currentNuGetProject != null) {
+					referencingProjects.Add (currentNuGetProject);
+				}
+			}
+		}
+
+		Task RestoreMultiplePackages (CancellationToken cancellationToken)
+		{
+			var projects = new List<BuildIntegratedNuGetProject> ();
+			projects.Add (nugetProject);
+			projects.AddRange (referencingProjects);
+
+			return packageRestorer.RestorePackages (projects, cancellationToken);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
@@ -34,21 +34,35 @@ namespace MonoDevelop.PackageManagement
 {
 	internal class RestoreNuGetPackagesInNuGetIntegratedProject : IPackageAction
 	{
-		DotNetProject project;
+		IDotNetProject project;
 		BuildIntegratedNuGetProject nugetProject;
-		MonoDevelopBuildIntegratedRestorer packageRestorer;
+		IMonoDevelopSolutionManager solutionManager;
+		IMonoDevelopBuildIntegratedRestorer packageRestorer;
 		IPackageManagementEvents packageManagementEvents;
 
 		public RestoreNuGetPackagesInNuGetIntegratedProject (
 			DotNetProject project,
 			BuildIntegratedNuGetProject nugetProject,
 			IMonoDevelopSolutionManager solutionManager)
+			: this (
+				new DotNetProjectProxy (project),
+				nugetProject,
+				solutionManager,
+				new MonoDevelopBuildIntegratedRestorer (solutionManager))
+		{
+		}
+
+		public RestoreNuGetPackagesInNuGetIntegratedProject (
+			IDotNetProject project,
+			BuildIntegratedNuGetProject nugetProject,
+			IMonoDevelopSolutionManager solutionManager,
+			IMonoDevelopBuildIntegratedRestorer packageRestorer)
 		{
 			this.project = project;
 			this.nugetProject = nugetProject;
+			this.solutionManager = solutionManager;
+			this.packageRestorer = packageRestorer;
 			packageManagementEvents = PackageManagementServices.PackageManagementEvents;
-
-			packageRestorer = new MonoDevelopBuildIntegratedRestorer (solutionManager);
 		}
 
 		public PackageActionType ActionType {


### PR DESCRIPTION
Fixed bug #58009 - Transitive assembly references not available until
project reloaded
https://bugzilla.xamarin.com/show_bug.cgi?id=58009

With a solution containing three .NET Standard projects: LibC
references LibB which references LibA. If the Newtonsoft.Json NuGet
package was installed into LibA the types from this NuGet packages
are not available in LibB or LibC until the solution is closed and
re-opened again. Closing and re-opening the solution refreshes the
reference information for the type system. To fix this when a NuGet
package is installed into a .NET Core project the projects that
reference this project have their reference information refreshed
by calling NotifyModified ("References") which causes the type system
to get the reference information again from MSBuild. Types from
the installed NuGet packages are then available in projects that
reference this updated project either directly or indirectly.