### PR TITLE
Unify most System.ValueTuple references to 4.3.1.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -62,7 +62,7 @@
       </NuGetPackage>
       <NuGetPackage Include="System.ValueTuple">
         <Name>System.ValueTuple</Name>
-        <Version>4.3.0</Version>
+        <Version>4.3.1</Version>
       </NuGetPackage>
     </ItemGroup>
     <Copy SourceFiles="..\packages\%(NuGetPackage.Name)\%(NuGetPackage.Name).%(NuGetPackage.Version).nupkg" DestinationFolder="$(OutputPath)/Packages" SkipUnchangedFiles="true" />

--- a/main/external/fsharpbinding/paket.lock
+++ b/main/external/fsharpbinding/paket.lock
@@ -17,4 +17,4 @@ NUGET
     System.Collections.Immutable (1.3.1)
     System.Reflection.Metadata (1.4.2)
       System.Collections.Immutable (>= 1.3.1)
-    System.ValueTuple (4.3)
+    System.ValueTuple (4.3.1)

--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -168,7 +168,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/CSharpBinding/packages.config
+++ b/main/src/addins/CSharpBinding/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
 </packages>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <PropertyGroup>
@@ -190,7 +190,7 @@
       <HintPath>..\..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -67,7 +67,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
This makes our build more deterministic, without different versions of System.ValueTuple.dll overwriting each other in the output directory.