### PR TITLE
Fixed 'Bug 58102 - FocusCurrentDocument command doesn't work if you

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
@@ -424,6 +424,7 @@ namespace MonoDevelop.Ide.Commands
 		{
 			IdeApp.Workbench.ActiveDocument.Select ();
 			IdeApp.Workbench.ActiveDocument.Editor.StartCaretPulseAnimation ();
+			IdeApp.Workbench.ActiveDocument.Editor.GrabFocus ();
 		}
 
 	}


### PR DESCRIPTION
are currently on a pad that has auto-hide'

This command used to be just to pulse the caret posititon without
focussing. However it's now called focus document - so the purpose
changed.