### PR TITLE
[CSharp] Fix completion for attributes without Attribute suffix

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/RoslynRecommendationsCompletionContextHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Completion/ContextHandler/RoslynRecommendationsCompletionContextHandler.cs
@@ -105,7 +105,11 @@ namespace ICSharpCode.NRefactory6.CSharp.Completion
 					if (isInAttribute) {
 						var type = (ITypeSymbol)symbol;
 						if (type.IsAttribute ()) {
-							var v = type.Name.Substring (0, type.Name.Length - "Attribute".Length);
+							const string attributeSuffix = "Attribute";
+							var v = type.Name.EndsWith (attributeSuffix, StringComparison.Ordinal)
+								? type.Name.Substring (0, type.Name.Length - attributeSuffix.Length)
+								: type.Name;
+
 							var needsEscaping = SyntaxFacts.GetKeywordKind(v) != SyntaxKind.None;
 							needsEscaping = needsEscaping || (isInQuery && SyntaxFacts.IsQueryContextualKeyword(SyntaxFacts.GetContextualKeywordKind(v)));
 							if (!needsEscaping) {


### PR DESCRIPTION
This is a common scenario for Unity developers, as all attributes defined in Unity's API are not suffixed with `Attribute`.