### PR TITLE
Update to LargeAddressAware 1.0.1 which supports incrementality.

### DIFF
--- a/main/src/core/MonoDevelop.Startup/MonoDevelop.Startup.csproj
+++ b/main/src/core/MonoDevelop.Startup/MonoDevelop.Startup.csproj
@@ -127,5 +127,5 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\packages\LargeAddressAware.1.0.0\build\LargeAddressAware.targets" Condition="$(OS) != 'Unix' AND Exists('$(MSBuildThisFileDirectory)..\..\..\packages\LargeAddressAware.1.0.0\build\LargeAddressAware.targets')" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets" Condition="$(OS) != 'Unix' AND Exists('$(MSBuildThisFileDirectory)..\..\..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets')" />
 </Project>

--- a/main/src/core/MonoDevelop.Startup/packages.config
+++ b/main/src/core/MonoDevelop.Startup/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LargeAddressAware" version="1.0.0" />
+  <package id="LargeAddressAware" version="1.0.1" />
 </packages>


### PR DESCRIPTION
The new version of the tool support incrementality, so if the binary is already patched, it won't touch it so the timestamp will remain the same and won't invalidate dependencies unnecessarily.