### PR TITLE
Fixed 'Bug 58219 - Keyword(Access) not working in custom text color

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/OldFormat.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/OldFormat.cs
@@ -196,6 +196,22 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			settings.Add (new ThemeSetting ("Variable", new List<string> { "variable" }, ConvertChunkStyle (colorScheme.UserVariableUsage)));
 			settings.Add (new ThemeSetting ("variable.other", new List<string> { "variable.other" }, ConvertChunkStyle (colorScheme.ScriptKeyword)));
 			settings.Add (new ThemeSetting ("Keyword", new List<string> { "keyword - (source.c keyword.operator | source.c++ keyword.operator | source.objc keyword.operator | source.objc++ keyword.operator), keyword.operator.word" }, ConvertChunkStyle (colorScheme.KeywordOther)));
+			settings.Add (new ThemeSetting ("Keyword (Access)", new List<string> { "keyword.other.access" }, ConvertChunkStyle (colorScheme.KeywordAccessors)));
+			settings.Add (new ThemeSetting ("Keyword (Types)", new List<string> { "keyword.other.type" }, ConvertChunkStyle (colorScheme.KeywordTypes)));
+			settings.Add (new ThemeSetting ("Keyword (Operator)", new List<string> { "keyword.operator" }, ConvertChunkStyle (colorScheme.KeywordOperators)));
+			settings.Add (new ThemeSetting ("Keyword (Selection)", new List<string> { "keyword.other.selection" }, ConvertChunkStyle (colorScheme.KeywordSelection)));
+			settings.Add (new ThemeSetting ("Keyword (Itarator)", new List<string> { "keyword.other.iteration" }, ConvertChunkStyle (colorScheme.KeywordIteration)));
+			settings.Add (new ThemeSetting ("Keyword (Jump)", new List<string> { "keyword.other.jump" }, ConvertChunkStyle (colorScheme.KeywordJump)));
+			settings.Add (new ThemeSetting ("Keyword (Context)", new List<string> { "keyword.other.context" }, ConvertChunkStyle (colorScheme.KeywordContext)));
+			settings.Add (new ThemeSetting ("Keyword (Exception)", new List<string> { "keyword.other.exception" }, ConvertChunkStyle (colorScheme.KeywordException)));
+			settings.Add (new ThemeSetting ("Keyword (Modifier)", new List<string> { "keyword.other.modifiers" }, ConvertChunkStyle (colorScheme.KeywordModifiers)));
+			settings.Add (new ThemeSetting ("Keyword (Void)", new List<string> { "keyword.other.void" }, ConvertChunkStyle (colorScheme.KeywordVoid)));
+			settings.Add (new ThemeSetting ("Keyword (Namespace)", new List<string> { "keyword.other.namespace" }, ConvertChunkStyle (colorScheme.KeywordNamespace)));
+			settings.Add (new ThemeSetting ("Keyword (Property)", new List<string> { "keyword.other.property" }, ConvertChunkStyle (colorScheme.KeywordProperty)));
+			settings.Add (new ThemeSetting ("Keyword (Declaration)", new List<string> { "keyword.other.declaration" }, ConvertChunkStyle (colorScheme.KeywordDeclaration)));
+			settings.Add (new ThemeSetting ("Keyword (Parameter)", new List<string> { "keyword.other.parameter" }, ConvertChunkStyle (colorScheme.KeywordParameter)));
+			settings.Add (new ThemeSetting ("Keyword (Operator)", new List<string> { "keyword.other.access" }, ConvertChunkStyle (colorScheme.KeywordOperatorDeclaration)));
+
 			settings.Add (new ThemeSetting ("storage", new List<string> { "storage" }, ConvertChunkStyle (colorScheme.KeywordOther)));
 			settings.Add (new ThemeSetting ("storage.type", new List<string> { "storage.type" }, ConvertChunkStyle (colorScheme.KeywordOther)));
 			settings.Add (new ThemeSetting ("punctuation", new List<string> { "punctuation" }, ConvertChunkStyle (colorScheme.Punctuation)));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/syntaxes/CSharp/C#.sublime-syntax
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/syntaxes/CSharp/C#.sublime-syntax
@@ -94,8 +94,38 @@ contexts:
       pop: true
   keywords:
     - match: '@\w+\b'
-    - match: '\b(this|base|as|is|new|sizeof|typeof|stackalloc|else|if|switch|case|default|do|for|foreach|in|while|break|continue|goto|return|yield|partial|global|where|__arglist|__makeref|__reftype|__refvalue|by|descending|from|group|into|orderby|select|let|ascending|join|on|equals|try|throw|catch|finally|abstract|async|await|const|event|extern|override|readonly|sealed|static|virtual|volatile|public|protected|private|internal|bool|byte|char|decimal|double|float|int|long|sbyte|short|uint|ushort|ulong|object|string|var|dynamic|void|namespace|using|get|set|add|remove|value|class|interface|delegate|enum|struct|params|ref|out|explicit|implicit|operator|checked|unchecked|fixed|unsafe|lock)\b'
-      scope: keyword.source.cs
+    - match: '\b(this|base)\b'
+      scope: keyword.other.access.source.cs
+    - match: '\b(as|is|new|sizeof|typeof|stackalloc)\b'
+      scope: keyword.operator.source.cs
+    - match: '\b(else|if|switch|case|default)\b'
+      scope: keyword.other.selection.source.cs
+    - match: '\b(do|for|foreach|in|while)\b'
+      scope: keyword.other.iteration.source.cs
+    - match: '\b(break|continue|goto|return)\b'
+      scope: keyword.other.jump.source.cs
+    - match: '\b(yield|partial|global|where|__arglist|__makeref|__reftype|__refvalue|by|descending|from|group|into|orderby|select|let|ascending|join|on|equals)\b'
+      scope: keyword.other.context.source.cs
+    - match: '\b(try|throw|catch|finally)\b'
+      scope: keyword.other.exception.source.cs
+    - match: '\b(abstract|async|await|const|event|extern|override|readonly|sealed|static|virtual|volatile|public|protected|private|internal)\b'
+      scope: keyword.other.modifiers.source.cs
+    - match: '\b(bool|byte|char|decimal|double|float|int|long|sbyte|short|uint|ushort|ulong|object|string|var|dynamic)\b'
+      scope: keyword.other.type.source.cs
+    - match: '\b(void)\b'
+      scope: keyword.other.void.source.cs
+    - match: '\b(namespace|using)\b'
+      scope: keyword.other.namespace.source.cs
+    - match: '\b(get|set|add|remove|value)\b'
+      scope: keyword.other.property.source.cs
+    - match: '\b(class|interface|delegate|enum|struct)\b'
+      scope: keyword.other.declaration.source.cs
+    - match: '\b(params|ref|out)\b'
+      scope: keyword.other.parameter.source.cs
+    - match: '\b(explicit|implicit|operator)\b'
+      scope: keyword.operator.declaration.source.cs
+    - match: '\b(checked|unchecked|fixed|unsafe|lock)\b'
+      scope: keyword.other.source.cs
     - match: '\b(true|false|null)\b'
       scope: constant.language.source.cs
   numbers:


### PR DESCRIPTION
theme'

Didn't think there were themes that used the old keyword colors.
They're a direct inheritance of SharpDevelop :). However there isn't
any reason we don't support that in the textmate theme - we still
control that.