### PR TITLE
[NuGet] Fix crash when displaying Chinese characters in dialog

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.cs
@@ -320,7 +320,9 @@ namespace MonoDevelop.PackageManagement
 
 		void ShowPackageInformation (PackageSearchResultViewModel packageViewModel)
 		{
-			this.packageNameLabel.Markup = packageViewModel.GetNameMarkup ();
+			// Use the package id and not the package title to prevent a pango crash if the title
+			// contains Chinese characters.
+			this.packageNameLabel.Markup = packageViewModel.GetIdMarkup ();
 			this.packageAuthor.Text = packageViewModel.Author;
 			this.packagePublishedDate.Text = packageViewModel.GetLastPublishedDisplayText ();
 			this.packageDownloads.Text = packageViewModel.GetDownloadCountDisplayText ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageCellView.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageCellView.cs
@@ -98,9 +98,11 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			// Package Id.
+			// Use the package id and not the package title to prevent a pango crash if the title
+			// contains Chinese characters.
 			var packageIdTextLayout = new TextLayout ();
 			packageIdTextLayout.Font = packageIdTextLayout.Font.WithSize (packageIdFontSize);
-			packageIdTextLayout.Markup = packageViewModel.GetNameMarkup ();
+			packageIdTextLayout.Markup = packageViewModel.GetIdMarkup ();
 			packageIdTextLayout.Trimming = TextTrimming.WordElipsis;
 			Size packageIdTextSize = packageIdTextLayout.GetSize ();
 			packageIdTextLayout.Width = packageIdWidth;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSearchResultViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSearchResultViewModel.cs
@@ -167,6 +167,11 @@ namespace MonoDevelop.PackageManagement
 			get { return viewModel.DownloadCount >= 0; }
 		}
 
+		public string GetIdMarkup ()
+		{
+			return GetBoldText (Id);
+		}
+
 		public string GetNameMarkup ()
 		{
 			return GetBoldText (Name);


### PR DESCRIPTION
Fixed bug #58238 - Searching for Microsoft.AspNet.WebApi.Client in
the Add Packages dialog terminates IDE
https://bugzilla.xamarin.com/show_bug.cgi?id=58238

With the NuGet v3 package source https://api.nuget.org/v3/index.json
enabled searching for Microsoft.AspNet.WebApi.Client would result in
the IDE terminating when an attempt was made to display the results.
The crash was in Pango when it attempts to determine the size of
the package title displayed in the search results. If the package
title contained Chinese characters this would throw an exception:

 Illegal byte sequence encounted in the input.
  at (wrapper managed-to-native) Pango.Layout:pango_layout_get_pixel_size (intptr,int&,int&)

Then when trying to use Pango again to determine the size of the text
would result in the IDE terminating.

Pango-WARNING (recursed) **: shaping failure, expect ugly output.
shape-engine='BasicEngineCoreText', font='.SF NS Text',
text='∫ê'Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) Pango.Layout.pango_layout_get_pixel_size (intptr,int&,int&) [0x0000b] in <c7aa2d93df4045df8dc71d5439f99d72>:0

If the NuGet v2 package source was used then this crash did not occur
since the package title was not returned and the package id would be
displayed instead which does not have Chinese characters.

As a workaround the Add Packages dialog now displays the package id
instead of the package title.