### PR TITLE
Stop the error pad resizing column widths constantly

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -631,17 +631,10 @@ namespace MonoDevelop.Ide.Gui.Pads
 			var descriptionCol = view.AppendColumn (GettextCatalog.GetString ("Description"), descriptionCellRenderer);
 			descriptionCol.SetCellDataFunc (descriptionCellRenderer, new Gtk.TreeCellDataFunc (DescriptionDataFunc));
 			descriptionCol.Resizable = true;
-			descriptionCellRenderer.WrapMode = Pango.WrapMode.Word;
 			descriptionCellRenderer.PreferedMaxWidth = IdeApp.Workbench.RootWindow.Allocation.Width / 3;
+			descriptionCellRenderer.WrapWidth = descriptionCellRenderer.PreferedMaxWidth;
+			descriptionCellRenderer.WrapMode = Pango.WrapMode.Word;
 
-			descriptionCol.AddNotification("width", delegate
-			{
-				if (descriptionCellRenderer.WrapWidth == descriptionCol.Width)
-					return;
-				descriptionCellRenderer.WrapWidth = descriptionCol.Width;
-				descriptionCol.QueueResize ();
-			});
-			
 			col = view.AppendColumn (GettextCatalog.GetString ("File"), view.TextRenderer);
 			col.SetCellDataFunc (view.TextRenderer, new Gtk.TreeCellDataFunc (FileDataFunc));
 			col.Resizable = true;


### PR DESCRIPTION
The error pad is constantly resizing the description column, which causes it to recalculate all the column widths,
update all the texts and strings.

This is playing havoc with the accessibility, even with only two errors shown

Instead of resizing the description column as needed, just set it to a sensible max width