### PR TITLE
[DotNetCore] Handle .NET Core 2.0 not being installed

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeBuilderExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeBuilderExtension.cs
@@ -51,16 +51,8 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 
 			if (dotNetCoreProject.HasSdk && !dotNetCoreProject.IsDotNetCoreSdkInstalled ()) {
 				nodeInfo.StatusSeverity = TaskSeverity.Error;
-				nodeInfo.StatusMessage = GetMessage (dotNetCoreProject);
+				nodeInfo.StatusMessage = dotNetCoreProject.GetDotNetCoreSdkRequiredMessage ();
 			}
-		}
-
-		string GetMessage (DotNetCoreProjectExtension dotNetCoreProject)
-		{
-			if (dotNetCoreProject.IsUnsupportedDotNetCoreSdkInstalled ())
-				return GettextCatalog.GetString ("The .NET Core SDK installed is not supported. Please install a more recent version. {0}", DotNetCoreNotInstalledDialog.DotNetCoreDownloadUrl);
-
-			return GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build .NET Core projects. {0}", DotNetCoreNotInstalledDialog.DotNetCoreDownloadUrl);
 		}
 
 		public override Type CommandHandlerType {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreProjectTests.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreMSBuildProjectTests.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreVersionTests.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreSdkTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkTests.cs
@@ -1,0 +1,73 @@
+﻿//
+// DotNetCoreSdkTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Core.Assemblies;
+using NUnit.Framework;
+using System.Linq;
+
+namespace MonoDevelop.DotNetCore.Tests
+{
+	[TestFixture]
+	class DotNetCoreSdkTests
+	{
+		/// <summary>
+		/// Checks that a project's target framework is supported based on the install .NET Core SDKs.
+		/// Also takes into account if Mono includes the .NET Core v1 SDKs
+		/// </summary>
+		[TestCase (".NETCoreApp", "1.0", new [] { "1.0.4" }, false, true)]
+		[TestCase (".NETCoreApp", "1.1", new [] { "1.0.4" }, false, true)] // .NET Core sdk 1.0 supports 1.1 projects.
+		[TestCase (".NETStandard" ,"1.0", new [] { "1.0.4" }, false, true)]
+		[TestCase (".NETCoreApp", "1.0", new [] { "1.0.4" }, true, true)] // Mono has .NET Core sdks.
+		[TestCase (".NETCoreApp", "1.1", new string [0], true, true)] // Mono has .NET Core sdks.
+		[TestCase (".NETStandard", "1.0", new string [0], true, true)] // Mono has .NET Core sdks.
+		[TestCase (".NETCoreApp", "2.0", new [] { "1.0.4" }, false, false)]
+		[TestCase (".NETStandard", "2.0", new [] { "1.0.4" }, false, false)]
+		[TestCase (".NETCoreApp", "2.0", new [] { "1.0.4", "2.0.0" }, false, true)]
+		[TestCase (".NETStandard", "2.0", new [] { "1.0.4", "2.0.0" }, false, true)]
+		[TestCase (".NETCoreApp", "2.0", new [] { "2.0.0-preview2-006497" }, false, true)] // Allow preview versions.
+		[TestCase (".NETStandard", "2.0", new [] { "2.0.0-preview2-006497" }, false, true)] // Allow preview versions.
+		[TestCase (".NETFramework", "2.0", new [] { "2.0.0" }, false, false)] // Only .NETCoreApp and .NETStandard are supported.
+		[TestCase (".NETCoreApp", "1.1", new [] { "2.0.0" }, false, true)] // v2.0 SDK can compile v1 projects
+		[TestCase (".NETStandard", "1.6", new [] { "2.0.0" }, false, true)] // v2.0 SDK can compile v1 projects
+		public void IsSupportedTargetFramework (
+			string frameworkIdentifier,
+			string frameworkVersion,
+			string[] installedSdkVersions,
+			bool msbuildSdksInstalled, // True if Mono has the .NET Core sdks.
+			bool expected)
+		{
+			string framework = $"{frameworkIdentifier},Version=v{frameworkVersion}";
+			var targetFrameworkMoniker = TargetFrameworkMoniker.Parse (framework);
+			var versions = installedSdkVersions.Select (version => DotNetCoreVersion.Parse (version))
+				.OrderByDescending (version => version)
+				.ToArray ();
+
+			bool actual = DotNetCoreSdk.IsSupported (targetFrameworkMoniker, versions, msbuildSdksInstalled);
+
+			Assert.AreEqual (expected, actual);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
@@ -34,9 +34,15 @@ namespace MonoDevelop.DotNetCore
 	class DotNetCoreNotInstalledDialog : IDisposable
 	{
 		public static readonly string DotNetCoreDownloadUrl = "https://aka.ms/vs/mac/install-netcore";
+		public static readonly string DotNetCore20DownloadUrl = "https://aka.ms/vs/mac/install-netcore2";
+
+		static readonly string defaultMessage = GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build and run .NET Core projects.");
+		static readonly string unsupportedMessage = GettextCatalog.GetString ("The .NET Core SDK installed is not supported. Please install a more recent version.");
+		static readonly string dotNetCore20Message = GettextCatalog.GetString (".NET Core 2.0 SDK is not installed. This is required to build and run .NET Core 2.0 projects.");
 
 		GenericMessage message;
 		AlertButton downloadButton;
+		string downloadUrl = DotNetCoreDownloadUrl;
 
 		public DotNetCoreNotInstalledDialog ()
 		{
@@ -46,7 +52,7 @@ namespace MonoDevelop.DotNetCore
 		void Build ()
 		{
 			message = new GenericMessage {
-				Text = GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build and run .NET Core projects."),
+				Text = defaultMessage,
 				DefaultButton = 1,
 				Icon = Stock.Information
 			};
@@ -61,7 +67,7 @@ namespace MonoDevelop.DotNetCore
 		void AlertButtonClicked (object sender, AlertButtonEventArgs e)
 		{
 			if (e.Button == downloadButton)
-				DesktopService.ShowUrl (DotNetCoreDownloadUrl);
+				DesktopService.ShowUrl (downloadUrl);
 		}
 
 		public void Dispose ()
@@ -71,6 +77,13 @@ namespace MonoDevelop.DotNetCore
 
 		public void Show ()
 		{
+			if (IsUnsupportedVersion)
+				Message = unsupportedMessage;
+			else if (RequiresDotNetCore20) {
+				Message = dotNetCore20Message;
+				downloadUrl = DotNetCore20DownloadUrl;
+			}
+
 			MessageService.GenericAlert (message);
 		}
 
@@ -78,5 +91,8 @@ namespace MonoDevelop.DotNetCore
 			get { return message.Text; }
 			set { message.Text = value; }
 		}
+
+		public bool IsUnsupportedVersion { get; set; }
+		public bool RequiresDotNetCore20 { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Linq;
 using MonoDevelop.Core;
+using MonoDevelop.Core.Assemblies;
 
 namespace MonoDevelop.DotNetCore
 {
@@ -64,6 +65,55 @@ namespace MonoDevelop.DotNetCore
 			sdkPaths.FindSdkPaths (sdk);
 
 			return sdkPaths;
+		}
+
+		/// <summary>
+		/// Checks that the target framework (e.g. .NETCoreApp1.1 or .NETStandard2.0) is supported
+		/// by the installed SDKs. Takes into account Mono having .NET Core v1 SDKs installed.
+		/// </summary>
+		internal static bool IsSupported (TargetFramework framework)
+		{
+			return IsSupported (framework.Id, Versions, MSBuildSdks.Installed);
+		}
+
+		/// <summary>
+		/// Used by unit tests.
+		/// </summary>
+		internal static bool IsSupported (
+			TargetFrameworkMoniker projectFramework,
+			DotNetCoreVersion[] versions,
+			bool msbuildSdksInstalled)
+		{
+			if (!projectFramework.IsNetStandardOrNetCoreApp ())
+				return false;
+
+			var projectFrameworkVersion = Version.Parse (projectFramework.Version);
+
+			if (versions.Any (sdkVersion => IsSupported (projectFrameworkVersion, sdkVersion)))
+				return true;
+
+			// .NET Core 1.x is supported by the MSBuild .NET Core SDKs if they are installed with Mono.
+			if (projectFrameworkVersion.Major == 1)
+				return msbuildSdksInstalled;
+
+			return false;
+		}
+
+		/// <summary>
+		/// Project framework version is considered supported if the major version of the
+		/// .NET Core SDK is greater or equal to the major version of the project framework.
+		/// The fact that a .NET Core SDK is a preview version is ignored in this check.
+		///
+		/// .NET Core SDK 1.0.4 supports .NET Core 1.0 and 1.1
+		/// .NET Core SDK 1.0.4 supports .NET Standard 1.0 to 1.6
+		/// .NET Core SDK 2.0 supports 1.0, 1.1 and 2.0
+		/// .NET Core SDK 2.0 supports .NET Standard 1.0 to 1.6 and 2.0
+		/// .NET Core SDK 2.1 supports 1.0, 1.1 and 2.0
+		/// .NET Core SDK 2.1 supports .NET Standard 1.0 to 1.6 and 2.0
+		/// </summary>
+		static bool IsSupported (Version projectFrameworkVersion, DotNetCoreVersion sdkVersion)
+		{
+			return sdkVersion.Major >= projectFrameworkVersion.Major;
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.DotNetCore
 	{
 		public static bool IsNetStandard (this TargetFramework framework)
 		{
-			return framework.Id.Identifier == ".NETStandard";
+			return framework.Id.IsNetStandard ();
 		}
 
 		public static bool IsNetStandard20 (this TargetFramework framework)
@@ -64,7 +64,7 @@ namespace MonoDevelop.DotNetCore
 
 		public static bool IsNetCoreApp (this TargetFramework framework)
 		{
-			return framework.Id.Identifier == ".NETCoreApp";
+			return framework.Id.IsNetCoreApp ();
 		}
 
 		public static bool IsNetCoreApp20 (this TargetFramework framework)
@@ -82,6 +82,11 @@ namespace MonoDevelop.DotNetCore
 		public static bool IsNetFramework (this TargetFramework framework)
 		{
 			return framework.Id.IsNetFramework ();
+		}
+
+		public static bool IsNetStandard20OrNetCore20 (this TargetFramework framework)
+		{
+			return framework.IsNetStandard20 () || framework.IsNetCoreApp ();
 		}
 
 		public static string GetDisplayName (this TargetFramework framework)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkMonikerExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkMonikerExtensions.cs
@@ -61,5 +61,20 @@ namespace MonoDevelop.DotNetCore
 		{
 			return framework.Identifier == ".NETFramework";
 		}
+
+		public static bool IsNetCoreApp (this TargetFrameworkMoniker framework)
+		{
+			return framework.Identifier == ".NETCoreApp";
+		}
+
+		public static bool IsNetStandard (this TargetFrameworkMoniker framework)
+		{
+			return framework.Identifier == ".NETStandard";
+		}
+
+		public static bool IsNetStandardOrNetCoreApp (this TargetFrameworkMoniker framework)
+		{
+			return framework.IsNetStandard () || framework.IsNetCoreApp ();
+		}
 	}
 }


### PR DESCRIPTION
Fixed bug #58271 - Handle .NET Core 2.0 SDK not being installed when
opening a .NET Core 2.0 project
https://bugzilla.xamarin.com/show_bug.cgi?id=58271

If a .NET Core 2.0 or .NET Standard 2.0 project is opened and .NET Core
2.0 SDK is not installed then a dialog is shown allowing the user to
download and install it. The project in the Solution window will show
an error icon with the same information about .NET Core 2.0 not being
installed. Currently the download link goes to the .NET Core 2.0
preview page - https://www.microsoft.com/net/core/preview#macos - the
url is shorted and can be redirected later without changing the code.