### PR TITLE
Fix NRE in FSharpPathExtension reported by @7sharp9

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs
@@ -51,7 +51,7 @@ type FSharpPathExtension() as x =
         |> Option.iter x.DocumentContext.AttachToProject)
 
     let getSolutions() =
-        ownerProjects |> Seq.map (fun p -> p.ParentSolution) |> Seq.distinct
+        ownerProjects |> Seq.choose (fun p -> p.ParentSolution |> Option.ofNull) |> Seq.distinct
 
     let untrackStartupProjectChanges () =
         getSolutions()

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs
@@ -50,13 +50,18 @@ type FSharpPathExtension() as x =
         |> Option.bind (Option.condition ownerProjects.Contains)
         |> Option.iter x.DocumentContext.AttachToProject)
 
+    let getSolutions() =
+        ownerProjects |> Seq.map (fun p -> p.ParentSolution) |> Seq.distinct
+
     let untrackStartupProjectChanges () =
-        for sol in (ownerProjects |> Seq.map (fun p -> p.ParentSolution) |> Seq.distinct) do
-            sol.StartupItemChanged.RemoveHandler handleStartupProjectChanged
+        getSolutions()
+        |> Seq.choose (fun s -> s.StartupItemChanged |> Option.ofNull)
+        |> Seq.iter (fun e -> e.RemoveHandler handleStartupProjectChanged)
 
     let trackStartupProjectChanges() =
-        for sol in (ownerProjects |> Seq.map (fun p -> p.ParentSolution) |> Seq.distinct) do
-            sol.StartupItemChanged.AddHandler handleStartupProjectChanged
+        getSolutions()
+        |> Seq.choose (fun s -> s.StartupItemChanged |> Option.ofNull)
+        |> Seq.iter (fun e -> e.AddHandler handleStartupProjectChanged)
 
     let setOwnerProjects (projects) =
         untrackStartupProjectChanges ()


### PR DESCRIPTION
Fixes NRE

```
ERROR [2017-07-21 15:33:12Z]: An unhandled exception has occured. Terminating Visual Studio? False
System.NullReferenceException: Object reference not set to an instance of an object
  at <StartupCode$FSharpBinding>.$FSharpPathExtension+clo@55-25.Invoke (System.EventHandler eventDelegate) [0x00000] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:55 
  at Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers+CreateEvent@341[TDelegate,TArgs].Microsoft-FSharp-Control-IDelegateEvent`1-RemoveHandler (TDelegate handler) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/fsharp-fsharp-991186f/src/fsharp/FSharp.Core/seqcore.fs:346 
  at MonoDevelop.FSharp.FSharpPathExtension.untrackStartupProjectChanges () [0x0002d] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:54 
  at MonoDevelop.FSharp.FSharpPathExtension.setOwnerProjects (System.Collections.Generic.IEnumerable`1[T] projects) [0x00000] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:62 
  at MonoDevelop.FSharp.FSharpPathExtension.updateOwnerProjects (System.Collections.Generic.IEnumerable`1[T] allProjects) [0x00026] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:70 
  at MonoDevelop.FSharp.FSharpPathExtension.updateOwnerProjectsWithReset () [0x00000] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:93 
  at MonoDevelop.FSharp.FSharpPathExtension.projectChanged[a] (a _args) [0x00000] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:102 
  at <StartupCode$FSharpBinding>.$FSharpPathExtension+Initialize@175-35.Invoke (MonoDevelop.Projects.SolutionItemChangeEventArgs _args) [0x00000] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:175 
  at Microsoft.FSharp.Control.CommonExtensions+SubscribeToObservable@2170[T].System-IObserver`1-OnNext (T value) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/fsharp-fsharp-991186f/src/fsharp/FSharp.Core/control.fs:2171 
  at Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers+h@349[TArgs].Invoke (System.Object _arg1, TArgs args) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/fsharp-fsharp-991186f/src/fsharp/FSharp.Core/seqcore.fs:349 
  at Microsoft.FSharp.Core.FSharpFunc`2[T,TResult].InvokeFast[V] (Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] func, T arg1, TResult arg2) <0x13017a6a0 + 0x000c8> in <596f77fedff9fae1a7450383fe776f59>:0 
  at <StartupCode$FSharpBinding>.$FSharpPathExtension+Initialize@175-34.Invoke (System.Object sender, MonoDevelop.Projects.SolutionItemChangeEventArgs e) [0x00000] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpPathExtension.fs:175 
  at (wrapper delegate-invoke) <Module>:invoke_void_object_SolutionItemChangeEventArgs (object,MonoDevelop.Projects.SolutionItemChangeEventArgs)
  at MonoDevelop.Ide.RootWorkspace+<>c__DisplayClass97_0.<NotifyItemAddedToSolution>b__0 (System.Object o2, System.EventArgs a2) [0x0000d] in /Users/builder/data/lanes/4349/cb33ab8f/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs:1098 
  at Gtk.Application+InvokeProxy.Invoke () [0x0000d] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:202 
  at GLib.SourceProxy.HandlerInternal (System.IntPtr data) [0x00017] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/glib/Source.cs:56 
```