### PR TITLE
[T4] Fix duplicate byte order marks in new T4 file.

### DIFF
--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/Templates/T4PreprocessedTemplateCSharp.xft.xml
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/Templates/T4PreprocessedTemplateCSharp.xft.xml
@@ -16,7 +16,7 @@
 	<!-- Template Content -->
 	<TemplateFiles>
 		<File name="${Name}.tt" CustomTool="TextTemplatingFilePreprocessor">
-		<![CDATA[﻿<#@ template language="C#" #>
+		<![CDATA[<#@ template language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/Templates/T4TemplateCSharp.xft.xml
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/Templates/T4TemplateCSharp.xft.xml
@@ -15,7 +15,7 @@
 	<!-- Template Content -->
 	<TemplateFiles>
 		<File name="${Name}.tt" CustomTool="TextTemplatingFileGenerator">
-		<![CDATA[﻿<#@ template language="C#" #>
+		<![CDATA[<#@ template language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>


### PR DESCRIPTION
Fixed bug #56625 - T4 editor breaks - no syntax highlighting and
typing issues
https://bugzilla.xamarin.com/show_bug.cgi?id=56625

Creating a new T4 file from the template would result in the file
having duplicate byte order marks at the start. Deleting characters
from the file in the text editor would then have odd behaviour where
some of the characters were not removed. The problem was that the file
templates had a byte order mark in the CDATA section which was causing
the duplicate byte order marks in the created .tt file.