### PR TITLE
[d15-4][Ide] Fix project not created in own directory with New Project dialog 

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -193,7 +193,8 @@ namespace MonoDevelop.Ide.Projects
 			SetDefaultLocation ();
 			SetDefaultGitSettings ();
 			SelectedLanguage = PropertyService.Get (SelectedLanguagePropertyName, "C#");
-			projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory = PropertyService.Get (CreateProjectSubDirectoryPropertyName, true);
+			if (IsNewSolution)
+				projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory = PropertyService.Get (CreateProjectSubDirectoryPropertyName, true);
 		}
 
 		void UpdateDefaultSettings ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -323,7 +323,7 @@ namespace MonoDevelop.Ide.Projects
 				recentTemplates = TemplatingService.RecentTemplates.GetTemplates (templateCategories).ToList ();
 		}
 
-		// Allow testing of the controller by allowing tests to specific the
+		// Allow testing of the controller by allowing tests to specify the
 		// TemplatingService. IdeApp.Services is not initialized during unit tests.
 		TemplatingService templatingService;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/TemplateImageProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/TemplateImageProvider.cs
@@ -52,7 +52,11 @@ namespace MonoDevelop.Ide.Templates
 
 		Image LoadImageFromResource (string imageId)
 		{
-			return IdeApp.Services.TemplatingService.LoadTemplateImage (imageId);
+			if (IdeApp.IsInitialized)
+				return IdeApp.Services.TemplatingService.LoadTemplateImage (imageId);
+
+			// Should only happen when running unit tests.
+			return null;
 		}
 
 		public void Dispose ()

--- a/main/tests/Ide.Tests/Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/Ide.Tests.csproj
@@ -39,6 +39,9 @@
   <ItemGroup>
     <Compile Include="ProjectTemplateTests.cs" />
     <Compile Include="FileTransferTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\NewProjectDialogTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\TestableNewProjectDialogController.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\DummyNewProjectDialogBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DummyNewProjectDialogBackend.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DummyNewProjectDialogBackend.cs
@@ -1,0 +1,50 @@
+﻿//
+// DummyNewProjectDialogBackend.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace MonoDevelop.Ide.Projects
+{
+	class DummyNewProjectDialogBackend : INewProjectDialogBackend
+	{
+		public bool CanMoveToNextPage { get; set; }
+
+		public void CloseDialog ()
+		{
+		}
+
+		public void RegisterController (INewProjectDialogController controller)
+		{
+		}
+
+		public Action OnShowDialogCalled = () => { };
+
+		public void ShowDialog ()
+		{
+			OnShowDialogCalled ();
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
@@ -1,0 +1,144 @@
+﻿//
+// NewProjectDialogTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using UnitTests;
+using NUnit.Framework;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.Ide.Projects
+{
+	class NewProjectDialogTests : TestBase
+	{
+		TestableNewProjectDialogController controller;
+		bool createProjectDirectoryOriginalValue;
+
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			Simulate ();
+
+			createProjectDirectoryOriginalValue = PropertyService.Get (
+				NewProjectDialogController.CreateProjectSubDirectoryPropertyName,
+				true);
+		}
+
+		public override void TearDown ()
+		{
+			// Reset original property values.
+			PropertyService.Set (
+				NewProjectDialogController.CreateProjectSubDirectoryPropertyName,
+				createProjectDirectoryOriginalValue);
+		}
+
+		void CreateDialog ()
+		{
+			controller = new TestableNewProjectDialogController ();
+
+			// Set base path to avoid use of IdeApp.Preferences which is not
+			// initialized during tests.
+			controller.BasePath = Util.TestsRootDir;
+		}
+
+		void CSharpLibraryTemplateSelectedByDefault ()
+		{
+			controller.SelectedTemplateId = "MonoDevelop.CSharp.Library";
+		}
+
+		void UseExistingSolution ()
+		{
+			var parentFolder = new SolutionFolder ();
+			controller.ParentFolder = parentFolder;
+		}
+
+		[Test]
+		public void Show_CSharpLibrary_NoItemsCreated ()
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			bool result = controller.Show ();
+
+			Assert.IsFalse (result);
+		}
+
+		[Test]
+		public void CreateProjectDirectorySetting_IsTrue_FinalPageHasCreateDirectoryEnabledAndChecked ()
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			PropertyService.Set (NewProjectDialogController.CreateProjectSubDirectoryPropertyName, true);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			Assert.IsTrue (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			Assert.IsTrue (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+		}
+
+		[Test]
+		public void CreateProjectDirectorySetting_IsFalse_FinalPageHasCreateDirectoryEnabledAndNotChecked ()
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			PropertyService.Set (NewProjectDialogController.CreateProjectSubDirectoryPropertyName, false);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			Assert.IsFalse (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			Assert.IsTrue (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+		}
+
+		[Test]
+		public void CreateProjectDirectorySetting_IsTrueAndAddingProjectToExistingSolution_FinalPageHasCreateDirectoryDisabledAndChecked ()
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			UseExistingSolution ();
+			PropertyService.Set (NewProjectDialogController.CreateProjectSubDirectoryPropertyName, true);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			Assert.IsTrue (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			Assert.IsFalse (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
@@ -140,5 +140,27 @@ namespace MonoDevelop.Ide.Projects
 			Assert.IsTrue (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
 			Assert.IsFalse (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
 		}
+
+		/// <summary>
+		/// Ensure a project directory is always created when adding a project to an existing solution even
+		/// if previously the create project directory setting was disabled.
+		/// </summary>
+		[Test]
+		public void CreateProjectDirectorySetting_IsFalseAndAddingProjectToExistingSolution_FinalPageHasCreateDirectoryDisabledAndChecked ()
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			UseExistingSolution ();
+			PropertyService.Set (NewProjectDialogController.CreateProjectSubDirectoryPropertyName, false);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			Assert.IsTrue (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			Assert.IsFalse (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/TestableNewProjectDialogController.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/TestableNewProjectDialogController.cs
@@ -1,0 +1,47 @@
+﻿//
+// TestableNewProjectDialogController.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Ide.Projects;
+using MonoDevelop.Ide.Templates;
+
+namespace MonoDevelop.Ide
+{
+	class TestableNewProjectDialogController : NewProjectDialogController
+	{
+		public TestableNewProjectDialogController ()
+		{
+			Backend = new DummyNewProjectDialogBackend ();
+			TemplatingService = new TemplatingService ();
+		}
+
+		public DummyNewProjectDialogBackend Backend { get; private set; }
+
+		protected override INewProjectDialogBackend CreateNewProjectDialog ()
+		{
+			return Backend;
+		}
+	}
+}


### PR DESCRIPTION
Fixed bug #57934 - When adding project to solution "Create a project
directory within the solution directory." checkbox is not respected
https://bugzilla.xamarin.com/show_bug.cgi?id=57934

To reproduce the original bug:

1. Create a new solution using the New Project dialog and ensure
the Create a project directory within the solution directory is
unchecked.
2. Add a new project to the existing solution.
3. The final page of the New Project dialog would have the Create
a project directory within the solution directory check box checked
and disabled. However the project would not be created in its own
directory.