### PR TITLE
[Azure Functions] Fix build by performing the download and copy of nugets at the same time as generating the imports.

### DIFF
--- a/main/src/addins/MonoDevelop.AzureFunctions/GenerateRuntimeImports.targets
+++ b/main/src/addins/MonoDevelop.AzureFunctions/GenerateRuntimeImports.targets
@@ -21,6 +21,11 @@
   </PropertyGroup>
 
   <Target Name="GenerateRuntimeImports">
+    <!-- HACK: explicitly perform this since we need the files to be present to generate the imports -->
+    <MDDownloadFiles Downloads="@(MDDownload)" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\..\packages\Microsoft.AzureFunctions.ProjectTemplates.1.0.0-beta3\Microsoft.AzureFunctions.ProjectTemplates.1.0.0-beta3.nupkg" DestinationFolder="$(OutputPath)\Templates" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\..\packages\Azure.Functions.Templates.1.0.1-beta1\Azure.Functions.Templates.1.0.1-beta1.nupkg" DestinationFolder="$(OutputPath)\Templates" />
+    
     <GenerateRuntimeImports AddinFolder="$(OutputPath)" ManifestFile="$(MSBuildThisFileDirectory)/Properties/AddinInfo.generated.cs" />
   </Target>
 </Project>


### PR DESCRIPTION
The prior fix to generate the imports automatically works fine if the files are already present. Unfortunately I forgot that the download tasks happen after the build. This temporarily fixes this issue for 15-4 (master and onwards shouldn't need any of this).