### PR TITLE
[DotNetCore] Fix build error for SDK projects targeting .NET Framework

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkTests.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		[TestCase (".NETStandard", "2.0", new [] { "1.0.4", "2.0.0" }, false, true)]
 		[TestCase (".NETCoreApp", "2.0", new [] { "2.0.0-preview2-006497" }, false, true)] // Allow preview versions.
 		[TestCase (".NETStandard", "2.0", new [] { "2.0.0-preview2-006497" }, false, true)] // Allow preview versions.
-		[TestCase (".NETFramework", "2.0", new [] { "2.0.0" }, false, false)] // Only .NETCoreApp and .NETStandard are supported.
+		[TestCase (".NETFramework", "2.0", new [] { "2.0.0" }, false, true)] // Allow other non-.NET Core frameworks to be supported.
 		[TestCase (".NETCoreApp", "1.1", new [] { "2.0.0" }, false, true)] // v2.0 SDK can compile v1 projects
 		[TestCase (".NETStandard", "1.6", new [] { "2.0.0" }, false, true)] // v2.0 SDK can compile v1 projects
 		public void IsSupportedTargetFramework (

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -84,8 +84,10 @@ namespace MonoDevelop.DotNetCore
 			DotNetCoreVersion[] versions,
 			bool msbuildSdksInstalled)
 		{
-			if (!projectFramework.IsNetStandardOrNetCoreApp ())
-				return false;
+			if (!projectFramework.IsNetStandardOrNetCoreApp ()) {
+				// Allow other frameworks to be supported such as .NET Framework.
+				return true;
+			}
 
 			var projectFrameworkVersion = Version.Parse (projectFramework.Version);
 


### PR DESCRIPTION
Fixed bug #58439 - SDK Style projects targeting .NET Core 4.6.1 fails
to build even when .NET Core 2.0 preview2 is installed
https://bugzilla.xamarin.com/show_bug.cgi?id=58439

Building a SDK style project that targeted the .NET Framework would
fail to build returning an error about the .NET Core SDK not being
installed even though it was installed. The project would also have
an error icon in the Solution window with an error message about
the .NET Core SDK not being installed.

The problem was that the check added to test for the .NET Core 2.0
SDK being installed for .NET Core 2.0 projects was indicating that
the .NET Framework was not supported. This resulted in the error
about the .NET Core SDK not being installed being reported. This
check has been changed so if the project's target framework is not
.NET Core or .NET Standard then it is assumed it is supported.