### PR TITLE
[Ide] Fix failure to create CocoaApp project from New Project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionTemplate.cs
@@ -255,6 +255,19 @@ namespace MonoDevelop.Ide.Templates
 				^ (Name != null ? Name.GetHashCode () : 0)
 				^ (Category != null ? Category.GetHashCode () : 0);
 		}
+
+		/// <summary>
+		/// Returns all other templates in the group. Does not include this template.
+		/// </summary>
+		internal IEnumerable<SolutionTemplate> GetGroupedTemplates ()
+		{
+			if (Parent != null)
+				return Parent.groupedTemplates
+					.Where (template => template != this)
+					.Concat (Parent);
+
+			return groupedTemplates;
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionTemplate.cs
@@ -114,14 +114,18 @@ namespace MonoDevelop.Ide.Templates
 		public void AddGroupTemplate (SolutionTemplate template)
 		{
 			groupedTemplates.Add (template);
+			template.Parent = this;
 
 			if (!availableLanguages.Contains (template.Language)) {
 				availableLanguages.Add (template.Language);
 			}
 		}
 
+		internal SolutionTemplate Parent { get; set; }
+
 		internal void ClearGroupedTemplates ()
 		{
+			Parent = null;
 			groupedTemplates.Clear ();
 		}
 
@@ -140,6 +144,9 @@ namespace MonoDevelop.Ide.Templates
 			if (predicate (this)) {
 				return this;
 			}
+
+			if (Parent != null)
+				return Parent.GetTemplate (predicate);
 
 			return groupedTemplates.FirstOrDefault (template => predicate (template));
 		}

--- a/main/tests/UnitTests/MonoDevelop.Ide.Templates/ProjectTemplateCategorizerTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Ide.Templates/ProjectTemplateCategorizerTests.cs
@@ -582,6 +582,35 @@ namespace MonoDevelop.Ide.Templates
 			});
 			Assert.AreEqual (2, templateCount);
 		}
+
+		[Test]
+		public void GetCategorizedTemplates_TwoTemplatesWithGroupCondition_CanGetTemplateMatchingConditionFromAnyGroupedTemplate ()
+		{
+			CreateCategories ("android", "app", "general");
+			CreateCategorizer ();
+			SolutionTemplate template1 = AddTemplate ("template-id1", "android/app/general");
+			template1.GroupId = "console";
+			template1.Language = "C#";
+			template1.Condition = "Device=IPhone";
+			SolutionTemplate template2 = AddTemplate ("template-id2", "android/app/general");
+			template2.GroupId = "console";
+			template2.Language = "C#";
+			template2.Condition = "Device=IPad";
+			ProjectCreateParameters ipadParameters = CreateParameters ("Device", "IPad");
+			ProjectCreateParameters iphoneParameters = CreateParameters ("Device", "IPhone");
+
+			CategorizeTemplates ();
+
+			TemplateCategory generalCategory = categorizedTemplates.First ().Categories.First ().Categories.First ();
+			SolutionTemplate firstTemplate = generalCategory.Templates.FirstOrDefault ();
+			SolutionTemplate matchedIPadTemplate = firstTemplate.GetTemplate ("C#", ipadParameters);
+			SolutionTemplate matchedIPhoneTemplate = firstTemplate.GetTemplate ("C#", iphoneParameters);
+
+			Assert.AreEqual (template2, matchedIPadTemplate);
+			Assert.AreEqual (template1, matchedIPhoneTemplate);
+			Assert.AreEqual (template2, matchedIPadTemplate.GetTemplate ("C#", ipadParameters));
+			Assert.AreEqual (template1, matchedIPadTemplate.GetTemplate ("C#", iphoneParameters));
+		}
 	}
 }
 


### PR DESCRIPTION
Fixed bug #58412 - Unable to create CocoaApp from recent templates
https://bugzilla.xamarin.com/show_bug.cgi?id=58412

After creating a CocoaApp (Mac - App - General) that targets
Mavericks if the CocoaApp project template was selected from the
recent projects list in the New Project dialog the project would not
be created if a later Mac OS was selected. In the IDE log an error
would be reported:

    No template found matching condition 'Yosemite=false'.

The problem was that the selected project template was part of a
group but the group was not selected. When a different Mac OS was
selected for the new project the condition applied would result in
no template being found.

Also fixed duplicate recent project template for grouped templates:

Creating a CocoaApp project that targeted Mavericks and then creating
another CocoaApp project that targeted a later Mac OS would then
result in two CocoaApp projects for C# shown in the recent project
templates list in the New Project dialog when they are logically the
same template just part of a group of templates.