### PR TITLE
[d15-4] F# Fix unit tests

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/ProjectCracking.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/ProjectCracking.fs
@@ -23,7 +23,8 @@ module ``Project Cracking`` =
         let! w = Services.ProjectService.ReadWorkspaceItem (monitor, FilePath(sln)) |> Async.AwaitTask
 
         let s = w :?> Solution
-        let fsproj = s.Items.[0] :?> DotNetProject
+        let fsproj = s.Items.[0] :?> FSharpProject
+        do! fsproj.GetReferences()
         let opts = languageService.GetProjectOptionsFromProjectFile fsproj
         return opts.Value.OtherOptions
     }

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -88,16 +88,7 @@ module CompilerArguments =
                       | Some asm -> [asm.Location]
                       | None -> []
                   else
-                      let package = reference.Package
-                      package.Assemblies
-                      |> Seq.choose (fun a -> match a.Name with
-                                              | "FSharp.Core"
-                                              | "mscorlib" -> None
-                                              | _ -> if package.IsGacPackage then
-                                                         Some a.Name
-                                                     else
-                                                         Some a.Location)
-                      |> List.ofSeq
+                      []
 
           | ReferenceType.Project ->
               let referencedProject = reference.Project :?> DotNetProject


### PR DESCRIPTION
Removed passing all package references to the compiler options.

This fixes the F# unit tests for d15-4 //cc: @manish . It's also a real error - There is a warning squiggle in the editor for the F# tvos template.