### PR TITLE
[d15-4][Ide] Ensure New Project dialog language selector matches language

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -223,6 +223,7 @@ namespace MonoDevelop.Ide.Projects
 			if (templateTextRenderer.RenderRecentTemplate && controller.SelectedTemplate != null) {
 				// reset selected language if a recent template has been selected
 				templateTextRenderer.SelectedLanguage = controller.SelectedTemplate.Language;
+				languageCellRenderer.SelectedLanguage = controller.SelectedTemplate.Language;
 				controller.SelectedLanguage = controller.SelectedTemplate.Language;
 			}
 			ShowSelectedTemplate ();


### PR DESCRIPTION
Fixed bug #58392 - Blank Forms App Template Uses C# Language Instead
of Previous Selection
https://bugzilla.xamarin.com/show_bug.cgi?id=58392

The language button selector was not updated when a recently used
project template was selected on opening the New Project dialog. This
resulted in the selected language in the UI not being the language
used when creating the project. Now the language selector is updated
if the language is changed when a recently used project template is
selected.