### PR TITLE
[d15-3][DotNetCore] Support other .NET Core 2.0 SDK versions

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
@@ -72,7 +72,7 @@ namespace MonoDevelop.DotNetCore.Templating
 		void GetTargetFrameworks ()
 		{
 			if (IsSupportedParameter ("NetStandard")) {
-				targetFrameworks = GetNetStandardTargetFrameworks ().ToList ();
+				targetFrameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().ToList ();
 
 				// Use 1.x target frameworks by default if none are available from the .NET Core sdk.
 				if (!targetFrameworks.Any ())
@@ -82,7 +82,7 @@ namespace MonoDevelop.DotNetCore.Templating
 					RemoveUnsupportedNetStandardTargetFrameworksForFSharp (targetFrameworks);
 				}
 			} else {
-				targetFrameworks = GetNetCoreAppTargetFrameworks ().ToList ();
+				targetFrameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().ToList ();
 
 				if (IsSupportedParameter ("FSharpNetCoreLibrary") || IsSupportedParameter ("RazorPages")) {
 					RemoveUnsupportedNetCoreApp1xTargetFrameworks (targetFrameworks);
@@ -114,7 +114,7 @@ namespace MonoDevelop.DotNetCore.Templating
 		void ConfigureDefaultParameters ()
 		{
 			if (IsSupportedParameter ("NetStandard")) {
-				var highestFramework = GetNetStandardTargetFrameworks ().FirstOrDefault ();
+				var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().FirstOrDefault ();
 
 				if (highestFramework != null && highestFramework.IsNetStandard20 ()) {
 					Parameters ["UseNetStandard20"] = "true";
@@ -125,7 +125,7 @@ namespace MonoDevelop.DotNetCore.Templating
 				if (IsSupportedParameter ("FSharpNetCoreLibrary") || IsSupportedParameter ("RazorPages")) {
 					Parameters ["UseNetCore20"] = "true";
 				} else {
-					var highestFramework = GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
+					var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
 					if (highestFramework != null && highestFramework.IsNetCoreApp20 ()) {
 						Parameters ["UseNetCore20"] = "true";
 					} else {
@@ -145,42 +145,12 @@ namespace MonoDevelop.DotNetCore.Templating
 			if (!IsSupportedParameter ("NetCoreLibrary"))
 				return;
 
-			var highestFramework = GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
+			var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
 			if (highestFramework != null) {
 				Parameters ["framework"] = highestFramework.Id.GetShortFrameworkName ();
 			} else {
 				Parameters ["framework"] = "netcoreapp1.1";
 			}
-		}
-
-		static IEnumerable<TargetFramework> GetNetStandardTargetFrameworks ()
-		{
-			bool includeNetCore20Frameworks = IncludeNetCore20TargetFrameworks ();
-			if (includeNetCore20Frameworks)
-				return DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ();
-
-			return DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ()
-				.Where (framework => !framework.IsNetStandard20 ());
-		}
-
-		static IEnumerable<TargetFramework> GetNetCoreAppTargetFrameworks ()
-		{
-			bool includeNetCore20Frameworks = IncludeNetCore20TargetFrameworks ();
-			if (includeNetCore20Frameworks)
-				return DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ();
-
-			return DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ()
-				.Where (framework => !framework.IsNetCoreApp20 ());
-		}
-
-		/// <summary>
-		/// Ignore .NET Core 2.0 and .NET Standard 2.0 frameworks if the .NET Core 2.0 SDK preview 2 final
-		/// is not installed. The .NET Core 2.0 project templates are disabled if this is not installed so
-		/// any 2.0 frameworks should also be ignored.
-		/// </summary>
-		static bool IncludeNetCore20TargetFrameworks ()
-		{
-			return DotNetCoreSdk.Versions.Any (version => version.ToString () == "2.0.0-preview2-006497");
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.UnitTesting/DotNetCoreTestPlatformAdapter.cs
@@ -493,8 +493,18 @@ namespace MonoDevelop.DotNetCore.UnitTesting
 			// custom test host process. The VSCodeDebuggerSession does not return
 			// the correct process id. If it did the process is not available
 			// immediately since it takes some time for it to start so a wait
-			// would be needed here.
-			return Process.GetCurrentProcess ().Id;
+			// would be needed here. Note that returning process id of 1 for .NET
+			// Core SDK versions 1.0 does not work the debugger never starts.
+			var latestVersion = DotNetCoreSdk.Versions.FirstOrDefault ();
+			if (latestVersion == null || latestVersion.Major  < 2)
+				return Process.GetCurrentProcess ().Id;
+
+			//This is horrible hack...
+			//VSTest wants us to send it PID of process our debugger just started so it can kill it when tests are finished
+			//VSCode debug protocol doesn't give us PID of debugee
+			//But we must give VSTest valid PID or it won't work... In past we gave it IDE PID, but with new versions of
+			//VSTest it means it will kill our IDE... Hence give it PID 1 and hope it won't kill it.
+			return 1;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>MonoDevelop.DotNetCore</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <Templates1xVersion>1.0.0-beta2-20170430-208</Templates1xVersion>
-    <TemplatesVersion>1.0.0-beta2-20170620-266</TemplatesVersion>
+    <TemplatesVersion>1.0.0-beta2-20170727-301</TemplatesVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -49,13 +49,13 @@
 			condition="UseNetCore1x=true"
 			category="netcore/app/general"/>
 		</Condition>
-		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.0.0-preview2-006497">
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.*">
 		<Template
 			id="Microsoft.Common.Console.CSharp"
 			templateId="Microsoft.Common.Console.CSharp.2.0"
 			_overrideName="Console Application"
 			_overrideDescription="Creates a new .NET Core console project."
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-console-project"
 			imageId="md-netcore-console-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -66,7 +66,7 @@
 			templateId="Microsoft.Common.Console.FSharp.2.0"
 			_overrideName="Console Application"
 			_overrideDescription="Creates a new .NET Core console project."
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-console-project"
 			imageId="md-netcore-console-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -103,13 +103,13 @@
 			condition="UseNetStandard1x=true"
 			category="multiplat/library/general" />
 		</Condition>
-		<Condition id="DotNetCoreSdkInstalled" requiresRuntime="false" sdkVersion="2.0.0-preview2-006497">
+		<Condition id="DotNetCoreSdkInstalled" requiresRuntime="false" sdkVersion="2.*">
 		<Template
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.CSharp"
 			templateId="Microsoft.Common.Library.CSharp.2.0"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-crossplatform-library-project"
 			imageId="md-crossplatform-library-project"
 			supportedParameters="NetStandard"
@@ -121,7 +121,7 @@
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.FSharp"
 			templateId="Microsoft.Common.Library.FSharp.2.0"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-crossplatform-library-project"
 			imageId="md-crossplatform-library-project"
 			supportedParameters="NetStandard;FSharpNetStandard"
@@ -158,13 +158,13 @@
 			condition="UseNetStandard1x=true"
 			category="netcore/library/general" />
 		</Condition>
-		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.0.0-preview2-006497">
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.*">
 		<Template
 			_overrideName=".NET Standard Library"
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.CSharp"
 			templateId="Microsoft.Common.Library.CSharp.2.0"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			supportedParameters="NetStandard"
@@ -176,7 +176,7 @@
 			_overrideDescription="Creates a new .NET Standard class library project."
 			id="Microsoft.Common.Library.FSharp"
 			templateId="Microsoft.Common.Library.FSharp.2.0"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			supportedParameters="NetStandard;FSharpNetStandard"
@@ -208,14 +208,14 @@
 			condition="UseNetCore1x=true"
 			category="netcore/library/general" />
 		</Condition>
-		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.0.0-preview2-006497">
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.*">
 		<Template
 			_overrideName="Class Library"
 			_overrideDescription="Creates a new .NET Core class library project."
 			id="Microsoft.Common.Library.CSharp-netcoreapp"
 			templateId="Microsoft.Common.Library.CSharp.2.0"
 			groupId="Microsoft.Common.Library-netcoreapp"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			supportedParameters="NetCoreLibrary"
@@ -228,7 +228,7 @@
 			id="Microsoft.Common.Library.FSharp-netcoreapp"
 			templateId="Microsoft.Common.Library.FSharp.2.0"
 			groupId="Microsoft.Common.Library-netcoreapp"
-			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Common.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			supportedParameters="FSharpNetCoreLibrary;NetCoreLibrary"
@@ -316,13 +316,13 @@
 			category="netcore/app/aspnet"
 			defaultParameters="IncludeLaunchSettings=true" />
 		</Condition>
-		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.0.0-preview2-006497">
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="2.*">
 		<Template
 			id="Microsoft.Test.xUnit.CSharp"
 			templateId="Microsoft.Test.xUnit.CSharp.2.0"
 			_overrideName="xUnit Test Project"
 			_overrideDescription="Creates a new xUnit test project."
-			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -333,7 +333,7 @@
 			templateId="Microsoft.Test.xUnit.FSharp.2.0"
 			_overrideName="xUnit Test Project"
 			_overrideDescription="Creates a new xUnit test project."
-			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -344,7 +344,7 @@
 			templateId="Microsoft.Test.MSTest.CSharp.2.0"
 			_overrideName="MSTest Project"
 			_overrideDescription="Creates a new MSTest project."
-			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -355,7 +355,7 @@
 			templateId="Microsoft.Test.MSTest.FSharp.2.0"
 			_overrideName="MSTest Project"
 			_overrideDescription="Creates a new MSTest project."
-			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -366,7 +366,7 @@
 			templateId="Microsoft.Web.Empty.CSharp.2.0"
 			_overrideName="ASP.NET Core Empty"
 			_overrideDescription="Creates a new ASP.NET Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -378,7 +378,7 @@
 			templateId="Microsoft.Web.Mvc.CSharp.2.0"
 			_overrideName="ASP.NET Core Web App"
 			_overrideDescription="Creates a new ASP.NET MVC Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -390,7 +390,7 @@
 			templateId="Microsoft.Web.Mvc.FSharp.2.0"
 			_overrideName="ASP.NET Core Web App"
 			_overrideDescription="Creates a new ASP.NET MVC Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -400,7 +400,7 @@
 		<Template
 			id="Microsoft.Web.RazorPages.CSharp.2.0"
 			_overrideDescription="Creates a new ASP.NET Web API Core web project using Razor Pages."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
@@ -413,7 +413,7 @@
 			templateId="Microsoft.Web.WebApi.CSharp.2.0"
 			_overrideName="ASP.NET Core Web Api"
 			_overrideDescription="Creates a new ASP.NET Web API Core web project."
-			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170620-266.nupkg"
+			path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.0.0-beta2-20170727-301.nupkg"
 			icon="md-netcore-empty-project"
 			imageId="md-netcore-empty-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"

--- a/main/src/addins/MonoDevelop.DotNetCore/packages.config
+++ b/main/src/addins/MonoDevelop.DotNetCore/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.Common.ProjectTemplates.1.x" version="1.0.0-beta2-20170430-208" targetFramework="net46" />
-  <package id="Microsoft.DotNet.Common.ProjectTemplates.2.0" version="1.0.0-beta2-20170620-266" targetFramework="net46" />
+  <package id="Microsoft.DotNet.Common.ProjectTemplates.2.0" version="1.0.0-beta2-20170727-301" targetFramework="net46" />
   <package id="Microsoft.DotNet.Test.ProjectTemplates.1.x" version="1.0.0-beta2-20170430-208" targetFramework="net46" />
-  <package id="Microsoft.DotNet.Test.ProjectTemplates.2.0" version="1.0.0-beta2-20170620-266" targetFramework="net46" />
+  <package id="Microsoft.DotNet.Test.ProjectTemplates.2.0" version="1.0.0-beta2-20170727-301" targetFramework="net46" />
   <package id="Microsoft.DotNet.Web.ProjectTemplates.1.x" version="1.0.0-beta2-20170430-208" targetFramework="net46" />
-  <package id="Microsoft.DotNet.Web.ProjectTemplates.2.0" version="1.0.0-beta2-20170620-266" targetFramework="net46" />
+  <package id="Microsoft.DotNet.Web.ProjectTemplates.2.0" version="1.0.0-beta2-20170727-301" targetFramework="net46" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
 - Allow .NET Core 2.0 project templates to be enabled for other .NET Core SDK versions being installed. Previously only .NET Core 2.0 preview 2 being installed would enable the project templates.

 - Updated the .NET Core 2.0 project templates to match those included with preview 3.

 - Fix IDE being terminated after debugging .NET Core unit tests with latest .NET Core 2.0 SDK.