### PR TITLE
[Debugger] Fix debug value popup cut off at edge of screen

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueWindow.cs
@@ -168,7 +168,7 @@ namespace MonoDevelop.SourceEditor
 
 			if (dy > 0 && sw.VscrollbarPolicy == PolicyType.Never) {
 				sw.VscrollbarPolicy = PolicyType.Always;
-				sw.HeightRequest = h - dy - 10;
+				sw.HeightRequest = h - dy - 20;
 			} else if (sw.VscrollbarPolicy == PolicyType.Always && sw.Vadjustment.Upper == sw.Vadjustment.PageSize) {
 				sw.VscrollbarPolicy = PolicyType.Never;
 				sw.HeightRequest = -1;
@@ -176,7 +176,7 @@ namespace MonoDevelop.SourceEditor
 
 			if (dx > 0 && sw.HscrollbarPolicy == PolicyType.Never) {
 				sw.HscrollbarPolicy = PolicyType.Always;
-				sw.WidthRequest = w - dx - 10;
+				sw.WidthRequest = w - dx - 20;
 			} else if (sw.HscrollbarPolicy == PolicyType.Always && sw.Hadjustment.Upper == sw.Hadjustment.PageSize) {
 				sw.HscrollbarPolicy = PolicyType.Never;
 				sw.WidthRequest = -1;


### PR DESCRIPTION
Fixed value of 10 was set before retina displays, hence making it 20 fixes problem of cut off popup at edge of screen
Before:
![image](https://user-images.githubusercontent.com/774791/28871815-7d9e33c4-7786-11e7-80bd-d24a438096c5.png)
After:
![image](https://user-images.githubusercontent.com/774791/28872047-b55cbe56-7787-11e7-8385-a61cec006d0c.png)
