### PR TITLE
Fixed 'Bug 58286 - Code Snippet won't expand'

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -596,7 +596,12 @@ namespace MonoDevelop.SourceEditor
 			string shortcut = CodeTemplate.GetTemplateShortcutBeforeCaret (EditorExtension.Editor);
 			foreach (CodeTemplate template in CodeTemplateService.GetCodeTemplatesAsync (EditorExtension.Editor).WaitAndGetResult (CancellationToken.None)) {
 				if (template.Shortcut == shortcut) {
-					InsertTemplate (template, view.WorkbenchWindow.Document.Editor, view.WorkbenchWindow.Document);
+					var doc = view.WorkbenchWindow?.Document ?? IdeApp.Workbench.ActiveDocument;
+					if (doc != null) {
+						InsertTemplate (template, doc.Editor, doc);
+					} else {
+						LoggingService.LogError ("DoInsertTemplate(): Can't find valid document");
+					}
 					return true;
 				}
 			}


### PR DESCRIPTION
The android designer uses source editor view directly - in that case
the WorkbenchWindow seems not to be set. This change makes the
template insertion more robust against that scenario.