### PR TITLE
Fixed 'Bug 58570 - cut & paste always inserts tabs in xml'.

### DIFF
--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -550,8 +550,8 @@ namespace MonoDevelop.Xml.Editor
 			//because that means there are closing tags on the line, and they de-indent the line they're on
 			var endElementDepth = GetElementIndentDepth (Tracker.Engine.Nodes);
 			var elementDepth = Math.Min (endElementDepth, startElementDepth);
-
-			//FIXME: use policies
+			if (Editor.Options.TabsToSpaces)
+				return new string (' ', elementDepth * Editor.Options.TabSize);
 			return new string ('\t', elementDepth /*+ attributeDepth*/);
 		}
 		


### PR DESCRIPTION
There is no real need for using policies here - the editor options are
already set according to the policies.