### PR TITLE
Fixed 'Bug 58576 - [VSFeedback Ticket] #438331 - "User Property

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/CSharpSyntaxMode.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Highlighting/CSharpSyntaxMode.cs
@@ -257,7 +257,7 @@ namespace MonoDevelop.CSharp.Highlighting
 		string CheckScopeExists (string color)
 		{
 			HslColor c;
-			if (!theme.TryGetColor (color, EditorThemeColors.Foreground, out c) || c.Equals (defaultColor))
+			if (!theme.TryGetColor (color, EditorThemeColors.Foreground, out c))
 				return null;
 			return color;
 		}


### PR DESCRIPTION
Declaration" key not working in custom text color theme'

Makes not really sense to check if the colors are equal - checking if
it exists is enough. If colors are equal then there are no visual
differences.