### PR TITLE
Fixed 'Bug 53583 - Using IExtendingLineMarker causes redraw issues'

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -2560,9 +2560,6 @@ namespace Mono.TextEditor
 			if (line != null) {
 				newMarkers.Clear ();
 				newMarkers.AddRange (textEditor.Document.GetMarkers (line).OfType<IActionTextLineMarker> ());
-				var extraMarker = Document.GetExtendingTextMarker (loc.Line) as IActionTextLineMarker;
-				if (extraMarker != null && !oldMarkers.Contains (extraMarker))
-					newMarkers.Add (extraMarker);
 				foreach (var marker in newMarkers) {
 					if (oldMarkers.Contains (marker))
 						continue;
@@ -2989,10 +2986,6 @@ namespace Mono.TextEditor
 			// Check if line is beyond the document length
 			if (line == null) {
 				DrawScrollShadow (cr, x, y, _lineHeight);
-
-				var marker = Document.GetExtendingTextMarker (lineNr);
-				if (marker != null)
-					marker.Draw (textEditor, cr, lineNr, lineArea);
 				return;
 			}
 			

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -856,13 +856,23 @@ namespace MonoDevelop.SourceEditor
 				}
 			}
 
-			public void Draw (MonoTextEditor editor, Cairo.Context cr, int lineNr, Cairo.Rectangle lineArea)
+			public void Draw (MonoTextEditor editor, Cairo.Context g, int lineNr, Cairo.Rectangle lineArea)
 			{
+				using (var layout = new Pango.Layout (editor.PangoContext)) {
+					g.Save ();
+					editor.EditorTheme.TryGetColor (EditorThemeColors.Foreground, out HslColor color);
+					g.SetSourceColor (color);
+					g.Translate (lineArea.X, lineArea.Y - editor.LineHeight * 2);
+					layout.SetText ("Line " + lineNr);
+					g.ShowLayout (layout);
+					g.Restore ();
+				}
+
 			}
 
 			public double GetLineHeight (MonoTextEditor editor)
 			{
-				return editor.LineHeight *  3 / 2;
+				return editor.LineHeight *  3;
 			}
 		}
 
@@ -931,6 +941,10 @@ namespace MonoDevelop.SourceEditor
 			}
 
 			document.TextChanged += OnTextReplaced;
+			//document.AddMarker (5, new MyExtendingLineMarker ());
+			//document.AddMarker (7, new MyExtendingLineMarker ());
+			//document.AddMarker (10, new MyExtendingLineMarker ());
+
 			return TaskUtil.Default<object>();
 		}
 


### PR DESCRIPTION
This was caused by some old code trying to manage the addition/removal
of line markers. Was a left over of times where line markers weren't
stored in segment trees. I removed the old handling code it was mostly
unused anyways.