### PR TITLE
[AutoTest] Added support for NSSegmentedControl

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -34,16 +34,24 @@ using AppKit;
 using Foundation;
 
 using MonoDevelop.Components.MainToolbar;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.AutoTest.Results
 {
 	public class NSObjectResult : AppResult
 	{
 		NSObject ResultObject;
+		int index = -1;
 
 		internal NSObjectResult (NSObject resultObject)
 		{
 			ResultObject = resultObject;
+		}
+
+		internal NSObjectResult (NSObject resultObject, int index)
+		{
+			ResultObject = resultObject;
+			this.index = index;
 		}
 
 		public override string ToString ()
@@ -126,6 +134,14 @@ namespace MonoDevelop.Components.AutoTest.Results
 				}
 			}
 
+			if(ResultObject is NSSegmentedControl){
+				NSSegmentedControl control = (NSSegmentedControl)ResultObject;
+				string value = control.GetLabel (this.index);
+				if (CheckForText (value, text, exact)) {
+					return this;
+				}
+			}
+
 			return null;
 		}
 
@@ -151,6 +167,12 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override AppResult Property (string propertyName, object value)
 		{
+			if (ResultObject is NSSegmentedControl) {
+				NSSegmentedControl control = (NSSegmentedControl)ResultObject;
+				if (this.index >= 0 && propertyName == "Sensitive" || propertyName == "Visible") {
+					return control.IsEnabled (this.index) == (bool)value ? this : null;
+				}
+			}
 			return MatchProperty (propertyName, ResultObject, value);
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Components.AutoTest.Operations;
 using MonoDevelop.Components.AutoTest.Results;
 using System.Linq;
 using System.Xml;
+using MonoDevelop.Core;
 
 #if MAC
 using AppKit;
@@ -93,6 +94,23 @@ namespace MonoDevelop.Components.AutoTest
 				if (child.Subviews != null) {
 					AppResult children = GenerateChildrenForNSView (child, resultSet);
 					node.FirstChild = children;
+				}
+			}
+
+			if (view is NSSegmentedControl || view.GetType ().IsSubclassOf (typeof (NSSegmentedControl))) {
+				var segmentedControl = (NSSegmentedControl)view;
+				LoggingService.LogInfo ($"Found 'NSSegmentedControl' with {segmentedControl.SegmentCount} children");
+				for (int i = 0; i < segmentedControl.SegmentCount; i++) {
+					var node = new NSObjectResult (view, i);
+					resultSet.Add (node);
+					if (firstChild == null) {
+						firstChild = node;
+						lastChild = node;
+					} else {
+						lastChild.NextSibling = node;
+						node.PreviousSibling = lastChild;
+						lastChild = node;
+					}
 				}
 			}
 


### PR DESCRIPTION
For Mac UI elements, we use `SubViews` to traverse the hierarchy, but this model breaks down when we have to handle special butterflies like `NSSegmentedControl` which is actually just one view with multiple segments.

1) Added support to generate `NSObjectResult` for each segment of `NSSegmentedControl`
2) Match using `Text` Operation and it matches using value fetched from `NSSegmentedControl. GetLabel `
3) For the `Property` operation we have to handle `NSSegmentedControl` specially by matching `NSSegmentedControl.IsEnabled ` for properties of - `Visible` and `Sensitive`