### PR TITLE
[d15-4][AspNetCore] Fix Razor Pages project template name

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
@@ -151,6 +151,7 @@
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.RazorPages.CSharp.2.0"
+				_overrideName="ASP.NET Core Web App (Razor Pages)"
 				_overrideDescription="Creates a new ASP.NET Web API Core web project using Razor Pages."
 				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 				icon="md-netcore-empty-project"


### PR DESCRIPTION
Fixed bug #58608 - Duplicate "ASP.NET Core Web App" shown in
"New Project" dialog
https://bugzilla.xamarin.com/show_bug.cgi?id=58608

The default name was changed in the latest .NET Core project templates
and did not include any mention about Razor pages being used.