### PR TITLE
[Ide] Make recent template tests more robust

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
@@ -240,7 +240,11 @@ namespace MonoDevelop.Ide.Desktop
 				if (recentSaveTask == null) {
 					recentSaveTask = Task.Run (async () => {
 						await Task.Delay (1000).ConfigureAwait (false);
-						await SaveRecentFiles ().ConfigureAwait (false);
+						try {
+							await SaveRecentFiles ().ConfigureAwait (false);
+						} catch (Exception ex) {
+							LoggingService.LogError ("Error while saving recent file store.", ex);
+						}
 					});
 				}
 			}


### PR DESCRIPTION
The RecentTemplates_TwoTemplatesInGroupDifferentLanguage_TreatedAsDifferentRecentTemplate test occasionally fails to find any recent templates. To make the recent template tests more robust the list of templates is retried several times before failing. This handles the case where the RecentFileStorage's constructor occasionally clears out the cached in-memory list whilst the test is
adding new items. The in-memory list is eventually updated when the file is saved but this can take some time to happen since the save is delayed.

Also a different file name is used with the recent file storage for each unit test to minimize the chance of a sharing violation from occuring.

Also added some logging to the RecentFileStorage class if the file save fails.