### PR TITLE
[VCS] Optimize log widget rendering

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseRepositoryTests.cs
@@ -669,6 +669,72 @@ namespace MonoDevelop.VersionControl.Tests
 			Assert.AreEqual (VersionStatus.Versioned, Repo.GetVersionInfo (srcFile, VersionInfoQueryFlags.IgnoreCache).Status);
 			
 		}
+
+		[Test]
+		public void RevisionFormatMessageChangelogStyle()
+		{
+			var res = RevisionHelpers.FormatMessage(
+@"2009-11-23 Test Author
+
+	* MonoDevelop.CSharp/CSharpBindingCompilerManager.cs: Emit the
+	  target platform option. Fixes bug #557146.");
+
+			var expected =
+@"Emit the target platform option. Fixes bug #557146.";
+			
+			Assert.AreEqual (expected, res);
+		}
+
+		[Test]
+		public void RevisionFormatMessageChangelogStyleMultipleLines ()
+		{
+			var res = RevisionHelpers.FormatMessage (
+@"2005-09-22 Test Author
+	* Services/NUnitService.cs:
+	* Services/CombineTestGroup.cs:
+	* Services/NUnitProjectTestSuite.cs:
+	* Services/SystemTestProvider.cs: Only generate a test suite for
+	projects that reference the nunit.framework assembly.");
+
+			var expected =
+@"* Services/CombineTestGroup.cs:
+ * Services/NUnitProjectTestSuite.cs:
+ * Services/SystemTestProvider.cs: Only generate a test suite for
+ projects that reference the nunit.framework assembly.";
+//			var expected =
+//@"Only generate a test suite for projects that reference the nunit.framework assembly.";
+
+			Assert.AreEqual (expected, res);
+		}
+
+		[Test]
+		public void RevisionFormatMessageChangelogStyleMultipleMessages ()
+		{
+			var res = RevisionHelpers.FormatMessage (
+@"2005-08-22 Test Author
+	* Commands/ViewCommands.cs: Implemented delete layout command.
+	* Gui/Workbench/Layouts/SdiWorkspaceLayout.cs: Properly load saved
+	layouts. Added DeleteLayout method.
+	* Gui/IWorkbenchLayout.cs: Added DeleteLayout method.
+	* MonoDevelopCore.addin.xml: Added Delete Layout command.");
+
+//			var expected =
+//@"Implemented delete layout command.
+// Properly load saved layouts. Added DeleteLayout method.
+// Added DeleteLayout method.
+// Added Delete Layout command.
+
+			var expected =
+@"Implemented delete layout command. * Gui/Workbench/Layouts/SdiWorkspaceLayout.cs: Properly load saved
+ layouts. Added DeleteLayout method.
+ * Gui/IWorkbenchLayout.cs: Added DeleteLayout method.
+ * MonoDevelopCore.addin.xml: Added Delete Layout command.";
+
+			Assert.AreEqual (expected, res);
+		}
+
+
+
 		#region Util
 
 		protected void Checkout (string path, string url)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
@@ -105,6 +105,9 @@
     <Compile Include="BaseGitRepositoryTests.cs" />
     <Compile Include="BaseRepositoryTests.cs" />
     <Compile Include="GitIntegrityTests.cs" />
+    <Compile Include="..\MonoDevelop.VersionControl\MonoDevelop.VersionControl\RevisionHelpers.cs">
+      <Link>RevisionHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Tests/MonoDevelop.VersionControl.Subversion.Tests.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Tests/MonoDevelop.VersionControl.Subversion.Tests.csproj
@@ -43,6 +43,9 @@
     <Compile Include="..\MonoDevelop.VersionControl.Git.Tests\BaseRepositoryTests.cs">
       <Link>BaseRepositoryTests.cs</Link>
     </Compile>
+    <Compile Include="..\MonoDevelop.VersionControl\MonoDevelop.VersionControl\RevisionHelpers.cs">
+      <Link>RevisionHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -755,7 +755,7 @@ namespace MonoDevelop.VersionControl.Views
 						if (ann != null && line - lineStart > 1) {
 							string msg = GetCommitMessage (lineStart, false);
 							if (!string.IsNullOrEmpty (msg)) {
-								msg = Revision.FormatMessage (msg);
+								msg = RevisionHelpers.FormatMessage (msg);
 
 								layout.SetText (msg);
 								layout.Width = (int)(Allocation.Width * Pango.Scale.PangoScale);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -559,7 +559,7 @@ namespace MonoDevelop.VersionControl.Views
 			if (string.IsNullOrEmpty (rev.Message)) {
 				renderer.Text = GettextCatalog.GetString ("(No message)");
 			} else {
-				string message = Revision.FormatMessage (rev.Message);
+				string message = RevisionHelpers.FormatMessage (rev.Message);
 				int idx = message.IndexOf ('\n');
 				if (idx > 0)
 					message = message.Substring (0, idx);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -1251,6 +1251,7 @@
     <Compile Include="MonoDevelop.VersionControl.Views\BaseView.cs" />
     <Compile Include="MonoDevelop.VersionControl.Views\Styles.cs" />
     <Compile Include="MonoDevelop.VersionControl\VersionControlInitializer.cs" />
+    <Compile Include="MonoDevelop.VersionControl\RevisionHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Revision.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Revision.cs
@@ -70,34 +70,6 @@ namespace MonoDevelop.VersionControl
 			get { return Name; }
 		}
 
-		internal static string FormatMessage (string msg)
-		{
-			StringBuilder sb = new StringBuilder ();
-			bool wasWs = false;
-			foreach (char ch in msg) {
-				if (ch == ' ' || ch == '\t') {
-					if (!wasWs)
-						sb.Append (' ');
-					wasWs = true;
-					continue;
-				}
-				wasWs = false;
-				sb.Append (ch);
-			}
-
-			var doc = TextDocument.CreateImmutableDocument (sb.ToString());
-			foreach (var line in doc.Lines) {
-				string text = doc.GetTextAt (line.Offset, line.Length).Trim ();
-				int idx = text.IndexOf (':');
-				if (text.StartsWith ("*", StringComparison.Ordinal) && idx >= 0 && idx < text.Length - 1) {
-					int offset = line.EndOffsetIncludingDelimiter;
-					msg = text.Substring (idx + 1) + doc.GetTextAt (offset, doc.Length - offset);
-					break;
-				}
-			}
-			return msg.TrimStart (' ', '\t');
-		}
-
 		public static bool operator ==(Revision a, Revision b)
 		{
 			if (System.Object.ReferenceEquals(a, b))

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/RevisionHelpers.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/RevisionHelpers.cs
@@ -1,0 +1,91 @@
+﻿//
+// RevisionHelpers.cs
+//
+// Author:
+//       Marius <>
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Text;
+
+namespace MonoDevelop.VersionControl
+{
+	static class RevisionHelpers
+	{
+		static readonly char[] trimChars = { ' ', '\t' };
+
+		internal static string FormatMessage(string msg)
+		{
+			StringBuilder sb = new StringBuilder();
+			bool wasWs = true, wasNewLine = true, foundStar = false, trimmedEndWhitespace = false;
+			int offset = 0;
+
+			foreach (char ch in msg)
+			{
+				// Fast-fail if we don't have any ':', meaning this is not a 
+				// changelog-style commit message 
+				if (msg.IndexOf (':') == -1)
+					return msg.TrimStart (trimChars);
+
+				// Parse change-log style commit message
+				if (ch == ' ' || ch == '\t') {
+					if (!wasWs)
+						sb.Append(' ');
+					wasWs = true;
+					continue;
+				}
+
+				if (offset == 0) {
+					if (!foundStar && wasNewLine) {
+						foundStar = ch == '*';
+					}
+
+					if (foundStar && ch == ':') {
+						offset = sb.Length + 1;
+					}
+
+					if (ch == '\n') {
+						// wasNewLine will remain true until the next non-whitespace char.
+						wasNewLine = true;
+					} else {
+						wasNewLine = false;
+					}
+				} else if (!trimmedEndWhitespace) {
+					if (ch == ' ' || ch == '\t')
+						continue;
+
+					if (ch == '\n') {
+						trimmedEndWhitespace = true;
+						continue;
+					}
+				}
+
+				wasWs = false;
+				sb.Append(ch);
+			}
+
+			if (offset != 0 && offset < sb.Length)
+				msg = sb.ToString (offset, sb.Length - offset);
+			
+			return msg.TrimStart (trimChars);
+		}
+	}
+}

--- a/main/src/addins/VersionControl/Subversion.Win32.Tests/VersionControl.Subversion.Win32.Tests.csproj
+++ b/main/src/addins/VersionControl/Subversion.Win32.Tests/VersionControl.Subversion.Win32.Tests.csproj
@@ -42,6 +42,9 @@
     <Compile Include="..\MonoDevelop.VersionControl.Subversion.Tests\BaseSvnRepositoryTests.cs">
       <Link>BaseSvnRepositoryTests.cs</Link>
     </Compile>
+    <Compile Include="..\MonoDevelop.VersionControl\MonoDevelop.VersionControl\RevisionHelpers.cs">
+      <Link>RevisionHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
The code retains old broken functionality, commented out expected values are in unit tests.

Consider fixing this if Changelog style commits are still a thing. For now, just optimize it
by removing the usage of the TextEditor

Avoid creating a text editor and doing text manipulation there and rely on simple string parsing
Bug 56965 - Version control log filtering hangs IDE