### PR TITLE
Fixed 'Bug 58077 - [VSFeedback Ticket] #461622 - Unable to save some

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -777,7 +777,7 @@ namespace MonoDevelop.SourceEditor
 					}
 				}
 				try {
-					this.Document.VsTextDocument.Save();
+					MonoDevelop.Core.Text.TextFileUtility.WriteText (fileName, Document);
 				} catch (InvalidEncodingException) {
 					var result = MessageService.AskQuestion (GettextCatalog.GetString ("Can't save file with current codepage."), 
 						GettextCatalog.GetString ("Some unicode characters in this file could not be saved with the current encoding.\nDo you want to resave this file as Unicode ?\nYou can choose another encoding in the 'save as' dialog."),
@@ -786,7 +786,7 @@ namespace MonoDevelop.SourceEditor
 						new AlertButton (GettextCatalog.GetString ("Save as Unicode")));
 					if (result != AlertButton.Cancel) {
 						this.Document.VsTextDocument.Encoding = Encoding.UTF8;
-						this.Document.VsTextDocument.Save();
+						MonoDevelop.Core.Text.TextFileUtility.WriteText (fileName, Document);
 					}
 					else {
 						return;


### PR DESCRIPTION
files after leaving VSfM open for extended period; affected file
content is corrupt'