### PR TITLE
Fixed 'Bug 58488 - Breakpoint highlighting not visible'

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1487,6 +1487,12 @@ namespace Mono.TextEditor
 				return textViewMargin;
 			}
 		}
+
+		public GutterMargin GutterMargin {
+			get {
+				return gutterMargin;
+			}
+		}
 		
 		public Margin IconMargin {
 			get { return iconMargin; }

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -1493,7 +1493,7 @@ namespace MonoDevelop.SourceEditor
 			}
 
 			if (hoverDebugLineMarker == null && e.LineSegment != null && e.Editor.Document.GetMarkers (e.LineSegment).FirstOrDefault (m => m is DebugIconMarker) == null) {
-				hoverDebugLineMarker = new DebugIconMarker (hoverBreakpointIcon) {
+				hoverDebugLineMarker = new DebugIconMarker (hoverBreakpointIcon, true) {
 					Tooltip = GettextCatalog.GetString ("Insert Breakpoint")
 				};
 				e.Editor.Document.AddMarker (e.LineSegment.LineNumber, hoverDebugLineMarker);


### PR DESCRIPTION
+ Turned on highlighting
+ The current line marker is now displayed in the empty space left of
the line numbers and not on top of the icon marker.