### PR TITLE
Exclude Azure libs from scanning

### DIFF
--- a/main/src/addins/MonoDevelop.AzureFunctions/Properties/Manifest.addin.xml
+++ b/main/src/addins/MonoDevelop.AzureFunctions/Properties/Manifest.addin.xml
@@ -1,4 +1,9 @@
 ﻿<ExtensionModel>
+	
+	<Runtime>
+		<ScanExclude path="azure-functions-cli-66a932fb" />
+	</Runtime>
+	
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateCategories">
 		<Category id="cloud" _name="Cloud" insertafter="netcore">
 			<Category id="general" _name="General">


### PR DESCRIPTION
Significantly reduces the amount of assemblies being scanned.