### PR TITLE
[F#] Fix a race condition when merging ItemGroups

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/ProjectTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/ProjectTests.fs
@@ -105,7 +105,7 @@ type ProjectTests() =
                                         File.Create(path).Dispose()
                                         project.AddFile(path, buildAction) |> ignore)
 
-                do! project.SaveAsync(monitor) |> Async.AwaitTask
+                do! project.SaveAsync(monitor)
                 let groups = project.MSBuildProject.ItemGroups |> List.ofSeq
                 groups.Length |> should equal 1
                 let includes =
@@ -122,6 +122,118 @@ type ProjectTests() =
                      "Resources\\AboutResources.txt"]
                 Assert.AreEqual(expected, includes, sprintf "%A" includes)
 
+        }
+
+    [<Test;AsyncStateMachine(typeof<Task>)>]
+    member this.``Adds two image assets``() =
+        toTask <| async {
+            if not MonoDevelop.Core.Platform.IsWindows then
+                let path = Path.GetTempPath()
+                let projectPath = path + Guid.NewGuid().ToString() + ".fsproj"
+                let project = Services.ProjectService.CreateDotNetProject ("F#")
+                project.FileName <- FilePath(projectPath)
+
+                let addFile path buildAction =
+                    Directory.CreateDirectory(Path.GetDirectoryName path) |> ignore
+                    File.Create(path).Dispose()
+                    project.AddFile(path, buildAction) |> ignore
+
+                addFile (path/"Assets.xcassets"/"test1.fs") "Compile"
+                addFile (path/"Assets.xcassets"/"test1.png") "ImageAsset"
+                do! project.SaveAsync(monitor)
+                addFile (path/"Assets.xcassets"/"test2.png") "ImageAsset"
+                do! project.SaveAsync(monitor)
+
+                let x = File.ReadAllText projectPath
+                let groups = project.MSBuildProject.ItemGroups |> List.ofSeq
+                groups.Length |> should equal 1
+                let includes =
+                    groups.[0].Items
+                    |> Seq.map (fun item -> item.Include)
+                    |> List.ofSeq
+                let expected =
+                    ["Assets.xcassets\\test1.fs"
+                     "Assets.xcassets\\test1.png"
+                     "Assets.xcassets\\test2.png"]
+                Assert.AreEqual(expected, includes, sprintf "%A" includes)
+
+        }
+    [<Test;AsyncStateMachine(typeof<Task>)>]
+    member this.``Adds new image assets``() =
+        toTask <| async {
+            if not MonoDevelop.Core.Platform.IsWindows then
+                let xml =
+                    """
+                    <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+                        <ProjectGuid>{A23F6451-2157-4673-8C0D-F1DE17D00D32}</ProjectGuid>
+                        <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectTypeGuids>
+                        <OutputType>Exe</OutputType>
+                        <RootNamespace>fsr</RootNamespace>
+                        <AssemblyName>fsr</AssemblyName>
+                        <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="System" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="mscorlib" />
+                        <Reference Include="FSharp.Core" />
+                        <Reference Include="Xamarin.iOS" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Folder Include="Resources\" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-App-29x29%401x.png" />
+                        <ImageAsset Include="Assets.xcassets\Contents.json" />
+                        <InterfaceDefinition Include="LaunchScreen.storyboard" />
+                        <InterfaceDefinition Include="Main.storyboard" />
+                        <None Include="Entitlements.plist" />
+                        <None Include="Info.plist" />
+                        <Compile Include="Main.fs" />
+                        <Compile Include="ViewController.fs" />
+                        <Compile Include="AppDelegate.fs" />
+                        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-App-76x76%402x.png" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.FSharp.targets" />
+                    </Project>
+                    """
+
+                let path = Path.GetTempPath() / (Guid.NewGuid().ToString())
+                Directory.CreateDirectory path |> ignore
+                let projectPath = path / "ImageAssets.fsproj"
+                printfn "%s" path
+                File.WriteAllText (projectPath, xml)
+                let project = Services.ProjectService.CreateDotNetProject ("F#")
+                let! (solutionItem:SolutionItem) = Services.ProjectService.ReadSolutionItem(monitor, projectPath) 
+                let project = solutionItem :?> DotNetProject
+                project.FileName <- FilePath(projectPath)
+
+                let addFile filePath buildAction =
+                    project.AddFile(path / filePath, buildAction) |> ignore
+
+                addFile ("Assets.xcassets"/"AppIcon.appiconset"/"Icon-App-test1.png") "ImageAsset"
+                do! project.SaveAsync(monitor)
+                addFile ("Assets.xcassets"/"AppIcon.appiconset"/"Icon-App-test2.png") "ImageAsset"
+                do! project.SaveAsync(monitor)
+                let groups = project.MSBuildProject.ItemGroups |> List.ofSeq
+                groups.Length |> should equal 3 // References, Folders, Rest
+                let includes =
+                    groups.[2].Items
+                    |> Seq.map (fun item -> item.Include)
+                    |> List.ofSeq
+                    |> List.filter(fun i -> i.StartsWith("Assets.xcassets\\AppIcon.appiconset"))
+                    |> List.sort
+
+                let expected =
+                    ["Assets.xcassets\\AppIcon.appiconset\\Icon-App-29x29%401x.png"
+                     "Assets.xcassets\\AppIcon.appiconset\\Icon-App-76x76%402x.png"
+                     "Assets.xcassets\\AppIcon.appiconset\\Icon-App-test1.png"
+                     "Assets.xcassets\\AppIcon.appiconset\\Icon-App-test2.png"]
+                Assert.AreEqual(expected, includes, sprintf "%A" includes)
         }
 
     [<Test;AsyncStateMachine(typeof<Task>)>]


### PR DESCRIPTION
Sometimes when a file is added to the project, it doesn't yet exist
in the MSBuildItems. Fix by checking for Project Files that don't yet
exist in MSBuildItems. Fixes #57689