### PR TITLE
Bug 58164 - Device/Simulator list is disabled upon creation of new iOS project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -177,8 +177,9 @@ namespace MonoDevelop.Components.MainToolbar
 
 			ToolbarView.RunConfigurationVisible = ToolbarView.RunConfigurationModel.Count () > 1;
 
-			FillRuntimes ();
 			SelectActiveConfiguration ();
+			FillRuntimes ();
+			SelectActiveRuntime (ToolbarView.ActiveRuntime as RuntimeModel);
 		}
 
 		void FillRuntimes ()
@@ -440,8 +441,6 @@ namespace MonoDevelop.Components.MainToolbar
 			} finally {
 				ignoreConfigurationChangedCount--;
 			}
-
-			SelectActiveRuntime (ToolbarView.ActiveRuntime as RuntimeModel);
 		}
 
 		IEnumerable<IRuntimeModel> AllRuntimes (IEnumerable<IRuntimeModel> runtimes)


### PR DESCRIPTION
Moved selection of target device from SelectActiveConfiguration to after target devices are actually set