### PR TITLE
[d15-4][DotNetCore] Fix project template names not being translated

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
@@ -73,6 +73,7 @@
 		<Condition id="AspNetCoreSdkInstalled" sdkVersion="1.*">
 			<Template
 				id="Microsoft.Web.Empty.CSharp"
+				_overrideName="ASP.NET Core Empty"
 				_overrideDescription="Creates a new ASP.NET Core web project."
 				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
@@ -83,6 +84,7 @@
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.CSharp"
+				_overrideName="ASP.NET Core Web App"
 				_overrideDescription="Creates a new ASP.NET MVC Core web project."
 				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
@@ -93,6 +95,7 @@
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.FSharp"
+				_overrideName="ASP.NET Core Web App"
 				_overrideDescription="Creates a new ASP.NET MVC Core web project."
 				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
@@ -103,6 +106,7 @@
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.WebApi.CSharp"
+				_overrideName="ASP.NET Core Web API"
 				_overrideDescription="Creates a new ASP.NET Web API Core web project."
 				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
@@ -164,7 +168,7 @@
 			<Template
 				id="Microsoft.Web.WebApi.CSharp"
 				templateId="Microsoft.Web.WebApi.CSharp.2.0"
-				_overrideName="ASP.NET Core Web Api"
+				_overrideName="ASP.NET Core Web API"
 				_overrideDescription="Creates a new ASP.NET Web API Core web project."
 				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
 				icon="md-netcore-empty-project"

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -238,6 +238,7 @@
 		<Condition id="DotNetCoreSdkInstalled" sdkVersion="1.*">
 		<Template
 			id="Microsoft.Test.xUnit.CSharp"
+			_overrideName="xUnit Test Project"
 			_overrideDescription="Creates a new xUnit test project."
 			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 			icon="md-netcore-test-project"
@@ -247,6 +248,7 @@
 			category="netcore/test/general" />
 		<Template
 			id="Microsoft.Test.xUnit.FSharp"
+			_overrideName="xUnit Test Project"
 			_overrideDescription="Creates a new xUnit test project."
 			path="Templates/Microsoft.DotNet.Test.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 			icon="md-netcore-test-project"


### PR DESCRIPTION
Some of the .NET Core project template names were not being
translated in the New Project dialog. This fixes the translation of:

 - xUnit Test Project
 - ASP.NET Core Empty
 - ASP.NET Core Web App

Not currently being translated:

 - ASP.NET Core Web API
 - ASP.NET Core Web App (Razor Pages)