### PR TITLE
[Ide] Fix external tool failing to run when solution selected

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -51,6 +51,7 @@ namespace MonoDevelop.Projects
 		
 		public SolutionFolder ()
 		{
+			Initialize (this);
 		}
 		
 		public SolutionFolderItemCollection Items {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
@@ -310,9 +310,9 @@ namespace MonoDevelop.Ide.ExternalTools
 			
 			toolListBoxStore.SetValue (SelectedIter, 0, titleTextBox.Text);
 			selectedItem.MenuCommand        = titleTextBox.Text;
-			selectedItem.Command            = browseButton.Path;
+			selectedItem.Command            = browseButton.Path.Trim ();
 			selectedItem.Arguments          = argumentTextBox.Text;
-			selectedItem.InitialDirectory   = workingDirTextBox.Text;
+			selectedItem.InitialDirectory   = workingDirTextBox.Text.Trim ();
 			selectedItem.PromptForArguments = promptArgsCheckBox.Active;
 			selectedItem.UseOutputPad       = useOutputPadCheckBox.Active;
 			selectedItem.SaveCurrentFile    = saveCurrentFileCheckBox.Active;

--- a/main/tests/UnitTests/MonoDevelop.Projects/StringTagTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/StringTagTests.cs
@@ -117,6 +117,28 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task SolutionFolderTags ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			Solution sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var model = sol.RootFolder.GetStringTagModel (ConfigurationSelector.Default);
+
+			Assert.AreEqual (sol.FileName, model.GetValue ("SolutionFile"));
+			Assert.AreEqual ("ConsoleProject", model.GetValue ("SolutionName"));
+			Assert.AreEqual (sol.ItemDirectory, model.GetValue ("SolutionDir"));
+
+			var mdesc = sol.GetStringTagModelDescription (ConfigurationSelector.Default);
+			var tt = mdesc.GetTags ().Select (t => t.Name).ToArray ();
+
+			Assert.That (tt.Contains ("SolutionFile"));
+			Assert.That (tt.Contains ("SolutionName"));
+			Assert.That (tt.Contains ("SolutionDir"));
+
+			sol.Dispose ();
+		}
+
+		[Test]
 		public void TagsInItemExtension ()
 		{
 			var p = new TestTagProvider ();


### PR DESCRIPTION
Fixed bug #58735 - Unable to start .exe from VSMac as External Tool
https://bugzilla.xamarin.com/show_bug.cgi?id=58735

When a solution is selected in the Solution window then running an
external tool would fail. With a project selected the external tool
would run successfully.

```
Error while executing command: Tool List
System.InvalidOperationException: The constructor of type MonoDevelop.Projects.SolutionFolder must call Initialize(this)
  at MonoDevelop.Projects.WorkspaceObject.AssertExtensionChainCreated ()  in MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs:331
  at MonoDevelop.Projects.WorkspaceObject.get_ItemExtension ()  in MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs:346
  at MonoDevelop.Projects.WorkspaceObject.GetStringTagModel (MonoDevelop.Projects.ConfigurationSelector conf)  in MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs:300
  at MonoDevelop.Ide.Gui.Workbench.GetStringTagModel ()  in main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs:765
  at MonoDevelop.Ide.ExternalTools.ExternalTool.Run ()  in MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalTool.cs:129
  at MonoDevelop.Ide.Commands.ToolListHandler.Run (System.Object dataItem)  in MonoDevelop.Ide/MonoDevelop.Ide.Commands/ToolsCommands.cs:94
  at MonoDevelop.Components.Commands.CommandHandler.InternalRun (System.Object dataItem)  in MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandHandler.cs:37
  at MonoDevelop.Components.Commands.CommandManager.DefaultDispatchCommand ()  in MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1502
  at MonoDevelop.Components.Commands.CommandManager.DispatchCommand ()  in MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1466
```

Also the Command and Working directory is now trimmed when an External Tool is created to avoid errors when running the External tool since it is difficult to know that a space is causing the problem.