### PR TITLE
[NUnit] Recognize unit-test projects when using PackageReference NuGet references instead of packages.config

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Xml;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects.MSBuild;
@@ -56,6 +57,34 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("1.2.3", packageReferenceElement.GetAttribute ("Version"));
 			Assert.AreEqual (0, packageReferenceElement.ChildNodes.Count);
 			Assert.IsTrue (packageReferenceElement.IsEmpty);
+		}
+
+		[Test]
+		public void IsAtLeastVersion_Simple ()
+		{
+			var reference = ProjectPackageReference.Create ("NUnit", "3.2");
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 0)));
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 2)));
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 0, 0)));
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 2, 0)));
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 2, 0, 0)));
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 0, 0, 0)));
+			Assert.IsFalse (reference.IsAtLeastVersion (new Version (4, 0)));
+			Assert.IsFalse (reference.IsAtLeastVersion (new Version (3, 3, 0)));
+			Assert.IsFalse (reference.IsAtLeastVersion (new Version (3, 2, 1)));
+		}
+
+		[Test]
+		[TestCase ("[3.2,)")]
+		[TestCase ("(3.2,]")]
+		[TestCase ("[3.2]")]
+		public void IsAtLeastVersion_Range (string versionRange)
+		{
+			var reference = ProjectPackageReference.Create ("NUnit", versionRange);
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 0)));
+			Assert.IsTrue (reference.IsAtLeastVersion (new Version (3, 2)));
+			Assert.IsFalse (reference.IsAtLeastVersion (new Version (3, 2, 1)));
+			Assert.IsFalse (reference.IsAtLeastVersion (new Version (3, 3)));
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -613,6 +613,7 @@
     <InternalsVisibleTo Include="MonoDevelop.PackageManagement.Tests" />
     <InternalsVisibleTo Include="MonoDevelop.Packaging" />
     <InternalsVisibleTo Include="Xamarin.Forms.Addin" />
+    <InternalsVisibleTo Include="MonoDevelop.UnitTesting.NUnit" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
@@ -75,11 +75,31 @@ namespace MonoDevelop.PackageManagement
 
 		NuGetFramework GetFramework ()
 		{
+			if (Project == null)
+				return NuGetFramework.AnyFramework;
 			string framework = Project.GetDotNetCoreTargetFrameworks ().FirstOrDefault ();
 			if (framework != null)
 				return NuGetFramework.Parse (framework);
 
 			return NuGetFramework.UnsupportedFramework;
+		}
+
+		public bool IsAtLeastVersion (Version version)
+		{
+			var packageReference = CreatePackageReference ();
+			var requestedVersion = new NuGetVersion (version);
+			var comparer = VersionComparer.VersionRelease;
+			if (packageReference.HasAllowedVersions) {
+				var versionRange = packageReference.AllowedVersions;
+				if (versionRange.HasLowerBound) {
+					var result = comparer.Compare (versionRange.MinVersion, requestedVersion);
+					return versionRange.IsMinInclusive ? result <= 0 : result < 0;
+				}
+			} else if (packageReference.PackageIdentity.HasVersion) {
+				var packageVersion = packageReference.PackageIdentity.Version;
+				return comparer.Compare (requestedVersion, packageVersion) <= 0;
+			}
+			return false;
 		}
 
 		public bool Equals (PackageIdentity packageIdentity, bool matchVersion = true)

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/AddinInfo.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/AddinInfo.cs
@@ -14,3 +14,4 @@ using Mono.Addins.Description;
 [assembly:AddinDependency ("Core", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("Ide", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("UnitTesting", MonoDevelop.BuildInfo.Version)]
+[assembly:AddinDependency ("PackageManagement", MonoDevelop.BuildInfo.Version)]

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit.csproj
@@ -70,6 +70,11 @@
       <Name>MonoDevelop.UnitTesting</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.csproj">
+      <Project>{F218643D-2E74-4309-820E-206A54B7133F}</Project>
+      <Name>MonoDevelop.PackageManagement</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelopNUnit.addin.xml">


### PR DESCRIPTION
This needed to use some (currently) internal types of MonoDevelop.PackageManagement for which a temporary InternalsVisibleTo was added.