### PR TITLE
Fixed 'Bug 58715 - Text editor shows no text when using go to

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
@@ -253,10 +253,10 @@ namespace MonoDevelop.CSharp
 
 		void UpdateOwnerProjects (IEnumerable<DotNetProject> allProjects)
 		{
-			if (DocumentContext == null) {
-				return;//This can happen if this object is disposed
-			}
 			Editor.RunWhenRealized (() => {
+				if (DocumentContext == null) {
+					return;//This can happen if this object is disposed
+				}
 				var projects = new HashSet<DotNetProject> (allProjects.Where (p => p.IsFileInProject (DocumentContext.Name)));
 				if (ownerProjects == null || !projects.SetEquals (ownerProjects)) {
 					SetOwnerProjects (projects.OrderBy (p => p.Name).ToList ());


### PR DESCRIPTION
declaration'

During the Editor.RunWhenRealized the if wasn't put into the delegate
- however the extension chain could change prior to editor ui
creation.