### PR TITLE
[Core] Support parsing MSBuild Exists condition with unquoted property

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionParser.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionParser.cs
@@ -220,9 +220,14 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 				if (token.Type == TokenType.Comma)
 					continue;
 					
-				tokenizer.Putback (token);
+				if (token.Type != TokenType.Property)
+					tokenizer.Putback (token);
+
 				e = (ConditionFactorExpression) ParseFactorExpression ();
 				list.Add (e);
+
+				if (token.Type == TokenType.Property)
+					tokenizer.Putback (tokenizer.Token);
 			}
 			
 			return list;

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -309,6 +309,17 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void EvalExistsWhenNotInsideQuotes ()
+		{
+			var p = LoadProject ();
+			p.Evaluate ();
+			var res = p.EvaluatedProperties.GetValue ("ExistsNotInsideQuotesTest");
+			Assert.AreEqual ("OK", res);
+
+			p.Dispose ();
+		}
+
+		[Test]
 		public void ImportGroups ()
 		{
 			var p = LoadAndEvaluate ("project-with-import-groups", "import-group-test.csproj");

--- a/main/tests/test-projects/msbuild-project-test/test.csproj
+++ b/main/tests/test-projects/msbuild-project-test/test.csproj
@@ -13,6 +13,7 @@
     <EvalProp>$(TestProp)</EvalProp>
   	<Foo>support\file1.txt</Foo>
   	<ExistsTest Condition="Exists('$(Foo)')">OK</ExistsTest>
+  	<ExistsNotInsideQuotesTest Condition="Exists($(Foo))">OK</ExistsNotInsideQuotesTest>
   	<CASE1>value1</CASE1>
   	<Case1>value2</Case1>
   	<Case2>$(CasE1)</Case2>


### PR DESCRIPTION
Fixed bug #58644 - Condition parsing issue with function calls
https://bugzilla.xamarin.com/show_bug.cgi?id=58644

.NET Core 2.0 SDK uses conditions that pass properties to the
Exists function without single quotes. These are now supported:

    <PropertyGroup Condition="Exists($(FileName))">

Previously the condition would only be evaluated correctly if it had
single quotes around the property passed to the Exists function:

    <PropertyGroup Condition="Exists('$(FileName)')">