### PR TITLE
[NuGet] Support imported package references

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -203,6 +203,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestablePackageReferenceNuGetProject.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeMonoDevelopBuildIntegratedRestorer.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\RestoreNuGetPackagesInNuGetIntegratedProjectTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\ImportedPackageReferenceProjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ImportedPackageReferenceProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ImportedPackageReferenceProjectTests.cs
@@ -1,0 +1,102 @@
+﻿//
+// ImportedPackageReferenceProjectTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class ImportedPackageReferenceProjectTests
+	{
+		string tempDirectory;
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (tempDirectory != null && Directory.Exists (tempDirectory)) {
+				Directory.Delete (tempDirectory, true);
+			}
+		}
+
+		void CreateTempDirectory ()
+		{
+			tempDirectory = FileService.CreateTempDirectory ();
+		}
+
+		void SaveFileInTempDirectory (string fileName, string contents)
+		{
+			string fullPath = Path.Combine (tempDirectory, fileName);
+			File.WriteAllText (fullPath, contents, Encoding.UTF8);
+		}
+
+		[Test]
+		public async Task CreatePackageReferenceNuGetProject_OneImportedPackageReference_ReturnsNuGetProject ()
+		{
+			string projectXml =
+				"<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" +
+				"<Project DefaultTargets=\"Build\" ToolsVersion=\"4.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <Configuration Condition=\" '$(Configuration)' == '' \">Debug</Configuration>\r\n" +
+				"    <Platform Condition=\" '$(Platform)' == '' \">AnyCPU</Platform>\r\n" +
+				"    <ProjectGuid>{29DE8CC5-1378-4A68-94CB-2B520618C4A1}</ProjectGuid>\r\n" +
+				"    <OutputType>Library</OutputType>\r\n" +
+				"    <RootNamespace>TestImportedPackageReferences</RootNamespace>\r\n" +
+				"    <AssemblyName>TestImportedPackageReferences</AssemblyName>\r\n" +
+				"    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>\r\n" +
+				"    <OutputPath>bin</OutputPath>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <Import Project=\"$(MSBuildBinPath)\\Microsoft.CSharp.targets\" />\r\n" +
+				"  <Import Project=\"PackageReferences.proj\" />\r\n" +
+				"</Project>";
+
+			string importedProjectXml =
+				"<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" +
+				"<Project DefaultTargets=\"Build\" ToolsVersion=\"4.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <PackageReference Include=\"Newtonsoft.Json\" Version=\"10.0.1\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+
+			CreateTempDirectory ();
+			SaveFileInTempDirectory ("PackageReferences.proj", importedProjectXml);
+			SaveFileInTempDirectory ("Project.csproj", projectXml);
+
+			string fileName = Path.Combine (tempDirectory, "Project.csproj");
+			var project = (DotNetProject) await Services.ProjectService.ReadSolutionItem (new ProgressMonitor (), fileName);
+
+			var nugetProject = new MonoDevelopNuGetProjectFactory ()
+				.CreateNuGetProject (project);
+
+			Assert.IsNotNull (nugetProject);
+			Assert.IsInstanceOf<PackageReferenceNuGetProject> (nugetProject);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
@@ -255,5 +255,26 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsTrue (packageReference.IsFloating ());
 			Assert.AreEqual ("2.6.0-*", packageReference.AllowedVersions.Float.ToString ());
 		}
+
+		[Test]
+		public void Create_NoPackageReferences_ReturnsNull ()
+		{
+			CreateNuGetProject ();
+
+			var nugetProject = PackageReferenceNuGetProject.Create (dotNetProject);
+
+			Assert.IsNull (nugetProject);
+		}
+
+		[Test]
+		public void Create_OnePackageReference_ReturnsNuGetProject ()
+		{
+			CreateNuGetProject ();
+			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+
+			var nugetProject = PackageReferenceNuGetProject.Create (dotNetProject);
+
+			Assert.IsNotNull (nugetProject);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static NuGetProject Create (DotNetProject project)
 		{
-			if (project.Items.OfType<ProjectPackageReference> ().Any ())
+			if (project.HasPackageReferences ())
 				return new PackageReferenceNuGetProject (project);
 
 			return null;


### PR DESCRIPTION
Fixed bug #58842 - Support imported PackageReferences
https://bugzilla.xamarin.com/show_bug.cgi?id=58842

If a project has no PackageReference items but imports a file that
does have PackageReference items the packages were not restored
on opening its solution. This was because only the PackageReference
items were checked inside the project itself to determine if the
project used any packages. Now the evaluated items are also checked
so any imported PackageReference items are detected and a restore
will then be run on opening the solution.

This only affected non .NET Core projects. Also the restore itself
already handled imported PackageReference items when generating the
project.assets.json file.

Imported PackageReference items are not currently displayed in the
Packages folder.