### PR TITLE
[Mac] Restore lost main menu features/fixes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs
@@ -60,6 +60,8 @@ namespace MonoDevelop.Components.Mac
 			foreach (CommandEntry ce in ces) {
 				if (ce.CommandId == Command.Separator) {
 					AddItem (NSMenuItem.SeparatorItem);
+					if (!string.IsNullOrEmpty (ce.OverrideLabel))
+						AddItem (new MDMenuHeaderItem (ce));
 					continue;
 				}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuHeaderItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuHeaderItem.cs
@@ -1,0 +1,51 @@
+﻿//
+// MDMenuHeaderItem.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@xamarin.com>
+//
+// Copyright (c) 2016 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using AppKit;
+using MonoDevelop.Components.Commands;
+
+namespace MonoDevelop.Components.Mac
+{
+	class MDMenuHeaderItem : NSMenuItem, IUpdatableMenuItem
+	{
+		CommandEntry ce;
+
+		public MDMenuHeaderItem (CommandEntry ce)
+		{
+			this.ce = ce;
+			if (!string.IsNullOrEmpty (ce.OverrideLabel))
+				Title = ce.OverrideLabel;
+			Enabled = false;
+			Hidden = false;
+		}
+
+		public void Update (MDMenu parent, ref int index)
+		{
+			if (!string.IsNullOrEmpty (ce.OverrideLabel))
+				Title = ce.OverrideLabel;
+		}
+	}
+}
+

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -29,6 +29,7 @@ using System;
 using AppKit;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
+using MonoDevelop.Ide.Navigation;
 using System.Text;
 using Foundation;
 using ObjCRuntime;
@@ -198,6 +199,47 @@ namespace MonoDevelop.Components.Mac
 
 			item.Enabled = enabled;
 			item.Hidden = !visible;
+
+			string fileName = null;
+			var doc = info.DataItem as Ide.Gui.Document;
+			if (doc != null) {
+				if (doc.IsFile)
+					fileName = doc.FileName;
+				else {
+					// Designer documents have no file bound to them, but the document name
+					// could be a valid path
+					var docName = doc.Name;
+					if (!string.IsNullOrEmpty (docName) && System.IO.Path.IsPathRooted (docName) && System.IO.File.Exists (docName))
+						fileName = docName;
+				}
+			} else if (info.DataItem is NavigationHistoryItem) {
+					var navDoc = ((NavigationHistoryItem)info.DataItem).NavigationPoint as DocumentNavigationPoint;
+					if (navDoc != null)
+						fileName = navDoc.FileName;
+			} else {
+				var str = info.DataItem as string;
+				if (str != null && System.IO.Path.IsPathRooted (str) && System.IO.File.Exists (str))
+					fileName = str;
+			}
+
+			if (!String.IsNullOrWhiteSpace (fileName)) {
+				item.ToolTip = fileName;
+				Xwt.Drawing.Image icon = null;
+				if (!info.Icon.IsNull)
+					icon = Ide.ImageService.GetIcon (info.Icon, Gtk.IconSize.Menu);
+				if (icon == null)
+					icon = Ide.DesktopService.GetIconForFile (fileName, Gtk.IconSize.Menu);
+				if (icon != null) {
+					var scale = GtkWorkarounds.GetScaleFactor (Ide.IdeApp.Workbench.RootWindow);
+
+					if (NSUserDefaults.StandardUserDefaults.StringForKey ("AppleInterfaceStyle") == "Dark")
+						icon = icon.WithStyles ("dark");
+					else
+						icon = icon.WithStyles ("-dark");
+					item.Image = icon.ToBitmap (scale).ToNSImage ();
+					item.Image.Template = true;
+				}
+			}
 
 			SetAccel (item, info.AccelKey);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -192,8 +192,6 @@ namespace MonoDevelop.Components.Mac
 		void SetItemValues (NSMenuItem item, CommandInfo info, bool disabledVisible, string overrideLabel = null)
 		{
 			item.SetTitleWithMnemonic (GetCleanCommandText (info, overrideLabel));
-			if (!string.IsNullOrEmpty (info.Description) && item.ToolTip != info.Description)
-				item.ToolTip = info.Description;
 
 			bool enabled = info.Enabled && (!IsGloballyDisabled || commandSource == CommandSource.ContextMenu);
 			bool visible = info.Visible && (disabledVisible || info.Enabled);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9423,6 +9423,7 @@
     <Compile Include="MonoDevelop.Components\Mac\MDLinkMenuItem.cs" />
     <Compile Include="MonoDevelop.Components\Mac\MDMenu.cs" />
     <Compile Include="MonoDevelop.Components\Mac\MDMenuItem.cs" />
+    <Compile Include="MonoDevelop.Components\Mac\MDMenuHeaderItem.cs" />
     <Compile Include="MonoDevelop.Components\Mac\MDServicesMenuItem.cs" />
     <Compile Include="MonoDevelop.Components\Mac\MDSubMenuItem.cs" />
     <Compile Include="MonoDevelop.Components\Mac\Messaging.cs" />


### PR DESCRIPTION
This PR restores some Menu features which got lost with https://github.com/mono/monodevelop/commit/c54c8434fb43588c9be621b8f3aa7c607723f020

This includes:
* Disabled Tooltips
* Menu icons
* Section (Separator items) headers