### PR TITLE
Add target to profile a unit test and write a report via mprof-report

### DIFF
--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -102,6 +102,17 @@ uitest:
 		exit 1; \
 	fi
 
+profile:
+	@if test -n "$(assembly)"; then \
+		for asm in $(TEST_ASSEMBLIES); do \
+			if test `basename $$asm` = $(assembly); then \
+				echo Generating profiling for `basename $$asm`...; \
+				($(MD_LAUNCH_SETUP) exec -a "mdtool" $(RUNTIME) --debug --profile=log:heapshot,alloc,calls,calldepth=100,zip,sample=cycles/1000,counters,output=ProfileResult_`basename $$asm`.mlpd "$(MD_BIN_PATH)/mdtool.exe" run-md-tests $$asm); \
+				mprof-report ProfileResult_`basename $$asm`.mlpd > ProfileAnalysis_`basename $$asm`.txt ; \
+			fi; \
+		done; \
+	fi
+
 coverage:
 	if ! test -n "$(assembly)"; then \
 		for asm in $(TEST_ASSEMBLIES); do \


### PR DESCRIPTION
Easy to use target to profile a unit test suite and get profiling reports and a mlpd