### PR TITLE
Part of fix for Bug 57012 - Xaml code completion disappears to early …

### DIFF
--- a/main/src/addins/Xml/Completion/XmlCompletionData.cs
+++ b/main/src/addins/Xml/Completion/XmlCompletionData.cs
@@ -40,7 +40,7 @@ namespace MonoDevelop.Xml.Completion
 {
 	public class BaseXmlCompletionData : CompletionData
 	{
-		const string commitChars = " <>()[]{}=+*%~&^|.,;:?\"'";
+		const string commitChars = " <>()[]{}=+*%~&^|,;:?\"'";
 
 		public BaseXmlCompletionData ()
 		{
@@ -97,14 +97,20 @@ namespace MonoDevelop.Xml.Completion
 		public XmlCompletionData(string text, DataType dataType)
 			: this(text, String.Empty, dataType)
 		{
-		}		
+		}
 
-		public XmlCompletionData(string text, string description, DataType dataType)
+		public XmlCompletionData (string text, string description, DataType dataType)
+			: this (text, description, dataType, IconId.Null)
+		{
+		}
+
+		public XmlCompletionData (string text, string description, DataType dataType, IconId icon)
+			: base (text, icon, description)
 		{
 			this.text = text;
 			this.description = description;
-			this.dataType = dataType;  
-		}		
+			this.dataType = dataType;
+		}
 		
 		public DataType XmlCompletionDataType {
 			get { return dataType; }


### PR DESCRIPTION
…when "." is typed for property name

Removes "." from list of commit characters for .xml code completion items and adds ability to set custom IconId for XmlCompletionData entries in code completion.