### PR TITLE
[Ide] Close file stream in RecentFileStorage constructor

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentFileStorage.cs
@@ -81,12 +81,13 @@ namespace MonoDevelop.Ide.Desktop
 					return;
 				}
 
-				var stream = t.Result;
-				lock (cacheLock) {
-					cachedItemList = ReadStore (stream);
-					cachedItemList.Sort ();
+				using (var stream = t.Result) {
+					lock (cacheLock) {
+						cachedItemList = ReadStore (stream);
+						cachedItemList.Sort ();
+					}
+					OnRecentFilesChanged (cachedItemList);
 				}
-				OnRecentFilesChanged (cachedItemList);
 			});
 		}
 		


### PR DESCRIPTION
The file used for storage is opened with an exclusive lock in the
RecentFileStorage's constructor and the stream associated with the
file is not closed. This can prevent the SaveRecentFiles method
from being able to acquire the file lock and write to the file.

This seemed to cause the RecentTemplates_TwoTemplatesInGroupDifferentLanguage_TreatedAsDifferentRecentTemplate test on Wrench to fail sometimes.