### PR TITLE
[Ide] Fix build when not on Mac

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuHeaderItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuHeaderItem.cs
@@ -23,6 +23,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
+#if MAC
 using AppKit;
 using MonoDevelop.Components.Commands;
 
@@ -48,4 +50,4 @@ namespace MonoDevelop.Components.Mac
 		}
 	}
 }
-
+#endif


### PR DESCRIPTION
The new MDMenuHeaderItem is Mac specific but was being compiled
on all platforms.