### PR TITLE
Delete a workaround that is no longer necessary.

### DIFF
--- a/main/MonoDevelop.props
+++ b/main/MonoDevelop.props
@@ -5,9 +5,6 @@
 		<CustomBeforeMicrosoftCommonTargets>$(MonoDevelopRootDir)\msbuild\MonoDevelop.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
 		<CustomAfterMicrosoftCommonTargets>$(MonoDevelopRootDir)\msbuild\MonoDevelop.AfterCommon.targets</CustomAfterMicrosoftCommonTargets>
 		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
-		<!-- temporary workaround for https://github.com/Microsoft/msbuild/issues/2165 -->
-		<CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
 	</PropertyGroup>
 	<!-- import common targets if they were not imported already by an MSBuild Sdk -->
 	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(MicrosoftCommonPropsHasBeenImported)' != 'true'" />


### PR DESCRIPTION
MSBuild 15.3 is out and the bug has been fixed.