### PR TITLE
[Ide] Support backslashes in template primary output paths

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
@@ -61,6 +61,12 @@ namespace MonoDevelop.Ide.Templates
 			//HasProjects = (template.SolutionDescriptor.EntryDescriptors.Length > 0);
 		}
 
+		internal MicrosoftTemplateEngineSolutionTemplate (string id, string name, string iconId, ITemplateInfo templateInfo)
+			: base (id, name, iconId)
+		{
+			this.templateInfo = templateInfo;
+		}
+
 		string MergeDefaultParameters (string defaultParameters)
 		{
 			List<TemplateParameter> priorityParameters = null;

--- a/main/tests/Ide.Tests/ProjectTemplateTests.cs
+++ b/main/tests/Ide.Tests/ProjectTemplateTests.cs
@@ -24,7 +24,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System.Collections.Generic;
+using System.IO;
 using MonoDevelop.Ide.Templates;
+using MonoDevelop.Ide.Projects;
 using MonoDevelop.Projects;
 using MonoDevelop.Projects.SharedAssetsProjects;
 using NUnit.Framework;
@@ -168,6 +170,40 @@ namespace MonoDevelop.Ide
 			var fileContentAfterForceFormatting = await TextFileUtility.ReadAllTextAsync (class1File);
 			Assert.AreEqual (fileContentAfterForceFormatting.Text, fileContentAfterCreation.Text,
 			                "We expect them to be same because we placed same formatting policy on solution before creataion as after creation on project when we manually formatted.");
+		}
+
+		[Test]
+		public async Task DotNetCoreProjectTemplateUsingBackslashesInPrimaryOutputPathsIsSupported ()
+		{
+			var templatingService = new TemplatingService ();
+
+			string templateId = "MonoDevelop.Ide.Tests.TwoProjects.CSharp";
+			string scanPath = Util.GetSampleProjectPath ("DotNetCoreTemplating");
+			var template = MicrosoftTemplateEngineProjectTemplatingProvider.CreateTemplate (templateId, scanPath);
+
+			string tempDirectory = Util.CreateTmpDir ("BackslashInPrimaryOutputTest");
+			string projectDirectory = Path.Combine (tempDirectory, "BackslashInPrimaryOutputTestProject");
+			Directory.CreateDirectory (projectDirectory);
+			string library1FileToOpen = Path.Combine (projectDirectory, "Library1", "MyClass.cs");
+			string library2FileToOpen = Path.Combine (projectDirectory, "Library2", "MyClass.cs");
+
+			var result = await templatingService.ProcessTemplate (template, new NewProjectConfiguration () {
+				CreateSolution = true,
+				Location = tempDirectory,
+				SolutionName = "BackslashInPrimaryOutputTest",
+				ProjectName = "BackslashInPrimaryOutputTestProject",
+				CreateProjectDirectoryInsideSolutionDirectory = false,
+			}, null);
+
+			var solution = result.WorkspaceItems.OfType<Solution> ().Single ();
+
+			await solution.SaveAsync (Util.GetMonitor ());
+			Assert.AreEqual (2, solution.GetAllProjects ().Count ());
+			Assert.IsNotNull (solution.FindProjectByName ("Library1"));
+			Assert.IsNotNull (solution.FindProjectByName ("Library2"));
+			Assert.AreEqual (2, result.Actions.Count ());
+			Assert.That (result.Actions, Contains.Item (library1FileToOpen));
+			Assert.That (result.Actions, Contains.Item (library2FileToOpen));
 		}
 	}
 }

--- a/main/tests/test-projects/DotNetCoreTemplating/.template.config/template.json
+++ b/main/tests/test-projects/DotNetCoreTemplating/.template.config/template.json
@@ -1,0 +1,37 @@
+﻿{
+	"$schema": "http://json.schemastore.org/template",
+	"author": "Microsoft",
+	"classifications": [ "Common", "Library" ],
+	"name": "Class library",
+	"description": "",
+	"groupIdentity": "MonoDevelop.Ide.Tests",
+	"precedence": "2000",
+	"identity": "MonoDevelop.Ide.Tests.TwoProjects.CSharp",
+	"shortName": "twoprojects",
+	"tags": {
+		"language": "C#",
+		"type": "project"
+	},
+	"sourceName": "sourceName",
+	"guids": [
+		"{7F63CBE6-2FE7-47A7-8930-EA078DA05062}",
+		"{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}"
+	],
+	"primaryOutputs": [
+		{ "path": "Library1\\Library1.csproj" },
+		{ "path": "Library2\\Library2.csproj" },
+		{ "path": "Library1\\MyClass.cs" },
+		{ "path": "Library2\\MyClass.cs" },
+	],
+	"postActions": [
+		{
+			"description": "Opens files in the editor",
+			"manualInstructions": [],
+			"actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+			"args": {
+				"files": "2;3"
+			},
+			"continueOnError": true
+		}
+	]
+}

--- a/main/tests/test-projects/DotNetCoreTemplating/library1/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreTemplating/library1/MyClass.cs
@@ -1,0 +1,12 @@
+
+using System;
+
+namespace library1
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/DotNetCoreTemplating/library1/library1.csproj
+++ b/main/tests/test-projects/DotNetCoreTemplating/library1/library1.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/DotNetCoreTemplating/library2/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreTemplating/library2/MyClass.cs
@@ -1,0 +1,12 @@
+
+using System;
+
+namespace library2
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/DotNetCoreTemplating/library2/library2.csproj
+++ b/main/tests/test-projects/DotNetCoreTemplating/library2/library2.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Fixed bug #58980 - Back slashes in .NET project templates result in
project not being added to solution
https://bugzilla.xamarin.com/show_bug.cgi?id=58980

The template.json file used by the new templating engine uses a
primaryOutputs property for projects and files. If the paths used
contained backslashes then the project would not be added to the
solution.

```
"primaryOutputs": [
  { "path": "Library1\\Library1.csproj" },
  { "path": "Library2\\Library2.csproj" }
]
```
Now the paths have the backslashes replaced with forward slashes if
the current platform does not support backslash as a directory
separator.