### PR TITLE
Work around an unhandled exception in ServiceHub

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -546,7 +546,7 @@ namespace MonoDevelop.Ide
 		{
 			// This is a workaround for a specific issue in ServiceHub where some 'success' event triggers an exception
 			// We should remove this once it's fixed upstream.
-			if (ex?.InnerException is System.Net.Sockets.SocketException && ex.InnerException.Message == "Success")
+			if (ex?.InnerException is System.Net.Sockets.SocketException sockEx && sockEx.Message == "Success")
 				return;
 
 			var msg = String.Format ("An unhandled exception has occured. Terminating {0}? {1}", BrandingService.ApplicationName, willShutdown);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -544,6 +544,11 @@ namespace MonoDevelop.Ide
 		
 		static void HandleException (Exception ex, bool willShutdown)
 		{
+			// This is a workaround for a specific issue in ServiceHub where some 'success' event triggers an exception
+			// We should remove this once it's fixed upstream.
+			if (ex?.InnerException is System.Net.Sockets.SocketException && ex.InnerException.Message == "Success")
+				return;
+
 			var msg = String.Format ("An unhandled exception has occured. Terminating {0}? {1}", BrandingService.ApplicationName, willShutdown);
 			var aggregateException = ex as AggregateException;
 			if (aggregateException != null) {


### PR DESCRIPTION
I couldn't find a place to simply catch this exception anywhere that worked, so here's another attempt to work around this issue. I've also reported it upstream so hopefully it'll be fixed there.

This is to solve the log error:

```
ERROR [2017-08-25 09:35:06Z]: An unhandled exception has occured. Terminating Visual Studio? False
System.Net.Sockets.SocketException (0x80004005): Success
  at Microsoft.ServiceHub.Utility.SocketClient+<ConnectAsync>d__0.MoveNext () [0x00231] in <77315aa4fd5d49b8add7ad003b8a13a2>:0
```