### PR TITLE
Update to x.y.3.z for 15.3 SR3

### DIFF
--- a/version.config
+++ b/version.config
@@ -1,4 +1,4 @@
-Version=7.1.1
-Label=7.1.1
+Version=7.1.3
+Label=7.1.3
 CompatVersion=7.0
 IsPreview=false


### PR DESCRIPTION
Reason for Patch: 

```
Release communications consistency.  We had to include the full build number in the release notes sections for the 15.3.2 release because the all of the builds were still versioned as x.x.0.x.  We can strive to improve upon that for the 15.3.3 release by aligning the 3rd-digit version number with the Visual Studio 2017 service release number.
```