### PR TITLE
[Core] Re-evaluate AppliesTo condition on capability change

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectCapabilityTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectCapabilityTests.cs
@@ -112,6 +112,33 @@ namespace MonoDevelop.Projects
 
 			item.Dispose ();
 		}
+
+		[Test]
+		public async Task AppliesTo_ActivateDeactivateCapability ()
+		{
+			string solFile = Util.GetSampleProject ("project-capability-tests", "ConsoleProject.csproj");
+			var item = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), solFile);
+
+			string azureFunctionsProjectExtension = "AzureFunctionsProjectExtension";
+			Func<ProjectExtension, bool> isMatch = f => f.GetType ().Name == azureFunctionsProjectExtension;
+			var ext = item.GetFlavors ().FirstOrDefault (isMatch);
+			Assert.IsNull (ext);
+
+			// Now activate "AzureFunctions" capability
+			var import = item.MSBuildProject.AddNewImport ("azurefunctions.targets");
+			await item.ReevaluateProject (Util.GetMonitor ());
+
+			ext = item.GetFlavors ().FirstOrDefault (isMatch);
+			Assert.IsNotNull (ext);
+
+			item.MSBuildProject.RemoveImport (import);
+			await item.ReevaluateProject (Util.GetMonitor ());
+
+			ext = item.GetFlavors ().FirstOrDefault (isMatch);
+			Assert.IsNull (ext);
+
+			item.Dispose ();
+		}
 	}
 
 	class CustomCapabilityNode : SolutionItemExtensionNode

--- a/main/tests/test-projects/project-capability-tests/azurefunctions.targets
+++ b/main/tests/test-projects/project-capability-tests/azurefunctions.targets
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectCapability Include="AzureFunctions" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If the project extension uses an AppliesTo attribute which is
initially false and then a new project capability is added and the
project is re-evaluated then the AppliesTo attribute is now
re-evaluated. This will then cause the project extension to be added
to the extension chain. If the project extension was attached to the
project and the project capability is removed then the project
extension will now be removed when the project is re-evaluated.

Also added a test for this in MonoDevelop.Core.Tests but it relies on the AzureFunctions project
extension which I do not like. Ideally this would be independent of that addin being available. Maybe instead a test addin could be created or registered somehow that defines its own project extension that uses the AppliesTo attribute.