### PR TITLE
[Core] Fix solution file format version for Visual Studio 2017

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
@@ -386,7 +386,7 @@ namespace MonoDevelop.Projects.MSBuild
 		}
 
 		public override string SlnVersion {
-			get { return "15.00"; }
+			get { return "12.00"; }
 		}
 
 		public override string ProductDescription {


### PR DESCRIPTION
Fixed bug #58839 - Solution converted to VS 2017 format cannot be
opened in VS 2017

https://bugzilla.xamarin.com/show_bug.cgi?id=58839

On converting the solution to Visual Studio 2017 format the solution
file it could then not be opened in Visual Studio 2017 since the
solution file format version was set to 15.0 which is not supported.
Visual Studio 2017 uses 12.0 as the solution file format.