### PR TITLE
Adjust signature help markers by a couple of pixels

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/TypeSignatureHelp.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/TypeSignatureHelp.fs
@@ -41,7 +41,7 @@ type SignatureHelpMarker(document, text, font, line) =
             let y = (editor.LineToY lineNr) - editor.VAdjustment.Value
 
             let currentPoint = g.CurrentPoint
-            g.MoveTo(x, y + editor.LineHeight * (1.0 - SignatureHelpMarker.FontScale))
+            g.MoveTo(x, y + editor.LineHeight * (1.0 - SignatureHelpMarker.FontScale) - 2.0)
             g.ShowLayout layout
             g.MoveTo currentPoint
 


### PR DESCRIPTION
Reported by @decriptor - when using Menlo font, the F# signature help markers sometimes slightly overlap the editor text. Adjusted by 2 pixels.
<img width="772" alt="screen shot 2017-08-30 at 13 14 12" src="https://user-images.githubusercontent.com/667194/29871940-827aaf2a-8d85-11e7-9811-fdeef596e6b3.png">
