### PR TITLE
[Core] Fix project ToolsVersion being upgraded to 15.0

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
@@ -393,9 +393,13 @@ namespace MonoDevelop.Projects.MSBuild
 			get { return "Visual Studio 2017"; }
 		}
 
+		static string[] supportedToolsVersions = new string[] {
+			"4.0", "12.0", "14.0", "15.0"
+		};
+
 		protected override bool SupportsToolsVersion (string version)
 		{
-			return version == "15.0";
+			return supportedToolsVersions.Contains (version);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
@@ -55,8 +55,13 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public static IEnumerable<MSBuildFileFormat> GetSupportedFormats ()
 		{
-			yield return VS2017;
+			// Return VS2012 format first since this is the default format used.
+			// If VS2017 is returned first then since it uses the same solution file
+			// version it would be used instead. This would cause the tools version for
+			// new projects added to an existing solution to be changed to 15.0 instead
+			// of using 4.0 which is the current default.
 			yield return VS2012;
+			yield return VS2017;
 			yield return VS2010;
 			yield return VS2008;
 			yield return VS2005;
@@ -393,13 +398,9 @@ namespace MonoDevelop.Projects.MSBuild
 			get { return "Visual Studio 2017"; }
 		}
 
-		static string[] supportedToolsVersions = new string[] {
-			"4.0", "12.0", "14.0", "15.0"
-		};
-
 		protected override bool SupportsToolsVersion (string version)
 		{
-			return supportedToolsVersions.Contains (version);
+			return version == "15.0";
 		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildTests.cs
@@ -2780,6 +2780,31 @@ namespace MonoDevelop.Projects
 
 			p.Dispose ();
 		}
+
+		/// <summary>
+		/// Tests that the default tools version is used for the new project.
+		/// </summary>
+		[Test]
+		public async Task ToolsVersion_CreateSolutionWithProjectReloadAndAddNewProject ()
+		{
+			string directory = Util.CreateTmpDir ("ToolsVersionTest");
+			string solutionFileName = Path.Combine (directory, "ToolsVersionTest.sln");
+			var solution = new Solution ();
+			solution.FileName = solutionFileName;
+			var project = Services.ProjectService.CreateDotNetProject ("C#");
+			project.FileName = Path.Combine (directory, "ToolsVersionTest.csproj");
+			solution.RootFolder.AddItem (project);
+
+			await solution.SaveAsync (Util.GetMonitor ());
+
+			solution = await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName) as Solution;
+
+			var project2 = Services.ProjectService.CreateDotNetProject ("C#");
+			project2.FileName = Path.Combine (directory, "ToolsVersionTest2.csproj");
+			solution.RootFolder.AddItem (project2);
+
+			Assert.AreEqual (project.ToolsVersion, project2.ToolsVersion);
+		}
 	}
 
 	class MyProjectTypeNode: ProjectTypeNode


### PR DESCRIPTION
This fixes the failing tests on Wrench due to the merge of pull request #2957

Also added a test verifying that a new project added to an existing solution uses the default tools version as the existing project instead of upgrading it.