### PR TITLE
[NuGet] Support RestoreProjectStyle MSBuild property

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
@@ -86,6 +86,11 @@ namespace MonoDevelop.PackageManagement.Tests
 			return specs.Single ();
 		}
 
+		void AddRestoreProjectStyle (string restoreStyle)
+		{
+			dotNetProject.ProjectProperties.SetValue ("RestoreProjectStyle", restoreStyle);
+		}
+
 		[Test]
 		public async Task GetInstalledPackagesAsync_OnePackageReference_ReturnsOnePackageReference ()
 		{
@@ -275,6 +280,36 @@ namespace MonoDevelop.PackageManagement.Tests
 			var nugetProject = PackageReferenceNuGetProject.Create (dotNetProject);
 
 			Assert.IsNotNull (nugetProject);
+		}
+
+		/// <summary>
+		/// If a project has the MSBuild property RestoreProjectStyle set to PackageReference
+		/// then it should be restored in the same way as if it had PackageReferences
+		/// even if the project does not have any.
+		///
+		/// https://www.hanselman.com/blog/ReferencingNETStandardAssembliesFromBothNETCoreAndNETFramework.aspx
+		/// </summary>
+		[TestCase ("PackageReference")]
+		[TestCase ("packagereference")]
+		public void Create_RestoreProjectStyle_ReturnsNuGetProject (string restoreStyle)
+		{
+			CreateNuGetProject ();
+			AddRestoreProjectStyle (restoreStyle);
+
+			var nugetProject = PackageReferenceNuGetProject.Create (dotNetProject);
+
+			Assert.IsNotNull (nugetProject);
+		}
+
+		[Test]
+		public void Create_RestoreProjectStyleIsNotPackageReference_ReturnsNull ()
+		{
+			CreateNuGetProject ();
+			AddRestoreProjectStyle ("Unknown");
+
+			var nugetProject = PackageReferenceNuGetProject.Create (dotNetProject);
+
+			Assert.IsNull (nugetProject);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -195,6 +195,12 @@ namespace MonoDevelop.PackageManagement
 				.Any (projectItem => StringComparer.OrdinalIgnoreCase.Equals (projectItem.Include, packageId));
 		}
 
+		public static bool HasPackageReferenceRestoreProjectStyle (this DotNetProject project)
+		{
+			string restoreStyle = project.ProjectProperties.GetValue ("RestoreProjectStyle");
+			return StringComparer.OrdinalIgnoreCase.Equals (restoreStyle, "PackageReference");
+		}
+
 		public static FilePath GetNuGetAssetsFilePath (this DotNetProject project)
 		{
 			return project.BaseIntermediateOutputPath.Combine (LockFileFormat.AssetsFileName);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static NuGetProject Create (DotNetProject project)
 		{
-			if (project.HasPackageReferences ())
+			if (project.HasPackageReferences () || project.HasPackageReferenceRestoreProjectStyle ())
 				return new PackageReferenceNuGetProject (project);
 
 			return null;


### PR DESCRIPTION
Fixed bug #58985 - Support RestoreProjectStyle MSBuild property
https://bugzilla.xamarin.com/show_bug.cgi?id=58985

If a project sets the RestoreProjectStyle property to be
PackageReference then it should be restored as though it has
PackageReferences even if it does not have any.

    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

This fixes runtime problems when a project references a .NET Standard
project that has PackageReferences since without this assemblies
from the NuGet packages are not copied to the output directory and
would have to be added to the main project.