### PR TITLE
[Core] Sanitize default namespace for new files

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1386,7 +1386,7 @@ namespace MonoDevelop.Projects
 			string root = null;
 			string dirNamespc = null;
 			string defaultNmspc = !string.IsNullOrEmpty (defaultNamespace)
-				? defaultNamespace
+				? SanitisePotentialNamespace (defaultNamespace)
 				: SanitisePotentialNamespace (project.Name) ?? "Application";
 
 			if (string.IsNullOrEmpty (fileName)) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1205,6 +1205,16 @@ namespace MonoDevelop.Projects
 				WorkspaceObject.UnregisterCustomExtension (node);
 			}
 		}
+
+		[Test]
+		public void GetDefaultNamespaceWhenProjectRootNamespaceContainsHyphen ()
+		{
+			var project = Services.ProjectService.CreateDotNetProject ("C#");
+			project.DefaultNamespace = "abc-test";
+			string defaultNamespace = project.GetDefaultNamespace (null);
+
+			Assert.AreEqual ("abctest", defaultNamespace);
+		}
 	}
 
 	class SerializedSaveTestExtension: SolutionItemExtension


### PR DESCRIPTION
Fixed bug # 59111 - New file added to project with hyphen in name has
invalid namespace
https://bugzilla.xamarin.com/show_bug.cgi?id=59111

Creating a new .NET Core project with a name that contains a hyphen
and then adding a new class file to the project would result in an
invalid namespace being used. The same thing could happen with a non
.NET Core project if the RootNamespace in the project file contains a
hyphen.