### PR TITLE
Bug 58764 - XAML Editor jumps to a new line when trying to insert property quote marks

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/AbstractTokenBraceCompletionSession.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/AbstractTokenBraceCompletionSession.cs
@@ -73,10 +73,8 @@ namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 			return token.RawKind == OpeningTokenKind && token.SpanStart == position;
 		}
 
-		ITextSourceVersion version;
 		protected override void OnEditorSet ()
 		{
-			version = Editor.Version;
 			this.startOffset = Editor.CaretOffset - 1;
 			this.endOffset = startOffset + 1;
 		}

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -521,6 +521,7 @@
     <InternalsVisibleTo Include="FSharpBinding" />
     <InternalsVisibleTo Include="MonoDevelop.FSharp.Tests" />
     <InternalsVisibleTo Include="MonoDevelop.CSharpBinding.Tests" />
+    <InternalsVisibleTo Include="MonoDevelop.Ide.Tests" />
   </ItemGroup>
   <Import Project="..\..\core\Mono.TextEditor.Shared\Mono.TextEditor.Shared.projitems" Label="Shared" Condition="Exists('..\..\core\Mono.TextEditor.Shared\Mono.TextEditor.Shared.projitems')" />
   <Import Project="..\..\core\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Impl.projitems" Label="Shared" Condition="Exists('..\..\core\Mono.TextEditor.Platform\Mono.TextEditor.Platform.Impl.projitems')" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditSession.cs
@@ -155,25 +155,26 @@ namespace MonoDevelop.Ide.Editor
 				return;
 			}
 			handledCommand = false;
-		}
+		}	
 
 		protected override void OnEditorSet ()
 		{
-			startOffset = Editor.CaretOffset;
-			endOffset = StartOffset + 1;
+			startOffset = Editor.CaretOffset - 1;
+			endOffset = startOffset + 1;
 		}
 
 		public override void BeforeBackspace (out bool handledCommand)
 		{
-			if (Editor.CaretOffset == StartOffset +  1) {
-				Editor.EndSession ();
-			}
 			base.BeforeBackspace (out handledCommand);
+			if (Editor.CaretOffset <= StartOffset + 1 || Editor.CaretOffset > EndOffset) {
+				Editor.EndSession ();
+			}	
 		}
 
-		public override void AfterDelete ()
+		public override void BeforeDelete (out bool handledCommand)
 		{
-			if (Editor.CaretOffset == StartOffset) {
+			base.BeforeDelete (out handledCommand);
+			if (Editor.CaretOffset <= StartOffset || Editor.CaretOffset >= EndOffset) {
 				Editor.EndSession ();
 			}
 		}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SkipCharSessionTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SkipCharSessionTests.cs
@@ -1,0 +1,76 @@
+﻿// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+using MonoDevelop.Ide.Editor.Extension;
+using MonoDevelop.Ide.Gui;
+using Gtk;
+using Mono.TextEditor;
+using Gdk;
+using System.Reflection;
+using MonoDevelop.SourceEditor;
+
+namespace MonoDevelop.Ide.Editor
+{
+	[TestFixture]
+	public class SkipCharSessionTests : IdeTestBase
+	{
+		[TestCase]
+		public void TestBug58764 ()
+		{
+			var tww = new TestWorkbenchWindow ();
+			var content = new TestViewContent ();
+			tww.ViewContent = content;
+
+			var document = new Document (tww);
+
+			var editor = TextEditorFactory.CreateNewEditor (document);
+			editor.MimeType = "text/xml";
+			const string originalText = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+             xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+             x:Class=""XamlSamples.HelloXamlPage"">
+             <Grid HeightRequest=
+</ContentPage>";
+			editor.Text = originalText;
+			var offset = editor.Text.IndexOf ("HeightRequest=", StringComparison.Ordinal) + "HeightRequest=".Length;
+			editor.GetContent<ITextEditorImpl> ().CaretOffset = offset;
+			//Reason why we use GetNativeWidget, and navigate to ExtensibleTextEditor child
+			//and execute KeyPress on it instead something more abstract is...
+			//EditSession key processing is done inside ExtensibleTextEditor.
+			var extensibleEditor = FindChild<ExtensibleTextEditor> (editor.GetNativeWidget<Container> ());
+			extensibleEditor.OnIMProcessedKeyPressEvent ((Gdk.Key)'"', '"', Gdk.ModifierType.None);
+			extensibleEditor.OnIMProcessedKeyPressEvent (Gdk.Key.BackSpace, '\0', Gdk.ModifierType.None);
+			extensibleEditor.OnIMProcessedKeyPressEvent ((Gdk.Key)'"', '"', Gdk.ModifierType.None);
+			Assert.AreEqual (originalText.Insert (offset, "\"\""), editor.Text);
+		}
+
+		private T FindChild<T> (Container container) where T : Widget
+		{
+			foreach (var child in container.Children)
+				if (child is T) {
+					return (T)child;
+				} else if (child is Container) {
+					var foundChild = FindChild<T> ((Container)child);
+					if (foundChild != null)
+						return foundChild;
+				}
+			return default (T);
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="MonoDevelop.Ide.Gui\TestWorkbenchWindow.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\TestDocument.cs" />
     <Compile Include="TypeSystemServiceTestExtensions.cs" />
+    <Compile Include="MonoDevelop.Ide.Editor\SkipCharSessionTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -149,6 +150,11 @@
     <ProjectReference Include="..\..\src\addins\CSharpBinding\CSharpBinding.csproj">
       <Project>{07CC7654-27D6-421D-A64C-0FFA40456FA2}</Project>
       <Name>CSharpBinding</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\addins\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
+      <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>
+      <Name>MonoDevelop.SourceEditor</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Problem was that when typing “” first time and deleting with backspace IDE still thought it’s in “SkipCharSession” which is keeping track of when to skip second “ if user types after writing string… Fix for this issue is inspired by commit fa40fd0ed which fixed it for C# brackets… I also added logic needed for unit tests + removed unused field from C# session handler.