### PR TITLE
[A11y] Reset the user defaults before restarting the app

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
@@ -81,6 +81,9 @@ namespace MonoDevelop.Components
 				LoggingService.LogInfo ($"Loading modules from {gtkPath}");
 				Environment.SetEnvironmentVariable ("GTK_MODULES", $"{gtkPath}/libatkcocoa.so");
 			} else {
+				// If we are restarted from a running instance when changing the accessibility setting then
+				// we inherit the environment from it
+				Environment.SetEnvironmentVariable ("GTK_MODULES", null);
 				LoggingService.LogInfo ("Accessibility disabled");
 			}
 #endif
@@ -88,6 +91,7 @@ namespace MonoDevelop.Components
 
 			// Reset our environment after initialization on Mac
 			if (Platform.IsMac) {
+				Environment.SetEnvironmentVariable ("GTK_MODULES", null);
 				Environment.SetEnvironmentVariable ("GTK2_RC_FILES", DefaultGtk2RcFiles);
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/D152AccessibilityPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/D152AccessibilityPanel.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Core;
 using Gtk;
 
 using Foundation;
+using System.Diagnostics;
 
 namespace MonoDevelop.Ide.Gui.OptionPanels
 {
@@ -110,8 +111,15 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 		public void Save ()
 		{
 			NSUserDefaults defaults = NSUserDefaults.StandardUserDefaults;
+			Debug.WriteLine ($"A11y: Setting {EnabledKey} -> {enabled.Active}");
 			defaults.SetBool (enabled.Active, EnabledKey);
 			defaults.Synchronize ();
+			Debug.WriteLine ("A11y: Synchronized");
+
+			NSUserDefaults.ResetStandardUserDefaults ();
+
+			defaults = NSUserDefaults.StandardUserDefaults;
+			Debug.WriteLine ($"A11y: {defaults.BoolForKey (EnabledKey)}");
 		}
 
 		void ShowQuitOption (object sender, EventArgs args)


### PR DESCRIPTION
NSUserDefaults seems to not want to synchronise when restarting the app, so reset it which seems to make it work.

Fixes BXC #59138