### PR TITLE
[A11y] Make VO read the correct menu item description

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs
@@ -104,25 +104,30 @@ namespace MonoDevelop.Components.Mac
 		}
 
 		// http://lists.apple.com/archives/cocoa-dev/2008/Apr/msg01696.html
-		void FlashMenu ()
+		NSMenuItem blink;
+		void FlashMenu (MDMenuItem item)
 		{
 			var f35 = ((char)0xF726).ToString ();
-			var blink = new NSMenuItem ("* blink *") {
+			if (blink != null) {
+				RemoveItem(blink);
+			}
+			blink = new NSMenuItem(item.CommandEntry.GetCommand(item.Manager).DisplayName) {
 				KeyEquivalent = f35,
 			};
+
+			AddItem(blink);
+
 			var f35Event = NSEvent.KeyEvent (
 				NSEventType.KeyDown, CGPoint.Empty, NSEventModifierMask.CommandKeyMask, 0, 0,
 				NSGraphicsContext.CurrentContext, f35, f35, false, 0);
-			AddItem (blink);
 			PerformKeyEquivalent (f35Event);
-			RemoveItem (blink);
 		}
 
 		public bool FlashIfContainsCommand (object command)
 		{
 			foreach (var item in ItemArray ().OfType<MDMenuItem> ()) {
 				if (item.CommandEntry.CommandId == command) {
-					FlashMenu ();
+					FlashMenu (item);
 					return true;
 				}
 				var submenu = item.Submenu as MDMenu;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -69,6 +69,7 @@ namespace MonoDevelop.Components.Mac
 			base.Dispose (disposing);
 		}
 
+		public CommandManager Manager { get { return manager; } }
 		public CommandEntry CommandEntry { get { return ce; } }
 
 		[Export (ActionSelName)]


### PR DESCRIPTION
When pressing a shortcut key VoiceOver kept saying "Divider". This change makes it read the command name instead
Based on work by Dmytro Ovcharov

Fixes BXC #53648