### PR TITLE
[Core] Fix MSBuild condition evaluation when using Czech locale

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionFactorExpresion.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionFactorExpresion.cs
@@ -117,8 +117,11 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 				return true;
 			else if (token.Type == TokenType.String) {
 				var text = StringEvaluate (context);
+
+				// Use same styles used by Single.TryParse by default when culture not specified.
+				var styles = NumberStyles.Float | NumberStyles.AllowThousands;
 				Single number;
-				return Single.TryParse (text, out number);
+				return Single.TryParse (text, styles, CultureInfo.InvariantCulture, out number);
 			}
 			else
 				return false;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -33,6 +33,8 @@ using System.Linq;
 using System.Xml;
 using ValueSet = MonoDevelop.Projects.ConditionedPropertyCollection.ValueSet;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 
 namespace MonoDevelop.Projects
 {
@@ -317,6 +319,25 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual ("OK", res);
 
 			p.Dispose ();
+		}
+
+		[Test]
+		//[SetCulture ("cs-CZ")] Does not work. Culture is not changed.
+		public void ConditionUsingEmptyStringsIsEvaluatedCorrectlyForCzechLocale ()
+		{
+			var currentCulture = Thread.CurrentThread.CurrentCulture;
+			Thread.CurrentThread.CurrentCulture = new CultureInfo ("cs-CZ");
+
+			try {
+				var p = LoadProject ();
+				p.Evaluate ();
+				var res = p.EvaluatedProperties.GetValue ("EmptyStringConditionProp");
+				Assert.AreEqual ("OK", res);
+
+				p.Dispose ();
+			} finally {
+				Thread.CurrentThread.CurrentCulture = currentCulture;
+			}
 		}
 
 		[Test]

--- a/main/tests/test-projects/msbuild-project-test/test.csproj
+++ b/main/tests/test-projects/msbuild-project-test/test.csproj
@@ -18,6 +18,7 @@
   	<Case1>value2</Case1>
   	<Case2>$(CasE1)</Case2>
   	<Case3>$(CASE1)</Case3>
+  	<EmptyStringConditionProp Condition="'$(UndefinedProperty)' == ''">OK</EmptyStringConditionProp>
   	<TestRewrite>Val</TestRewrite>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Fixed bug #58338 - New .NET Core project has net461 target framework
when primary Mac OS language is Czech
https://bugzilla.xamarin.com/show_bug.cgi?id=58338

Single.TryParse returns true for an empty string when the machine's
culture is 'cs-CZ'. This was causing the MSBuild condition evaluation
to be treated as a boolean comparison incorrectly in some cases.
The condition below would return false even though the property was
not defined and both sides of the condition were empty strings:

<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">

This was causing the TargetFrameworkIdentifier to not be set for
.NET Core projects so the default of .NETFramework was being used.