### PR TITLE
[A11y] Only emit the container::add/remove signal on macOS

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -224,7 +224,7 @@ namespace Mono.TextEditor
 
 			// Emit the add signal so that the A11y system will pick up that a widget has been added to the box
 			// but the box won't handle it because widget.Parent has already been set.
-			GLib.Signal.Emit (this, "add", widget);
+			GtkWorkarounds.EmitAddSignal(this, widget);
 		}
 		
 		public void MoveTopLevelWidget (Gtk.Widget widget, int x, int y)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -265,7 +265,7 @@ namespace MonoDevelop.Components.Docking
 					notebooks.Add (ts);
 					ts.Parent = this;
 
-					GLib.Signal.Emit (this, "add", ts);
+					GtkWorkarounds.EmitAddSignal(this, ts);
 				}
 				frame.UpdateRegionStyle (grp);
 				ts.VisualStyle = grp.VisualStyle;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -163,7 +163,7 @@ namespace MonoDevelop.Components.Docking
 
 			// Emit the add signal so that the A11y system will pick up that a widget has been added to the box
 			// but the box won't handle it because widget.Parent has already been set.
-			GLib.Signal.Emit (this, "add", widget);
+			GtkWorkarounds.EmitAddSignal(this, widget);
 
 			OverlayWidgetVisible = true;
 			MinimizeAllAutohidden ();
@@ -212,7 +212,7 @@ namespace MonoDevelop.Components.Docking
 				} else {
 					overlayWidget.Unparent ();
 					// After we've unparented the widget, we call remove so the A11y system can clean up as well.
-					GLib.Signal.Emit (this, "remove", overlayWidget);
+					GtkWorkarounds.EmitRemoveSignal(this, overlayWidget);
 
 					overlayWidget = null;
 					QueueResize ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1497,6 +1497,24 @@ namespace MonoDevelop.Components
 			window.Mapped += OnMappedDisableButtons;
 #endif
 		}
+
+
+		public static void EmitAddSignal(Container container, Widget child)
+		{
+#if MAC
+			// On Mac if we add a widget to a parent by hand, we need to inform the accessibility system of the fact
+			// If this is called from Linux or Windows custom Gtk then it will trigger warnings because we've protected
+			// for the situation in the Mac version of Gtk
+			GLib.Signal.Emit(container, "add", child);
+#endif
+		}
+
+		public static void EmitRemoveSignal(Container container, Widget child)
+		{
+#if MAC
+			GLib.Signal.Emit(container, "remove", child);
+#endif
+		}
 	}
 
 	public struct KeyboardShortcut : IEquatable<KeyboardShortcut>


### PR DESCRIPTION
On macOS we need to emit the add/remove signals for the accessibility system to work correctly. Normally doing it triggers a critical warning in Gtk, but the Xamarin macOS Gtk has code to work around it. Gtk on Linux/Windows do not so the code spams Criticals to the log.

Fix this by only emiting on macOS

Fixes BXC #57083