### PR TITLE
Remove retry as it makes portable pdb debugging fail

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/Extensions.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/Extensions.fs
@@ -244,21 +244,6 @@ module LoggingService =
     let logInfo format = log LoggingService.LogInfo format
     let logWarning format = log LoggingService.LogWarning format
 
-type RetryBuilder(max) = 
-  member x.Return(a) = a               // Enable 'return'
-  member x.Delay(f) = f                // Gets wrapped body and returns it (as it is)
-                                       // so that the body is passed to 'Run'
-  member x.Zero() = failwith "Zero"    // Support if .. then 
-  member x.Run(f) =                    // Gets function created by 'Delay'
-    let rec loop(n) = 
-      if n = 0 then failwith "Failed"  // Number of retries exceeded
-      else try f() with _ -> loop(n-1)
-    loop max
-
-[<AutoOpen>]
-module Retry =
-    let retry = RetryBuilder(3)
-
 module Async =
     let inline startAsPlainTask (work : Async<unit>) =
         System.Threading.Tasks.Task.Factory.StartNew(fun () -> work |> Async.RunSynchronously)

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -334,7 +334,7 @@ type LanguageService(dirtyNotify, _extraProjectInfo) as x =
         |> Option.map(fun p -> p :?> DotNetProject)
 
     member x.GetReferencedAssembliesSynchronously (project:DotNetProject) =
-        retry { return (project.GetReferencedAssemblies(CompilerArguments.getConfig())).Result }
+        project.GetReferencedAssemblies(CompilerArguments.getConfig()).Result
 
     member x.GetReferencedAssembliesAsync projectFile =
         async {


### PR DESCRIPTION
Without this change, it's not possible to debug the F# addin at all due to hitting an [assert](https://github.com/mono/mono/blame/90450cc1480d4b76732fd725da06d75da40665c6/mono/metadata/metadata.c#L1116)  in Mono.

This needs to be fixed in the compiler, but this change allows me to keep working.