### PR TITLE
Folder icons reference cleanup

### DIFF
--- a/main/src/addins/MonoDevelop.ConnectedServices/ConnectedServiceDependency.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/ConnectedServiceDependency.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
+using MonoDevelop.Ide.Gui;
+
 using Xwt.Drawing;
 
 namespace MonoDevelop.ConnectedServices
@@ -22,13 +24,13 @@ namespace MonoDevelop.ConnectedServices
 		/// The category string for packages, this will be localised to the user
 		/// </summary>
 		public readonly static ConnectedServiceDependencyCategory PackageDependencyCategory =
-			new ConnectedServiceDependencyCategory (GettextCatalog.GetString ("Packages"), "md-folder-services");
+			new ConnectedServiceDependencyCategory (GettextCatalog.GetString ("Packages"), Stock.ServicesFolder);
 
 		/// <summary>
 		/// The category string for code, this will be localised to the user
 		/// </summary>
 		public readonly static ConnectedServiceDependencyCategory CodeDependencyCategory =
-			new ConnectedServiceDependencyCategory (GettextCatalog.GetString ("Code"), "md-folder-code");
+			new ConnectedServiceDependencyCategory (GettextCatalog.GetString ("Code"), Stock.CodeFolder);
 
 		Status status = (Status)(-1);
 

--- a/main/src/addins/MonoDevelop.ConnectedServices/Gui.SolutionPad/ConnectedServicesFolderNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.ConnectedServices/Gui.SolutionPad/ConnectedServicesFolderNodeBuilder.cs
@@ -40,8 +40,8 @@ namespace MonoDevelop.ConnectedServices.Gui.SolutionPad
 		public override void BuildNode (ITreeBuilder treeBuilder, object dataObject, NodeInfo nodeInfo)
 		{
 			nodeInfo.Label = ConnectedServices.SolutionTreeNodeName;
-			nodeInfo.Icon = Context.GetIcon ("md-folder-services");
-			nodeInfo.ClosedIcon = Context.GetIcon ("md-folder-services");
+			nodeInfo.Icon = Context.GetIcon (Stock.ServicesFolder);
+			nodeInfo.ClosedIcon = Context.GetIcon (Stock.ServicesFolder);
 		}
 
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1271,7 +1271,7 @@ namespace MonoDevelop.Debugger
 			case ObjectValueFlags.Method: source = "method"; break;
 			case ObjectValueFlags.Literal: return "md-literal";
 			case ObjectValueFlags.Namespace: return "md-name-space";
-			case ObjectValueFlags.Group: return "md-open-resource-folder";
+			case ObjectValueFlags.Group: return Ide.Gui.Stock.OpenResourceFolder;
 			case ObjectValueFlags.Field: source = "field"; break;
 			case ObjectValueFlags.Variable: return "md-variable";
 			default: return "md-empty";

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
@@ -140,7 +140,6 @@
 	<StockIcon stockid="md-file-unit-test" resource="file-unit-test-32.png" size="Dnd" />
 	<StockIcon stockid="md-find-next" resource="find-next-16.png" size="Menu" />
 	<StockIcon stockid="md-find-prev" resource="find-prev-16.png" size="Menu" />
-	<StockIcon stockid="md-folder-assets" resource="folder-assets-16.png" size="Menu" />
 	<StockIcon stockid="md-reference-assembly" resource="reference-assembly-16.png" size="Menu" />
 	<StockIcon stockid="md-reference-folder" resource="reference-assembly-16.png" size="Menu" />
 	<StockIcon stockid="md-fs-field" resource="element-fs-field-16.png" size="Menu" />
@@ -263,16 +262,6 @@
 	<StockIcon stockid="md-workspace" resource="workspace-16.png" size="Menu" />
 	<StockIcon stockid="md-xml-file-icon" resource="file-xml-16.png" size="Menu" />
 	<StockIcon stockid="md-xml-file-icon" resource="file-xml-32.png" size="Dnd" />
-	<StockIcon stockid="md-closed-folder" resource="folder-generic-16.png" size="Menu" />
-	<StockIcon stockid="md-closed-reference-folder" resource="folder-component-16.png" size="Menu" />
-	<StockIcon stockid="md-closed-resource-folder" resource="folder-resource-16.png" size="Menu" />
-	<StockIcon stockid="md-solution-folder-closed" resource="folder-solution-16.png" size="Menu" />
-	<StockIcon stockid="md-component-folder-closed" resource="folder-component-16.png" size="Menu" />
-	<StockIcon stockid="md-open-folder" resource="folder-generic-16.png" size="Menu" />
-	<StockIcon stockid="md-open-reference-folder" resource="folder-component-16.png" size="Menu" />
-	<StockIcon stockid="md-open-resource-folder" resource="folder-resource-16.png" size="Menu" />
-	<StockIcon stockid="md-solution-folder-open" resource="folder-solution-16.png" size="Menu" />
-	<StockIcon stockid="md-component-folder-open" resource="folder-component-16.png" size="Menu" />
 	<StockIcon stockid="md-web-search" resource="web-search-16.png" size="Menu" />
 	<StockIcon stockid="md-pad-download" resource="pad-download-16.png" size="Menu" />
 	<StockIcon stockid="md-pad-upload" resource="pad-upload-16.png" size="Menu" />
@@ -286,8 +275,6 @@
 	<StockIcon stockid="md-dependency" resource="dependency-16.png" size="Menu" />
 	<StockIcon stockid="md-expander-arrow-closed" resource="expander-arrow-closed-8.png" />
 	<StockIcon stockid="md-expander-arrow-expanded" resource="expander-arrow-expanded-8.png" />
-	<StockIcon stockid="md-folder-code" resource="folder-code-16.png" />
-	<StockIcon stockid="md-folder-services" resource="folder-services-16.png" />
 	<StockIcon stockid="md-getting-started" resource="getting-started-16.png" size="Menu" />
 	<StockIcon stockid="md-recent" resource="recent-16.png" size="Menu" />
 	<StockIcon stockid="md-palette" resource="palette-16.png" size="Menu" />
@@ -295,6 +282,21 @@
 	<StockIcon stockid="md-typography" resource="typography-16.png" size="Menu" />
 	<StockIcon stockid="md-scroll" resource="scroll-16.png" size="Menu" />
 	<StockIcon stockid="md-widget" resource="widget-16.png" size="Menu" />
+
+	<!-- Folder icons -->
+	<StockIcon stockid="md-open-folder" resource="folder-generic-16.png" size="Menu" />
+	<StockIcon stockid="md-closed-folder" resource="folder-generic-16.png" size="Menu" />
+	<StockIcon stockid="md-open-reference-folder" resource="folder-component-16.png" size="Menu" />
+	<StockIcon stockid="md-closed-reference-folder" resource="folder-component-16.png" size="Menu" />
+	<StockIcon stockid="md-open-resource-folder" resource="folder-resource-16.png" size="Menu" />
+	<StockIcon stockid="md-closed-resource-folder" resource="folder-resource-16.png" size="Menu" />
+	<StockIcon stockid="md-solution-folder-open" resource="folder-solution-16.png" size="Menu" />
+	<StockIcon stockid="md-solution-folder-closed" resource="folder-solution-16.png" size="Menu" />
+	<StockIcon stockid="md-component-folder-open" resource="folder-component-16.png" size="Menu" />
+	<StockIcon stockid="md-component-folder-closed" resource="folder-component-16.png" size="Menu" />
+	<StockIcon stockid="md-folder-assets" resource="folder-assets-16.png" size="Menu" />
+	<StockIcon stockid="md-folder-code" resource="folder-code-16.png" size="Menu" />
+	<StockIcon stockid="md-folder-services" resource="folder-services-16.png" size="Menu" />
 
 	<!-- Project icons -->
 	<StockIcon stockid="md-workspace" resource="workspace-32.png" size="Dnd" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StockIcons.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StockIcons.cs
@@ -33,7 +33,6 @@ namespace MonoDevelop.Ide.Gui
 {
 	public class Stock
 	{
-		public static readonly IconId AssetsFolder = "md-folder-assets";
 		public static readonly IconId AddNamespace = "md-add-namespace";
 		public static readonly IconId BreakPoint = "md-break-point";
 		public static readonly IconId BuildCombine = "md-build-combine";
@@ -42,9 +41,6 @@ namespace MonoDevelop.Ide.Gui
 		public static readonly IconId CloseAllDocuments = "md-close-all-documents";
 		public static readonly IconId CloseCombine = "md-close-combine-icon";
 		public static readonly IconId CloseIcon = Gtk.Stock.Close;
-		public static readonly IconId ClosedFolder = "md-closed-folder";
-		public static readonly IconId ClosedReferenceFolder = "md-closed-reference-folder";
-		public static readonly IconId ClosedResourceFolder = "md-closed-resource-folder";
 		public static readonly IconId Solution = "md-solution";
 		public static readonly IconId Workspace = "md-workspace";
 		public static readonly IconId CopyIcon = Gtk.Stock.Copy;
@@ -82,9 +78,6 @@ namespace MonoDevelop.Ide.Gui
 		public static readonly IconId NewDocumentIcon = Gtk.Stock.New;
 		public static readonly IconId NextWindowIcon = Gtk.Stock.GoForward;
 		public static readonly IconId OpenFileIcon = Gtk.Stock.Open;
-		public static readonly IconId OpenFolder = "md-open-folder";
-		public static readonly IconId OpenReferenceFolder = "md-open-reference-folder";
-		public static readonly IconId OpenResourceFolder = "md-open-resource-folder";
 		public static readonly IconId Options = "md-preferences";
 		public static readonly IconId OutputIcon = "md-output-icon";
 		public static readonly IconId PasteIcon = Gtk.Stock.Paste;
@@ -135,8 +128,6 @@ namespace MonoDevelop.Ide.Gui
 		public static readonly IconId UndoIcon = Gtk.Stock.Undo;
 		public static readonly IconId Warning = "md-warning";
 		public static readonly IconId XmlFileIcon = "md-xml-file-icon";
-		public static readonly IconId SolutionFolderOpen = "md-solution-folder-open";
-		public static readonly IconId SolutionFolderClosed = "md-solution-folder-closed";
 		public static readonly IconId Package = "md-package";
 		public static readonly IconId StatusSolutionOperation = "md-status-waiting";
 		public static readonly IconId StatusDownload = "md-status-download";
@@ -169,5 +160,20 @@ namespace MonoDevelop.Ide.Gui
 		public static readonly IconId PadUpload = "md-pad-upload";
 		public static readonly IconId PadDeviceDeployment = "md-pad-device-deployment";
 		public static readonly IconId PadExecute = "md-pad-execute";
+
+		// Folder icons
+		public static readonly IconId OpenFolder = "md-open-folder";
+		public static readonly IconId ClosedFolder = "md-closed-folder";
+		public static readonly IconId OpenReferenceFolder = "md-open-reference-folder";
+		public static readonly IconId ClosedReferenceFolder = "md-closed-reference-folder";
+		public static readonly IconId OpenResourceFolder = "md-open-resource-folder";
+		public static readonly IconId ClosedResourceFolder = "md-closed-resource-folder";
+		public static readonly IconId SolutionFolderOpen = "md-solution-folder-open";
+		public static readonly IconId SolutionFolderClosed = "md-solution-folder-closed";
+		public static readonly IconId ComponentFolderOpen = "md-component-folder-open"; // TODO: Unused
+		public static readonly IconId ComponentFolderClosed = "md-component-folder-closed"; // TODO: Unused
+		public static readonly IconId AssetsFolder = "md-folder-assets"; // TODO: Unused
+		public static readonly IconId CodeFolder = "md-folder-code";
+		public static readonly IconId ServicesFolder = "md-folder-services";
 	}
 }


### PR DESCRIPTION
As a part of https://github.com/xamarin/icons/issues/194 I cleaned up our special folder references. Results: `md-component-folder-*` and `md-folder-assets` are unused. I'll have more icons to use soon, so we'll work on references afterward.

Please don't merge, this is WIP.