### PR TITLE
[Core] Fix MSBuild remove item not added

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3377,7 +3377,8 @@ namespace MonoDevelop.Projects
 							msproject.RemoveItem (it);
 					}
 					// Check if the file is included in a glob.
-					var globItem = msproject.FindGlobItemsIncludingFile (item.Include).FirstOrDefault (gi => gi.Name == item.ItemName);
+					var matchingGlobItems = msproject.FindGlobItemsIncludingFile (item.Include).ToList ();
+					var globItem = matchingGlobItems.FirstOrDefault (gi => gi.Name == item.ItemName);
 
 					if (globItem != null) {
 						// Globbing magic can only be done if there is no metadata (for now)
@@ -3416,6 +3417,18 @@ namespace MonoDevelop.Projects
 						include = item.Include;
 						var removeItem = new MSBuildItem (item.WildcardItem.Name) { Remove = include };
 						msproject.AddItem (removeItem);
+					}
+
+					// Add remove item if file is included in a glob with a different MSBuild item type.
+					var removeGlobItem = matchingGlobItems.FirstOrDefault (gi => gi.Name != item.ItemName);
+					if (removeGlobItem != null) {
+						// Do not add the remove item if one already exists or if the Items contains
+						// an include for the item.
+						if (!msproject.GetAllItems ().Any (it => it.Name == removeGlobItem.Name && it.Remove == item.Include) &&
+							!Items.Any (it => it.ItemName == removeGlobItem.Name && it.Include == item.Include)) {
+							var removeItem = new MSBuildItem (removeGlobItem.Name) { Remove = item.Include };
+							msproject.AddItem (removeItem);
+						}
 					}
 				}
 				if (buildItem == null)

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-remove-test-saved.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-remove-test-saved.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="glob-import-test.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="test.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="test.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Fixed bug #59139 - Duplicate .xaml files in .NET Standard project
https://bugzilla.xamarin.com/show_bug.cgi?id=59139

Adding a new .xaml file to a project was not adding a None Remove
item for the .xaml file to remove it from the default glob for all
files.

     <None Remove="MyNewPage.xaml" />

On reloading the solution the Solution window would show two .xaml
files - one EmbeddedResource item and one None item.