### PR TITLE
[A11y] Refocus the parent window when closing the Add Scheme dialog

### DIFF
--- a/main/src/addins/Xml/Editor/XmlSchemasPanelWidget.cs
+++ b/main/src/addins/Xml/Editor/XmlSchemasPanelWidget.cs
@@ -421,6 +421,10 @@ namespace MonoDevelop.Xml.Editor
 		protected virtual void addRegisteredSchema (object sender, EventArgs args)
 		{
 			string fileName = XmlEditorService.BrowseForSchemaFile ();
+
+			// We need to present the window so that the keyboard focus returns to the correct parent window
+			((Gtk.Window)Toplevel).Present();
+
 			if (string.IsNullOrEmpty (fileName))
 				return;
 			


### PR DESCRIPTION
On Mac the parent window only gets focused if you Present it after the dialog has been closed

Fixes BXC 53773