### PR TITLE
[d15-4][Ide] Fix being unable to open Find in Files dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -245,10 +245,6 @@ namespace MonoDevelop.Ide.FindInFiles
 												"Find",
 												GettextCatalog.GetString ("Enter string to find"));
 			comboboxentryFind.SetAccessibilityLabelRelationship (labelFind);
-			searchentryFileMask.SetCommonAccessibilityAttributes ("FindInFilesDialog.searchentryFileMask",
-												"File Mask",
-												GettextCatalog.GetString ("Enter the file mask"));
-			searchentryFileMask.SetAccessibilityLabelRelationship (labelFileMask);
 		}
 
 		void SetupAccessibilityForReplace ()
@@ -259,7 +255,6 @@ namespace MonoDevelop.Ide.FindInFiles
 			comboboxentryReplace.SetAccessibilityLabelRelationship (labelReplace);
 		}
 
-
 		void SetupAccessibilityForPath ()
 		{
 			comboboxentryPath.SetCommonAccessibilityAttributes ("FindInFilesDialog.comboboxentryPath",
@@ -268,7 +263,13 @@ namespace MonoDevelop.Ide.FindInFiles
 			comboboxentryPath.SetAccessibilityLabelRelationship (labelPath);
 		}
 
-
+		void SetupAccessibilityForSearch ()
+		{
+			searchentryFileMask.SetCommonAccessibilityAttributes ("FindInFilesDialog.searchentryFileMask",
+				"File Mask",
+				GettextCatalog.GetString ("Enter the file mask"));
+			searchentryFileMask.SetAccessibilityLabelRelationship (labelFileMask);
+		}
 
 		static void TableAddRow (Table table, uint row, Widget column1, Widget column2)
 		{
@@ -518,6 +519,8 @@ namespace MonoDevelop.Ide.FindInFiles
 			
 			searchentryFileMask.Entry.ActivatesDefault = true;
 			searchentryFileMask.Show ();
+
+			SetupAccessibilityForSearch ();
 			
 			TableAddRow (tableFindAndReplace, row, labelFileMask, searchentryFileMask);
 		}


### PR DESCRIPTION
Fixed bug #59373 - Unable to open Find in Files dialog if Current
Document was selected
https://bugzilla.xamarin.com/show_bug.cgi?id=59373

Accessibility was being configured on the searchentryFileMask when
it was not created. Depending on the search option selected in the
'Look in' drop down list the searchentryFileMask is not always
created.

Not sure if this meets the requirements for inclusion in 15.4. It affects searching in the current document or selection, but you could use the inline search instead here. However if one of those options were selected then the dialog cannot be re-opened until all documents are closed or the solution is closed.

It is a regression from VS Mac 7.1