### PR TITLE
Fixed 'Bug 59287 - [VSFeedback Ticket] #490276 - Automatic Space

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -430,6 +430,7 @@
     <Compile Include="MonoDevelop.CSharp.Features\GotoDefinition\GotoDefinitionHelpers.cs" />
     <Compile Include="MonoDevelop.CSharp.Features\GotoDefinition\GotoDefinitionService.cs" />
     <Compile Include="Util\PortingExtensions.cs" />
+    <Compile Include="MonoDevelop.CSharp.Features\Formatter\SmartTokenFormatter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Formatter/CSharpEditorFormattingService.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Formatter/CSharpEditorFormattingService.cs
@@ -185,56 +185,56 @@ namespace ICSharpCode.NRefactory6.CSharp
 			return token;
 		}
 
-		//		private async Task<IList<TextChange>> FormatTokenAsync(Document document, SyntaxToken token, IEnumerable<IFormattingRule> formattingRules, CancellationToken cancellationToken)
-		//		{
-		//			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-		//			var formatter = CreateSmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, root);
-		//			var changes = formatter.FormatToken(document.Project.Solution.Workspace, token, cancellationToken);
-		//			return changes;
-		//		}
-		//
-		//		private ISmartTokenFormatter CreateSmartTokenFormatter(OptionSet optionSet, IEnumerable<IFormattingRule> formattingRules, SyntaxNode root)
-		//		{
-		//			return new SmartTokenFormatter(optionSet, formattingRules, (CompilationUnitSyntax)root);
-		//		}
-		//
-		//		private async Task<IList<TextChange>> FormatRangeAsync(
-		//			Document document, SyntaxToken endToken, IEnumerable<IFormattingRule> formattingRules,
-		//			CancellationToken cancellationToken)
-		//		{
-		//			if (!IsEndToken(endToken))
-		//			{
-		//				return SpecializedCollections.EmptyList<TextChange>();
-		//			}
-		//
-		//			var tokenRange = FormattingRangeHelper.FindAppropriateRange(endToken);
-		//			if (tokenRange == null || tokenRange.Value.Item1.Equals(tokenRange.Value.Item2))
-		//			{
-		//				return SpecializedCollections.EmptyList<TextChange>();
-		//			}
-		//
-		//			if (IsInvalidTokenKind(tokenRange.Value.Item1) || IsInvalidTokenKind(tokenRange.Value.Item2))
-		//			{
-		//				return SpecializedCollections.EmptyList<TextChange>();
-		//			}
-		//
-		//			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-		//			var formatter = new SmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, (CompilationUnitSyntax)root);
-		//
-		//			var changes = formatter.FormatRange(document.Project.Solution.Workspace, tokenRange.Value.Item1, tokenRange.Value.Item2, cancellationToken);
-		//			return changes;
-		//		}
-		//
-		//		private bool IsEndToken(SyntaxToken endToken)
-		//		{
-		//			if (endToken.IsKind(SyntaxKind.OpenBraceToken))
-		//			{
-		//				return false;
-		//			}
-		//
-		//			return true;
-		//		}
-		//
+		public static async Task<IList<TextChange>> FormatTokenAsync(Document document, SyntaxToken token, IEnumerable<IFormattingRule> formattingRules, CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			var formatter = CreateSmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, root);
+			var changes = await formatter.FormatTokenAsync(document.Project.Solution.Workspace, token, cancellationToken);
+			return changes;
+		}
+
+		static SmartTokenFormatter CreateSmartTokenFormatter(OptionSet optionSet, IEnumerable<IFormattingRule> formattingRules, SyntaxNode root)
+		{
+			return new SmartTokenFormatter(optionSet, formattingRules, (CompilationUnitSyntax)root);
+		}
+		
+		public static async Task<IList<TextChange>> FormatRangeAsync(
+			Document document, SyntaxToken endToken, IEnumerable<IFormattingRule> formattingRules,
+			CancellationToken cancellationToken)
+		{
+			if (!IsEndToken(endToken))
+			{
+				return SpecializedCollections.EmptyList<TextChange>();
+			}
+
+			var tokenRange = FormattingRangeHelper.FindAppropriateRange(endToken);
+			if (tokenRange == null || tokenRange.Value.Item1.Equals(tokenRange.Value.Item2))
+			{
+				return SpecializedCollections.EmptyList<TextChange>();
+			}
+
+			if (IsInvalidTokenKind(tokenRange.Value.Item1) || IsInvalidTokenKind(tokenRange.Value.Item2))
+			{
+				return SpecializedCollections.EmptyList<TextChange>();
+			}
+
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			var formatter = new SmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, (CompilationUnitSyntax)root);
+
+			var changes = formatter.FormatRange(document.Project.Solution.Workspace, tokenRange.Value.Item1, tokenRange.Value.Item2, cancellationToken);
+			return changes;
+		}
+
+		static bool IsEndToken(SyntaxToken endToken)
+		{
+			if (endToken.IsKind(SyntaxKind.OpenBraceToken))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
 		public bool ValidSingleOrMultiCharactersTokenKind(char typedChar, SyntaxKind kind)
 		{
 			ImmutableHashSet<SyntaxKind> set;
@@ -247,7 +247,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 			return set.Contains(kind);
 		}
 
-		public bool IsInvalidToken(char typedChar, SyntaxToken token)
+		public static bool IsInvalidToken(char typedChar, SyntaxToken token)
 		{
 			string text = null;
 			if (IsInvalidToken(token, ref text))
@@ -258,7 +258,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 			return text[0] != typedChar;
 		}
 
-		public bool IsInvalidToken(SyntaxToken token, ref string text)
+		public static bool IsInvalidToken(SyntaxToken token, ref string text)
 		{
 			if (IsInvalidTokenKind(token))
 			{
@@ -274,7 +274,7 @@ namespace ICSharpCode.NRefactory6.CSharp
 			return false;
 		}
 
-		private bool IsInvalidTokenKind(SyntaxToken token)
+		static bool IsInvalidTokenKind(SyntaxToken token)
 		{
 			// invalid token to be formatted
 			return token.IsKind(SyntaxKind.None) ||

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Formatter/SmartTokenFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/Formatter/SmartTokenFormatter.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace ICSharpCode.NRefactory6.CSharp
+{
+	internal class SmartTokenFormatter
+	{
+		private readonly OptionSet _optionSet;
+		private readonly IEnumerable<IFormattingRule> _formattingRules;
+
+		private readonly CompilationUnitSyntax _root;
+
+		public SmartTokenFormatter(
+			OptionSet optionSet,
+			IEnumerable<IFormattingRule> formattingRules,
+			CompilationUnitSyntax root)
+		{
+			Contract.ThrowIfNull(optionSet);
+			Contract.ThrowIfNull(formattingRules);
+			Contract.ThrowIfNull(root);
+
+			_optionSet = optionSet;
+			_formattingRules = formattingRules;
+
+			_root = root;
+		}
+
+		public IList<TextChange> FormatRange(
+			Workspace workspace, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken)
+		{
+			Contract.ThrowIfTrue(startToken.Kind() == SyntaxKind.None || startToken.Kind() == SyntaxKind.EndOfFileToken);
+			Contract.ThrowIfTrue(endToken.Kind() == SyntaxKind.None || endToken.Kind() == SyntaxKind.EndOfFileToken);
+
+			var smartTokenformattingRules = _formattingRules;
+			var common = startToken.GetCommonRoot(endToken);
+
+			// if there are errors, do not touch lines
+			// Exception 1: In the case of try-catch-finally block, a try block without a catch/finally block is considered incomplete
+			//            but we would like to apply line operation in a completed try block even if there is no catch/finally block
+			// Exception 2: Similar behavior for do-while
+			if (common.ContainsDiagnostics && !CloseBraceOfTryOrDoBlock(endToken))
+			{
+				smartTokenformattingRules = (new NoLineChangeFormattingRule()).Concat(_formattingRules);
+			}
+
+			return Formatter.GetFormattedTextChanges(_root, new TextSpan[] { TextSpan.FromBounds(startToken.SpanStart, endToken.Span.End) }, workspace, _optionSet, smartTokenformattingRules, cancellationToken);
+		}
+
+		private bool CloseBraceOfTryOrDoBlock(SyntaxToken endToken)
+		{
+			return endToken.IsKind(SyntaxKind.CloseBraceToken) &&
+				endToken.Parent.IsKind(SyntaxKind.Block) &&
+				(endToken.Parent.IsParentKind(SyntaxKind.TryStatement) || endToken.Parent.IsParentKind(SyntaxKind.DoStatement));
+		}
+
+		public async Task<IList<TextChange>> FormatTokenAsync(
+			Workspace workspace, SyntaxToken token, CancellationToken cancellationToken)
+		{
+			Contract.ThrowIfTrue(token.Kind() == SyntaxKind.None || token.Kind() == SyntaxKind.EndOfFileToken);
+
+			// get previous token
+			var previousToken = token.GetPreviousToken(includeZeroWidth: true);
+			if (previousToken.Kind() == SyntaxKind.None)
+			{
+				// no previous token. nothing to format
+				return SpecializedCollections.EmptyList<TextChange>();
+			}
+
+			// This is a heuristic to prevent brace completion from breaking user expectation/muscle memory in common scenarios (see Devdiv:823958).
+			// Formatter uses FindToken on the position, which returns token to left, if there is nothing to the right and returns token to the right
+			// if there exists one. If the shape is "{|}", we're including '}' in the formatting range. Avoid doing that to improve verbatim typing
+			// in the following special scenarios.  
+			int adjustedEndPosition = token.Span.End;
+			if (token.IsKind(SyntaxKind.OpenBraceToken) &&
+				(token.Parent.IsInitializerForArrayOrCollectionCreationExpression() ||
+					token.Parent is AnonymousObjectCreationExpressionSyntax))
+			{
+				var nextToken = token.GetNextToken(includeZeroWidth: true);
+				if (nextToken.IsKind(SyntaxKind.CloseBraceToken))
+				{
+					// Format upto '{' and exclude '}'
+					adjustedEndPosition = token.SpanStart;
+				}
+			}
+
+			var smartTokenformattingRules = (new SmartTokenFormattingRule()).Concat(_formattingRules);
+			var adjustedStartPosition = previousToken.SpanStart;
+			var indentStyle = _optionSet.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp);
+			if (token.IsKind(SyntaxKind.OpenBraceToken) &&
+				indentStyle != FormattingOptions.IndentStyle.Smart)
+			{
+				var text = await token.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+				if (token.IsFirstTokenOnLine(text))
+				{
+					adjustedStartPosition = token.SpanStart;
+				}
+			}
+
+			return await Formatter.GetFormattedTextChangesAsync(_root,
+				new TextSpan[] { TextSpan.FromBounds(adjustedStartPosition, adjustedEndPosition) },
+				workspace, _optionSet, smartTokenformattingRules, cancellationToken).ConfigureAwait(false);
+		}
+
+		private class NoLineChangeFormattingRule : AbstractFormattingRule
+		{
+			public override AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken, OptionSet optionSet, NextOperation<AdjustNewLinesOperation> nextOperation)
+			{
+				// no line operation. no line changes what so ever
+				var lineOperation = base.GetAdjustNewLinesOperation(previousToken, currentToken, optionSet, nextOperation);
+				if (lineOperation != null)
+				{
+					// ignore force if same line option
+					if (lineOperation.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
+					{
+						return null;
+					}
+
+					// basically means don't ever put new line if there isn't already one, but do
+					// indentation.
+					return FormattingOperations.CreateAdjustNewLinesOperation(line: 0, option: AdjustNewLinesOption.PreserveLines);
+				}
+
+				return null;
+			}
+		}
+
+		private class SmartTokenFormattingRule : NoLineChangeFormattingRule
+		{
+			public override void AddSuppressOperations(List<SuppressOperation> list, SyntaxNode node, SyntaxToken lastToken, OptionSet optionSet, NextAction<SuppressOperation> nextOperation)
+			{
+				// don't suppress anything
+			}
+
+			public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, OptionSet optionSet, NextOperation<AdjustSpacesOperation> nextOperation)
+			{
+				var spaceOperation = base.GetAdjustSpacesOperation(previousToken, currentToken, optionSet, nextOperation);
+
+				// if there is force space operation, convert it to ForceSpaceIfSingleLine operation.
+				// (force space basically means remove all line breaks)
+				if (spaceOperation != null && spaceOperation.Option == AdjustSpacesOption.ForceSpaces)
+				{
+					return FormattingOperations.CreateAdjustSpacesOperation(spaceOperation.Space, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+				}
+
+				return spaceOperation;
+			}
+		}
+	}
+}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextEditorIndentation.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextEditorIndentation.cs
@@ -45,6 +45,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
 using MonoDevelop.Refactoring;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MonoDevelop.CSharp.Formatting
 {
@@ -583,7 +584,13 @@ namespace MonoDevelop.CSharp.Formatting
 					using (var undo = Editor.OpenUndoGroup ()) {
 						if (OnTheFlyFormatting && Editor != null && Editor.EditMode == EditMode.Edit) {
 							var oldVersion = Editor.Version;
-							OnTheFlyFormatter.FormatStatmentAt (Editor, DocumentContext, Editor.CaretLocation, optionSet: optionSet);
+							int start = token.SpanStart;
+							var parentStatement = token.Parent.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault();
+							if (parentStatement != null)
+								start = parentStatement.SpanStart;
+							Console.WriteLine(start +"-"+ Editor.CaretOffset);
+							OnTheFlyFormatter.Format(Editor, DocumentContext, start, Editor.CaretOffset, exact:true, optionSet: optionSet);
+							//OnTheFlyFormatter.FormatStatmentAt (Editor, DocumentContext, Editor.CaretLocation, optionSet: optionSet);
 							if (oldVersion.CompareAge (Editor.Version) != 0)
 								CompletionWindowManager.HideWindow ();
 						}
@@ -629,7 +636,7 @@ namespace MonoDevelop.CSharp.Formatting
 				return;
 
 			string text = null;
-			if (service.IsInvalidToken (token, ref text))
+			if (CSharpEditorFormattingService.IsInvalidToken (token, ref text))
 				return;
 			// Check to see if the token is ')' and also the parent is a using statement. If not, bail
 			if (CSharpEditorFormattingService.TokenShouldNotFormatOnReturn (token))

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs
@@ -26,7 +26,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using ICSharpCode.NRefactory6.CSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
@@ -77,8 +81,10 @@ namespace MonoDevelop.CSharp.Formatting
 				try {
 					var syntaxTree = await analysisDocument.GetSyntaxTreeAsync ();
 					var root = syntaxTree.GetRoot ();
+					bool smartIndentOnly = false;
+					var token = root.FindToken(endOffset);
+					smartIndentOnly = token.IsKind(SyntaxKind.CloseBraceToken);
 					if (formatLastStatementOnly) {
-						var token = root.FindToken (endOffset);
 						var tokens = Microsoft.CodeAnalysis.CSharp.Utilities.FormattingRangeHelper.FindAppropriateRange (token);
 						if (tokens.HasValue) {
 							span = new TextSpan (tokens.Value.Item1.SpanStart, editor.CaretOffset - tokens.Value.Item1.SpanStart);
@@ -95,8 +101,21 @@ namespace MonoDevelop.CSharp.Formatting
 						optionSet = policy.CreateOptions (textPolicy);
 					}
 					var rules = Formatter.GetDefaultFormattingRules (analysisDocument);
-					var changes = Formatter.GetFormattedTextChanges (root, SpecializedCollections.SingletonEnumerable (span), context.RoslynWorkspace, optionSet, rules, default(CancellationToken));
-					editor.ApplyTextChanges (changes);
+					IList<TextChange> changes;
+
+					if (smartIndentOnly) {
+						// if we're only doing smart indent, then ignore all edits to this token that occur before
+						// the span of the token. They're irrelevant and may screw up other code the user doesn't 
+						// want touched.
+						var tokenEdits = await CSharpEditorFormattingService.FormatTokenAsync(analysisDocument, token, rules, default(CancellationToken)).ConfigureAwait(false);
+						changes = tokenEdits.Where(t => t.Span.Start >= token.FullSpan.Start).ToList();
+					} else {
+						changes = await CSharpEditorFormattingService.FormatRangeAsync(analysisDocument, token, rules, default(CancellationToken)).ConfigureAwait(false);
+						if (changes.Count == 0)
+							changes = await CSharpEditorFormattingService.FormatTokenAsync(analysisDocument, token, rules, default(CancellationToken)).ConfigureAwait(false);
+					}
+
+					editor.ApplyTextChanges(changes);
 				} catch (Exception e) {
 					LoggingService.LogError ("Error in on the fly formatter", e);
 				}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
@@ -28,6 +28,7 @@ using System;
 using System.Diagnostics;
 using Mono.TextEditor.Highlighting;
 using MonoDevelop.Ide.Editor.Highlighting;
+using MonoDevelop.Core;
 
 namespace Mono.TextEditor
 {
@@ -396,7 +397,7 @@ namespace Mono.TextEditor
 					try {
 						font = Pango.FontDescription.FromString (FontName);
 					} catch {
-						Console.WriteLine ("Could not load font: {0}", FontName);
+						LoggingService.LogError("Could not load text editor font");
 					}
 					if (font == null || String.IsNullOrEmpty (font.Family))
 						font = Pango.FontDescription.FromString (DEFAULT_FONT);
@@ -427,7 +428,7 @@ namespace Mono.TextEditor
 						if (!string.IsNullOrEmpty (GutterFontName))
 							gutterFont = Pango.FontDescription.FromString (GutterFontName);
 					} catch {
-						Console.WriteLine ("Could not load gutter font: {0}", GutterFontName);
+						LoggingService.LogError("Error while loading gutter font.");
 					}
 					if (gutterFont == null || String.IsNullOrEmpty (gutterFont.Family))
 						gutterFont = Gtk.Widget.DefaultStyle.FontDescription.Copy ();


### PR DESCRIPTION
Inserted in Parenthesis'

I now fully ported the on typing formatter from roslyn - however that
code should be refactored when we have a working editorfeatures roslyn
subsystem.