### PR TITLE
Fix bug 58445 - Closing a solution with unsaved changes and selecting "Save" before closing, solution doesn't close

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -840,8 +840,11 @@ namespace MonoDevelop.Ide.Gui
 		protected virtual async Task OnClosing (WorkbenchWindowEventArgs e)
 		{
 			if (Closing != null) {
-				foreach (var handler in Closing.GetInvocationList ().Cast<WorkbenchWindowAsyncEventHandler> ())
+				foreach (var handler in Closing.GetInvocationList ().Cast<WorkbenchWindowAsyncEventHandler> ()) {
 					await handler (this, e);
+					if (e.Cancel)
+						break;
+				}
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -866,6 +866,7 @@ namespace MonoDevelop.Ide.Gui
 						// This may happen if the save operation failed
 						args.Cancel = true;
 						doc.Select ();
+						return;
 					}
 				} else if (result == AlertButton.SaveAs) {
 					var doc = FindDocument (window);
@@ -874,6 +875,7 @@ namespace MonoDevelop.Ide.Gui
 						// This may happen if the save operation failed or Save As was canceled
 						args.Cancel = true;
 						doc.Select ();
+						return;
 					}
 				} else {
 					args.Cancel |= result != AlertButton.CloseWithoutSave;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -860,21 +860,21 @@ namespace MonoDevelop.Ide.Gui
 					GettextCatalog.GetString ("If you don't save, all changes will be permanently lost."),
 					AlertButton.CloseWithoutSave, AlertButton.Cancel, viewContent.IsUntitled ? AlertButton.SaveAs : AlertButton.Save);
 				if (result == AlertButton.Save) {
-					args.Cancel = true;
-					await FindDocument (window).Save ();
-					viewContent.IsDirty = false;
-					await window.CloseWindow (true);
-					return;
-				} else if (result == AlertButton.SaveAs) {
-					args.Cancel = true;
-					var resultSaveAs = await FindDocument (window).SaveAs ();
-					if (resultSaveAs) {
-						viewContent.IsDirty = false;
-						await window.CloseWindow (true);
-					} else {
-						window.SelectWindow ();
+					var doc = FindDocument (window);
+					await doc.Save ();
+					if (viewContent.IsDirty) {
+						// This may happen if the save operation failed
+						args.Cancel = true;
+						doc.Select ();
 					}
-					return;
+				} else if (result == AlertButton.SaveAs) {
+					var doc = FindDocument (window);
+					var resultSaveAs = await doc.SaveAs ();
+					if (!resultSaveAs || viewContent.IsDirty) {
+						// This may happen if the save operation failed or Save As was canceled
+						args.Cancel = true;
+						doc.Select ();
+					}
 				} else {
 					args.Cancel |= result != AlertButton.CloseWithoutSave;
 					if (!args.Cancel)


### PR DESCRIPTION
This bug was fixed in d15-2, but for some reason the fix didn't made it to master.