### PR TITLE
Block selection improved

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
@@ -339,8 +339,12 @@ namespace Mono.TextEditor
 										if (curLine.Length + 1 < lineCol) {
 											result += lineCol - curLine.Length;
 											data.Insert (curLine.Offset + curLine.Length, new string (' ', lineCol - curLine.Length));
+											curLine = data.Document.GetLine (lineNr + i);
 										}
-										data.Insert (curLine.Offset + lineCol, lines [i]);
+										if (curLine.Length == 0)
+											data.Insert(curLine.Offset, lines[i]);
+										else
+											data.Insert (curLine.Offset + lineCol, lines [i]);
 										result += lines [i].Length;
 									}
 									if (!preserveState)

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentLine.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentLine.cs
@@ -211,16 +211,16 @@ namespace Mono.TextEditor
 			int result = 1;
 			int offset = Offset;
 			var tabSize = editor.Options.TabSize;
-			if (editor.Options.IndentStyle == IndentStyle.Virtual && Length == 0 && logicalColumn > DocumentLocation.MinColumn) {
-				foreach (char ch in editor.GetIndentationString (Offset)) {
-					if (ch == '\t') {
-						result += tabSize;
-						continue;
-					}
-					result++;
-				}
-				return result;
-			}
+			//if (editor.Options.IndentStyle == IndentStyle.Virtual && Length == 0 && logicalColumn > DocumentLocation.MinColumn) {
+			//	foreach (char ch in editor.GetIndentationString (Offset)) {
+			//		if (ch == '\t') {
+			//			result += tabSize;
+			//			continue;
+			//		}
+			//		result++;
+			//	}
+			//	return result;
+			//}
 
 			for (int i = 0; i < logicalColumn - 1; i++) {
 				if (i < Length && editor.Document.GetCharAt (offset + i) == '\t') {

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Selection.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Selection.cs
@@ -40,5 +40,36 @@ namespace Mono.TextEditor
 		{
 			return data.Document.LocationToOffset (selection.Lead);
 		}
+
+		public static int GetVirtualSpacesCount(this Selection selection, TextEditorData data)
+		{
+			if (selection.SelectionMode == SelectionMode.Normal)
+				return 0;
+
+			int result = 0;
+			bool found = false;
+			int minColumn = Math.Min(selection.Anchor.Column, selection.Lead.Column);
+			int maxColumn = Math.Max(selection.Anchor.Column, selection.Lead.Column);
+
+			for (int line = selection.MinLine; line <= selection.MaxLine; line++)
+			{
+				for (int column = minColumn; column <= maxColumn; column++)
+				{
+					if (data.Document.GetCharAt(line, column) == '\n')
+					{
+						result++;
+						found = true;
+					}
+				}
+
+				if (found)
+				{
+					result--;
+					found = false;
+				}
+			}
+
+			return result;
+		}
 	}
 }


### PR DESCRIPTION
Block selection now works as in Visual Studio for Windows
Virtual spaces are highlighted when using a block selection
Paste from clipboard now works correctly when using a block selection
Fixed bug with jumping caret when moving selected text