### PR TITLE
[d15-4][NuGet] Update to NuGet 4.3.1.4445 

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/DummyDotNetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/DummyDotNetProject.cs
@@ -35,6 +35,9 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public DummyDotNetProject ()
 			: base ("C#")
 		{
+			// Set the TypeGuid to be a C# project so the default file extension will
+			// be .csproj and not .mdproj
+			TypeGuid = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
 			Initialize (this);
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
@@ -500,5 +500,16 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("References", modifiedHintMainProject);
 			Assert.IsNull (modifiedHintProjectWithReference);
 		}
+
+		[Test]
+		public async Task GetCacheFilePathAsync_BaseIntermediatePathNotSet_BaseIntermediatePathUsedForCacheFilePath ()
+		{
+			CreateNuGetProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			string expectedCacheFilePath = @"d:\projects\MyProject\obj\MyProject.csproj.nuget.cache".ToNativePath ();
+
+			string cacheFilePath = await project.GetCacheFilePathAsync ();
+
+			Assert.AreEqual (expectedCacheFilePath, cacheFilePath);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNuGetProjectTests.cs
@@ -257,6 +257,17 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
+		public async Task GetCacheFilePathAsync_BaseIntermediatePathNotSet_BaseIntermediatePathUsedForCacheFilePath ()
+		{
+			CreateNuGetProject ("MyProject", @"d:\projects\MyProject\MyProject.csproj");
+			string expectedCacheFilePath = @"d:\projects\MyProject\obj\MyProject.csproj.nuget.cache".ToNativePath ();
+
+			string cacheFilePath = await project.GetCacheFilePathAsync ();
+
+			Assert.AreEqual (expectedCacheFilePath, cacheFilePath);
+		}
+
+		[Test]
 		public void Create_NoPackageReferences_ReturnsNull ()
 		{
 			CreateNuGetProject ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -30,6 +30,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
 using MonoDevelop.Projects;
+using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.PackageManagement;
 using NuGet.Packaging;
@@ -203,6 +204,14 @@ namespace MonoDevelop.PackageManagement
 		public override Task<string> GetAssetsFilePathOrNullAsync ()
 		{
 			return GetAssetsFilePathAsync ();
+		}
+
+		public override Task<string> GetCacheFilePathAsync ()
+		{
+			string cacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath (
+				project.BaseIntermediateOutputPath,
+				msbuildProjectPath);
+			return Task.FromResult (cacheFilePath);
 		}
 
 		public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync (DependencyGraphCacheContext context)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -30,6 +30,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
 using MonoDevelop.Projects;
+using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.PackageManagement;
 using NuGet.Packaging;
@@ -194,6 +195,14 @@ namespace MonoDevelop.PackageManagement
 		public override Task<string> GetAssetsFilePathOrNullAsync ()
 		{
 			return GetAssetsFilePathAsync ();
+		}
+
+		public override Task<string> GetCacheFilePathAsync ()
+		{
+			string cacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath (
+				project.BaseIntermediateOutputPath,
+				msbuildProjectPath);
+			return Task.FromResult (cacheFilePath);
 		}
 
 		public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync (DependencyGraphCacheContext context)


### PR DESCRIPTION
Fixed bug #59447 - Package is not compatible error for project.json
with imports
https://bugzilla.xamarin.com/show_bug.cgi?id=59447

Imports in a project.json file are ignored with older NuGet 4.3
versions. Updating to NuGet 4.3.1 fixes this. NuGet bug:

NuGet/Home#5806