### PR TITLE
[Packaging] Fix UI hang creating new NuGet package project

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/PackagingNuGetProject.cs
@@ -55,14 +55,17 @@ namespace MonoDevelop.Packaging
 			InternalMetadata.Add (NuGetProjectMetadataKeys.UniqueName, project.Name);
 		}
 
-		public override async Task<IEnumerable<NuGet.Packaging.PackageReference>> GetInstalledPackagesAsync (CancellationToken token)
+		public override Task<IEnumerable<NuGet.Packaging.PackageReference>> GetInstalledPackagesAsync (CancellationToken token)
 		{
-			return await Runtime.RunInMainThread (() => {
-				return project
-					.PackageReferences
-					.Select (packageReference => packageReference.ToNuGetPackageReference ())
-					.ToList ();
-			});
+			return Task.FromResult (GetPackageReferences ());
+		}
+
+		IEnumerable<NuGet.Packaging.PackageReference> GetPackageReferences ()
+		{
+			return project
+				.PackageReferences
+				.Select (packageReference => packageReference.ToNuGetPackageReference ())
+				.ToList ();
 		}
 
 		public override async Task<bool> InstallPackageAsync (


### PR DESCRIPTION
Fixed bug #59461 - UI hang creating packaging project
https://bugzilla.xamarin.com/show_bug.cgi?id=59461

The VSTest addin checks the installed NuGet packages for test adapters
when a new solution is created. Returning the installed NuGet packages
for the packaging project was causing the UI thread to be blocked and
caused the IDE to hang.