### PR TITLE
[Fix 56053] Force Bash shell when executing commandline apps

### DIFF
--- a/main/src/addins/MacPlatform/MacExternalConsoleProcess.cs
+++ b/main/src/addins/MacPlatform/MacExternalConsoleProcess.cs
@@ -145,12 +145,14 @@ bash pause on exit trick
 				};
 				
 				if (pauseWhenFinished)
-					sb.Append ("; echo; read -p 'Press any key to continue...' -n1");
+					sb.Append ("; echo; read -p \"Press any key to continue...\" -n1");
 				sb.Append ("; exit");
 			}
 
 			//run the command in Terminal.app and extract tab and window IDs
-			var ret = AppleScript.Run ("tell app \"{0}\" to do script \"{1}\"", TERMINAL_APP, Escape (sb.ToString ()));
+			// run the command inside Bash because we do echo $? and that is a bash extension and breaks when people
+			// use other shells such as zsh or fish. https://bugzilla.xamarin.com/show_bug.cgi?id=56053
+			var ret = AppleScript.Run ("tell app \"{0}\" to do script \"bash -c '{1}'; exit\"", TERMINAL_APP, Escape (sb.ToString ()));
 			int i = ret.IndexOf ("of", StringComparison.Ordinal);
 			tabId = ret.Substring (0, i -1);
 			windowId = ret.Substring (i + 3);


### PR DESCRIPTION
Our terminal script used echo $? which is a Bash extension, and doesn't work for other shells such as zsh or fish, so
always execute out script inside a bash shell
Fixs BXC #56053