### PR TITLE
Fixed 'Bug 58551 - Memory leak when editing .xaml files'

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/EditorFactory.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/EditorFactory.cs
@@ -83,7 +83,7 @@ namespace MonoDevelop.SourceEditor
 
 		ITextEditorImpl ITextEditorFactory.CreateNewEditor (TextEditorType textEditorType)
 		{
-			return new SourceEditorView ( textEditorType);
+			return new SourceEditorView (textEditorType);
 		}
 
 		ITextEditorImpl ITextEditorFactory.CreateNewEditor (string fileName, string mimeType, TextEditorType textEditorType)
@@ -93,7 +93,7 @@ namespace MonoDevelop.SourceEditor
 
 		ITextEditorImpl ITextEditorFactory.CreateNewEditor (IReadonlyTextDocument document, TextEditorType textEditorType)
 		{
-			return new SourceEditorView (document, textEditorType );
+			return new SourceEditorView (document, textEditorType);
 		}
 
 		string[] ITextEditorFactory.GetSyntaxProperties (string mimeType, string name)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/EditorFactory.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/EditorFactory.cs
@@ -71,14 +71,29 @@ namespace MonoDevelop.SourceEditor
 			return new SourceEditorView ();
 		}
 
-        ITextEditorImpl ITextEditorFactory.CreateNewEditor(string fileName, string mimeType)
-        {
-            return new SourceEditorView(fileName, mimeType);
-        }
+		ITextEditorImpl ITextEditorFactory.CreateNewEditor (string fileName, string mimeType)
+		{
+			return new SourceEditorView (fileName, mimeType);
+		}
 
-        ITextEditorImpl ITextEditorFactory.CreateNewEditor (IReadonlyTextDocument document)
+		ITextEditorImpl ITextEditorFactory.CreateNewEditor (IReadonlyTextDocument document)
 		{
 			return new SourceEditorView (document);
+		}
+
+		ITextEditorImpl ITextEditorFactory.CreateNewEditor (TextEditorType textEditorType)
+		{
+			return new SourceEditorView ( textEditorType);
+		}
+
+		ITextEditorImpl ITextEditorFactory.CreateNewEditor (string fileName, string mimeType, TextEditorType textEditorType)
+		{
+			return new SourceEditorView (fileName, mimeType, textEditorType);
+		}
+
+		ITextEditorImpl ITextEditorFactory.CreateNewEditor (IReadonlyTextDocument document, TextEditorType textEditorType)
+		{
+			return new SourceEditorView (document, textEditorType );
 		}
 
 		string[] ITextEditorFactory.GetSyntaxProperties (string mimeType, string name)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/FileRegistry.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/FileRegistry.cs
@@ -57,18 +57,22 @@ namespace MonoDevelop.SourceEditor
 
 		public static void Add (SourceEditorView sourceEditorView)
 		{
+			if (sourceEditorView.TextEditorType == TextEditorType.Projection)
+				return;
 			openFiles.Add (sourceEditorView);
 		}
 
 		public static void Remove (SourceEditorView sourceEditorView)
 		{
+			if (sourceEditorView.TextEditorType == TextEditorType.Projection)
+				return;
 			openFiles.Remove (sourceEditorView);
 			UpdateEolMessages ();
 		}
 
 		static bool SkipView (SourceEditorView view)
 		{
-			return view.Document == null || !view.IsFile || view.IsUntitled;
+			return view.Document == null || !view.IsFile || view.IsUntitled || view.TextEditorType == TextEditorType.Projection;
 		}
 
 		static void HandleFileServiceChange (object sender, FileEventArgs e)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -186,17 +186,19 @@ namespace MonoDevelop.SourceEditor
 
 		public SourceEditorView (TextEditorType textEditorType = TextEditorType.Default)
 		{
-
+			this.textEditorType = textEditorType;
 		}
 		public SourceEditorView(string fileName, string mimeType, TextEditorType textEditorType = TextEditorType.Default)
 			: this(new DocumentAndLoaded(fileName, mimeType))
 		{
+			this.textEditorType = textEditorType;
 			FileRegistry.Add(this);
 		}
 
 		public SourceEditorView(IReadonlyTextDocument document, TextEditorType textEditorType = TextEditorType.Default)
 			: this(new DocumentAndLoaded(document))
 		{
+			this.textEditorType = textEditorType;
 			if (document != null)
 			{
 				Document.MimeType = document.MimeType;
@@ -3636,7 +3638,5 @@ namespace MonoDevelop.SourceEditor
 				return this.TextEditor.HasFocus;
 			}
 		}
-
-		public TextEditorType TextEditorType1 { get => textEditorType; set => textEditorType = value; }
 	}
 } 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -176,14 +176,25 @@ namespace MonoDevelop.SourceEditor
 		}
 
 		bool loadedInCtor = false;
+		TextEditorType textEditorType;
 
-		public SourceEditorView(string fileName, string mimeType)
+		public TextEditorType TextEditorType {
+			get {
+				return textEditorType;
+			}
+		}
+
+		public SourceEditorView (TextEditorType textEditorType = TextEditorType.Default)
+		{
+
+		}
+		public SourceEditorView(string fileName, string mimeType, TextEditorType textEditorType = TextEditorType.Default)
 			: this(new DocumentAndLoaded(fileName, mimeType))
 		{
 			FileRegistry.Add(this);
 		}
 
-		public SourceEditorView(IReadonlyTextDocument document = null)
+		public SourceEditorView(IReadonlyTextDocument document, TextEditorType textEditorType = TextEditorType.Default)
 			: this(new DocumentAndLoaded(document))
 		{
 			if (document != null)
@@ -3625,5 +3636,7 @@ namespace MonoDevelop.SourceEditor
 				return this.TextEditor.HasFocus;
 			}
 		}
+
+		public TextEditorType TextEditorType1 { get => textEditorType; set => textEditorType = value; }
 	}
 } 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorFactory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorFactory.cs
@@ -40,6 +40,10 @@ namespace MonoDevelop.Ide.Editor
 		ITextEditorImpl CreateNewEditor (string fileName, string mimeType);
 		ITextEditorImpl CreateNewEditor (IReadonlyTextDocument document);
 
+		ITextEditorImpl CreateNewEditor (TextEditorType textEditorType);
+		ITextEditorImpl CreateNewEditor (string fileName, string mimeType, TextEditorType textEditorType);
+		ITextEditorImpl CreateNewEditor (IReadonlyTextDocument document, TextEditorType textEditorType);
+
 		string[] GetSyntaxProperties (string mimeType, string name);
 	}
 	

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/Projection.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/Projection.cs
@@ -33,7 +33,7 @@ using System.Collections.Generic;
 
 namespace MonoDevelop.Ide.Editor.Projection
 {
-	public sealed class Projection
+	public sealed class Projection : IDisposable
 	{
 		public ITextDocument Document { get; private set; }
 
@@ -152,6 +152,14 @@ namespace MonoDevelop.Ide.Editor.Projection
 			}
 			projectedOffset = -1;
 			return false;
+		}
+
+		public void Dispose ()
+		{
+			if (projectedEditor != null) {
+				projectedEditor.Dispose ();
+				projectedEditor = null;
+			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorFactory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorFactory.cs
@@ -108,7 +108,7 @@ namespace MonoDevelop.Ide.Editor
 		{
 			if (document == null)
 				throw new System.ArgumentNullException ("document");
-			var result = new TextEditor (currentFactory.CreateNewEditor (document), textEditorType) {
+			var result = new TextEditor (currentFactory.CreateNewEditor (document, textEditorType), textEditorType) {
 				ZoomLevel = zoomLevel
 			};
 			result.ZoomLevelChanged += delegate {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -230,6 +230,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			return Task.Run (async delegate {
 				var projects = new ConcurrentBag<ProjectInfo> ();
 				var mdProjects = solution.GetAllProjects ();
+				foreach (var p in projectionList)
+					p.Dispose ();
 				projectionList = projectionList.Clear ();
 				projectIdMap.Clear ();
 				projectIdToMdProjectMap = projectIdToMdProjectMap.Clear ();
@@ -495,6 +497,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				foreach (var entry in projectionList) {
 					if (entry?.File?.FilePath == projectFile.FilePath) {
 						projectionList = projectionList.Remove (entry);
+						entry.Dispose ();
 						break;
 					}
 				}
@@ -532,10 +535,16 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		internal class ProjectionEntry
+		internal class ProjectionEntry : IDisposable
 		{
 			public MonoDevelop.Projects.ProjectFile File;
 			public IReadOnlyList<Projection> Projections;
+
+			public void Dispose ()
+			{
+				foreach (var p in Projections)
+					p.Dispose ();
+			}
 		}
 
 		static bool CanGenerateAnalysisContextForNonCompileable (MonoDevelop.Projects.Project p, MonoDevelop.Projects.ProjectFile f)


### PR DESCRIPTION
Disposing the editor would be enough to fix that leak. But there is no
reason a projection should listen for file changes since projected
files are purely virtual and change only when the main document
changes. Giving the text editor type to the backends can allow some
optimizations for non UI text editor use cases.