### PR TITLE
Fix NRE in highlightUnusedCode.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/HighlightUnusedCode.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/HighlightUnusedCode.fs
@@ -24,8 +24,8 @@ module highlightUnusedCode =
                 | _ -> () ]
 
     let getOpenStatements (tree: ParsedInput option) = 
-        match tree.Value with
-        | ParsedInput.ImplFile(implFile) ->
+        match tree with
+        | Some (ParsedInput.ImplFile(implFile)) ->
             let (ParsedImplFileInput(_fn, _script, _name, _, _, modules, _)) = implFile
             visitModulesAndNamespaces modules
         | _ -> []


### PR DESCRIPTION
Seen while debugging the F# compiler

```
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.FSharp.highlightUnusedCode.getOpenStatements (Microsoft.FSharp.Core.FSharpOption`1[T] tree) [0x00000] in /Users/jason/src/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/HighlightUnusedCode.fs:27
  at MonoDevelop.FSharp.highlightUnusedCode+getUnusedCode@95.Invoke (System.Tuple`2[T1,T2] tupledArg) [0x00087] in /Users/jason/src/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/HighlightUnusedCode.fs:152
  at Microsoft.FSharp.Core.OptionModule.Bind[T,TResult] (Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] binder, Microsoft.FSharp.Core.FSharpOption`1[T] option) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/fsharp-fsharp-9687f27/src/fsharp/FSharp.Core/option.fs:68
  at MonoDevelop.FSharp.highlightUnusedCode.getUnusedCode (MonoDevelop.Ide.Editor.DocumentContext context, MonoDevelop.Ide.Editor.TextEditor editor) [0x00017] in /Users/jason/src/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/HighlightUnusedCode.fs:95
  at
  <StartupCode$FSharpBinding>.$HighlightUnusedCode+Initialize@181-56.Invoke (System.EventArgs
  _arg1) [0x00000] in
  /Users/jason/src/monodevelop/main/external/fsharpbinding/MonoDevelop.FSharpBinding/HighlightUnusedCode.fs:182
  ```