### PR TITLE
[DotNetCore] Allow PCL projects to be referenced

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -190,5 +190,30 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.IsNotNull (jsonNetReferenceLibB);
 			Assert.IsNotNull (jsonNetReferenceLibC);
 		}
+
+		/// <summary>
+		/// Mirror Visual Studio on Windows behaviour where a .NET Standard project or a .NET Core
+		/// project can add a reference to any PCL project.
+		/// </summary>
+		[Test]
+		public async Task CanReference_PortableClassLibrary_FromNetStandardOrNetCoreAppProject ()
+		{
+			string solutionFileName = Util.GetSampleProject ("dotnetcore-pcl", "dotnetcore-pcl.sln");
+			var solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var pclProject = solution.FindProjectByName ("PclProfile111") as DotNetProject;
+			var netStandardProject = solution.FindProjectByName ("NetStandard14") as DotNetProject;
+			var netCoreProject = solution.FindProjectByName ("NetCore11") as DotNetProject;
+
+			string reason = null;
+			bool canReferenceFromNetStandard = netStandardProject.CanReferenceProject (pclProject, out reason);
+			bool canReferenceFromNetCore = netCoreProject.CanReferenceProject (pclProject, out reason);
+			bool canReferenceNetCoreFromNetStandard = netStandardProject.CanReferenceProject (netCoreProject, out reason);
+			bool canReferenceNetStandardFromNetCore = netCoreProject.CanReferenceProject (netStandardProject, out reason);
+
+			Assert.IsTrue (canReferenceFromNetStandard);
+			Assert.IsTrue (canReferenceFromNetCore);
+			Assert.IsFalse (canReferenceNetCoreFromNetStandard);
+			Assert.IsTrue (canReferenceNetStandardFromNetCore);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -98,6 +98,9 @@ namespace MonoDevelop.DotNetCore
 
 		bool CanReferenceProject (DotNetProject targetProject)
 		{
+			if (targetProject.IsPortableLibrary)
+				return true;
+
 			if (!targetProject.TargetFramework.IsNetStandard ())
 				return false;
 

--- a/main/tests/test-projects/dotnetcore-pcl/NetCore11/NetCore11.csproj
+++ b/main/tests/test-projects/dotnetcore-pcl/NetCore11/NetCore11.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/dotnetcore-pcl/NetStandard14/NetStandard14.csproj
+++ b/main/tests/test-projects/dotnetcore-pcl/NetStandard14/NetStandard14.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/dotnetcore-pcl/PclProfile111/PclProfile111.csproj
+++ b/main/tests/test-projects/dotnetcore-pcl/PclProfile111/PclProfile111.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4D145A54-478E-41FA-BB0F-EEAC578AF234}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <UseMSBuildEngine>true</UseMSBuildEngine>
+    <OutputType>Library</OutputType>
+    <RootNamespace>PclProfile111</RootNamespace>
+    <AssemblyName>PclProfile111</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/dotnetcore-pcl/dotnetcore-pcl.sln
+++ b/main/tests/test-projects/dotnetcore-pcl/dotnetcore-pcl.sln
@@ -1,0 +1,29 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard14", "NetStandard14\NetStandard14.csproj", "{87B9046C-04BA-4094-A2AD-BD7AE730592F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PclProfile111", "PclProfile111\PclProfile111.csproj", "{4D145A54-478E-41FA-BB0F-EEAC578AF234}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCore11", "NetCore11\NetCore11.csproj", "{A9AE4F25-13FA-4148-BD8D-8F87F68DAD5A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D145A54-478E-41FA-BB0F-EEAC578AF234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D145A54-478E-41FA-BB0F-EEAC578AF234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D145A54-478E-41FA-BB0F-EEAC578AF234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D145A54-478E-41FA-BB0F-EEAC578AF234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9AE4F25-13FA-4148-BD8D-8F87F68DAD5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9AE4F25-13FA-4148-BD8D-8F87F68DAD5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9AE4F25-13FA-4148-BD8D-8F87F68DAD5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9AE4F25-13FA-4148-BD8D-8F87F68DAD5A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Fixed bug #58526 - "Incompatible target framework" when referencing
PCL project from netstandard project
https://bugzilla.xamarin.com/show_bug.cgi?id=58526

Mirror Visual Studio on Windows behaviour where a .NET Core or a
.NET Standard project can reference any PCL project.