### PR TITLE
[MacInterop] Throw AppleScriptException instead of Exception

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/AppleScript.cs
+++ b/main/src/addins/MacPlatform/MacInterop/AppleScript.cs
@@ -118,7 +118,7 @@ namespace MonoDevelop.MacInterop
 		{
 			var component = ComponentManager.OpenDefaultComponent ((OSType)(int)OsaType.OsaComponent, (OSType)(int)OsaType.AppleScript);
 			if (component.IsNull)
-				throw new Exception ("Could not load component");
+				throw new AppleScriptException (OsaError.GeneralError, "Could not load component");
 			AEDesc resultData = new AEDesc ();
 			OsaId contextId = new OsaId (), scriptId = new OsaId (), resultId = new OsaId ();
 			try {


### PR DESCRIPTION
When we fail to load the OSA component, throw an AppleScriptException
instead of a general Exception to make it easier to catch.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57438
