### PR TITLE
Fixes performance issue running msbuild targets

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -874,7 +874,8 @@ namespace MonoDevelop.Ide.Gui
 						newProject.References.Add (ProjectReference.CreateAssemblyReference ("System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"));
 						newProject.References.Add (ProjectReference.CreateAssemblyReference ("System.Core"));
 
-						newProject.FileName = "test.csproj";
+						// Use a different name for each project, otherwise the msbuild builder will complain about duplicate projects.
+						newProject.FileName = "adhoc_" + (++adhocProjectCount) + ".csproj";
 						if (!Window.ViewContent.IsUntitled) {
 							adHocFile = Editor.FileName;
 						} else {
@@ -943,6 +944,7 @@ namespace MonoDevelop.Ide.Gui
 			return project is SharedAssetsProject;
 		}
 
+		static int adhocProjectCount = 0;
 		object adhocProjectLock = new object();
 		object analysisDocumentLock = new object ();
 		void UnloadAdhocProject ()

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -150,6 +150,13 @@ namespace MonoDevelop.Projects.MSBuild
 					project = p;
 			}
 
+			// Reload referenced projects if they have changed in disk. ProjectCollection doesn't do it automatically.
+
+			foreach (var p in project.Imports) {
+				if (p.ImportedProject.LastWriteTimeWhenRead != File.GetLastWriteTime (p.ImportedProject.FullPath))
+					p.ImportedProject.Reload (false);
+			}
+
 			var projectDir = Path.GetDirectoryName (file);
 			if (!string.IsNullOrEmpty (projectDir) && Directory.Exists (projectDir))
 				Environment.CurrentDirectory = projectDir;
@@ -184,12 +191,20 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 
-			p.SetGlobalProperty ("CurrentSolutionConfigurationContents", slnConfigContents);
-			p.SetGlobalProperty ("Configuration", configuration);
-			if (!string.IsNullOrEmpty (platform))
-				p.SetGlobalProperty ("Platform", platform);
-			else
-				p.RemoveGlobalProperty ("Platform");
+			if (p.GetPropertyValue ("Configuration") != configuration || (p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
+				p.SetGlobalProperty ("Configuration", configuration);
+				if (!string.IsNullOrEmpty (platform))
+					p.SetGlobalProperty ("Platform", platform);
+				else
+					p.RemoveGlobalProperty ("Platform");
+
+			}
+
+			// The CurrentSolutionConfigurationContents property only needs to be set once
+			// for the project actually being built
+
+			if (this.file == file && p.GetPropertyValue ("CurrentSolutionConfigurationContents") != slnConfigContents)
+				p.SetGlobalProperty ("CurrentSolutionConfigurationContents", slnConfigContents);
 
 			p.ReevaluateIfNecessary ();
 

--- a/main/tests/test-projects/test-project-refresh/Extra.cs
+++ b/main/tests/test-projects/test-project-refresh/Extra.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace testprojectrefresh
+{
+    class ExtraClass
+    {
+        public static void WriteLine(string s)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/main/tests/test-projects/test-project-refresh/Program.cs
+++ b/main/tests/test-projects/test-project-refresh/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace testprojectrefresh
+{
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            ExtraClass.WriteLine("Hello World!");  
+        }
+    }
+}

--- a/main/tests/test-projects/test-project-refresh/extra.targets
+++ b/main/tests/test-projects/test-project-refresh/extra.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+     <Compile Include="Extra.xx"  />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/test-project-refresh/test-project-refresh.csproj
+++ b/main/tests/test-projects/test-project-refresh/test-project-refresh.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{6B51038D-1402-40EC-B9DC-6D6767EEB588}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>testprojectrefresh</RootNamespace>
+    <AssemblyName>test-project-refresh</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="extra.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-project-refresh/test-project-refresh.sln
+++ b/main/tests/test-projects/test-project-refresh/test-project-refresh.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-project-refresh", "test-project-refresh.csproj", "{6B51038D-1402-40EC-B9DC-6D6767EEB588}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6B51038D-1402-40EC-B9DC-6D6767EEB588}.Debug|x86.ActiveCfg = Debug|x86
+		{6B51038D-1402-40EC-B9DC-6D6767EEB588}.Debug|x86.Build.0 = Debug|x86
+		{6B51038D-1402-40EC-B9DC-6D6767EEB588}.Release|x86.ActiveCfg = Release|x86
+		{6B51038D-1402-40EC-B9DC-6D6767EEB588}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The problem was that when a project is modified and then refreshed in
the remote builder, the builder would unload not only the modified
project, but all loaded projects. This issue was introduced in this
commit: mono/monodevelop@ebf6c0a, when trying to fix another bug
(23435).

This fix was slowing down project loading because during source analysis,
several projects were marked for refresh, which caused all loaded projects
to be unloaded, so projects had to be loaded again and again. It was
much worse when installing .NET Core 2.0 because for some reason,
.NET Standard projects are much slower to evaluate when it is installed,
(but that's a different issue), and Main.sln has one of such projects:
RefactoringEssentials.

The bug that the original commit was fixing was that target files imported
by an msbuild project are not reloaded if they change in disk. This patch
fixes this specific reloading problem, and then reverts the previous fix.

Fixes bug #58586 - Evaluation is slow with .netcore 2.x installed