### PR TITLE
Fixed 'Bug 59149 - Code completion stops working after a file is

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1341,7 +1341,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (freezeProjectModify)
 					return;
 				try {
-					if (!args.Any (x => x.Hint == "TargetFramework" || x.Hint == "References" || x.Hint == "CompilerParameters"))
+					if (!args.Any (x => x.Hint == "TargetFramework" || x.Hint == "References" || x.Hint == "CompilerParameters" || x.Hint == "Files"))
 						return;
 					var project = sender as MonoDevelop.Projects.DotNetProject;
 					if (project == null)


### PR DESCRIPTION
renamed'

Project modify handler was missing the file changes.