### PR TITLE
[SourceEditor] Fixed unit test. Empty constructor is used in many

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -184,10 +184,11 @@ namespace MonoDevelop.SourceEditor
 			}
 		}
 
-		public SourceEditorView (TextEditorType textEditorType = TextEditorType.Default)
+		public SourceEditorView (TextEditorType textEditorType = TextEditorType.Default) : this(new DocumentAndLoaded(new TextDocument(), true))
 		{
 			this.textEditorType = textEditorType;
 		}
+
 		public SourceEditorView(string fileName, string mimeType, TextEditorType textEditorType = TextEditorType.Default)
 			: this(new DocumentAndLoaded(fileName, mimeType))
 		{

--- a/main/tests/Ide.Tests/MonoDevelop.SourceEditor/JSonIndentEngineTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.SourceEditor/JSonIndentEngineTests.cs
@@ -36,7 +36,7 @@ namespace MonoDevelop.SourceEditor
 	[TestFixture]
 	public class JSonIndentEngineTests : IdeTestBase
 	{
-		const string indentString = "    ";
+		const string indentString = "\t";
 
 		internal static IDocumentIndentEngine CreateEngine (string text)
 		{


### PR DESCRIPTION
tests - one of the last patches added a new "empty" constructor
breaking many tests.