### PR TITLE
[mac] Bump the minimum nursery size in mono

### DIFF
--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -310,7 +310,7 @@ int main (int argc, char **argv)
 		}
 	}
 
-	setenv ("MONO_GC_PARAMS", "major=marksweep-conc", 0);
+	setenv ("MONO_GC_PARAMS", "major=marksweep-conc,nursery-size=8m", 0);
 
   NSString *exePath;
   char **extra_argv;


### PR DESCRIPTION
Let's try with 8MB and see if it improves things.