### PR TITLE
Include all available MSBuild item metadata when returning evaluated items

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -109,8 +109,8 @@ namespace MonoDevelop.Projects.MSBuild
 							var list = new List<MSBuildEvaluatedItem> ();
 							foreach (var item in grp) {
 								var evItem = new MSBuildEvaluatedItem (name, UnescapeString (item.EvaluatedInclude));
-								foreach (var m in item.Metadata) {
-									evItem.Metadata [m.Name] = UnescapeString (m.EvaluatedValue);
+								foreach (var metadataName in item.MetadataNames) {
+									evItem.Metadata [metadataName] = UnescapeString (item.GetMetadataValue (metadataName));
 								}
 								list.Add (evItem);
 							}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTargetEvaluationTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTargetEvaluationTests.cs
@@ -88,6 +88,11 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (1, items.Length);
 			Assert.AreEqual ("bar", items [0].Include);
 			Assert.AreEqual ("Hello", items [0].Metadata.GetValue ("MyMetadata"));
+			if (Runtime.Preferences.BuildWithMSBuild.Value) {
+				// Standard metadata inclusion is only supported via 4.0 API builder
+				Assert.AreEqual ("bar", items [0].Metadata.GetValue ("Filename"));
+				Assert.AreEqual (p.ItemDirectory.Combine ("bar").ToString (), items [0].Metadata.GetValue ("FullPath"));
+			}
 
 			p.Dispose ();
 		}


### PR DESCRIPTION
The previous code would only include custom metadata from the item and none of the default provided ones (such as FullPath).

Using MetadataNames and GetMetadataValue instead ensures every bit of metadata that an item normally exposes is returned to the caller.