### PR TITLE
Fixed 'Bug 59260 - VS4M and MonoDevelop not adapting to applied fonts'

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -489,7 +489,7 @@ namespace Mono.TextEditor
 		static TextViewMargin()
 		{
 #if MAC
-			var img = MacCursorImage.Image;
+			var img = OSXEditor.IBeamCursorImage;
 			xtermCursorInverted = new Cursor(xtermCursor.Display, (InvertCursorPixbuf (img.ToPixbuf())), (int)img.Width / 2, (int)img.Height / 2);
 #else
 			xtermCursorInverted = xtermCursor;

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/UnderlineMarker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/UnderlineMarker.cs
@@ -138,11 +138,12 @@ namespace Mono.TextEditor
 			}
 			//}
 			if (Wave) {	
-				Pango.CairoHelper.ShowErrorUnderline (cr, @from, y + editor.LineHeight - height, to - @from, height);
+				Pango.CairoHelper.ShowErrorUnderline (cr, @from, y + editor.TextViewMargin.UnderlinePosition, to - @from, height);
 			} else {
-				cr.LineWidth = 1;
-				cr.MoveTo (@from, y + editor.LineHeight - 1.5);
-				cr.LineTo (to, y + editor.LineHeight - 1.5);
+				cr.LineWidth = editor.TextViewMargin.UnderLineThickness;
+
+				cr.MoveTo (@from, y + editor.TextViewMargin.UnderlinePosition - 0.5);
+				cr.LineTo (to, y + editor.TextViewMargin.UnderlinePosition - 0.5);
 				cr.Stroke ();
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/OSXEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/OSXEditor.cs
@@ -32,14 +32,12 @@ using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Editor
 {
-	class MacCursorImage
+	class OSXEditor
 	{
 		static Xwt.Drawing.Image image;
 
-		public static Xwt.Drawing.Image Image
-		{
-			get
-			{
+		public static Xwt.Drawing.Image IBeamCursorImage {
+			get {
 				if (image != null)
 					return image;
 				var cacheFileName = Path.Combine(UserProfile.Current.CacheDir, "MacCursorImage.tiff");
@@ -50,6 +48,15 @@ namespace MonoDevelop.Ide.Editor
 				image = img.WithSize(size.Width, size.Height);
 				return image;
 			}
+		}
+
+		public static int GetLineHeight(string fontName)
+		{
+			var editorFont = Xwt.Drawing.Font.FromName(fontName);
+
+			using (var nsFont = NSFont.FromFontName(editorFont.Family, (nfloat)editorFont.Size))
+				using (var lm = new NSLayoutManager())
+			 		return (int)lm.DefaultLineHeightForFont(nsFont);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9652,7 +9652,7 @@
     <Compile Include="MonoDevelop.Ide.Projects\LanguageCellRenderer.cs" />
     <Compile Include="MonoDevelop.Components\RestartPanel.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.OptionPanels\DotNetCompileTargetSelector.cs" />
-    <Compile Include="MonoDevelop.Ide.Editor\MacCursorImage.cs" />
+    <Compile Include="MonoDevelop.Ide.Editor\OSXEditor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
The line gap is not supported by pango therefore I use the os x
routines to determine the line height. However that only works on os x
- on linux the fluent fonts don't have that gap. But there is no
single gtk editor (and even sublime text) which supports that setting
there.
Underline position metrics are now taken into account for underlines
as well.