### PR TITLE
Bug 59517 - xUnit tests not discovered

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
@@ -47,6 +47,7 @@ using System.Threading.Tasks;
 using System.Collections.Concurrent;
 using MonoDevelop.PackageManagement;
 using System.Runtime.CompilerServices;
+using System.Net;
 
 namespace MonoDevelop.UnitTesting.VsTest
 {
@@ -65,7 +66,8 @@ namespace MonoDevelop.UnitTesting.VsTest
 				TargetFrameworkVersion = Framework.FromString ((project as DotNetProject)?.TargetFramework?.Id?.ToString ()),
 				DisableAppDomain = true,
 				ShouldCollectSourceInformation = false,
-				TestAdaptersPaths = GetTestAdapters (project)
+				TestAdaptersPaths = GetTestAdapters (project),
+				TestSessionTimeout = 60000,
 			}.ToXml ().OuterXml + "</RunSettings>";
 		}
 
@@ -140,9 +142,9 @@ namespace MonoDevelop.UnitTesting.VsTest
 			var token = restartTokenSource.Token;
 			startedSource = new TaskCompletionSource<bool> ();
 			communicationManager = new SocketCommunicationManager ();
-			int port = communicationManager.HostServer ();
+			var endPoint = communicationManager.HostServer(new IPEndPoint(IPAddress.Loopback, 0));
 			communicationManager.AcceptClientAsync ().Ignore ();
-			vsTestConsoleExeProcess = StartVsTestConsoleExe(port);
+			vsTestConsoleExeProcess = StartVsTestConsoleExe(endPoint.Port);
 			vsTestConsoleExeProcess.Task.ContinueWith(delegate {
 				VsTestProcessExited(vsTestConsoleExeProcess);
 			}).Ignore();

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestRunAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestRunAdapter.cs
@@ -254,7 +254,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 					((DotNetCoreExecutionCommand)command).Arguments = startInfo.Arguments;
 				} else {
 					var portArgument = startInfo.Arguments.IndexOf (" --port", StringComparison.Ordinal);
-					var assembly = startInfo.Arguments.Remove (portArgument - 1);
+                    var assembly = startInfo.Arguments.Remove (portArgument - 1).Trim (new char[] { '"' });
 					var arguments = startInfo.Arguments.Substring (portArgument + 1);
 					command = new DotNetExecutionCommand (
 						assembly,

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -86,22 +86,22 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\..\..\packages\Microsoft.TestPlatform.ObjectModel.15.3.0-preview-20170710-01\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TestPlatform.ObjectModel.15.5.0-preview-20170919-04\lib\net451\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CommunicationUtilities">
-      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.3.0-preview-20170710-01\lib\net46\Microsoft.TestPlatform.CommunicationUtilities.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.5.0-preview-20170919-04\lib\net451\Microsoft.TestPlatform.CommunicationUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.CoreUtilities">
-      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.3.0-preview-20170710-01\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.5.0-preview-20170919-04\lib\net451\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.PlatformAbstractions">
-      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.3.0-preview-20170710-01\lib\net46\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.5.0-preview-20170919-04\lib\net451\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TestPlatform.VsTestConsole.TranslationLayer">
-      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.3.0-preview-20170710-01\lib\net46\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.5.0-preview-20170919-04\lib\net451\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.Common">
-      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.3.0-preview-20170710-01\lib\net46\Microsoft.VisualStudio.TestPlatform.Common.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TestPlatform.TranslationLayer.15.5.0-preview-20170919-04\lib\net451\Microsoft.VisualStudio.TestPlatform.Common.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -318,16 +318,16 @@
     <Folder Include="MonoDevelop.UnitTesting.VsTest\" />
   </ItemGroup>
   <ItemGroup>
-    <VsTestConsole Include="..\..\..\packages\Microsoft.TestPlatform.15.3.0-preview-20170710-01\tools\net46\**\*.*">
+    <VsTestConsole Include="..\..\..\packages\Microsoft.TestPlatform.15.5.0-preview-20170919-04\tools\net451\**\*.*">
       <Visible>false</Visible>
     </VsTestConsole>
-    <VsTestConsole Remove="..\..\..\packages\Microsoft.TestPlatform.15.3.0-preview-20170710-01\tools\net46\Extensions\**\*.*" />
+    <VsTestConsole Remove="..\..\..\packages\Microsoft.TestPlatform.15.5.0-preview-20170919-04\tools\net451\Extensions\**\*.*" />
   </ItemGroup>
   <ItemGroup>
-    <VsTestConsoleExtensions Include="..\..\..\packages\Microsoft.TestPlatform.15.3.0-preview-20170710-01\tools\net46\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll">
+    <VsTestConsoleExtensions Include="..\..\..\packages\Microsoft.TestPlatform.15.5.0-preview-20170919-04\tools\net451\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll">
       <Visible>false</Visible>
     </VsTestConsoleExtensions>
-    <VsTestConsoleExtensions Include="..\..\..\packages\Microsoft.TestPlatform.15.3.0-preview-20170710-01\tools\net46\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll">
+    <VsTestConsoleExtensions Include="..\..\..\packages\Microsoft.TestPlatform.15.5.0-preview-20170919-04\tools\net451\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll">
       <Visible>false</Visible>
     </VsTestConsoleExtensions>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.UnitTesting/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.TestPlatform" version="15.3.0-preview-20170710-01" targetFramework="net461" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="15.3.0-preview-20170710-01" targetFramework="net461" />
-  <package id="Microsoft.TestPlatform.TranslationLayer" version="15.3.0-preview-20170710-01" targetFramework="net461" />
+  <package id="Microsoft.TestPlatform" version="15.5.0-preview-20170919-04" targetFramework="net461" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
+  <package id="Microsoft.TestPlatform.TranslationLayer" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />


### PR DESCRIPTION
Issue was in vstest which is fixed in https://github.com/Microsoft/vstest/pull/1108
So this commit updates to latest version of vstest and changes logic around extracting path from arguments to remove new quotes
Plus follows API changes