### PR TITLE
Fix Windows build.

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/WPFToolbar.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/WPFToolbar.cs
@@ -295,6 +295,17 @@ namespace WindowsPlatform.MainToolbar
 				PropertyChanged (this, new System.ComponentModel.PropertyChangedEventArgs (propName));
 		}
 
+		public void Focus ()
+		{
+			FocusSearchBar ();
+		}
+
+		public void Focus (System.Action exitAction)
+		{
+			FocusSearchBar ();
+			exitAction ();
+		}
+
 		public event PropertyChangedEventHandler PropertyChanged;
 		public event EventHandler RunConfigurationChanged;
 	}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -34,7 +34,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.3.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Don't resolve references from the output directory because there's no guarantee they will be there at the time the project builds. Instead resolve deterministically from the packages directory. It is annoying because Nuget forces you to specify the version in the HintPath, but hopefully with the new SDK projects and PackageReference this can go away soon.

Implement missing members on WPFToolbar.