### PR TITLE
Bump md-addins to build with XCode 9

### DIFF
--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=641418663583c49cbfbf990ee5656ff18c152c27
+DEP_NEEDED_VERSION[0]=4e169d839d9a1793b45ad197855f94762821d86b
 DEP_BRANCH_AND_REMOTE[0]="d15-5 origin/d15-5"
 
 # heap-shot


### PR DESCRIPTION
Xamarin Mac was bumped to 4.0.0.1 which requires XCode 9 for linking