### PR TITLE
Fix bxc #58815 build breakage

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/DotNetProjectExtensions.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Packaging
 		public static void InstallBuildPackagingNuGetPackage (IEnumerable<Project> projects)
 		{
 			string packagesFolder = GetPackagesFolder ();
-			var packageReference = new PackageManagementPackageReference ("NuGet.Build.Packaging", "0.1.276");
+			var packageReference = new PackageManagementPackageReference ("NuGet.Build.Packaging", "0.2.0");
 
 			var packageReferences = new [] { packageReference };
 

--- a/main/src/addins/MonoDevelop.Packaging/PostBuild.proj
+++ b/main/src/addins/MonoDevelop.Packaging/PostBuild.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);_MyPostBuildTarget</PrepareForRunDependsOn>
-    <_BuildPackagingVersion>0.1.276</_BuildPackagingVersion>
+    <_BuildPackagingVersion>0.2.0</_BuildPackagingVersion>
   </PropertyGroup>
   <ItemGroup>
     <_MyNuGetPackage Include="$(MSBuildProjectDirectory)\..\..\..\packages\NuGet.Build.Packaging.$(_BuildPackagingVersion)\NuGet.Build.Packaging.$(_BuildPackagingVersion).nupkg" />

--- a/main/src/addins/MonoDevelop.Packaging/Templates/CrossPlatformLibrary.xpt.xml
+++ b/main/src/addins/MonoDevelop.Packaging/Templates/CrossPlatformLibrary.xpt.xml
@@ -29,7 +29,7 @@
 				DefaultNamespace="${ProjectName}"
 				HideGettingStarted="true" />
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.2.0" directory="../packages" />
 			</Packages>
 			<Files>
 				<FileTemplateReference TemplateID="EmptyClass" name="MyClass.cs" />
@@ -50,7 +50,7 @@
 				<Reference type="Project" refto="${ProjectName}.Shared" />
 			</References>
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.2.0" directory="../packages" />
 			</Packages>
 			<Files>
 				<FileTemplateReference TemplateID="CSharpAssemblyInfo" name="AssemblyInfo.cs" />
@@ -67,7 +67,7 @@
 				<Reference type="Project" refto="${ProjectName}.Shared" />
 			</References>
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.2.0" directory="../packages" />
 			</Packages>
 			<Files>
 				<FileTemplateReference TemplateID="CSharpAssemblyInfo" name="AssemblyInfo.cs" />
@@ -77,7 +77,7 @@
 		<Project name="${ProjectName}.NuGet" directory="${ProjectName}.NuGet" type="NuGetPackaging" if="CreateNuGetProject">
 			<Options TargetFrameworkVersion="4.5" DefaultNamespace="${ProjectName}" HideGettingStarted="true" />
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.2.0" directory="../packages" />
 			</Packages>
 			<References>
 				<Reference type="Project" refto="${ProjectName}.Android" if="CreateAndroidProject" />

--- a/main/src/addins/MonoDevelop.Packaging/Templates/PackagingProject.xpt.xml
+++ b/main/src/addins/MonoDevelop.Packaging/Templates/PackagingProject.xpt.xml
@@ -18,7 +18,7 @@
 		<Project name="${ProjectName}" directory="." type="NuGetPackaging">
 			<Options TargetFrameworkVersion="4.5" />
 			<Packages>
-				<Package ID="NuGet.Build.Packaging" Version="0.1.276" directory="../packages" />
+				<Package ID="NuGet.Build.Packaging" Version="0.2.0" directory="../packages" />
 			</Packages>
 			<Files>
 				<File name="readme.txt"><![CDATA[

--- a/main/src/addins/MonoDevelop.Packaging/packages.config
+++ b/main/src/addins/MonoDevelop.Packaging/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.Build.Packaging" version="0.1.276" targetFramework="net45" />
+  <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
NuGet.Build.Packaging was bumped[1] to fix the build in mono-addins.
So, we pick up that change from mono-addins. And update
NuGet.Build.Packaging to v0.2.0 to be in sync.

--
1. https://github.com/mono/mono-addins/pull/88