### PR TITLE
Improve handling of remote builder shutdown

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngine.cs
@@ -294,6 +294,11 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
+		public void DisposeGracefully ()
+		{
+			Task.WhenAny (connection.ProcessQueuedMessages (), Task.Delay (5000)).ContinueWith (t => Dispose ());
+		}
+
 		[MessageHandler]
 		void OnLogMessage (LogMessage msg)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
@@ -639,7 +639,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (engine.ReferenceCount == 0) {
 				engine.CancelScheduledDisposal ();
 				builders.Remove (engine);
-				engine.Dispose ();
+				engine.DisposeGracefully ();
 			}
 		}
 
@@ -650,7 +650,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (engine.IsShuttingDown) {
 				// If the engine is being shut down, dispose it now.
 				builders.Remove (engine);
-				engine.Dispose ();
+				engine.DisposeGracefully ();
 			} else {
 				// Wait a bit before disposing the engine. We may need to use it again.
 				engine.ScheduleForDisposal (EngineDisposalDelay).ContinueWith (async t => {
@@ -663,7 +663,7 @@ namespace MonoDevelop.Projects.MSBuild
 						// If after the wait there are still 0 references, dispose the builder
 						if (engine.ReferenceCount == 0) {
 							builders.Remove (engine);
-							engine.Dispose ();
+							engine.DisposeGracefully ();
 						}
 					}
 				}, TaskContinuationOptions.NotOnCanceled);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -240,9 +240,9 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			lock (usageLock) {
 				if (--references == 0) {
-					RemoteBuildEngineManager.ReleaseProjectBuilder (engine).Ignore ();
 					if (shuttingDown)
 						Dispose ();
+					RemoteBuildEngineManager.ReleaseProjectBuilder (engine).Ignore ();
 				}
 			}
 		}


### PR DESCRIPTION
Before shutting down a remote builder make sure that all remote calls have
been completed. It avoids unnecessary exceptions that might happen if
the builder is shut down too early.