### PR TITLE
[Core] Update solution startup item on re-evaluation

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3677,6 +3677,7 @@ namespace MonoDevelop.Projects
 			return BindTask (ct => Runtime.RunInMainThread (async () => {
 				using (await writeProjectLock.EnterAsync ()) {
 					var oldCapabilities = new HashSet<string> (projectCapabilities);
+					bool oldSupportsExecute = SupportsExecute ();
 
 					try {
 						IsReevaluating = true;
@@ -3702,8 +3703,31 @@ namespace MonoDevelop.Projects
 						NotifyProjectCapabilitiesChanged ();
 
 					NotifyExecutionTargetsChanged (); // Maybe...
+
+					if (oldSupportsExecute != SupportsExecute ()) {
+						OnSupportsExecuteChanged (!oldSupportsExecute);
+					}
 				}
 			}));
+		}
+
+		/// <summary>
+		/// If the project's SupportsExecute has changed then check if the solution's startup
+		/// configuration needs to be refreshed. If the solution has no startup item and
+		/// the project can now be executed then refresh the startup configuration since a
+		/// startup item can now be set for the solution. If the solution's startup item is
+		/// this project and can no longer be executed then refresh the startup configuration
+		/// so another startup item can be selected.
+		/// </summary>
+		void OnSupportsExecuteChanged (bool supportsExecute)
+		{
+			if (ParentSolution == null)
+				return;
+
+			if ((!supportsExecute && ParentSolution.StartupItem == this) ||
+				(supportsExecute && ParentSolution.StartupConfiguration == null)) {
+				ParentSolution.RefreshStartupConfiguration ();
+			}
 		}
 
 		protected virtual async Task OnReevaluateProject (ProgressMonitor monitor)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
@@ -284,12 +284,17 @@ namespace MonoDevelop.Projects
 
 			if (!startupConfigSet) {
 				// Startup configuration has not been set by legacy properties. Do it now.
-				var sconfig = UserProperties.GetValue<string> ("StartupConfiguration");
-				if (!string.IsNullOrEmpty (sconfig))
-					StartupConfiguration = GetRunConfigurations ().FirstOrDefault (c => c.Id == sconfig);
-				else
-					StartupConfiguration = GetRunConfigurations ().FirstOrDefault ();
+				RefreshStartupConfiguration ();
 			}
+		}
+
+		internal void RefreshStartupConfiguration ()
+		{
+			var sconfig = UserProperties.GetValue<string> ("StartupConfiguration");
+			if (!string.IsNullOrEmpty (sconfig))
+				StartupConfiguration = GetRunConfigurations ().FirstOrDefault (c => c.Id == sconfig);
+			else
+				StartupConfiguration = GetRunConfigurations ().FirstOrDefault ();
 		}
 
 		internal protected override Task OnSave (ProgressMonitor monitor)

--- a/main/tests/test-projects/project-capability-tests/Library/Library.csproj
+++ b/main/tests/test-projects/project-capability-tests/Library/Library.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Library</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/project-capability-tests/Library/Library.sln
+++ b/main/tests/test-projects/project-capability-tests/Library/Library.sln
@@ -1,0 +1,17 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Library", "Library.csproj", "{7F63CBE6-2FE7-47A7-8930-EA078DA05062}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/project-capability-tests/Library/testcapability.targets
+++ b/main/tests/test-projects/project-capability-tests/Library/testcapability.targets
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectCapability Include="TestCapability" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixed bug #58021 - New Azure Functions project can't be debugged
https://bugzilla.xamarin.com/show_bug.cgi?id=58021

When re-evaluating the project check to see if the project's
SupportsExecute has changed, which can happen if a new project
capability is installed via a NuGet package. If this has changed
then check to see if the solution's StartupItem should be refreshed
since it may now be possible to set a startup item for the solution.
Also handle the case where the project capability is removed and the
project can no longer be executed. In this case if the solution's
StartupItem is the project then the startup item should be changed.