### PR TITLE
[59642][TextEditor] Don't load PreeditString while resetting IMContext

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -483,7 +483,10 @@ namespace Mono.TextEditor
 
 		void PreeditStringChanged (object sender, EventArgs e)
 		{
-			imContext.GetPreeditString (out preeditString, out preeditAttrs, out preeditCursorCharIndex);
+			if (imContextNeedsReset)
+				preeditString = null;
+			else
+				imContext.GetPreeditString (out preeditString, out preeditAttrs, out preeditCursorCharIndex);
 			if (!string.IsNullOrEmpty (preeditString)) {
 				if (preeditOffset < 0) {
 					preeditOffset = Caret.Offset;


### PR DESCRIPTION
#3102 for `d15-5`

IMMulticontext.Reset might raise the PreeditChanged event, but
trying to retrieve the PreeditString leads to a native crash at this
point. Resetting the current preeditString if a IMContext reset is
requested fixes this issue.

(fixes bug #59642)

(cherry picked from commit 3cfb1b3d13ceb04017a6ecb19a03667e7cc5508a)