### PR TITLE
Work around a Gtk bug on Windows where mouse coordinates are not repo…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1331,6 +1331,23 @@ namespace Mono.TextEditor
 				double x = (int) e.XRoot - rx;
 				double y = (int) e.YRoot - ry;
 
+				if (Platform.IsWindows) {
+					// TODO: revisit this when we move to a newer Gtk.
+					// https://bugzilla.xamarin.com/show_bug.cgi?id=57086
+					// There seems to be a bug in Gtk+ where for a 4K multi-monitor configuration
+					// on Windows the e.XRoot reported in EventMotion above is negative. Hence the
+					// logic of computing x and y above based on XRoot results in incorrect (negative)
+					// coordinates and hovering in the editor doesn't work (no tooltip showing, etc)
+					// The good news is that the original reported TextArea-relative coordinates
+					// are correct, so lets just use them. This fixes numerous bad symptoms:
+					//  1. tooltips and hovering doesn't work
+					//  2. selection with mouse doesn't properly work (selects from beginning of line)
+					//  3. mouse caret doesn't change to beam when over the editor area
+					//  4. possibly more
+					x = e.X;
+					y = e.Y;
+				}
+
 				overChildWidget = containerChildren.Any (w => w.Child.Allocation.Contains ((int)x, (int)y));
 
 				RemoveScrollWindowTimer ();


### PR DESCRIPTION
…rted correctly.

Bug https://bugzilla.xamarin.com/show_bug.cgi?id=57086 outlines the symptoms.