### PR TITLE
Debugger source lookups

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -63,7 +63,12 @@ namespace MonoDevelop.MacIntegration
 						return;
 					data.SelectedFiles = new FilePath [] { selectedPath };
 					pathAlreadySet = true;
-					panel.Cancel (panel);
+
+					// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
+					// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
+					// in that case calling .Cancel() leaves dialog in weird state...
+					// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
+					System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate { panel.Cancel (panel); }, Runtime.MainTaskScheduler);
 				};
 				MacSelectFileDialogHandler.SetCommonPanelProperties (data, panel);
 				

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
@@ -275,7 +275,7 @@
 	<Extension path = "/MonoDevelop/ProjectModel/Gui/ItemOptionPanels/Common">
 		<Condition id="ItemType" value="Solution">
 			<Condition id="SolutionHasDebugSourceFiles">
-				<Section id="DebugSourceFiles" _label="Debug Source Files" icon="md-prefs-debugger"
+				<Section id="DebugSourceFiles" _label="Debug Source Files" icon="md-prefs-debugger" fill="true"
 					class="MonoDevelop.Debugger.DebugSourceFilesOptionsPanel" />
 			</Condition>
 		</Condition>

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
@@ -269,5 +269,16 @@
 	<Extension path = "/MonoDevelop/Ide/TextEditorExtensions">
 		<Class class="MonoDevelop.Debugger.ExceptionCaughtTextEditorExtension" />
 	</Extension>
+	
+	<ConditionType id="SolutionHasDebugSourceFiles" type="MonoDevelop.Debugger.SolutionHasDebugSourceFilesCondition" />
+
+	<Extension path = "/MonoDevelop/ProjectModel/Gui/ItemOptionPanels/Common">
+		<Condition id="ItemType" value="Solution">
+			<Condition id="SolutionHasDebugSourceFiles">
+				<Section id="DebugSourceFiles" _label="Debug Source Files" icon="md-prefs-debugger"
+					class="MonoDevelop.Debugger.DebugSourceFilesOptionsPanel" />
+			</Condition>
+		</Condition>
+	</Extension>
 </ExtensionModel>
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -208,6 +208,8 @@
     <Compile Include="MonoDevelop.Debugger\Styles.cs" />
     <Compile Include="MonoDevelop.Debugger\ProcessAttacher.cs" />
     <Compile Include="MonoDevelop.Debugger\NoSourceView.cs" />
+    <Compile Include="MonoDevelop.Debugger\DebugSourceFilesOptionsPanel.cs" />
+    <Compile Include="MonoDevelop.Debugger\SolutionHasDebugSourceFilesCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.Debugger.addin.xml">

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -207,6 +207,7 @@
     <Compile Include="MonoDevelop.Debugger\DebugApplicationDialog.cs" />
     <Compile Include="MonoDevelop.Debugger\Styles.cs" />
     <Compile Include="MonoDevelop.Debugger\ProcessAttacher.cs" />
+    <Compile Include="MonoDevelop.Debugger\NoSourceView.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.Debugger.addin.xml">

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugSourceFilesOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugSourceFilesOptionsPanel.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.Debugger
 
 			label = new Label (BrandingService.BrandApplicationName (GettextCatalog.GetString ("Folders where MonoDevelop should look for debug source files:")));
 			label.Xalign = 0;
-			PackStart (label);
+			PackStart (label, false, false, 0);
 			selector.Directories = new List<string> (SourceCodeLookup.GetDebugSourceFolders (solution));
 			PackStart (selector, true, true, 0);
 			ShowAll ();

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugSourceFilesOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugSourceFilesOptionsPanel.cs
@@ -1,0 +1,83 @@
+﻿//
+// DebugSourceFilesOptionsPanel.cs
+//
+// Author:
+//       David Karlaš <david.karlas@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using Gtk;
+using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui.Dialogs;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.Debugger
+{
+	class DebugSourceFilesOptionsPanel : ItemOptionsPanel
+	{
+		DebugSourceFilesOptionsPanelWidget widget;
+
+		public override Control CreatePanelWidget ()
+		{
+			return widget = new DebugSourceFilesOptionsPanelWidget (this.ConfiguredSolution);
+		}
+
+		public override void ApplyChanges ()
+		{
+			widget.Store ();
+		}
+	}
+
+	class DebugSourceFilesOptionsPanelWidget : VBox
+	{
+		Solution solution;
+		Label label;
+		FolderListSelector selector = new FolderListSelector ();
+
+		public DebugSourceFilesOptionsPanelWidget (Solution solution)
+		{
+			this.solution = solution;
+
+			label = new Label (BrandingService.BrandApplicationName (GettextCatalog.GetString ("Folders where MonoDevelop should look for debug source files:")));
+			label.Xalign = 0;
+			PackStart (label);
+			selector.Directories = new List<string> (SourceCodeLookup.GetDebugSourceFolders (solution));
+			PackStart (selector, true, true, 0);
+			ShowAll ();
+			SetupAccessibility ();
+		}
+
+		void SetupAccessibility ()
+		{
+			selector.EntryAccessible.SetCommonAttributes (null, null, GettextCatalog.GetString ("Enter a folder to search for debug source files"));
+			selector.EntryAccessible.SetTitleUIElement (label.Accessible);
+			label.Accessible.SetTitleFor (selector.EntryAccessible);
+		}
+
+		public void Store ()
+		{
+			SourceCodeLookup.SetDebugSourceFolders (solution, selector.Directories.ToArray ());
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DisassemblyView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DisassemblyView.cs
@@ -133,7 +133,7 @@ namespace MonoDevelop.Debugger
 				var newFilePath = dlg.SelectedFile;
 				try {
 					if (File.Exists (newFilePath)) {
-						if (SourceCodeLookup.CheckFileMd5 (newFilePath, sf.SourceLocation.FileHash)) {
+						if (SourceCodeLookup.CheckFileHash (newFilePath, sf.SourceLocation.FileHash)) {
 							SourceCodeLookup.AddLoadedFile (newFilePath, sf.SourceLocation.FileName);
 							sf.UpdateSourceFile (newFilePath);
 							if (IdeApp.Workbench.OpenDocument (newFilePath, null, sf.SourceLocation.Line, 1, OpenDocumentOptions.Debugger) != null) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DisassemblyView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DisassemblyView.cs
@@ -92,65 +92,6 @@ namespace MonoDevelop.Debugger
 			DebuggingService.StoppedEvent += OnStop;
 		}
 
-		HBox messageOverlayContent;
-
-		void ShowLoadSourceFile (StackFrame sf)
-		{
-			if (messageOverlayContent != null) {
-				editor.RemoveOverlay (messageOverlayContent);
-				messageOverlayContent = null;
-			}
-			messageOverlayContent = new HBox ();
-
-			var hbox = new HBox ();
-			hbox.Spacing = 8;
-			var label = new Label (GettextCatalog.GetString ("{0} not found. Find source file at alternative location.", Path.GetFileName (sf.SourceLocation.FileName)));
-			hbox.TooltipText = sf.SourceLocation.FileName;
-
-			var color = SyntaxHighlightingService.GetColor (editor.Options.GetEditorTheme (), EditorThemeColors.NotificationText);
-			label.ModifyFg (StateType.Normal, color);
-
-			int w, h;
-			label.Layout.GetPixelSize (out w, out h);
-
-			hbox.PackStart (label, true, true, 0);
-			var openButton = new Button (Gtk.Stock.Open);
-			openButton.WidthRequest = 60;
-			hbox.PackEnd (openButton, false, false, 0); 
-
-			const int containerPadding = 8;
-			messageOverlayContent.PackStart (hbox, true, true, containerPadding);
-			editor.AddOverlay (messageOverlayContent,() => openButton.SizeRequest ().Width + w + hbox.Spacing * 5 + containerPadding * 2);
-
-			openButton.Clicked += delegate {
-				var dlg = new OpenFileDialog (GettextCatalog.GetString ("File to Open"), MonoDevelop.Components.FileChooserAction.Open) {
-					TransientFor = IdeApp.Workbench.RootWindow,
-					ShowEncodingSelector = true,
-					ShowViewerSelector = true
-				};
-				if (!dlg.Run ())
-					return;
-				var newFilePath = dlg.SelectedFile;
-				try {
-					if (File.Exists (newFilePath)) {
-						if (SourceCodeLookup.CheckFileHash (newFilePath, sf.SourceLocation.FileHash)) {
-							SourceCodeLookup.AddLoadedFile (newFilePath, sf.SourceLocation.FileName);
-							sf.UpdateSourceFile (newFilePath);
-							if (IdeApp.Workbench.OpenDocument (newFilePath, null, sf.SourceLocation.Line, 1, OpenDocumentOptions.Debugger) != null) {
-								this.WorkbenchWindow.CloseWindow (false);
-							}
-						} else {
-							MessageService.ShowWarning (GettextCatalog.GetString("File checksum doesn't match."));
-						}
-					} else {
-						MessageService.ShowWarning (GettextCatalog.GetString ("File not found."));
-					}
-				} catch (Exception) {
-					MessageService.ShowWarning (GettextCatalog.GetString ("Error opening file."));
-				}
-			};
-		}
-
 		public override string TabPageLabel {
 			get {
 				return GettextCatalog.GetString ("Disassembly");
@@ -178,24 +119,12 @@ namespace MonoDevelop.Debugger
 			}
 			
 			if (DebuggingService.CurrentFrame == null) {
-				if (messageOverlayContent != null) {
-					editor.RemoveOverlay (messageOverlayContent);
-					messageOverlayContent = null;
-				}
 				sw.Sensitive = false;
 				return;
 			}
 			
 			sw.Sensitive = true;
 			var sf = DebuggingService.CurrentFrame;
-			if (!string.IsNullOrWhiteSpace (sf.SourceLocation.FileName) && sf.SourceLocation.Line != -1 && sf.SourceLocation.FileHash != null) {
-				ShowLoadSourceFile (sf);
-			} else {
-				if (messageOverlayContent != null) {
-					editor.RemoveOverlay (messageOverlayContent);
-					messageOverlayContent = null;
-				}
-			}
 			if (!string.IsNullOrEmpty (sf.SourceLocation.FileName) && File.Exists (sf.SourceLocation.FileName))
 				FillWithSource ();
 			else
@@ -406,10 +335,6 @@ namespace MonoDevelop.Debugger
 				return;
 			addressLines.Clear ();
 			currentFile = null;
-			if (messageOverlayContent != null) {
-				editor.RemoveOverlay (messageOverlayContent);
-				messageOverlayContent = null;
-			}
 			sw.Sensitive = false;
 			autoRefill = false;
 			editor.Text = string.Empty;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -59,13 +59,13 @@ namespace MonoDevelop.Debugger
 				headerLabel.Markup = GettextCatalog.GetString ("{0} file not found", $"<b>{fileName}</b>");
 				box.PackStart (headerLabel);
 				var actionsBox = new HBox ();
-				var buttonBrowseAndFind = new Button (GettextCatalog.GetString ($"Browse and find {fileName}"));
+				var buttonBrowseAndFind = new Button (GettextCatalog.GetString ("Browse and find {0}", fileName));
 				buttonBrowseAndFind.Clicked += OpenFindSourceFileDialog;
 				actionsBox.PackStart (buttonBrowseAndFind);
 				box.PackStart (actionsBox);
 				if (IdeApp.ProjectOperations.CurrentSelectedSolution != null) {
 					var manageLookupsLabel = new Label ();
-					manageLookupsLabel.Markup = GettextCatalog.GetString ("Manage the locations used to find source files in the {0}", $"<a href=\"clicked\">{GettextCatalog.GetString ("Solution Options")}</a>");
+					manageLookupsLabel.Markup = GettextCatalog.GetString ("Manage the locations used to find source files in the {0}", "<a href=\"clicked\">" + GettextCatalog.GetString ("Solution Options") + "</a>");
 					manageLookupsLabel.LinkClicked += (sender, e) => {
 						if (IdeApp.ProjectOperations.CurrentSelectedSolution == null)
 							return;
@@ -84,7 +84,7 @@ namespace MonoDevelop.Debugger
 			}
 			if (!disassemblyNotSupported) {
 				var labelDisassembly = new Label ();
-				labelDisassembly.Markup = GettextCatalog.GetString ("View disassembly in the {0}", $"<a href=\"clicked\">{GettextCatalog.GetString ("Disassembly Tab")}</a>");
+				labelDisassembly.Markup = GettextCatalog.GetString ("View disassembly in the {0}", "<a href=\"clicked\">" + GettextCatalog.GetString ("Disassembly Tab") + "</a>");
 				labelDisassembly.LinkClicked += (sender, e) => {
 					DebuggingService.ShowDisassembly ();
 					this.WorkbenchWindow.CloseWindow (false);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -69,6 +69,7 @@ namespace MonoDevelop.Debugger
 				headerLabel.Font = label.Font.WithScaledSize (2);
 				optionsLabel.Font = label.Font.WithScaledSize (1.5);
 				box.PackStart (browseAndFindLabel);
+				box.PackStart (new Label (GettextCatalog.GetString ("You can manage the locations used to find source files in the Solution Options.")));
 			} else {
 				ContentName = GettextCatalog.GetString ("Source Not Available");
 				var headerLabel = new Label (GettextCatalog.GetString ("Source Not Available"));

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -1,0 +1,138 @@
+﻿//
+// NoSourceView.cs
+//
+// Author:
+//       David Karlaš <david.karlas@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.IO;
+using MonoDevelop.Components;
+using MonoDevelop.Core;
+using MonoDevelop.Ide;
+using MonoDevelop.Ide.Gui;
+using Xwt;
+
+namespace MonoDevelop.Debugger
+{
+	public class NoSourceView : ViewContent
+	{
+		XwtControl xwtControl;
+		ScrollView scrollView = new ScrollView ();
+		public NoSourceView ()
+		{
+			xwtControl = new XwtControl (scrollView);
+		}
+
+		public void Update (bool disassemblyNotSupported)
+		{
+			scrollView.Content = CreateContent (disassemblyNotSupported);
+		}
+
+		Widget CreateContent (bool disassemblyNotSupported)
+		{
+			var fileName = GetFilename (DebuggingService.CurrentFrame?.SourceLocation?.FileName);
+			var box = new VBox ();
+			box.Margin = 30;
+			box.Spacing = 10;
+			if (!string.IsNullOrEmpty (fileName)) {
+				ContentName = GettextCatalog.GetString ("Source Not Found");
+				var headerLabel = new Label (GettextCatalog.GetString ("{0} not found", fileName));
+				box.PackStart (headerLabel);
+				var label = new Label (GettextCatalog.GetString ("You need to find {0} to view the source for the current call stack frame", fileName));
+				box.PackStart (label);
+
+				var optionsLabel = new Label (GettextCatalog.GetString ("Try one of the following options:"));
+				box.PackStart (optionsLabel);
+
+				var browseAndFindLabel = new Label ();
+				browseAndFindLabel.Markup = $"    - <a href=\"clicked\">{GettextCatalog.GetString ("Browse and find {0}...", fileName)}</a>";
+				browseAndFindLabel.LinkClicked += OpenFindSourceFileDialog;
+				headerLabel.Font = label.Font.WithScaledSize (2);
+				optionsLabel.Font = label.Font.WithScaledSize (1.5);
+				box.PackStart (browseAndFindLabel);
+			} else {
+				ContentName = GettextCatalog.GetString ("Source Not Available");
+				var headerLabel = new Label (GettextCatalog.GetString ("Source Not Available"));
+				box.PackStart (headerLabel);
+				var label = new Label (GettextCatalog.GetString ("Source information is missing from the debug information for this module"));
+				box.PackStart (label);
+				headerLabel.Font = label.Font.WithScaledSize (2);
+			}
+			if (!disassemblyNotSupported) {
+				var labelDisassembly = new Label ();
+				labelDisassembly.Markup = GettextCatalog.GetString ("You can {0} in the Disassembly window.", $"<a href=\"clicked\">{GettextCatalog.GetString ("view disassembly")}</a>");
+				labelDisassembly.LinkClicked += (sender, e) => {
+					DebuggingService.ShowDisassembly ();
+					this.WorkbenchWindow.CloseWindow (false);
+				};
+				box.PackStart (labelDisassembly);
+			}
+			return box;
+		}
+
+		string GetFilename (string fileName)
+		{
+			if (fileName == null)
+				return null;
+			var index = fileName.LastIndexOfAny (new char [] { '/', '\\' });
+			if (index != -1)
+				return fileName.Substring (index + 1);
+			return fileName;
+		}
+
+		private void OpenFindSourceFileDialog (object sender, LinkEventArgs e)
+		{
+			var sf = DebuggingService.CurrentFrame;
+			if (sf == null) {
+				LoggingService.LogWarning ($"CurrentFrame was null in {nameof (OpenFindSourceFileDialog)}");
+				return;
+			}
+			var dlg = new Ide.Gui.Dialogs.OpenFileDialog (GettextCatalog.GetString ("File to Open") + " " + sf.SourceLocation.FileName, FileChooserAction.Open) {
+				TransientFor = IdeApp.Workbench.RootWindow,
+				ShowEncodingSelector = true,
+				ShowViewerSelector = true
+			};
+			if (!dlg.Run ())
+				return;
+			var newFilePath = dlg.SelectedFile;
+			try {
+				if (File.Exists (newFilePath)) {
+					var ignoreButton = new AlertButton (GettextCatalog.GetString ("Ignore"));
+					if (SourceCodeLookup.CheckFileHash (newFilePath, sf.SourceLocation.FileHash) ||
+						MessageService.AskQuestion (GettextCatalog.GetString ("File checksum doesn't match."), 1, ignoreButton, new AlertButton (GettextCatalog.GetString ("Cancel"))) == ignoreButton) {
+						SourceCodeLookup.AddLoadedFile (newFilePath, sf.SourceLocation.FileName);
+						sf.UpdateSourceFile (newFilePath);
+						if (IdeApp.Workbench.OpenDocument (newFilePath, null, sf.SourceLocation.Line, 1, OpenDocumentOptions.Debugger) != null) {
+							this.WorkbenchWindow.CloseWindow (false);
+						}
+					}
+				} else {
+					MessageService.ShowWarning (GettextCatalog.GetString ("File not found."));
+				}
+			} catch (Exception) {
+				MessageService.ShowWarning (GettextCatalog.GetString ("Error opening file."));
+			}
+		}
+
+		public override Control Control => xwtControl;
+	}
+}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -116,6 +116,9 @@ namespace MonoDevelop.Debugger
 				ShowEncodingSelector = true,
 				ShowViewerSelector = true
 			};
+			dlg.DirectoryChangedHandler = (s, path) => {
+				return SourceCodeLookup.TryDebugSourceFolders (sf.SourceLocation.FileName, sf.SourceLocation.FileHash, new string [] { path });
+			};
 			if (!dlg.Run ())
 				return;
 			var newFilePath = dlg.SelectedFile;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -55,21 +55,25 @@ namespace MonoDevelop.Debugger
 			box.Spacing = 10;
 			if (!string.IsNullOrEmpty (fileName)) {
 				ContentName = GettextCatalog.GetString ("Source Not Found");
-				var headerLabel = new Label (GettextCatalog.GetString ("{0} not found", fileName));
+				var headerLabel = new Label ();
+				headerLabel.Markup = GettextCatalog.GetString ("{0} file not found", $"<b>{fileName}</b>");
 				box.PackStart (headerLabel);
-				var label = new Label (GettextCatalog.GetString ("You need to find {0} to view the source for the current call stack frame", fileName));
-				box.PackStart (label);
-
-				var optionsLabel = new Label (GettextCatalog.GetString ("Try one of the following options:"));
-				box.PackStart (optionsLabel);
-
-				var browseAndFindLabel = new Label ();
-				browseAndFindLabel.Markup = $"    - <a href=\"clicked\">{GettextCatalog.GetString ("Browse and find {0}...", fileName)}</a>";
-				browseAndFindLabel.LinkClicked += OpenFindSourceFileDialog;
-				headerLabel.Font = label.Font.WithScaledSize (2);
-				optionsLabel.Font = label.Font.WithScaledSize (1.5);
-				box.PackStart (browseAndFindLabel);
-				box.PackStart (new Label (GettextCatalog.GetString ("You can manage the locations used to find source files in the Solution Options.")));
+				var actionsBox = new HBox ();
+				var buttonBrowseAndFind = new Button (GettextCatalog.GetString ($"Browse and find {fileName}"));
+				buttonBrowseAndFind.Clicked += OpenFindSourceFileDialog;
+				actionsBox.PackStart (buttonBrowseAndFind);
+				box.PackStart (actionsBox);
+				if (IdeApp.ProjectOperations.CurrentSelectedSolution != null) {
+					var manageLookupsLabel = new Label ();
+					manageLookupsLabel.Markup = GettextCatalog.GetString ("Manage the locations used to find source files in the {0}", $"<a href=\"clicked\">{GettextCatalog.GetString ("Solution Options")}</a>");
+					manageLookupsLabel.LinkClicked += (sender, e) => {
+						if (IdeApp.ProjectOperations.CurrentSelectedSolution == null)
+							return;
+						IdeApp.ProjectOperations.ShowOptions (IdeApp.ProjectOperations.CurrentSelectedSolution, "DebugSourceFiles");
+					};
+					box.PackStart (manageLookupsLabel);
+				}
+				headerLabel.Font = headerLabel.Font.WithScaledSize (2);
 			} else {
 				ContentName = GettextCatalog.GetString ("Source Not Available");
 				var headerLabel = new Label (GettextCatalog.GetString ("Source Not Available"));
@@ -80,7 +84,7 @@ namespace MonoDevelop.Debugger
 			}
 			if (!disassemblyNotSupported) {
 				var labelDisassembly = new Label ();
-				labelDisassembly.Markup = GettextCatalog.GetString ("You can {0} in the Disassembly window.", $"<a href=\"clicked\">{GettextCatalog.GetString ("view disassembly")}</a>");
+				labelDisassembly.Markup = GettextCatalog.GetString ("View disassembly in the {0}", $"<a href=\"clicked\">{GettextCatalog.GetString ("Disassembly Tab")}</a>");
 				labelDisassembly.LinkClicked += (sender, e) => {
 					DebuggingService.ShowDisassembly ();
 					this.WorkbenchWindow.CloseWindow (false);
@@ -100,7 +104,7 @@ namespace MonoDevelop.Debugger
 			return fileName;
 		}
 
-		private void OpenFindSourceFileDialog (object sender, LinkEventArgs e)
+		private void OpenFindSourceFileDialog (object sender, EventArgs e)
 		{
 			var sf = DebuggingService.CurrentFrame;
 			if (sf == null) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/SolutionHasDebugSourceFilesCondition.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/SolutionHasDebugSourceFilesCondition.cs
@@ -1,0 +1,43 @@
+﻿//
+// SolutionHasDebugSourceFilesCondition.cs
+//
+// Author:
+//       David Karlaš <david.karlas@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Mono.Addins;
+using MonoDevelop.Ide;
+using System.Linq;
+
+namespace MonoDevelop.Debugger
+{
+	public class SolutionHasDebugSourceFilesCondition : ConditionType
+	{
+		public override bool Evaluate (NodeElement conditionNode)
+		{
+			var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+			if(solution == null)
+				return false;
+			return SourceCodeLookup.GetDebugSourceFolders (solution).Any ();
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/SourceCodeLookup.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/SourceCodeLookup.cs
@@ -176,6 +176,9 @@ namespace MonoDevelop.Debugger
 
 		public static void SetDebugSourceFolders (Solution solution, string [] folders)
 		{
+			// Invalidate existing mappings so new DebugSourceFolders are used.
+			directMapping.Clear ();
+			possiblePaths.Clear ();
 			solution.UserProperties.SetValue (DebugSourceFoldersKey, folders);
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Extensions/ISelectFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Extensions/ISelectFileDialog.cs
@@ -40,7 +40,9 @@ namespace MonoDevelop.Components.Extensions
 	public interface ISelectFileDialogHandler : IDialogHandler<SelectFileDialogData>
 	{
 	}
-	
+
+	public delegate FilePath DirectoryChangedDelegate (object sender, string path);
+
 	/// <summary>
 	/// Data for the ISelectFileDialogHandler implementation
 	/// </summary>
@@ -61,8 +63,13 @@ namespace MonoDevelop.Components.Extensions
 			set { FilterSet.DefaultFilter = value; }
 		}
 		public bool ShowHidden { get; set; }
-	}	
-			
+		public DirectoryChangedDelegate DirectoryChangedHandler;
+		public FilePath OnDirectoryChanged (object sender, string path)
+		{
+			return DirectoryChangedHandler?.Invoke (sender, path) ?? FilePath.Null;
+		}
+	}
+
 	/// <summary>
 	/// Filter option to be displayed in file selector dialogs.
 	/// </summary>
@@ -326,6 +333,11 @@ namespace MonoDevelop.Components.Extensions
 				fdiag.Destroy ();
 				fdiag.Dispose ();
 			}
+		}
+
+		public DirectoryChangedDelegate DirectoryChangedHandler {
+			get { return data.DirectoryChangedHandler; }
+			set { data.DirectoryChangedHandler = value; }
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OpenFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OpenFileDialog.cs
@@ -98,6 +98,15 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			win.SelectedEncoding = Encoding != null ? Encoding.CodePage : 0;
 			win.ShowEncodingSelector = ShowEncodingSelector;
 			win.ShowViewerSelector = ShowViewerSelector;
+			bool pathAlreadySet = false;
+			win.CurrentFolderChanged += (s, e) => {
+				var selectedPath = data.OnDirectoryChanged (this, win.CurrentFolder);
+				if (selectedPath.IsNull)
+					return;
+				data.SelectedFiles = new FilePath [] { selectedPath };
+				pathAlreadySet = true;
+				win.Respond (Gtk.ResponseType.Cancel);
+			};
 			
 			SetDefaultProperties (win);
 			
@@ -110,7 +119,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 					data.SelectedViewer = win.SelectedViewer;
 					return true;
 				} else
-					return false;
+					return pathAlreadySet;
 			} finally {
 				win.Destroy ();
 				win.Dispose ();


### PR DESCRIPTION
Card:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/500134

This pull request adds support also for Portable .pdb(beside .mdb).
Adds UI familiar to VS2017 developer when source is missing instead going to Diasassembly view directly:
VSfM:
![image](https://user-images.githubusercontent.com/774791/31017213-1b77c3fc-a528-11e7-9916-4155fe8cace2.png)
VS2017:
![image](https://user-images.githubusercontent.com/774791/31016913-ef4b59f2-a526-11e7-8423-9fba1cf0b9d3.png)

It also adds options to manage "Debug Sources Files" into Solution options
![image](https://user-images.githubusercontent.com/774791/31016455-0d1dfc84-a525-11e7-9db7-7fb02dc2f599.png)