### PR TITLE
[59738] Fix Titlebar background color on HighSierra

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/MacSystemInformation.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/MacSystemInformation.cs
@@ -30,6 +30,8 @@ namespace MonoDevelop.Core
 {
 	public class MacSystemInformation : UnixSystemInformation
 	{
+		public static readonly Version HighSierra = new Version (10, 13);
+		public static readonly Version Sierra = new Version (10, 12);
 		public static readonly Version ElCapitan = new Version (10, 11);
 		public static readonly Version Yosemite = new Version (10, 10);
 		public static readonly Version Mavericks = new Version (10, 9);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
@@ -349,6 +349,8 @@ namespace MonoDevelop.Components
 					window.BackgroundColor = NSColor.FromPatternImage (image.ToBitmap().ToNSImage());
 				}
 			}
+			if (MacSystemInformation.OsVersion >= MacSystemInformation.HighSierra)
+				window.TitlebarAppearsTransparent = true;
 			window.StyleMask |= NSWindowStyle.TexturedBackground;
 		}
 


### PR DESCRIPTION
This patch fixes just the dark titlebar background color (but not all the other `VibrantDark` `NSAppearance` issues on High Sierra :disappointed: ).