### PR TITLE
Implemented Quick Info for folded code.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -2478,14 +2478,14 @@ namespace Mono.TextEditor
 
 		uint codeSegmentTooltipTimeoutId = 0;
 
-		void ShowTooltip (ISegment segment, Rectangle hintRectangle)
+		internal void ShowTooltip (ISegment segment, Rectangle hintRectangle)
 		{
 			if (previewWindow != null && previewWindow.Segment.Equals (segment))
 				return;
 			CancelCodeSegmentTooltip ();
-			HideCodeSegmentPreviewWindow ();
 			if (segment.IsInvalid () || segment.Length == 0)
 				return;
+			HideCodeSegmentPreviewWindow ();
 			codeSegmentTooltipTimeoutId = GLib.Timeout.Add (650, delegate {
 				codeSegmentTooltipTimeoutId = 0;
 				previewWindow = new CodeSegmentPreviewWindow (textEditor, false, segment);


### PR DESCRIPTION
That changes was made for implementing  "quick info" popup keyboard accessibility (bug 53730). 
Short cut was changed from "Ctrl+F1" to "Shift+F1", because Ctrl + ... reserved for MacOs and don't firing OnKeyPressEvent.  
Also was provided  TextViewMargin.ShowTooltip(ISegment segment, Rectangle hintRectangle), calling, and hiding "Quick Info" popup, when it lost focus. 