### PR TITLE
[Ide][59844] Fix unicode markup parsing

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1330,6 +1330,9 @@ namespace MonoDevelop.Components
 				buffer.Clear ();
 				var mark = buffer.CreateMark (null, iter, false);
 				var attrIter = attrList.Iterator;
+				//HACK: the parsed attribute indexes are byte based and need to be converted
+				//      to char indexes. Otherwise they won't match multibyte characters.
+				var indexer = new TextIndexer (text);
 
 				do {
 					int start, end;
@@ -1337,9 +1340,12 @@ namespace MonoDevelop.Components
 					attrIter.Range (out start, out end);
 
 					if (end == int.MaxValue) // last chunk
-						end = text.Length - 1;
+						end = indexer.IndexToByteIndex (text.Length - 1);
 					if (end <= start)
 						break;
+
+					start = indexer.ByteIndexToIndex (start);
+					end = indexer.ByteIndexToIndex (end);
 
 					TextTag tag;
 					if (attrIter.GetTagForAttributes (null, out tag)) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PangoUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PangoUtil.cs
@@ -257,4 +257,52 @@ namespace MonoDevelop.Components
 			});
 		}
 	}
+
+	internal class TextIndexer
+	{
+		int [] indexToByteIndex;
+		int [] byteIndexToIndex;
+
+		public TextIndexer (string text)
+		{
+			SetupTables (text);
+		}
+
+		public int IndexToByteIndex (int i)
+		{
+			if (i >= indexToByteIndex.Length)
+				// if the index exceeds the byte index range, return the last byte index + 1
+				// telling pango to span the attribute to the end of the string
+				// this happens if the string contains multibyte characters
+				return indexToByteIndex [i - 1] + 1;
+			return indexToByteIndex [i];
+		}
+
+		public int ByteIndexToIndex (int i)
+		{
+			return byteIndexToIndex [i];
+		}
+
+		public void SetupTables (string text)
+		{
+			if (text == null) {
+				this.indexToByteIndex = new int [0];
+				this.byteIndexToIndex = new int [0];
+				return;
+			}
+
+			var arr = text.ToCharArray ();
+			int byteIndex = 0;
+			int [] indexToByteIndex = new int [arr.Length];
+			var byteIndexToIndex = new System.Collections.Generic.List<int> ();
+			for (int i = 0; i < arr.Length; i++) {
+				indexToByteIndex [i] = byteIndex;
+				byteIndex += System.Text.Encoding.UTF8.GetByteCount (arr, i, 1);
+				while (byteIndexToIndex.Count < byteIndex)
+					byteIndexToIndex.Add (i);
+			}
+			this.indexToByteIndex = indexToByteIndex;
+			this.byteIndexToIndex = byteIndexToIndex.ToArray ();
+		}
+	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PangoUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PangoUtil.cs
@@ -260,8 +260,9 @@ namespace MonoDevelop.Components
 
 	internal class TextIndexer
 	{
+		static System.Collections.Generic.List<int> emptyList = new System.Collections.Generic.List<int> ();
 		int [] indexToByteIndex;
-		int [] byteIndexToIndex;
+		System.Collections.Generic.List<int> byteIndexToIndex;
 
 		public TextIndexer (string text)
 		{
@@ -285,24 +286,27 @@ namespace MonoDevelop.Components
 
 		public void SetupTables (string text)
 		{
-			if (text == null) {
-				this.indexToByteIndex = new int [0];
-				this.byteIndexToIndex = new int [0];
+			if (string.IsNullOrEmpty (text)) {
+				this.indexToByteIndex = Array.Empty<int> ();
+				this.byteIndexToIndex = emptyList;
 				return;
 			}
 
-			var arr = text.ToCharArray ();
 			int byteIndex = 0;
-			int [] indexToByteIndex = new int [arr.Length];
-			var byteIndexToIndex = new System.Collections.Generic.List<int> ();
-			for (int i = 0; i < arr.Length; i++) {
-				indexToByteIndex [i] = byteIndex;
-				byteIndex += System.Text.Encoding.UTF8.GetByteCount (arr, i, 1);
-				while (byteIndexToIndex.Count < byteIndex)
-					byteIndexToIndex.Add (i);
+			int [] indexToByteIndex = new int [text.Length];
+			var byteIndexToIndex = new System.Collections.Generic.List<int> (text.Length);
+			unsafe {
+				fixed (char *p = text) {
+					for (int i = 0; i < text.Length; i++) {
+						indexToByteIndex [i] = byteIndex;
+						byteIndex += System.Text.Encoding.UTF8.GetByteCount (p + i, 1);
+						while (byteIndexToIndex.Count < byteIndex)
+							byteIndexToIndex.Add (i);
+						}
+					}
 			}
 			this.indexToByteIndex = indexToByteIndex;
-			this.byteIndexToIndex = byteIndexToIndex.ToArray ();
+			this.byteIndexToIndex = byteIndexToIndex;
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Components/PangoUtilTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Components/PangoUtilTests.cs
@@ -33,6 +33,7 @@ namespace MonoDevelop.Components
 	{
 		[TestCase ("Test", 3, 3, 3, 3)]
 		[TestCase ("バージョン", 1, 3, 3, 1)]
+		[TestCase ("バージョン", 1, 3, 4, 1)]
 		public void TextIndexerWorks (string arg, int index, int indexToByteIndex, int byteIndex, int byteIndexToIndex)
 		{
 			var indexer = new TextIndexer (arg);

--- a/main/tests/Ide.Tests/MonoDevelop.Components/PangoUtilTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Components/PangoUtilTests.cs
@@ -31,15 +31,56 @@ namespace MonoDevelop.Components
 	[TestFixture]
 	public class PangoUtilTests
 	{
-		[TestCase ("Test", 3, 3, 3, 3)]
-		[TestCase ("バージョン", 1, 3, 3, 1)]
-		[TestCase ("バージョン", 1, 3, 4, 1)]
-		public void TextIndexerWorks (string arg, int index, int indexToByteIndex, int byteIndex, int byteIndexToIndex)
+		[Test]
+		public void TextIndexerAscii ()
 		{
-			var indexer = new TextIndexer (arg);
+			var str = "Test";
+			var indexer = new TextIndexer (str);
 
-			Assert.AreEqual (indexToByteIndex, indexer.IndexToByteIndex (index));
-			Assert.AreEqual (byteIndexToIndex, indexer.ByteIndexToIndex (byteIndex));
+			Assert.AreEqual (0, indexer.IndexToByteIndex (0));
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (0));
+			Assert.AreEqual (1, indexer.IndexToByteIndex (1));
+			Assert.AreEqual (1, indexer.ByteIndexToIndex (1));
+			Assert.AreEqual (2, indexer.IndexToByteIndex (2));
+			Assert.AreEqual (2, indexer.ByteIndexToIndex (2));
+			Assert.AreEqual (3, indexer.IndexToByteIndex (3));
+			Assert.AreEqual (3, indexer.ByteIndexToIndex (3));
+		}
+
+		[Test]
+		public void TextIndexerUnicode ()
+		{
+			var str = "バージョン";
+			var indexer = new TextIndexer (str);
+
+			Assert.AreEqual (0, indexer.IndexToByteIndex (0));
+			Assert.AreEqual (3, indexer.IndexToByteIndex (1));
+			Assert.AreEqual (6, indexer.IndexToByteIndex (2));
+
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (0));
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (1));
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (2));
+			Assert.AreEqual (1, indexer.ByteIndexToIndex (3));
+			Assert.AreEqual (1, indexer.ByteIndexToIndex (4));
+			Assert.AreEqual (1, indexer.ByteIndexToIndex (5));
+		}
+
+		[Test]
+		public void TextIndexerMixed ()
+		{
+			var str = "バAジョン";
+			var indexer = new TextIndexer (str);
+
+			Assert.AreEqual (0, indexer.IndexToByteIndex (0));
+			Assert.AreEqual (3, indexer.IndexToByteIndex (1));
+			Assert.AreEqual (4, indexer.IndexToByteIndex (2));
+
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (0));
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (1));
+			Assert.AreEqual (0, indexer.ByteIndexToIndex (2));
+			Assert.AreEqual (1, indexer.ByteIndexToIndex (3));
+			Assert.AreEqual (2, indexer.ByteIndexToIndex (4));
+			Assert.AreEqual (2, indexer.ByteIndexToIndex (5));
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Components/PangoUtilTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Components/PangoUtilTests.cs
@@ -1,0 +1,44 @@
+﻿//
+// PangoUtilTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace MonoDevelop.Components
+{
+	[TestFixture]
+	public class PangoUtilTests
+	{
+		[TestCase ("Test", 3, 3, 3, 3)]
+		[TestCase ("バージョン", 1, 3, 3, 1)]
+		public void TextIndexerWorks (string arg, int index, int indexToByteIndex, int byteIndex, int byteIndexToIndex)
+		{
+			var indexer = new TextIndexer (arg);
+
+			Assert.AreEqual (indexToByteIndex, indexer.IndexToByteIndex (index));
+			Assert.AreEqual (byteIndexToIndex, indexer.ByteIndexToIndex (byteIndex));
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="MonoDevelop.Ide.Gui\TestDocument.cs" />
     <Compile Include="TypeSystemServiceTestExtensions.cs" />
     <Compile Include="MonoDevelop.Ide.Editor\SkipCharSessionTests.cs" />
+    <Compile Include="MonoDevelop.Components\PangoUtilTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -166,5 +167,6 @@
     <Folder Include="MonoDevelop.Ide.Templates\" />
     <Folder Include="MonoDevelop.Components.PropertyGrid\" />
     <Folder Include="MonoDevelop.SourceEditor\" />
+    <Folder Include="MonoDevelop.Components\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Pango parses a markup without respecting multibyte
characters (byte based), hence the attribute indexes
need to be converted, in order to match the encoded
string representation.

(fixes bug #59844)