### PR TITLE
Nuke leaks caused by a11y event handlers

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskStrip.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskStrip.cs
@@ -155,8 +155,12 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			if (mapMode != null) {
 				mapMode.Destroy ();
 				mapMode = null;
+			}
+			if (overviewMode != null) {
+				overviewMode.Destroy ();
 				overviewMode = null;
 			}
+
 			if (EnableFancyFeatures) {
 				switch (ScrollBarMode) {
 				case ScrollBarMode.Overview:

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebookTab.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebookTab.cs
@@ -33,7 +33,7 @@ using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.Components.DockNotebook
 {
-	class DockNotebookTab: IAnimatable
+	class DockNotebookTab: IAnimatable, IDisposable
 	{
 		DockNotebook notebook;
 		readonly TabStrip strip;
@@ -223,7 +223,7 @@ namespace MonoDevelop.Components.DockNotebook
 			CloseButtonAccessible.PerformPress += OnPressCloseButton;
 			CloseButtonAccessible.SetRole (AtkCocoa.Roles.AXButton);
 			CloseButtonAccessible.GtkParent = strip;
-			CloseButtonAccessible.PerformShowMenu += OnShowMenu;
+			CloseButtonAccessible.PerformShowMenu += OnCloseButtonShowMenu;
 			CloseButtonAccessible.Title = Core.GettextCatalog.GetString ("Close document");
 			CloseButtonAccessible.Identifier = "DockNotebook.Tab.CloseButton";
 			Accessible.AddAccessibleChild (CloseButtonAccessible);
@@ -267,6 +267,14 @@ namespace MonoDevelop.Components.DockNotebook
 		void OnCloseButtonShowMenu (object sender, EventArgs args)
 		{
 			AccessibilityShowMenu?.Invoke (this, args);
+		}
+
+		public void Dispose ()
+		{
+			Accessible.PerformPress -= OnPressTab;
+			Accessible.PerformShowMenu -= OnShowMenu;
+			CloseButtonAccessible.PerformShowMenu -= OnCloseButtonShowMenu;
+			CloseButtonAccessible.PerformPress -= OnPressCloseButton;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/TabStrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/TabStrip.cs
@@ -268,6 +268,8 @@ namespace MonoDevelop.Components.DockNotebook
 
 			Accessible.RemoveAccessibleElement (tab.Accessible);
 
+			tab.Dispose ();
+
 			QueueResize ();
 
 			UpdateAccessibilityTabs ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
@@ -257,6 +257,7 @@ namespace MonoDevelop.Components
 				}
 			}
 
+			TextElement[] textElements;
 			void CalcAccessibility ()
 			{
 				var columnElement = new AtkCocoaHelper.AccessibilityElementProxy ();
@@ -264,7 +265,9 @@ namespace MonoDevelop.Components
 				columnElement.SetRole (AtkCocoa.Roles.AXColumn);
 				Accessible.AddAccessibleElement (columnElement);
 
-				for (int i = 0; i < win.DataProvider.IconCount; i++) {
+				int count = win.DataProvider.IconCount;
+				textElements = new TextElement[count];
+				for (int i = 0; i < count; i++) {
 					var rowElement = new AtkCocoaHelper.AccessibilityElementProxy ();
 					rowElement.GtkParent = this;
 					rowElement.SetRole (AtkCocoa.Roles.AXRow);
@@ -276,7 +279,7 @@ namespace MonoDevelop.Components
 					columnElement.AddAccessibleChild (cellElement);
 					rowElement.AddAccessibleChild (cellElement);
 
-					var textElement = new TextElement ();
+					var textElement = textElements[i] = new TextElement ();
 					textElement.RowIndex = i;
 					textElement.PerformPress += PerformPress;
 					textElement.GtkParent = this;
@@ -287,7 +290,7 @@ namespace MonoDevelop.Components
 
 			void PerformPress (object sender, EventArgs args)
 			{
-				var element = sender as TextElement;
+				var element = (TextElement)sender;
 				win.DataProvider.ActivateItem (element.RowIndex);
 			}
 
@@ -313,6 +316,13 @@ namespace MonoDevelop.Components
 
 			protected override void OnDestroyed ()
 			{
+				if (textElements != null) {
+					foreach (var textElement in textElements) {
+						textElement.PerformPress -= PerformPress;
+					}
+					textElements = null;
+				}
+
 				if (layout != null) {
 					layout.Dispose ();
 					layout = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
@@ -110,7 +110,8 @@ namespace MonoDevelop.Components
 
 		public void SelectItem (object item)
 		{
-			for (int i = 0; i < DataProvider.IconCount; i++) {
+			int count = DataProvider.IconCount;
+			for (int i = 0; i < count; i++) {
 				if (DataProvider.GetTag (i) == item) {
 					list.Selection = i;
 					vScrollbar.Vadjustment.Value = Math.Max (0, i * list.RowHeight - vScrollbar.Vadjustment.PageSize / 2);
@@ -122,7 +123,8 @@ namespace MonoDevelop.Components
 		void SwitchToSeletedWord ()
 		{
 			string selection = list.WordSelection.ToString ();
-			for (int i = 0; i < DataProvider.IconCount; i++) {
+			int count = DataProvider.IconCount;
+			for (int i = 0; i < count; i++) {
 				if (DataProvider.GetMarkup (i).StartsWith (selection, StringComparison.OrdinalIgnoreCase)) {
 					list.Selection = i;
 					list.WordSelection.Append (selection);
@@ -537,8 +539,9 @@ namespace MonoDevelop.Components
 					return 0;
 				int longest = 0;
 				string longestText = win.DataProvider.GetMarkup (0) ?? "";
-				
-				for (int i = 1; i < win.DataProvider.IconCount; i++) {
+
+				int count = win.DataProvider.IconCount;
+				for (int i = 1; i < count; i++) {
 					string curText = win.DataProvider.GetMarkup (i) ?? "";
 					if (curText.Length > longestText.Length) {
 						longestText = curText;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -44,7 +44,7 @@ namespace MonoDevelop.Components
 		Right
 	}
 	
-	public class PathEntry 
+	public class PathEntry : IDisposable
 	{
 		Xwt.Drawing.Image darkIcon;
 
@@ -135,6 +135,14 @@ namespace MonoDevelop.Components
 		void OnPerformShowMenu (object sender, EventArgs e)
 		{
 			PerformShowMenu?.Invoke (this, EventArgs.Empty);
+		}
+
+		public void Dispose ()
+		{
+			if (accessible != null) {
+				accessible.PerformPress -= OnPerformShowMenu;
+				accessible = null;
+			}
 		}
 	}
 	
@@ -233,11 +241,22 @@ namespace MonoDevelop.Components
 			Accessible.ReplaceAccessibilityElements (elements);
 		}
 
+		void DisposeProxies()
+		{
+			if (Path == null)
+				return;
+
+			foreach (var entry in Path) {
+				entry.PerformShowMenu -= PerformShowMenu;
+			}
+		}
+
 		public void SetPath (PathEntry[] path)
 		{
 			if (ArrSame (this.leftPath, path))
 				return;
 
+			DisposeProxies ();
 			HideMenu ();
 
 			this.Path = path ?? new PathEntry[0];

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
@@ -383,8 +383,13 @@ namespace MonoDevelop.Components
 		
 		public void Dispose ()
 		{
+			if (Accessible != null) {
+				Accessible.PerformPress -= OnTabPressed;
+				Accessible = null;
+			}
+
 			if (layout != null)
-				layout.Dispose ();
+				layout.Dispose();
 		}
 
 		public AtkCocoaHelper.AccessibilityElementProxy Accessible { get; private set; }


### PR DESCRIPTION
After lots of trial and error, the main way to fix this leak is by manually unsubscribing events from the a11y proxies, as they can cause strong ref cycles between the object defining the event handler and the one holding the multicast delegate.

This fixes most of the source editor leaks caused by typing and opening/closing docs.