### PR TITLE
[Xml] Fix possible crash when opening Xaml file

### DIFF
--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -961,7 +961,7 @@ namespace MonoDevelop.Xml.Editor
 			var path = new List<PathEntry> ();
 			if (ownerProjects.Count > 1) {
 				// Current project if there is more than one
-				path.Add (new PathEntry (ImageService.GetIcon (DocumentContext.Project.StockIcon), GLib.Markup.EscapeText (DocumentContext.Project.Name)) { Tag = DocumentContext.Project });
+				path.Add (new PathEntry (ImageService.GetIcon (DocumentContext.Project.StockIcon, Gtk.IconSize.Menu), GLib.Markup.EscapeText (DocumentContext.Project.Name)) { Tag = DocumentContext.Project });
 			}
 			if (l != null) {
 				for (int i = 0; i < l.Count; i++) {


### PR DESCRIPTION
@nosami was seeing a crash on opening a xaml file, caused by possibly not having an image size set on the path entry icon.
```
FATAL ERROR [2017-10-06 13:11:32Z]: An unhandled exception has occured. Terminating Visual Studio? True
System.InvalidOperationException: Image size has not been set and the image doesn't have a default size
  at Xwt.Drawing.Image.GetFixedSize () [0x0001b] in /Users/builder/data/lanes/5525/83cafc1a/source/monodevelop/main/external/xwt/Xwt/Xwt.Drawing/Image.cs:545
  at Xwt.Toolkit.RenderImage (System.Object nativeWidget, System.Object nativeContext, Xwt.Drawing.Image img, System.Double x, System.Double y) [0x00008] in /Users/builder/data/lanes/5525/83cafc1a/source/monodevelop/main/external/xwt/Xwt/Xwt/Toolkit.cs:782
  at MonoDevelop.Components.GtkUtil.DrawImage (Cairo.Context s, Gtk.Widget widget, Xwt.Drawing.Image image, System.Double x, System.Double y) [0x00000] in /Users/builder/data/lanes/5525/83cafc1a/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkUtil.cs:154
  at MonoDevelop.Components.PathBar.OnExposeEvent (Gdk.EventExpose evnt) [0x00178] in /Users/builder/data/lanes/5525/83cafc1a/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs:353
  at Gtk.Widget.exposeevent_cb (System.IntPtr widget, System.IntPtr evnt) [0x00016] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/gtk/generated/Widget.cs:1349
```