### PR TITLE
[d15-4] Support xamarin forms 2.4

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -226,10 +226,6 @@ namespace MonoDevelop.Projects.MSBuild
 					list.Insert (index++, new MSBuildImport { Sdk = sdkPath, Project = "Sdk.props" });
 					list.Add (new MSBuildImport { Sdk = sdkPath, Project = "Sdk.targets" });
 				}
-				var nugetPropsPath = $"$(BaseIntermediateOutputPath)\\{pi.Project.FileName.FileName}.nuget.g.props";
-				var nugetTargetsPath = $"$(BaseIntermediateOutputPath)\\{pi.Project.FileName.FileName}.nuget.g.targets";
-				list.Insert (index, new MSBuildImport { Project = nugetPropsPath, Condition = $"Exists('{nugetPropsPath}')" });
-				list.Add (new MSBuildImport { Project = nugetTargetsPath, Condition = $"Exists('{nugetTargetsPath}')" });
 				objects = list;
 			}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngine.cs
@@ -103,6 +103,8 @@ namespace MonoDevelop.Projects.MSBuild
 		public abstract ConditionedPropertyCollection GetConditionedProperties (object projectInstance);
 
 		public abstract IEnumerable<MSBuildItem> FindGlobItemsIncludingFile  (object projectInstance, string include);
+
+		internal abstract IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (object projectInstance, string include, MSBuildItem globItem);
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngineV12.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngineV12.cs
@@ -194,6 +194,11 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			throw new NotImplementedException ();
 		}
+
+		internal override IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (object projectInstance, string include, MSBuildItem globItem)
+		{
+			throw new NotImplementedException ();
+		}
 	}
 
 	#if !WINDOWS

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
@@ -126,6 +126,11 @@ namespace MonoDevelop.Projects.MSBuild
 			writer.WriteAttributeString ("Condition", cond);
 			writer.WriteEndElement ();
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("<Import Project='{0}'>", Project);
+		}
 	}
 
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -683,6 +683,11 @@ namespace MonoDevelop.Projects.MSBuild
 			return mainProjectInstance.FindGlobItemsIncludingFile (include);
 		}
 
+		internal IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (string include, MSBuildItem globItem)
+		{
+			return mainProjectInstance.FindUpdateGlobItemsIncludingFile (include, globItem);
+		}
+
 		public MSBuildPropertyGroup GetGlobalPropertyGroup ()
 		{
 			return PropertyGroups.FirstOrDefault (g => g.Condition.Length == 0);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -231,6 +231,11 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			return engine?.FindGlobItemsIncludingFile (projectInstance, include);
 		}
+
+		internal IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (string include, MSBuildItem globItem)
+		{
+			return engine?.FindUpdateGlobItemsIncludingFile (projectInstance, include, globItem);
+		}
 	}
 
 	class MSBuildProjectInstanceInfo

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -1371,6 +1371,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 					var vcTargetsPath = Path.Combine (extensionsPath, "Common7", "IDE", "VC", "VCTargets");
 					SetMSBuildConfigProperty (toolset, "VCTargetsPath", vcTargetsPath);
+				} else {
+					var path = MSBuildProjectService.GetProjectImportSearchPaths (runtime, false).FirstOrDefault (p => p.Property == "MSBuildSDKsPath");
+					if (path != null)
+						SetMSBuildConfigProperty (toolset, path.Property, path.Path);
 				}
 
 				var projectImportSearchPaths = doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")?.FirstOrDefault ()?.Element ("projectImportSearchPaths");

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildTarget.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildTarget.cs
@@ -229,6 +229,11 @@ namespace MonoDevelop.Projects.MSBuild
 			task.RemoveIndent ();
 			ChildNodes = ChildNodes.Remove (task);
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("<Target Name='{0}'>", Name);
+		}
 	}
 
 	public interface IMSBuildTargetEvaluated

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3346,14 +3346,6 @@ namespace MonoDevelop.Projects
 							buildItem = updateGlobItems [0];
 						} else {
 							buildItem = globItem;
-
-							var evaluatedItem = CreateFakeEvaluatedItem (msproject, buildItem, item.Include, sourceItems);
-
-							// Updating properties in the project item may fire events which assume they are
-							// on the UI thread.
-							Runtime.RunInMainThread (() => {
-								item.Read (this, evaluatedItem);
-							}).Wait ();
 						}
 					} else if (item.IsFromWildcardItem && item.ItemName != item.WildcardItem.Name) {
 						include = item.Include;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3309,8 +3309,9 @@ namespace MonoDevelop.Projects
 					var globItem = matchingGlobItems.FirstOrDefault (gi => gi.Name == item.ItemName);
 
 					if (globItem != null) {
+						var updateGlobItems = msproject.FindUpdateGlobItemsIncludingFile (item.Include, globItem).ToList ();
 						// Globbing magic can only be done if there is no metadata (for now)
-						if (globItem.Metadata.GetProperties ().Count () == 0) {
+						if (globItem.Metadata.GetProperties ().Count () == 0 && !updateGlobItems.Any ()) {
 							var it = new MSBuildItem (item.ItemName);
 							item.Write (this, it);
 							if (it.Metadata.GetProperties ().Count () == 0)
@@ -3340,6 +3341,9 @@ namespace MonoDevelop.Projects
 								buildItem = new MSBuildItem (item.ItemName) { Update = item.Include };
 								msproject.AddItem (buildItem);
 							}
+						} else if (updateGlobItems.Any ()) {
+							// Multiple update items not supported yet.
+							buildItem = updateGlobItems [0];
 						} else {
 							buildItem = globItem;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.Ide.Templates
 		string buildAction;
 		string customTool;
 		string customToolNamespace;
+		string subType;
 		List<string> references = new List<string> ();
 		
 		public override void Load (XmlElement filenode, FilePath baseDirectory)
@@ -70,6 +71,7 @@ namespace MonoDevelop.Ide.Templates
 			dependsOn = filenode.GetAttribute ("DependsOn");
 			customTool = filenode.GetAttribute ("CustomTool");
 			customToolNamespace = filenode.GetAttribute ("CustomToolNamespace");
+			subType = filenode.GetAttribute ("SubType");
 			
 			buildAction = BuildAction.Compile;
 			buildAction = filenode.GetAttribute ("BuildAction");
@@ -136,7 +138,10 @@ namespace MonoDevelop.Ide.Templates
 					var model = CombinedTagModel.GetTagModel (ProjectTagModel, policyParent, project, language, name, generatedFile);
 					projectFile.CustomToolNamespace = StringParserService.Parse (customToolNamespace, model);
 				}
-				
+
+				if (!string.IsNullOrEmpty (subType))
+					projectFile.ContentType = subType;
+
 				DotNetProject netProject = project as DotNetProject;
 				if (netProject != null) {
 					// Add required references

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -738,6 +738,8 @@ namespace MonoDevelop.Projects
 				File.WriteAllText (xamlFileName1, "xaml1");
 				var xamlFileName2 = projFile.ParentDirectory.Combine ("MyView2.xaml");
 				File.WriteAllText (xamlFileName2, "xaml2");
+				var xamlCSharpFileName = projFile.ParentDirectory.Combine ("MyView2.xaml.cs");
+				File.WriteAllText (xamlCSharpFileName, "csharpxaml");
 
 				var xamlFile1 = new ProjectFile (xamlFileName1, BuildAction.EmbeddedResource);
 				p.Files.Add (xamlFile1);
@@ -746,6 +748,9 @@ namespace MonoDevelop.Projects
 				var xamlFile2 = new ProjectFile (xamlFileName2, BuildAction.EmbeddedResource);
 				xamlFile2.Generator = "MSBuild:UpdateDesignTimeXaml";
 				p.Files.Add (xamlFile2);
+
+				var xamlCSharpFile = p.AddFile (xamlCSharpFileName);
+				xamlCSharpFile.DependsOn = "MyView2.xaml";
 
 				// Ensure no items are added to the project on saving.
 				await p.SaveAsync (Util.GetMonitor ());

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -736,21 +736,17 @@ namespace MonoDevelop.Projects
 
 				var xamlFileName1 = projFile.ParentDirectory.Combine ("MyView1.xaml");
 				File.WriteAllText (xamlFileName1, "xaml1");
-				var xamlFileName2 = projFile.ParentDirectory.Combine ("MyView2.xaml");
-				File.WriteAllText (xamlFileName2, "xaml2");
-				var xamlCSharpFileName = projFile.ParentDirectory.Combine ("MyView2.xaml.cs");
+				var xamlCSharpFileName = projFile.ParentDirectory.Combine ("MyView1.xaml.cs");
 				File.WriteAllText (xamlCSharpFileName, "csharpxaml");
 
+				// Xaml file with Generator and Subtype set to match that defined in the glob.
 				var xamlFile1 = new ProjectFile (xamlFileName1, BuildAction.EmbeddedResource);
+				xamlFile1.Generator = "MSBuild:UpdateDesignTimeXaml";
+				xamlFile1.ContentType = "Designer";
 				p.Files.Add (xamlFile1);
 
-				// Xaml file but with Generator set that matches that defined in the glob.
-				var xamlFile2 = new ProjectFile (xamlFileName2, BuildAction.EmbeddedResource);
-				xamlFile2.Generator = "MSBuild:UpdateDesignTimeXaml";
-				p.Files.Add (xamlFile2);
-
 				var xamlCSharpFile = p.AddFile (xamlCSharpFileName);
-				xamlCSharpFile.DependsOn = "MyView2.xaml";
+				xamlCSharpFile.DependsOn = "MyView1.xaml";
 
 				// Ensure no items are added to the project on saving.
 				await p.SaveAsync (Util.GetMonitor ());

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -721,6 +721,51 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		[Test]
+		public async Task AddFile_WildCardHasMetadataProperties ()
+		{
+			var fn = new CustomItemNode<SupportImportedProjectFilesProjectExtension> ();
+			WorkspaceObject.RegisterCustomExtension (fn);
+
+			try {
+				FilePath projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-import-metadata-prop.csproj");
+				string expectedProjectXml = File.ReadAllText (projFile);
+
+				var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+				p.UseAdvancedGlobSupport = true;
+
+				var xamlFileName1 = projFile.ParentDirectory.Combine ("MyView1.xaml");
+				File.WriteAllText (xamlFileName1, "xaml1");
+				var xamlFileName2 = projFile.ParentDirectory.Combine ("MyView2.xaml");
+				File.WriteAllText (xamlFileName2, "xaml2");
+
+				var xamlFile1 = new ProjectFile (xamlFileName1, BuildAction.EmbeddedResource);
+				p.Files.Add (xamlFile1);
+
+				// Xaml file but with Generator set that matches that defined in the glob.
+				var xamlFile2 = new ProjectFile (xamlFileName2, BuildAction.EmbeddedResource);
+				xamlFile2.Generator = "MSBuild:UpdateDesignTimeXaml";
+				p.Files.Add (xamlFile2);
+
+				// Ensure no items are added to the project on saving.
+				await p.SaveAsync (Util.GetMonitor ());
+
+				string projectXml = File.ReadAllText (p.FileName);
+				Assert.AreEqual (expectedProjectXml, projectXml);
+
+				// Save again. A second save was adding an include for the .xaml file whilst
+				// the first save was not.
+				await p.SaveAsync (Util.GetMonitor ());
+
+				projectXml = File.ReadAllText (p.FileName);
+				Assert.AreEqual (expectedProjectXml, projectXml);
+
+				p.Dispose ();
+			} finally {
+				WorkspaceObject.UnregisterCustomExtension (fn);
+			}
+		}
+
 		class SupportImportedProjectFilesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override bool OnGetSupportsImportedItem (IMSBuildItemEvaluated buildItem)

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -681,6 +681,38 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Tests that the %(FileName) metadata is correctly applied to a file from a Update glob.
+		///
+		/// Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)"
+		/// </summary>
+		[Test]
+		public async Task DependentUponUsingFileNameMetadataProperty ()
+		{
+			var fn = new CustomItemNode<SupportImportedProjectFilesProjectExtension> ();
+			WorkspaceObject.RegisterCustomExtension (fn);
+
+			try {
+				FilePath projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-import-metadata-prop.csproj");
+				var xamlCSharpFileName = projFile.ParentDirectory.Combine ("test.xaml.cs");
+				File.WriteAllText (xamlCSharpFileName, "csharp");
+				var xamlFileName = projFile.ParentDirectory.Combine ("test.xaml");
+				File.WriteAllText (xamlFileName, "xaml");
+				var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+				p.UseAdvancedGlobSupport = true;
+
+				var xamlCSharpFile = p.Files.Single (fi => fi.FilePath.FileName == "test.xaml.cs");
+				var xamlFile = p.Files.Single (fi => fi.FilePath.FileName == "test.xaml");
+
+				Assert.AreEqual (xamlFileName.ToString (), xamlCSharpFile.DependsOn);
+				Assert.AreEqual (xamlCSharpFile.DependsOnFile, xamlFile);
+
+				p.Dispose ();
+			} finally {
+				WorkspaceObject.UnregisterCustomExtension (fn);
+			}
+		}
+
 		class SupportImportedProjectFilesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override bool OnGetSupportsImportedItem (IMSBuildItemEvaluated buildItem)

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -694,6 +694,8 @@ namespace MonoDevelop.Projects
 
 			try {
 				FilePath projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-import-metadata-prop.csproj");
+				string expectedProjectXml = File.ReadAllText (projFile);
+
 				var xamlCSharpFileName = projFile.ParentDirectory.Combine ("test.xaml.cs");
 				File.WriteAllText (xamlCSharpFileName, "csharp");
 				var xamlFileName = projFile.ParentDirectory.Combine ("test.xaml");
@@ -706,6 +708,12 @@ namespace MonoDevelop.Projects
 
 				Assert.AreEqual (xamlFileName.ToString (), xamlCSharpFile.DependsOn);
 				Assert.AreEqual (xamlCSharpFile.DependsOnFile, xamlFile);
+
+				// Ensure the expanded %(FileName) does not get added to the main project on saving.
+				await p.SaveAsync (Util.GetMonitor ());
+
+				string projectXml = File.ReadAllText (p.FileName);
+				Assert.AreEqual (expectedProjectXml, projectXml);
 
 				p.Dispose ();
 			} finally {

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -1220,6 +1220,13 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// ProjectName.nuget.g.props and ProjectName.nuget.g.targets files are imported by Microsoft.Common.props
+		/// and Microsoft.Common.targets that are included with Mono:
+		///
+		/// /Library/Frameworks/Mono.framework/Versions/5.4.0/lib/mono/xbuild/15.0/Microsoft.Common.props
+		/// /Library/Frameworks/Mono.framework/Versions/5.4.0/lib/mono/msbuild/15.0/bin/Microsoft.Common.targets
+		/// </summary>
 		[Test]
 		public async Task GeneratedNuGetMSBuildFilesAreImportedWithDotNetCoreProject ()
 		{

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -3097,21 +3097,17 @@ namespace MonoDevelop.Projects
 			// Add new xaml files.
 			var xamlFileName1 = p.BaseDirectory.Combine ("MyView1.xaml");
 			File.WriteAllText (xamlFileName1, "xaml1");
-			var xamlFileName2 = p.BaseDirectory.Combine ("MyView2.xaml");
-			File.WriteAllText (xamlFileName2, "xaml2");
 			var xamlCSharpFileName = p.BaseDirectory.Combine ("MyView1.xaml.cs");
 			File.WriteAllText (xamlCSharpFileName, "csharpxaml");
 
+			// Xaml file with Generator and Subtype set to match that defined in the glob.
 			var xamlFile1 = new ProjectFile (xamlFileName1, BuildAction.EmbeddedResource);
+			xamlFile1.Generator = "MSBuild:UpdateDesignTimeXaml";
+			xamlFile1.ContentType = "Designer";
 			p.Files.Add (xamlFile1);
 
-			// Xaml file but with Generator set that matches that defined in the glob.
-			var xamlFile2 = new ProjectFile (xamlFileName2, BuildAction.EmbeddedResource);
-			xamlFile2.Generator = "MSBuild:UpdateDesignTimeXaml";
-			p.Files.Add (xamlFile2);
-
 			var xamlCSharpFile = p.AddFile (xamlCSharpFileName);
-			xamlCSharpFile.DependsOn = "MyView2.xaml";
+			xamlCSharpFile.DependsOn = "MyView1.xaml";
 
 			// The project file should be unchanged after saving.
 			await p.SaveAsync (Util.GetMonitor ());

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -3092,6 +3092,8 @@ namespace MonoDevelop.Projects
 			File.WriteAllText (xamlFileName1, "xaml1");
 			var xamlFileName2 = p.BaseDirectory.Combine ("MyView2.xaml");
 			File.WriteAllText (xamlFileName2, "xaml2");
+			var xamlCSharpFileName = p.BaseDirectory.Combine ("MyView1.xaml.cs");
+			File.WriteAllText (xamlCSharpFileName, "csharpxaml");
 
 			var xamlFile1 = new ProjectFile (xamlFileName1, BuildAction.EmbeddedResource);
 			p.Files.Add (xamlFile1);
@@ -3100,6 +3102,9 @@ namespace MonoDevelop.Projects
 			var xamlFile2 = new ProjectFile (xamlFileName2, BuildAction.EmbeddedResource);
 			xamlFile2.Generator = "MSBuild:UpdateDesignTimeXaml";
 			p.Files.Add (xamlFile2);
+
+			var xamlCSharpFile = p.AddFile (xamlCSharpFileName);
+			xamlCSharpFile.DependsOn = "MyView2.xaml";
 
 			// The project file should be unchanged after saving.
 			await p.SaveAsync (Util.GetMonitor ());

--- a/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
+++ b/main/tests/UnitTests/MonoDevelop.Projects/MSBuildTests.cs
@@ -3073,6 +3073,49 @@ namespace MonoDevelop.Projects
 
 			sol.Dispose ();
 		}
+
+		[Test]
+		public async Task AddFiles_NetStandardProjectWithXamarinFormsVersion24PackageReference ()
+		{
+			FilePath solFile = Util.GetSampleProject ("NetStandardXamarinForms", "NetStandardXamarinForms.sln");
+
+			var process = Process.Start ("msbuild", $"/t:Restore {solFile}");
+			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+			Assert.AreEqual (0, process.ExitCode);
+
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (Project)sol.Items [0];
+			string expectedProjectXml = File.ReadAllText (p.FileName);
+
+			// Add new xaml files.
+			var xamlFileName1 = p.BaseDirectory.Combine ("MyView1.xaml");
+			File.WriteAllText (xamlFileName1, "xaml1");
+			var xamlFileName2 = p.BaseDirectory.Combine ("MyView2.xaml");
+			File.WriteAllText (xamlFileName2, "xaml2");
+
+			var xamlFile1 = new ProjectFile (xamlFileName1, BuildAction.EmbeddedResource);
+			p.Files.Add (xamlFile1);
+
+			// Xaml file but with Generator set that matches that defined in the glob.
+			var xamlFile2 = new ProjectFile (xamlFileName2, BuildAction.EmbeddedResource);
+			xamlFile2.Generator = "MSBuild:UpdateDesignTimeXaml";
+			p.Files.Add (xamlFile2);
+
+			// The project file should be unchanged after saving.
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (expectedProjectXml, projectXml);
+
+			// Save again. A second save was adding an include for the .xaml file whilst
+			// the first save was not.
+			await p.SaveAsync (Util.GetMonitor ());
+
+			projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (expectedProjectXml, projectXml);
+
+			sol.Dispose ();
+		}
 	}
 
 	class MyProjectTypeNode: ProjectTypeNode

--- a/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms.sln
+++ b/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandardXamarinForms", "NetStandardXamarinForms\NetStandardXamarinForms.csproj", "{B32D4C8C-809E-4AD8-A71B-196D206AB0A4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B32D4C8C-809E-4AD8-A71B-196D206AB0A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B32D4C8C-809E-4AD8-A71B-196D206AB0A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B32D4C8C-809E-4AD8-A71B-196D206AB0A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B32D4C8C-809E-4AD8-A71B-196D206AB0A4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms/MyPage.xaml
+++ b/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms/MyPage.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="NetStandardXamarinForms.MyPage">
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms/MyPage.xaml.cs
+++ b/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms/MyPage.xaml.cs
@@ -1,0 +1,13 @@
+﻿
+using Xamarin.Forms;
+
+namespace NetStandardXamarinForms
+{
+	public partial class MyPage : ContentPage
+	{
+		public MyPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms/NetStandardXamarinForms.csproj
+++ b/main/tests/test-projects/NetStandardXamarinForms/NetStandardXamarinForms/NetStandardXamarinForms.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/dotnetcore-console/dotnetcore-console/dotnetcore-disable-default-items.csproj
+++ b/main/tests/test-projects/dotnetcore-console/dotnetcore-console/dotnetcore-disable-default-items.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Test.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-metadata-prop.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-metadata-prop.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="glob-import-metadata-prop.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-metadata-prop.props
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-metadata-prop.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.xaml" />
+    <Compile Include="**\*.cs" />
+    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/msbuild-glob-tests/glob-import-metadata-prop.props
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-import-metadata-prop.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <EmbeddedResource Include="**\*.xaml" />
+    <EmbeddedResource Include="**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
     <Compile Include="**\*.cs" />
-    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
+    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" SubType="Code" />
   </ItemGroup>
 </Project>

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=a8da992c78f7eb65b3cdb3f951c34a30337cab35
-DEP_BRANCH_AND_REMOTE[0]="d15-4 origin/d15-4"
+DEP_NEEDED_VERSION[0]=25824a2714bb5cb96e470a0113f13236809b323d
+DEP_BRANCH_AND_REMOTE[0]="d15-4-support-xamarin-forms-2.4 origin/d15-4-support-xamarin-forms-2.4"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
Various fixes for [bug 59286](https://bugzilla.xamarin.com/show_bug.cgi?id=59286).

The changes made to Project.cs are enough to get Xamarin.Forms 2.4 mostly working in a .NET Standard project. However the changes may not be enough to handle other MSBuild update items added by other NuGet packages.

Testing this branch the following problems have been identified and are not yet fixed. Renaming seems to be problematic independent of using Xamarin.Forms 2.4.

 - Add ContentPage with xaml then change build action to None for .xaml file.
 - Add ContentPage with xaml and then remove .xaml but do not delete .xaml file
 - Add ContentPage with xaml and then remove .xaml.cs file but do not delete .xaml.cs file
 - Add ContentPage with xaml. Then both .xaml and .xaml.cs file removed from the project but not deleted. Then edit .csproj and remove associated MSBuild items
 - Add ContentPage with xaml then rename .xaml file
 - Add ContentPage with xaml then rename .xaml.cs file

More detailed test steps:

https://gist.github.com/mrward/0c6f15ac2d781d1c154b76766e87c505