### PR TITLE
[Xml] Always show code completion when typing(not just Cmd+Space or start)

### DIFF
--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -346,11 +346,7 @@ namespace MonoDevelop.Xml.Editor
 
 			//attribute value completion
 			//determine whether to trigger completion within attribute values quotes
-			if ((Tracker.Engine.CurrentState is XmlAttributeValueState)
-			    //trigger on the opening quote
-			    && ((Tracker.Engine.CurrentStateLength == 1 && (currentChar == '\'' || currentChar == '"'))
-			    //or trigger on first letter of value, if unforced
-			    || (forced || Tracker.Engine.CurrentStateLength == 2))) {
+			if (Tracker.Engine.CurrentState is XmlAttributeValueState) {
 				var att = (XAttribute)Tracker.Engine.Nodes.Peek ();
 
 				if (att.IsNamed) {


### PR DESCRIPTION
To match VS2017 behaviour

This is basically same as https://github.com/mono/monodevelop/commit/fb7a266e308c670011611e12916e1d0d7219b63e but to also include attribute value(didn't realise at time that VS2017 also does this for attribute values)