### PR TITLE
[Core] Fix incorrect SDK style project updates when moving a file

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3237,7 +3237,7 @@ namespace MonoDevelop.Projects
 						if (file != null) {
 							if (File.Exists (file.FilePath)) {
 								AddRemoveItemIfMissing (msproject, file);
-							} else {
+							} else if (!string.IsNullOrEmpty (it.Include)) {
 								// Remove any "Remove" items that match if the file has been deleted.
 								var toRemove = msproject.GetAllItems ().Where (i => i.Remove == it.Include).ToList ();
 								foreach (var item in toRemove) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -491,6 +491,7 @@ namespace MonoDevelop.Projects
 			pf.VirtualPathChanged = null;
 			pf.PathChanged = null;
 			pf.BackingItem = null;
+			pf.BackingEvalItem = null;
 			return pf;
 		}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DotNetCoreProjectTests.cs
@@ -1,0 +1,64 @@
+﻿//
+// DotNetCoreProjectTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Ide.Projects
+{
+	[TestFixture]
+	public class DotNetCoreProjectTests : TestBase
+	{
+		[Test]
+		public async Task MoveResourceFilesToFolder ()
+		{
+			FilePath projFile = Util.GetSampleProject ("DotNetCoreResources", "NetStandardProject", "NetStandardProject.csproj");
+
+			var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			var resxFile = p.Files.Single (f => f.FilePath.FileName == "Resources.resx");
+
+			var newFolder = p.BaseDirectory.Combine ("NewFolder");
+			Directory.CreateDirectory (newFolder);
+
+			var resxFileTarget = newFolder.Combine ("Resources.resx");
+
+			bool move = true;
+			ProjectOperations.TransferFilesInternal (Util.GetMonitor (), p, resxFile.FilePath, p, resxFileTarget, move, true);
+
+			string expectedProjectXml = File.ReadAllText (p.FileName.ChangeName ("NetStandardProject-saved"));
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (expectedProjectXml, projectXml);
+			p.Dispose ();
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="TypeSystemServiceTestExtensions.cs" />
     <Compile Include="MonoDevelop.Ide.Editor\SkipCharSessionTests.cs" />
     <Compile Include="MonoDevelop.Components\PangoUtilTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\DotNetCoreProjectTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/tests/test-projects/DotNetCoreResources/NetStandardProject/NetStandardProject-saved.csproj
+++ b/main/tests/test-projects/DotNetCoreResources/NetStandardProject/NetStandardProject-saved.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Condition=" '$(EnableDefaultEmbeddedResourceItems)' == 'true' " Update="NewFolder\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Condition=" '$(EnableDefaultCompileItems)' == 'true' " Update="NewFolder\Resources.Designer.cs">
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixed bug #59418 - SDK project file not updated correctly when moving
file to different folder
https://bugzilla.xamarin.com/show_bug.cgi?id=59418

Moving a Resource file from one folder to another would not update
the project file correctly. Either the project file would not be
modified or the items would be removed from the project file.
One problem was that on moving a clone is taken of the original item
and the evaluated MSBuild item was copied but was still referring
back to the original location. Another problem was that MSBuild items
were incorrectly being removed when matching a null include.

The conditions being added to the MSBuild items is being tracked in another bug.