### PR TITLE
[AutoTest] Add ability to reference a TreeView column by number without having to add SemanticAttribute

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -279,7 +279,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			if (resultIter.HasValue) {
 				var modelValue = TModel.GetValue ((TreeIter)resultIter, Column);
 
-				SetProperty (modelValue, propertyName, value);
+				base.SetProperty (modelValue, propertyName, value);
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -528,7 +528,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 		public override void SetProperty (string propertyName, object value)
 		{
-			SetProperty (resultWidget, propertyName, value);
+			base.SetProperty (resultWidget, propertyName, value);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -192,7 +192,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 				AttributeCollection attrs = TypeDescriptor.GetAttributes (model);
 				attr = (SemanticModelAttribute)attrs [typeof(SemanticModelAttribute)];
 				if (attr == null) {
-					return -1;
+					if(column.StartsWith("column__")){
+						int columnNum;
+						if (int.TryParse(column.Replace("column__", string.Empty), out columnNum))
+							return columnNum;
+					}
+					else
+						return -1;
 				}
 			}
 			return Array.IndexOf (attr.ColumnNames, column);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -192,7 +192,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 				AttributeCollection attrs = TypeDescriptor.GetAttributes (model);
 				attr = (SemanticModelAttribute)attrs [typeof(SemanticModelAttribute)];
 				if (attr == null) {
-					if(column.StartsWith("column__")){
+					if(column.StartsWith("column__")) {
 						int columnNum;
 						if (int.TryParse(column.Replace("column__", string.Empty), out columnNum))
 							return columnNum;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -192,9 +192,9 @@ namespace MonoDevelop.Components.AutoTest.Results
 				AttributeCollection attrs = TypeDescriptor.GetAttributes (model);
 				attr = (SemanticModelAttribute)attrs [typeof(SemanticModelAttribute)];
 				if (attr == null) {
-					if(column.StartsWith("column__")) {
+					if (column.StartsWith ("column__")) {
 						int columnNum;
-						if (int.TryParse(column.Replace("column__", string.Empty), out columnNum))
+						if (int.TryParse (column.Replace ("column__", string.Empty), out columnNum))
 							return columnNum;
 					}
 					else

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -110,7 +110,7 @@ namespace MonoDevelop.Components.AutoTest
 		public void SetProperty (object o, string propertyName, object value)
 		{
 			var splitProperties = propertyName.Split(new[] { '.' });
-			var propertyName = splitProperties.Last();
+			propertyName = splitProperties.Last();
 			var exceptLast = splitProperties.Except(new List<string> { propertyName });
 			o = GetRecursiveObjectProperty(string.Join(".", exceptLast), o);
 
@@ -193,7 +193,7 @@ namespace MonoDevelop.Components.AutoTest
 
 		protected AppResult MatchProperty (string propertyName, object objectToCompare, object value)
 		{
-			var objectToCompare = GetRecursiveObjectProperty(propertyName, objectToCompare);
+			objectToCompare = GetRecursiveObjectProperty(propertyName, objectToCompare);
 			if (objectToCompare != null && value != null &&
 				CheckForText(objectToCompare.ToString(), value.ToString(), false)) {
 				return this;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -188,14 +188,20 @@ namespace MonoDevelop.Components.AutoTest
 
 		protected AppResult MatchProperty (string propertyName, object objectToCompare, object value)
 		{
-			foreach (var singleProperty in propertyName.Split (new [] { '.' })) {
-				objectToCompare = GetPropertyValue (singleProperty, objectToCompare);
-			}
+			var objectToCompare = GetRecursiveObjectProperty(propertyName, objectToCompare);
 			if (objectToCompare != null && value != null &&
-				CheckForText (objectToCompare.ToString (), value.ToString (), false)) {
+				CheckForText(objectToCompare.ToString(), value.ToString(), false)) {
 				return this;
 			}
 			return null;
+		}
+
+		protected object GetRecursiveObjectProperty (string propertyName, object obj)
+		{
+			foreach (var singleProperty in propertyName.Split(new[] { '.' })) {
+				obj = GetPropertyValue(singleProperty, obj);
+			}
+			return obj;
 		}
 
 		protected bool CheckForText (string haystack, string needle, bool exact)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -109,6 +109,11 @@ namespace MonoDevelop.Components.AutoTest
 
 		public void SetProperty (object o, string propertyName, object value)
 		{
+			var splitProperties = propertyName.Split(new[] { '.' });
+			var propertyName = splitProperties.Last();
+			var exceptLast = splitProperties.Except(new List<string> { propertyName });
+			o = GetRecursiveObjectProperty(string.Join(".", exceptLast), o);
+
 			// Find the property for the name
 			PropertyInfo propertyInfo = o.GetType().GetProperty(propertyName,
 				BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/PackageServices.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/PackageServices.cs
@@ -1,0 +1,35 @@
+﻿//
+// PackageServices.cs
+//
+// Author:
+//       manish <xamarinqa@gmail.com>
+//
+// Copyright (c) 2017 (c) Xamarin QA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace MonoDevelop.Components.AutoTest
+{
+	public class PackageServices
+	{
+		public PackageServices ()
+		{
+		}
+	}
+}


### PR DESCRIPTION
cherry-picked from master https://github.com/mono/monodevelop/pull/3162