### PR TITLE
Fixed 'Bug 60120 - Code completing selects wrong entry when typing new

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -458,12 +458,16 @@ namespace MonoDevelop.CSharp.Completion
 
 			var result = new CompletionDataList ();
 			result.TriggerWordLength = triggerWordLength;
-
+			CSharpCompletionData defaultCompletionData = null;
 			foreach (var item in completionList.Items) {
 				if (string.IsNullOrEmpty (item.DisplayText))
 					continue;
 				var data = new CSharpCompletionData (analysisDocument, triggerSnapshot, cs, item);
 				result.Add (data);
+				if (item.Rules.MatchPriority > 0) {
+					if (defaultCompletionData == null || defaultCompletionData.Rules.MatchPriority < item.Rules.MatchPriority)
+						defaultCompletionData = data;
+				}
 			}
 
 			result.AutoCompleteUniqueMatch = (triggerInfo.CompletionTriggerReason == CompletionTriggerReason.CompletionCommand);
@@ -475,6 +479,9 @@ namespace MonoDevelop.CSharp.Completion
 			if (forceSymbolCompletion || !syntaxContext.LeftToken.IsKind (SyntaxKind.DotToken)) {
 				AddImportCompletionData (syntaxContext, result, semanticModel, completionContext.TriggerOffset, token);
 			}
+
+			if (defaultCompletionData != null)
+				result.DefaultCompletionString = defaultCompletionData.DisplayText;
 
 			if (completionList.SuggestionModeItem != null) {
 				result.DefaultCompletionString = completionList.SuggestionModeItem.DisplayText;


### PR DESCRIPTION
object creation'

The roslyn version is a bit more flexible than ours since the match
priority is more flexible - like in case the original item fails out
of the list the next match priority item is taken when 2 items have
the same pattern match priority. Supporting that will happen when we
use the roslyn controllers inside our IDE.