### PR TITLE
[Core] Add support for multi-dimensional array writing.

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Execution/BinaryMessageTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Execution/BinaryMessageTests.cs
@@ -1,0 +1,125 @@
+﻿//
+// BinaryMessage.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace MonoDevelop.Core.Execution
+{
+	[TestFixture]
+	public class BinaryMessageTests
+	{
+		public class Data
+		{
+			public Data (Array arr, int expectedEnumerations, int[][] expectedValues)
+			{
+				ExpectedEnumerations = expectedEnumerations;
+				Array = arr;
+			}
+
+			public int ExpectedEnumerations { get; }
+			public Array Array { get; }
+		}
+
+		public Data [] TestCase = {
+			new Data (new int[1, 2, 3], 6, new int[][] {
+				new int[] {0, 0, 0},
+				new int[] {0, 0, 1},
+				new int[] {0, 0, 2},
+				new int[] {0, 1, 0},
+				new int[] {0, 1, 1},
+				new int[] {0, 1, 2},
+			}),
+			new Data (new int[0, 0, 0], 0, new int[][] {}),
+			new Data (new int[0, 0, 1], 1, new int[][] { new int[] { 0, 0, 0 } }),
+			new Data (new int[3, 3, 3], 27, new int[][] {
+				new int[] {0, 0, 0},
+				new int[] {0, 0, 1},
+				new int[] {0, 0, 2},
+
+				new int[] {0, 1, 0},
+				new int[] {0, 1, 1},
+				new int[] {0, 1, 2},
+
+				new int[] {0, 2, 0},
+				new int[] {0, 2, 1},
+				new int[] {0, 2, 2},
+
+				new int[] {1, 0, 0},
+				new int[] {1, 0, 1},
+				new int[] {1, 0, 2},
+
+				new int[] {1, 1, 0},
+				new int[] {1, 1, 1},
+				new int[] {1, 1, 2},
+
+				new int[] {1, 2, 0},
+				new int[] {1, 2, 1},
+				new int[] {1, 2, 2},
+
+				new int[] {2, 0, 0},
+				new int[] {2, 0, 1},
+				new int[] {2, 0, 2},
+
+				new int[] {2, 1, 0},
+				new int[] {2, 1, 1},
+				new int[] {2, 1, 2},
+
+				new int[] {2, 2, 0},
+				new int[] {2, 2, 1},
+				new int[] {2, 2, 2},
+			}),
+		};
+
+		[TestCaseSource ("TestCase")]
+		public void TestIteration (Data data)
+		{
+			var iter = new BinaryMessage.MultiDimensionalIterator (data.Array);
+			int count = 0;
+			(bool, int []) res;
+			while ((res = iter.TryMoveNext ()).Item1) {
+				count++;
+			}
+
+			Assert.AreEqual (data.ExpectedEnumerations, count);
+		}
+
+		[Test]
+		public void TestFill ()
+		{
+			int count = 0;
+			var toFill = new int [3, 3, 3];
+
+			var iter = new BinaryMessage.MultiDimensionalIterator (toFill);
+			iter.Fill (() => count++);
+
+			int expected = 0;
+			foreach (var val in toFill) {
+				Assert.AreEqual (expected, val);
+				expected++;
+			}
+		}
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -37,6 +37,9 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.3.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />
@@ -90,11 +93,13 @@
     <Compile Include="MonoDevelop.Projects\GenericProjectTests.cs" />
     <Compile Include="MonoDevelop.Projects\NetStandardProjectTests.cs" />
     <Compile Include="MonoDevelop.Projects\BuilderManagerTests.cs" />
+    <Compile Include="MonoDevelop.Core.Execution\BinaryMessageTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.Core\" />
     <Folder Include="MonoDevelop.Core.Assemblies\" />
     <Folder Include="MonoDevelop.Projects\" />
+    <Folder Include="MonoDevelop.Core.Execution\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
@@ -115,6 +120,9 @@
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
       <Name>GuiUnit_NET_4_5</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/MonoDevelop.Core.Tests/packages.config
+++ b/main/tests/MonoDevelop.Core.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
The problem with the old code is that it assumed that any Array was uni-dimensional. Therefore, it would end up with an invalid cast exception.
When writing any array into the binary message, flatten the array. Thus, when reading the array back, we read it as uni-dimensional. It should not impact anything.

There is a fast-path for rank1 arrays, as the foreach is rewritten to handle generalized iteration.

Bug 59805 - Visual Studio for Mac potential issue on unit testing support