### PR TITLE
Fixed 'Bug 52524 - Xamarin Studio crashes on adding Break-point to any

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DisplayBindingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DisplayBindingService.cs
@@ -99,8 +99,11 @@ namespace MonoDevelop.Ide.Gui
 				if (attachable == null)
 					continue;
 
-				if (attachable.CanAttachTo (workbenchWindow.ViewContent))
-					workbenchWindow.InsertViewContent (index++, attachable.CreateViewContent (workbenchWindow.ViewContent));
+				if (attachable.CanAttachTo (workbenchWindow.ViewContent)) {
+					var subViewContent = attachable.CreateViewContent (workbenchWindow.ViewContent);
+					workbenchWindow.InsertViewContent (index++, subViewContent);
+					subViewContent.WorkbenchWindow = workbenchWindow;
+				}
 			}
 		}
 


### PR DESCRIPTION
line of Main.axml file.'

This ensures that the workbench window is correctly set for all sub
view contents.