### PR TITLE
[Refactoring] If we build debug builds, enable RoslynClrHeapAnalyzer

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/AddinInfo.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/AddinInfo.cs
@@ -16,4 +16,7 @@ using Mono.Addins.Description;
 [assembly:AddinDependency ("DesignerSupport", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("SourceEditor2", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("RegexToolkit", MonoDevelop.BuildInfo.Version)]
- 
+
+#if DEBUG
+[assembly: ImportAddinAssembly ("ClrHeapAllocationAnalyzer.dll", Scan = false)]
+#endif

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeIssues/AnalyzersFromAssembly.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeIssues/AnalyzersFromAssembly.cs
@@ -78,6 +78,7 @@ namespace MonoDevelop.CodeIssues
 				case "Microsoft.CodeAnalysis.Features":
 				case "Microsoft.CodeAnalysis.VisualBasic.Features":
 				case "Microsoft.CodeAnalysis.CSharp.Features":
+				case "ClrHeapAllocationAnalyzer":
 					break;
 				//blacklist
 				case "FSharpBinding":

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -126,6 +126,11 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'DebugMac' ">
+    <Reference Include="ClrHeapAllocationAnalyzer">
+      <HintPath>..\..\..\packages\ClrHeapAllocationAnalyzer.1.0.0.8\analyzers\dotnet\cs\ClrHeapAllocationAnalyzer.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="gtk-gui\generated.cs" />
@@ -373,6 +378,7 @@
     <None Include="MonoDevelop.CodeIssues\Pad\AnalysisState.cs" />
     <None Include="MonoDevelop.CodeIssues\Pad\AnalysisStateChangeEventArgs.cs" />
     <None Include="MonoDevelop.CodeIssues\Pad\CategoryGroupingProvider.cs" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>

--- a/main/src/addins/MonoDevelop.Refactoring/packages.config
+++ b/main/src/addins/MonoDevelop.Refactoring/packages.config
@@ -1,2 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<packages />
+<packages>
+  <package id="ClrHeapAllocationAnalyzer" version="1.0.0.8" targetFramework="net461" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
This will provide us with code issues for writing code. Also, serves
as an infrastructure on how to add more analyzers that are specifically
for MonoDevelop developers usage