### PR TITLE
[DotNetCore] Fix failing tests

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="..\..\..\core\MonoDevelop.Ide\MonoDevelop.Ide.Templates\TemplateParameter.cs">
       <Link>MonoDevelop.DotNetCore.Tests\TemplateParameter.cs</Link>
     </Compile>
+    <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreTestBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -43,9 +43,8 @@ namespace MonoDevelop.DotNetCore.Tests
 	/// Creates and builds .NET Core projects.
 	/// </summary>
 	[TestFixture]
-	class DotNetCoreProjectTemplateTests : TestBase
+	class DotNetCoreProjectTemplateTests : DotNetCoreTestBase
 	{
-		static bool firstRun;
 		TemplatingService templatingService;
 
 		[TestFixtureSetUp]
@@ -58,10 +57,7 @@ namespace MonoDevelop.DotNetCore.Tests
 
 			templatingService = new TemplatingService ();
 
-			if (!firstRun) {
-				firstRun = true;
-				Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
-				DesktopService.Initialize ();
+			if (!IdeApp.IsInitialized) {
 				IdeApp.Initialize (Util.GetMonitor ());
 			}
 		}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -36,7 +36,7 @@ using UnitTests;
 namespace MonoDevelop.DotNetCore.Tests
 {
 	[TestFixture]
-	class DotNetCoreProjectExtensionTests : TestBase
+	class DotNetCoreProjectExtensionTests : DotNetCoreTestBase
 	{
 		/// <summary>
 		/// ProjectGuid and DefaultTargets should not be added to .NET Core project when it is saved.

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreTestBase.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreTestBase.cs
@@ -1,0 +1,41 @@
+﻿//
+// DotNetCoreTestBase.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Ide;
+using UnitTests;
+
+namespace MonoDevelop.DotNetCore.Tests
+{
+	class DotNetCoreTestBase : TestBase
+	{
+		protected override void InternalSetup (string rootDir)
+		{
+			base.InternalSetup (rootDir);
+			Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
+			DesktopService.Initialize ();
+		}
+	}
+}


### PR DESCRIPTION
After commit 7b6587aaa8dcc796b70ea66f79d5237fdcaea3b0 the template tests were failing with an error:

```
DotNetCoreProjectTemplateTests
   System.Exception : Toolkit could not be loaded
  ----> System.IO.FileNotFoundException : Could not load file or
assembly 'PresentationFramework, Version=4.0.0.0, Culture=neutral,
PublicKeyToken=31bf3856ad364e35' or one of its dependencies.
  at Xwt.Toolkit.LoadBackend (System.String type, System.Boolean isGuest, System.Boolean throwIfFails) [0x00081] in monodevelop/main/external/xwt/Xwt/Xwt/Toolkit.cs:295
  at Xwt.Toolkit.Load (Xwt.ToolkitType type) [0x00049] in monodevelop/main/external/xwt/Xwt/Xwt/Toolkit.cs:235
  at MonoDevelop.MacIntegration.MacPlatformService.LoadNativeToolkit () [0x00028] in monodevelop/main/src/addins/MacPlatform/MacPlatform.cs:144
  at MonoDevelop.Ide.DesktopService.get_NativeToolkit () [0x0000d] in monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs:85
  at MonoDevelop.Ide.DesktopService.Initialize () [0x000a5] in monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs:73
  at MonoDevelop.DotNetCore.Tests.DotNetCoreProjectTemplateTests.SetUp () [0x0004b] in monodevelop/main/src/addins/MonoDevelop.DotNetCore/
```

The test setup has now been re-arranged to avoid this exception.