### PR TITLE
[Core] Fix remove item added when UseAdvancedGlobSupport is false

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3231,6 +3231,9 @@ namespace MonoDevelop.Projects
 					if (!it.IsWildcardItem || it.ParentProject == msproject) {
 						msproject.RemoveItem (it);
 
+						if (!UseAdvancedGlobSupport)
+							continue;
+
 						var file = loadedProjectItems.FirstOrDefault (i => {
 							return i.ItemName == it.Name && (i.Include == it.Include || i.Include == it.Update);
 						}) as ProjectFile;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -959,6 +959,28 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task RemoveFile_WhenNotUsingAdvancedGlobSupport_ShouldNotAddRemoveItemWhenFileNotDeleted ()
+		{
+			string projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-import-test.csproj");
+			var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+			string expectedProjectXml = File.ReadAllText (p.FileName);
+
+			string fileName = p.BaseDirectory.Combine ("test.txt");
+			File.WriteAllText (fileName, "Test");
+			var projectFile = p.AddFile (fileName);
+			await p.SaveAsync (Util.GetMonitor ());
+
+			p.Files.Remove (projectFile);
+
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (expectedProjectXml, projectXml);
+
+			p.Dispose ();
+		}
+
+		[Test]
 		public async Task AddFile_WildCardHasMetadataProperties ()
 		{
 			var fn = new CustomItemNode<SupportImportedProjectFilesProjectExtension> ();


### PR DESCRIPTION
Removing a file but not deleting it would add an MSBuild remove item
for non .NET Core projects that were not using the advanced file glob
support.