### PR TITLE
[Core] Fix remove item added when removing file link

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3234,7 +3234,7 @@ namespace MonoDevelop.Projects
 						var file = loadedProjectItems.FirstOrDefault (i => {
 							return i.ItemName == it.Name && (i.Include == it.Include || i.Include == it.Update);
 						}) as ProjectFile;
-						if (file != null) {
+						if (file != null && !file.IsLink) {
 							if (File.Exists (file.FilePath)) {
 								AddRemoveItemIfMissing (msproject, file);
 							} else if (!string.IsNullOrEmpty (it.Include)) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildGlobTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildGlobTests.cs
@@ -604,6 +604,39 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task RemoveFileLink ()
+		{
+			var fn = new CustomItemNode<SupportImportedProjectFilesProjectExtension> ();
+			WorkspaceObject.RegisterCustomExtension (fn);
+
+			try {
+				FilePath projFile = Util.GetSampleProject ("msbuild-glob-tests", "glob-file-link-test.csproj");
+
+				string linkedFile = Path.Combine (projFile.ParentDirectory, "..", "test.txt");
+				File.WriteAllText (linkedFile, "test");
+
+				var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile);
+				p.UseAdvancedGlobSupport = true;
+
+				Assert.AreEqual (4, p.Files.Count);
+
+				var f = p.Files.First (fi => fi.FilePath.FileName == "test.txt");
+				Assert.IsTrue (f.IsLink);
+				p.Files.Remove (f);
+
+				await p.SaveAsync (Util.GetMonitor ());
+
+				string expectedProjectXml = File.ReadAllText (p.FileName.ChangeName ("glob-file-link-test-saved1"));
+				string projectXml = File.ReadAllText (p.FileName);
+				Assert.AreEqual (expectedProjectXml, projectXml);
+
+				p.Dispose ();
+			} finally {
+				WorkspaceObject.UnregisterCustomExtension (fn);
+			}
+		}
+
+		[Test]
 		public async Task FileUpdateRemoveMetadataDefinedInGlob ()
 		{
 			// The glob item defines a metadata. All evaluated items have that value.

--- a/main/tests/test-projects/msbuild-glob-tests/glob-file-link-test-saved1.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-file-link-test-saved1.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="glob-import-test.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/msbuild-glob-tests/glob-file-link-test.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-file-link-test.csproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="glob-import-test.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\test.txt">
+      <Link>Linked.txt</Link>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Deleting a file link in a .NET Core project would add a remove item
for the file instead of just removing the link from the project.