### PR TITLE
[UnitTesting] Fix xUnit test messages not displayed  …

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/BasicTests.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/BasicTests.cs
@@ -23,7 +23,6 @@ using MonoDevelop.Projects;
 using System.Linq;
 using MonoDevelop.Ide;
 using MonoDevelop.Core;
-using MonoDevelop.PackageManagement;
 using System.Diagnostics;
 using System.Threading;
 

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/BasicTests.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/BasicTests.cs
@@ -23,6 +23,7 @@ using MonoDevelop.Projects;
 using System.Linq;
 using MonoDevelop.Ide;
 using MonoDevelop.Core;
+using MonoDevelop.DotNetCore;
 using System.Diagnostics;
 using System.Threading;
 
@@ -42,13 +43,17 @@ namespace MonoDevelop.UnitTesting.Tests
 		[Test()]
 		public async Task TestsXUnitDotNetFull()
 		{
-			await CommonTestDiscovery("unit-testing-xunit-dotnetcore");
+			await CommonTestDiscovery("unit-testing-xunit-dotnetfull");
 		}
 
 		[Test()]
 		public async Task TestsXUnitDotNetCore()
 		{
-			await CommonTestDiscovery("unit-testing-xunit-dotnetfull");
+			if (!DotNetCoreRuntime.IsInstalled) {
+				Assert.Ignore (".NET Core needs to be installed.");
+			}
+
+			await CommonTestDiscovery("unit-testing-xunit-dotnetcore");
 		}
 
 		async Task CommonTestDiscovery(string projectName)

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
@@ -83,10 +83,6 @@
       <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>
       <Name>MonoDevelop.UnitTesting</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.csproj">
-      <Project>{F218643D-2E74-4309-820E-206A54B7133F}</Project>
-      <Name>MonoDevelop.PackageManagement</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\MonoDevelop.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -28,9 +29,36 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
+      <HintPath>..\..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities">
+      <HintPath>..\..\..\..\packages\Microsoft.TestPlatform.ObjectModel.15.5.0-preview-20170919-04\lib\net451\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TestPlatform.PlatformAbstractions">
+      <HintPath>..\..\..\..\packages\Microsoft.TestPlatform.ObjectModel.15.5.0-preview-20170919-04\lib\net451\Microsoft.TestPlatform.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
+      <HintPath>..\..\..\..\packages\Microsoft.TestPlatform.ObjectModel.15.5.0-preview-20170919-04\lib\net451\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicTests.cs" />
+    <Compile Include="MonoDevelop.UnitTesting.Tests\TestResultBuilderTests.cs" />
+    <Compile Include="MonoDevelop.UnitTesting.Tests\TestProgressMonitor.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
@@ -59,6 +87,9 @@
       <Project>{F218643D-2E74-4309-820E-206A54B7133F}</Project>
       <Name>MonoDevelop.PackageManagement</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
@@ -83,6 +83,11 @@
       <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>
       <Name>MonoDevelop.UnitTesting</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\MonoDevelop.DotNetCore\MonoDevelop.DotNetCore.csproj">
+      <Project>{6868153E-41EA-43A4-A81A-C1E7256373F7}</Project>
+      <Name>MonoDevelop.DotNetCore</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/TestProgressMonitor.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/TestProgressMonitor.cs
@@ -1,0 +1,52 @@
+﻿//
+// TestProgressMonitor.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Threading;
+
+namespace MonoDevelop.UnitTesting.Tests
+{
+	class TestProgressMonitor : ITestProgressMonitor
+	{
+		public CancellationToken CancellationToken { get; set; }
+
+		public void BeginTest (UnitTest test)
+		{
+		}
+
+		public void EndTest (UnitTest test, UnitTestResult result)
+		{
+		}
+
+		public void ReportRuntimeError (string message, Exception exception)
+		{
+		}
+
+		public void WriteGlobalLog (string message)
+		{
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/TestResultBuilderTests.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/TestResultBuilderTests.cs
@@ -1,0 +1,114 @@
+﻿//
+// TestResultBuilderTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using MonoDevelop.Core.Execution;
+using MonoDevelop.Projects;
+using MonoDevelop.UnitTesting.VsTest;
+using NUnit.Framework;
+
+namespace MonoDevelop.UnitTesting.Tests
+{
+	[TestFixture]
+	public class TestResultBuilderTests
+	{
+		TestResultBuilder builder;
+		TestContext context;
+		TestProgressMonitor monitor;
+
+		void CreateTestResultBuilder (IVsTestTestProvider testProvider)
+		{
+			var executionContext = new ExecutionContext ((IExecutionHandler)null, null, null);
+			monitor = new TestProgressMonitor ();
+			context = new TestContext (monitor, null, executionContext, DateTime.Now);
+
+			builder = new TestResultBuilder (context, testProvider);
+		}
+
+		VsTestUnitTest CreateVsUnitTest (string fullyQualifedName)
+		{
+			var testCase = new TestCase {
+				DisplayName = fullyQualifedName,
+				FullyQualifiedName = fullyQualifedName,
+				CodeFilePath = "test.cs"
+			};
+			return new VsTestUnitTest (null, testCase, null);
+		}
+
+		TestRunChangedEventArgs CreateTestRunChangedEventArgsWithTestResults (params TestResult[] newTestResults)
+		{
+			return new TestRunChangedEventArgs (null, newTestResults, null);
+		}
+
+		[Test]
+		public void ConsoleOutputText_SingleTestUsingTestOutputHelperWriteLine_ConsoleOutputInTestResultOutput ()
+		{
+			var unitTest = CreateVsUnitTest ("MyNamespace.MyTest");
+			CreateTestResultBuilder (unitTest);
+			var testCase = new TestCase ();
+			var testResult = new TestResult (testCase);
+			testResult.Messages.Add (new TestResultMessage ("Category", "Line 1"));
+			testResult.Messages.Add (new TestResultMessage ("Category", "Line 2"));
+			var eventArgs = CreateTestRunChangedEventArgsWithTestResults (testResult);
+
+			builder.OnTestRunChanged (eventArgs);
+
+			string expectedConsoleOutputMessage = "Line 1" + Environment.NewLine + "Line 2";
+			Assert.AreEqual (expectedConsoleOutputMessage, builder.TestResult.ConsoleOutput);
+		}
+
+		[Test]
+		public void SingleTest_Failure_TestResultIndicatesFailure ()
+		{
+			var unitTest = CreateVsUnitTest ("MyNamespace.MyTest");
+			CreateTestResultBuilder (unitTest);
+			var testCase = new TestCase ();
+			var testResult = new TestResult (testCase) {
+				ErrorMessage = "Error Message",
+				ErrorStackTrace = "Error Stack Trace",
+				Outcome = TestOutcome.Failed,
+				StartTime = new DateTimeOffset (new DateTime (2000, 1, 2, 12, 58, 30)),
+				Duration = new TimeSpan (0, 1, 30)
+			};
+			var eventArgs = CreateTestRunChangedEventArgsWithTestResults (testResult);
+
+			builder.OnTestRunChanged (eventArgs);
+
+			Assert.AreEqual ("Error Message", builder.TestResult.ConsoleError);
+			Assert.AreEqual ("Error Message", builder.TestResult.Message);
+			Assert.AreEqual (ResultStatus.Failure, builder.TestResult.Status);
+			Assert.AreEqual ("Error Stack Trace", builder.TestResult.StackTrace);
+			Assert.AreEqual (testResult.StartTime.DateTime, builder.TestResult.TestDate);
+			Assert.AreEqual (testResult.Duration, builder.TestResult.Time);
+			Assert.AreEqual (1, builder.TestResult.Failures);
+			Assert.AreEqual (0, builder.TestResult.Ignored);
+			Assert.AreEqual (0, builder.TestResult.Passed);
+			Assert.AreEqual (0, builder.TestResult.Inconclusive);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+</packages>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/TestResultBuilder.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/TestResultBuilder.cs
@@ -174,7 +174,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 		string GetConsoleOutput (TestResult result)
 		{
 			if (result.Messages != null) {
-				return string.Join (Environment.NewLine, result.Messages);
+				return string.Join (Environment.NewLine, result.Messages.Select (message => message.Text));
 			}
 
 			return string.Empty;

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -318,6 +318,9 @@
     <Folder Include="MonoDevelop.UnitTesting.VsTest\" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="MonoDevelop.UnitTesting.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <VsTestConsole Include="..\..\..\packages\Microsoft.TestPlatform.15.5.0-preview-20170919-04\tools\net451\**\*.*">
       <Visible>false</Visible>
     </VsTestConsole>

--- a/main/tests/test-projects/unit-testing-addin/unit-testing-xunit-dotnetcore/unit-testing-xunit-dotnetcore.csproj
+++ b/main/tests/test-projects/unit-testing-addin/unit-testing-xunit-dotnetcore/unit-testing-xunit-dotnetcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
xUnit tests support an ITestOutputHelper interface which can be
passed to the constructor of the test. This has a WriteLine method
which can be used to output messages whilst running the test. When
this was used the text displayed in the Test Results window would
show:

    Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResultMessage

Instead of the actual text. Includes some tests for the test result generation.

Removed the NuGet addin project reference which is not needed.

Disabled some tests that only work if .NET Core is installed so the tests will run on Wrench without failing.