### PR TITLE
Fixed bug where .NET 4.6 project using SDK .csproj was debugged as .NET Core

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -373,6 +373,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.AspNetCore" />
     <InternalsVisibleTo Include="DotNetCore.Debugger" />
+    <InternalsVisibleTo Include="MonoDevelop.UnitTesting" />
     <InternalsVisibleTo Include="MonoDevelop.DotNetCore.Tests" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			if (assemblyFileName.IsNull)
 				return false;
 			if (Project is DotNetProject dnp) {
-				if (Project.HasFlavor<DotNetCoreProjectExtension> ())
+				if (Project.HasFlavor<DotNetCoreProjectExtension> () && dnp.TargetFramework.Id.Identifier.IndexOf ("netcoreapp", StringComparison.OrdinalIgnoreCase) != -1)
 					return executionContext.CanExecute (new DotNetCoreExecutionCommand (Path.GetDirectoryName (assemblyFileName), assemblyFileName, ""));
 				else
 					return executionContext.CanExecute (new DotNetExecutionCommand ());

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			if (assemblyFileName.IsNull)
 				return false;
 			if (Project is DotNetProject dnp) {
-				if (Project.HasFlavor<DotNetCoreProjectExtension> () && dnp.TargetFramework.Id.Identifier.IndexOf ("netcoreapp", StringComparison.OrdinalIgnoreCase) != -1)
+				if (Project.HasFlavor<DotNetCoreProjectExtension> () && dnp.TargetFramework.IsNetCoreApp())
 					return executionContext.CanExecute (new DotNetCoreExecutionCommand (Path.GetDirectoryName (assemblyFileName), assemblyFileName, ""));
 				else
 					return executionContext.CanExecute (new DotNetExecutionCommand ());

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestRunAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestRunAdapter.cs
@@ -242,7 +242,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			ExecutionCommand command;
 
 			if (runJobInProgress.Project is DotNetProject dnp) {
-				if (dnp.HasFlavor<DotNetCoreProjectExtension> ()) {
+				if (dnp.HasFlavor<DotNetCoreProjectExtension> () && dnp.TargetFramework.Id.Identifier.IndexOf ("netcoreapp", StringComparison.OrdinalIgnoreCase) != -1) {
 					command = new DotNetCoreExecutionCommand (
 						startInfo.WorkingDirectory,
 						startInfo.FileName,

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestRunAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestRunAdapter.cs
@@ -242,7 +242,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			ExecutionCommand command;
 
 			if (runJobInProgress.Project is DotNetProject dnp) {
-				if (dnp.HasFlavor<DotNetCoreProjectExtension> () && dnp.TargetFramework.Id.Identifier.IndexOf ("netcoreapp", StringComparison.OrdinalIgnoreCase) != -1) {
+				if (dnp.HasFlavor<DotNetCoreProjectExtension> () && dnp.TargetFramework.IsNetCoreApp ()) {
 					command = new DotNetCoreExecutionCommand (
 						startInfo.WorkingDirectory,
 						startInfo.FileName,


### PR DESCRIPTION
This is fixed by making check if project is .NET Core or not more strict

Unfortunately adding unit test for this would not be simple :(