### PR TITLE
[NuGet] Fix transitive dependencies for project.json

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -205,6 +205,8 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeMonoDevelopBuildIntegratedRestorer.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\RestoreNuGetPackagesInNuGetIntegratedProjectTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\ImportedPackageReferenceProjectTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectSystemReferencesReaderTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectJsonBuildIntegratedNuGetProjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
@@ -224,6 +226,11 @@
     <ProjectReference Include="..\..\..\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
       <Name>MonoDevelop.Ide</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\tests\UnitTests\UnitTests.csproj">
+      <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
+      <Name>UnitTests</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectJsonBuildIntegratedNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectJsonBuildIntegratedNuGetProjectTests.cs
@@ -1,0 +1,100 @@
+﻿//
+// ProjectJsonBuildIntegratedNuGetProjectTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NuGet.ProjectManagement;
+using NUnit.Framework;
+using UnitTests;
+using MonoDevelop.Core;
+using System.IO;
+using System.Linq;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	class ProjectJsonBuildIntegratedNuGetProjectTests
+	{
+		ProjectJsonBuildIntegratedNuGetProject projectJsonNuGetProject;
+
+		static DummyDotNetProject CreateDotNetProject (
+			string projectName,
+			string fileName)
+		{
+			var project = new DummyDotNetProject ();
+			project.Name = projectName;
+			project.FileName = fileName;
+			return project;
+		}
+
+		void CreateSolution (params Project [] projects)
+		{
+			var solution = new Solution ();
+			foreach (var project in projects) {
+				solution.RootFolder.AddItem (project);
+			}
+		}
+
+		void CreateProjectJsonNuGetProject (DotNetProject project)
+		{
+			var settings = new FakeNuGetSettings ();
+			var projectJsonFileName = project.BaseDirectory.Combine ("project.json");
+			projectJsonNuGetProject = new ProjectJsonBuildIntegratedNuGetProject (
+				projectJsonFileName,
+				project.FileName,
+				project,
+				settings);
+
+			string json = "{ \"frameworks\": { \".NETPortable,Version=v4.5,Profile=Profile111\": {} }}";
+			File.WriteAllText (projectJsonFileName, json);
+		}
+
+		[Test]
+		public async Task GetPackageSpecsAsync_ProjectHasOneProjectReference_RestoreMetadataHasProjectReference ()
+		{
+			FilePath directory = Util.CreateTmpDir ("ProjectJsonNuGetTests");
+			string expectedProjectFileName = directory.Combine ("ReferencedProject.csproj");
+			var projectToBeReferenced = CreateDotNetProject ("ReferencedProject", expectedProjectFileName);
+			string mainProjectFileName = directory.Combine ("MainTest.csproj");
+			var mainProject = CreateDotNetProject ("MainTest", mainProjectFileName);
+			CreateSolution (mainProject, projectToBeReferenced);
+			var projectReference = ProjectReference.CreateProjectReference (projectToBeReferenced);
+			mainProject.References.Add (projectReference);
+			CreateProjectJsonNuGetProject (mainProject);
+			var context = new DependencyGraphCacheContext ();
+
+			var specs = await projectJsonNuGetProject.GetPackageSpecsAsync (context);
+
+			var spec = specs [0];
+			var targetFramework = spec.RestoreMetadata.TargetFrameworks.FirstOrDefault ();
+			Assert.AreEqual (1, specs.Count);
+			Assert.AreEqual (1, spec.RestoreMetadata.TargetFrameworks.Count);
+			Assert.AreEqual (1, targetFramework.ProjectReferences.Count);
+			Assert.AreEqual (expectedProjectFileName, targetFramework.ProjectReferences [0].ProjectPath);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectSystemReferencesReaderTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectSystemReferencesReaderTests.cs
@@ -1,0 +1,175 @@
+﻿//
+// ProjectSystemReferencesReaderTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using MonoDevelop.Projects.SharedAssetsProjects;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NUnit.Framework;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	class ProjectSystemReferencesReaderTests
+	{
+		ProjectSystemReferencesReader reader;
+		PackageManagementEvents packageManagementEvents;
+		PackageManagementLogger logger;
+
+		static DummyDotNetProject CreateDotNetProject (
+			string projectName = "MyProject",
+			string fileName = @"d:\projects\MyProject\MyProject.csproj")
+		{
+			var project = new DummyDotNetProject ();
+			project.Name = projectName;
+			project.FileName = fileName.ToNativePath ();
+			return project;
+		}
+
+		void CreateProjectReferencesReader (DotNetProject project)
+		{
+			packageManagementEvents = new PackageManagementEvents ();
+			logger = new PackageManagementLogger (packageManagementEvents);
+			reader = new ProjectSystemReferencesReader (project);
+		}
+
+		void CreateSolution (params Project [] projects)
+		{
+			var solution = new Solution ();
+			foreach (var project in projects) {
+				solution.RootFolder.AddItem (project);
+			}
+		}
+
+		List<ProjectRestoreReference> GetProjectReferences ()
+		{
+			return reader.GetProjectReferences (logger).ToList ();
+		}
+
+		[Test]
+		public void GetProjectReferencesAsync_OneProjectReference_ReturnedInProjectReferences ()
+		{
+			string expectedProjectFileName = @"d:\projects\Test\MyTest.csproj".ToNativePath ();
+			var projectToBeReferenced = CreateDotNetProject ("Test", expectedProjectFileName);
+			var mainProject = CreateDotNetProject ();
+			CreateSolution (mainProject, projectToBeReferenced);
+			var projectReference = ProjectReference.CreateProjectReference (projectToBeReferenced);
+			mainProject.References.Add (projectReference);
+			CreateProjectReferencesReader (mainProject);
+
+			var references = GetProjectReferences ();
+
+			Assert.AreEqual (1, references.Count);
+			Assert.AreEqual (expectedProjectFileName, references [0].ProjectPath);
+			Assert.AreEqual (expectedProjectFileName, references [0].ProjectUniqueName);
+		}
+
+		[Test]
+		public void GetProjectReferencesAsync_OneProjectReferenceWithReferenceOutputAssemblyFalse_NoProjectReferences ()
+		{
+			var projectToBeReferenced = CreateDotNetProject ("Test");
+			var mainProject = CreateDotNetProject ();
+			CreateSolution (mainProject, projectToBeReferenced);
+			var projectReference = ProjectReference.CreateProjectReference (projectToBeReferenced);
+			// Do not reference output assembly of project.
+			projectReference.ReferenceOutputAssembly = false;
+			mainProject.References.Add (projectReference);
+			CreateProjectReferencesReader (mainProject);
+
+			var references = GetProjectReferences ();
+
+			Assert.AreEqual (0, references.Count);
+		}
+
+		[Test]
+		public void GetProjectReferencesAsync_OneInvalidProjectReference_NoProjectReferencesAndWarningLogged ()
+		{
+			var projectToBeReferenced = CreateDotNetProject ("Test");
+			var mainProject = CreateDotNetProject ("MyProject");
+			CreateSolution (mainProject, projectToBeReferenced);
+			var projectReference = ProjectReference.CreateProjectReference (projectToBeReferenced);
+			// Mark project reference as invalid.
+			projectReference.SetInvalid ("Not valid");
+			mainProject.References.Add (projectReference);
+			CreateProjectReferencesReader (mainProject);
+			PackageOperationMessage messageLogged = null;
+			packageManagementEvents.PackageOperationMessageLogged += (sender, e) => {
+				messageLogged = e.Message;
+			};
+
+			var references = GetProjectReferences ();
+
+			string expectedMessage = "Failed to resolve all project references. The package restore result for 'MyProject' or a dependant project may be incomplete.";
+			Assert.AreEqual (0, references.Count);
+			Assert.IsNotNull (messageLogged);
+			Assert.AreEqual (MessageLevel.Warning, messageLogged.Level);
+			Assert.AreEqual (expectedMessage, messageLogged.ToString ());
+		}
+
+		[Test]
+		public void GetProjectReferencesAsync_OneSharedAssetProjectReference_SharedProjectIsNotIncluded ()
+		{
+			var projectToBeReferenced = new SharedAssetsProject ("C#");
+			var mainProject = CreateDotNetProject ();
+			CreateSolution (mainProject, projectToBeReferenced);
+			var projectReference = ProjectReference.CreateProjectReference (projectToBeReferenced);
+			mainProject.References.Add (projectReference);
+			CreateProjectReferencesReader (mainProject);
+
+			var references = GetProjectReferences ();
+
+			Assert.AreEqual (0, references.Count);
+		}
+
+		[Test]
+		public void GetProjectReferencesAsync_ExceptionThrownWhenResolvingProject_ErrorLogged ()
+		{
+			var projectToBeReferenced = CreateDotNetProject ("Test");
+			var mainProject = CreateDotNetProject ("MyProject");
+			var projectReference = ProjectReference.CreateProjectReference (projectToBeReferenced);
+			// Project has no parent solution - which will cause an exception.
+			mainProject.References.Add (projectReference);
+			CreateProjectReferencesReader (mainProject);
+			var messagesLogged = new List<PackageOperationMessage> ();
+			packageManagementEvents.PackageOperationMessageLogged += (sender, e) => {
+				messagesLogged.Add (e.Message);
+			};
+
+			var references = GetProjectReferences ();
+
+			string expectedMessage = "Failed to resolve all project references. The package restore result for 'MyProject' or a dependant project may be incomplete.";
+			Assert.AreEqual (0, references.Count);
+			Assert.AreEqual (2, messagesLogged.Count);
+			Assert.AreEqual (MessageLevel.Debug, messagesLogged [0].Level);
+			Assert.That (messagesLogged [0].ToString (), Contains.Substring ("ArgumentNullException"));
+			Assert.AreEqual (MessageLevel.Warning, messagesLogged [1].Level);
+			Assert.AreEqual (expectedMessage, messagesLogged [1].ToString ());
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -410,6 +410,8 @@
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementPathResolver.cs" />
     <Compile Include="MonoDevelop.PackageManagement\MonoDevelopMSBuildNuGetProject.cs" />
     <Compile Include="MonoDevelop.PackageManagement\IMonoDevelopBuildIntegratedRestorer.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\NuGetProjectServices.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\ProjectSystemReferencesReader.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetProjectServices.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetProjectServices.cs
@@ -1,0 +1,94 @@
+﻿//
+// NuGetProjectServices.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Projects;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+
+namespace MonoDevelop.PackageManagement
+{
+	class NuGetProjectServices : INuGetProjectServices, IProjectSystemService, IProjectScriptHostService
+	{
+		IProjectSystemReferencesReader referencesReader;
+
+		public NuGetProjectServices (DotNetProject project)
+		{
+			referencesReader = new ProjectSystemReferencesReader (project);
+		}
+
+		public IProjectBuildProperties BuildProperties => throw new NotImplementedException ();
+
+		public IProjectSystemCapabilities Capabilities => throw new NotImplementedException ();
+
+		public IProjectSystemReferencesReader ReferencesReader {
+			get { return referencesReader; }
+		}
+
+		public IProjectSystemReferencesService References => throw new NotImplementedException ();
+
+		public IProjectSystemService ProjectSystem {
+			get { return this; }
+		}
+
+		public IProjectScriptHostService ScriptService {
+			get { return this; }
+		}
+
+		public T GetGlobalService<T> () where T : class
+		{
+			return null;
+		}
+
+		public Task SaveProjectAsync (CancellationToken token)
+		{
+			return Task.FromResult (0);
+		}
+
+		public Task<bool> ExecutePackageInitScriptAsync (
+			PackageIdentity packageIdentity,
+			string packageInstallPath,
+			INuGetProjectContext projectContext,
+			bool throwOnFailure,
+			CancellationToken token)
+		{
+			return Task.FromResult (false);
+		}
+
+		public Task ExecutePackageScriptAsync (
+			PackageIdentity packageIdentity,
+			string packageInstallPath,
+			string scriptRelativePath,
+			INuGetProjectContext projectContext,
+			bool throwOnFailure,
+			CancellationToken token)
+		{
+			return Task.FromResult (0);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -53,6 +53,8 @@ namespace MonoDevelop.PackageManagement
 
 			string path = SettingsUtility.GetGlobalPackagesFolder (settings);
 			packagePathResolver = new VersionFolderPathResolver (path);
+
+			ProjectServices = new NuGetProjectServices (dotNetProject);
 		}
 
 		public Task SaveProject ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectSystemReferencesReader.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectSystemReferencesReader.cs
@@ -1,0 +1,159 @@
+﻿//
+// ProjectSystemReferencesReader.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Based on src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/
+// VsCoreProjectSystemReferenceReader.cs
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+
+namespace MonoDevelop.PackageManagement
+{
+	class ProjectSystemReferencesReader : IProjectSystemReferencesReader
+	{
+		DotNetProject project;
+
+		public ProjectSystemReferencesReader (DotNetProject project)
+		{
+			this.project = project;
+		}
+
+		public Task<IEnumerable<LibraryDependency>> GetPackageReferencesAsync (
+			NuGetFramework targetFramework,
+			CancellationToken token)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Task<IEnumerable<ProjectRestoreReference>> GetProjectReferencesAsync (
+			ILogger logger,
+			CancellationToken token)
+		{
+			return Runtime.RunInMainThread (() => GetProjectReferences (logger));
+		}
+
+		internal IEnumerable<ProjectRestoreReference> GetProjectReferences (ILogger logger)
+		{
+			var results = new List<ProjectRestoreReference> ();
+
+			// Verify ReferenceOutputAssembly
+			var excludedProjects = GetExcludedReferences (project);
+			bool hasMissingReferences = false;
+
+			// find all references in the project
+			foreach (var childReference in project.References) {
+				try {
+					if (childReference.ReferenceType != ReferenceType.Project) {
+						continue;
+					}
+
+					if (!childReference.IsValid) {
+						// Skip missing references and show a warning
+						hasMissingReferences = true;
+						continue;
+					}
+
+					// Skip missing references
+					var sourceProject = childReference.ResolveProject (project.ParentSolution) as DotNetProject;
+
+					// Skip missing references
+					if (sourceProject != null) {
+						string childProjectPath = sourceProject.FileName;
+
+						// Skip projects which have ReferenceOutputAssembly=false
+						if (!string.IsNullOrEmpty (childProjectPath) &&
+							!excludedProjects.Contains (childProjectPath, StringComparer.OrdinalIgnoreCase)) {
+							var restoreReference = new ProjectRestoreReference () {
+								ProjectPath = childProjectPath,
+								ProjectUniqueName = childProjectPath
+							};
+
+							results.Add (restoreReference);
+						}
+					}
+				} catch (Exception ex) {
+					// Exceptions are expected in some scenarios for native projects,
+					// ignore them and show a warning
+					hasMissingReferences = true;
+
+					logger.LogDebug (ex.ToString ());
+
+					LoggingService.LogError ("Unable to find project dependencies.", ex);
+				}
+			}
+
+			if (hasMissingReferences) {
+				// Log a warning message once per project
+				// This warning contains only the names of the root project and the project with the
+				// broken reference. Attempting to display more details on the actual reference
+				// that has the problem may lead to another exception being thrown.
+				var warning = GettextCatalog.GetString (
+					"Failed to resolve all project references. The package restore result for '{0}' or a dependant project may be incomplete.",
+					project.Name);
+
+				logger.LogWarning (warning);
+			}
+
+			return results;
+		}
+
+		/// <summary>
+		/// Get the unique names of all references which have ReferenceOutputAssembly set to false.
+		/// </summary>
+		static List<string> GetExcludedReferences (DotNetProject project)
+		{
+			var excludedReferences = new List<string> ();
+
+			foreach (var reference in project.References) {
+				// 1. Verify that this is a project reference
+				// 2. Check that it is valid and resolved
+				// 3. Follow the reference to the DotNetProject and get the unique name
+				if (!reference.ReferenceOutputAssembly &&
+					reference.IsValid &&
+					reference.ReferenceType == ReferenceType.Project) {
+
+					var sourceProject = reference.ResolveProject (project.ParentSolution);
+					if (sourceProject != null) {
+						string childPath = sourceProject.FileName;
+						excludedReferences.Add (childPath);
+					}
+				}
+			}
+
+			return excludedReferences;
+		}
+	}
+}


### PR DESCRIPTION
With two projects A and B that both use project.json files, project B
referencing project A, the NuGet package dependencies used by project
A were not available to project B transitively. This was because the
project reference information was not being added to the package spec
when a restore occurred so the assemblies from the transitively
referenced NuGet packages were not being added to the
project.lock.json file for Project B.