### PR TITLE
[AutoTest] Added VirtualMemorySize and WorkingSet to MemoryStats

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -70,6 +70,8 @@ namespace MonoDevelop.Components.AutoTest
 		[Serializable]
 		public struct MemoryStats {
 			public long PrivateMemory;
+			public long VirtualMemorySize;
+			public long WorkingSet;
 			public long PeakVirtualMemory;
 			public long PagedSystemMemory;
 			public long PagedMemory;
@@ -82,6 +84,8 @@ namespace MonoDevelop.Components.AutoTest
 			using (Process proc = Process.GetCurrentProcess ()) {
 				stats = new MemoryStats {
 					PrivateMemory = proc.PrivateMemorySize64,
+					VirtualMemorySize = proc.VirtualMemorySize64,
+					WorkingSet = proc.WorkingSet64,
 					PeakVirtualMemory = proc.PeakVirtualMemorySize64,
 					PagedSystemMemory = proc.PagedSystemMemorySize64,
 					PagedMemory = proc.PagedMemorySize64,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Components.AutoTest
 		[Serializable]
 		public struct MemoryStats {
 			public long PrivateMemory;
-			public long VirtualMemorySize;
+			public long VirtualMemory;
 			public long WorkingSet;
 			public long PeakVirtualMemory;
 			public long PagedSystemMemory;


### PR DESCRIPTION
Part of the job to capture relevant details of memory usage as required by @Therzok 
corresponding PR: https://github.com/xamarin/QualityAssurance/pull/1314