### PR TITLE
[DotNetCore] Do not show .NET Core version 2.1 for new projects

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -92,6 +92,11 @@ namespace MonoDevelop.DotNetCore
 		public static IEnumerable<TargetFramework> GetNetCoreAppTargetFrameworks ()
 		{
 			foreach (Version runtimeVersion in GetMajorRuntimeVersions ()) {
+				if (runtimeVersion.Major == 2 && runtimeVersion.Minor > 0) {
+					// Skip version 2.1 since this is not currently supported.
+					continue;
+				}
+
 				string version = runtimeVersion.ToString (2);
 				yield return CreateTargetFramework (".NETCoreApp", version);
 			}


### PR DESCRIPTION
Project options and the New Project dialog would show .NET Core 2.1
as an option if version 2.1 was installed along with 2.0. Currently
there are no project templates for 2.1 so project creation would
fail. So now only up to version 2.0 is shown as supported.