### PR TITLE
[AutoTest] Fix build error

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -84,7 +84,7 @@ namespace MonoDevelop.Components.AutoTest
 			using (Process proc = Process.GetCurrentProcess ()) {
 				stats = new MemoryStats {
 					PrivateMemory = proc.PrivateMemorySize64,
-					VirtualMemorySize = proc.VirtualMemorySize64,
+					VirtualMemory = proc.VirtualMemorySize64,
 					WorkingSet = proc.WorkingSet64,
 					PeakVirtualMemory = proc.PeakVirtualMemorySize64,
 					PagedSystemMemory = proc.PagedSystemMemorySize64,


### PR DESCRIPTION
VirtualMemorySize field was renamed to VirtualMemory but not
all code was updated with this change.