### PR TITLE
Switch the default button to 'Build'. Fixes #60344

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1388,7 +1388,7 @@ namespace MonoDevelop.Ide
 			var res = MessageService.AskQuestion (
 				GettextCatalog.GetString ("Outdated Build"),
 				GettextCatalog.GetString ("The project you are executing has changes done after the last time it was compiled. Do you want to continue?"),
-				2,
+				1,
 				AlertButton.Cancel,
 				bBuild,
 				bRun);


### PR DESCRIPTION
<img width="636" alt="screen shot 2017-10-26 at 11 15 36" src="https://user-images.githubusercontent.com/667194/32047960-a5322d5e-ba3f-11e7-82ae-a93669ac5941.png">

The default button was "Cancel" previously, which is rarely the button that you want to be selected by default.
