### PR TITLE
[UnitTesting] Fix possible null reference exception

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/TestResultBuilder.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/TestResultBuilder.cs
@@ -247,8 +247,10 @@ namespace MonoDevelop.UnitTesting.VsTest
 			var result = UnitTestResult.CreateSuccess ();
 			foreach (UnitTest test in parent.Tests) {
 				UnitTestResult childResult = test.GetLastResult ();
-				result.Add (childResult);
-				UpdateCounts (result, childResult);
+				if (childResult != null) {
+					result.Add (childResult);
+					UpdateCounts (result, childResult);
+				}
 			}
 			return result;
 		}


### PR DESCRIPTION
Fixed bug #57783 - Null reference when running unit tests
https://bugzilla.xamarin.com/show_bug.cgi?id=57783

When building the test results the builder now handles null
returned from UnitTest.GetLastResult.