### PR TITLE
[CSharp] Performance optimisation, code completion list appearence blocked UI for up to 1 second

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.CSharp.Completion
 	{
 		CSharpCompletionTextEditorExtension completionExt;
 		ISymbol type;
+		string displayText;//This is just for caching, because Sorting completion list can call DisplayText many times
 		bool useFullName;
 
 		public ISymbol Symbol { get { return type; } }
@@ -48,7 +49,7 @@ namespace MonoDevelop.CSharp.Completion
 		}
 		static CompletionItemRules rules = CompletionItemRules.Create (matchPriority: -10000);
         public override CompletionItemRules Rules => rules;
-		public override string DisplayText { get => type.ToDisplayString (); }
+		public override string DisplayText { get => displayText; }
 		public override string CompletionText { get =>  useFullName ? type.ContainingNamespace.GetFullName () + "." + type.Name : type.Name; }
 
         public override int PriorityGroup { get { return int.MinValue; } }
@@ -58,6 +59,7 @@ namespace MonoDevelop.CSharp.Completion
 			this.completionExt = ext;
 			this.useFullName = useFullName;
 			this.type = type;
+			this.displayText = type.ToDisplayString ();
 			this.DisplayFlags |= DisplayFlags.IsImportCompletion;
 		}
 


### PR DESCRIPTION
When typing something like `backtrace.GetFrame(i);` after I typed `i` typing would get stuck for almost 1 second, so I profiled and noticed that problem is in list sorting and calls to ToDisplayString which put a lot of pressure on GC... Later I checked how many times it's called... turns out... out of 6,6k completion items `DisplayText` was called 181,7k...
Solution is cache all DisplayText up front...