### PR TITLE
[NuGet] Fix unhandled exception when searching for packages

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/MultiSourcePackageFeed.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/MultiSourcePackageFeed.cs
@@ -157,6 +157,11 @@ namespace NuGet.PackageManagement.UI
 				              .ToDictionary(kv => kv.Key, kv => GetLoadingStatus(kv.Value.Status)));
 			}
 
+			// Observe the aggregate task exception to prevent an unhandled exception.
+			// The individual task exceptions are logged in LogError and will be reported
+			// in the Add Packages dialog.
+			var ex = aggregatedTask.Exception;
+
 			return aggregated;
 		}
 


### PR DESCRIPTION
The MultiSourcePackageFeed was not observing in the aggregated task
returned from Task.WhenAll. An unhandled exception was logged if the
package source returned an error or the url was invalid.