### PR TITLE
Update to VS Editor implementation that matches 15.6.150-pre.

### DIFF
--- a/main/msbuild/ReferencesVSEditor.props
+++ b/main/msbuild/ReferencesVSEditor.props
@@ -31,7 +31,7 @@
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Implementation">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.0.1\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.0.2-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -24,7 +24,7 @@
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.6.150-preview" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.6.150-preview" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.0.1" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.0.2-pre" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />


### PR DESCRIPTION
Update to a version of MS.VS.Text.Implementation.dll that matches 15.6.150-preview (the version of VS Editor definitions we're currently referencing).

This version also removes a dependency on MS.VS.Text.Internal.dll so so one more step towards removing it and Text.UI.Wpf.dll from our list of dependencies.