### PR TITLE
[Core] Add Sierra and High Sierra Mac version to system information

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/MacSystemInformation.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/MacSystemInformation.cs
@@ -30,6 +30,8 @@ namespace MonoDevelop.Core
 {
 	public class MacSystemInformation : UnixSystemInformation
 	{
+		public static readonly Version HighSierra = new Version (10, 13);
+		public static readonly Version Sierra = new Version (10, 12);
 		public static readonly Version ElCapitan = new Version (10, 11);
 		public static readonly Version Yosemite = new Version (10, 10);
 		public static readonly Version Mavericks = new Version (10, 9);


### PR DESCRIPTION
Fix the build after https://github.com/xamarin/md-addins/pull/2645 was merged in. 