### PR TITLE
Fixed '294858 [Feedback] Do NOT go to definition if Ctrl/Cmd is

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/AbstractNavigationExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/AbstractNavigationExtension.cs
@@ -89,6 +89,8 @@ namespace MonoDevelop.Ide.Editor.Extension
 
 		static AbstractNavigationExtension ()
 		{
+			if (IdeApp.Workbench?.RootWindow == null)
+				return;
 			// snooperId =
 				Gtk.Key.SnooperInstall (TooltipKeySnooper);
 			//if (snooperId != 0)
@@ -178,6 +180,8 @@ namespace MonoDevelop.Ide.Editor.Extension
 				y = e.Y;
 			}
 			CancelRequestLinks ();
+			if (!IsHoverNavigationValid (Editor))
+				return;
 			var token = src.Token;
 			if (LinksShown) {
 				var lineNumber = Editor.PointToLocation (x, y).Line;
@@ -198,7 +202,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 				}
 				if (segments == null || token.IsCancellationRequested)
 					return;
-				await Runtime.RunInMainThread (delegate {
+				await Runtime.RunInMainThread(delegate {
 					try {
 						foreach (var segment in segments) {
 							if (token.IsCancellationRequested) {
@@ -214,6 +218,11 @@ namespace MonoDevelop.Ide.Editor.Extension
 					}
 				});
 			}
+		}
+
+		internal static bool IsHoverNavigationValid (TextEditor editor)
+		{
+			return !editor.IsSomethingSelected;
 		}
 
 		void CancelRequestLinks ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9713,6 +9713,7 @@
     <InternalsVisibleTo Include="MonoDevelop.VBNetBinding" />
     <InternalsVisibleTo Include="MonoDevelop.CSharpBinding.Tests" />
     <InternalsVisibleTo Include="Xamarin.Forms.Addin" />
+    <InternalsVisibleTo Include="MonoDevelop.TextEditor.Tests" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Extension/NavigationExtensionTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Extension/NavigationExtensionTests.cs
@@ -1,0 +1,50 @@
+﻿//
+// NavigationExtensionTests.cs
+//
+// Author:
+//       Mike Krüger <mikkrg@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+using System;
+using NUnit.Framework;
+using System.Linq;
+using MonoDevelop.Ide.Editor.Extension;
+using MonoDevelop.Ide.Editor;
+
+namespace Mono.TextEditor.Tests.Actions
+{
+	[TestFixture]
+	class NavigationExtensionTests : TextEditorTestBase
+	{
+		[Test]
+		public void TestBug294858 () // [Feedback] Do NOT go to definition if Ctrl/Cmd is pressed AFTER mouse down.
+		{
+			var editor = TextEditorFactory.CreateNewEditor ();
+			editor.Text = "Hello World";
+			Assert.IsTrue (AbstractNavigationExtension.IsHoverNavigationValid (editor));
+			editor.SetSelection (0, editor.Length);
+			Assert.IsFalse (AbstractNavigationExtension.IsHoverNavigationValid (editor));
+		}
+	}
+
+}

--- a/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Mono.TextEditor.Tests\SearchAndReplaceTests.cs" />
     <Compile Include="Mono.TextEditor.Tests\SemanticRuleTests.cs" />
     <Compile Include="Mono.TextEditor.Tests\TextEditorDataTests.cs" />
+    <Compile Include="MonoDevelop.TextEditor.Extension\NavigationExtensionTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
pressed AFTER mouse down.'

Ctrl+Navigation should be turned off while selection.