### PR TITLE
Fix NRE when quitting before error list is shown

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -300,7 +300,9 @@ namespace MonoDevelop.Ide.Gui.Pads
 			IdeApp.Workspace.LastWorkspaceItemClosed -= OnCombineClosed;
 
 			// Set the model to null as it makes Gtk clean up faster
-			view.Model = null;
+			if (view != null) {
+				view.Model = null;
+			}
 
 			base.Dispose ();
 		}


### PR DESCRIPTION
```
ERROR [2017-11-01 18:47:39Z]: Async operation failed
System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Ide.Gui.Pads.ErrorListPad.Dispose () [0x0002f] in /Users/jason/src/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs:303
  at MonoDevelop.Ide.Gui.DefaultWorkbench.OnClosed (System.EventArgs e) [0x000a0] in /Users/jason/src/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs:748
  at MonoDevelop.Ide.Gui.DefaultWorkbench+<Close>d__97.MoveNext () [0x001ef] in /Users/jason/src/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs:789
```