### PR TITLE
[Core] Save user preferences in subdirectory

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -423,29 +423,22 @@ namespace MonoDevelop.Projects
 
 		internal string GetPreferencesFileName ()
 		{
-			return GetPreferencesFileName (BrandingService.ApplicationName, BuildInfo.CompatVersion);
+			return GetPreferencesFileName (BuildInfo.CompatVersion);
 		}
 
-		internal string GetPreferencesFileName (string appName, string appVersion)
+		internal string GetPreferencesFileName (string appVersion)
 		{
-			bool isVisualStudio = appName == "Visual Studio";
-			string appNameDirectory = isVisualStudio ? ".vs" : ".md";
-			string appVersionDirectory = GetAppVersionDirectory (appVersion, isVisualStudio);
-
-			return BaseDirectory.Combine (appNameDirectory, Name, appVersionDirectory, "UserPrefs.xml");
+			return BaseDirectory.Combine (".vs", Name, GetAppVersionDirectory (appVersion), "UserPrefs.xml");
 		}
 
-		static string GetAppVersionDirectory (string appVersion, bool isVisualStudio)
+		static string GetAppVersionDirectory (string appVersion)
 		{
 			int index = appVersion.IndexOf ('.');
 			if (index != -1) {
 				appVersion = appVersion.Substring (0, index);
 			}
 
-			if (isVisualStudio) {
-				return "mac-v" + appVersion;
-			}
-			return "v" + appVersion;
+			return "xs-v" + appVersion;
 		}
 
 		public virtual StringTagModelDescription GetStringTagModelDescription ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -423,22 +423,7 @@ namespace MonoDevelop.Projects
 
 		internal string GetPreferencesFileName ()
 		{
-			return GetPreferencesFileName (BuildInfo.CompatVersion);
-		}
-
-		internal string GetPreferencesFileName (string appVersion)
-		{
-			return BaseDirectory.Combine (".vs", Name, GetAppVersionDirectory (appVersion), "UserPrefs.xml");
-		}
-
-		static string GetAppVersionDirectory (string appVersion)
-		{
-			int index = appVersion.IndexOf ('.');
-			if (index != -1) {
-				appVersion = appVersion.Substring (0, index);
-			}
-
-			return "xs-v" + appVersion;
+			return BaseDirectory.Combine (".vs", Name, "xs", "UserPrefs.xml");
 		}
 
 		public virtual StringTagModelDescription GetStringTagModelDescription ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -339,9 +339,12 @@ namespace MonoDevelop.Projects
 			userProperties.Dispose ();
 			userProperties = new PropertyBag ();
 
+			string oldPreferencesFileName = GetLegacyPreferencesFileName ();
 			string preferencesFileName = GetPreferencesFileName ();
 
 			return Task.Run (() => {
+				MigrateLegacyUserPreferencesFile (oldPreferencesFileName, preferencesFileName);
+
 				if (!File.Exists (preferencesFileName))
 					return;
 
@@ -373,7 +376,7 @@ namespace MonoDevelop.Projects
 
 		protected virtual Task OnSaveUserProperties ()
 		{
-			string file = GetPreferencesFileName ();
+			FilePath file = GetPreferencesFileName ();
 			var userProps = userProperties;
 
 			return Task.Run (() => {
@@ -385,6 +388,8 @@ namespace MonoDevelop.Projects
 			
 				XmlTextWriter writer = null;
 				try {
+					Directory.CreateDirectory (file.ParentDirectory);
+
 					writer = new XmlTextWriter (file, System.Text.Encoding.UTF8);
 					writer.Formatting = Formatting.Indented;
 					XmlDataSerializer ser = new XmlDataSerializer (new DataContext ());
@@ -399,9 +404,48 @@ namespace MonoDevelop.Projects
 			});
 		}
 		
-		string GetPreferencesFileName ()
+		string GetLegacyPreferencesFileName ()
 		{
 			return FileName.ChangeExtension (".userprefs");
+		}
+
+		static void MigrateLegacyUserPreferencesFile (string legacyPreferencesFileName, FilePath preferencesFileName)
+		{
+			if (!File.Exists (legacyPreferencesFileName))
+				return;
+
+			if (!File.Exists (preferencesFileName)) {
+				Directory.CreateDirectory (preferencesFileName.ParentDirectory);
+
+				File.Move (legacyPreferencesFileName, preferencesFileName);
+			}
+		}
+
+		internal string GetPreferencesFileName ()
+		{
+			return GetPreferencesFileName (BrandingService.ApplicationName, BuildInfo.CompatVersion);
+		}
+
+		internal string GetPreferencesFileName (string appName, string appVersion)
+		{
+			bool isVisualStudio = appName == "Visual Studio";
+			string appNameDirectory = isVisualStudio ? ".vs" : ".md";
+			string appVersionDirectory = GetAppVersionDirectory (appVersion, isVisualStudio);
+
+			return BaseDirectory.Combine (appNameDirectory, Name, appVersionDirectory, "UserPrefs.xml");
+		}
+
+		static string GetAppVersionDirectory (string appVersion, bool isVisualStudio)
+		{
+			int index = appVersion.IndexOf ('.');
+			if (index != -1) {
+				appVersion = appVersion.Substring (0, index);
+			}
+
+			if (isVisualStudio) {
+				return "mac-v" + appVersion;
+			}
+			return "v" + appVersion;
 		}
 
 		public virtual StringTagModelDescription GetStringTagModelDescription ()

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
@@ -72,19 +72,17 @@ namespace MonoDevelop.Ide
 			sol.Dispose ();
 		}
 
-		[TestCase ("7.0", new [] { ".vs", "MySolution", "xs-v7", "UserPrefs.xml" })]
-		[TestCase ("8.0", new [] { ".vs", "MySolution", "xs-v8", "UserPrefs.xml" })]
-		[TestCase ("7.1", new [] { ".vs", "MySolution", "xs-v7", "UserPrefs.xml" })]
-		[TestCase ("8.1", new [] { ".vs", "MySolution", "xs-v8", "UserPrefs.xml" })]
-		public void UserPreferencesFileName (string appVersion, string[] paths)
+		[Test]
+		public void UserPreferencesFileName ()
 		{
 			FilePath directory = Util.CreateTmpDir ("MySolution");
 			var fileName = directory.Combine ("MySolution.sln");
 			var solution = new Solution ();
 			solution.FileName = fileName;
+			var paths = new [] { ".vs", "MySolution", "xs", "UserPrefs.xml" };
 			string expectedFileName = solution.BaseDirectory.Combine (paths);
 
-			string userPreferencesFileName = solution.GetPreferencesFileName (appVersion);
+			string userPreferencesFileName = solution.GetPreferencesFileName ();
 
 			Assert.AreEqual (expectedFileName, userPreferencesFileName);
 		}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
@@ -72,11 +72,11 @@ namespace MonoDevelop.Ide
 			sol.Dispose ();
 		}
 
-		[TestCase ("MonoDevelop", "7.0", new [] { ".md", "MySolution", "v7", "UserPrefs.xml" })]
-		[TestCase ("MonoDevelop", "8.0", new [] { ".md", "MySolution", "v8", "UserPrefs.xml" })]
-		[TestCase ("Visual Studio", "7.1", new [] { ".vs", "MySolution", "mac-v7", "UserPrefs.xml" })]
-		[TestCase ("Visual Studio", "8.1", new [] { ".vs", "MySolution", "mac-v8", "UserPrefs.xml" })]
-		public void UserPreferencesFileName (string appName, string appVersion, string[] paths)
+		[TestCase ("7.0", new [] { ".vs", "MySolution", "xs-v7", "UserPrefs.xml" })]
+		[TestCase ("8.0", new [] { ".vs", "MySolution", "xs-v8", "UserPrefs.xml" })]
+		[TestCase ("7.1", new [] { ".vs", "MySolution", "xs-v7", "UserPrefs.xml" })]
+		[TestCase ("8.1", new [] { ".vs", "MySolution", "xs-v8", "UserPrefs.xml" })]
+		public void UserPreferencesFileName (string appVersion, string[] paths)
 		{
 			FilePath directory = Util.CreateTmpDir ("MySolution");
 			var fileName = directory.Combine ("MySolution.sln");
@@ -84,7 +84,7 @@ namespace MonoDevelop.Ide
 			solution.FileName = fileName;
 			string expectedFileName = solution.BaseDirectory.Combine (paths);
 
-			string userPreferencesFileName = solution.GetPreferencesFileName (appName, appVersion);
+			string userPreferencesFileName = solution.GetPreferencesFileName (appVersion);
 
 			Assert.AreEqual (expectedFileName, userPreferencesFileName);
 		}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
 using MonoDevelop.Projects;
@@ -49,6 +50,83 @@ namespace MonoDevelop.Ide
 			Assert.AreEqual("Release", userData.ActiveConfiguration);
 
 			ws.Dispose();
+		}
+
+		[Test]
+		public async Task UserProperties ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (DotNetProject)sol.Items [0];
+			sol.UserProperties.SetValue ("SolProp", "foo");
+			p.UserProperties.SetValue ("ProjectProp", "bar");
+			await sol.SaveUserProperties ();
+			sol.Dispose ();
+
+			sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			p = (DotNetProject)sol.Items [0];
+
+			Assert.AreEqual ("foo", sol.UserProperties.GetValue<string> ("SolProp"));
+			Assert.AreEqual ("bar", p.UserProperties.GetValue<string> ("ProjectProp"));
+
+			sol.Dispose ();
+		}
+
+		[TestCase ("MonoDevelop", "7.0", new [] { ".md", "MySolution", "v7", "UserPrefs.xml" })]
+		[TestCase ("MonoDevelop", "8.0", new [] { ".md", "MySolution", "v8", "UserPrefs.xml" })]
+		[TestCase ("Visual Studio", "7.1", new [] { ".vs", "MySolution", "mac-v7", "UserPrefs.xml" })]
+		[TestCase ("Visual Studio", "8.1", new [] { ".vs", "MySolution", "mac-v8", "UserPrefs.xml" })]
+		public void UserPreferencesFileName (string appName, string appVersion, string[] paths)
+		{
+			FilePath directory = Util.CreateTmpDir ("MySolution");
+			var fileName = directory.Combine ("MySolution.sln");
+			var solution = new Solution ();
+			solution.FileName = fileName;
+			string expectedFileName = solution.BaseDirectory.Combine (paths);
+
+			string userPreferencesFileName = solution.GetPreferencesFileName (appName, appVersion);
+
+			Assert.AreEqual (expectedFileName, userPreferencesFileName);
+		}
+
+		[Test]
+		public async Task UserPreferencesAreMigratedToNewLocation ()
+		{
+			FilePath directory = Util.CreateTmpDir ("MigrateUserPreferences");
+			var fileName = directory.Combine ("MigrateUserPreferences.sln");
+
+			var solution = new Solution ();
+			solution.FileName = fileName;
+			solution.UserProperties.SetValue ("Test", "Test-Value");
+
+			// Create a user prefs file.
+			await solution.SaveAsync (Util.GetMonitor ());
+
+			Assert.IsTrue (File.Exists (solution.GetPreferencesFileName ()));
+
+			var userPreferencesOldLocationFileName = solution.FileName.ChangeExtension (".userprefs");
+			Assert.IsFalse (File.Exists (userPreferencesOldLocationFileName));
+
+			// Create a legacy user prefs file.
+			FilePath preferencesFileName = solution.GetPreferencesFileName ();
+			File.Move (preferencesFileName, userPreferencesOldLocationFileName);
+
+			// Ensure migration handles the missing directory for the new prefs file.
+			Directory.Delete (preferencesFileName.ParentDirectory);
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), fileName);
+
+			Assert.AreEqual ("Test-Value", solution.UserProperties.GetValue<string> ("Test"));
+
+			// Change user property and save user prefs.
+			solution.UserProperties.SetValue ("Test", "Test-Value-Updated");
+			await solution.SaveUserProperties ();
+
+			Assert.IsFalse (File.Exists (userPreferencesOldLocationFileName));
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), fileName);
+
+			Assert.AreEqual ("Test-Value-Updated", solution.UserProperties.GetValue<string> ("Test"));
 		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectLoadSaveTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectLoadSaveTests.cs
@@ -1097,26 +1097,6 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
-		public async Task UserProperties ()
-		{
-			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
-			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
-			var p = (DotNetProject)sol.Items [0];
-			sol.UserProperties.SetValue ("SolProp", "foo");
-			p.UserProperties.SetValue ("ProjectProp", "bar");
-			await sol.SaveUserProperties ();
-			sol.Dispose ();
-
-			sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
-			p = (DotNetProject)sol.Items [0];
-
-			Assert.AreEqual ("foo", sol.UserProperties.GetValue<string> ("SolProp"));
-			Assert.AreEqual ("bar", p.UserProperties.GetValue<string> ("ProjectProp"));
-
-			sol.Dispose ();
-		}
-
-		[Test]
 		public async Task AddImportThenRemoveImportAndThenAddImportAgain ()
 		{
 			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");


### PR DESCRIPTION
The solution's user preferences file (SolutionName.userprefs) is now
saved in a subdirectory. For MonoDevelop this is:

  .md/SolutionName/v7/UserPrefs.xml

For Visual Studio:

  .vs/SolutionName/mac-v7/UserPrefs.xml