### PR TITLE
[Ide][Mac] Enable Alert sheeting on Mac

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -156,8 +156,8 @@ namespace MonoDevelop.MacIntegration
 				}
 				
 				if (!data.Message.CancellationToken.IsCancellationRequested) {
-
-					var result = (int)alert.RunModal () - (long)(int)NSAlertButtonReturn.First;
+					NSWindow parent = data.TransientFor ?? IdeApp.Workbench.RootWindow;
+					var result = (int)(parent == null ? alert.RunModal () : alert.RunSheetModal (parent)) - (long)(int)NSAlertButtonReturn.First;
 					
 					completed = true;
 					if (result >= 0 && result < buttons.Count) {

--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -149,7 +149,10 @@ namespace MonoDevelop.MacIntegration
 					data.Message.CancellationToken.Register (delegate {
 						alert.InvokeOnMainThread (() => {
 							if (!completed) {
-								NSApplication.SharedApplication.AbortModal ();
+								if (alert.Window.IsSheet && alert.Window.SheetParent != null)
+									alert.Window.SheetParent.EndSheet (alert.Window);
+								else
+									NSApplication.SharedApplication.AbortModal ();
 							}
 						});
 					});

--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -159,7 +159,9 @@ namespace MonoDevelop.MacIntegration
 				}
 				
 				if (!data.Message.CancellationToken.IsCancellationRequested) {
-					NSWindow parent = data.TransientFor ?? IdeApp.Workbench.RootWindow;
+					NSWindow parent = null;
+					if (IdeTheme.UserInterfaceTheme != Theme.Dark || MacSystemInformation.OsVersion < MacSystemInformation.HighSierra) // sheeting is broken on High Sierra with dark NSAppearance
+						parent = data.TransientFor ?? IdeApp.Workbench.RootWindow;
 					var result = (int)(parent == null ? alert.RunModal () : alert.RunSheetModal (parent)) - (long)(int)NSAlertButtonReturn.First;
 					
 					completed = true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
@@ -70,6 +70,9 @@ namespace MonoDevelop.Components
 		{
 			if (d is XwtWindowControl)
 				return (XwtWindowControl)d;
+			if (d?.nativeWidget is Gtk.Window)
+				return Mac.GtkMacInterop.GetNSWindow (d.GetNativeWidget<Gtk.Window> ());
+			
 			return d?.GetNativeWidget<AppKit.NSWindow> ();
 		}
 


### PR DESCRIPTION
This patch enables alert dialog sheeting on Mac:

<img width="756" alt="grafik" src="https://user-images.githubusercontent.com/951587/32317150-1a1f56aa-bfb3-11e7-9974-994e30372a2b.png">
