### PR TITLE
[F#] Fix debugger expression resolver for record fields

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/DebuggerExpressionResolver.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/DebuggerExpressionResolver.fs
@@ -17,7 +17,11 @@ type TestOne() =
 let local|One = TestOne()
 let local|Two = localOne.Prope|rtyOne
 let localThree = local|One.PropertyOne
-let localFour = localOne.Property|One"""
+let localFour = localOne.Property|One
+
+type Test = { recordfield: string }
+let a = { recordfield = "A" }
+let x = a.record|field"""
 
     let getOffset expr =
         let startOffset = content.IndexOf (expr, StringComparison.Ordinal)
@@ -40,6 +44,7 @@ let localFour = localOne.Property|One"""
     [<TestCase("localOne.Prope|rtyOne", "localOne.PropertyOne")>]
     [<TestCase("local|One.PropertyOne", "localOne")>]
     [<TestCase("localOne.Property|One", "localOne.PropertyOne")>]
+    [<TestCase("a.record|field", "a.recordfield")>]
     member x.TestBasicLocalVariable(localVariable, expected) =
         let basicOffset = getOffset (localVariable)
         let doc = TestHelpers.createDoc (content.Replace("|" ,"")) ""

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpDebuggerExpressionResolver.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpDebuggerExpressionResolver.fs
@@ -24,11 +24,11 @@ type FSharpDebuggerExpressionResolver() =
                             | SymbolUse.ActivePatternCase apc ->
                                 Some (apc.DeclarationLocation, apc.DisplayName)
                             | SymbolUse.Entity _ent -> None
-                            | SymbolUse.Field field ->
-                                Some (field.DeclarationLocation, field.DisplayName)
+                            | SymbolUse.Field _field ->
+                                let loc = symbolUse.RangeAlternate
+                                Some (loc, lineTxt.[loc.StartColumn..loc.EndColumn-1])
                             | SymbolUse.GenericParameter gp ->
                                 Some (gp.DeclarationLocation, gp.DisplayName)
-                            //| CorePatterns.MemberFunctionOrValue
                             | SymbolUse.Parameter p ->
                                 Some (p.DeclarationLocation, p.DisplayName)
                             | SymbolUse.StaticParameter sp ->


### PR DESCRIPTION
```
type Test = { thing: string }
let a = { thing = "A" }
let x = a.thing
               ^^ put breakpoint here and hover over thing
```