### PR TITLE
Added "Skip building unmodified projects" setting

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -548,6 +548,7 @@ namespace MonoDevelop.Core
 		public readonly ConfigurationProperty<string> UserInterfaceLanguage = ConfigurationProperty.Create ("MonoDevelop.Ide.UserInterfaceLanguage", "");
 		public readonly ConfigurationProperty<MonoDevelop.Projects.MSBuild.MSBuildVerbosity> MSBuildVerbosity = ConfigurationProperty.Create ("MonoDevelop.Ide.MSBuildVerbosity", MonoDevelop.Projects.MSBuild.MSBuildVerbosity.Normal);
 		public readonly ConfigurationProperty<bool> BuildWithMSBuild = ConfigurationProperty.Create ("MonoDevelop.Ide.BuildWithMSBuild", true);
+		public readonly ConfigurationProperty<bool> SkipBuildingUnmodifiedProjects = ConfigurationProperty.Create ("MonoDevelop.Ide.SkipBuildingUnmodifiedProjects", false);
 		public readonly ConfigurationProperty<bool> ParallelBuild = ConfigurationProperty.Create ("MonoDevelop.ParallelBuild", true);
 
 		public readonly ConfigurationProperty<string> AuthorName = ConfigurationProperty.Create ("Author.Name", Environment.UserName, oldName:"ChangeLogAddIn.Name");

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -641,7 +641,13 @@ namespace MonoDevelop.Projects
 			BuildResult result = null;
 
 			try {
-				
+
+				if (Runtime.Preferences.SkipBuildingUnmodifiedProjects)
+					allProjects = allProjects.Where (si => {
+						if (si is Project p)
+							return p.FastCheckNeedsBuild (configuration);
+						return true;//Don't filter things that don't have FastCheckNeedsBuild
+					}).ToList ().AsReadOnly ();
 				monitor.BeginTask (GettextCatalog.GetString ("Building Solution: {0} ({1})", Name, configuration.ToString ()), allProjects.Count);
 
 				operationStarted = ParentSolution != null && await ParentSolution.BeginBuildOperation (monitor, configuration, operationContext);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -633,7 +633,12 @@ namespace MonoDevelop.Projects
 				var referenced = new List<SolutionItem> ();
 				var visited = new Set<SolutionItem> ();
 				GetBuildableReferencedItems (visited, referenced, this, solutionConfiguration);
-
+				if (Runtime.Preferences.SkipBuildingUnmodifiedProjects)
+					referenced.RemoveAll (si => {
+						if (si is Project p)
+							return !p.FastCheckNeedsBuild (solutionConfiguration);
+						return false;//Don't filter things that don't have FastCheckNeedsBuild
+					});
 				var sortedReferenced = TopologicalSort (referenced, solutionConfiguration);
 
 				SolutionItemConfiguration iconf = GetConfiguration (solutionConfiguration);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
@@ -64,6 +64,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			verbosityCombo.Active = (int)IdeApp.Preferences.MSBuildVerbosity.Value;
 			buildBeforeTestCheckBox.Active = IdeApp.Preferences.BuildBeforeRunningTests;
 			buildWithMSBuildCheckBox.Active = Runtime.Preferences.BuildWithMSBuild;
+			skipBuildingUnmodifiedProjectsCheckbox.Active = Runtime.Preferences.SkipBuildingUnmodifiedProjects;
 			parallelBuildCheckbox.Active = MonoDevelop.Core.Runtime.Preferences.ParallelBuild.Value;
 
 			SetupAccessibility ();
@@ -79,6 +80,8 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			                                                          GettextCatalog.GetString ("Check to build the solution before running tests"));
 			buildWithMSBuildCheckBox.SetCommonAccessibilityAttributes ("BuildPanel.buildWithMSBuild", "",
 			                                                           GettextCatalog.GetString ("Check to use MSBuild to build the solution"));
+			skipBuildingUnmodifiedProjectsCheckbox.SetCommonAccessibilityAttributes ("BuildPanel.skipUnmodifiedProject", "",
+																					 GettextCatalog.GetString ("Check to skip building unmodified projects"));
 			parallelBuildCheckbox.SetCommonAccessibilityAttributes ("BuildPanel.parallelBuild", "",
 			                                                        GettextCatalog.GetString ("Check to enable parallel building"));
 
@@ -100,6 +103,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			IdeApp.Preferences.MSBuildVerbosity.Value = (MSBuildVerbosity) verbosityCombo.Active;
 			IdeApp.Preferences.BuildBeforeRunningTests.Value = buildBeforeTestCheckBox.Active;
 			Runtime.Preferences.BuildWithMSBuild.Value = buildWithMSBuildCheckBox.Active;
+			Runtime.Preferences.SkipBuildingUnmodifiedProjects.Value = skipBuildingUnmodifiedProjectsCheckbox.Active;
 			MonoDevelop.Core.Runtime.Preferences.ParallelBuild.Value = parallelBuildCheckbox.Active;
 			if (saveChangesRadioButton.Active)
 				IdeApp.Preferences.BeforeBuildSaveAction.Value = BeforeCompileAction.SaveAllFiles;

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget.cs
@@ -16,6 +16,8 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		private global::Gtk.CheckButton buildWithMSBuildCheckBox;
 
+		private global::Gtk.CheckButton skipBuildingUnmodifiedProjectsCheckbox;
+
 		private global::Gtk.Alignment alignment1;
 
 		private global::Gtk.HBox hbox1;
@@ -109,6 +111,18 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			w5.Expand = false;
 			w5.Fill = false;
 			// Container child vbox66.Gtk.Box+BoxChild
+			this.skipBuildingUnmodifiedProjectsCheckbox = new global::Gtk.CheckButton();
+			this.skipBuildingUnmodifiedProjectsCheckbox.CanFocus = true;
+			this.skipBuildingUnmodifiedProjectsCheckbox.Name = "skipBuildingUnmodifiedProjectsCheckbox";
+			this.skipBuildingUnmodifiedProjectsCheckbox.Label = global::Mono.Unix.Catalog.GetString("Skip building unmodified projects");
+			this.skipBuildingUnmodifiedProjectsCheckbox.DrawIndicator = true;
+			this.skipBuildingUnmodifiedProjectsCheckbox.UseUnderline = true;
+			this.vbox66.Add(this.skipBuildingUnmodifiedProjectsCheckbox);
+			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.skipBuildingUnmodifiedProjectsCheckbox]));
+			w6.Position = 5;
+			w6.Expand = false;
+			w6.Fill = false;
+			// Container child vbox66.Gtk.Box+BoxChild
 			this.alignment1 = new global::Gtk.Alignment(0.5F, 0.5F, 1F, 1F);
 			this.alignment1.Name = "alignment1";
 			this.alignment1.LeftPadding = ((uint)(36));
@@ -122,10 +136,10 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.label1.LabelProp = global::Mono.Unix.Catalog.GetString("Log _verbosity:");
 			this.label1.UseUnderline = true;
 			this.hbox1.Add(this.label1);
-			global::Gtk.Box.BoxChild w6 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.label1]));
-			w6.Position = 0;
-			w6.Expand = false;
-			w6.Fill = false;
+			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.label1]));
+			w7.Position = 0;
+			w7.Expand = false;
+			w7.Fill = false;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this.verbosityCombo = global::Gtk.ComboBox.NewText();
 			this.verbosityCombo.AppendText(global::Mono.Unix.Catalog.GetString("Quiet"));
@@ -136,16 +150,16 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.verbosityCombo.Name = "verbosityCombo";
 			this.verbosityCombo.Active = 2;
 			this.hbox1.Add(this.verbosityCombo);
-			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.verbosityCombo]));
-			w7.Position = 1;
-			w7.Expand = false;
-			w7.Fill = false;
+			global::Gtk.Box.BoxChild w8 = ((global::Gtk.Box.BoxChild)(this.hbox1[this.verbosityCombo]));
+			w8.Position = 1;
+			w8.Expand = false;
+			w8.Fill = false;
 			this.alignment1.Add(this.hbox1);
 			this.vbox66.Add(this.alignment1);
-			global::Gtk.Box.BoxChild w9 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.alignment1]));
-			w9.Position = 5;
-			w9.Expand = false;
-			w9.Fill = false;
+			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.alignment1]));
+			w10.Position = 6;
+			w10.Expand = false;
+			w10.Fill = false;
 			// Container child vbox66.Gtk.Box+BoxChild
 			this.buildAndRunOptionsLabel = new global::Gtk.Label();
 			this.buildAndRunOptionsLabel.Name = "buildAndRunOptionsLabel";
@@ -154,11 +168,11 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.buildAndRunOptionsLabel.LabelProp = global::Mono.Unix.Catalog.GetString("<b>File Save Options Before Building</b>");
 			this.buildAndRunOptionsLabel.UseMarkup = true;
 			this.vbox66.Add(this.buildAndRunOptionsLabel);
-			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.buildAndRunOptionsLabel]));
-			w10.Position = 6;
-			w10.Expand = false;
-			w10.Fill = false;
-			w10.Padding = ((uint)(6));
+			global::Gtk.Box.BoxChild w11 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.buildAndRunOptionsLabel]));
+			w11.Position = 7;
+			w11.Expand = false;
+			w11.Fill = false;
+			w11.Padding = ((uint)(6));
 			// Container child vbox66.Gtk.Box+BoxChild
 			this.hbox44 = new global::Gtk.HBox();
 			this.hbox44.Name = "hbox44";
@@ -170,10 +184,10 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.label71.Yalign = 0F;
 			this.label71.LabelProp = "    ";
 			this.hbox44.Add(this.label71);
-			global::Gtk.Box.BoxChild w11 = ((global::Gtk.Box.BoxChild)(this.hbox44[this.label71]));
-			w11.Position = 0;
-			w11.Expand = false;
-			w11.Fill = false;
+			global::Gtk.Box.BoxChild w12 = ((global::Gtk.Box.BoxChild)(this.hbox44[this.label71]));
+			w12.Position = 0;
+			w12.Expand = false;
+			w12.Fill = false;
 			// Container child hbox44.Gtk.Box+BoxChild
 			this.vbox67 = new global::Gtk.VBox();
 			this.vbox67.Name = "vbox67";
@@ -185,10 +199,10 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.saveChangesRadioButton.UseUnderline = true;
 			this.saveChangesRadioButton.Group = new global::GLib.SList(global::System.IntPtr.Zero);
 			this.vbox67.Add(this.saveChangesRadioButton);
-			global::Gtk.Box.BoxChild w12 = ((global::Gtk.Box.BoxChild)(this.vbox67[this.saveChangesRadioButton]));
-			w12.Position = 0;
-			w12.Expand = false;
-			w12.Fill = false;
+			global::Gtk.Box.BoxChild w13 = ((global::Gtk.Box.BoxChild)(this.vbox67[this.saveChangesRadioButton]));
+			w13.Position = 0;
+			w13.Expand = false;
+			w13.Fill = false;
 			// Container child vbox67.Gtk.Box+BoxChild
 			this.promptChangesRadioButton = new global::Gtk.RadioButton(global::Mono.Unix.Catalog.GetString("_Prompt to save changes to open documents"));
 			this.promptChangesRadioButton.Name = "promptChangesRadioButton";
@@ -196,10 +210,10 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.promptChangesRadioButton.UseUnderline = true;
 			this.promptChangesRadioButton.Group = this.saveChangesRadioButton.Group;
 			this.vbox67.Add(this.promptChangesRadioButton);
-			global::Gtk.Box.BoxChild w13 = ((global::Gtk.Box.BoxChild)(this.vbox67[this.promptChangesRadioButton]));
-			w13.Position = 1;
-			w13.Expand = false;
-			w13.Fill = false;
+			global::Gtk.Box.BoxChild w14 = ((global::Gtk.Box.BoxChild)(this.vbox67[this.promptChangesRadioButton]));
+			w14.Position = 1;
+			w14.Expand = false;
+			w14.Fill = false;
 			// Container child vbox67.Gtk.Box+BoxChild
 			this.noSaveRadioButton = new global::Gtk.RadioButton(global::Mono.Unix.Catalog.GetString("_Don't save changes to open documents "));
 			this.noSaveRadioButton.Name = "noSaveRadioButton";
@@ -207,17 +221,17 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.noSaveRadioButton.UseUnderline = true;
 			this.noSaveRadioButton.Group = this.saveChangesRadioButton.Group;
 			this.vbox67.Add(this.noSaveRadioButton);
-			global::Gtk.Box.BoxChild w14 = ((global::Gtk.Box.BoxChild)(this.vbox67[this.noSaveRadioButton]));
-			w14.Position = 2;
-			w14.Expand = false;
-			w14.Fill = false;
-			this.hbox44.Add(this.vbox67);
-			global::Gtk.Box.BoxChild w15 = ((global::Gtk.Box.BoxChild)(this.hbox44[this.vbox67]));
-			w15.Position = 1;
+			global::Gtk.Box.BoxChild w15 = ((global::Gtk.Box.BoxChild)(this.vbox67[this.noSaveRadioButton]));
+			w15.Position = 2;
 			w15.Expand = false;
+			w15.Fill = false;
+			this.hbox44.Add(this.vbox67);
+			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.hbox44[this.vbox67]));
+			w16.Position = 1;
+			w16.Expand = false;
 			this.vbox66.Add(this.hbox44);
-			global::Gtk.Box.BoxChild w16 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.hbox44]));
-			w16.Position = 7;
+			global::Gtk.Box.BoxChild w17 = ((global::Gtk.Box.BoxChild)(this.vbox66[this.hbox44]));
+			w17.Position = 8;
 			this.Add(this.vbox66);
 			if ((this.Child != null))
 			{

--- a/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
+++ b/main/src/core/MonoDevelop.Ide/gtk-gui/gui.stetic
@@ -901,7 +901,7 @@
       </widget>
     </child>
   </widget>
-  <widget class="Gtk.Bin" id="MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget" design-size="471 300">
+  <widget class="Gtk.Bin" id="MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget" design-size="471 358">
     <property name="MemberName" />
     <property name="GeneratePublic">False</property>
     <child>
@@ -989,6 +989,22 @@
           </packing>
         </child>
         <child>
+          <widget class="Gtk.CheckButton" id="skipBuildingUnmodifiedProjectsCheckbox">
+            <property name="MemberName" />
+            <property name="CanFocus">True</property>
+            <property name="Label" translatable="yes">Skip building unmodified projects</property>
+            <property name="DrawIndicator">True</property>
+            <property name="HasLabel">True</property>
+            <property name="UseUnderline">True</property>
+          </widget>
+          <packing>
+            <property name="Position">5</property>
+            <property name="AutoSize">True</property>
+            <property name="Expand">False</property>
+            <property name="Fill">False</property>
+          </packing>
+        </child>
+        <child>
           <widget class="Gtk.Alignment" id="alignment1">
             <property name="MemberName" />
             <property name="LeftPadding">36</property>
@@ -1035,7 +1051,7 @@ Diagnostic</property>
             </child>
           </widget>
           <packing>
-            <property name="Position">5</property>
+            <property name="Position">6</property>
             <property name="AutoSize">True</property>
             <property name="Expand">False</property>
             <property name="Fill">False</property>
@@ -1050,7 +1066,7 @@ Diagnostic</property>
             <property name="UseMarkup">True</property>
           </widget>
           <packing>
-            <property name="Position">6</property>
+            <property name="Position">7</property>
             <property name="AutoSize">False</property>
             <property name="Expand">False</property>
             <property name="Fill">False</property>
@@ -1137,7 +1153,7 @@ Diagnostic</property>
             </child>
           </widget>
           <packing>
-            <property name="Position">7</property>
+            <property name="Position">8</property>
             <property name="AutoSize">False</property>
           </packing>
         </child>


### PR DESCRIPTION
which speeds up building projects with many project references

Here are some numbers, notice that all this numbers assume projects were built before inside IDE(this is needed for "unmodified projects" detection)
- Modify file in MonoDevelop.Debugger project and press Cmd+K(Build this project) and right after Cmd+Return(start debugging)
  - before: ~9sec total: ~5.5 sec to build MD.Debugger + ~3.5sec to build MD.Startup
  - after: ~3sec total: ~3sec to build MD.Debugger and ~0sec to build MD.Startup(0 invoking MSBuild, since Startup or any reference didn't change)
- Modify MD.CSharpBinding and use Cmd+K
  - before: ~8.5sec
  - after: ~4.5ses
- Modify MD.Startup and use Cmd+B(build all), this is most extreme one
  - before:~18sec
  - after:~2.5sec

Notice that all this differences come from MSBuild figuring out there is no need to call csc.exe, most of time remaining(3sec on MD.Debugger, 4.5sec on MD.CSharpBinding or 2.5sec on MD.Startup) come from roslyn compile times...

I looked into this because I got sick of always having "Build project before running" disabled and using Cmd+K on MonoDevelop.Debugger, Cmd+Return and then after build finished pressing "Execute" in dialog that pops up...

I put this setting on off by default because I'm not sure of side effects... Notice that Rebuilding project means it won't skip MSBuild part...