### PR TITLE
Bug 60486 - VSmac pads don't appear to be updating when state changes

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/StackTracePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/StackTracePad.cs
@@ -233,6 +233,12 @@ namespace MonoDevelop.Debugger
 
 		async void Update ()
 		{
+			if (tree.IsRealized)
+				tree.ScrollToPoint (0, 0);
+
+			needsUpdate = false;
+			store.Clear ();
+
 			if (!DebuggingService.IsPaused)
 				return;
 
@@ -250,13 +256,6 @@ namespace MonoDevelop.Debugger
 			// Another fetch of all data already in progress, return
 			if (token.IsCancellationRequested)
 				return;
-
-
-			if (tree.IsRealized)
-				tree.ScrollToPoint (0, 0);
-
-			needsUpdate = false;
-			store.Clear ();
 
 			var externalCodeIter = TreeIter.Zero;
 			for (int i = 0; i < stackFrames.Count; i++) {


### PR DESCRIPTION
This was regression from https://github.com/mono/monodevelop/pull/3279 where clearing was accidentally moved after `if(Debugger.IsPaused) return;` check...