### PR TITLE
Fixed 'Bug 514890 - [Feedback] #region indentation changes when #if

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
@@ -96,7 +97,11 @@ namespace MonoDevelop.CSharp.Formatting
 					}
 					var rules = Formatter.GetDefaultFormattingRules (analysisDocument);
 					var changes = Formatter.GetFormattedTextChanges (root, SpecializedCollections.SingletonEnumerable (span), context.RoslynWorkspace, optionSet, rules, default(CancellationToken));
-					editor.ApplyTextChanges (changes);
+					editor.ApplyTextChanges (changes.Where(c => {
+						if (!exact)
+							return true;
+						return span.Contains (c.Span.Start);
+					}));
 				} catch (Exception e) {
 					LoggingService.LogError ("Error in on the fly formatter", e);
 				}

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/OnTheFlyFormatterTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/OnTheFlyFormatterTests.cs
@@ -709,5 +709,33 @@ class MyContext
 }", content.Text);
 			}, policy);
 		}
+
+
+		/// <summary>
+		/// Bug 514890 - [Feedback] #region indentation changes when #if added to C# source file (VS 7.2 build 636).
+		/// </summary>
+		[Test]
+		public async Task TestBug514890 ()
+		{
+			var text = @"using System;
+namespace TestConsole
+{
+#if
+    public class Test
+    {
+        #region foo
+        public Test()
+        {
+        }
+        #endregion
+    }
+}
+";
+			await Simulate (text, (content, ext) => { 
+				OnTheFlyFormatter.Format (ext.Editor, ext.DocumentContext, 39, 41);
+				Assert.AreEqual (text, content.Text);
+			});
+
+		} 
 	}
 }


### PR DESCRIPTION
added to C# source file (VS 7.2 build 636).'