### PR TITLE
[F#] Fixes #524437. Restore F# packages sooner

### DIFF
--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -29,6 +29,8 @@ NUGET_RESTORE = mono external/nuget-binary/nuget.exe restore -DisableParallelPro
 restore-packages:
 	@$(NUGET_RESTORE)
 	msbuild /t:Restore /p:RestoreDisableParallel=true external/RefactoringEssentials/RefactoringEssentials/RefactoringEssentials.csproj
+	mono external/fsharpbinding/.paket/paket.bootstrapper.exe
+	pushd . && cd external/fsharpbinding && mono .paket/paket.exe restore && popd
 
 vcrevision:
 	touch vcrevision


### PR DESCRIPTION
So that StrongNamer is restored before the F# addin is built.