### PR TITLE
[AspNetCore] Do not format minified files and map files

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
@@ -103,6 +103,7 @@
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 				condition="UseNetCore1x=true"
 				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.FSharp"
@@ -114,6 +115,7 @@
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 				condition="UseNetCore1x=true"
 				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.WebApi.CSharp"
@@ -163,6 +165,7 @@
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 				condition="UseNetCore20=true"
 				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.FSharp"
@@ -175,6 +178,7 @@
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 				condition="UseNetCore20=true"
 				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.RazorPages.CSharp.2.0"
@@ -187,6 +191,7 @@
 				supportedParameters="RazorPages"
 				condition="UseNetCore20=true"
 				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.WebApi.CSharp"

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Codons/TemplateExtensionNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Codons/TemplateExtensionNode.cs
@@ -139,5 +139,14 @@ namespace MonoDevelop.Ide.Codons
 				return condition;
 			}
 		}
+
+		[NodeAttribute ("formatExclude", "Project files that should not be formatted. For example: readme.txt|*.xml")]
+		string fileFormatExclude;
+
+		public string FileFormatExclude {
+			get {
+				return fileFormatExclude;
+			}
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineProjectTemplatingProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineProjectTemplatingProvider.cs
@@ -233,9 +233,13 @@ namespace MonoDevelop.Ide.Templates
 
 			// Format all source files generated during the project creation
 			foreach (var p in workspaceItems.OfType<Project> ()) {
-				foreach (var file in p.Files)
-					if (!filesBeforeCreation.Contains ((string)file.FilePath, FilePath.PathComparer)) //Format only newly created files
-						await FormatFile (parentFolder?.Policies ?? p.Policies, file.FilePath);
+				foreach (var file in p.Files) {
+					if (!filesBeforeCreation.Contains ((string)file.FilePath, FilePath.PathComparer)) { //Format only newly created files
+						if (solutionTemplate.ShouldFormatFile (file.FilePath)) {
+							await FormatFile (parentFolder?.Policies ?? p.Policies, file.FilePath);
+						}
+					}
+				}
 			}
 			processResult.SetFilesToOpen (filesToOpen);
 			return processResult;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineSolutionTemplate.cs
@@ -55,6 +55,7 @@ namespace MonoDevelop.Ide.Templates
 			SupportedParameters = template.SupportedParameters;
 			DefaultParameters = MergeDefaultParameters (template.DefaultParameters);
 			ImageId = template.ImageId;
+			FileFormattingExclude = template.FileFormatExclude;
 			//ImageFile = template.ImageFile;
 			//Visibility = GetVisibility (template.Visibility);
 
@@ -87,6 +88,41 @@ namespace MonoDevelop.Ide.Templates
 			}
 
 			return defaultParameters += string.Join (",", parameters);
+		}
+
+		internal string FileFormattingExclude { get; set; }
+
+		internal bool ShouldFormatFile (string fileName)
+		{
+			if (string.IsNullOrEmpty (FileFormattingExclude))
+				return true;
+
+			if (excludedFileEndings == null) {
+				excludedFileEndings = GetFileEndings (FileFormattingExclude);
+			}
+
+			foreach (string ending in excludedFileEndings) {
+				if (fileName.EndsWith (ending, StringComparison.OrdinalIgnoreCase)) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		List<string> excludedFileEndings;
+
+		static List<string> GetFileEndings (string exclude)
+		{
+			var result = new List<string> ();
+			foreach (string pattern in exclude.Split ('|')) {
+				if (pattern.StartsWith ("*.", StringComparison.Ordinal)) {
+					result.Add (pattern.Substring (1));
+				} else {
+					result.Add (pattern);
+				}
+			}
+			return result;
 		}
 	}
 }

--- a/main/tests/test-projects/FileFormatExclude/.template.config/template.json
+++ b/main/tests/test-projects/FileFormatExclude/.template.config/template.json
@@ -1,0 +1,22 @@
+﻿{
+	"$schema": "http://json.schemastore.org/template",
+	"author": "Microsoft",
+	"classifications": [ "Common", "Library" ],
+	"name": "Class library",
+	"description": "",
+	"groupIdentity": "MonoDevelop.Ide.Tests.FileFormatExclude",
+	"precedence": "2000",
+	"identity": "MonoDevelop.Ide.Tests.FileFormatExclude.CSharp",
+	"shortName": "fileformatexclude",
+	"tags": {
+		"language": "C#",
+		"type": "project"
+	},
+	"sourceName": "sourceName",
+	"guids": [
+		"{7F63CBE6-2FE7-47A7-8930-EA078DA05062}"
+	],
+	"primaryOutputs": [
+		{ "path": "library.csproj" },
+	]
+}

--- a/main/tests/test-projects/FileFormatExclude/library.csproj
+++ b/main/tests/test-projects/FileFormatExclude/library.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="test.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/FileFormatExclude/test.xml
+++ b/main/tests/test-projects/FileFormatExclude/test.xml
@@ -1,0 +1,1 @@
+<root><child/></root>


### PR DESCRIPTION
Fixed bug #60627 - In Core MVC 2.0 template, site.min.css is not minified
https://bugzilla.xamarin.com/show_bug.cgi?id=60627

Do not format *.min.css, *.min.js and *.map files. The web tools
addin was re-formatting the minified files when the project was
created from the project template.