### PR TITLE
[Core] Fix failing progress monitor test

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/AggregatedProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/AggregatedProgressMonitor.cs
@@ -48,7 +48,7 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		Cancel = 0x40,
 		FollowerCancel = 0x80,	// when the follower is cancelled, the whole aggregated monitor is cancelled.
 		ReportObject = 0x100,
-		All =  0xff
+		All =  0xfff
 	}
 	
 	public class AggregatedProgressMonitor: ProgressMonitor


### PR DESCRIPTION
The MonitorAction.All enum value did not include the ReportObject value.