### PR TITLE
Fixed '51873-Implement abstract class adds code without any spaces'

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
@@ -407,7 +407,7 @@ namespace MonoDevelop.CodeActions
 				var oldSolution = documentContext.AnalysisDocument.Project.Solution;
 				var updatedSolution = oldSolution;
 				using (var undo = editor.OpenUndoGroup ()) {
-					updatedSolution = await act.GetChangedSolutionAsync (new RoslynProgressTracker (), token);
+					updatedSolution = await act.GetChangedSolutionInternalAsync(true, token);
 					documentContext.RoslynWorkspace.TryApplyChanges (updatedSolution, new RoslynProgressTracker ());
 				}
 				await TryStartRenameSession (documentContext.RoslynWorkspace, oldSolution, updatedSolution, token);

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
@@ -407,6 +407,8 @@ namespace MonoDevelop.CodeActions
 				var oldSolution = documentContext.AnalysisDocument.Project.Solution;
 				var updatedSolution = oldSolution;
 				using (var undo = editor.OpenUndoGroup ()) {
+					// TODO: Fix workaround for https://devdiv.visualstudio.com/DevDiv/_workitems?id=518783&fullScreen=true&_a=edit
+					// Roslyn issue: https://github.com/dotnet/roslyn/issues/23239
 					updatedSolution = await act.GetChangedSolutionInternalAsync(true, token);
 					documentContext.RoslynWorkspace.TryApplyChanges (updatedSolution, new RoslynProgressTracker ());
 				}


### PR DESCRIPTION
Seems that this is a roslyn bug - the GetChangedSolutionAsync call is
missing all post processing for the code generation. Fortunately there
is an internal method forcing the post procession to be done.