### PR TITLE
[build] fix issues bundling live player

### DIFF
--- a/main/build/MacOSX/make-dmg-bundle.sh
+++ b/main/build/MacOSX/make-dmg-bundle.sh
@@ -34,7 +34,7 @@ rm -f "$DMG_FILE.master"
  	
 # Compute an approximated image size in MB, and bloat by 1MB
 image_size=$(du -ck "$DMG_APP" | tail -n1 | cut -f1)
-image_size=$((($image_size + 40000) / 1000))
+image_size=$((($image_size *2) / 1000))
 
 echo "Creating disk image (${image_size}MB)..."
 hdiutil create "$DMG_FILE" -megabytes $image_size -volname "$VOLUME_NAME" -fs HFS+ -quiet || exit $?


### PR DESCRIPTION
Really bump the size of the .dmg when creating it. There does not appear to be a suitable way to calculate this accurately and playing trial and error trying to find a value that works is painful and likely to break again. This is a hammer approach, but since all the extra space in the .dmg is compressed away to nothing it doesn't really matter that much.