### PR TITLE
Rollback PR #3211 temporarily.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
@@ -190,7 +190,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 				var caretOffset = Editor.CaretOffset;
 				var token = completionTokenSrc.Token;
 				try {
-					var task = Task.Run (() => HandleCodeCompletionAsync (CurrentCompletionContext, new CompletionTriggerInfo (CompletionTriggerReason.CharTyped, descriptor.KeyChar), token));
+					var task = HandleCodeCompletionAsync (CurrentCompletionContext, new CompletionTriggerInfo (CompletionTriggerReason.CharTyped, descriptor.KeyChar), token);
 					if (task != null) {
 						// Show the completion window in two steps. The call to PrepareShowWindow creates the window but
 						// it doesn't show it. It is used only to process the keys while the completion data is being retrieved.


### PR DESCRIPTION
It breaks WebTooling completion for several reasons:

1. Sometimes HandleCodeCompletionAsync used to return null, which was semantically significant for WebTooling. Now it never returns null, but always returns a task.

2. WebTooling is not yet prepared to be able to run on a background thread. We need to do work to make our code properly thread-safe.

3. The timings have changed, so certain logic in WebTooling async completion is now wrong (we check if a completion is already up and don't return anything, and that check returns different results based on whether we're still on the UI thread or on a background thread now).

We will be revisiting the entire Completion story pretty soon with Roslyn EditorFeatures so I'm sure we'll arrive at a good solution that works for everybody. For now we want to keep the current WebTooling working in master, because it would take us a lot of work to adapt for this change.

So while we agree that this is a good change in theory (frees up the UI thread) it is currently breaking so we'd like to pursue a tactical fix short term.