### PR TITLE
Fixed 'Bug 60724 - No way of changing behavior of Automatically insert

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/RoslynSymbolCompletionData.cs
@@ -201,7 +201,7 @@ namespace MonoDevelop.CSharp.Completion
 			bool runCompletionCompletionCommand = false;
 			var method = Symbol as IMethodSymbol;
 
-			bool addParens = DefaultSourceEditorOptions.Instance.AutoInsertMatchingBracket;
+			bool addParens = false;
 			var Editor = ext.Editor;
 			var Policy = ext.FormattingPolicy;
 			var ctx = window.CodeCompletionContext;


### PR DESCRIPTION
parentheses after completion in the IDE'

This behavior should be disabled completely because it's gone in the
next iteration of the completion engine.