### PR TITLE
Fix incorrect completion popup position

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -1014,6 +1014,9 @@ namespace Mono.TextEditor
 				descriptor.Dispose ();
 				layoutDict.Remove (lineNumber);
 			}
+
+			OnLineShowing (line);
+
 			var wrapper = new LayoutWrapper (this, textEditor.LayoutCache.RequestLayout ());
 			wrapper.IsUncached = containsPreedit;
 			if (logicalRulerColumn < 0)
@@ -1236,7 +1239,6 @@ namespace Mono.TextEditor
 					layoutDict [lineNumber] = descriptor;
 				}
 				//			textEditor.GetTextEditorData ().HeightTree.SetLineHeight (line.LineNumber, System.Math.Max (LineHeight, wrapper.Height));
-				OnLineShown (line);
 				return wrapper;
 			} finally {
 				sw.Stop ();
@@ -1264,12 +1266,12 @@ namespace Mono.TextEditor
 				throw new NotImplementedException ();
 			}
 
-		void OnLineShown (DocumentLine line)
+		void OnLineShowing (DocumentLine line)
 		{
-			LineShown?.Invoke (this, new LineEventArgs (line));
+			LineShowing?.Invoke (this, new LineEventArgs (line));
 		}
 
-		public event EventHandler<LineEventArgs> LineShown;
+		public event EventHandler<LineEventArgs> LineShowing;
 
 		public IEnumerable<DocumentLine> CachedLine {
 			get {
@@ -3482,7 +3484,8 @@ namespace Mono.TextEditor
 			try {
 				index = (int)TranslateToUTF8Index (wrapper.Text, (uint)System.Math.Min (System.Math.Max (0, column), wrapper.Text.Length), ref curIndex, ref byteIndex);
 				pos = wrapper.IndexToPos (index);
-			} catch {
+			} catch (Exception ex) {
+				LoggingService.LogError ($"Error calculating X position for {line}@{column}", ex);
 				return 0;
 			} finally {
 				if (wrapper.IsUncached)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -223,7 +223,7 @@ namespace MonoDevelop.SourceEditor
 			widget.TextEditor.Document.TextChanged += OnTextReplaced;
 			widget.TextEditor.Document.ReadOnlyCheckDelegate = CheckReadOnly;
 
-			widget.TextEditor.TextViewMargin.LineShown += TextViewMargin_LineShown;
+			widget.TextEditor.TextViewMargin.LineShowing += TextViewMargin_LineShowing;
 			//			widget.TextEditor.Document.DocumentUpdated += delegate {
 			//				this.IsDirty = Document.IsDirty;
 			//			};
@@ -1067,7 +1067,7 @@ namespace MonoDevelop.SourceEditor
 
 			widget.TextEditor.Document.ReadOnlyCheckDelegate = null;
 			widget.TextEditor.Options.Changed -= HandleWidgetTextEditorOptionsChanged;
-			widget.TextEditor.TextViewMargin.LineShown -= TextViewMargin_LineShown;
+			widget.TextEditor.TextViewMargin.LineShowing -= TextViewMargin_LineShowing;
 			widget.TextEditor.TextArea.FocusOutEvent -= TextArea_FocusOutEvent;
 			widget.TextEditor.Document.MimeTypeChanged -= Document_MimeTypeChanged;
 
@@ -3234,9 +3234,9 @@ namespace MonoDevelop.SourceEditor
 			widget.RemoveOverlay (messageOverlayContent.GetNativeWidget<Widget> ());
 		}
 
-		void TextViewMargin_LineShown (object sender, Mono.TextEditor.LineEventArgs e)
+		void TextViewMargin_LineShowing (object sender, Mono.TextEditor.LineEventArgs e)
 		{
-			LineShown?.Invoke (this, new Ide.Editor.LineEventArgs (e.Line));
+			LineShowing?.Invoke (this, new Ide.Editor.LineEventArgs (e.Line));
 		}
 
 		public IEnumerable<IDocumentLine> VisibleLines {
@@ -3247,7 +3247,7 @@ namespace MonoDevelop.SourceEditor
 			}
 		}
 
-		public event EventHandler<Ide.Editor.LineEventArgs> LineShown;
+		public event EventHandler<Ide.Editor.LineEventArgs> LineShowing;
 
 
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/HighlightUrlExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/HighlightUrlExtension.cs
@@ -47,13 +47,13 @@ namespace MonoDevelop.Ide.Editor.Extension
 		protected override void Initialize ()
 		{
 			base.Initialize ();
-			Editor.LineShown += Editor_LineShown;
+			Editor.LineShowing += Editor_LineShowing;
 			Editor.TextChanged += Editor_TextChanged;
 		}
 
 		public override void Dispose ()
 		{
-			Editor.LineShown -= Editor_LineShown;
+			Editor.LineShowing -= Editor_LineShowing;
 			Editor.TextChanged -= Editor_TextChanged;
 			src.Cancel ();
 			DisposeUrlTextMarker ();
@@ -69,7 +69,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 			scannedSegmentTree.Clear ();
 		}
 
-		void Editor_LineShown (object sender, LineEventArgs e)
+		void Editor_LineShowing (object sender, LineEventArgs e)
 		{
 			var matches = new List<Tuple<UrlType, Match>> ();
 			var input = Editor;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
@@ -223,7 +223,7 @@ namespace MonoDevelop.Ide.Editor
 		void GrabFocus ();
 		bool HasFocus { get; }
 
-		event EventHandler<LineEventArgs> LineShown;
+		event EventHandler<LineEventArgs> LineShowing;
 		event EventHandler FocusLost;
 
 		void ShowTooltipWindow (Components.Window window, TooltipWindowOptions options);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1516,7 +1516,7 @@ namespace MonoDevelop.Ide.Editor
 		}
 
 		internal IEnumerable<IDocumentLine> VisibleLines { get { return textEditorImpl.VisibleLines; } }
-		internal event EventHandler<LineEventArgs> LineShown { add { textEditorImpl.LineShown += value; } remove { textEditorImpl.LineShown -= value; } }
+		internal event EventHandler<LineEventArgs> LineShowing { add { textEditorImpl.LineShowing += value; } remove { textEditorImpl.LineShowing -= value; } }
 
 		internal ITextEditorImpl Implementation { get { return this.textEditorImpl; } }
 


### PR DESCRIPTION
When completion was triggered in an attribute value (`=""`) after typing the `"`, the completion window would attempt to determine the position by calling `TextViewMargin.ColumnToX`, which in turn would call `TextViewMargin.CreateLinePartLayout`.

Since the editor had just inserted the matching ", the line would not be present in the cache. CreateLinePartLayout would therefore build the line layout from scratch and then fire the
LineShown event.

`LineShown` appeared to exist purely to trigger `HighlightUrlExtension.Editor_LineShown`. If there was an URL in the line, this would add a marker... which immediately invalidates the cache and destroys the layout.

Hence the layout created by `TextViewMargin.CreateLinePartLayout` would become destroyed before being returned to its caller, and throw exceptions when used.

However, the caller, `TextViewMargin.ColumnToX` **SWALLOWS EXCEPTIONS** and simply returns 0. As a result, the popup location was wrong.

Fixed by switching `LineShown` to be fired _before_ the layout is created and cached (and renaming it to `LineShowing`).

Also, log exceptions.