### PR TITLE
[Ide] Fix different locales causing crashes in the IDE

### DIFF
--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -238,6 +238,7 @@ correct_locale(void)
 
 	setenv("MONODEVELOP_STUB_LANGUAGE", [preferredLanguage UTF8String], 1);
 	setenv("LANGUAGE", [preferredLanguage UTF8String], 1);
+	setenv("LC_CTYPE", [preferredLanguage UTF8String], 1);
 }
 
 static void


### PR DESCRIPTION
Bug 60378 - [VSFeedback Ticket] #513042 - Global search function, enter a letter collapse