### PR TITLE
[Ide] Fix "Mono runtime settings > Clear All Options"

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/MonoExecutionParameters.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/MonoExecutionParameters.cs
@@ -172,6 +172,11 @@ namespace MonoDevelop.Projects
 
 		public MonoExecutionParameters ()
 		{
+			ResetProperties ();
+		}
+
+		public void ResetProperties ()
+		{
 			foreach (var kvp in itemPropertyAttributes) {
 				var prop = kvp.Key;
 				var propAttr = kvp.Value;
@@ -179,7 +184,7 @@ namespace MonoDevelop.Projects
 					prop.SetValue (this, propAttr.DefaultValue, null);
 			}
 		}
-		
+
 		public void GenerateOptions (IDictionary<string,string> envVars, out string options)
 		{
 			StringBuilder ops = new StringBuilder ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/MonoExecutionParametersWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/MonoExecutionParametersWidget.cs
@@ -64,8 +64,8 @@ namespace MonoDevelop.Ide.Execution
 			propertyGrid.CommitPendingChanges ();
 			if (!MessageService.Confirm (GettextCatalog.GetString ("Are you sure you want to clear all specified options?"), AlertButton.Clear))
 				return;
-			config = new MonoExecutionParameters ();
-			propertyGrid.CurrentObject = config;
+			config.ResetProperties ();
+			propertyGrid.Refresh ();
 		}
 	}
 }


### PR DESCRIPTION
Fixes non-public bug <https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=527540>

`OnButtonResetClicked ()` needs to modify the original `MonoExecutionParameters` object that was passed into the `MonoExecutionParametersWidget.Load ()` method rather than creating a new `MonoExecutionParameters` object. Otherwise the changes will not be visible to the `DotNetRunConfigurationEditorWidget` object, and they will be discarded.

Preliminary verification
========================

I was able to save the cleared dialog as expected after I added this fix to a local build of the IDE.  I used the following testing scenario:

1. Create a new "Other > .NET > Console Project".

2. Under the project options, open "Run > Configurations > Default > Advanced \[tab\]" and click the "..." button next to "Mono runtime settings".

3. Click a couple of the checkboxes and enter text values in a few of the text fields, and then click "Ok".

4. Click the "..." button again.

5. Click "Clear All Options", then "Clear", and then "Ok".