### PR TITLE
Preserve the app bundle directory instead of moving it into .dmg

### DIFF
--- a/main/build/MacOSX/make-dmg-bundle.sh
+++ b/main/build/MacOSX/make-dmg-bundle.sh
@@ -48,7 +48,9 @@ hdiutil attach "$DMG_FILE" -readwrite -noautoopen -mountpoint "$MOUNT_POINT" -qu
 
 echo "Populating image..."
 
-mv "$DMG_APP" "$MOUNT_POINT"
+# this used to be mv, but we need to preserve the bundle directory to do more checks on the contents
+# such as compatibility-check
+ditto "$DMG_APP" "$MOUNT_POINT/$DMG_APP"
 
 # This won't result in any deletions 
 #find "$MOUNT_POINT" -type d -iregex '.*\.svn$' &>/dev/null | xargs rm -rf

--- a/main/build/MacOSX/make-dmg-bundle.sh
+++ b/main/build/MacOSX/make-dmg-bundle.sh
@@ -32,9 +32,13 @@ MOUNT_POINT="$VOLUME_NAME.mounted"
 rm -f "$DMG_FILE"
 rm -f "$DMG_FILE.master"
  	
-# Compute an approximated image size in MB, and bloat by 1MB
+# Compute an approximated image size in MB, and bloat by double
+# codesign adds a unknown amount of extra size requirements and there are some
+# files where the additional size required is even more "unknown". doubling
+# is a brute force approach, but doesn't really impact final distribution size
+# because the empty space is compressed to nothing.
 image_size=$(du -ck "$DMG_APP" | tail -n1 | cut -f1)
-image_size=$((($image_size + 40000) / 1000))
+image_size=$((($image_size *2) / 1000))
 
 echo "Creating disk image (${image_size}MB)..."
 hdiutil create "$DMG_FILE" -megabytes $image_size -volname "$VOLUME_NAME" -fs HFS+ -quiet || exit $?


### PR DESCRIPTION
We need to do more checks on the bundle directory after the .dmg is created (such as compatibility-check).