### PR TITLE
[PathBar] Stop PathBar stealing focus when path changes in text editor

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -880,6 +880,12 @@ namespace MonoDevelop.Components
 			return ret;
 		}
 
+		protected override bool OnFocusOutEvent(EventFocus evnt)
+		{
+			alreadyHaveFocus = false;
+			return base.OnFocusOutEvent(evnt);
+		}
+
 		protected override void OnActivate ()
 		{
 			if (focusedPathIndex < 0) {


### PR DESCRIPTION
PathBar doesn't lose its alreadyHaveFocus flag when it loses focus. Fixed by
unsetting it in OnFocusOutEvent

Fixes BXC #60584