### PR TITLE
Fixed NullReferenceException

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -58,7 +58,10 @@ namespace MonoDevelop.MacIntegration
 				}
 				bool pathAlreadySet = false;
 				panel.DidChangeToDirectory += (sender, e) => {
-					var selectedPath = data.OnDirectoryChanged (this, e.NewDirectoryUrl.AbsoluteString);
+					var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
+					if (string.IsNullOrEmpty (directoryPath))
+						return;
+					var selectedPath = data.OnDirectoryChanged (this, directoryPath);
 					if (selectedPath.IsNull)
 						return;
 					data.SelectedFiles = new FilePath [] { selectedPath };


### PR DESCRIPTION
This code was recently introduced by me, I didn't realised NewDirectoryUrl can be `null`... This can happen when using search inside open dialog