### PR TITLE
[529486][Ide] Improve dialog auto-parenting logic

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -376,7 +376,11 @@ namespace MonoDevelop.Ide
 
 		static Gtk.Window GetFocusedToplevel ()
 		{
-			return Gtk.Window.ListToplevels ().FirstOrDefault (w => w.HasToplevelFocus) ?? RootWindow;
+			// use the first "normal" toplevel window (skipping docks, popups, etc.) or the main IDE window
+			return Gtk.Window.ListToplevels ().FirstOrDefault (w => w.HasToplevelFocus &&
+			                                                   (w.TypeHint == Gdk.WindowTypeHint.Dialog ||
+			                                                    w.TypeHint == Gdk.WindowTypeHint.Normal ||
+			                                                    w.TypeHint == Gdk.WindowTypeHint.Utility)) ?? RootWindow;
 		}
 		
 		/// <summary>


### PR DESCRIPTION
Don't use "special" top level windows (popups, pads, etc.) for message dialog auto-parenting.
First of all this is important for sheeting alerts on macOS, which should never be parented to pads or other "special" windows. But also in general we shouldn't use pads, or special windows (popups, menus, etc.) for dialog auto-parenting, not only on Mac.

(fixes bug #529486)