### PR TITLE
[Core] Fix assembly check for frameworks without assemblies

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkBackend.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkBackend.cs
@@ -56,10 +56,12 @@ namespace MonoDevelop.Core.Assemblies
 							isInstalled = true;
 							return true;
 						}
-						string firstAsm = Path.Combine (dir, framework.Assemblies [0].Name) + ".dll";
-						if (File.Exists (firstAsm)) {
-							isInstalled = true;
-							return true;
+						if (framework.Assemblies.Length > 0) {
+							string firstAsm = Path.Combine (dir, framework.Assemblies [0].Name) + ".dll";
+							if (File.Exists (firstAsm)) {
+								isInstalled = true;
+								return true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
As of cf0a3720c80b6320d7dea9163ffc11096a01020b frameworks may contain
0 assemblies. This patch fixes the broken assembly check if the framework has also
no manifest.