### PR TITLE
[C#] Fix performance issue with files opened for a long time

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/CSharpParsedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/CSharpParsedDocument.cs
@@ -59,11 +59,11 @@ namespace MonoDevelop.CSharp.Parser
 		{
 			tagComments = MonoDevelop.Ide.Tasks.CommentTag.SpecialCommentTags.Select (t => t.Tag).ToArray ();
 		}
-		Ide.TypeSystem.ParseOptions options;
+		bool isAdHocProject;
 
 		public CSharpParsedDocument (Ide.TypeSystem.ParseOptions options,  string fileName) : base (fileName)
 		{
-			this.options = options;
+			isAdHocProject = options.IsAdhocProject;
 		}
 		
 
@@ -528,7 +528,7 @@ namespace MonoDevelop.CSharp.Parser
 				try {
 					errors = model
 						.GetDiagnostics (null, cancellationToken)
-						.Where (diag => !SkipError(options.IsAdhocProject, diag.Id) && (diag.Severity == DiagnosticSeverity.Error || diag.Severity == DiagnosticSeverity.Warning))
+						.Where (diag => !SkipError(isAdHocProject, diag.Id) && (diag.Severity == DiagnosticSeverity.Error || diag.Severity == DiagnosticSeverity.Warning))
 						.Select ((Diagnostic diag) => new Error (GetErrorType (diag.Severity), diag.Id, diag.GetMessage (), GetRegion (diag)) { Tag = diag })
 						.ToList ();
 				} catch (OperationCanceledException) {

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Parser/CSharpParsedDocumentTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Parser/CSharpParsedDocumentTests.cs
@@ -1,0 +1,89 @@
+﻿//
+// CSharpParsedDocumentTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2017 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using MonoDevelop.CSharp.Parser;
+using MonoDevelop.Ide.TypeSystem;
+using NUnit.Framework;
+
+namespace MonoDevelop.CSharpBinding.Parser
+{
+	[TestFixture]
+	public class CSharpParsedDocumentTests
+	{
+		static int finalized;
+
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			finalized = 0;
+		}
+
+		[Test]
+		public void DoesNotLeakPreviousDocument ()
+		{
+			const int DocumentCount = 100;
+
+			// Force only the last doc to be alive at this point.
+			var doc = GetParsedDocumentStress (DocumentCount);
+
+			GC.Collect ();
+			GC.WaitForPendingFinalizers ();
+
+			GC.KeepAlive (doc);
+
+			// GC can  be lazy, seen this value reach both 98 and 99.
+			Assert.That (finalized, Is.GreaterThanOrEqualTo (98));
+		}
+
+		class LeakTrackingCSharpParsedDocument : CSharpParsedDocument
+		{
+			public LeakTrackingCSharpParsedDocument (ParseOptions options) : base (options, "mock")
+			{
+			}
+
+			~LeakTrackingCSharpParsedDocument ()
+			{
+				System.Threading.Interlocked.Increment (ref finalized);
+			}
+		}
+
+		CSharpParsedDocument GetParsedDocumentStress (int count)
+		{
+			CSharpParsedDocument old = null, doc = null;
+
+			for (int i = 0; i < count; ++i) {
+				old = doc;
+
+				var options = new ParseOptions {
+					OldParsedDocument = old,
+				};
+
+				doc = new LeakTrackingCSharpParsedDocument (options);
+			}
+			return doc;
+		}
+	}
+}

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="MonoDevelop.CSharpBinding\PolicyTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\CSharpAutoInsertBracketHandlerTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\ExpandSelectionHandlerTests.cs" />
+    <Compile Include="MonoDevelop.CSharpBinding.Parser\CSharpParsedDocumentTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\addins\CSharpBinding\CSharpBinding.csproj">
@@ -194,6 +195,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="MonoDevelop.CSharpBinding\AutomaticBracketInsertionTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="MonoDevelop.CSharpBinding.Parser\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
The logic about this change is not keeping around all previous versions
of a CSharpParsedDocument. What happened here was:
* ParseOptions contained a ref to the old ParsedDocument
* ParsedDocument contained a reference to the current ParseOptions
* On the next query, both of these instances are kept alive in the new
ParsedDocument.

This caused a huge chain of live document+options+others to be alive
after many edits.