### PR TITLE
[Gtk] Switch overrides of Destroy to OnDestroyed.

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/AttachToProcessDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/AttachToProcessDialog.cs
@@ -132,14 +132,14 @@ namespace MonoDevelop.Debugger
 			Runtime.RunInMainThread (new Action (FillList)).Ignore ();
 		}
 
-		public override void Destroy ()
+		protected override void OnDestroyed ()
 		{
 			if (processAttacher != null) {
 				processAttacher.AttachableProcessesChanged -= ProcessAttacher_AttachableProcessesChanged;
 				processAttacher.Dispose ();
 			}
 			refreshLoopTokenSource.Cancel ();
-			base.Destroy ();
+			base.OnDestroyed ();
 		}
 
 		void Refresh (object tokenObject)

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkProjectNuGetBuildOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkProjectNuGetBuildOptionsPanelWidget.cs
@@ -85,10 +85,10 @@ namespace MonoDevelop.Packaging.Gui
 			ProjectHasMetadata = hasMetadata;
 		}
 
-		public override void Destroy ()
+		protected override void OnDestroyed ()
 		{
 			GtkNuGetPackageMetadataOptionsPanelWidget.OnProjectHasMetadataChanged = null;
-			base.Destroy ();
+			base.OnDestroyed ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NSViewContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NSViewContainer.cs
@@ -77,11 +77,11 @@ namespace MonoDevelop.Components.Mac
 			}
 		}
 
-		public override void Destroy ()
+		protected override void OnDestroyed ()
 		{
-			base.Destroy ();
 			if (nsview != null)
 				containers.Remove (nsview);
+			base.OnDestroyed ();
 		}
 
 		protected override void OnAdded (Widget widget)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/VersionInformationTabPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/VersionInformationTabPage.cs
@@ -151,10 +151,10 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			return box;
 		}
 
-		public override void Destroy ()
+		protected override void OnDestroyed ()
 		{
-			base.Destroy ();
 			destroyed = true;
+			base.OnDestroyed ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TasksOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/TasksOptionsPanel.cs
@@ -253,10 +253,10 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			return color;
 		}
 
-		public override void Destroy ()
+		protected override void OnDestroyed ()
 		{
 			Styles.Changed -= HandleUserInterfaceThemeChanged;
-			base.Destroy ();
+			base.OnDestroyed ();
 		}
 	}
 	

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -278,7 +278,7 @@ namespace MonoDevelop.Ide.Projects
 			Destroy ();
 		}
 
-		public override void Destroy ()
+		protected override void OnDestroyed ()
 		{
 			if (popupMenu != null) {
 				popupMenu.Destroy ();
@@ -294,7 +294,7 @@ namespace MonoDevelop.Ide.Projects
 			controller.ProjectCreationFailed -= ProjectCreationFailed;
 			controller.ProjectCreated -= ProjectCreated;
 
-			base.Destroy ();
+			base.OnDestroyed ();
 		}
 
 		void LoadTemplates ()


### PR DESCRIPTION
The former is only called when explicitly invoking widget.Destroy.

The latter is called properly (i.e. when you destroy a dialog, it'll
recursively destroy all children, thus hitting OnDestroyed)