### PR TITLE
[NuGet] Check for packages no longer blocking waits on bg thread

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForNuGetPackageUpdatesTaskRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForNuGetPackageUpdatesTaskRunner.cs
@@ -110,7 +110,7 @@ namespace MonoDevelop.PackageManagement
 				.CreateNuGetProject (project);
 		}
 
-		List<UpdatedNuGetPackagesInProject> CheckForUpdates (List<UpdatedNuGetPackagesProvider> providers, CancellationToken cancellationToken)
+		static async Task<List<UpdatedNuGetPackagesInProject>> CheckForUpdates (List<UpdatedNuGetPackagesProvider> providers, CancellationToken cancellationToken)
 		{
 			var updatedPackages = new List<UpdatedNuGetPackagesInProject> ();
 			foreach (UpdatedNuGetPackagesProvider provider in providers) {
@@ -118,7 +118,7 @@ namespace MonoDevelop.PackageManagement
 					break;
 				}
 
-				provider.FindUpdatedPackages ().Wait ();
+				await provider.FindUpdatedPackages ().ConfigureAwait (false);
 
 				if (provider.UpdatedPackagesInProject.AnyPackages ()) {
 					updatedPackages.Add (provider.UpdatedPackagesInProject);


### PR DESCRIPTION
This allows other tasks to run while we're waiting for updated packages to be done. Amounted to around 6000ms.