### PR TITLE
Removed localising of headers(INFO, ERROR...) from FileLogger

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Logging/FileLogger.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Logging/FileLogger.cs
@@ -57,22 +57,22 @@ namespace MonoDevelop.Core.Logging
 			
 			switch (level) {
 			case LogLevel.Fatal:
-				header = GettextCatalog.GetString ("FATAL ERROR");
+				header = "FATAL ERROR";
 				break;
 			case LogLevel.Error:
-				header = GettextCatalog.GetString ("ERROR");
+				header = "ERROR";
 				break;
 			case LogLevel.Warn:
-				header = GettextCatalog.GetString ("WARNING");
+				header = "WARNING";
 				break;
 			case LogLevel.Info:
-				header = GettextCatalog.GetString ("INFO");
+				header = "INFO";
 				break;
 			case LogLevel.Debug:
-				header = GettextCatalog.GetString ("DEBUG");
+				header = "DEBUG";
 				break;
 			default:
-				header = GettextCatalog.GetString ("LOG");
+				header = "LOG";
 				break;
 			}
 			


### PR DESCRIPTION
Main reason for this is that static constructors initialization failed, see stacktrace of NullReferenceException below...
`GettextCatalog.cctor` depends on `RuntimePreferences` being set(to figure out user Locale) but `RuntimePreferences` depends on `PropertyService` so it can get properties...
But `PropertyService.cctor` logs message "Didn't migrate any data"(or something like that) which makes full circle back to `RuntimePreferences` not being there yet for `GettextCatalog.cctor`.

For this issue to appear "MONODEVELOP_FILE_LOG_LEVEL" must be set(very rare) so FileLogger is created in 1st place and "MONODEVELOP_PROFILE" so `PropertyService` has something to log...
I found this testing StressTest.

Also our main logger(ConsoleLogger) which also logs into "Help->Open Logs Directory" doesn't localise... Which makes sense imo to not localise logs, because how can I help user which uses language I don't know...
```
MonoDevelop.Core.GettextCatalog..cctor()
MonoDevelop.Core.Logging.FileLogger.Log(MonoDevelop.Core.Logging.LogLevel level, string message)
MonoDevelop.Core.LoggingService.Log(MonoDevelop.Core.Logging.LogLevel level, string message)
MonoDevelop.Core.LoggingService.LogInfo(string message)
MonoDevelop.Core.PropertyService..cctor()
MonoDevelop.Core.CoreConfigurationProperty<bool>..ctor(string name, bool defaultValue, string oldName)
MonoDevelop.Core.ConfigurationProperty.Create<bool>(string propertyName, bool defaultValue, string oldName)
MonoDevelop.Core.RuntimePreferences..ctor()
MonoDevelop.Core.Runtime..cctor()
MonoDevelop.Ide.IdeStartup.Main(string[] args, MonoDevelop.Ide.Extensions.IdeCustomizer customizer)
MonoDevelop.Startup.MonoDevelopMain.Main(string[] args)
```