### PR TITLE
[TaskListEntry] Fix 'JumpToPosition' to not show url on first jump

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
@@ -251,11 +251,14 @@ namespace MonoDevelop.Ide.Tasks
 			return false;
 		}
 
-		public virtual void JumpToPosition()
+		void ShowDocumentation ()
 		{
 			if (HasDocumentationLink ())
 				DesktopService.ShowUrl (DocumentationLink);
+		}
 
+		public virtual void JumpToPosition ()
+		{
 			if (!file.IsNullOrEmpty) {
 				if (System.IO.File.Exists (file)) {
 					var project = WorkspaceObject as Project;
@@ -263,6 +266,7 @@ namespace MonoDevelop.Ide.Tasks
 				} else {
 					var pad = IdeApp.Workbench.GetPad<ErrorListPad> ()?.Content as ErrorListPad;
 					pad?.FocusOutputView ();
+					ShowDocumentation ();
 				}
 			} else if (parentObject != null) {
 				Pad pad = IdeApp.Workbench.GetPad<ProjectSolutionPad> ();
@@ -273,6 +277,7 @@ namespace MonoDevelop.Ide.Tasks
 					nav.Selected = true;
 					nav.Expanded = true;
 				}
+				ShowDocumentation ();
 			}
 			TaskService.InformJumpToTask (this);
 		}


### PR DESCRIPTION
'JumpToPosition' isn't only called when double clicking an error in the error pad. It can also be called when we can jump to the first result.

For instance in an iOS project with the following code snippet (build for device):

```
class Foo : NSObject {
    [Export ("b a r")]
    void Bar () { }
}
```

Will throw this: `/Users/vidondai/Projects/iOSTest/iOSTest/ViewController.cs(31): error MT4160: Invalid character ' ' (0x20) found in selector 'b a r' for 'iOSTest.Foo.Bar()'`.
An error at a specific line of a specific file which we can jump to.

Because of that we needed to `ShowDocumentation ()` only when we can't open a specific file at a specific line. This is also a much better behavior since it's better to open a file in the IDE if possible than open the documentation (and we certainly don't want both behaviors at the same time).