### PR TITLE
Added `--profiler:` option to StressTest so it can automatically  take…

### DIFF
--- a/main/tests/StressTest/Mono.Profiling.Log/LogBufferHeader.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogBufferHeader.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Mono.Profiler.Log {
+
+	public sealed class LogBufferHeader {
+
+		const int Id = 0x4d504c01;
+
+		public LogStreamHeader StreamHeader { get; }
+
+		public int Length { get; }
+
+		public ulong TimeBase { get; }
+
+		public long PointerBase { get; }
+
+		public long ObjectBase { get; }
+
+		public long ThreadId { get; }
+
+		public long MethodBase { get; }
+
+		internal ulong CurrentTime { get; set; }
+
+		internal long CurrentMethod { get; set; }
+
+		internal LogBufferHeader (LogStreamHeader streamHeader, LogReader reader)
+		{
+			StreamHeader = streamHeader;
+
+			var id = reader.ReadInt32 ();
+
+			if (id != Id)
+				throw new LogException ($"Invalid buffer header ID (0x{id:X}).");
+
+			Length = reader.ReadInt32 ();
+			TimeBase = CurrentTime = reader.ReadUInt64 ();
+			PointerBase = reader.ReadInt64 ();
+			ObjectBase = reader.ReadInt64 ();
+			ThreadId = reader.ReadInt64 ();
+			MethodBase = CurrentMethod = reader.ReadInt64 ();
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEnums.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEnums.cs
@@ -1,0 +1,240 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Mono.Profiler.Log {
+
+	// mono/profiler/log.h : TYPE_*
+	enum LogEventType {
+		Allocation = 0,
+		GC = 1,
+		Metadata = 2,
+		Method = 3,
+		Exception = 4,
+		Monitor = 5,
+		Heap = 6,
+		Sample = 7,
+		Runtime = 8,
+		Meta = 10,
+
+		AllocationNoBacktrace = 0 << 4,
+		AllocationBacktrace = 1 << 4,
+
+		GCEvent = 1 << 4,
+		GCResize = 2 << 4,
+		GCMove = 3 << 4,
+		GCHandleCreationNoBacktrace = 4 << 4,
+		GCHandleDeletionNoBacktrace = 5 << 4,
+		GCHandleCreationBacktrace = 6 << 4,
+		GCHandleDeletionBacktrace = 7 << 4,
+		GCFinalizeBegin = 8 << 4,
+		GCFinalizeEnd = 9 << 4,
+		GCFinalizeObjectBegin = 10 << 4,
+		GCFinalizeObjectEnd = 11 << 4,
+
+		MetadataExtra = 0 << 4,
+		MetadataEndLoad = 2 << 4,
+		MetadataEndUnload = 4 << 4,
+
+		MethodLeave = 1 << 4,
+		MethodEnter = 2 << 4,
+		MethodLeaveExceptional = 3 << 4,
+		MethodJit = 4 << 4,
+
+		ExceptionThrowNoBacktrace = 0 << 7,
+		ExceptionThrowBacktrace = 1 << 7,
+		ExceptionClause = 1 << 4,
+
+		MonitorNoBacktrace = 0 << 7,
+		MonitorBacktrace = 1 << 7,
+
+		HeapBegin = 0 << 4,
+		HeapEnd = 1 << 4,
+		HeapObject = 2 << 4,
+		HeapRoots = 3 << 4,
+		HeapRootRegister = 4 << 4,
+		HeapRootUnregister = 5 << 4,
+
+		SampleHit = 0 << 4,
+		SampleUnmanagedSymbol = 1 << 4,
+		SampleUnmanagedBinary = 2 << 4,
+		SampleCounterDescriptions = 3 << 4,
+		SampleCounters = 4 << 4,
+
+		RuntimeJitHelper = 1 << 4,
+
+		MetaSynchronizationPoint = 0 << 4,
+	}
+
+	// mono/profiler/log.h : TYPE_*
+	enum LogMetadataType {
+		Class = 1,
+		Image = 2,
+		Assembly = 3,
+		AppDomain = 4,
+		Thread = 5,
+		Context = 6,
+		VTable = 7,
+	}
+
+	// mono/utils/mono-counters.h : MONO_COUNTER_*
+	public enum LogCounterType {
+		Int32 = 0,
+		UInt32 = 1,
+		Word = 2,
+		Int64 = 3,
+		UInt64 = 4,
+		Double = 5,
+		String = 6,
+		Interval = 7,
+	}
+
+	// mono/utils/mono-counters.h : MONO_COUNTER_*
+	public enum LogCounterSection {
+		Jit = 1 << 8,
+		GC = 1 << 9,
+		Metadata = 1 << 10,
+		Generics = 1 << 11,
+		Security = 1 << 12,
+		Runtime = 1 << 13,
+		System = 1 << 14,
+		User = 1 << 15,
+		Profiler = 1 << 16,
+	}
+
+	// mono/utils/mono-counters.h : MONO_COUNTER_*
+	public enum LogCounterUnit {
+		Raw = 0 << 24,
+		Bytes = 1 << 24,
+		Time = 2 << 24,
+		Count = 3 << 24,
+		Percentage = 4 << 24,
+	}
+
+	// mono/utils/mono-counters.h : MONO_COUNTER_*
+	public enum LogCounterVariance {
+		Monotonic = 1 << 28,
+		Constant = 1 << 29,
+		Variable = 1 << 30,
+	}
+
+	// mono/metadata/profiler.h : MonoProfilerCodeBufferType
+	public enum LogJitHelper {
+		Unknown = 0,
+		Method = 1,
+		MethodTrampoline = 2,
+		UnboxTrampoline = 3,
+		ImtTrampoline = 4,
+		GenericsTrampoline = 5,
+		SpecificTrampoline = 6,
+		Helper = 7,
+		Monitor = 8,
+		DelegateInvoke = 9,
+		ExceptionHandling = 10,
+	}
+
+	// mono/metadata/profiler.h : MonoProfilerGCRootType
+	[Flags]
+	[Obsolete ("The event field using this enum is no longer produced.")]
+	public enum LogHeapRootAttributes {
+		Pinning = 1 << 8,
+		WeakReference = 2 << 8,
+		Interior = 4 << 8,
+
+		Stack = 1 << 0,
+		Finalizer = 1 << 1,
+		Handle = 1 << 2,
+		Other = 1 << 3,
+		Miscellaneous = 1 << 4,
+
+		TypeMask = 0xff,
+	}
+
+	// mono/metadata/mono-gc.h : MonoGCRootSource
+	public enum LogHeapRootSource {
+		External = 0,
+		Stack = 1,
+		FinalizerQueue = 2,
+		Static = 3,
+		ThreadStatic = 4,
+		ContextStatic = 5,
+		GCHandle = 6,
+		Jit = 7,
+		Threading = 8,
+		AppDomain = 9,
+		Reflection = 10,
+		Marshal = 11,
+		ThreadPool = 12,
+		Debugger = 13,
+		RuntimeHandle = 14,
+	}
+
+	// mono/profiler/log.h : MonoProfilerMonitorEvent
+	public enum LogMonitorEvent {
+		Contention = 1,
+		Done = 2,
+		Fail = 3,
+	}
+
+	// mono/metadata/metadata.h : MonoExceptionEnum
+	public enum LogExceptionClause {
+		Catch = 0,
+		Filter = 1,
+		Finally = 2,
+		Fault = 4,
+	}
+
+	// mono/metadata/profiler.h : MonoProfilerGCEvent
+	public enum LogGCEvent {
+		PreStopWorld = 6,
+		PreStopWorldLocked = 10,
+		PostStopWorld = 7,
+		Begin = 0,
+		End = 5,
+		PreStartWorld = 8,
+		PostStartWorld = 9,
+		PostStartWorldUnlocked = 11,
+		// Following are v13 and older only
+		[Obsolete ("This event is no longer produced.")]
+		MarkBegin = 1,
+		[Obsolete ("This event is no longer produced.")]
+		MarkEnd = 2,
+		[Obsolete ("This event is no longer produced.")]
+		ReclaimBegin = 3,
+		[Obsolete ("This event is no longer produced.")]
+		ReclaimEnd = 4
+	}
+
+	// mono/metadata/mono-gc.h : MonoGCHandleType
+	public enum LogGCHandleType {
+		Weak = 0,
+		WeakTrackResurrection = 1,
+		Normal = 2,
+		Pinned = 3,
+	}
+
+	// mono/profiler/log.h : MonoProfilerSyncPointType
+	public enum LogSynchronizationPoint {
+		Periodic = 0,
+		WorldStop = 1,
+		WorldStart = 2,
+	}
+
+	// mono/metadata/profiler.h : MonoProfilerSampleMode
+	public enum LogSampleMode {
+		None = 0,
+		Process = 1,
+		Real = 2,
+	}
+
+	// mono/profiler/log.h : MonoProfilerHeapshotMode
+	public enum LogHeapshotMode {
+		None = 0,
+		EveryMajor = 1,
+		OnDemand = 2,
+		Milliseconds = 3,
+		Collections = 4,
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEvent.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEvent.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Mono.Profiler.Log {
+
+	public abstract class LogEvent {
+
+		const BindingFlags PropertyFlags = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public;
+
+		const string Indent = "  ";
+
+		internal LogEvent ()
+		{
+		}
+
+		public LogBufferHeader Buffer { get; internal set; }
+
+		public ulong Timestamp { get; internal set; }
+
+		public override string ToString ()
+		{
+			var sb = new StringBuilder ();
+
+			ToString (this, sb, string.Empty, GetType ().Name, 0);
+
+			return sb.ToString ();
+		}
+
+		static void ToString (object source, StringBuilder result, string indent, string header, int level)
+		{
+			result.AppendLine ($"{indent}{header} {{");
+
+			foreach (var prop in source.GetType ().GetProperties (PropertyFlags).OrderBy (p => p.MetadataToken)) {
+				var name = prop.Name;
+				var propIndent = indent + Indent;
+				var value = prop.GetValue (source);
+
+				if (value is IList list) {
+					result.AppendLine ($"{propIndent}{name} = [{list.Count}] {{");
+
+					for (var i = 0; i < list.Count; i++) {
+						var elem = list [i];
+						var type = elem.GetType ();
+						var elemIndent = propIndent + Indent;
+						var elemHeader = $"[{i}] = ";
+
+						if (type.IsClass && type != typeof (string))
+							ToString (elem, result, elemIndent, $"{elemHeader}{type.Name}", level + 1);
+						else
+							result.AppendLine ($"{elemIndent}{elemHeader}{elem}");
+					}
+
+					result.AppendLine ($"{propIndent}}}");
+				} else
+					result.AppendLine ($"{propIndent}{name} = {value}");
+			}
+
+			var end = $"{indent}}}";
+
+			if (level == 0)
+				result.Append (end);
+			else
+				result.AppendLine (end);
+		}
+
+		internal abstract void Accept (LogEventVisitor visitor);
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEventVisitor.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEventVisitor.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Mono.Profiler.Log {
+
+	public abstract class LogEventVisitor {
+
+		public virtual void VisitBefore (LogEvent ev)
+		{
+		}
+
+		public virtual void VisitAfter (LogEvent ev)
+		{
+		}
+
+		public virtual void Visit (AppDomainLoadEvent ev)
+		{
+		}
+
+		public virtual void Visit (AppDomainUnloadEvent ev)
+		{
+		}
+
+		public virtual void Visit (AppDomainNameEvent ev)
+		{
+		}
+
+		public virtual void Visit (ContextLoadEvent ev)
+		{
+		}
+
+		public virtual void Visit (ContextUnloadEvent ev)
+		{
+		}
+
+		public virtual void Visit (ThreadStartEvent ev)
+		{
+		}
+
+		public virtual void Visit (ThreadEndEvent ev)
+		{
+		}
+
+		public virtual void Visit (ThreadNameEvent ev)
+		{
+		}
+
+		public virtual void Visit (ImageLoadEvent ev)
+		{
+		}
+
+		public virtual void Visit (ImageUnloadEvent ev)
+		{
+		}
+
+		public virtual void Visit (AssemblyLoadEvent ev)
+		{
+		}
+
+		public virtual void Visit (AssemblyUnloadEvent ev)
+		{
+		}
+
+		public virtual void Visit (ClassLoadEvent ev)
+		{
+		}
+
+		public virtual void Visit (VTableLoadEvent ev)
+		{
+		}
+
+		public virtual void Visit (JitEvent ev)
+		{
+		}
+
+		public virtual void Visit (JitHelperEvent ev)
+		{
+		}
+
+		public virtual void Visit (AllocationEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapBeginEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapEndEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapObjectEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapRootsEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapRootRegisterEvent ev)
+		{
+		}
+
+		public virtual void Visit (HeapRootUnregisterEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCResizeEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCMoveEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCHandleCreationEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCHandleDeletionEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCFinalizeBeginEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCFinalizeEndEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCFinalizeObjectBeginEvent ev)
+		{
+		}
+
+		public virtual void Visit (GCFinalizeObjectEndEvent ev)
+		{
+		}
+
+		public virtual void Visit (ThrowEvent ev)
+		{
+		}
+
+		public virtual void Visit (ExceptionClauseEvent ev)
+		{
+		}
+
+		public virtual void Visit (EnterEvent ev)
+		{
+		}
+
+		public virtual void Visit (LeaveEvent ev)
+		{
+		}
+
+		public virtual void Visit (ExceptionalLeaveEvent ev)
+		{
+		}
+
+		public virtual void Visit (MonitorEvent ev)
+		{
+		}
+
+		public virtual void Visit (SampleHitEvent ev)
+		{
+		}
+
+		public virtual void Visit (CounterSamplesEvent ev)
+		{
+		}
+
+		public virtual void Visit (CounterDescriptionsEvent ev)
+		{
+		}
+
+		public virtual void Visit (UnmanagedBinaryEvent ev)
+		{
+		}
+
+		public virtual void Visit (UnmanagedSymbolEvent ev)
+		{
+		}
+
+		public virtual void Visit (SynchronizationPointEvent ev)
+		{
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEvents.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEvents.cs
@@ -1,0 +1,596 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Mono.Profiler.Log {
+
+	public sealed class AppDomainLoadEvent : LogEvent {
+
+		public long AppDomainId { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class AppDomainUnloadEvent : LogEvent {
+
+		public long AppDomainId { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class AppDomainNameEvent : LogEvent {
+
+		public long AppDomainId { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ContextLoadEvent : LogEvent {
+
+		public long ContextId { get; internal set; }
+
+		public long AppDomainId { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ContextUnloadEvent : LogEvent {
+
+		public long ContextId { get; internal set; }
+
+		public long AppDomainId { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ThreadStartEvent : LogEvent {
+
+		public long ThreadId { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ThreadEndEvent : LogEvent {
+
+		public long ThreadId { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ThreadNameEvent : LogEvent {
+
+		public long ThreadId { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ImageLoadEvent : LogEvent {
+
+		public long ImagePointer { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ImageUnloadEvent : LogEvent {
+
+		public long ImagePointer { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class AssemblyLoadEvent : LogEvent {
+
+		public long AssemblyPointer { get; internal set; }
+
+		public long ImagePointer { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class AssemblyUnloadEvent : LogEvent {
+
+		public long AssemblyPointer { get; internal set; }
+
+		public long ImagePointer { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ClassLoadEvent : LogEvent {
+
+		public long ClassPointer { get; internal set; }
+
+		public long ImagePointer { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class VTableLoadEvent : LogEvent {
+
+		public long VTablePointer { get; internal set; }
+
+		public long AppDomainId { get; internal set; }
+
+		public long ClassPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class JitEvent : LogEvent {
+
+		public long MethodPointer { get; internal set; }
+
+		public long CodePointer { get; internal set; }
+
+		public long CodeSize { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class JitHelperEvent : LogEvent {
+
+		public LogJitHelper Type { get; internal set; }
+
+		public long BufferPointer { get; internal set; }
+
+		public long BufferSize { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class AllocationEvent : LogEvent {
+
+		[Obsolete ("This field is no longer produced.")]
+		public long ClassPointer { get; internal set; }
+
+		public long VTablePointer { get; internal set; }
+
+		public long ObjectPointer { get; internal set; }
+
+		public long ObjectSize { get; internal set; }
+
+		public IReadOnlyList<long> Backtrace { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapBeginEvent : LogEvent {
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapEndEvent : LogEvent {
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapObjectEvent : LogEvent {
+
+		public struct HeapObjectReference {
+
+			public long Offset { get; internal set; }
+
+			public long ObjectPointer { get; internal set; }
+		}
+
+		public long ObjectPointer { get; internal set; }
+
+		[Obsolete ("This field is no longer produced.")]
+		public long ClassPointer { get; internal set; }
+
+		public long VTablePointer { get; internal set; }
+
+		public long ObjectSize { get; internal set; }
+
+		public IReadOnlyList<HeapObjectReference> References { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapRootsEvent : LogEvent {
+
+		public struct HeapRoot {
+
+			public long AddressPointer { get; internal set; }
+
+			public long ObjectPointer { get; internal set; }
+
+			[Obsolete ("This field is no longer produced.")]
+			public LogHeapRootAttributes Attributes { get; internal set; }
+
+			[Obsolete ("This field is no longer produced.")]
+			public long ExtraInfo { get; internal set; }
+		}
+
+		[Obsolete ("This field is no longer produced.")]
+		public long MaxGenerationCollectionCount { get; internal set; }
+
+		public IReadOnlyList<HeapRoot> Roots { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapRootRegisterEvent : LogEvent {
+
+		public long RootPointer { get; internal set; }
+
+		public long RootSize { get; internal set; }
+
+		public LogHeapRootSource Source { get; internal set; }
+
+		public long Key { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class HeapRootUnregisterEvent : LogEvent {
+
+		public long StartPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCEvent : LogEvent {
+
+		public LogGCEvent Type { get; internal set; }
+
+		public byte Generation { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCResizeEvent : LogEvent {
+
+		public long NewSize { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCMoveEvent : LogEvent {
+
+		public IReadOnlyList<long> OldObjectPointers { get; internal set; }
+
+		public IReadOnlyList<long> NewObjectPointers { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCHandleCreationEvent : LogEvent {
+
+		public LogGCHandleType Type { get; internal set; }
+
+		public long Handle { get; internal set; }
+
+		public long ObjectPointer { get; internal set; }
+
+		public IReadOnlyList<long> Backtrace { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCHandleDeletionEvent : LogEvent {
+
+		public LogGCHandleType Type { get; internal set; }
+
+		public long Handle { get; internal set; }
+
+		public IReadOnlyList<long> Backtrace { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCFinalizeBeginEvent : LogEvent {
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCFinalizeEndEvent : LogEvent {
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCFinalizeObjectBeginEvent : LogEvent {
+
+		public long ObjectPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class GCFinalizeObjectEndEvent : LogEvent {
+
+		public long ObjectPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ThrowEvent : LogEvent {
+
+		public long ObjectPointer { get; internal set; }
+
+		public IReadOnlyList<long> Backtrace { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ExceptionClauseEvent : LogEvent {
+
+		public LogExceptionClause Type { get; internal set; }
+
+		public long Index { get; internal set; }
+
+		public long MethodPointer { get; internal set; }
+
+		public long ObjectPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class EnterEvent : LogEvent {
+
+		public long MethodPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class LeaveEvent : LogEvent {
+
+		public long MethodPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class ExceptionalLeaveEvent : LogEvent {
+
+		public long MethodPointer { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class MonitorEvent : LogEvent {
+
+		public LogMonitorEvent Event { get; internal set; }
+
+		public long ObjectPointer { get; internal set; }
+
+		public IReadOnlyList<long> Backtrace { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class SampleHitEvent : LogEvent {
+
+		public long ThreadId { get; internal set; }
+
+		public IReadOnlyList<long> UnmanagedBacktrace { get; internal set; }
+
+		public IReadOnlyList<long> ManagedBacktrace { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class CounterSamplesEvent : LogEvent {
+
+		public struct CounterSample {
+
+			public long Index { get; internal set; }
+
+			public LogCounterType Type { get; internal set; }
+
+			public object Value { get; internal set; }
+		}
+
+		public IReadOnlyList<CounterSample> Samples { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class CounterDescriptionsEvent : LogEvent {
+
+		public struct CounterDescription {
+
+			public LogCounterSection Section { get; internal set; }
+
+			public string SectionName { get; internal set; }
+
+			public string CounterName { get; internal set; }
+
+			public LogCounterType Type { get; internal set; }
+
+			public LogCounterUnit Unit { get; internal set; }
+
+			public LogCounterVariance Variance { get; internal set; }
+
+			public long Index { get; internal set; }
+		}
+
+		public IReadOnlyList<CounterDescription> Descriptions { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class UnmanagedBinaryEvent : LogEvent {
+
+		public long SegmentPointer { get; internal set; }
+
+		public long SegmentOffset { get; internal set; }
+
+		public long SegmentSize { get; internal set; }
+
+		public string FileName { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class UnmanagedSymbolEvent : LogEvent {
+
+		public long CodePointer { get; internal set; }
+
+		public long CodeSize { get; internal set; }
+
+		public string Name { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class SynchronizationPointEvent : LogEvent {
+
+		public LogSynchronizationPoint Type { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogException.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogException.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Mono.Profiler.Log {
+
+	public sealed class LogException : Exception {
+
+		public LogException (string message)
+			: base (message)
+		{
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogProcessor.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogProcessor.cs
@@ -1,0 +1,628 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace Mono.Profiler.Log {
+
+	public sealed class LogProcessor {
+
+		public LogStream Stream { get; }
+
+		public LogEventVisitor ImmediateVisitor { get; }
+
+		public LogEventVisitor SortedVisitor { get; }
+
+		public LogStreamHeader StreamHeader { get; private set; }
+
+		LogReader _reader;
+
+		LogBufferHeader _bufferHeader;
+
+		ulong _time;
+
+		bool _used;
+
+		public LogProcessor (LogStream stream, LogEventVisitor immediateVisitor, LogEventVisitor sortedVisitor)
+		{
+			if (stream == null)
+				throw new ArgumentNullException (nameof (stream));
+
+			Stream = stream;
+			ImmediateVisitor = immediateVisitor;
+			SortedVisitor = sortedVisitor;
+		}
+
+		public void Process ()
+		{
+			Process (CancellationToken.None);
+		}
+
+		static void ProcessEvent (LogEventVisitor visitor, LogEvent ev)
+		{
+			if (visitor != null) {
+				visitor.VisitBefore (ev);
+				ev.Accept (visitor);
+				visitor.VisitAfter (ev);
+			}
+		}
+
+		public void Process (CancellationToken token)
+		{
+			if (_used)
+				throw new InvalidOperationException ("This log processor cannot be reused.");
+
+			_used = true;
+			_reader = new LogReader (Stream, true);
+
+			StreamHeader = new LogStreamHeader (_reader);
+
+			while (!Stream.EndOfStream) {
+				token.ThrowIfCancellationRequested ();
+
+				_bufferHeader = new LogBufferHeader (StreamHeader, _reader);
+
+				// Read the entire buffer into a MemoryStream ahead of time to
+				// reduce the amount of I/O system calls we do. This should be
+				// fine since the profiler tries to keep buffers small and
+				// flushes them every second at minimum. This also has the
+				// advantage that we can use the Position and Length properties
+				// even if the stream we read the buffer from is actually
+				// non-seekable.
+				var stream = new MemoryStream (_reader.ReadBytes (_bufferHeader.Length), false);
+
+				using (var reader = new LogReader (stream, false)) {
+					var oldReader = _reader;
+
+					_reader = reader;
+
+					while (stream.Position < stream.Length) {
+						token.ThrowIfCancellationRequested ();
+
+						var ev = ReadEvent ();
+
+						ProcessEvent (ImmediateVisitor, ev);
+					}
+
+					_reader = oldReader;
+				}
+			}
+		}
+
+		LogEvent ReadEvent ()
+		{
+			var type = _reader.ReadByte ();
+			var basicType = (LogEventType) (type & 0xf);
+			var extType = (LogEventType) (type & 0xf0);
+
+			_time = ReadTime ();
+			LogEvent ev = null;
+
+			switch (basicType) {
+			case LogEventType.Allocation:
+				switch (extType) {
+				case LogEventType.AllocationBacktrace:
+				case LogEventType.AllocationNoBacktrace:
+					ev = new AllocationEvent {
+						ClassPointer = StreamHeader.FormatVersion < 15 ? ReadPointer () : 0,
+						VTablePointer = StreamHeader.FormatVersion >= 15 ? ReadPointer () : 0,
+						ObjectPointer = ReadObject (),
+						ObjectSize = (long) _reader.ReadULeb128 (),
+						Backtrace = ReadBacktrace (extType == LogEventType.AllocationBacktrace),
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.GC:
+				switch (extType) {
+				case LogEventType.GCEvent:
+					ev = new GCEvent {
+						Type = (LogGCEvent) _reader.ReadByte (),
+						Generation = _reader.ReadByte (),
+					};
+					break;
+				case LogEventType.GCResize:
+					ev = new GCResizeEvent {
+						NewSize = (long) _reader.ReadULeb128 (),
+					};
+					break;
+				case LogEventType.GCMove: {
+					var list = new long [(int) _reader.ReadULeb128 ()];
+
+					for (var i = 0; i < list.Length; i++)
+						list [i] = ReadObject ();
+
+					ev = new GCMoveEvent {
+						OldObjectPointers = list.Where ((_, i) => i % 2 == 0).ToArray (),
+						NewObjectPointers = list.Where ((_, i) => i % 2 != 0).ToArray (),
+					};
+					break;
+				}
+				case LogEventType.GCHandleCreationNoBacktrace:
+				case LogEventType.GCHandleCreationBacktrace:
+					ev = new GCHandleCreationEvent {
+						Type = (LogGCHandleType) _reader.ReadULeb128 (),
+						Handle = (long) _reader.ReadULeb128 (),
+						ObjectPointer = ReadObject (),
+						Backtrace = ReadBacktrace (extType == LogEventType.GCHandleCreationBacktrace),
+					};
+					break;
+				case LogEventType.GCHandleDeletionNoBacktrace:
+				case LogEventType.GCHandleDeletionBacktrace:
+					ev = new GCHandleDeletionEvent {
+						Type = (LogGCHandleType) _reader.ReadULeb128 (),
+						Handle = (long) _reader.ReadULeb128 (),
+						Backtrace = ReadBacktrace (extType == LogEventType.GCHandleDeletionBacktrace),
+					};
+					break;
+				case LogEventType.GCFinalizeBegin:
+					ev = new GCFinalizeBeginEvent ();
+					break;
+				case LogEventType.GCFinalizeEnd:
+					ev = new GCFinalizeEndEvent ();
+					break;
+				case LogEventType.GCFinalizeObjectBegin:
+					ev = new GCFinalizeObjectBeginEvent {
+						ObjectPointer = ReadObject (),
+					};
+					break;
+				case LogEventType.GCFinalizeObjectEnd:
+					ev = new GCFinalizeObjectEndEvent {
+						ObjectPointer = ReadObject (),
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Metadata: {
+				var load = false;
+				var unload = false;
+
+				switch (extType) {
+				case LogEventType.MetadataExtra:
+					break;
+				case LogEventType.MetadataEndLoad:
+					load = true;
+					break;
+				case LogEventType.MetadataEndUnload:
+					unload = true;
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+
+				var metadataType = (LogMetadataType) _reader.ReadByte ();
+
+				switch (metadataType) {
+				case LogMetadataType.Class:
+					if (load) {
+						ev = new ClassLoadEvent {
+							ClassPointer = ReadPointer (),
+							ImagePointer = ReadPointer (),
+							Name = _reader.ReadCString (),
+						};
+					} else
+						throw new LogException ("Invalid class metadata event.");
+					break;
+				case LogMetadataType.Image:
+					if (load) {
+						ev = new ImageLoadEvent {
+							ImagePointer = ReadPointer (),
+							Name = _reader.ReadCString (),
+						};
+					} else if (unload) {
+						ev = new ImageUnloadEvent {
+							ImagePointer = ReadPointer (),
+							Name = _reader.ReadCString (),
+						};
+					} else
+						throw new LogException ("Invalid image metadata event.");
+					break;
+				case LogMetadataType.Assembly:
+					if (load) {
+						ev = new AssemblyLoadEvent {
+							AssemblyPointer = ReadPointer (),
+							ImagePointer = StreamHeader.FormatVersion >= 14 ? ReadPointer () : 0,
+							Name = _reader.ReadCString (),
+						};
+					} else if (unload) {
+						ev = new AssemblyUnloadEvent {
+							AssemblyPointer = ReadPointer (),
+							ImagePointer = StreamHeader.FormatVersion >= 14 ? ReadPointer () : 0,
+							Name = _reader.ReadCString (),
+						};
+					} else
+						throw new LogException ("Invalid assembly metadata event.");
+					break;
+				case LogMetadataType.AppDomain:
+					if (load) {
+						ev = new AppDomainLoadEvent {
+							AppDomainId = ReadPointer (),
+						};
+					} else if (unload) {
+						ev = new AppDomainUnloadEvent {
+							AppDomainId = ReadPointer (),
+						};
+					} else {
+						ev = new AppDomainNameEvent {
+							AppDomainId = ReadPointer (),
+							Name = _reader.ReadCString (),
+						};
+					}
+					break;
+				case LogMetadataType.Thread:
+					if (load) {
+						ev = new ThreadStartEvent {
+							ThreadId = ReadPointer (),
+						};
+					} else if (unload) {
+						ev = new ThreadEndEvent {
+							ThreadId = ReadPointer (),
+						};
+					} else {
+						ev = new ThreadNameEvent {
+							ThreadId = ReadPointer (),
+							Name = _reader.ReadCString (),
+						};
+					}
+					break;
+				case LogMetadataType.Context:
+					if (load) {
+						ev = new ContextLoadEvent {
+							ContextId = ReadPointer (),
+							AppDomainId = ReadPointer (),
+						};
+					} else if (unload) {
+						ev = new ContextUnloadEvent {
+							ContextId = ReadPointer (),
+							AppDomainId = ReadPointer (),
+						};
+					} else
+						throw new LogException ("Invalid context metadata event.");
+					break;
+				case LogMetadataType.VTable:
+					if (load) {
+						ev = new VTableLoadEvent {
+							VTablePointer = ReadPointer (),
+							AppDomainId = ReadPointer (),
+							ClassPointer = ReadPointer (),
+						};
+					} else
+						throw new LogException ("Invalid VTable metadata event.");
+					break;
+				default:
+					throw new LogException ($"Invalid metadata type ({metadataType}).");
+				}
+				break;
+			}
+			case LogEventType.Method:
+				switch (extType) {
+				case LogEventType.MethodLeave:
+					ev = new LeaveEvent {
+						MethodPointer = ReadMethod (),
+					};
+					break;
+				case LogEventType.MethodEnter:
+					ev = new EnterEvent {
+						MethodPointer = ReadMethod (),
+					};
+					break;
+				case LogEventType.MethodLeaveExceptional:
+					ev = new ExceptionalLeaveEvent {
+						MethodPointer = ReadMethod (),
+					};
+					break;
+				case LogEventType.MethodJit:
+					ev = new JitEvent {
+						MethodPointer = ReadMethod (),
+						CodePointer = ReadPointer (),
+						CodeSize = (long) _reader.ReadULeb128 (),
+						Name = _reader.ReadCString (),
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Exception:
+				switch (extType) {
+				case LogEventType.ExceptionThrowNoBacktrace:
+				case LogEventType.ExceptionThrowBacktrace:
+					ev = new ThrowEvent {
+						ObjectPointer = ReadObject (),
+						Backtrace = ReadBacktrace (extType == LogEventType.ExceptionThrowBacktrace),
+					};
+					break;
+				case LogEventType.ExceptionClause:
+					ev = new ExceptionClauseEvent {
+						Type = (LogExceptionClause) _reader.ReadByte (),
+						Index = (long) _reader.ReadULeb128 (),
+						MethodPointer = ReadMethod (),
+						ObjectPointer = StreamHeader.FormatVersion >= 14 ? ReadObject () : 0,
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Monitor:
+				if (StreamHeader.FormatVersion < 14) {
+					if (extType.HasFlag (LogEventType.MonitorBacktrace)) {
+						extType = LogEventType.MonitorBacktrace;
+					} else {
+						extType = LogEventType.MonitorNoBacktrace;
+					}
+				}
+				switch (extType) {
+				case LogEventType.MonitorNoBacktrace:
+				case LogEventType.MonitorBacktrace:
+					ev = new MonitorEvent {
+						Event = StreamHeader.FormatVersion >= 14 ?
+						        (LogMonitorEvent) _reader.ReadByte () :
+						        (LogMonitorEvent) ((((byte) type & 0xf0) >> 4) & 0x3),
+						ObjectPointer = ReadObject (),
+						Backtrace = ReadBacktrace (extType == LogEventType.MonitorBacktrace),
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Heap:
+				switch (extType) {
+				case LogEventType.HeapBegin:
+					ev = new HeapBeginEvent ();
+					break;
+				case LogEventType.HeapEnd:
+					ev = new HeapEndEvent ();
+					break;
+				case LogEventType.HeapObject: {
+					HeapObjectEvent hoe = new HeapObjectEvent {
+						ObjectPointer = ReadObject (),
+						ClassPointer = StreamHeader.FormatVersion < 15 ? ReadPointer () : 0,
+						VTablePointer = StreamHeader.FormatVersion >= 15 ? ReadPointer () : 0,
+						ObjectSize = (long) _reader.ReadULeb128 (),
+					};
+
+					var list = new HeapObjectEvent.HeapObjectReference [(int) _reader.ReadULeb128 ()];
+
+					for (var i = 0; i < list.Length; i++) {
+						list [i] = new HeapObjectEvent.HeapObjectReference {
+							Offset = (long) _reader.ReadULeb128 (),
+							ObjectPointer = ReadObject (),
+						};
+					}
+
+					hoe.References = list;
+					ev = hoe;
+
+					break;
+				}
+
+				case LogEventType.HeapRoots: {
+					var hre = new HeapRootsEvent ();
+					var list = new HeapRootsEvent.HeapRoot [(int) _reader.ReadULeb128 ()];
+
+					if (StreamHeader.FormatVersion < 15)
+						hre.MaxGenerationCollectionCount = (long) _reader.ReadULeb128 ();
+
+					for (var i = 0; i < list.Length; i++) {
+						list [i] = new HeapRootsEvent.HeapRoot {
+							AddressPointer = StreamHeader.FormatVersion >= 15 ? ReadPointer () : 0,
+							ObjectPointer = ReadObject (),
+							Attributes = StreamHeader.FormatVersion < 15 ?
+							             (StreamHeader.FormatVersion == 13 ?
+							              (LogHeapRootAttributes) _reader.ReadByte () :
+							              (LogHeapRootAttributes) _reader.ReadULeb128 ()) :
+							             0,
+							ExtraInfo = StreamHeader.FormatVersion < 15 ? (long) _reader.ReadULeb128 () : 0,
+						};
+					}
+
+					hre.Roots = list;
+					ev = hre;
+
+					break;
+				}
+				case LogEventType.HeapRootRegister:
+					ev = new HeapRootRegisterEvent {
+						RootPointer = ReadPointer (),
+						RootSize = (long) _reader.ReadULeb128 (),
+						Source = (LogHeapRootSource) _reader.ReadByte (),
+						Key = ReadPointer (),
+						Name = _reader.ReadCString (),
+					};
+					break;
+				case LogEventType.HeapRootUnregister:
+					ev = new HeapRootUnregisterEvent {
+						StartPointer = ReadPointer (),
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Sample:
+				switch (extType) {
+				case LogEventType.SampleHit:
+					if (StreamHeader.FormatVersion < 14) {
+						// Read SampleType (always set to .Cycles) for versions < 14
+						_reader.ReadByte ();
+					}
+					ev = new SampleHitEvent {
+						ThreadId = ReadPointer (),
+						UnmanagedBacktrace = ReadBacktrace (true, false),
+						ManagedBacktrace = ReadBacktrace (true).Reverse ().ToArray (),
+					};
+					break;
+				case LogEventType.SampleUnmanagedSymbol:
+					ev = new UnmanagedSymbolEvent {
+						CodePointer = ReadPointer (),
+						CodeSize = (long) _reader.ReadULeb128 (),
+						Name = _reader.ReadCString (),
+					};
+					break;
+				case LogEventType.SampleUnmanagedBinary:
+					ev = new UnmanagedBinaryEvent {
+						SegmentPointer = StreamHeader.FormatVersion >= 14 ? ReadPointer () : _reader.ReadSLeb128 (),
+						SegmentOffset = (long) _reader.ReadULeb128 (),
+						SegmentSize = (long) _reader.ReadULeb128 (),
+						FileName = _reader.ReadCString (),
+					};
+					break;
+				case LogEventType.SampleCounterDescriptions: {
+					var cde = new CounterDescriptionsEvent ();
+					var list = new CounterDescriptionsEvent.CounterDescription [(int) _reader.ReadULeb128 ()];
+
+					for (var i = 0; i < list.Length; i++) {
+						var section = (LogCounterSection) _reader.ReadULeb128 ();
+
+						list [i] = new CounterDescriptionsEvent.CounterDescription {
+							Section = section,
+							SectionName = section == LogCounterSection.User ? _reader.ReadCString () : null,
+							CounterName = _reader.ReadCString (),
+							Type = StreamHeader.FormatVersion < 15 ? (LogCounterType) _reader.ReadByte () : (LogCounterType) _reader.ReadULeb128 (),
+							Unit = StreamHeader.FormatVersion < 15 ? (LogCounterUnit) _reader.ReadByte () : (LogCounterUnit) _reader.ReadULeb128 (),
+							Variance = StreamHeader.FormatVersion < 15 ? (LogCounterVariance) _reader.ReadByte () : (LogCounterVariance) _reader.ReadULeb128 (),
+							Index = (long) _reader.ReadULeb128 (),
+						};
+					}
+
+					cde.Descriptions = list;
+					ev = cde;
+
+					break;
+				}
+				case LogEventType.SampleCounters: {
+					var cse = new CounterSamplesEvent ();
+					var list = new List<CounterSamplesEvent.CounterSample> ();
+
+					while (true) {
+						var index = (long) _reader.ReadULeb128 ();
+
+						if (index == 0)
+							break;
+
+						var counterType = StreamHeader.FormatVersion < 15 ? (LogCounterType) _reader.ReadByte () : (LogCounterType) _reader.ReadULeb128 ();
+
+						object value = null;
+
+						switch (counterType) {
+						case LogCounterType.String:
+							value = _reader.ReadByte () == 1 ? _reader.ReadCString () : null;
+							break;
+						case LogCounterType.Int32:
+						case LogCounterType.Word:
+						case LogCounterType.Int64:
+						case LogCounterType.Interval:
+							value = _reader.ReadSLeb128 ();
+							break;
+						case LogCounterType.UInt32:
+						case LogCounterType.UInt64:
+							value = _reader.ReadULeb128 ();
+							break;
+						case LogCounterType.Double:
+							value = _reader.ReadDouble ();
+							break;
+						default:
+							throw new LogException ($"Invalid counter type ({counterType}).");
+						}
+
+						list.Add (new CounterSamplesEvent.CounterSample {
+							Index = index,
+							Type = counterType,
+							Value = value,
+						});
+					}
+
+					cse.Samples = list;
+					ev = cse;
+
+					break;
+				}
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Runtime:
+				switch (extType) {
+				case LogEventType.RuntimeJitHelper: {
+					var helperType = (LogJitHelper) _reader.ReadByte ();
+
+					ev = new JitHelperEvent {
+						Type = helperType,
+						BufferPointer = ReadPointer (),
+						BufferSize = (long) _reader.ReadULeb128 (),
+						Name = helperType == LogJitHelper.SpecificTrampoline ? _reader.ReadCString () : null,
+					};
+					break;
+				}
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			case LogEventType.Meta:
+				switch (extType) {
+				case LogEventType.MetaSynchronizationPoint:
+					ev = new SynchronizationPointEvent {
+						Type = (LogSynchronizationPoint) _reader.ReadByte (),
+					};
+					break;
+				default:
+					throw new LogException ($"Invalid extended event type ({extType}).");
+				}
+				break;
+			default:
+				throw new LogException ($"Invalid basic event type ({basicType}).");
+			}
+
+			ev.Timestamp = _time;
+			ev.Buffer = _bufferHeader;
+
+			return ev;
+		}
+
+		long ReadPointer ()
+		{
+			var ptr = _reader.ReadSLeb128 () + _bufferHeader.PointerBase;
+
+			return StreamHeader.PointerSize == sizeof (long) ? ptr : ptr & 0xffffffffL;
+		}
+
+		long ReadObject ()
+		{
+			return _reader.ReadSLeb128 () + _bufferHeader.ObjectBase << 3;
+		}
+
+		long ReadMethod ()
+		{
+			return _bufferHeader.CurrentMethod += _reader.ReadSLeb128 ();
+		}
+
+		ulong ReadTime ()
+		{
+			return _bufferHeader.CurrentTime += _reader.ReadULeb128 ();
+		}
+
+		IReadOnlyList<long> ReadBacktrace (bool actuallyRead, bool managed = true)
+		{
+			if (!actuallyRead)
+				return Array.Empty<long> ();
+
+			var list = new long [(int) _reader.ReadULeb128 ()];
+
+			for (var i = 0; i < list.Length; i++)
+				list [i] = managed ? ReadMethod () : ReadPointer ();
+
+			return list;
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogProfiler.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogProfiler.cs
@@ -1,0 +1,265 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Mono.Profiler.Log {
+
+	public static class LogProfiler {
+
+		static bool? _attached;
+
+		public static bool IsAttached {
+			get {
+				if (_attached != null)
+					return (bool) _attached;
+
+				try {
+					GetMaxStackTraceFrames ();
+					return (bool) (_attached = true);
+				} catch (Exception e) when (e is MissingMethodException || e is SecurityException) {
+					return (bool) (_attached = false);
+				}
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static int GetMaxStackTraceFrames ();
+
+		public static int MaxStackTraceFrames {
+			get { return GetMaxStackTraceFrames (); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static int GetStackTraceFrames ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetStackTraceFrames (int value);
+
+		public static int StackTraceFrames {
+			get { return GetStackTraceFrames (); }
+			set {
+				var max = MaxStackTraceFrames;
+
+				if (value < 0 || value > max)
+					throw new ArgumentOutOfRangeException (nameof (value), value, $"Value must be between 0 and {max}.");
+
+				SetStackTraceFrames (value);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static LogHeapshotMode GetHeapshotMode ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetHeapshotMode (LogHeapshotMode value);
+
+		public static LogHeapshotMode HeapshotMode {
+			get { return GetHeapshotMode (); }
+			set {
+				if (!Enum.IsDefined (typeof (LogHeapshotMode), value))
+					throw new ArgumentException ("Invalid heapshot mode.", nameof (value));
+
+				SetHeapshotMode (value);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static int GetHeapshotMillisecondsFrequency ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetHeapshotMillisecondsFrequency (int value);
+
+		public static int HeapshotMillisecondsFrequency {
+			get { return GetHeapshotMillisecondsFrequency (); }
+			set {
+				if (value < 0)
+					throw new ArgumentOutOfRangeException (nameof (value), value, "Value must be non-negative.");
+
+				SetHeapshotMillisecondsFrequency (value);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static int GetHeapshotCollectionsFrequency ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetHeapshotCollectionsFrequency (int value);
+
+		public static int HeapshotCollectionsFrequency {
+			get { return GetHeapshotCollectionsFrequency (); }
+			set {
+				if (value < 0)
+					throw new ArgumentOutOfRangeException (nameof (value), value, "Value must be non-negative.");
+
+				SetHeapshotCollectionsFrequency (value);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public extern static void TriggerHeapshot ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static int GetCallDepth ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetCallDepth (int value);
+
+		public static int CallDepth {
+			get { return GetCallDepth (); }
+			set {
+				if (value < 0)
+					throw new ArgumentOutOfRangeException (nameof (value), value, "Value must be non-negative.");
+
+				SetCallDepth (value);
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void GetSampleMode (out LogSampleMode mode, out int frequency);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool SetSampleMode (LogSampleMode value, int frequency);
+
+		public static LogSampleMode SampleMode {
+			get {
+				GetSampleMode (out var mode, out var _);
+
+				return mode;
+			}
+		}
+
+		public static int SampleFrequency {
+			get {
+				GetSampleMode (out var _, out var frequency);
+
+				return frequency;
+			}
+		}
+
+		public static bool SetSampleParameters (LogSampleMode mode, int frequency)
+		{
+			if (!Enum.IsDefined (typeof (LogSampleMode), mode))
+				throw new ArgumentException ("Invalid sample mode.", nameof (mode));
+
+			if (frequency < 1)
+				throw new ArgumentOutOfRangeException (nameof (frequency), frequency, "Frequency must be positive.");
+
+			return SetSampleMode (mode, frequency);
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetExceptionEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetExceptionEvents (bool value);
+
+		public static bool ExceptionEventsEnabled {
+			get { return GetExceptionEvents (); }
+			set { SetExceptionEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetMonitorEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetMonitorEvents (bool value);
+
+		public static bool MonitorEventsEnabled {
+			get { return GetMonitorEvents (); }
+			set { SetMonitorEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetGCEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetGCEvents (bool value);
+
+		public static bool GCEventsEnabled {
+			get { return GetGCEvents (); }
+			set { SetGCEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetGCAllocationEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetGCAllocationEvents (bool value);
+
+		public static bool GCAllocationEventsEnabled {
+			get { return GetGCAllocationEvents (); }
+			set { SetGCAllocationEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetGCMoveEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetGCMoveEvents (bool value);
+
+		public static bool GCMoveEventsEnabled {
+			get { return GetGCMoveEvents (); }
+			set { SetGCMoveEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetGCRootEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetGCRootEvents (bool value);
+
+		public static bool GCRootEventsEnabled {
+			get { return GetGCRootEvents (); }
+			set { SetGCRootEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetGCHandleEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetGCHandleEvents (bool value);
+
+		public static bool GCHandleEventsEnabled {
+			get { return GetGCHandleEvents (); }
+			set { SetGCHandleEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetGCFinalizationEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetGCFinalizationEvents (bool value);
+
+		public static bool GCFinalizationEventsEnabled {
+			get { return GetGCFinalizationEvents (); }
+			set { SetGCFinalizationEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetCounterEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetCounterEvents (bool value);
+
+		public static bool CounterEventsEnabled {
+			get { return GetCounterEvents (); }
+			set { SetCounterEvents (value); }
+		}
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static bool GetJitEvents ();
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		extern static void SetJitEvents (bool value);
+
+		public static bool JitEventsEnabled {
+			get { return GetJitEvents (); }
+			set { SetJitEvents (value); }
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogReader.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogReader.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace Mono.Profiler.Log {
+
+	sealed class LogReader : IDisposable {
+
+		static readonly Encoding _encoding = Encoding.UTF8;
+
+		readonly BinaryReader _reader;
+
+		byte[] _stringBuffer = new byte [1024];
+
+		public LogReader (Stream stream, bool leaveOpen)
+		{
+			_reader = new BinaryReader (stream, _encoding, leaveOpen);
+		}
+
+		public void Dispose ()
+		{
+			_reader.Dispose ();
+		}
+
+		public byte[] ReadBytes (int count)
+		{
+			return _reader.ReadBytes (count);
+		}
+
+		public byte ReadByte ()
+		{
+			return _reader.ReadByte ();
+		}
+
+		public ushort ReadUInt16 ()
+		{
+			return _reader.ReadUInt16 ();
+		}
+
+		public int ReadInt32 ()
+		{
+			return _reader.ReadInt32 ();
+		}
+
+		public long ReadInt64 ()
+		{
+			return _reader.ReadInt64 ();
+		}
+
+		public ulong ReadUInt64 ()
+		{
+			return _reader.ReadUInt64 ();
+		}
+
+		public double ReadDouble ()
+		{
+			return _reader.ReadDouble ();
+		}
+
+		public string ReadHeaderString ()
+		{
+			return _encoding.GetString (ReadBytes (ReadInt32 ()));
+		}
+
+		public string ReadCString ()
+		{
+			var pos = 0;
+
+			byte val;
+
+			while ((val = ReadByte ()) != 0) {
+				if (pos == _stringBuffer.Length)
+					Array.Resize (ref _stringBuffer, System.Math.Max (_stringBuffer.Length * 2, pos + 1));
+
+				_stringBuffer [pos++] = val;
+			}
+
+			return _encoding.GetString (_stringBuffer, 0, pos);
+		}
+
+		public long ReadSLeb128 ()
+		{
+			long result = 0;
+			var shift = 0;
+
+			while (true) {
+				var b = ReadByte ();
+
+				result |= (long) (b & 0x7f) << shift;
+				shift += 7;
+
+				if ((b & 0x80) != 0x80) {
+					if (shift < sizeof (long) * 8 && (b & 0x40) == 0x40)
+						result |= -(1L << shift);
+
+					break;
+				}
+			}
+
+			return result;
+		}
+
+		public ulong ReadULeb128 ()
+		{
+			ulong result = 0;
+			var shift = 0;
+
+			while (true) {
+				var b = ReadByte ();
+
+				result |= (ulong) (b & 0x7f) << shift;
+
+				if ((b & 0x80) != 0x80)
+					break;
+
+				shift += 7;
+			}
+
+			return result;
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogStream.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogStream.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace Mono.Profiler.Log {
+
+	public class LogStream : Stream {
+
+		public Stream BaseStream { get; }
+
+		public virtual bool EndOfStream => BaseStream.Position == BaseStream.Length;
+
+		public override bool CanRead => true;
+
+		public override bool CanSeek => false;
+
+		public override bool CanWrite => false;
+
+		public override long Length => throw new NotSupportedException ();
+
+		public override long Position {
+			get => throw new NotSupportedException ();
+			set => throw new NotSupportedException ();
+		}
+
+		readonly byte[] _byteBuffer = new byte [1];
+
+		public LogStream (Stream baseStream)
+		{
+			if (baseStream == null)
+				throw new ArgumentNullException (nameof (baseStream));
+
+			if (!baseStream.CanRead)
+				throw new ArgumentException ("Stream does not support reading.", nameof (baseStream));
+
+			BaseStream = baseStream;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (disposing)
+				BaseStream.Dispose ();
+		}
+
+		public override void Flush ()
+		{
+			throw new NotSupportedException ();
+		}
+
+		public override int ReadByte ()
+		{
+			// The base method on Stream is extremely inefficient in that it
+			// allocates a 1-byte array for every call. Simply use a private
+			// buffer instead.
+			return Read (_byteBuffer, 0, sizeof (byte)) == 0 ? -1 : _byteBuffer [0];
+		}
+
+		public override int Read (byte[] buffer, int offset, int count)
+		{
+			return BaseStream.Read (buffer, offset, count);
+		}
+
+		public override long Seek (long offset, SeekOrigin origin)
+		{
+			throw new NotSupportedException ();
+		}
+
+		public override void SetLength (long value)
+		{
+			throw new NotSupportedException ();
+		}
+
+		public override void Write (byte[] buffer, int offset, int count)
+		{
+			throw new NotSupportedException ();
+		}
+	}
+}

--- a/main/tests/StressTest/Mono.Profiling.Log/LogStreamHeader.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogStreamHeader.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Mono.Profiler.Log {
+
+	public sealed class LogStreamHeader {
+		
+		const int MinVersion = 13;
+		const int MaxVersion = 15;
+
+		const int Id = 0x4d505a01;
+
+		public Version Version { get; }
+
+		public int FormatVersion { get; }
+
+		public byte PointerSize { get; }
+
+		public ulong StartupTime { get; }
+
+		public int TimerOverhead { get; }
+
+		public int Flags { get; }
+
+		public int ProcessId { get; }
+
+		public int Port { get; }
+
+		public string Arguments { get; }
+
+		public string Architecture { get; }
+
+		public string OperatingSystem { get; }
+
+		internal LogStreamHeader (LogReader reader)
+		{
+			var id = reader.ReadInt32 ();
+
+			if (id != Id)
+				throw new LogException ($"Invalid stream header ID (0x{id:X}).");
+
+			Version = new Version (reader.ReadByte (), reader.ReadByte ());
+			FormatVersion = reader.ReadByte ();
+
+			if (FormatVersion < MinVersion || FormatVersion > MaxVersion)
+				throw new LogException ($"Unsupported MLPD version {FormatVersion}. Should be >= {MinVersion} and <= {MaxVersion}.");
+			
+			PointerSize = reader.ReadByte ();
+			StartupTime = reader.ReadUInt64 ();
+			TimerOverhead = reader.ReadInt32 ();
+			Flags = reader.ReadInt32 ();
+			ProcessId = reader.ReadInt32 ();
+			Port = reader.ReadUInt16 ();
+			Arguments = reader.ReadHeaderString ();
+			Architecture = reader.ReadHeaderString ();
+			OperatingSystem = reader.ReadHeaderString ();
+		}
+	}
+}

--- a/main/tests/StressTest/MonoDevelop.StressTest/ProfilerProcessor.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/ProfilerProcessor.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Mono.Profiler.Log;
+
+namespace MonoDevelop.StressTest
+{
+	public class ProfilerProcessor
+	{
+		public StressTestOptions.ProfilerOptions Options { get; }
+		private Thread processingThread;
+		private Visitor visitor;
+		private LogProcessor processor;
+		private CancellationTokenSource cts = new CancellationTokenSource ();
+
+		public ProfilerProcessor (StressTestOptions.ProfilerOptions options)
+		{
+			this.Options = options;
+			visitor = new Visitor (this);
+			processingThread = new Thread (new ThreadStart (ProcessFile));
+			processingThread.Start ();
+		}
+
+		public void Stop ()
+		{
+			cts.Cancel ();
+		}
+
+		class NeverEndingLogStream : LogStream
+		{
+			readonly CancellationToken token;
+
+			public NeverEndingLogStream (Stream baseStream, CancellationToken token) : base (baseStream)
+			{
+				this.token = token;
+			}
+
+			public override bool EndOfStream => false;
+
+			byte[] _byteBuffer = new byte[1];
+			public override int ReadByte ()
+			{
+				while (BaseStream.Length - BaseStream.Position < 1) {
+					Thread.Sleep (100);
+					token.ThrowIfCancellationRequested ();
+				}
+				// The base method on Stream is extremely inefficient in that it
+				// allocates a 1-byte array for every call. Simply use a private
+				// buffer instead.
+				return Read (_byteBuffer, 0, sizeof (byte)) == 0 ? -1 : _byteBuffer[0];
+			}
+
+			public override int Read (byte[] buffer, int offset, int count)
+			{
+				while (BaseStream.Length - BaseStream.Position < count) {
+					Thread.Sleep (100);
+					token.ThrowIfCancellationRequested ();
+				}
+				return BaseStream.Read (buffer, offset, count);
+			}
+		}
+
+		private void ProcessFile ()
+		{
+			try {
+				//Give runtime 10 seconds to create .mlpd
+				for (int i = 0; i < 100; i++) {
+					if (File.Exists (Options.MlpdOutputPath))
+						break;
+					Thread.Sleep (100);
+				}
+				using (var fs = new FileStream (Options.MlpdOutputPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+				using (var logStream = new NeverEndingLogStream (fs, cts.Token)) {
+					processor = new LogProcessor (logStream, new Visitor (this), null);
+					processor.Process (cts.Token);
+				}
+			} catch (OperationCanceledException) { } catch (Exception ex) {
+				Console.WriteLine (ex);
+			}
+		}
+
+		public class Heapshot
+		{
+			public Dictionary<long, int> ObjectsPerClassCounter = new Dictionary<long, int> ();
+			public Dictionary<long, ClassLoadEvent> ClassInfos;
+		}
+
+		class Visitor : Mono.Profiler.Log.LogEventVisitor
+		{
+			ProfilerProcessor profilerProcessor;
+			Heapshot currentHeapshot;
+			Dictionary<long, ClassLoadEvent> classInfos = new Dictionary<long, ClassLoadEvent> ();
+			Dictionary<long, long> vtableToClassInfo = new Dictionary<long, long> ();
+
+			public Visitor (ProfilerProcessor profilerProcessor)
+			{
+				this.profilerProcessor = profilerProcessor;
+			}
+
+			public override void Visit (ClassLoadEvent ev)
+			{
+				classInfos[ev.ClassPointer] = ev;
+			}
+
+			public override void Visit (VTableLoadEvent ev)
+			{
+				vtableToClassInfo[ev.VTablePointer] = ev.ClassPointer;
+			}
+
+			public override void Visit (HeapBeginEvent ev)
+			{
+				currentHeapshot = new Heapshot ();
+			}
+
+			public override void Visit (HeapObjectEvent ev)
+			{
+				if (ev.ObjectSize == 0)//This means it's just reporting references
+					return;
+				var classInfoId = vtableToClassInfo[ev.VTablePointer];
+				if (currentHeapshot.ObjectsPerClassCounter.ContainsKey (classInfoId))
+					currentHeapshot.ObjectsPerClassCounter[classInfoId]++;
+				else
+					currentHeapshot.ObjectsPerClassCounter[classInfoId] = 0;
+			}
+
+			public override void Visit (HeapEndEvent ev)
+			{
+				currentHeapshot.ClassInfos = classInfos;
+				profilerProcessor.completionSource.SetResult (currentHeapshot);
+			}
+		}
+
+		int TcpPort {
+			get {
+				return processor.StreamHeader.Port;
+			}
+		}
+		TcpClient client;
+		StreamWriter writer;
+		TaskCompletionSource<Heapshot> completionSource;
+
+		public async Task<Heapshot> TakeHeapshot ()
+		{
+			if (completionSource != null) {
+				throw new InvalidOperationException ("Heapshot taking in progress");
+			}
+			completionSource = new TaskCompletionSource<Heapshot> ();
+			if (client == null) {
+				client = new TcpClient ();
+				await client.ConnectAsync (IPAddress.Loopback, TcpPort);
+				writer = new StreamWriter (client.GetStream ());
+			}
+			await writer.WriteAsync ("heapshot\n");
+			await writer.FlushAsync ();
+			var result = await completionSource.Task;
+			completionSource = null;
+			return result;
+		}
+
+		public string GetMonoArguments ()
+		{
+			switch (Options.Type) {
+				case StressTestOptions.ProfilerOptions.ProfilerType.HeapOnly:
+					return $"--profile=log:heapshot=ondemand,noalloc,nocalls,maxframes=0,output=\"{Options.MlpdOutputPath}\"";
+				case StressTestOptions.ProfilerOptions.ProfilerType.All:
+					return $"--profile=log:heapshot=ondemand,alloc,nocalls,maxframes={Options.MaxFrames},output=\"{Options.MlpdOutputPath}\"";
+				case StressTestOptions.ProfilerOptions.ProfilerType.Custom:
+					return Options.CustomProfilerArguments;
+				default:
+					throw new NotImplementedException (Options.Type.ToString ());
+			}
+		}
+		List<Heapshot> heapshots = new List<Heapshot> ();
+		public async Task TakeHeapshotAndMakeReport ()
+		{
+			var newHeapshot = await TakeHeapshot ();
+
+			if (Options.PrintReportTypes.HasFlag (StressTestOptions.ProfilerOptions.PrintReport.ObjectsTotal)) {
+				Console.WriteLine ($"Total objects per type({newHeapshot.ObjectsPerClassCounter.Count}):");
+				foreach (var typeWithCount in newHeapshot.ObjectsPerClassCounter.Where (p => p.Value > 0).OrderByDescending (p => p.Value)) {
+					Console.WriteLine ($"{newHeapshot.ClassInfos[typeWithCount.Key].Name}:{typeWithCount.Value}");
+				}
+			}
+
+			if (Options.PrintReportTypes.HasFlag (StressTestOptions.ProfilerOptions.PrintReport.ObjectsDiff)) {
+				heapshots.Add (newHeapshot);
+				if (heapshots.Count == 1) {
+					Console.WriteLine ("No objects diff report on 1st Heapshot.");
+					return;
+				}
+				var oldHeapshot = heapshots[heapshots.Count - 2];
+				var diffCounter = new List<Tuple<long, int>> ();
+				foreach (var classInfoId in newHeapshot.ClassInfos.Keys)//ClassInfos is not Heapshot specific, all heapshot has same
+				{
+					if (!oldHeapshot.ObjectsPerClassCounter.TryGetValue (classInfoId, out int oldCount))
+						oldCount = 0;
+					if (!newHeapshot.ObjectsPerClassCounter.TryGetValue (classInfoId, out int newCount))
+						newCount = 0;
+					if (newCount - oldCount != 0)
+						diffCounter.Add (Tuple.Create (classInfoId, newCount - oldCount));
+				}
+				Console.WriteLine ($"Heapshot diff has {diffCounter.Count} entries:");
+				foreach (var diff in diffCounter.OrderByDescending (d => d.Item2)) {
+					Console.WriteLine ($"{newHeapshot.ClassInfos[diff.Item1].Name}:{diff.Item2}");
+				}
+			}
+		}
+	}
+}

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestOptions.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestOptions.cs
@@ -34,10 +34,7 @@ namespace MonoDevelop.StressTest
 		const string IterationsArgument = "--iterations:";
 		const string MonoDevelopBinPathArgument = "--mdbinpath:";
 		const string UseInstalledAppArgument = "--useinstalledapp";
-
-		public StressTestOptions ()
-		{
-		}
+		const string ProfilerArgument = "--profiler:";
 
 		public void Parse (string[] args)
 		{
@@ -46,6 +43,8 @@ namespace MonoDevelop.StressTest
 					ParseIterations (arg);
 				} else if (arg.StartsWith (MonoDevelopBinPathArgument)) {
 					ParseMonoDevelopBinPath (arg);
+				} else if (arg.StartsWith (ProfilerArgument)) {
+					ParseProfilerOptions (arg);
 				} else if (arg == UseInstalledAppArgument) {
 					UseInstalledApplication = true;
 				} else {
@@ -55,10 +54,33 @@ namespace MonoDevelop.StressTest
 			}
 		}
 
+		public class ProfilerOptions
+		{
+			public enum ProfilerType
+			{
+				Disabled,
+				HeapOnly,
+				All,
+				Custom
+			}
+			[Flags]
+			public enum PrintReport
+			{
+				ObjectsDiff = 1 << 0,
+				ObjectsTotal = 1 << 1,
+			}
+			public ProfilerType Type { get; set; } = ProfilerType.Disabled;
+			public PrintReport PrintReportTypes { get; set; }
+			public int MaxFrames { get; set; }
+			public string MlpdOutputPath { get; set; }
+			public string CustomProfilerArguments { get; set; }
+		}
+
 		public bool Help { get; set; }
 		public int Iterations { get; set; } = 1;
 		public string MonoDevelopBinPath { get; set; }
 		public bool UseInstalledApplication { get; set; }
+		public ProfilerOptions Profiler { get; } = new ProfilerOptions ();
 
 		public void ShowHelp ()
 		{
@@ -68,6 +90,7 @@ namespace MonoDevelop.StressTest
 			Console.WriteLine ("  --iterations:number     Number of times the stress test will be run");
 			Console.WriteLine ("  --mdbinpath:path        Path to MonoDevelop.exe or VisualStudio.exe");
 			Console.WriteLine ("  --useinstalledapp       Use installed Visual Studio.app");
+			Console.WriteLine ("  --profiler:             Use profiler to make more detailed leak reporting");
 		}
 
 		void ParseIterations (string arg)
@@ -84,6 +107,82 @@ namespace MonoDevelop.StressTest
 		void ParseMonoDevelopBinPath (string arg)
 		{
 			MonoDevelopBinPath = arg.Substring (MonoDevelopBinPathArgument.Length);
+		}
+
+		void ParseProfilerOptions (string arg)
+		{
+			var options = arg.Substring (ProfilerArgument.Length).Split (new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+			foreach (var o in options) {
+				var nameValuePair = o.Split (new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+				switch (nameValuePair[0]) {
+					case "type":
+						if (Profiler.Type != ProfilerOptions.ProfilerType.Disabled)
+							throw new Exception ("--profiler:type= can be defined only once.");
+						switch (nameValuePair[1]) {
+							case "heaponly":
+								Profiler.Type = ProfilerOptions.ProfilerType.HeapOnly;
+								break;
+							case "all":
+								Profiler.Type = ProfilerOptions.ProfilerType.All;
+								break;
+							case "custom":
+								Profiler.Type = ProfilerOptions.ProfilerType.Custom;
+								break;
+							default:
+								PrintProfilerHelpAndExit ($"Unknown --profiler=type:{nameValuePair[1]}");
+								break;
+						}
+						break;
+					case "printreport":
+						switch (nameValuePair[1]) {
+							case "objectsdiff":
+								Profiler.PrintReportTypes |= ProfilerOptions.PrintReport.ObjectsDiff;
+								break;
+							case "objectstotal":
+								Profiler.PrintReportTypes |= ProfilerOptions.PrintReport.ObjectsTotal;
+								break;
+							default:
+								PrintProfilerHelpAndExit ($"Unknown --profiler=printreport:{nameValuePair[1]}");
+								break;
+						}
+						break;
+					case "output":
+						Profiler.MlpdOutputPath = nameValuePair[1];
+						break;
+					case "maxframes":
+						Profiler.MaxFrames = int.Parse (nameValuePair[1]);
+						break;
+					case "custom":
+						Profiler.CustomProfilerArguments = nameValuePair[1];
+						break;
+					default:
+						PrintProfilerHelpAndExit ($"Unknown --profiler= option:{nameValuePair[0]}");
+						break;
+				}
+			}
+			if (Profiler.Type == ProfilerOptions.ProfilerType.Disabled)
+				Profiler.Type = ProfilerOptions.ProfilerType.HeapOnly;//Default value
+		}
+
+		void PrintProfilerHelpAndExit (string reason = null)
+		{
+			if (!string.IsNullOrEmpty (reason))
+				Console.WriteLine (reason);
+			Console.WriteLine ("Usage: --profiler=[<option>=<value>,...]");
+			Console.WriteLine ("Available options:");
+			Console.WriteLine ("Option type");
+			Console.WriteLine ("  type=<type>             Defines how detailed logging is. Possible options:");
+			Console.WriteLine ("                            'heaponly' is default value, and logs minimal needed to get number of objects after each iteration");
+			Console.WriteLine ("                            'all' tracks also allocations which can later be used in UI profiler to further analyse leak reasons");
+			Console.WriteLine ("                            'custom' is for advanced usages where user supplies mono profiler parameters to fine tune logging");
+			Console.WriteLine ("  printreport=<name>      Defines what to print between interations. Can be used multiple times. Possible options:");
+			Console.WriteLine ("                            'objectsdiff' prints object count difference between iterations for each class");
+			Console.WriteLine ("                            'objectstotal' prints object count difference between iterations for each class");
+			Console.WriteLine ("  output=<output>         Output .mlpd file path");
+			Console.WriteLine ("  maxframes=<maxframes>   How many stackframes should be logged on each allocation, used only with 'all'");
+			Console.WriteLine ("  custom=<custom>         This value will be passed directly to mono --profiler=<custom>, used only with 'custom'");
+			Console.WriteLine ("Usage example: --profiler:type=all,maxframes=15,output=/tmp/profile.mlpd");
+			System.Environment.Exit (33);
 		}
 	}
 }

--- a/main/tests/StressTest/StressTest.csproj
+++ b/main/tests/StressTest/StressTest.csproj
@@ -75,9 +75,22 @@
     <Compile Include="MonoDevelop.StressTest\ITestScenario.cs" />
     <Compile Include="MonoDevelop.StressTest\TestScenarioProvider.cs" />
     <Compile Include="MonoDevelop.StressTest\StressTestOptions.cs" />
+    <Compile Include="MonoDevelop.StressTest\ProfilerProcessor.cs" />
+    <Compile Include="Mono.Profiling.Log\LogEnums.cs" />
+    <Compile Include="Mono.Profiling.Log\LogStreamHeader.cs" />
+    <Compile Include="Mono.Profiling.Log\LogStream.cs" />
+    <Compile Include="Mono.Profiling.Log\LogReader.cs" />
+    <Compile Include="Mono.Profiling.Log\LogProfiler.cs" />
+    <Compile Include="Mono.Profiling.Log\LogProcessor.cs" />
+    <Compile Include="Mono.Profiling.Log\LogException.cs" />
+    <Compile Include="Mono.Profiling.Log\LogEvents.cs" />
+    <Compile Include="Mono.Profiling.Log\LogEventVisitor.cs" />
+    <Compile Include="Mono.Profiling.Log\LogEvent.cs" />
+    <Compile Include="Mono.Profiling.Log\LogBufferHeader.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="UserInterfaceTests\" />
+    <Folder Include="Mono.Profiling.Log\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/main/tests/UserInterfaceTests/TestService.cs
+++ b/main/tests/UserInterfaceTests/TestService.cs
@@ -34,11 +34,11 @@ namespace UserInterfaceTests
 	{
 		public static AutoTestClientSession Session { get; private set; }
 
-		public static void StartSession (string monoDevelopBinPath = null, string profilePath = null)
+		public static void StartSession (string file = null, string profilePath = null, string args = null)
 		{
 			Session = new AutoTestClientSession ();
 
-			Session.StartApplication (file: monoDevelopBinPath, environment: new Dictionary<string,string> {
+			Session.StartApplication (file: file, args: args, environment: new Dictionary<string, string> {
 				{ "MONODEVELOP_PROFILE", profilePath ?? Util.CreateTmpDir ("profile") }
 			});
 


### PR DESCRIPTION
... heapshots and make more detailed reports

Primary idea here, is not so much `printreport=` option but `type=all`, which will allow us to create "reproducable" and good heapshots for later use in UI profiler.
Code outside `--profiler:` was modified as minimal as possible(parsing arguments and passing options around).
Mono.Profiling.Log was copied as source from runtime primary to make few optimisations and avoid problems with GAC being out of sync.