### PR TITLE
[Structured build output] Save build output doc

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -39,6 +39,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 	{
 		BuildOutputProgressMonitor progressMonitor;
 		readonly List<BuildOutputProcessor> projects = new List<BuildOutputProcessor> ();
+		string filePath;
+
+		public string FilePath {
+			get{
+				return filePath;
+			}
+		}
 
 		public event EventHandler OutputChanged;
 
@@ -60,6 +67,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			switch (Path.GetExtension (filePath)) {
 			case ".binlog":
 				AddProcessor (new MSBuildOutputProcessor (filePath, removeFileOnDispose));
+				this.filePath = filePath;
 				break;
 			default:
 				LoggingService.LogError ($"Unknown file type {filePath}");
@@ -67,8 +75,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 		}
 
-		public void Save (string filePath)
+		internal void UpdateFilePath (FilePath fileName)
 		{
+			filePath = fileName;
 		}
 
 		internal void AddProcessor (BuildOutputProcessor processor)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -25,6 +25,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.IO;
+using System.Threading.Tasks;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui;
@@ -33,12 +35,12 @@ namespace MonoDevelop.Ide.BuildOutputView
 {
 	class BuildOutputViewContent : ViewContent
 	{
-		FilePath filename;
+		string defaultName = "build ({0}).binlog";
 		BuildOutputWidget control;
+		bool isTemp;
 
 		public BuildOutputViewContent (FilePath filename)
 		{
-			this.filename = filename;
 			this.ContentName = filename;
 			control = new BuildOutputWidget (filename);
 		}
@@ -46,6 +48,26 @@ namespace MonoDevelop.Ide.BuildOutputView
 		public BuildOutputViewContent (BuildOutput buildOutput)
 		{
 			control = new BuildOutputWidget (buildOutput);
+			isTemp = Path.GetDirectoryName (buildOutput.FilePath).TrimEnd ('/') == Path.GetTempPath ().TrimEnd ('/');
+			this.ContentName = isTemp ? string.Format (defaultName, 1) : buildOutput.FilePath;
+		}
+
+		public override Task Save (FileSaveInformation fileSaveInformation)
+		{
+			var result = false;
+
+			if (File.Exists (fileSaveInformation.FileName))
+				File.Delete (fileSaveInformation.FileName); //TODO: backup before removing?
+
+			File.Copy (control.BuildOutput.FilePath, fileSaveInformation.FileName);
+
+			result = File.Exists (fileSaveInformation.FileName);
+			if (result) {
+				control.BuildOutput.UpdateFilePath (fileSaveInformation.FileName);
+				this.IsDirty = isTemp = false;
+			}
+
+			return Task.FromResult (result);
 		}
 
 		public override Control Control {
@@ -56,25 +78,26 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		public override bool IsReadOnly {
 			get {
-				return true;
+				return false;
 			}
 		}
 
 		public override bool IsFile {
 			get {
-				return System.IO.File.Exists (filename.FullPath);
+				//if isTemp = true, the ContentName contains default naming
+				return  isTemp ? true : File.Exists (ContentName);
 			}
 		}
 
 		public override bool IsViewOnly {
 			get {
-				return true;
+				return false;
 			}
 		}
 
 		public override string TabPageLabel {
 			get {
-				return filename.FileName ?? GettextCatalog.GetString ("Build Output");
+				return ContentName ?? GettextCatalog.GetString ("Build Output");
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -208,6 +208,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			toolbar.Add (logBtn);
 
 			buildOutput = new BuildOutput ();
+			buildOutput.OutputChanged += BuildOutput_OutputChanged;
 
 			//Dummy widget to take all space between "Build Output" button and SearchEntry
 			var spacer = new HBox ();
@@ -1039,6 +1040,12 @@ namespace MonoDevelop.Ide.Gui.Pads
 			buildOutputViewContent.Dispose ();
 			buildOutputViewContent = null;
 			buildOutputDoc = null;
+		}
+
+		void BuildOutput_OutputChanged (object sender, EventArgs e)
+		{
+			if (buildOutputDoc != null)
+				buildOutputViewContent.IsDirty = true;
 		}
 
 		class DescriptionCellRendererText : CellRendererText


### PR DESCRIPTION
Enables Save / SaveAs, execute such commands, and initialise ErrorPad accordingly. 
Updates .binlog when new build is launched. 
