### PR TITLE
Queue alert sheets

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -193,13 +193,15 @@ namespace MonoDevelop.MacIntegration
 
 				if (optionButtons != null) {
 					foreach (var button in optionButtons) {
-						var option = data.Options [(int)button.Tag];
+						var option = data.Options[(int)button.Tag];
 						data.Message.SetOptionValue (option.Id, button.State != 0);
 					}
 				}
-
+				
 				if (applyToAllCheck != null && applyToAllCheck.State != 0)
 					data.ApplyToAll = true;
+
+
 
 				GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 			}

--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -190,7 +190,7 @@ namespace MonoDevelop.MacIntegration
 				if (data.ResultButton == null || data.Message.CancellationToken.IsCancellationRequested) {
 					data.SetResultToCancelled ();
 				}
-
+				
 				if (optionButtons != null) {
 					foreach (var button in optionButtons) {
 						var option = data.Options[(int)button.Tag];

--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -162,33 +162,41 @@ namespace MonoDevelop.MacIntegration
 					NSWindow parent = null;
 					if (IdeTheme.UserInterfaceTheme != Theme.Dark || MacSystemInformation.OsVersion < MacSystemInformation.HighSierra) // sheeting is broken on High Sierra with dark NSAppearance
 						parent = data.TransientFor ?? IdeApp.Workbench.RootWindow;
-					var result = (int)(parent == null ? alert.RunModal () : alert.RunSheetModal (parent)) - (long)(int)NSAlertButtonReturn.First;
-					
+
+					if (parent == null) {
+						OnAlertClosed ((NSModalResponse)(int)alert.RunModal ());
+					} else {
+						alert.BeginSheet (parent, OnAlertClosed);
+					}
+				}
+
+				void OnAlertClosed (NSModalResponse response)
+				{
+					var result = (int)response - (long)(int)NSAlertButtonReturn.First;
+
 					completed = true;
 					if (result >= 0 && result < buttons.Count) {
 						data.ResultButton = buttons [(int)result];
 					} else {
 						data.ResultButton = null;
 					}
-				}
-				
-				if (data.ResultButton == null || data.Message.CancellationToken.IsCancellationRequested) {
-					data.SetResultToCancelled ();
-				}
-				
-				if (optionButtons != null) {
-					foreach (var button in optionButtons) {
-						var option = data.Options[(int)button.Tag];
-						data.Message.SetOptionValue (option.Id, button.State != 0);
+
+					if (data.ResultButton == null || data.Message.CancellationToken.IsCancellationRequested) {
+						data.SetResultToCancelled ();
 					}
+
+					if (optionButtons != null) {
+						foreach (var button in optionButtons) {
+							var option = data.Options [(int)button.Tag];
+							data.Message.SetOptionValue (option.Id, button.State != 0);
+						}
+					}
+
+					if (applyToAllCheck != null && applyToAllCheck.State != 0)
+						data.ApplyToAll = true;
+
+					GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 				}
-				
-				if (applyToAllCheck != null && applyToAllCheck.State != 0)
-					data.ApplyToAll = true;
-
-
-
-				GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 			}
 			
 			return true;


### PR DESCRIPTION
In some cases, a window should show multiple alerts simultaneously.

At the moment if a window needs to show two alerts at the same time one of them will be displayed in a proper manner (sliding from the top and attached to the title bar). The second alert, however, will be just "floating" in the air.

Example:

<img width="1040" alt="screen shot 2017-12-11 at 2 21 35 pm" src="https://user-images.githubusercontent.com/1524073/33849465-a8fed0aa-de7e-11e7-99bf-e98f35baae93.png">

Ideally, alerts should be queued and shown one by one. Like this:

![alerts](https://user-images.githubusercontent.com/1524073/33849671-4cf0dbf4-de7f-11e7-8ce7-ad598a995971.gif)