### PR TITLE
[Mac] Fix MDMenu leak when using async updates

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -101,7 +101,7 @@ namespace MonoDevelop.Components.Mac
 			}
 		}
 
-		int FindMeInParent (MDMenu parent)
+		int FindMeInParent (NSMenu parent)
 		{
 			for (int n = 0; n < parent.Count; n++)
 				if (parent.ItemAt (n) == this)
@@ -129,13 +129,13 @@ namespace MonoDevelop.Components.Mac
 		{
 			if (lastInfo != sender)
 				return;
-			var parent = (MDMenu)Menu;
+			var parent = Menu;
 			var ind = FindMeInParent (parent);
 			Update (parent, ref ind, lastInfo);
-			parent.UpdateSeparators ();
+			(parent as MDMenu)?.UpdateSeparators ();
 		}
 
-		void Update (MDMenu parent, ref int index, CommandInfo info)
+		void Update (NSMenu parent, ref int index, CommandInfo info)
 		{
 			if (!isArrayItem) {
 				SetItemValues (this, info, ce.DisabledVisible, ce.OverrideLabel);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -127,6 +127,8 @@ namespace MonoDevelop.Components.Mac
 
 		void OnLastInfoChanged (object sender, EventArgs args)
 		{
+			if (lastInfo != sender)
+				return;
 			var parent = (MDMenu)Menu;
 			var ind = FindMeInParent (parent);
 			Update (parent, ref ind, lastInfo);


### PR DESCRIPTION
This fixes leaks of whole projects caused by the editor context menu on refactoring. 