### PR TITLE
[Ide] Reduce clutter in normal view with just some simple filtering

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/MSBuildOutputProcessor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/MSBuildOutputProcessor.cs
@@ -123,11 +123,21 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		private void BinLog_TaskStarted (object sender, TaskStartedEventArgs e)
 		{
+			if (e.TaskName == "Message") {
+				// <Task Message></Task> are removed, we just display the messages
+				return;
+			}
+
 			AddNode (BuildOutputNodeType.Task, e.Message, true);
 		}
 
 		private void BinLog_TaskFinished (object sender, TaskFinishedEventArgs e)
 		{
+			if (e.TaskName == "Message") {
+				// <Task Message></Task> are removed, we just display the messages
+				return;
+			}
+
 			EndCurrentNode (e.Message);
 		}
 	}


### PR DESCRIPTION
* Remove "Task Message" opening/closing nodes
* Don't display "empty" nodes (nodes that have neither a message,
  a warning or an error
* Don't add closing Message node to nodes