### PR TITLE
[Core] Support .NET Core multi target framework using MSBuild property

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1316,7 +1316,7 @@ namespace MonoDevelop.Projects
 			if (propertyValue != null)
 				return null;
 
-			propertyValue = propertyGroup.GetValue ("TargetFrameworks", null);
+			propertyValue = project.EvaluatedProperties.GetValue ("TargetFrameworks", null);
 			if (propertyValue != null)
 				return propertyValue.Split (new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -287,6 +287,32 @@ namespace MonoDevelop.Projects
 		}
 
 		/// <summary>
+		/// Project defines an MSBuild property in an imported file which is used as the value of
+		/// TargetFrameworks in the main project file.
+		/// </summary>
+		[Test]
+		public async Task LoadDotNetCoreProjectWithMultipleTargetFrameworksDefinedByMSBuildProperty ()
+		{
+			FilePath solFile = Util.GetSampleProject ("DotNetCoreMultiTargetFrameworkProperty", "DotNetCoreMultiTargetFrameworkProperty.sln");
+
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (Project)sol.Items [0];
+			var capabilities = p.GetProjectCapabilities ().ToList ();
+
+			Assert.That (capabilities, Contains.Item ("TestCapabilityNetStandard10"));
+			Assert.That (capabilities, Has.None.EqualTo ("TestCapabilityNetStandard11"));
+
+			await p.ReevaluateProject (Util.GetMonitor ());
+
+			capabilities = p.GetProjectCapabilities ().ToList ();
+
+			Assert.That (capabilities, Contains.Item ("TestCapabilityNetStandard10"));
+			Assert.That (capabilities, Has.None.EqualTo ("TestCapabilityNetStandard11"));
+
+			sol.Dispose ();
+		}
+
+		/// <summary>
 		/// Tests that metadata from the imported file globs for the Compile update items is not saved
 		/// in the main project file. The DependentUpon property was being saved with the evaluated
 		/// filename.

--- a/main/tests/test-projects/DotNetCoreMultiTargetFrameworkProperty/DotNetCoreMultiTargetFrameworkProperty.csproj
+++ b/main/tests/test-projects/DotNetCoreMultiTargetFrameworkProperty/DotNetCoreMultiTargetFrameworkProperty.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TheFramework)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <ProjectCapability Include="TestCapabilityNetStandard10" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+    <ProjectCapability Include="TestCapabilityNetStandard11" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreMultiTargetFrameworkProperty/DotNetCoreMultiTargetFrameworkProperty.sln
+++ b/main/tests/test-projects/DotNetCoreMultiTargetFrameworkProperty/DotNetCoreMultiTargetFrameworkProperty.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCoreMultiTargetFrameworkProperty", "DotNetCoreMultiTargetFrameworkProperty.csproj", "{0D7F8A77-1A8E-40A3-85FD-87CB8433C1A2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0D7F8A77-1A8E-40A3-85FD-87CB8433C1A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D7F8A77-1A8E-40A3-85FD-87CB8433C1A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D7F8A77-1A8E-40A3-85FD-87CB8433C1A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D7F8A77-1A8E-40A3-85FD-87CB8433C1A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreMultiTargetFrameworkProperty/Frameworks.props
+++ b/main/tests/test-projects/DotNetCoreMultiTargetFrameworkProperty/Frameworks.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <TheFramework>netstandard1.0;netstandard1.1</TheFramework>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
VSTS 540666

An SDK style project that defined the <TargetFrameworks> element to
be another imported MSBuild property would fail to restore. The
unevaluated MSBuild property value would be used and result in an
unknown target framework being used causing the restore to fail.

<Project Sdk="Microsoft.NET.Sdk">
  <Import Project="Frameworks.props" />
  <PropertyGroup>
    <TargetFrameworks>$(TheFramework)</TargetFrameworks>
  </PropertyGroup>
</Project>

MSBuild property TheFramework is defined in the Frameworks.props file.

Now the evaluated property value is used for the TargetFrameworks
property.