### PR TITLE
[DotNetCore] Allow unknown target framework projects to be loaded

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -215,5 +215,15 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.IsFalse (canReferenceNetCoreFromNetStandard);
 			Assert.IsTrue (canReferenceNetStandardFromNetCore);
 		}
+
+		[Test]
+		public async Task TizenProject_OpenProject_LoadedAsDotNetProjectNotUnknownSolutionItem ()
+		{
+			string solutionFileName = Util.GetSampleProject ("TizenProject", "TizenProject.sln");
+			var solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.Items.Single (item => item.Name == "TizenProject");
+
+			Assert.IsInstanceOf<DotNetProject> (project);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -71,10 +71,9 @@ namespace MonoDevelop.DotNetCore
 
 		protected override bool OnGetSupportsFramework (TargetFramework framework)
 		{
-			if (framework.IsNetCoreApp () ||
-				framework.IsNetStandard ())
-				return true;
-			return base.OnGetSupportsFramework (framework);
+			// Allow all SDK style projects to be loaded even if the framework is unknown.
+			// A PackageReference may define the target framework with an imported MSBuild file.
+			return true;
 		}
 
 		/// <summary>

--- a/main/tests/test-projects/TizenProject/Class1.cs
+++ b/main/tests/test-projects/TizenProject/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace TizenProject
+{
+	public class Class1
+	{
+	}
+}

--- a/main/tests/test-projects/TizenProject/TizenProject.csproj
+++ b/main/tests/test-projects/TizenProject/TizenProject.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>tizen40</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Tizen.NET" Version="4.0.0" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/TizenProject/TizenProject.sln
+++ b/main/tests/test-projects/TizenProject/TizenProject.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TizenProject", "TizenProject.csproj", "{84A4891D-9718-4DEF-A5CF-EB9A1C605CF6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{84A4891D-9718-4DEF-A5CF-EB9A1C605CF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A4891D-9718-4DEF-A5CF-EB9A1C605CF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84A4891D-9718-4DEF-A5CF-EB9A1C605CF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84A4891D-9718-4DEF-A5CF-EB9A1C605CF6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Fixed bug #57307 Unable to use Xamarin.iOS10 with TargetFramework
https://bugzilla.xamarin.com/show_bug.cgi?id=57307

The target framework of an SDK style project is no longer restricted.
This allows Tizen projects to be loaded without the error message
"Project does not support framework 'Tizen,Version=v4.0'" being
displayed. Tizen projects have a Tizen.NET package reference which
imports MSBuild .props file that defines the Tizen target framework.

The MSBuild.Sdk.Extras NuGet package is now also supported so
SDK style projects can use target frameworks that this NuGet package
supports, such as Xamarin.iOS and MonoAndroid.

On building an unknown target framework, that is not defined by
any used NuGet package references, a build error that indicates
the framework is not supported will occur:

The TargetFramework value 'test1.0' was not recognized.

This is the same behaviour as Visual Studio on Windows.

NuGet restore will also fail for an unknown target framework with
a message indicating the framework is invalid.