### PR TITLE
Fixed  ignoring  "build before running" setting when running unit test

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
@@ -303,8 +303,12 @@ namespace MonoDevelop.UnitTesting
 						return;
 					}
 
-					await IdeApp.ProjectOperations.Build (project).Task;
-					await UnitTestService.RefreshTests (CancellationToken.None);
+					bool buildBeforeExecuting = IdeApp.Preferences.BuildBeforeExecuting;
+
+					if (buildBeforeExecuting) {
+						await IdeApp.ProjectOperations.Build (project).Task;
+						await UnitTestService.RefreshTests (CancellationToken.None);
+					}
 
 					foundTest = UnitTestService.SearchTestById (testCase);
 					if (foundTest != null)


### PR DESCRIPTION
I know, but other option about a building tested project, before testing.  Bug report was about building tests project.

https://devdiv.visualstudio.com/DevDiv/_workitems?id=a2108d31-086c-4fb0-afda-097e4cc46df4&_a=query&fullScreen=true 