### PR TITLE
[Git] Add .vs directory to .gitignore used with new projects

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/GitIgnore.txt
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/GitIgnore.txt
@@ -27,6 +27,7 @@ autom4te.cache/
 tarballs/
 test-results/
 Thumbs.db
+.vs/
 
 # Mac bundle stuff
 *.dmg


### PR DESCRIPTION
Creating a new project with a .gitignore file would add the solution
preferences file from the .vs directory to the local Git repository.
The solution preferences file should not be included in the Git
repository by default.