### PR TITLE
[Core] Fix project reference to shared project considered invalid

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -492,13 +492,14 @@ namespace MonoDevelop.Projects
 					}
 				} else if (ReferenceType == ReferenceType.Project) {
 					if (ownerProject != null && ownerProject.ParentSolution != null && ReferenceOutputAssembly) {
-						DotNetProject p = ResolveProject (ownerProject.ParentSolution) as DotNetProject;
-						if (p != null) {
+						var p = ResolveProject (ownerProject.ParentSolution);
+						var dotNetProject = p as DotNetProject;
+						if (dotNetProject != null) {
 							string reason;
 
-							if (!ownerProject.CanReferenceProject (p, out reason))
+							if (!ownerProject.CanReferenceProject (dotNetProject, out reason))
 								return reason;
-						} else 
+						} else if (p == null)
 							return GettextCatalog.GetString ("Project not found");
 					}
 				} else if (ReferenceType == ReferenceType.Assembly) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/SharedAssetsProjectTests.cs
@@ -530,6 +530,23 @@ namespace MonoDevelop.Projects
 
 			sol.Dispose ();
 		}
+
+		[Test]
+		public async Task ProjectReferenceToSharedProjectThatExistsIsValid ()
+		{
+			string solFile = Util.GetSampleProject ("SharedProjectTest", "SharedProjectTest.sln");
+			Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var pcs = sol.FindProjectByName ("Shared");
+			var pc1 = (DotNetProject)sol.FindProjectByName ("Console1");
+
+			var r = pc1.References.FirstOrDefault (re => re.Reference == "Shared");
+			Assert.IsNotNull (r);
+			Assert.AreEqual (string.Empty, r.ValidationErrorMessage);
+			Assert.IsTrue (r.IsValid);
+
+			sol.Dispose ();
+		}
 	}
 }
 


### PR DESCRIPTION
A project reference to a shared project that exists was shown as
invalid in the Solution window. It would have an error icon and have
the tooltip 'Project not found.' even though the shared project did
exist.

The problem was that the code was changed in commit d40ba5fec794edbe14ccf58c1e177944cd2a6fe9
so that if a project was not a DotNetProject then it was marked as
invalid even if it existed. The SharedAssetsProject class does
not derive from DotNetProject so the project was treated as though
it could not be found.