### PR TITLE
Don't deploy Microsoft.Build.Tasks.Core.dll.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -155,6 +155,7 @@
     </Reference>
     <Reference Include="Microsoft.Build.Tasks.Core">
       <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.Tasks.Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf">

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -485,6 +485,7 @@ namespace MonoDevelop.Core
 			var path = systemAssemblyService.CurrentRuntime.GetMSBuildBinPath ("15.0");
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.dll"));
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Framework.dll"));
+			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Tasks.Core.dll"));
 			SystemAssemblyService.LoadAssemblyFrom (System.IO.Path.Combine (path, "Microsoft.Build.Utilities.Core.dll"));
 
 			if (Type.GetType ("Mono.Runtime") == null) {


### PR DESCRIPTION
We don't deploy the 3 other MSBuild dlls, so let's not deploy this one.
MSBuild is taken from the toolset that's installed separately from MonoDevelop. Otherwise we might run into situations where our own copy is loaded instead of the official one and cause a mismatch.