### PR TITLE
Fixed '527496 - Error "while update show code surroundings window"'

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/TextEditorResolverProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/TextEditorResolverProvider.cs
@@ -63,10 +63,14 @@ namespace MonoDevelop.CSharp.Resolver
 			if (model == null)
 				return null;
 
-			int index = identifier.IndexOf ("`", System.StringComparison.Ordinal);
+			int index = identifier.LastIndexOf ("`", System.StringComparison.Ordinal);
 			int arity = 0;
 			if (index != -1) {
-				arity = int.Parse (identifier.Substring (index + 1));
+				try {
+					arity = int.Parse (identifier.Substring (index + 1));
+				} catch {
+					return null;
+				}
 				identifier = identifier.Remove (index);
 			}
 


### PR DESCRIPTION
TextEditorResolverProvider needs to be removed - resolving doesn't
work this way. Fortunately it's only used in some very old scenarios.