### PR TITLE
[Ide] Improve BuildOutputWidget's toolbar

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -129,11 +129,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			var toolbar = new DocumentToolbar ();
 
-			// Dummy widget to take all space on the left
-			var spacer = new HBox ();
-			spacer.Accessible.SetShouldIgnore (true);
-			toolbar.Add (spacer, true);
-
+			toolbar.AddSpace ();
 			toolbar.Add (showDiagnosticsButton);
 			toolbar.Add (saveButton); 
 			PackStart (toolbar.Container, expand: false, fill: true, padding: 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentToolbar.cs
@@ -27,6 +27,7 @@ using System;
 using System.Linq;
 using Gtk;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.Ide.Gui
 {
@@ -104,6 +105,13 @@ namespace MonoDevelop.Ide.Gui
 				Box.BoxChild bc = (Box.BoxChild) box [widget];
 				bc.Position = index;
 			}
+		}
+
+		public void AddSpace ()
+		{
+			var spacer = new HBox ();
+			spacer.Accessible.SetShouldIgnore (true);
+			Add (spacer, true); 
 		}
 
 		void ChangeColor (Gtk.Widget w)


### PR DESCRIPTION
* Place buttons on the right, as was specified in the designs
* Add a11y to the toolbar buttons
* Make 'Save' button look like in other pads' toolbars