### PR TITLE
[NUnit] Properly enumerate project assembly reference dependencies. 

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
@@ -205,21 +205,26 @@ namespace MonoDevelop.UnitTesting.NUnit
 		protected override string TestInfoCachePath {
 			get { return Path.Combine (resultsPath, storeId + ".test-cache"); }
 		}
-		
-		protected override IEnumerable<string> SupportAssemblies {
-			get {
+
+		protected override async Task<IEnumerable<string>> GetSupportAssembliesAsync ()
+		{
+			DotNetProject project = base.OwnerSolutionItem as DotNetProject;
+
+			if (project != null) {
+				var references = await project.GetReferences (IdeApp.Workspace.ActiveConfiguration).ConfigureAwait (false);
 				// Referenced assemblies which are not in the gac and which are not localy copied have to be preloaded
-				DotNetProject project = base.OwnerSolutionItem as DotNetProject;
-				if (project != null) {
-					foreach (var pr in project.References) {
-						if (pr.ReferenceType != ReferenceType.Package && !pr.LocalCopy && pr.ReferenceOutputAssembly) {
-							foreach (string file in pr.GetReferencedFileNames (IdeApp.Workspace.ActiveConfiguration))
-								yield return file;
-						}
-					}
-				}
+				var supportAssemblies = references.Where (r => !r.IsCopyLocal && (!r.IsProjectReference || r.ReferenceOutputAssembly) && !r.IsFrameworkFile && !r.IsImplicit && !IsGacReference (r))
+				                                  .Select (r => r.FilePath.FullPath.ToString ())
+				                                  .Where (File.Exists)
+				                                  .Distinct ()
+				                                  .ToList ();
+				return supportAssemblies;
 			}
+
+			return Enumerable.Empty<string> ();
 		}
+
+		bool IsGacReference (AssemblyReference r) => string.Equals (r.Metadata.GetValue ("ResolvedFrom"), "{GAC}", StringComparison.OrdinalIgnoreCase);
 	}
 }
 

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
@@ -216,8 +216,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 				var supportAssemblies = references.Where (r => !r.IsCopyLocal && (!r.IsProjectReference || r.ReferenceOutputAssembly) && !r.IsFrameworkFile && !r.IsImplicit && !IsGacReference (r))
 				                                  .Select (r => r.FilePath.FullPath.ToString ())
 				                                  .Where (File.Exists)
-				                                  .Distinct ()
-				                                  .ToList ();
+				                                  .Distinct ();
 				return supportAssemblies;
 			}
 

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnitTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnitTestRunner.cs
@@ -205,8 +205,14 @@ namespace NUnit3Runner
 		void InitSupportAssemblies (string[] supportAssemblies)
 		{
 			// Preload support assemblies (they may not be in the test assembly directory nor in the gac)
-			foreach (string asm in supportAssemblies)
-				Assembly.LoadFrom (asm);
+			foreach (string asm in supportAssemblies) {
+				try {
+					Assembly.LoadFrom (asm);
+				} catch (Exception e) {
+					Console.WriteLine ("Couldn't load assembly {0}", asm);
+					Console.WriteLine (e);
+				}
+			}
 		}
 		
 		private TestFilter CreateTestFilter (string[] nameFilter)

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitTestRunner.cs
@@ -155,8 +155,14 @@ namespace MonoDevelop.UnitTesting.NUnit.External
 		void InitSupportAssemblies (string[] supportAssemblies)
 		{
 			// Preload support assemblies (they may not be in the test assembly directory nor in the gac)
-			foreach (string asm in supportAssemblies)
-				Assembly.LoadFrom (asm);
+			foreach (string asm in supportAssemblies) {
+				try {
+					Assembly.LoadFrom (asm);
+				} catch (Exception e) {
+					Console.WriteLine ("Couldn't load assembly {0}", asm);
+					Console.WriteLine (e);
+				}
+			}
 		}
 		
 		public override object InitializeLifetimeService ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -911,9 +911,9 @@ namespace MonoDevelop.Projects
 		{
 			List<AssemblyReference> result = new List<AssemblyReference> ();
 			if (CheckUseMSBuildEngine (configuration)) {
-					// Get the references list from the msbuild project
-					using (Counters.ResolveMSBuildReferencesTimer.BeginTiming (GetProjectEventMetadata (configuration)))
-						result = await RunResolveAssemblyReferencesTarget (configuration);
+				// Get the references list from the msbuild project
+				using (Counters.ResolveMSBuildReferencesTimer.BeginTiming (GetProjectEventMetadata (configuration)))
+					result.AddRange (await RunResolveAssemblyReferencesTarget (configuration));
 			} else {
 				foreach (ProjectReference pref in References) {
 					if (pref.ReferenceType != ReferenceType.Project) {


### PR DESCRIPTION
This PR changes the way dependencies of a test project are computed by relying on the MSBuild machinery instead of being limited to only the project model.

This fixes cases where assembly references are computed on the fly e.g. when custom `ReferencePath` are specified in the project so that `<Reference />` with no hint path are still resolved (something the old system would mistakenly think of as GAC assemblies).

The commits changes the API for gathering dependencies to be asynchronous and applies the same sort of filtering as before to only load dependencies that wouldn't be otherwise loaded.

An exception here is that facades are pulled in by the underlying call to `GetReferences` without a way to differentiate them from other references, that causes assembly load errors down the line which this commit works around that by wrapping the call in `InitSupportAssemblies` in a try/catch.

NB: The scenario that called for this fix is a MonoDevelop addin testsuite which has very specific considerations when it comes to assembly loading. Since that test-suite already uses a custom console runner (via vstool\mdtool) to execute unit-tests maybe it would be a good idea in general to also allow delegation of `GetTestInfo` to a custom runner as well.

