### PR TITLE
Make HelpService lazy initialized.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/HelpService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/HelpService.cs
@@ -43,21 +43,6 @@ namespace MonoDevelop.Projects
 		static object helpTreeLock = new object ();
 		static HashSet<string> sources = new HashSet<string> ();
 		
-		/// <summary>
-		/// Starts loading the MonoDoc tree in the background.
-		/// </summary>
-		public static void AsyncInitialize ()
-		{
-			lock (helpTreeLock) {
-				if (helpTreeInitialized)
-					return;
-			}
-			ThreadPool.QueueUserWorkItem (delegate {
-				// Load the help tree asynchronously. Reduces startup time.
-				InitializeHelpTree ();
-			});
-		}
-		
 		//FIXME: allow adding sources without restart when extension installed (will need to be async)
 		// will also be tricky we cause we'll also have update any running MonoDoc viewer
 		static void InitializeHelpTree ()
@@ -107,11 +92,8 @@ namespace MonoDevelop.Projects
 		///  </remarks>
 		public static RootTree HelpTree {
 			get {
-				lock (helpTreeLock) {
-					if (!helpTreeInitialized)
-						InitializeHelpTree ();
-					return helpTree;
-				}
+				InitializeHelpTree ();
+				return helpTree;
 			}
 		}
 		
@@ -125,7 +107,10 @@ namespace MonoDevelop.Projects
 		}
 		
 		public static IEnumerable<string> Sources {
-			get { return sources; }
+			get {
+				InitializeHelpTree ();
+				return sources;
+			}
 		}
 		
 		//note: this method is very careful to check that the generated URLs exist in MonoDoc

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -298,9 +298,6 @@ namespace MonoDevelop.Ide
 				initializedEvent = null;
 			}
 			
-			//FIXME: we should really make this on-demand. consumers can display a "loading help cache" message like VS
-			MonoDevelop.Projects.HelpService.AsyncInitialize ();
-			
 			UpdateInstrumentationIcon ();
 			IdeApp.Preferences.EnableInstrumentation.Changed += delegate {
 				UpdateInstrumentationIcon ();


### PR DESCRIPTION
I think it's better to remove it from the startup path entirely because in 99% of cases we pay for it even though we won't need it. An on-demand slow down is probably better. This also removes another first-chance exception from the startup path.