### PR TITLE
Avoid a first-chance exception in WindowsPlatform ImageHelper.

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsPlatform/ImageHelper.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/ImageHelper.cs
@@ -46,8 +46,10 @@ namespace WindowsPlatform
 				var resourceName = stockId + ".png";
 
 				// first check if such a resource exists to avoid a first-chance exception
-				if (typeof (ImageHelper).Assembly.GetManifestResourceStream (resourceName) != null) {
-					image = Image.FromResource (typeof (ImageHelper), resourceName);
+				using (var stream = typeof (ImageHelper).Assembly.GetManifestResourceStream (resourceName)) {
+					if (stream != null) {
+						image = Image.FromResource (typeof (ImageHelper), resourceName);
+					}
 				}
 
 				if (image == null) {

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/ImageHelper.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/ImageHelper.cs
@@ -43,9 +43,14 @@ namespace WindowsPlatform
 				return null;
 			Image image;
 			if (!cachedIcons.TryGetValue (stockId, out image)) {
-				try {
-					image = Image.FromResource (typeof (ImageHelper), stockId + ".png");
-				} catch (InvalidOperationException) {
+				var resourceName = stockId + ".png";
+
+				// first check if such a resource exists to avoid a first-chance exception
+				if (typeof (ImageHelper).Assembly.GetManifestResourceStream (resourceName) != null) {
+					image = Image.FromResource (typeof (ImageHelper), resourceName);
+				}
+
+				if (image == null) {
 					image = ImageService.GetIcon (stockId);
 				}
 			}
@@ -69,7 +74,7 @@ namespace WindowsPlatform
 
 		public static ImageSource GetImageSource (this Image image)
 		{
-			return (ImageSource)MonoDevelop.Platform.WindowsPlatform.WPFToolkit.GetNativeImage (image);	
+			return (ImageSource)MonoDevelop.Platform.WindowsPlatform.WPFToolkit.GetNativeImage (image);
 		}
 	}
 }


### PR DESCRIPTION
This should be a good safe tactical fix (WindowsPlatform only), no Xwt changes needed.