### PR TITLE
Avoid loading Monodoc on Windows

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/HelpService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/HelpService.cs
@@ -65,7 +65,15 @@ namespace MonoDevelop.Projects
 			lock (helpTreeLock) {
 				if (helpTreeInitialized)
 					return;
-				
+
+				// Only attempt on Windows if we can find monodoc.xml (currently not the case).
+				// This avoids a first-chance FileNotFoundException in LoadTree.
+				if (Platform.IsWindows && !File.Exists ("monodoc.xml")) {
+					LoggingService.LogError ("Monodoc documentation tree could not be loaded because monodoc.xml was not found.");
+					helpTreeInitialized = true;
+					return;
+				}
+
 				Counters.HelpServiceInitialization.BeginTiming ();
 				
 				try {


### PR DESCRIPTION
Since we know it's going to fail anyway, do not attempt to load Monodoc. This prevents a first-chance exception in the startup path.