### PR TITLE
Makefile: fix all-recursive when $PATH has spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ CONFIG_MAKE=$(top_srcdir)/config.make
 	case $$2 in *=*) dk="exit 1" ;; *k*) dk=: ;; *) dk="exit 1" ;; esac; \
 	for dir in $(SUBDIRS); do \
 		case $$dir in \
-		.) PATH=$(PATH):/Library/Frameworks/Mono.framework/Versions/Current/bin $(MAKE) $*-local || { final_exit="exit 1"; $$dk; };;\
-		*) (cd $$dir && PATH=$(PATH):/Library/Frameworks/Mono.framework/Versions/Current/bin $(MAKE) $*) || { final_exit="exit 1"; $$dk; };;\
+		.) PATH="$(PATH):/Library/Frameworks/Mono.framework/Versions/Current/bin" $(MAKE) $*-local || { final_exit="exit 1"; $$dk; };;\
+		*) (cd $$dir && PATH="$(PATH):/Library/Frameworks/Mono.framework/Versions/Current/bin" $(MAKE) $*) || { final_exit="exit 1"; $$dk; };;\
 		esac \
 	done
 	$$final_exit


### PR DESCRIPTION
Reproduce by installing Workbooks 1.4 RC1 and enabling terminal usage from its main menu. This adds    `/Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin` to a file in `/etc/paths.d/`, introducing spaces in `$PATH`.