### PR TITLE
Add support for comparing Versions in ConditionExpression

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionExpression.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionExpression.cs
@@ -30,14 +30,16 @@ using System.Xml;
 
 namespace MonoDevelop.Projects.MSBuild.Conditions {
 	internal abstract class ConditionExpression {
-	
+
 		public abstract bool BoolEvaluate (IExpressionContext context);
 		public abstract float NumberEvaluate (IExpressionContext context);
 		public abstract string StringEvaluate (IExpressionContext context);
+		public virtual Version VersionEvaluate (IExpressionContext context) => throw new NotSupportedException();
 		
 		public abstract bool CanEvaluateToBool (IExpressionContext context);
 		public abstract bool CanEvaluateToNumber (IExpressionContext context);
 		public abstract bool CanEvaluateToString (IExpressionContext context);
+		public virtual bool CanEvaluateToVersion (IExpressionContext context) => false;
 
 		public virtual void CollectConditionProperties (ConditionedPropertyCollection properties)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionFactorExpresion.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionFactorExpresion.cs
@@ -65,47 +65,38 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			this.token = token;
 		}
 
-		Token EvaluateToken(IExpressionContext context)
-		{
-			// FIXME: in some situations items might not be allowed
-			string val = context.EvaluateString (token.Value);
-			return new Token (val, TokenType.String, 0);
-		}
-
 		public override bool BoolEvaluate (IExpressionContext context)
 		{
-			Token evaluatedToken = EvaluateToken (context);
+			string evaluatedString = StringEvaluate (context);
 		
-			if (trueValues [evaluatedToken.Value] != null)
+			if (trueValues [evaluatedString] != null)
 				return true;
-			else if (falseValues [evaluatedToken.Value] != null)
+			else if (falseValues [evaluatedString] != null)
 				return false;
 			else
 				throw new ExpressionEvaluationException (
 						String.Format ("Expression \"{0}\" evaluated to \"{1}\" instead of a boolean value",
-								token.Value, evaluatedToken.Value));
+								token.Value, evaluatedString));
 		}
 		
 		public override float NumberEvaluate (IExpressionContext context)
 		{
-			Token evaluatedToken = EvaluateToken (context);
-		
-			return Single.Parse (evaluatedToken.Value, CultureInfo.InvariantCulture);
+			string evaluatedString = StringEvaluate (context);
+			return Single.Parse (evaluatedString, CultureInfo.InvariantCulture);
 		}
 		
 		public override string StringEvaluate (IExpressionContext context)
 		{
-			Token evaluatedToken = EvaluateToken (context);
-		
-			return evaluatedToken.Value;
+			var evaluated = context.EvaluateString (token.Value);
+			return evaluated;
 		}
 		
 		// FIXME: check if we really can do it
 		public override bool CanEvaluateToBool (IExpressionContext context)
 		{
-			Token evaluatedToken = EvaluateToken (context);
+			string evaluatedToken = StringEvaluate (context);
 		
-			if (token.Type == TokenType.String && allValues [evaluatedToken.Value] != null)
+			if (token.Type == TokenType.String && allValues [evaluatedToken] != null)
 				return true;
 			else
 				return false;
@@ -132,10 +123,19 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			return true;
 		}
 
-		internal Conditions.Token Token {
-			get {
-				return this.token;
-			}
+		public override bool CanEvaluateToVersion (IExpressionContext context)
+		{
+			var text = StringEvaluate (context);
+			return Version.TryParse (text, out var version);
 		}
+
+		public override Version VersionEvaluate (IExpressionContext context)
+		{
+			var text = StringEvaluate (context);
+			Version.TryParse (text, out var version);
+			return version;
+		}
+
+		internal Token Token => token;
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionRelationalExpression.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/ConditionRelationalExpression.cs
@@ -31,7 +31,8 @@ using System.Xml;
 using System.Text;
 using System.Collections.Generic;
 
-namespace MonoDevelop.Projects.MSBuild.Conditions {
+namespace MonoDevelop.Projects.MSBuild.Conditions
+{
 	internal sealed class ConditionRelationalExpression : ConditionExpression {
 	
 		readonly ConditionExpression left;
@@ -47,30 +48,42 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			this.op = op;
 		}
 		
-		public override  bool BoolEvaluate (IExpressionContext context)
+		public override bool BoolEvaluate (IExpressionContext context)
 		{
-			if (left.CanEvaluateToNumber (context) && right.CanEvaluateToNumber (context)) {
-				float l,r;
-				
-				l = left.NumberEvaluate (context);
-				r = right.NumberEvaluate (context);
-				
-				return NumberCompare (l, r, op);
-			} else if (left.CanEvaluateToBool (context) && right.CanEvaluateToBool (context)) {
-				bool l,r;
-				
-				l = left.BoolEvaluate (context);
-				r = right.BoolEvaluate (context);
-				
+			if (left.CanEvaluateToBool (context) && right.CanEvaluateToBool (context)) {
+				bool l = left.BoolEvaluate (context);
+				bool r = right.BoolEvaluate (context);
 				return BoolCompare (l, r, op);
-			} else {
-				string l,r;
-				
-				l = left.StringEvaluate (context);
-				r = right.StringEvaluate (context);
-				
-				return StringCompare (l, r, op);
 			}
+
+			if (left.CanEvaluateToVersion (context)) {
+				if (right.CanEvaluateToVersion (context)) {
+					Version l = left.VersionEvaluate (context);
+					Version r = right.VersionEvaluate (context);
+					return VersionCompare (l, r, op);
+				}
+				else if (right.CanEvaluateToNumber (context)) {
+					Version l = left.VersionEvaluate (context);
+					float r = right.NumberEvaluate (context);
+					return VersionCompare (l, r, op);
+				}
+			}
+			else if (left.CanEvaluateToNumber (context)) {
+				if (right.CanEvaluateToNumber (context)) {
+					float l = left.NumberEvaluate (context);
+					float r = right.NumberEvaluate (context);
+					return NumberCompare (l, r, op);
+				}
+				else if (right.CanEvaluateToVersion (context)) {
+					float l = left.NumberEvaluate (context);
+					Version r = right.VersionEvaluate (context);
+					return VersionCompare (l, r, op);
+				}
+			}
+
+			string ls = left.StringEvaluate (context);
+			string rs = right.StringEvaluate (context);
+			return StringCompare (ls, rs, op);
 		}
 		
 		public override float NumberEvaluate (IExpressionContext context)
@@ -149,8 +162,75 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			}
 		}
 
-		// PERF: Cache this value to prevent recalculation.
-		List<string> combinedProperty = null;
+		// see https://github.com/Microsoft/msbuild/blob/03d1435c95e6a85fbf949f94958e743bc44c4186/src/Build/Evaluation/Conditionals/NumericComparisonExpressionNode.cs#L42
+		static bool VersionCompare (Version l,
+					   Version r,
+					   RelationOperator op)
+		{
+			switch (op) {
+			case RelationOperator.Equal:
+				return l == r;
+			case RelationOperator.NotEqual:
+				return l != r;
+			case RelationOperator.Less:
+				return l < r;
+			case RelationOperator.Greater:
+				return l > r;
+			case RelationOperator.LessOrEqual:
+				return l <= r;
+			case RelationOperator.GreaterOrEqual:
+				return l >= r;
+			default:
+				throw new NotSupportedException ($"Relational operator {op} is not supported.");
+			}
+		}
+
+		static bool VersionCompare (Version l,
+					   float r,
+					   RelationOperator op)
+		{
+			switch (op) {
+			case RelationOperator.Equal:
+				return l.Major == r && l.Minor == 0 && l.Build == 0 && l.Revision == 0;
+			case RelationOperator.NotEqual:
+				return l.Major != r || l.Minor != 0 && l.Build != 0 || l.Revision != 0;
+			case RelationOperator.Less:
+				return l.Major != r ? l.Major < r : false;
+			case RelationOperator.Greater:
+				return l.Major != r ? l.Major > r : true;
+			case RelationOperator.LessOrEqual:
+				return l.Major != r ? l.Major <= r : false;
+			case RelationOperator.GreaterOrEqual:
+				return l.Major != r ? l.Major >= r : true;
+			default:
+				throw new NotSupportedException ($"Relational operator {op} is not supported.");
+			}
+		}
+
+		static bool VersionCompare (float l,
+					   Version r,
+					   RelationOperator op)
+		{
+			switch (op) {
+			case RelationOperator.Equal:
+				return r.Major == l && r.Minor == 0 && r.Build == 0 && r.Revision == 0;
+			case RelationOperator.NotEqual:
+				return r.Major != l || r.Minor != 0 && r.Build != 0 || r.Revision != 0;
+			case RelationOperator.Less:
+				return r.Major != l ? l < r.Major : true;
+			case RelationOperator.Greater:
+				return r.Major != l ? l > r.Major : false;
+			case RelationOperator.LessOrEqual:
+				return r.Major != l ? l <= r.Major : true;
+			case RelationOperator.GreaterOrEqual:
+				return r.Major != l ? l >= r.Major : false;
+			default:
+				throw new NotSupportedException ($"Relational operator {op} is not supported.");
+			}
+		}
+
+        // PERF: Cache this value to prevent recalculation.
+        List<string> combinedProperty = null;
 		List<string> combinedValue = null;
 		bool combinedPropertySet;
 		object conditionPropertiesLock = new object ();

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -381,6 +381,14 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void ConditionRelationalExpressions ()
+		{
+			var p = LoadAndEvaluate ("msbuild-tests", "condition-relational-expressions.targets");
+			Assert.AreEqual ("С2С3С4С7С10С12С14С17С18С20С23С24", p.EvaluatedProperties.GetValue("Answer"));
+			p.Dispose ();
+		}
+
+		[Test]
 		public void EvalItemsAfterProperties ()
 		{
 			var p = LoadAndEvaluate ("msbuild-tests", "property-eval-order.csproj");

--- a/main/tests/UnitTests/Util.cs
+++ b/main/tests/UnitTests/Util.cs
@@ -133,7 +133,7 @@ namespace UnitTests
 				Directory.CreateDirectory (dst);
 			
 			foreach (string file in Directory.GetFiles (src))
-				File.Copy (file, Path.Combine (dst, Path.GetFileName (file)));
+				File.Copy (file, Path.Combine (dst, Path.GetFileName (file)), overwrite: true);
 			
 			foreach (string dir in Directory.GetDirectories (src))
 				CopyDir (dir, Path.Combine (dst, Path.GetFileName (dir)));

--- a/main/tests/test-projects/msbuild-tests/condition-relational-expressions.targets
+++ b/main/tests/test-projects/msbuild-tests/condition-relational-expressions.targets
@@ -1,0 +1,87 @@
+<Project>
+	<PropertyGroup>
+		<P1>11.2.3</P1>
+		<P2>3.1</P2>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(P1) == 1.2.3">
+		<C1>С1</C1>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) != 1.2.3">
+		<C2>С2</C2>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) > 1.2.3">
+		<C3>С3</C3>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) >= 1.2.3">
+		<C4>С4</C4>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) &lt; 1.2.3">
+		<C5>С5</C5>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) &lt;= 1.2.3">
+		<C6>С6</C6>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(P2) == 3.1">
+		<C7>С7</C7>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P2) != 3.1">
+		<C8>С8</C8>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P2) > 3.1">
+		<C9>С9</C9>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P2) >= 3.1">
+		<C10>С10</C10>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P2) &lt; 3.1">
+		<C11>С11</C11>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P2) &lt;= 3.1">
+		<C12>С12</C12>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(P1) == 12.3.4">
+		<C13>С13</C13>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) != 12.3.4">
+		<C14>С14</C14>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) > 12.3.4">
+		<C15>С15</C15>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) >= 12.3.4">
+		<C16>С16</C16>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) &lt; 12.3.4">
+		<C17>С17</C17>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) &lt;= 12.3.4">
+		<C18>С18</C18>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(P1) == 12">
+		<C19>С19</C19>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) != 12">
+		<C20>С20</C20>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) > 12">
+		<C21>С21</C21>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) >= 12">
+		<C22>С22</C22>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) &lt; 12">
+		<C23>С23</C23>
+	</PropertyGroup>
+	<PropertyGroup Condition="$(P1) &lt;= 12">
+		<C24>С24</C24>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<Answer>$(C1)$(C2)$(C3)$(C4)$(C5)$(C6)$(C7)$(C8)$(C9)$(C10)$(C11)$(C12)$(C13)$(C14)$(C15)$(C16)$(C17)$(C18)$(C19)$(C20)$(C21)$(C22)$(C23)$(C24)</Answer>
+	</PropertyGroup>
+
+</Project>


### PR DESCRIPTION
MSBuild has intrinsic support for comparing double and Version values. See http://source.dot.net/#Microsoft.Build/Evaluation/Conditionals/NumericComparisonExpressionNode.cs

Example file:
https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets#L18