### PR TITLE
[atkcocoa] AtkCocoaHelper.Enabled is used everywhere and broke Linux …

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperNoOp.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperNoOp.cs
@@ -175,6 +175,12 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			return new AccessibilityElementProxy ();
 		}
 
+		public static bool Enabled {
+			get {
+				return false;
+			}
+		}
+		
 		public string Identifier {
 			get {
 				return null;


### PR DESCRIPTION
…build.