### PR TITLE
Make UnitTesting BinaryResultsStore lazy initialize XmlSerializer

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/BinaryResultsStore.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/BinaryResultsStore.cs
@@ -55,7 +55,17 @@ namespace MonoDevelop.UnitTesting
 		const string xmlExtension = ".xml";
 
 		FastSerializer fastSerializer = new FastSerializer();
-		XmlSerializer xmlSerializer = new XmlSerializer(typeof(TestRecord));
+		XmlSerializer xmlSerializer;
+
+		XmlSerializer XmlSerializer {
+			get {
+				if (xmlSerializer == null) {
+					xmlSerializer = new XmlSerializer (typeof (TestRecord));
+				}
+
+				return xmlSerializer;
+			}
+		}
 
 		public void Serialize (string xmlFilePath, TestRecord testRecord)
 		{
@@ -81,7 +91,7 @@ namespace MonoDevelop.UnitTesting
 			// deserialize from xml if the file exists
 			if (File.Exists(xmlFilePath)) {
 				using (var reader = new StreamReader (xmlFilePath)) {
-					return (TestRecord) xmlSerializer.Deserialize (reader);
+					return (TestRecord) XmlSerializer.Deserialize (reader);
 				}
 			}
 


### PR DESCRIPTION
This avoids another first-chance exception and unnecessary expensive XmlSerializer initialization until it's actually needed. This used to happen on startup with this stack:

```
> MonoDevelop.UnitTesting.BinaryResultsStore.BinaryResultsStore Line 38 C# Symbols loaded.
  [Native to Managed Transition]  Annotated Frame
  [Managed to Native Transition]  Annotated Frame
  MonoDevelop.UnitTesting.SolutionFolderTestGroup.SolutionFolderTestGroup Line 48 C# Symbols loaded.
  MonoDevelop.UnitTesting.SolutionFolderTestGroup.CreateTest Line 61 C# Symbols loaded.
  MonoDevelop.UnitTesting.SystemTestProvider.CreateUnitTest Line 43 C# Symbols loaded.
  MonoDevelop.UnitTesting.UnitTestService.BuildTest Line 359 C# Symbols loaded.
  MonoDevelop.UnitTesting.UnitTestService.RebuildTests Line 346 C# Symbols loaded.
  MonoDevelop.UnitTesting.UnitTestService.OnWorkspaceChanged Line 294 C# Symbols loaded.
  MonoDevelop.Ide.RootWorkspace.NotifyItemAddedGui Line 970 C# Symbols loaded.
  MonoDevelop.Ide.RootWorkspace.NotifyItemAdded Line 942 C# Symbols loaded.
  MonoDevelop.Ide.RootWorkspaceItemCollection.OnItemsAdded Line 1378 C# Symbols loaded.
  MonoDevelop.Projects.ItemCollection<MonoDevelop.Projects.WorkspaceItem>.Add Line 66 C# Symbols loaded.
  MonoDevelop.Ide.RootWorkspace.BackgroundLoadWorkspace Line 597 C# Symbols loaded.
```
  