### PR TITLE
Update Roslyn dependencies.

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -6,7 +6,7 @@
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <NuGetVersionRoslyn>2.7.0-beta3-62509-03</NuGetVersionRoslyn>
-    <NuGetVersionVSEditor>15.6.150-preview</NuGetVersionVSEditor>
+    <NuGetVersionVSEditor>15.6.161-preview</NuGetVersionVSEditor>
   </PropertyGroup>
 
 </Project>

--- a/main/msbuild/ReferencesRoslyn.props
+++ b/main/msbuild/ReferencesRoslyn.props
@@ -13,6 +13,10 @@
       <HintPath>$(PackagesDirectory)\Microsoft.CodeAnalysis.CSharp.$(NuGetVersionRoslyn)\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>$(ReferencesRoslynCopyToOutput)</Private>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
+      <HintPath>$(PackagesDirectory)\Microsoft.CodeAnalysis.EditorFeatures.$(NuGetVersionRoslyn)\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
+      <Private>$(ReferencesRoslynCopyToOutput)</Private>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Features">
       <HintPath>$(PackagesDirectory)\Microsoft.CodeAnalysis.CSharp.Features.$(NuGetVersionRoslyn)\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
       <Private>$(ReferencesRoslynCopyToOutput)</Private>

--- a/main/msbuild/ReferencesVSEditor.props
+++ b/main/msbuild/ReferencesVSEditor.props
@@ -30,7 +30,7 @@
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Implementation">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.0.6-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.0.7-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
   </ItemGroup>

--- a/main/msbuild/ReferencesVSEditor.props
+++ b/main/msbuild/ReferencesVSEditor.props
@@ -13,10 +13,6 @@
       <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Data.$(NuGetVersionVSEditor)\lib\net46\Microsoft.VisualStudio.Text.Data.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Internal">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Internal.$(NuGetVersionVSEditor)\lib\net46\Microsoft.VisualStudio.Text.Internal.dll</HintPath>
-      <Private>$(ReferencesVSEditorCopyToOutput)</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Logic">
       <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Logic.$(NuGetVersionVSEditor)\lib\net46\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -103,6 +103,9 @@
     <MSBuild_OSS_BinDir Condition="'$(OS)' == 'Unix' and '$(MSBuild_OSS_BinDir)' == '' and Exists('$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\MSBuild.dll')">$(MSBuildToolsPath)\..\..\..\msbuild\15.0\bin\</MSBuild_OSS_BinDir>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Humanizer.Core">
+      <HintPath>..\..\..\packages\Humanizer.Core.2.2.0\lib\netstandard1.0\Humanizer.dll</HintPath>
+    </Reference>
     <Reference Include="Esent.Interop, Version=1.9.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\ManagedEsent.1.9.4\lib\net40\Esent.Interop.dll</HintPath>
     </Reference>
@@ -158,10 +161,6 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.UI.Wpf.$(NuGetVersionVSEditor)\lib\net46\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
-      <Private>true</Private>
-    </Reference>
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Humanizer.Core" version="2.2.0" targetFramework="net461" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis" version="2.7.0-beta3-62509-03" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.2.0-beta2" targetFramework="net461" />
@@ -17,15 +18,15 @@
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.7.0-beta3-62509-03" targetFramework="net461" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Composition" version="15.3.38" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Data" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Internal" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Logic" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.UI" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.6.150-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.0.6-pre" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Internal" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.6.161-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.0.7-pre" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />


### PR DESCRIPTION
Update VS Editor to 15.6.161-preview since that's the version referenced by Roslyn.
Remove a reference to Text.Internal.
Add a reference to Humanizer.Core 2.2.0. It is now a prerequisite.