### PR TITLE
[Toolbar][Mac] Fix various configuration selector issues

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -128,6 +128,18 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 		}
 
+		public override bool BecomeFirstResponder()
+		{
+			if (Window.FirstResponder != RealSelectorView)
+				return Window.MakeFirstResponder(RealSelectorView);
+			return false;
+		}
+
+		public override bool AcceptsFirstResponder()
+		{
+			return Window.FirstResponder != RealSelectorView;
+		}
+
 		#region PathSelectorView
 		[Register]
 		public class PathSelectorView : NSPathControl
@@ -443,7 +455,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				PopupMenuForCell (item);
 			}
 
-			int focusedCellIndex = 1;
+			int focusedCellIndex = 0;
 			NSPathComponentCellFocusable focusedItem;
 
 			public override void KeyDown (NSEvent theEvent)
@@ -461,7 +473,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 						if (NextKeyView != null) {
 							Window.MakeFirstResponder (NextKeyView);
 							SetSelection ();
-							focusedCellIndex = 1;
+							focusedCellIndex = 0;
 							focusedItem = null;
 							return;
 						}
@@ -489,6 +501,16 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			{
 				SetSelection ();
 				return base.BecomeFirstResponder ();
+			}
+
+			public override bool ResignFirstResponder ()
+			{
+				focusedCellIndex = 0;
+				if (focusedItem != null) {
+					focusedItem.HasFocus = false;
+					focusedItem = null;
+				}
+				return base.ResignFirstResponder ();
 			}
 
 			void PopupMenuForCell (NSPathComponentCell item)

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		internal const int ConfigurationIdx = 1;
 		internal const int RuntimeIdx = 2;
 
-		internal const int SeparatorWidth = 10;
+		internal const int SeparatorWidth = 5;
 
 		internal PathSelectorView RealSelectorView { get; private set; }
 
@@ -190,22 +190,41 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			public override CGSize SizeThatFits (CGSize size)
 			{
-				int n = 0;
-				nfloat totalWidth = SeparatorWidth * VisibleCells.Length - 1;
-				nfloat allIconsWidth = iconSize * VisibleCells.Length;
+				// compatibility mode for older macOS versions
+				if (MacSystemInformation.OsVersion < MacSystemInformation.HighSierra) {
+					int n = 0;
+					nfloat totalWidth = SeparatorWidth * VisibleCellIds.Length - 1;
+					nfloat allIconsWidth = iconSize * VisibleCellIds.Length;
 
-				allIconsWidth -= iconSize;
-				totalWidth += AddCellSize (LastSelectedCell, totalWidth, size.Width, allIconsWidth);
-
-				for (;n < VisibleCells.Length; n++) {
-					var cellId = VisibleCellIds [n];
-					if (cellId == LastSelectedCell)
-						continue;
-					
 					allIconsWidth -= iconSize;
-					totalWidth += AddCellSize (cellId, totalWidth, size.Width, allIconsWidth);
+					totalWidth += AddCellSize (LastSelectedCell, totalWidth, size.Width, allIconsWidth);
+
+					for (; n < VisibleCellIds.Length; n++) {
+						var cellId = VisibleCellIds [n];
+						if (cellId == LastSelectedCell)
+							continue;
+
+						allIconsWidth -= iconSize;
+						totalWidth += AddCellSize (cellId, totalWidth, size.Width, allIconsWidth);
+					}
+					return new CGSize (totalWidth, size.Height);
 				}
-				return new CGSize (totalWidth, size.Height);
+
+				var fullSize = base.SizeThatFits (size);
+				if (size.Width > fullSize.Width) // use the default size calculation if there is enough space
+					return fullSize;
+
+				// show at least one component, either the last selected or the last one (device)
+				var fullWidthCellId = LastSelectedCell > -1 ? LastSelectedCell : VisibleCellIds.Length - 1;
+
+				// On High Sierra NSPathControl will always expand the selected or the last component
+				// and show only the icon for the others. The minimal size must include the selected cell
+				// width and the remaining cells with icons
+				var fullWidthCellSize = Cells[fullWidthCellId].Cell.CellSize.Width;
+				var minSize = (VisibleCellIds.Length - 1) * iconSize + fullWidthCellSize;
+
+				// if the shrinked min size is now smaller than the available space, expand the view to fill it
+				return new CGSize (Math.Max (minSize, size.Width), fullSize.Height);
 			}
 
 			string EllipsizeString (string s)
@@ -256,7 +275,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			nfloat GetRequiredWidthForPathCell (int cellId)
 			{
 				var cell = Cells [cellId];
-				return new NSAttributedString (GetTextForCell (cellId), new NSStringAttributes { Font = cell.Font }).Size.Width + iconSize;
+				return new NSAttributedString (GetTextForCell (cellId), new NSStringAttributes { Font = cell.Cell.Font }).Size.Width + iconSize;
 			}
 
 			NSMenu CreateSubMenuForRuntime (IRuntimeModel runtime)
@@ -334,8 +353,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				}
 			}
 
-			NSPathComponentCellFocusable [] Cells;
-			NSPathComponentCellFocusable [] VisibleCells;
+			CellWrapper [] Cells;
 			int [] VisibleCellIds;
 
 			int lastSelectedCell;
@@ -357,20 +375,25 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			NSImage lastDeviceImageDisabled;
 			public PathSelectorView (CGRect frameRect) : base (frameRect)
 			{
+				iconSize = new NSPathComponentCellFocusable { Image = projectImageDisabled, Title = string.Empty }.CellSize.Width;
+
+				// Depending on the current macOS version we must reuse existing cells to enforce the desired behaviour (before HighSierra),
+				// or we must recreate the whole path on each selection change (HighSierra). Using an additional wrapper class
+				// makes it possible to share most of the code between OS versions.
 				Cells = new [] {
-					new NSPathComponentCellFocusable {
+					new CellWrapper {
 						Image = projectImageDisabled,
 						Title = TextForActiveRunConfiguration,
 						Enabled = false,
 						Identifier = RunConfigurationIdentifier
 					},
-					new NSPathComponentCellFocusable {
+					new CellWrapper {
 						Image = projectImageDisabled,
 						Title = TextForActiveConfiguration,
 						Enabled = false,
 						Identifier = ConfigurationIdentifier
 					},
-					new NSPathComponentCellFocusable {
+					new CellWrapper {
 						Image = deviceImageDisabled,
 						Title = TextForRuntimeConfiguration,
 						Enabled = false,
@@ -392,20 +415,44 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				nsa.AccessibilityHelp = GettextCatalog.GetString ("Set the project runtime configuration");
 			}
 
-			void SetVisibleCells (params int[] ids)
+			void SetVisibleCells (params int [] ids)
 			{
 				VisibleCellIds = ids;
 				LastSelectedCell = ids [0];
-				VisibleCells = new NSPathComponentCellFocusable [ids.Length];
-				for (int n = 0; n < ids.Length; n++)
-					VisibleCells [n] = Cells [ids [n]];
-				PathComponentCells = VisibleCells;
+				var visibleCells = new NSPathComponentCell [ids.Length];
+
+				for (int n = 0; n < ids.Length; n++) {
+					var cellData = Cells [ids [n]];
+					// on HighSierra cells can't be reused without breaking the rendering
+					if (MacSystemInformation.OsVersion >= MacSystemInformation.HighSierra || cellData.Cell == null)
+						cellData.Cell = new NSPathComponentCellFocusable ();
+					visibleCells [n] = cellData.Cell;
+				}
+
+				// On HighSierra the NSPathControl doesn't render correctly without a valid URL and
+				// it won't remeasure cells with updated titles, hence we must always update the whole path
+				if (MacSystemInformation.OsVersion >= MacSystemInformation.HighSierra) {
+					var url = string.Empty;
+					for (int n = 0; n < ids.Length; n++)
+						url += Cells [ids [n]].Title + "/";
+
+					// we need to encode the url, to ensure that NSUrl.FromString doesn't fail for certain configuration names
+					var uri = new Uri ("md://configuration/" + url).GetComponents (UriComponents.HttpRequestUrl, UriFormat.UriEscaped);
+					Url = NSUrl.FromString (uri);
+
+					// path items must match the cells, including images
+					for (int n = 0; n < ids.Length; n++)
+						Cells [ids [n]].UpdatePathItem (PathItems [n]);
+				}
+
+				PathComponentCells = visibleCells;
+				UpdateStyle ();
 			}
 
 			int IndexOfCellAtX (nfloat x)
 			{
 				var cell = ((NSPathCell)Cell).GetPathComponent (new CGPoint (x, Frame.Height / 2), Frame, this);
-				var i = VisibleCells.IndexOf (cell);
+				var i = PathComponentCells.IndexOf (cell);
 				if (i > -1)
 					i = VisibleCellIds [i];
 				return i;
@@ -435,7 +482,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					return;
 				}
 
-				var item = Cells [cellIdx];
+				var item = Cells [cellIdx].Cell;
 				if (item == null || !item.Enabled)
 					return;
 
@@ -449,14 +496,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			{
 				if(theEvent.Characters == " ")
 				{
-					var item = Cells [focusedCellIndex];
+					var item = Cells [focusedCellIndex].Cell;
 					PopupMenuForCell (item);
 					return;
 				}
 
 				if (theEvent.Characters == "\t") {
 					focusedCellIndex++;
-					if(focusedCellIndex > VisibleCells.Count ()){
+					if(focusedCellIndex > VisibleCellIds.Length){
 						if (NextKeyView != null) {
 							Window.MakeFirstResponder (NextKeyView);
 							SetSelection ();
@@ -476,10 +523,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				if (focusedItem != null) {
 					focusedItem.HasFocus = false;
 				}
-				if (focusedCellIndex < Cells.Count ()) {
-					var item = Cells [focusedCellIndex];
+				if (focusedCellIndex < Cells.Length) {
+					var item = Cells [focusedCellIndex].Cell as NSPathComponentCellFocusable;
 					focusedItem = item;
-					item.HasFocus = true;
+					if (item != null)
+						item.HasFocus = true;
 				}
 				SetNeedsDisplay ();
 			}
@@ -595,9 +643,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			void UpdateStyle (object sender = null, EventArgs e = null)
 			{
-				Cells [RunConfigurationIdx].TextColor = Styles.BaseForegroundColor.ToNSColor ();
-				Cells [ConfigurationIdx].TextColor = Styles.BaseForegroundColor.ToNSColor ();
-				Cells [RuntimeIdx].TextColor = Styles.BaseForegroundColor.ToNSColor ();
+				foreach (var cell in PathComponentCells)
+					cell.TextColor = Styles.BaseForegroundColor.ToNSColor ();
 
 				UpdateImages ();
 			}
@@ -625,15 +672,18 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 				// fix the icon alignment, move it slightly up
 				var alignFix = new CGRect (0, Window.BackingScaleFactor == 2 ? -0.5f : -1f, 16, 16);
-				Cells [RunConfigurationIdx].Image.AlignmentRect = alignFix;
-				Cells [ConfigurationIdx].Image.AlignmentRect = alignFix;
-				Cells [RuntimeIdx].Image.AlignmentRect = alignFix;
+				foreach (var cell in Cells)
+					cell.Image.AlignmentRect = alignFix;
 			}
 
 			void UpdatePathText (int idx, string text)
 			{
 				Cells [idx].Title = text;
-				UpdateImages ();
+				// On HighSierra we must update the whole path, otherwise the rendering will break
+				if (MacSystemInformation.OsVersion >= MacSystemInformation.HighSierra)
+					SetVisibleCells (VisibleCellIds);
+				else
+					UpdateImages ();
 			}
 
 			static NSImage FixImageServiceImage (Xwt.Drawing.Image image, double scale, string[] styles)
@@ -835,6 +885,70 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				}
 			}
 
+
+			class CellWrapper
+			{
+				NSPathComponentCell cell;
+				string title;
+				NSImage image;
+				string identifier;
+				bool enabled;
+
+				public NSPathComponentCell Cell {
+					get { return cell; }
+					set {
+						cell = value;
+						if (cell != null) {
+							cell.Title = title;
+							cell.Image = image;
+							cell.Identifier = identifier;
+							cell.Enabled = enabled;
+						}
+					}
+				}
+
+				public string Title {
+					get { return title; }
+					set {
+						title = value;
+						if (cell != null)
+							cell.Title = title;
+					}
+				}
+
+				public NSImage Image {
+					get { return image; }
+					set {
+						image = value;
+						if (cell != null)
+							cell.Image = image;
+					}
+				}
+
+				public string Identifier {
+					get { return identifier; }
+					set {
+						identifier = value;
+						if (cell != null)
+							cell.Identifier = identifier;
+					}
+				}
+
+				public bool Enabled {
+					get { return enabled; }
+					set {
+						enabled = value;
+						if (cell != null)
+							cell.Enabled = enabled;
+					}
+				}
+
+				public void UpdatePathItem (NSPathControlItem pathItem)
+				{
+					pathItem.Title = title;
+					pathItem.Image = image;
+				}
+			}
 		}
 		#endregion
 	}

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -259,12 +259,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				return new NSAttributedString (GetTextForCell (cellId), new NSStringAttributes { Font = cell.Font }).Size.Width + iconSize;
 			}
 
-			nfloat GetWidthForPathCell (int cellId)
-			{
-				var cell = Cells [cellId];
-				return new NSAttributedString (cell.Title, new NSStringAttributes { Font = cell.Font }).Size.Width + iconSize;
-			}
-
 			NSMenu CreateSubMenuForRuntime (IRuntimeModel runtime)
 			{
 				if (!runtime.Children.Any ())
@@ -410,18 +404,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			int IndexOfCellAtX (nfloat x)
 			{
-				nfloat cx = 0;
-				for (int n = 0; n < VisibleCells.Length; n++) {
-					var cellWidth = GetWidthForPathCell (VisibleCellIds [n]);
-					if (x > cx && x <= cx + cellWidth)
-						return VisibleCellIds [n];
-					cx += cellWidth;
-					if (x >= cx && x < cx + SeparatorWidth)
-						// The > in the middle
-						return -1;
-					cx += SeparatorWidth;
-				}
-				return -1;
+				var cell = ((NSPathCell)Cell).GetPathComponent (new CGPoint (x, Frame.Height / 2), Frame, this);
+				var i = VisibleCells.IndexOf (cell);
+				if (i > -1)
+					i = VisibleCellIds [i];
+				return i;
 			}
 
 			public override bool AccessibilityPerformShowMenu ()


### PR DESCRIPTION
This PR fixes a couple of issues with the configuration selector (Toolbar), icluding weird behaviour on HighSierra.

* [53733](https://bugzilla.xamarin.com/show_bug.cgi?id=53733): broken Tab-Focus
* [60722](https://bugzilla.xamarin.com/show_bug.cgi?id=60722): wrong hit area calculation
* [59751](https://bugzilla.xamarin.com/show_bug.cgi?id=59751): Layout/Rendering issues on HighSierra

~~TODO: the SelectorView is still not really accessible, it is possible to navigate between the cells with the Tab key,  but VoiceOver sees only one big area without any possible action.~~ done in 
8827e7a 