### PR TITLE
[61102][Mac] Fix open project dialog on High Sierra

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -123,33 +123,40 @@ namespace MonoDevelop.MacIntegration
 								if (encodingSelector != null)
 									encodingSelector.Enabled = !workbenchViewerSelected;
 								if (closeSolutionButton != null) {
-									if (closeSolutionButton.Hidden == workbenchViewerSelected) {
-										closeSolutionButton.Hidden = !workbenchViewerSelected;
-										CenterAccessoryView (box);
+									if (closeSolutionButton.Enabled != workbenchViewerSelected) {
+										closeSolutionButton.Enabled = workbenchViewerSelected;
+										closeSolutionButton.State = workbenchViewerSelected ? NSCellStateValue.On : NSCellStateValue.Off;
 									}
 								}
 							};
 						}
-						
+
+						if (IdeApp.Workspace.IsOpen) {
+							closeSolutionButton = new NSButton {
+								Title = GettextCatalog.GetString ("Close current workspace"),
+								Enabled = false,
+								State = NSCellStateValue.Off,
+							};
+
+							closeSolutionButton.SetButtonType (NSButtonType.Switch);
+							closeSolutionButton.SizeToFit ();
+
+							var closeSolutionLabelBox = new MDAlignment (new MDLabel (string.Empty), true);
+							var closeSolutionBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
+								{ closeSolutionLabelBox },
+								{ new MDAlignment (closeSolutionButton, true) { MinWidth = 200 } }
+							};
+
+							labels.Add (closeSolutionLabelBox);
+							box.Add (closeSolutionBox);
+						}
+
 						var viewSelLabel = new MDLabel (GettextCatalog.GetString ("Open with:"));
 						var viewSelBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
 							{ viewSelLabel, true },
 							{ new MDAlignment (viewerSelector, true) { MinWidth = 200 }  }
 						};
-						
-						if (IdeApp.Workspace.IsOpen) {
-							closeSolutionButton = new NSButton {
-								Title = GettextCatalog.GetString ("Close current workspace"),
-								Hidden = true,
-								State = NSCellStateValue.On,
-							};
-							
-							closeSolutionButton.SetButtonType (NSButtonType.Switch);
-							closeSolutionButton.SizeToFit ();
-							
-							viewSelBox.Add (closeSolutionButton, true);
-						}
-						
+
 						box.Add (viewSelBox);
 					}
 				}
@@ -172,9 +179,10 @@ namespace MonoDevelop.MacIntegration
 					bool slnViewerSelected = false;
 					if (viewerSelector != null) {
 						slnViewerSelected = FillViewers (currentViewers, viewerSelector, closeSolutionButton, selection);
-						if (closeSolutionButton != null)
-							closeSolutionButton.Hidden = !slnViewerSelected;
-						CenterAccessoryView (box);
+						if (closeSolutionButton != null) {
+							closeSolutionButton.Enabled = slnViewerSelected;
+							closeSolutionButton.State = slnViewerSelected ? NSCellStateValue.On : NSCellStateValue.Off;
+						}
 					} 
 					if (encodingSelector != null)
 						encodingSelector.Enabled = !slnViewerSelected;
@@ -261,24 +269,6 @@ namespace MonoDevelop.MacIntegration
 		static bool CanBeOpenedInAssemblyBrowser (FilePath filename)
 		{
 			return string.Equals (filename.Extension, ".exe", StringComparison.OrdinalIgnoreCase) || string.Equals (filename.Extension, ".dll", StringComparison.OrdinalIgnoreCase);
-		}
-
-		static void CenterAccessoryView (MDBox box)
-		{
-			box.Layout ();
-
-			//re-center the accessory view in its parent, Cocoa does this for us initially and after
-			//resizing the window, but we need to do it again after altering its layout
-			var superView = box.View.Superview;
-			if (superView == null)
-				return;
-			
-			var superFrame = superView.Frame;
-			var frame = box.View.Frame;
-			//not sure why it's ceiling, but this matches the Cocoa layout
-			frame.X = (float)Math.Ceiling ((superFrame.Width - frame.Width) / 2);
-			frame.Y = (float)Math.Ceiling ((superFrame.Height - frame.Height) / 2);
-			box.View.Frame = frame;
 		}
 	}
 }

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -83,17 +83,20 @@ namespace MonoDevelop.MacIntegration
 				
 				List<FileViewer> currentViewers = null;
 				var labels = new List<MDAlignment> ();
+				var controls = new List<MDAlignment> ();
 				
 				if ((data.Action & FileChooserAction.FileFlags) != 0) {
 					var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
 
 					if (filterPopup != null) {
-						var filterLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Show files:")), true);
+						var filterLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Show files:")) { Alignment = NSTextAlignment.Right }, true);
+						var filterPopupAlignment = new MDAlignment (filterPopup, true) { MinWidth = 200 };
 						var filterBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
 							{ filterLabel },
-							{ new MDAlignment (filterPopup, true) { MinWidth = 200 } }
+							{ filterPopupAlignment }
 						};
 						labels.Add (filterLabel);
+						controls.Add (filterPopupAlignment);
 						box.Add (filterBox);
 					}
 
@@ -101,12 +104,14 @@ namespace MonoDevelop.MacIntegration
 						encodingSelector = new SelectEncodingPopUpButton (data.Action != FileChooserAction.Save);
 						encodingSelector.SelectedEncodingId = data.Encoding != null ? data.Encoding.CodePage : 0;
 						
-						var encodingLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Encoding:")), true);
+						var encodingLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Encoding:")) { Alignment = NSTextAlignment.Right }, true);
+						var encodingSelectorAlignment = new MDAlignment (encodingSelector, true) { MinWidth = 200 };
 						var encodingBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
 							{ encodingLabel },
-							{ new MDAlignment (encodingSelector, true) { MinWidth = 200 }  }
+							{ encodingSelectorAlignment }
 						};
 						labels.Add (encodingLabel);
+						controls.Add (encodingSelectorAlignment);
 						box.Add (encodingBox);
 					}
 					
@@ -142,21 +147,26 @@ namespace MonoDevelop.MacIntegration
 							closeSolutionButton.SizeToFit ();
 
 							var closeSolutionLabelBox = new MDAlignment (new MDLabel (string.Empty), true);
+							var closeSolutionButtonAlignment = new MDAlignment (closeSolutionButton, true);
 							var closeSolutionBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
 								{ closeSolutionLabelBox },
-								{ new MDAlignment (closeSolutionButton, true) { MinWidth = 200 } }
+								{ closeSolutionButtonAlignment }
 							};
 
 							labels.Add (closeSolutionLabelBox);
+							controls.Add (closeSolutionButtonAlignment);
 							box.Add (closeSolutionBox);
 						}
 
-						var viewSelLabel = new MDLabel (GettextCatalog.GetString ("Open with:"));
+						var viewSelLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Open with:")) { Alignment = NSTextAlignment.Right }, true);
+						var viewSelectorAlignemnt = new MDAlignment (viewerSelector, true) { MinWidth = 200 };
 						var viewSelBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-							{ viewSelLabel, true },
-							{ new MDAlignment (viewerSelector, true) { MinWidth = 200 }  }
+							{ viewSelLabel },
+							{ viewSelectorAlignemnt }
 						};
 
+						labels.Add (viewSelLabel);
+						controls.Add (viewSelectorAlignemnt);
 						box.Add (viewSelBox);
 					}
 				}
@@ -166,6 +176,14 @@ namespace MonoDevelop.MacIntegration
 					foreach (var l in labels) {
 						l.MinWidth = w;
 						l.XAlign = LayoutAlign.Begin;
+					}
+				}
+
+				if (controls.Count > 0) {
+					float w = controls.Max (c => c.MinWidth);
+					foreach (var c in controls) {
+						c.MinWidth = w;
+						c.XAlign = LayoutAlign.Begin;
 					}
 				}
 				

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -89,7 +89,7 @@ namespace MonoDevelop.MacIntegration
 					var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
 
 					if (filterPopup != null) {
-						var filterLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Show files:")) { Alignment = NSTextAlignment.Right }, true);
+						var filterLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Show Files:")) { Alignment = NSTextAlignment.Right }, true);
 						var filterPopupAlignment = new MDAlignment (filterPopup, true) { MinWidth = 200 };
 						var filterBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
 							{ filterLabel },
@@ -158,7 +158,7 @@ namespace MonoDevelop.MacIntegration
 							box.Add (closeSolutionBox);
 						}
 
-						var viewSelLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Open with:")) { Alignment = NSTextAlignment.Right }, true);
+						var viewSelLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Open With:")) { Alignment = NSTextAlignment.Right }, true);
 						var viewSelectorAlignemnt = new MDAlignment (viewerSelector, true) { MinWidth = 200 };
 						var viewSelBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
 							{ viewSelLabel },


### PR DESCRIPTION
Changing the layout of the NSSavePanel AccessoryView does not work on High Sierra, which seems to always enforce initial constraints resulting in a wrong layout:

<img width="722" alt="grafik" src="https://user-images.githubusercontent.com/951587/34933759-66668fa6-f9d8-11e7-9f73-d81327cbc390.png">

With this patch the accessory view layout remains always the same and it just enables/disables the "Close current workspace" checkbox:

![grafik](https://user-images.githubusercontent.com/951587/34942299-74026972-f9f7-11e7-95d5-5bf450357f24.png)
![grafik](https://user-images.githubusercontent.com/951587/34942323-8440a98e-f9f7-11e7-852c-a5bf9593055a.png)


(fixes bug #61102)