### PR TITLE
[DotNetCore] Fix tests timing out on build server

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -234,7 +234,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		public async Task TizenProject_OpenProject_LoadedAsDotNetProjectNotUnknownSolutionItem ()
 		{
 			string solutionFileName = Util.GetSampleProject ("TizenProject", "TizenProject.sln");
-			var solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = solution.Items.Single (item => item.Name == "TizenProject");
 
 			Assert.IsInstanceOf<DotNetProject> (project);


### PR DESCRIPTION
Ensure projects are disposed after running tests to prevent the file
watcher not being disposed and stopping the unit tests from finishing
on the build server.