### PR TITLE
Canonicalize assembly paths

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -235,7 +235,7 @@ module CompilerArguments =
         let getAbsolutePath (ref:AssemblyReference) =
             let assemblyPath = ref.FilePath
             if assemblyPath.IsAbsolute then
-                assemblyPath |> string
+                assemblyPath.FullPath |> string
             else
                 let s = Path.Combine(project.FileName.ParentDirectory.ToString(), assemblyPath.ToString())
                 Path.GetFullPath s


### PR DESCRIPTION
Noticed while trying to load FSharp.Compiler.Service that the paths
weren't canonicalized

```
  "-r:/Users/jason/src/FSharp.Compiler.Service/fcs/FSharp.Compiler.Service/../../src/../packages/System.Reflection.Metadata.1.4.2/lib/portable-net45+win8/System.Reflection.Metadata.dll";
 "-r:/Users/jason/src/FSharp.Compiler.Service/fcs/FSharp.Compiler.Service/../../src/../packages/System.ValueTuple.4.3.1/lib/netstandard1.0/System.ValueTuple.dll";
```