### PR TITLE
[d15-6][Core] Fix UI hang on loading Xamarin.Forms solution

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectNodeBuilder.cs
@@ -341,7 +341,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 						: file.FilePath.ParentDirectory;
 					
 					if (!tb.MoveToObject (new ProjectFolder (parentPath, project))) {
-						if (project.UseFileWatcher) {
+						if (project.UseFileWatcher && parentPath.IsChildPathOf (project.BaseDirectory)) {
 							// Keep looking for folder higher up the tree so any empty folders
 							// can be removed.
 							while (parentPath != project.BaseDirectory) {


### PR DESCRIPTION
On loading the Xamarin.Forms solution, with NuGet restore enabled,
the UI thread would be stuck in a loop trying to refresh the project
folders. When a project uses a shared project the re-evaluation
would cause the shared files to be removed from the project. Then
an attempt was made to refresh a parent folder for that file being
removed, if the project had the file watcher enabled. Since the file
was outside the project directory the while loop would not finish
and cause the UI thread to be blocked.