### PR TITLE
[15.6][540610][Ide] Add Find Command command

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -895,6 +895,13 @@
 			macShortcut = "Alt|Meta|Shift|F"
 			_description = "Search for and replace text in all files of a directory" />
 
+	<Command id = "MonoDevelop.Ide.Commands.SearchCommands.RunCommand"
+			defaultHandler = "MonoDevelop.Components.MainToolbar.RunCommandHandler"
+			_label = "_Command..."
+			shortcut = "Control|Shift|P"
+			macShortcut = "Meta|Shift|P"
+			_description = "Find and run a specific command." />
+
 	<Command id = "MonoDevelop.Ide.Commands.SearchCommands.GotoType"
 			defaultHandler = "MonoDevelop.Components.MainToolbar.GotoTypeHandler"
 	         _label = "_Type..."

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarCommandHandlers.cs
@@ -51,4 +51,12 @@ namespace MonoDevelop.Components.MainToolbar
 			Ide.IdeApp.Workbench.Toolbar.SetSearchCategory ("file");
 		}
 	}
+
+	class RunCommandHandler : CommandHandler
+	{
+		protected override void Run ()
+		{
+			Ide.IdeApp.Workbench.Toolbar.SetSearchCategory ("command");
+		}
+	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -133,6 +133,7 @@ namespace MonoDevelop.Components.MainToolbar
 				new SearchMenuModel (GettextCatalog.GetString ("Search Files"), "file"),
 				new SearchMenuModel (GettextCatalog.GetString ("Search Types"), "type"),
 				new SearchMenuModel (GettextCatalog.GetString ("Search Members"), "member"),
+				new SearchMenuModel (GettextCatalog.GetString ("Search Commands"), "command"),
 			};
 
 			// Attach menu category handlers.


### PR DESCRIPTION
#3658 for `d15-6`

This PR adds a "Run Command" (VS Code binding: Ctrl+Shift+P, Mac: Cmd+Shift+P) command to search commands and shows the appropriate category in the global search menu.

<img width="280" alt="grafik" src="https://user-images.githubusercontent.com/951587/34980473-f829f3a2-faa4-11e7-8168-685aa8f8e8aa.png">

(fixes bug #540610)
(closes #3479)