### PR TITLE
[d15-6][Core] Fix a stack overflow exception bubbled via the msbuild builder

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AsyncCriticalSection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AsyncCriticalSection.cs
@@ -75,13 +75,15 @@ namespace MonoDevelop.Projects
 
 		void Exit ()
 		{
+			TaskCompletionSource<IDisposable> cs = null;
 			lock (queue) {
 				if (queue.Count > 0) {
-					var cs = queue.Dequeue ();
-					cs.SetResult (criticalSectionDisposer);
+					cs = queue.Dequeue ();
 				} else
 					locked = false;
 			}
+			// Set the result outside the lock, otherwise this can lead to stack overflow on task continuations.
+			cs?.SetResult (criticalSectionDisposer);
 		}
 	}
 }


### PR DESCRIPTION
The code before would hold the lock while exiting, thus forcing the continuation to run under the lock. This ended up causing Exit tasks to be chained on the same stack frame, ending up in a stack overflow for solutions which queued a lot of builders.

Fixes #3649