### PR TITLE
Optimize project save

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -999,8 +999,15 @@ namespace MonoDevelop.Projects
 				return refs;
 
 			using (await referenceCacheLock.EnterAsync ().ConfigureAwait (false)) {
+
+				if (referenceCacheNeedsRefresh) {
+					// Refresh requested. Clear the whole cache.
+					referenceCache = ImmutableDictionary<string, List<AssemblyReference>>.Empty;
+					referenceCacheNeedsRefresh = false;
+				}
+
 				// Check again the cache before starting the task
-				if (!referenceCacheNeedsRefresh && referenceCache.TryGetValue (confId, out refs))
+				if (referenceCache.TryGetValue (confId, out refs))
 					return refs;
 
 				var monitor = new ProgressMonitor ();
@@ -1016,7 +1023,6 @@ namespace MonoDevelop.Projects
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();
 
 				referenceCache = referenceCache.SetItem (confId, refs);
-				referenceCacheNeedsRefresh = false;
 			}
 			return refs;
 		}
@@ -1054,8 +1060,15 @@ namespace MonoDevelop.Projects
 				return packageDependencies;
 			
 			using (await packageDependenciesCacheLock.EnterAsync ().ConfigureAwait (false)) {
+
+				if (packageDependenciesNeedRefresh) {
+					// Refresh requested. Clear the whole cache.
+					packageDependenciesCache = ImmutableDictionary<string, List<PackageDependency>>.Empty;
+					packageDependenciesNeedRefresh = false;
+				}
+
 				// Check the cache before starting the task
-				if (!packageDependenciesNeedRefresh && packageDependenciesCache.TryGetValue (confId, out packageDependencies))
+				if (packageDependenciesCache.TryGetValue (confId, out packageDependencies))
 					return packageDependencies;
 
 				var monitor = new ProgressMonitor ().WithCancellationToken (cancellationToken);
@@ -1074,7 +1087,6 @@ namespace MonoDevelop.Projects
 				packageDependencies = result.Items.Select (i => PackageDependency.Create (i)).Where (dependency => dependency != null).ToList ();
 
 				packageDependenciesCache = packageDependenciesCache .SetItem (confId, packageDependencies);
-				packageDependenciesNeedRefresh = false;
 			}
 
 			return packageDependencies;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2314,6 +2314,8 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		ITimeTracker writeTimer;
+
 		void WriteProject (ProgressMonitor monitor)
 		{
 			if (saving) {
@@ -2323,10 +2325,15 @@ namespace MonoDevelop.Projects
 			
 			saving = true;
 
+			writeTimer = Counters.WriteMSBuildProject.BeginTiming ();
+
 			try {
 				sourceProject.FileName = FileName;
 
+				writeTimer.Trace ("Writing project header");
 				OnWriteProjectHeader (monitor, sourceProject);
+
+				writeTimer.Trace ("Writing project content");
 				ProjectExtension.OnWriteProject (monitor, sourceProject);
 
 				var globalGroup = sourceProject.GetGlobalPropertyGroup ();
@@ -2346,7 +2353,9 @@ namespace MonoDevelop.Projects
 				}
 
 				sourceProject.IsNewProject = false;
+				writeTimer.Trace ("Project written");
 			} finally {
+				writeTimer.End ();
 				saving = false;
 			}
 		}
@@ -2898,11 +2907,17 @@ namespace MonoDevelop.Projects
 		{
 			IMSBuildPropertySet globalGroup = msproject.GetGlobalPropertyGroup ();
 
+			writeTimer.Trace ("Writing configurations");
 			WriteConfigurations (monitor, msproject, globalGroup);
+			writeTimer.Trace ("Done writing configurations");
 
+			writeTimer.Trace ("Writing run configurations");
 			WriteRunConfigurations (monitor, msproject, globalGroup);
+			writeTimer.Trace ("Done writing run configurations");
 
+			writeTimer.Trace ("Saving project items");
 			SaveProjectItems (monitor, msproject, usedMSBuildItems);
+			writeTimer.Trace ("Done saving project items");
 
 			if (msproject.IsNewProject) {
 				foreach (var im in DefaultImports)
@@ -2920,7 +2935,10 @@ namespace MonoDevelop.Projects
 			}
 			importsAdded.Clear ();
 			importsRemoved.Clear ();
+
+			writeTimer.Trace ("Writing external properties");
 			msproject.WriteExternalProjectProperties (this, GetType (), true);
+			writeTimer.Trace ("Done writing external properties");
 		}
 
 		void WriteConfigurations (ProgressMonitor monitor, MSBuildProject msproject, IMSBuildPropertySet globalGroup)
@@ -3008,6 +3026,8 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		ProjectRunConfiguration defaultBlankRunConfiguration;
+
 		void WriteRunConfigurations (ProgressMonitor monitor, MSBuildProject msproject, IMSBuildPropertySet globalGroup)
 		{
 			List<ConfigData> configData = new List<ConfigData> ();
@@ -3018,7 +3038,9 @@ namespace MonoDevelop.Projects
 
 				// Write configuration data, creating new property groups if necessary
 
-				var defaultConfig = CreateRunConfigurationInternal ("Default");
+				// Create the default configuration just once, and reuse it for comparing in subsequent writes
+				if (defaultBlankRunConfiguration == null)
+					defaultBlankRunConfiguration = CreateRunConfigurationInternal ("Default");
 
 				foreach (ProjectRunConfiguration runConfig in RunConfigurations) {
 
@@ -3026,7 +3048,7 @@ namespace MonoDevelop.Projects
 					ConfigData cdata = configData.FirstOrDefault (cd => cd.Group == pg);
 					var targetProject = runConfig.StoreInUserFile ? userProject : msproject;
 
-					if (runConfig.IsDefaultConfiguration && runConfig.Equals (defaultConfig)) {
+					if (runConfig.IsDefaultConfiguration && runConfig.Equals (defaultBlankRunConfiguration)) {
 						// If the default configuration has the default values, then there is no need to save it.
 						// If this configuration was added after loading the project, we are not adding it to the msproject and we are done.
 						// If this configuration was loaded from the project and later modified to the default values, we dont set cdata.Exists=true,


### PR DESCRIPTION
Two optimizations: first, the default run configuration required for comparing
is generated only once and then cached. Generating the configuration is slow
because it needs a project evaluation.

Second, invalidation of the assembly and package references caches is now
instant. Instead of having to acquire a lock to clear the cache, there is now
a flag that can be set to signal that the cache is invalid and needs refresh.

Also added some logging.

This should fix VSTS issue #530382.