### PR TITLE
Fix serialization issue with ItemProperty and MergeToProject

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -241,9 +241,9 @@ namespace MonoDevelop.Projects.MSBuild
 		/// Notifies that a property has been modified in the project, so that the evaluated
 		/// value for that property in this instance may be out of date.
 		/// </summary>
-		internal void SetPropertyDirty (string name)
+		internal void SetPropertyValueStale (string name)
 		{
-			evaluatedProperties.SetPropertyDirty (name);
+			evaluatedProperties.SetPropertyValueStale (name);
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -236,6 +236,15 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			return engine?.FindUpdateGlobItemsIncludingFile (projectInstance, include, globItem);
 		}
+
+		/// <summary>
+		/// Notifies that a property has been modified in the project, so that the evaluated
+		/// value for that property in this instance may be out of date.
+		/// </summary>
+		internal void SetPropertyDirty (string name)
+		{
+			evaluatedProperties.SetPropertyDirty (name);
+		}
 	}
 
 	class MSBuildProjectInstanceInfo

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyEvaluated.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		internal bool EvaluatedValueModified {
+		internal bool EvaluatedValueIsStale {
 			get { return (flags & LinkedPropertyFlags.EvaluatedValueModified) != 0; }
 			set {
 				if (value)
@@ -105,6 +105,19 @@ namespace MonoDevelop.Projects.MSBuild
 			// Binds this evaluated property to a property defined in a property group, so that if this evaluated property
 			// is modified, the change will be propagated to that linked property.
 			linkedProperty = property;
+
+			if (EvaluatedValueIsStale && property != null) {
+				
+				// This will be true if the property has been modified in the project,
+				// which means that the evaluated value of the property may be out of date.
+				// In that case, we set the EvaluatedValueModified on the linked property,
+				// which means that the property will be saved no matter what the
+				// evaluated value was. Also, InitEvaluatedValue() is not called
+				// because the evaluated value we have is stale
+
+				property.EvaluatedValueModified = true;
+				return;
+			}
 
 			// Initialize the linked property with the evaluated property only if it has not yet modified (it doesn't have
 			// its own value).

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyEvaluated.cs
@@ -71,6 +71,16 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
+		internal bool EvaluatedValueModified {
+			get { return (flags & LinkedPropertyFlags.EvaluatedValueModified) != 0; }
+			set {
+				if (value)
+					flags |= LinkedPropertyFlags.EvaluatedValueModified;
+				else
+					flags &= ~LinkedPropertyFlags.EvaluatedValueModified;
+			}
+		}
+
 		public MSBuildProperty LinkedProperty {
 			get {
 				return linkedProperty;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
@@ -175,12 +175,12 @@ namespace MonoDevelop.Projects.MSBuild
 		/// Notifies that a property has been modified in the project, so that the evaluated
 		/// value for that property in this instance *may* be out of date.
 		/// </summary>
-		internal void SetPropertyDirty (string name)
+		internal void SetPropertyValueStale (string name)
 		{
 			var p = (MSBuildPropertyEvaluated)GetProperty (name);
 			if (p == null)
 				p = AddProperty (name);
-			p.EvaluatedValueModified = true;
+			p.EvaluatedValueIsStale = true;
 		}
 
 		public void RemoveRedundantProperties ()
@@ -259,14 +259,6 @@ namespace MonoDevelop.Projects.MSBuild
 				if (p == null)
 					p = AddProperty (prop.Name);
 				p.LinkToProperty (prop);
-
-				// This will be true if the property has been modified in the project,
-				// which means that the evaluated value of the property may be out of date.
-				// In that case, we set the EvaluatedValueModified on the linked property,
-				// which means that the property will be saved no matter what the
-				// evaluated value was.
-				if (p.EvaluatedValueModified)
-					prop.EvaluatedValueModified = true;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
@@ -171,6 +171,18 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
+		/// <summary>
+		/// Notifies that a property has been modified in the project, so that the evaluated
+		/// value for that property in this instance *may* be out of date.
+		/// </summary>
+		internal void SetPropertyDirty (string name)
+		{
+			var p = (MSBuildPropertyEvaluated)GetProperty (name);
+			if (p == null)
+				p = AddProperty (name);
+			p.EvaluatedValueModified = true;
+		}
+
 		public void RemoveRedundantProperties ()
 		{
 			// Remove properties whose value is the same as the one set in the global group
@@ -247,6 +259,14 @@ namespace MonoDevelop.Projects.MSBuild
 				if (p == null)
 					p = AddProperty (prop.Name);
 				p.LinkToProperty (prop);
+
+				// This will be true if the property has been modified in the project,
+				// which means that the evaluated value of the property may be out of date.
+				// In that case, we set the EvaluatedValueModified on the linked property,
+				// which means that the property will be saved no matter what the
+				// evaluated value was.
+				if (p.EvaluatedValueModified)
+					prop.EvaluatedValueModified = true;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3036,8 +3036,8 @@ namespace MonoDevelop.Projects
 				foreach (var p in globalGroup.GetProperties ()) {
 					if (p.Modified) {
 						foreach (ProjectConfiguration config in Configurations)
-                            if (config.ProjectInstance != null)
-    							config.ProjectInstance.SetPropertyDirty (p.Name);
+							if (config.ProjectInstance != null)
+								config.ProjectInstance.SetPropertyValueStale (p.Name);
 					}
 				}
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2969,7 +2969,7 @@ namespace MonoDevelop.Projects
 					ConfigData cdata = FindPropertyGroup (configData, conf);
 					var propGroup = (MSBuildPropertyGroup)cdata.Group;
 
-					// Get properties wit the MergeToProject flag, and check that the value they have matches the
+					// Get properties with the MergeToProject flag, and check that the value they have matches the
 					// value all the other groups have so far. If one of the groups have a different value for
 					// the same property, then the property is discarded as mergeable to parent.
 					CollectMergetoprojectProperties (propGroup, mergeToProjectProperties, mergeToProjectPropertyValues);
@@ -3005,6 +3005,22 @@ namespace MonoDevelop.Projects
 
 				foreach (ProjectConfiguration config in Configurations)
 					config.MainPropertyGroup.ResetIsNewFlags ();
+
+
+				// For properties that have changed in the main group, set the
+				// dirty flag for the corresponding properties in the evaluated
+				// project instances. The evaluated values of those properties
+				// can't be used anymore to decide wether or not a property
+				// needs to be saved. The ideal solution would be to re-evaluate
+				// the instance and get the new evaluated values, but that
+				// would have a high impact in performance.
+
+				foreach (var p in globalGroup.GetProperties ()) {
+					if (p.Modified) {
+						foreach (ProjectConfiguration config in Configurations)
+							config.ProjectInstance.SetPropertyDirty (p.Name);
+					}
+				}
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3018,7 +3018,8 @@ namespace MonoDevelop.Projects
 				foreach (var p in globalGroup.GetProperties ()) {
 					if (p.Modified) {
 						foreach (ProjectConfiguration config in Configurations)
-							config.ProjectInstance.SetPropertyDirty (p.Name);
+                            if (config.ProjectInstance != null)
+    							config.ProjectInstance.SetPropertyDirty (p.Name);
 					}
 				}
 			}

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging10.csproj
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging10.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.csproj
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.csproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="TestConfigurationMerging11.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.csproj.saved
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.csproj.saved
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="TestConfigurationMerging11.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.csproj.saved2
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.csproj.saved2
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="TestConfigurationMerging11.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.props
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging11.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging9.csproj
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging9.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging9.csproj.saved
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging9.csproj.saved
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging9.csproj.saved2
+++ b/main/tests/test-projects/test-configuration-merging/TestConfigurationMerging9.csproj.saved2
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BFE8691A-D323-4622-9021-7B8B27F81599}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>mdhost</AssemblyName>
+    <RootNamespace>mdhost</RootNamespace>
+    <OutputPath>..\..\..\build\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
After saving a project, if properties are changed in the main group, make
sure the initially evaluated values for those properties are not used
anymore to decide wether or not the property has to be serialized,
since the values may not be valid anymore.

Fixes VSTS bug #518933.