### PR TITLE
Fix potential project save issue

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -999,8 +999,15 @@ namespace MonoDevelop.Projects
 				return refs;
 
 			using (await referenceCacheLock.EnterAsync ().ConfigureAwait (false)) {
+
+				if (referenceCacheNeedsRefresh) {
+					// Refresh requested. Clear the whole cache.
+					referenceCache = ImmutableDictionary<string, List<AssemblyReference>>.Empty;
+					referenceCacheNeedsRefresh = false;
+				}
+
 				// Check again the cache before starting the task
-				if (!referenceCacheNeedsRefresh && referenceCache.TryGetValue (confId, out refs))
+				if (referenceCache.TryGetValue (confId, out refs))
 					return refs;
 
 				var monitor = new ProgressMonitor ();
@@ -1016,7 +1023,6 @@ namespace MonoDevelop.Projects
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();
 
 				referenceCache = referenceCache.SetItem (confId, refs);
-				referenceCacheNeedsRefresh = false;
 			}
 			return refs;
 		}
@@ -1054,8 +1060,15 @@ namespace MonoDevelop.Projects
 				return packageDependencies;
 			
 			using (await packageDependenciesCacheLock.EnterAsync ().ConfigureAwait (false)) {
+
+				if (packageDependenciesNeedRefresh) {
+					// Refresh requested. Clear the whole cache.
+					packageDependenciesCache = ImmutableDictionary<string, List<PackageDependency>>.Empty;
+					packageDependenciesNeedRefresh = false;
+				}
+
 				// Check the cache before starting the task
-				if (!packageDependenciesNeedRefresh && packageDependenciesCache.TryGetValue (confId, out packageDependencies))
+				if (packageDependenciesCache.TryGetValue (confId, out packageDependencies))
 					return packageDependencies;
 
 				var monitor = new ProgressMonitor ().WithCancellationToken (cancellationToken);
@@ -1074,7 +1087,6 @@ namespace MonoDevelop.Projects
 				packageDependencies = result.Items.Select (i => PackageDependency.Create (i)).Where (dependency => dependency != null).ToList ();
 
 				packageDependenciesCache = packageDependenciesCache .SetItem (confId, packageDependencies);
-				packageDependenciesNeedRefresh = false;
 			}
 
 			return packageDependencies;


### PR DESCRIPTION
When the flag for clearing the references cache is set, clear the whole
cache. The current implementation was just forcing a re-query of the
configuration being requested, and that's not enough. Cached references
for all configurations must be cleared.