### PR TITLE
[Refactoring] Fix quick fixes not appearing for compiler errors

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/CSharpParsedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/CSharpParsedDocument.cs
@@ -517,8 +517,8 @@ namespace MonoDevelop.CSharp.Parser
 		static readonly IReadOnlyList<Error> emptyErrors = Array.Empty<Error> ();
 		public override async Task<IReadOnlyList<Error>> GetErrorsAsync (CancellationToken cancellationToken = default(CancellationToken))
 		{
-			if (Ide.IdeApp.Preferences.EnableSourceAnalysis)
-				return emptyErrors;
+			//if (Ide.IdeApp.Preferences.EnableSourceAnalysis)
+			//	return emptyErrors;
 			
 			var model = GetAst<SemanticModel> ();
 			if (model == null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -103,8 +103,8 @@ namespace MonoDevelop.Ide.TypeSystem
 				IdeApp.Workspace.ActiveConfigurationChanged += HandleActiveConfigurationChanged;
 			}
 			ISolutionCrawlerRegistrationService solutionCrawler = Services.GetService<ISolutionCrawlerRegistrationService> ();
-			Options = Options.WithChangedOption (Microsoft.CodeAnalysis.Diagnostics.InternalRuntimeDiagnosticOptions.Syntax, true)
-				.WithChangedOption (Microsoft.CodeAnalysis.Diagnostics.InternalRuntimeDiagnosticOptions.Semantic, true);
+			//Options = Options.WithChangedOption (Microsoft.CodeAnalysis.Diagnostics.InternalRuntimeDiagnosticOptions.Syntax, true)
+			//	.WithChangedOption (Microsoft.CodeAnalysis.Diagnostics.InternalRuntimeDiagnosticOptions.Semantic, true);
 
 			if (IdeApp.Preferences.EnableSourceAnalysis) {
 				solutionCrawler.Register (this);


### PR DESCRIPTION
The old code fixes code runs diagnostics manually, so compiler diagnostics are skipped. We need to retain backwards compat here, will enable the new error system in editorFeatures

cc @mrward 