### PR TITLE
[Core] Fix failure to create add new file to project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1523,7 +1523,7 @@ namespace MonoDevelop.Projects
 			string root = null;
 			string dirNamespc = null;
 			string defaultNmspc = !string.IsNullOrEmpty (defaultNamespace)
-				? SanitisePotentialNamespace (defaultNamespace)
+				? SanitisePotentialNamespace (defaultNamespace) ?? "Application"
 				: SanitisePotentialNamespace (project.Name) ?? "Application";
 
 			if (string.IsNullOrEmpty (fileName)) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -799,5 +799,24 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual ("abctest", defaultNamespace);
 		}
+
+		[TestCase ("ProjectName", null, "ProjectName")]
+		[TestCase ("ProjectName", "", "ProjectName")]
+		[TestCase ("ProjectName", "MyProject", "MyProject")]
+		[TestCase ("1", "", "Application")]
+		[TestCase ("ProjectName", "1", "Application")]
+		public void GetDefaultNamespace_NullFileName (
+			string projectName,
+			string projectDefaultNamespace,
+			string expectedDefaultNamespace)
+		{
+			var project = Services.ProjectService.CreateDotNetProject ("C#");
+			project.Name = projectName;
+			project.DefaultNamespace = projectDefaultNamespace;
+
+			string result = project.GetDefaultNamespace (null);
+
+			Assert.AreEqual (expectedDefaultNamespace, result);
+		}
 	}
 }


### PR DESCRIPTION
If a project has a default namespace of '1' then adding a new C#
file from a template to the project would throw a null reference
exception in the FileTemplateTagsModifier.ModifyTags method since
the namespace returned from DotNetProject.GetDefaultNamespace was
null. The problem was that the sanitized namespace for the default
namespace was null.

VSTS 524637