### PR TITLE
[TextEditor] IDE crash when closing C# files

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -2542,7 +2542,7 @@ namespace MonoDevelop.SourceEditor
 
 		IReadonlyTextDocument ITextEditorImpl.Document {
 			get {
-				return widget.TextEditor.Document;
+				return widget.TextEditor?.Document;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -409,7 +409,8 @@ namespace MonoDevelop.Ide.Editor
 
 		public int Length {
 			get {
-				return ReadOnlyTextDocument.Length;
+				var rotd = ReadOnlyTextDocument;
+				return rotd != null ? rotd.Length : 0;
 			}
 		}
 


### PR DESCRIPTION
Check that TextEditor isn't null before accessing it.

Fixes VSTS #513338