### PR TITLE
[d15-6][NUnit] NUnit PackageReference not recognized

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
@@ -209,6 +209,8 @@ namespace MonoDevelop.UnitTesting.NUnit
 				Runtime.RunInMainThread (delegate {
 					if (ld.Error != null)
 						this.ErrorMessage = ld.Error.Message;
+					else
+						ErrorMessage = string.Empty;
 					AsyncCreateTests (ld);
 				});
 			};

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
@@ -135,7 +135,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 		{
 			if (p.Include.IndexOf ("GuiUnit", StringComparison.OrdinalIgnoreCase) != -1)
 				return NUnitVersion.NUnit2;
-			if (p.Include.IndexOf ("nunit.framework", StringComparison.OrdinalIgnoreCase) != -1)
+			if (p.Include.IndexOf ("nunit", StringComparison.OrdinalIgnoreCase) != -1)
 				return p.IsAtLeastVersion (new Version (3, 0)) ? NUnitVersion.NUnit3 : NUnitVersion.NUnit2;
 			return null;
 		}


### PR DESCRIPTION
The Unit Tests window would not show any unit tests when the project
contained an NUnit PackageReference.

Also fixed the load error not being cleared from the Unit Tests window.