### PR TITLE
[NUnit] Fix load error displayed for ignored tests

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnitTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnitTestRunner.cs
@@ -149,6 +149,15 @@ namespace NUnit3Runner
 
 		bool CheckXmlForError(XmlElement root, out string result)
 		{
+			if (root.GetAttribute ("type") != "Assembly" || root.GetAttribute ("runstate") != "NotRunnable") {
+				// Only interested in _SKIPREASON if the test-suite is an assembly and the
+				// state is NotRunnable. This will indicate a load failure. This check
+				// prevents Ignore attributes incorrectly indicating an error since these
+				// also have a _SKIPREASON.
+				result = null;
+				return false;
+			}
+
 			var elements = root.GetElementsByTagName ("properties");
 			var skipReasonString = string.Empty;
 			foreach (XmlElement element in elements)


### PR DESCRIPTION
When a test used an Ignore attribute the Unit Tests window would
show a load error for the entire project and prevent any tests from
being run. The problem was that the load error check was looking for
a _SKIPREASON property on every test-suite xml element in the xml
produced by NUnit v3. When an Ignore attribute is used the xml has a
_SKIPREASON property for the test case and that was being found and
treated as an error. To avoid this only a test-suite xml element that
has a type of Assembly and has a runstate of NotRunnable is checked
for a _SKIPREASON.

VSTS 544671