### PR TITLE
[Backport] Fix 525841 - Unit tests window displays blank after  the .Net Core xu…

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageManagementProjectOperations.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageManagementProjectOperations.cs
@@ -114,6 +114,7 @@ namespace MonoDevelop.PackageManagement
 
 		event EventHandler<PackageManagementPackageReferenceEventArgs> PackageReferenceAdded;
 		event EventHandler<PackageManagementPackageReferenceEventArgs> PackageReferenceRemoved;
+		event EventHandler PackagesRestored;
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProjectOperations.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProjectOperations.cs
@@ -52,10 +52,12 @@ namespace MonoDevelop.PackageManagement
 
 			packageManagementEvents.PackageInstalled += PackageInstalled;
 			packageManagementEvents.PackageUninstalled += PackageUninstalled;
+			packageManagementEvents.PackagesRestored += OnPackagesRestored;
 		}
 
 		public event EventHandler<PackageManagementPackageReferenceEventArgs> PackageReferenceAdded;
 		public event EventHandler<PackageManagementPackageReferenceEventArgs> PackageReferenceRemoved;
+		public event EventHandler PackagesRestored;
 
 		public void InstallPackages (
 			string packageSourceUrl,
@@ -302,6 +304,11 @@ namespace MonoDevelop.PackageManagement
 		void PackageInstalled (object sender, PackageManagementEventArgs e)
 		{
 			OnPackageReferenceAdded (e);
+		}
+
+		void OnPackagesRestored (object sender, EventArgs e)
+		{
+			PackagesRestored?.Invoke (sender, e);
 		}
 
 		void OnPackageReferencedRemoved (PackageManagementEventArgs e)

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
@@ -82,9 +82,16 @@ namespace MonoDevelop.UnitTesting.VsTest
 						return cachePackages.Item2;
 
 				var result = string.Empty;
+				bool cache = true;
 				foreach (var folder in nugetsFolders) {
-					if (string.IsNullOrEmpty (folder) || !Directory.Exists (folder))
+					if (string.IsNullOrEmpty (folder))
 						continue;
+					if (!Directory.Exists (folder)) {
+						//NuGet gives us valid location of where package will be restored
+						//so we may not cache invalid result until package has been actually restored
+						cache = false;
+						continue;
+					}
 					foreach (var path in Directory.GetFiles (folder, "*.TestAdapter.dll", SearchOption.AllDirectories))
 						result += path + ";";
 					foreach (var path in Directory.GetFiles (folder, "*.testadapter.dll", SearchOption.AllDirectories))
@@ -94,7 +101,8 @@ namespace MonoDevelop.UnitTesting.VsTest
 				if (result.Length > 0)
 					result = result.Remove (result.Length - 1);
 				projectTestAdapterListCache.Remove (project);
-				projectTestAdapterListCache.Add (project, new Tuple<HashSet<string>, string> (new HashSet<string> (nugetsFolders), result));
+				if (cache)
+					projectTestAdapterListCache.Add (project, new Tuple<HashSet<string>, string> (new HashSet<string> (nugetsFolders), result));
 				return result;
 			}
 		}

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -64,6 +64,7 @@ namespace MonoDevelop.UnitTesting
 
 			PackageManagementServices.ProjectOperations.PackageReferenceAdded += ProjectOperations_PackageReferencesModified;
 			PackageManagementServices.ProjectOperations.PackageReferenceRemoved += ProjectOperations_PackageReferencesModified;
+			PackageManagementServices.ProjectOperations.PackagesRestored += ProjectOperations_PackageReferencesModified;
 
 			Mono.Addins.AddinManager.AddExtensionNodeHandler ("/MonoDevelop/UnitTesting/TestProviders", OnExtensionChange);
 
@@ -323,7 +324,7 @@ namespace MonoDevelop.UnitTesting
 
 		static CancellationTokenSource throttling = new CancellationTokenSource ();
 
-		static void ProjectOperations_PackageReferencesModified (object sender, PackageManagementPackageReferenceEventArgs e)
+		static void ProjectOperations_PackageReferencesModified(object sender, EventArgs e)
 		{
 			throttling.Cancel ();
 			throttling = new CancellationTokenSource ();
@@ -332,6 +333,11 @@ namespace MonoDevelop.UnitTesting
 					return;
 				RebuildTests ();
 			}, throttling.Token, TaskContinuationOptions.None, Runtime.MainTaskScheduler);
+		}
+
+		static void ProjectOperations_PackageReferencesModified (object sender, PackageManagementPackageReferenceEventArgs e)
+		{
+			ProjectOperations_PackageReferencesModified (sender, e);
 		}
 
 		static bool IsSolutionGroupPresent (Solution sol, IEnumerable<UnitTest> tests)


### PR DESCRIPTION
…nits console project is build after restoring the Nuget packages

https://github.com/mono/monodevelop/pull/3710 but for master