### PR TITLE
[d15-6][Ide] Remove NuGet imports when migrating to project.json

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/PortableRuntimeOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/PortableRuntimeOptionsPanel.cs
@@ -38,6 +38,7 @@ using Gtk;
 using MonoDevelop.Ide.Gui.Dialogs;
 using Newtonsoft.Json.Linq;
 using MonoDevelop.Ide.Editor;
+using MonoDevelop.Projects.MSBuild;
 
 namespace MonoDevelop.Ide.Projects.OptionPanels
 {
@@ -376,7 +377,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			return false;
 		}
 
-		static ProjectFile MigrateToProjectJson (DotNetProject project)
+		internal static ProjectFile MigrateToProjectJson (DotNetProject project)
 		{
 			var projectJsonName = project.BaseDirectory.Combine ("project.json");
 			var projectJsonFile = new ProjectFile (projectJsonName, BuildAction.None);
@@ -401,6 +402,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 				);
 			}
 
+			List<string> packages = null;
 			var packagesConfigFile = project.GetProjectFile (project.BaseDirectory.Combine ("packages.config"));
 			if (packagesConfigFile != null) {
 				//NOTE: it might also be open and unsaved, but that's an unimportant edge case, ignore it
@@ -408,7 +410,13 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 				if (configDoc.Root != null) {
 					var deps = (json ["dependencies"] as JObject) ?? ((JObject)(json ["dependencies"] = new JObject ()));
 					foreach (var packagelEl in configDoc.Root.Elements ("package")) {
-						deps [(string)packagelEl.Attribute ("id")] = (string)packagelEl.Attribute ("version");
+						var packageId = (string)packagelEl.Attribute ("id");
+						var packageVersion = (string)packagelEl.Attribute ("version");
+						deps [packageId] = packageVersion;
+
+						if (packages == null)
+							packages = new List<string> ();
+						packages.Add (packageId + "." + packageVersion);
 					}
 				}
 			}
@@ -433,6 +441,16 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 
 				//remove the package refs nuget put in the file, project.json doesn't use those
 				project.References.RemoveRange (project.References.Where (IsFromPackage).ToArray ());
+
+				// Remove any imports from NuGet packages. These will be added by NuGet into the generated
+				// ProjectName.nuget.props and ProjectName.nuget.targets files when using project.json.
+				if (packages != null) {
+					foreach (var import in project.MSBuildProject.Imports.ToArray ()) {
+						if (packages.Any (p => import.Project.IndexOf (p, StringComparison.OrdinalIgnoreCase) >= 0)) {
+							import.ParentObject.ParentProject.Remove (import);
+						}
+					}
+				}
 			}
 
 			return projectJsonFile;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/PclToProjectJsonConversionTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/PclToProjectJsonConversionTests.cs
@@ -1,0 +1,64 @@
+﻿//
+// PclToProjectJsonConversionTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+using MonoDevelop.Ide.Projects.OptionPanels;
+
+namespace MonoDevelop.Ide.Projects
+{
+	[TestFixture]
+	public class PclToProjectJsonConversionTests : TestBase
+	{
+		/// <summary>
+		/// Tests that the project.json file is added to the project and the Xamarin.Forms
+		/// MSBuild import is removed.
+		/// </summary>
+		[Test]
+		public async Task MigrateXamarinFormsPclProjectToProjectJson ()
+		{
+			FilePath solFile = Util.GetSampleProject ("XamarinFormsPcl", "XamarinFormsPcl.sln");
+
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (DotNetProject)sol.Items [0];
+			string expectedProjectXml = File.ReadAllText (p.FileName.ChangeName ("XamarinFormsPcl-migrated"));
+
+			var projectJsonFile = PortableRuntimeOptionsPanelWidget.MigrateToProjectJson (p);
+			await p.SaveAsync (Util.GetMonitor ());
+
+			string projectXml = File.ReadAllText (p.FileName);
+			Assert.AreEqual (BuildAction.None, projectJsonFile.BuildAction);
+			Assert.AreEqual (p.BaseDirectory.Combine ("project.json"), projectJsonFile.FilePath);
+			Assert.AreEqual (expectedProjectXml, projectXml);
+			sol.Dispose ();
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="MonoDevelop.Ide.Gui\ReslynCompletionDataTests.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\MockCompletionView.cs" />
     <Compile Include="MonoDevelop.Ide\MonoDocDocumentationProviderTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\PclToProjectJsonConversionTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl.sln
+++ b/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamarinFormsPcl", "XamarinFormsPcl\XamarinFormsPcl.csproj", "{9A359D60-E8E0-4E37-8C80-544A71EB6C46}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9A359D60-E8E0-4E37-8C80-544A71EB6C46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A359D60-E8E0-4E37-8C80-544A71EB6C46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A359D60-E8E0-4E37-8C80-544A71EB6C46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A359D60-E8E0-4E37-8C80-544A71EB6C46}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl/XamarinFormsPcl-migrated.csproj
+++ b/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl/XamarinFormsPcl-migrated.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9A359D60-E8E0-4E37-8C80-544A71EB6C46}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <UseMSBuildEngine>true</UseMSBuildEngine>
+    <OutputType>Library</OutputType>
+    <RootNamespace>XamarinFormsPcl</RootNamespace>
+    <AssemblyName>XamarinFormsPcl</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl/XamarinFormsPcl.csproj
+++ b/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl/XamarinFormsPcl.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9A359D60-E8E0-4E37-8C80-544A71EB6C46}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <UseMSBuildEngine>true</UseMSBuildEngine>
+    <OutputType>Library</OutputType>
+    <RootNamespace>XamarinFormsPcl</RootNamespace>
+    <AssemblyName>XamarinFormsPcl</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.0.121934\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.121934\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
+</Project>

--- a/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl/packages.config
+++ b/main/tests/test-projects/XamarinFormsPcl/XamarinFormsPcl/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Forms" version="2.5.0.121934" targetFramework="portable45-net45+win8+wpa81" />
+</packages>


### PR DESCRIPTION
When a PCL project was migrated to project.json the imports for
MSBuild .targets were not removed. These imports are added by NuGet
into the generated ProjectName.nuget.props and
ProjectName.nuget.targets files on restoring when a project.json file
is used. Having the import in the project file results in the import
being used twice. When a PCL project that uses Xamarin.Forms was
migrated to project.json the build would fail with an error:

Error XF001: Xamarin.Forms targets have been imported multiple times.
Please check your project file and remove the duplicate import(s).

Now on migrating the imports from the packages that were used by
the project are removed from the project file.

VSTS 552280