### PR TITLE
[d15-6][UnitTesting] Fix stackoverflow when installing NuGet packages

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -320,11 +320,6 @@ namespace MonoDevelop.UnitTesting
 			}, throttling.Token, TaskContinuationOptions.None, Runtime.MainTaskScheduler);
 		}
 
-		static void ProjectOperations_PackageReferencesModified (object sender, PackageManagementPackageReferenceEventArgs e)
-		{
-			ProjectOperations_PackageReferencesModified (sender, e);
-		}
-
 		static bool IsSolutionGroupPresent (Solution sol, IEnumerable<UnitTest> tests)
 		{
 			foreach (var t in tests) {


### PR DESCRIPTION
The NuGet package install/remove event handler method was calling
itself. Removed the duplicate event handler method since it is not
needed.