### PR TITLE
[Core] Fix TypeInitializationException using file watcher on Windows

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/FileSystemWatcher.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/FileSystemWatcher.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.FSW
 		static FileSystemWatcher ()
 		{
 			try {
-				if (HasOSXSupport ()) {
+				if (Core.Platform.IsMac && HasOSXSupport ()) {
 					_platform = Platform.OSX;
 					return;
 				}


### PR DESCRIPTION
A TypeInitializationException is thrown when a .NET Core project
is used on Windows. On Windows when a DllImport cannot be found a
DllNotFoundException is thrown not an EntryPointNotFoundException. To
avoid this the native Mac support check is now only run when the
platform is Mac.