### PR TITLE
[Ide] Use void instead of bool for pinvoke return types

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -603,11 +603,11 @@ namespace MonoDevelop.Components
 
 		//introduced in GTK 2.20
 		[DllImport (PangoUtil.LIBGDK, CallingConvention = CallingConvention.Cdecl)]
-		extern static bool gdk_keymap_add_virtual_modifiers (IntPtr keymap, ref Gdk.ModifierType state);
+		extern static void gdk_keymap_add_virtual_modifiers (IntPtr keymap, ref Gdk.ModifierType state);
 
 		//Custom patch in Mono Mac w/GTK+ 2.24.8+
 		[DllImport (PangoUtil.LIBGDK, CallingConvention = CallingConvention.Cdecl)]
-		extern static bool gdk_quartz_set_fix_modifiers (bool fix);
+		extern static void gdk_quartz_set_fix_modifiers (bool fix);
 
 		static Gdk.Keymap keymap = Gdk.Keymap.Default;
 		static Dictionary<ulong,MappedKeys> mappedKeys = new Dictionary<ulong,MappedKeys> ();


### PR DESCRIPTION
This matches these two functions to the C return types

See https://github.com/bratsche/gtk/blob/393f44073cf81c17d8c84138d3fa0549b6f07cf4/gdk/quartz/gdkkeys-quartz.c#L778

https://github.com/bratsche/gtk/blob/393f44073cf81c17d8c84138d3fa0549b6f07cf4/gdk/quartz/gdkglobals-quartz.c#L53