### PR TITLE
Fix --verify-all MonoArg attribute

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/MonoExecutionParameters.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/MonoExecutionParameters.cs
@@ -352,7 +352,7 @@ namespace MonoDevelop.Projects
 		[LocalizedDisplayName ("Verify All")]
 		[LocalizedDescription ("Verifies mscorlib and assemblies in the global assembly cache " +
 		              "for valid IL, and all user code for IL verifiability.")]
-		[MonoArg ("--verifyAll")]
+		[MonoArg ("--verify-all")]
 		[ItemProperty (DefaultValue=false)]
 		public bool MonoVerifyAll { get; set; }
 		


### PR DESCRIPTION
The option is `--verify-all`, not `--verifyAll`.

This was discovered while trying to debug something that needed the `--verify-all` option set. MonoDevelop just hung when pressing F5 to start the program. After enabling the show terminal option, I discovered that it said "unknown option --verifyAll".