### PR TITLE
Fixes "VSTS 524616 - can't refresh the website successfully after del…

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -234,7 +234,6 @@ namespace Mono.TextEditor
 		{
 			if (args.Changes == null)
 				return;
-			cachedText = null;
 			var changes = new List<TextChange> ();
 			foreach (var change in args.Changes) {
 				changes.Add (new TextChange (change.OldPosition, change.NewPosition, change.OldText, change.NewText));
@@ -337,17 +336,9 @@ namespace Mono.TextEditor
 
 		public bool SuppressHighlightUpdate { get; set; }
 		internal DocumentLine longestLineAtTextSet;
-		WeakReference cachedText;
 
 		public string Text {
-			get {
-				string completeText = cachedText != null ? (cachedText.Target as string) : null;
-				if (completeText == null) {
-					completeText = this.currentSnapshot.GetText ();
-					cachedText = new WeakReference(completeText);
-				}
-				return completeText;
-			}
+			get => currentSnapshot.GetText ();
 			set {
 				var tmp = IsReadOnly;
 				IsReadOnly = false;

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/DocumentTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/DocumentTests.cs
@@ -40,7 +40,7 @@ namespace Mono.TextEditor.Tests
 		public void TestDocumentCreation ()
 		{
 			var document = new Mono.TextEditor.TextDocument ();
-			
+
 			string text = 
 			"1234567890\n" +
 			"12345678\n" +
@@ -194,6 +194,22 @@ namespace Mono.TextEditor.Tests
 			} finally {
 				File.Delete (path);
 			}
+		}
+
+		/// <summary>
+		/// VSTS 524616 can't refresh the website successfully after delete the content in '.cshtml' file
+		/// </summary>
+		[Test]
+		public void TestVSTS524616 ()
+		{
+			var document = new Mono.TextEditor.TextDocument ();
+			document.Text = "test";
+			string txt;
+			document.TextChanging += delegate {
+				txt = document.Text;
+			};
+			document.InsertText (0, "test");
+			Assert.AreEqual ("testtest", document.Text);
 		}
 	}
 }


### PR DESCRIPTION
…ete the content in '.cshtml' file"

https://devdiv.visualstudio.com/DevDiv/_workitems?id=524616
Was caused by an incompatibility of the vs text buffer with our text buffer due to the changed event behavior.