### PR TITLE
[IDE] Previous solution not opened if projects are favourited

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentOpen.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/RecentOpen.cs
@@ -185,6 +185,12 @@ namespace MonoDevelop.Ide.Desktop
 			return OnGetFiles ();
 		}
 
+		public RecentFile MostRecentlyUsedProject {
+			get {
+				return OnGetProjects ().FirstOrDefault ();
+			}
+		}
+
 		public abstract event EventHandler Changed;
 		public abstract void ClearProjects ();
 		public abstract void ClearFiles ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -239,7 +239,7 @@ namespace MonoDevelop.Ide
 				// load previous combine
 				RecentFile openedProject = null;
 				if (IdeApp.Preferences.LoadPrevSolutionOnStartup && !startupInfo.HasSolutionFile && !IdeApp.Workspace.WorkspaceItemIsOpening && !IdeApp.Workspace.IsOpen) {
-					openedProject = DesktopService.RecentFiles.GetProjects ().FirstOrDefault ();
+					openedProject = DesktopService.RecentFiles.MostRecentlyUsedProject;
 					if (openedProject != null)
 						IdeApp.Workspace.OpenWorkspaceItem (openedProject.FileName).ContinueWith (t => IdeApp.OpenFiles (startupInfo.RequestedFileList), TaskScheduler.FromCurrentSynchronizationContext ());
 				}


### PR DESCRIPTION
RecentFiles.GetProjects sorts the favourited projects first in the list, which
isn't what we want when opening the most recently used project. Create a
MostRecentlyUsedProject property and use it instead

Fixes VSTS #536619