### PR TITLE
Consume new IFilePathRegistryService from vs platform to allow the fi…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -128,6 +128,11 @@
       <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.Threading.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Implementation">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Posix" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/PlatformCatalog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/PlatformCatalog.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.Platform
                 return mimeType;
             }
 
-            return null;
+            return (ContentTypeRegistryService as IContentTypeRegistryService2).GetMimeType (type);
         }
 
         public IContentType GetContentType(string type)
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.Platform
                 return contentType;
             }
 
-            return null;
+            return (ContentTypeRegistryService as IContentTypeRegistryService2).GetContentTypeForMimeType (type);
         }
 
         public void LinkTypes(string mimeType, IContentType contentType)
@@ -136,15 +136,6 @@ namespace Microsoft.VisualStudio.Platform
 		{
 			LinkTypes ("text/plain", "text");
 			LinkTypes ("text/x-csharp", "csharp");
-
-			if (this.ContentTypeRegistryService.GetContentType ("css") != null) {
-				LinkTypes ("text/x-cshtml-web", "RazorCSharp");
-				LinkTypes ("text/x-css", "css");
-				LinkTypes ("text/x-less-web", "LESS");
-				LinkTypes ("text/x-scss-web", "SCSS");
-				LinkTypes ("text/x-html", "htmlx");
-				LinkTypes ("text/x-json", "JSON");
-			}
 		}
 
 		Tuple<ImmutableDictionary<string, IContentType>, ImmutableDictionary<IContentType, string>> maps = Tuple.Create(ImmutableDictionary<string, IContentType>.Empty, ImmutableDictionary<IContentType, string>.Empty);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -304,7 +304,12 @@ namespace MonoDevelop.Ide.Desktop
 			IContentType contentType = filePathRegistryService.GetContentTypeForPath (fileName);
 			if (contentType != PlatformCatalog.Instance.ContentTypeRegistryService.UnknownContentType) {
 				string mimeType = PlatformCatalog.Instance.MimeToContentTypeRegistryService.GetMimeType(contentType);
-				return FindMimeType (mimeType);
+				if (mimeType != null) {
+					MimeTypeNode mt = FindMimeType(mimeType);
+					if (mt != null) {
+						return mt;
+					}
+				}
 			}
 
 			foreach (MimeTypeNode mt in mimeTypeNodes) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -34,6 +34,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 
+using Microsoft.VisualStudio.Platform;
+using Microsoft.VisualStudio.Utilities;
+
 using Mono.Addins;
 using MonoDevelop.Core;
 using Mono.Unix;
@@ -41,7 +44,7 @@ using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Core.Execution;
 using MonoDevelop.Components;
 using MonoDevelop.Components.MainToolbar;
-
+using MonoDevelop.Ide.Composition;
 
 namespace MonoDevelop.Ide.Desktop
 {
@@ -296,6 +299,14 @@ namespace MonoDevelop.Ide.Desktop
 
 		MimeTypeNode FindMimeTypeForFile (string fileName)
 		{
+			IFilePathRegistryService filePathRegistryService = CompositionManager.GetExportedValue<IFilePathRegistryService> ();
+
+			IContentType contentType = filePathRegistryService.GetContentTypeForPath (fileName);
+			if (contentType != PlatformCatalog.Instance.ContentTypeRegistryService.UnknownContentType) {
+				string mimeType = PlatformCatalog.Instance.MimeToContentTypeRegistryService.GetMimeType(contentType);
+				return FindMimeType (mimeType);
+			}
+
 			foreach (MimeTypeNode mt in mimeTypeNodes) {
 				if (mt.SupportsFile (fileName))
 					return mt;


### PR DESCRIPTION
…le path to determine the content type / mimetype

Remove the LinkTypes code that was specific to webtooling as the code now falls back to using the corresponding methods from IContentTypeRegistryService2