### PR TITLE
Fix NRE in Unit Test Gatherer

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.UnitTesting
 	public abstract class AbstractUnitTestTextEditorExtension : TextEditorExtension
 	{
 		const string TestMarkersPath = "/MonoDevelop/UnitTesting/UnitTestMarkers";
-		static IUnitTestMarkers [] unitTestMarkers;
+		static IUnitTestMarkers [] unitTestMarkers = Array.Empty<IUnitTestMarkers> ();
 
 		static AbstractUnitTestTextEditorExtension ()
 		{


### PR DESCRIPTION
Code is assuming that IUnitTestMarkers [] is never null but I keep hitting this.

```
FATAL ERROR [2018-01-30 10:50:52Z]: An unhandled exception has occured. Terminating Visual Studio? True
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.CSharp.UnitTestTextEditorExtension.HasMethodMarkerAttribute (Microsoft.CodeAnalysis.SemanticModel model, MonoDevelop.UnitTesting.IUnitTestMarkers[] markers) [0x00031] in /Users/jason/src/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp.UnitTests/UnitTestTextEditorExtension.cs:53
  at MonoDevelop.CSharp.UnitTestTextEditorExtension.GatherUnitTests (MonoDevelop.UnitTesting.IUnitTestMarkers[] unitTestMarkers, System.Threading.CancellationToken token) [0x00045] in /Users/jason/src/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp.UnitTests/UnitTestTextEditorExtension.cs:69
  at MonoDevelop.UnitTesting.AbstractUnitTestTextEditorExtension+<>c__DisplayClass9_0.<HandleDocumentParsed>b__0 (System.Object <p0>) [0x00027] in /Users/jason/src/monodevelop/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs:97
  at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context (System.Object state) [0x0000d] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1306
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:957
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:904
  at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00021] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1283
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:856
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1211
```