### PR TITLE
[Editor] Reset IM context when filtering keypresses

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1081,9 +1081,12 @@ namespace Mono.TextEditor
 				return true;
 			}
 			bool filter = IMFilterKeyPress (evt, key, unicodeChar, mod);
-			if (filter)
+			if (filter) {
+				imContextNeedsReset = false;
+				ResetIMContext ();
 				return true;
-			
+			}
+
 			//FIXME: OnIMProcessedKeyPressEvent should return false when it didn't handle the event
 			if (editor.OnIMProcessedKeyPressEvent (key, unicodeChar, mod))
 				return true;


### PR DESCRIPTION
This fixes issues in languages like Japanese and Chinese where
the text isn't visible until it gets committed from the preedit
buffer.

Fixes VSTS #535828