### PR TITLE
[Ide] Add Toggle Completion Mode menu and keys

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -970,7 +970,8 @@
 			shortcut = "Control|space" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ToggleCompletionSuggestionMode"
 			defaultHandler = "MonoDevelop.Ide.Commands.ToggleCompletionSuggestionModeHandler"
-			_label = "Toggle Completion Suggestion Mode" />
+			_label = "Toggle Completion Mode"
+			_displayName = "Toggle Completion Suggestion Mode" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeTemplateWindow"
 			_description="Inserts a snippet"
 			_label = "_Snippet..."

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -970,8 +970,8 @@
 			shortcut = "Control|space" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ToggleCompletionSuggestionMode"
 			defaultHandler = "MonoDevelop.Ide.Commands.ToggleCompletionSuggestionModeHandler"
-			_label = "Toggle Completion Mode"
-			_displayName = "Toggle Completion Suggestion Mode" />
+			_label = "Switch Completion/Suggestion Mode"
+			_displayName = "Switch Completion/Suggestion Mode" />
 	<Command id = "MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeTemplateWindow"
 			_description="Inserts a snippet"
 			_label = "_Snippet..."

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -95,6 +95,7 @@
 		<SeparatorItem id = "Separator5" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.TextEditorCommands.ShowCompletionWindow" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.TextEditorCommands.ShowParameterCompletionWindow" />
+		<CommandItem id = "MonoDevelop.Ide.Commands.TextEditorCommands.ToggleCompletionSuggestionMode" />
 		<SeparatorItem id = "optionssep5" />
 		<Condition id="Platform" value="linux">
 			<CommandItem id = "MonoDevelop.Ide.Commands.EditCommands.MonodevelopPreferences" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/TextEditorCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/TextEditorCommands.cs
@@ -112,5 +112,10 @@ namespace MonoDevelop.Ide.Commands
 		{
 			IdeApp.Preferences.ForceSuggestionMode.Value = !IdeApp.Preferences.ForceSuggestionMode;
 		}
+
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = IdeApp.Workbench.ActiveDocument?.Editor != null;
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/TextEditorCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/TextEditorCommands.cs
@@ -27,6 +27,7 @@
 
 using System;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Commands
 {
@@ -116,6 +117,10 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			info.Enabled = IdeApp.Workbench.ActiveDocument?.Editor != null;
+			if (IdeApp.Preferences.ForceSuggestionMode)
+				info.Text = GettextCatalog.GetString ("Switch to Completion Mode");
+			else
+				info.Text = GettextCatalog.GetString ("Switch to Suggestion Mode");
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio-mac.xml
@@ -125,6 +125,7 @@
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeSurroundingsWindow" shortcut="Meta+K|S Meta+K|Meta+S" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeTemplateWindow" shortcut="Meta+K|X Meta+K|Meta+X" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCompletionWindow" shortcut="Meta+Space Meta+J" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ToggleCompletionSuggestionMode" shortcut="Control+Alt+Space" />
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.CenterAndFocusCurrentDocument" shortcut="" />
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.FocusCurrentDocument" shortcut="F7" />
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.FullScreen" shortcut="Alt+Shift+Return" />

--- a/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
+++ b/main/src/core/MonoDevelop.Ide/options/KeyBindingSchemeVisualStudio.xml
@@ -125,6 +125,7 @@
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeSurroundingsWindow" shortcut="Control+K|S Control+K|Control+S" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeTemplateWindow" shortcut="Control+K|X Control+K|Control+X" />
     <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCompletionWindow" shortcut="Control+Space Control+J" />
+    <binding command="MonoDevelop.Ide.Commands.TextEditorCommands.ToggleCompletionSuggestionMode" shortcut="Control+Alt+Space" />
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.CenterAndFocusCurrentDocument" shortcut="" />
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.FocusCurrentDocument" shortcut="F7" />
     <binding command="MonoDevelop.Ide.Commands.ViewCommands.FullScreen" shortcut="Alt+Shift+Return" />


### PR DESCRIPTION
This PR brings back the "Edit → Toggle Completion Mode" menu entry and adds it's default _Ctrl + Alt + Space_ binding to the VS binding schemes.

<img width="315" alt="grafik" src="https://user-images.githubusercontent.com/951587/35614023-f22e712e-066d-11e8-9605-6fa061227902.png">

EDIT: We can't add _Ctrl + Alt + Space_ as a default MonoDevelop binding, because it would overlap with _Import Symbol_.

Fixes gh #3640