### PR TITLE
[IDE] Use ContextMenu on the Errors and Tasks pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -44,7 +44,7 @@ namespace MonoDevelop.Components
 			if (menu == null)
 				throw new ArgumentNullException ("menu");
 
-			var nsMenu = FromMenu (menu, closeHandler);
+			var nsMenu = FromMenu (menu, closeHandler, null);
 			ShowContextMenu (parent, evt, nsMenu);
 		}
 
@@ -55,7 +55,7 @@ namespace MonoDevelop.Components
 
 		public static void ShowContextMenu (Gtk.Widget parent, int x, int y, ContextMenu menu, Action closeHandler, bool selectFirstItem = false)
 		{
-			var nsMenu = FromMenu (menu, closeHandler);
+			var nsMenu = FromMenu (menu, closeHandler, null);
 			ShowContextMenu (parent, x, y, nsMenu, selectFirstItem);
 		}
 
@@ -128,7 +128,7 @@ namespace MonoDevelop.Components
 				return;
 			}
 
-			var menuItem = new NSMenuItem (item.Label.Replace ("_",""), (s, e) => item.Click ());
+			var menuItem = new NSContextMenuItem (item.Label.Replace ("_",""), item);
 
 			menuItem.Hidden = !item.Visible;
 			menuItem.Enabled = item.Sensitive;
@@ -143,17 +143,35 @@ namespace MonoDevelop.Components
 			} 
 
 			if (item.SubMenu != null && item.SubMenu.Items.Count > 0) {
-				var subMenu = FromMenu (item.SubMenu, null);
-				subMenu.Parent = menu;
+				var subMenu = FromMenu (item.SubMenu, null, menu);
 				menuItem.Submenu = subMenu;
 			}
 
 			menu.AddItem (menuItem);
 		}
 
-		static NSLocationAwareMenu FromMenu (ContextMenu menu, Action closeHandler)
+		class NSContextMenuItem : NSMenuItem
 		{
-			var result = new NSLocationAwareMenu (menu, closeHandler) { AutoEnablesItems = false };
+			readonly WeakReference<ContextMenuItem> contextMenu;
+
+			public NSContextMenuItem (string label, ContextMenuItem item) : base (label)
+			{
+				contextMenu = new WeakReference<ContextMenuItem> (item);
+				this.Activated += OnActivated;
+			}
+
+			static void OnActivated (object sender, EventArgs args)
+			{
+				var obj = (NSContextMenuItem)sender;
+
+				obj.contextMenu.TryGetTarget (out var contextMenuItem);
+				contextMenuItem.Click ();
+			}
+		}
+
+		static NSLocationAwareMenu FromMenu (ContextMenu menu, Action closeHandler, NSLocationAwareMenu parent)
+		{
+			var result = new NSLocationAwareMenu (menu, closeHandler, parent) { AutoEnablesItems = false };
 
 			foreach (var menuItem in menu.Items) {
 				AddMenuItem (result, menuItem);
@@ -172,11 +190,12 @@ namespace MonoDevelop.Components
 		class NSLocationAwareMenu : NSMenu
 		{
 			public CGPoint Location { get; private set; }
-			public NSLocationAwareMenu Parent { get; set; }
+			readonly WeakReference<NSLocationAwareMenu> Parent;
 
-			public NSLocationAwareMenu (ContextMenu menu, Action closeHandler)
+			public NSLocationAwareMenu (ContextMenu menu, Action closeHandler, NSLocationAwareMenu parent)
 			{
 				WeakDelegate = new ContextMenuDelegate (menu) { CloseHandler = closeHandler };
+				Parent = parent != null ? new WeakReference<NSLocationAwareMenu> (parent) : null;
 			}
 
 			public override bool PopUpMenu (NSMenuItem item, CGPoint location, NSView view)
@@ -229,8 +248,8 @@ namespace MonoDevelop.Components
 					nfloat x = 0, y = 0;
 					var locationAwareMenu = menu as NSLocationAwareMenu;
 					if (locationAwareMenu != null) {
-						while (locationAwareMenu.Parent != null)
-							locationAwareMenu = locationAwareMenu.Parent;
+						while (locationAwareMenu.Parent != null && locationAwareMenu.Parent.TryGetTarget (out var other))
+							locationAwareMenu = other;
 						x = locationAwareMenu.Location.X;
 						y = locationAwareMenu.Location.Y;
 						menu = locationAwareMenu;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -164,8 +164,8 @@ namespace MonoDevelop.Components
 			{
 				var obj = (NSContextMenuItem)sender;
 
-				obj.contextMenu.TryGetTarget (out var contextMenuItem);
-				contextMenuItem.Click ();
+				if (obj.contextMenu.TryGetTarget (out var contextMenuItem))
+					contextMenuItem.Click ();
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/PadTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/PadTreeView.cs
@@ -26,7 +26,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Gtk;
+using MonoDevelop.Components;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Gui.Components
 {
@@ -119,6 +122,76 @@ namespace MonoDevelop.Ide.Gui.Components
 		{
 			renderer.FontDesc = IdeApp.Preferences.CustomPadFont;
 			renderers.Add (renderer);
+		}
+
+		// Util helper to check for column visibility
+		public bool IsAColumnVisible ()
+		{
+			foreach (var c in Columns) {
+				if (c.Visible) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	// A ContextMenu to hide and show columns.
+	public class ColumnSelectorMenu : ContextMenu
+	{
+		class ColumnSelectorMenuItem : CheckBoxContextMenuItem
+		{
+			TreeViewColumn column;
+
+			public ColumnSelectorMenuItem (TreeViewColumn column, string label) : base (label)
+			{
+				this.column = column;
+
+				Checked = column.Visible;
+				Clicked += OnItemClicked;
+			}
+
+			void OnItemClicked (object sender, EventArgs args)
+			{
+				column.Visible = Checked;
+				ColumnVisibilityChanged?.Invoke (this, EventArgs.Empty);
+			}
+
+			public event EventHandler ColumnVisibilityChanged;
+		}
+
+		string id;
+
+		public ColumnSelectorMenu (TreeView treeview, string restoreID, params string[] columnNames)
+		{
+			id = restoreID;
+
+			int i = 0;
+			foreach (var column in treeview.Columns) {
+				var name = i < columnNames.Length ? columnNames[i] : null;
+
+				var item = new ColumnSelectorMenuItem (column, string.IsNullOrEmpty(name) ? column.Title : name);
+				item.ColumnVisibilityChanged += OnColumnVisibilityChanged;
+
+				Add (item);
+
+				i++;
+			}
+		}
+
+		void OnColumnVisibilityChanged (object sender, EventArgs args)
+		{
+			StringBuilder builder = new StringBuilder ();
+			foreach (var c in Items) {
+				var item = c as CheckBoxContextMenuItem;
+				if (item == null) {
+					continue;
+				}
+				builder.AppendFormat ("{0};", item.Checked);
+			}
+			builder.Remove (builder.Length - 1, 1);
+
+			PropertyService.Set (id, builder.ToString ());
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/PadTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/PadTreeView.cs
@@ -148,11 +148,11 @@ namespace MonoDevelop.Ide.Gui.Components
 				this.column = column;
 
 				Checked = column.Visible;
-				Clicked += OnItemClicked;
 			}
 
-			void OnItemClicked (object sender, EventArgs args)
+			protected override void DoClick ()
 			{
+				base.DoClick ();
 				column.Visible = Checked;
 				ColumnVisibilityChanged?.Invoke (this, EventArgs.Empty);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -75,8 +75,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 		int infoCount;
 		bool initialLogShow = true;
 
-		Menu menu;
-		Dictionary<ToggleAction, int> columnsActions = new Dictionary<ToggleAction, int> ();
 		Clipboard clipboard;
 
 		Xwt.Drawing.Image iconWarning;
@@ -84,6 +82,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 		Xwt.Drawing.Image iconInfo;
 		Xwt.Drawing.Image iconEmpty;
 
+		static readonly string restoreID = "Monodevelop.ErrorListColumns";
 		public readonly ConfigurationProperty<bool> ShowErrors = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowErrors", true);
 		public readonly ConfigurationProperty<bool> ShowWarnings = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowWarnings", true);
 		public readonly ConfigurationProperty<bool> ShowMessages = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowMessages", true);
@@ -241,7 +240,9 @@ namespace MonoDevelop.Ide.Gui.Pads
 			view.Selection.Mode = SelectionMode.Multiple;
 			view.ShowExpanders = true;
 			view.RulesHint = true;
-			view.DoPopupMenu = (evnt) => IdeApp.CommandService.ShowContextMenu (view, evnt, CreateMenu ());
+
+			view.DoPopupMenu += ShowPopup;
+
 			AddColumns ();
 			LoadColumnsVisibility ();
 			view.Columns [VisibleColumns.Type].SortColumnId = VisibleColumns.Type;
@@ -369,7 +370,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 		void LoadColumnsVisibility ()
 		{
-			var columns = PropertyService.Get ("Monodevelop.ErrorListColumns", string.Join (";", Enumerable.Repeat ("TRUE", view.Columns.Length)));
+			var columns = PropertyService.Get (restoreID, string.Join (";", Enumerable.Repeat ("TRUE", view.Columns.Length)));
 			var tokens = columns.Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 			if (view.Columns.Length == tokens.Length) {
 				for (int i = 0; i < tokens.Length; i++) {
@@ -380,140 +381,46 @@ namespace MonoDevelop.Ide.Gui.Pads
 			}
 		}
 
-		void StoreColumnsVisibility ()
+		void ShowPopup (Gdk.EventButton evt)
 		{
-			PropertyService.Set ("Monodevelop.ErrorListColumns", string.Join (";", view.Columns.Select (c => c.Visible ? "TRUE" : "FALSE")));
-		}
+			var menu = new ContextMenu ();
 
-		Gtk.Menu CreateMenu ()
-		{
-			if (menu != null)
-				return menu;
+			var help = new ContextMenuItem (GettextCatalog.GetString ("Show Error Reference"));
+			help.Clicked += OnShowReference;
+			menu.Add (help);
 
-			var group = new ActionGroup ("Popup");
+			var copy = new ContextMenuItem (GettextCatalog.GetString ("_Copy"));
+			copy.Clicked += OnTaskCopied;
+			menu.Add (copy);
 
-			var help = new Gtk.Action ("help", GettextCatalog.GetString ("Show Error Reference"),
-				GettextCatalog.GetString ("Show Error Reference"), Gtk.Stock.Help);
-			help.Activated += OnShowReference;
-			group.Add (help, "F1");
+			var jump = new ContextMenuItem (GettextCatalog.GetString ("_Go to Task"));
+			jump.Clicked += OnTaskJumpto;
+			menu.Add (jump);
 
-			var copy = new Gtk.Action ("copy", GettextCatalog.GetString ("_Copy"),
-				GettextCatalog.GetString ("Copy task"), Gtk.Stock.Copy);
-			copy.Activated += OnTaskCopied;
-			group.Add (copy, "<Control><Mod2>c");
+			var columnsMenu = new ColumnSelectorMenu (view,
+			                                          restoreID,
+			                                          GettextCatalog.GetString ("Type"),
+			                                          GettextCatalog.GetString ("Validity"));
 
-			var jump = new Gtk.Action ("jump", GettextCatalog.GetString ("_Go to"),
-				GettextCatalog.GetString ("Go to task"), Gtk.Stock.JumpTo);
-			jump.Activated += OnTaskJumpto;
-			group.Add (jump);
+			var columns = new ContextMenuItem (GettextCatalog.GetString ("Columns"));
+			columns.SubMenu = columnsMenu;
+			menu.Add (columns);
 
-			var columns = new Gtk.Action ("columns", GettextCatalog.GetString ("Columns"));
-			group.Add (columns, null);
+			help.Sensitive = copy.Sensitive = jump.Sensitive =
+				view.Selection != null &&
+				view.Selection.CountSelectedRows () > 0 &&
+				view.IsAColumnVisible ();
 
-			var columnType = new ToggleAction ("columnType", GettextCatalog.GetString ("Type"),
-				GettextCatalog.GetString ("Toggle visibility of Type column"), null);
-			columnType.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnType] = VisibleColumns.Type;
-			group.Add (columnType);
+			// Disable Help and Go To if multiple rows selected.
+			if (help.Sensitive && view.Selection.CountSelectedRows () > 1) {
+				help.Sensitive = false;
+				jump.Sensitive = false;
+			}
 
-			var columnValidity = new ToggleAction ("columnValidity", GettextCatalog.GetString ("Validity"),
-				GettextCatalog.GetString ("Toggle visibility of Validity column"), null);
-			columnValidity.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnValidity] = VisibleColumns.Marked;
-			group.Add (columnValidity);
+			string dummyString;
+			help.Sensitive &= GetSelectedErrorReference (out dummyString);
 
-			var columnLine = new ToggleAction ("columnLine", GettextCatalog.GetString ("Line"),
-				GettextCatalog.GetString ("Toggle visibility of Line column"), null);
-			columnLine.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnLine] = VisibleColumns.Line;
-			group.Add (columnLine);
-
-			var columnDescription = new ToggleAction ("columnDescription", GettextCatalog.GetString ("Description"),
-				GettextCatalog.GetString ("Toggle visibility of Description column"), null);
-			columnDescription.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnDescription] = VisibleColumns.Description;
-			group.Add (columnDescription);
-
-			var columnFile = new ToggleAction ("columnFile", GettextCatalog.GetString ("File"),
-				GettextCatalog.GetString ("Toggle visibility of File column"), null);
-			columnFile.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnFile] = VisibleColumns.File;
-			group.Add (columnFile);
-
-			var columnProject = new ToggleAction ("columnProject", GettextCatalog.GetString ("Project"),
-				GettextCatalog.GetString ("Toggle visibility of Project column"), null);
-			columnProject.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnProject] = VisibleColumns.Project;
-			group.Add (columnProject);
-
-			var columnPath = new ToggleAction ("columnPath", GettextCatalog.GetString ("Path"),
-				GettextCatalog.GetString ("Toggle visibility of Path column"), null);
-			columnPath.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnPath] = VisibleColumns.Path;
-			group.Add (columnPath);
-
-			var columnCategory = new ToggleAction ("columnCategory", GettextCatalog.GetString ("Category"),
-												   GettextCatalog.GetString ("Toggle visibility of Category column"), null);
-			columnCategory.Toggled += OnColumnVisibilityChanged;
-			columnsActions [columnCategory] = VisibleColumns.Category;
-			group.Add (columnCategory);
-
-
-
-			var uiManager = new UIManager ();
-			uiManager.InsertActionGroup (group, 0);
-
-			string uiStr = "<ui><popup name='popup'>"
-				+ "<menuitem action='help'/>"
-				+ "<menuitem action='copy'/>"
-				+ "<menuitem action='jump'/>"
-				+ "<separator/>"
-				+ "<menu action='columns'>"
-				+ "<menuitem action='columnType' />"
-				+ "<menuitem action='columnValidity' />"
-				+ "<menuitem action='columnLine' />"
-				+ "<menuitem action='columnDescription' />"
-				+ "<menuitem action='columnFile' />"
-				+ "<menuitem action='columnProject' />"
-				+ "<menuitem action='columnPath' />"
-				+ "<menuitem action='columnCategory' />"
-				+ "</menu>"
-				+ "</popup></ui>";
-
-			uiManager.AddUiFromString (uiStr);
-			menu = (Menu)uiManager.GetWidget ("/popup");
-			menu.ShowAll ();
-
-			menu.Shown += delegate {
-				columnType.Active = view.Columns [VisibleColumns.Type].Visible;
-				columnValidity.Active = view.Columns [VisibleColumns.Marked].Visible;
-				columnLine.Active = view.Columns [VisibleColumns.Line].Visible;
-				columnDescription.Active = view.Columns [VisibleColumns.Description].Visible;
-				columnFile.Active = view.Columns [VisibleColumns.File].Visible;
-				columnProject.Active = view.Columns [VisibleColumns.Project].Visible;
-				columnPath.Active = view.Columns [VisibleColumns.Path].Visible;
-				columnCategory.Active = view.Columns [VisibleColumns.Category].Visible;
-				help.Sensitive = copy.Sensitive = jump.Sensitive =
-					view.Selection != null &&
-					view.Selection.CountSelectedRows () > 0 &&
-					(columnType.Active ||
-						columnValidity.Active ||
-						columnLine.Active ||
-						columnDescription.Active ||
-						columnFile.Active ||
-						columnPath.Active);
-
-				// Disable Help and Go To if multiple rows selected.
-				if (help.Sensitive && view.Selection.CountSelectedRows () > 1) {
-					help.Sensitive = false;
-					jump.Sensitive = false;
-				}
-
-				string dummyString;
-				help.Sensitive &= GetSelectedErrorReference (out dummyString);
-			};
-
-			return menu;
+			menu.Show (view, evt);
 		}
 
 		TaskListEntry SelectedTask {
@@ -631,15 +538,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 					TaskService.Errors.CurrentLocationTask = task;
 					IdeApp.Workbench.ActiveLocationList = TaskService.Errors;
 				}
-			}
-		}
-
-		void OnColumnVisibilityChanged (object o, EventArgs args)
-		{
-			ToggleAction action = o as ToggleAction;
-			if (action != null) {
-				view.Columns [columnsActions [action]].Visible = action.Active;
-				StoreColumnsVisibility ();
 			}
 		}
 


### PR DESCRIPTION
Use the cross platform ContextMenu on for the Error and Tasks pads' popup menu.
Means that
 - An ugly Gtk menu isn't used on Cocoa
 - Fixes refcycles and leaks

Create a ColumnSelectorMenu for automatically generating context menus for
hiding or showing treeview columns