### PR TITLE
Fix VSTS 555349 - Assembly browser doesn't work

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.addin.xml
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.addin.xml
@@ -1,4 +1,8 @@
 <ExtensionModel>
+
+	<Runtime>
+		<Import assembly="ICSharpCode.Decompiler.dll" />
+	</Runtime>
 	
 	<!-- Extension points -->
 	<ExtensionPoint path = "/MonoDevelop/AssemblyBrowser/TypeNode/ContextMenu">


### PR DESCRIPTION
Add explicit dependency on our copy of ICSharpCode.Decompiler, otherwise a newer copy is loaded from build\bin.