### PR TITLE
[IDE] Don't show the document switcher if no pads/documents

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
@@ -260,10 +260,16 @@ namespace MonoDevelop.Ide.Commands
 			
 			var toplevel = Window.ListToplevels ().FirstOrDefault (w => w.HasToplevelFocus)
 				?? IdeApp.Workbench.RootWindow;
-			var sw = new DocumentSwitcher (toplevel, next);
-			sw.Present ();
+
+			bool hasContent;
+			var sw = new DocumentSwitcher (toplevel, next, out hasContent);
+			if (hasContent) {
+				sw.Present ();
+			} else {
+				sw.Destroy ();
+			}
 		}
-		
+
 		protected override void Run ()
 		{
 			Switch (true);
@@ -287,8 +293,14 @@ namespace MonoDevelop.Ide.Commands
 
 			var toplevel = Window.ListToplevels ().FirstOrDefault (w => w.HasToplevelFocus)
 				?? IdeApp.Workbench.RootWindow;
-			var sw = new DocumentSwitcher (toplevel, GettextCatalog.GetString ("Pads"), next);
-			sw.Present ();
+
+			bool hasContent;
+			var sw = new DocumentSwitcher (toplevel, GettextCatalog.GetString ("Pads"), next, out hasContent);
+			if (hasContent) {
+				sw.Present ();
+			} else {
+				sw.Destroy ();
+			}
 		}
 
 		protected override void Run ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentSwitcher.cs
@@ -513,11 +513,10 @@ namespace MonoDevelop.Ide
 			layout.Dispose ();
 			int totalWidth = 0;
 			int totalHeight = 0;
-			
+
 			var firstNonEmptyCat = categories.FirstOrDefault (c => c.Items.Count > 0);
 			if (firstNonEmptyCat == null)
 				return;
-			
 			var icon = firstNonEmptyCat.Items[0].Icon;
 			var iconHeight = Math.Max (h, (int)icon.Height + 2) + itemPadding * 2;
 			var iconWidth = (int) icon.Width + 2 + w  + itemPadding * 2;
@@ -615,11 +614,11 @@ namespace MonoDevelop.Ide
 		Label labelTitle    = new Label ();
 		DocumentList documentList = new DocumentList ();
 
-		public DocumentSwitcher (Gtk.Window parent, bool startWithNext) : this (parent, null, startWithNext)
+		public DocumentSwitcher (Gtk.Window parent, bool startWithNext, out bool created) : this (parent, null, startWithNext, out created)
 		{
 		}
 
-		public DocumentSwitcher (Gtk.Window parent, string category, bool startWithNext) : base(Gtk.WindowType.Toplevel)
+		public DocumentSwitcher (Gtk.Window parent, string category, bool startWithNext, out bool dialogHasContent) : base(Gtk.WindowType.Toplevel)
 		{
 			if (string.IsNullOrEmpty (category))
 				category = GettextCatalog.GetString ("Documents");
@@ -723,7 +722,9 @@ namespace MonoDevelop.Ide
 				} else if (padCategory.Items.Count > 0) {
 					activeItem = padCategory.Items [0];
 				} else {
-					DestroyWindow ();
+					// We can't destroy the window in the constructor
+					// so we need to let the caller know that there are no items
+					dialogHasContent = false;
 					return;
 				}
 			}
@@ -753,6 +754,8 @@ namespace MonoDevelop.Ide
 			this.ShowAll ();
 			documentList.GrabFocus ();
 			this.GrabDefault ();
+
+			dialogHasContent = true;
 		}
 		
 		Xwt.Drawing.Image GetIconForDocument (MonoDevelop.Ide.Gui.Document document, Gtk.IconSize iconSize)


### PR DESCRIPTION
Showing the document switcher when there were no pads or documents left a blank
window in the top left corner of the screen because we were trying to destroy
it inside the constructor. Instead just pass if there's content or not to the
caller and let it decide what to do

Fixes VSTS #561851