### PR TITLE
[Core] Add a fallback when a given culture does not exist in .NET

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
@@ -68,7 +68,15 @@ namespace MonoDevelop.Core
 			string cultureLang;
 			if (!localeToCulture.TryGetValue (locale, out cultureLang))
 				cultureLang = locale.Replace ("_", "-");
-			CultureInfo ci = CultureInfo.GetCultureInfo (cultureLang);
+
+			CultureInfo ci;
+			try {
+				ci = CultureInfo.GetCultureInfo (cultureLang);
+			} catch (Exception e) {
+				LoggingService.LogError ($"Failed to grab culture {cultureLang}, using default", e);
+				return;
+			}
+
 			if (ci.IsNeutralCulture) {
 				// We need a non-neutral culture
 				foreach (CultureInfo c in CultureInfo.GetCultures (CultureTypes.AllCultures & ~CultureTypes.NeutralCultures))


### PR DESCRIPTION
OS X seems to have some cultures that do not exist in .NET. Fallback to default when they're not found.

Fixes VSTS #532970