### PR TITLE
Fixed 'VSTS Bug 561844: [Feedback] Code snippets don't highlight

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeFormatting/CodeFormatter.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeFormatting/CodeFormatter.cs
@@ -53,12 +53,13 @@ namespace MonoDevelop.Ide.CodeFormatting
 			this.formatter = formatter;
 		}
 
-		[Obsolete("Use Format (PolicyContainer policyParent, ITextSource input, ISegment segment = null) instead. This function is going to be removed.")]
+		[Obsolete ("Use roslyn instead")]
 		public ITextSource Format (PolicyContainer policyParent, ITextSource input, int fromOffset, int toOffset)
 		{
 			return formatter.Format (policyParent, mimeType, input, fromOffset, toOffset);
 		}
 
+		[Obsolete ("Use roslyn instead")]
 		public ITextSource Format (PolicyContainer policyParent, ITextSource input, ISegment segment = null)
 		{
 			try {
@@ -73,12 +74,13 @@ namespace MonoDevelop.Ide.CodeFormatting
 			}
 		}
 
-		[Obsolete("Use FormatText (PolicyContainer policyParent, string input, ISegment segment) instead. This function is going to be removed.")]
+		[Obsolete ("Use roslyn instead")]
 		public string FormatText (PolicyContainer policyParent, string input, int fromOffset, int toOffset)
 		{
 			return formatter.FormatText (policyParent, mimeType, input, fromOffset, toOffset);
 		}
 
+		[Obsolete ("Use roslyn instead")]
 		public string FormatText (PolicyContainer policyParent, string input, ISegment segment = null)
 		{
 			try {
@@ -122,11 +124,13 @@ namespace MonoDevelop.Ide.CodeFormatting
 
 		public bool SupportsCorrectingIndent { get { return formatter.SupportsCorrectingIndent; } }
 
+		[Obsolete ("Use roslyn instead")]
 		public void CorrectIndenting (PolicyContainer policyParent, TextEditor editor, int line)
 		{
 			formatter.CorrectIndenting (policyParent, editor, line);
 		}
 
+		[Obsolete ("Use roslyn instead")]
 		public void CorrectIndenting (PolicyContainer policyParent, TextEditor editor, IDocumentLine line)
 		{
 			try {


### PR DESCRIPTION
defined input variables upon creation'

https://devdiv.visualstudio.com/DevDiv/_workitems?id=561844

I obsoleted the formatting infrastructure - it should be taken out and
replaced with the roslyn infrastructure.