### PR TITLE
[IDE] Errors pad autohides after a few moments

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -292,7 +292,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				AddTask (t);
 			}
 
-			control.FocusChain = new Gtk.Widget [] { outputView };
+			control.FocusChain = new Gtk.Widget [] { outputView, sw };
 		}
 
 		public override void Dispose ()


### PR DESCRIPTION
The focus chain for the error pad is set to only let the Build Output be focused, but if Build Output is hidden, then nothing can be focused and so the autohide
closes the pad.

Add the scrolled window as a secondary focus widget as a back up if the Build
Output is hidden.

Fixes VSTS #561864