### PR TITLE
[15.5][IDE] Errors pad autohides after a few moments

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -291,7 +291,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				AddTask (t);
 			}
 
-			control.FocusChain = new Gtk.Widget [] { outputView };
+			control.FocusChain = new Gtk.Widget [] { outputView, sw };
 		}
 
 		public override void Dispose ()


### PR DESCRIPTION
(#3783 for d15-5)

The focus chain for the error pad is set to only let the Build Output be focused, but if Build Output is hidden, then nothing can be focused and so the autohide
closes the pad.

Add the scrolled window as a secondary focus widget as a back up if the Build
Output is hidden.

Fixes VSTS #561864

(cherry picked from commit 1d6a8648da9661f5d16934a24a2eb1faa5323b83)