### PR TITLE
[Git] Fix progress reporting on clone

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -170,6 +170,7 @@ namespace MonoDevelop.VersionControl.Git
 		static bool OnTransferProgress (TransferProgress tp, ProgressMonitor monitor, ref int progress)
 		{
 			if (progress == 0 && tp.ReceivedObjects == 0) {
+				progress = 1;
 				monitor.BeginTask (GettextCatalog.GetString ("Receiving and indexing objects"), 2 * tp.TotalObjects);
 				throttleWatch.Restart ();
 			}
@@ -179,8 +180,8 @@ namespace MonoDevelop.VersionControl.Git
 			if (throttleWatch.ElapsedMilliseconds > progressThrottle) {
 				monitor.Step (steps);
 				throttleWatch.Restart ();
+				progress = currentProgress;
 			}
-			progress = currentProgress;
 
 			if (tp.IndexedObjects >= tp.TotalObjects) {
 				monitor.EndTask ();
@@ -193,7 +194,8 @@ namespace MonoDevelop.VersionControl.Git
 		static void OnCheckoutProgress (int completedSteps, int totalSteps, ProgressMonitor monitor, ref int progress)
 		{
 			if (progress == 0 && completedSteps == 0) {
-				monitor.BeginTask (GettextCatalog.GetString ("Checking out files"), totalSteps);
+				progress = 1;
+				monitor.BeginTask (GettextCatalog.GetString ("Checking out files"), 2 * totalSteps);
 				throttleWatch.Restart ();
 			}
 
@@ -201,8 +203,8 @@ namespace MonoDevelop.VersionControl.Git
 			if (throttleWatch.ElapsedMilliseconds > progressThrottle) {
 				monitor.Step (steps);
 				throttleWatch.Restart ();
+				progress = completedSteps;
 			}
-			progress = completedSteps;
 
 			if (completedSteps >= totalSteps) {
 				monitor.EndTask ();
@@ -619,7 +621,7 @@ namespace MonoDevelop.VersionControl.Git
 			monitor.EndTask ();
 		}
 
-		static void RetryUntilSuccess (ProgressMonitor monitor, Action<GitCredentialsType> func)
+		static void RetryUntilSuccess (ProgressMonitor monitor, Action<GitCredentialsType> func, Action onRetry = null)
 		{
 			bool retry;
 			using (var tfsSession = new TfsSmartSession ()) {
@@ -650,6 +652,7 @@ namespace MonoDevelop.VersionControl.Git
 						if (credType == GitCredentialsType.Tfs) {
 							retry = true;
 							tfsSession.Dispose ();
+							onRetry?.Invoke ();
 							continue;
 						}
 
@@ -925,21 +928,91 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			int transferProgress = 0;
 			int checkoutProgress = 0;
+
+			monitor.BeginTask ("Cloning...", 2);
+
 			RetryUntilSuccess (monitor, credType => {
 				RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, new CloneOptions {
-					CredentialsProvider = (url, userFromUrl, types) => GitCredentials.TryGet (url, userFromUrl, types, credType),
-
+					CredentialsProvider = (url, userFromUrl, types) => {
+						transferProgress = checkoutProgress = 0;
+						return GitCredentials.TryGet (url, userFromUrl, types, credType);
+					},
+					RepositoryOperationStarting = ctx => {
+						Runtime.RunInMainThread (() => {
+							monitor.Log.WriteLine ("Checking out repository at '{0}'", ctx.RepositoryPath);
+						});
+						return true;
+					},
 					OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
-					OnCheckoutProgress = (path, completedSteps, totalSteps) => OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress),
-					RecurseSubmodules = true,
+					OnCheckoutProgress = (path, completedSteps, totalSteps) => {
+						OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
+						Runtime.RunInMainThread (() => {
+							monitor.Log.WriteLine ("Checking out file '{0}'", path);
+						});
+					},
 				});
 			});
 
 			if (monitor.CancellationToken.IsCancellationRequested || RootPath.IsNull)
 				return;
+
+			monitor.Step (1);
 			
 			RootPath = RootPath.ParentDirectory;
 			RootRepository = new LibGit2Sharp.Repository (RootPath);
+
+			RecursivelyCloneSubmodules (RootPath, monitor);
+
+			monitor.EndTask ();
+		}
+
+		static void RecursivelyCloneSubmodules (string path, ProgressMonitor monitor)
+		{
+			var submodules = new List<string> ();
+			using (var repo = new LibGit2Sharp.Repository (path)) {
+				RetryUntilSuccess (monitor, credType => {
+					int transferProgress = 0, checkoutProgress = 0;
+					SubmoduleUpdateOptions updateOptions = new SubmoduleUpdateOptions () {
+						Init = true,
+						CredentialsProvider = (url, userFromUrl, types) => {
+							transferProgress = checkoutProgress = 0;
+							return GitCredentials.TryGet (url, userFromUrl, types, credType);
+						},
+						OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
+						OnCheckoutProgress = (file, completedSteps, totalSteps) => {
+							OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
+							Runtime.RunInMainThread (() => {
+								monitor.Log.WriteLine ("Checking out file '{0}'", file);
+							});
+						},
+					};
+
+					// Iterate through the submodules (where the submodule is in the index),
+					// and clone them.
+					var submoduleArray = repo.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
+					monitor.BeginTask (submoduleArray.Length);
+					foreach (var sm in submoduleArray) {
+						if (monitor.CancellationToken.IsCancellationRequested) {
+							throw new UserCancelledException ("Recursive clone of submodules was cancelled.");
+						}
+
+						Runtime.RunInMainThread (() => {
+							monitor.Log.WriteLine ("Checking out submodule at '{0}'", sm.Path);
+						});
+						repo.Submodules.Update (sm.Name, updateOptions);
+						monitor.Step (1);
+
+						submodules.Add (Path.Combine (repo.Info.WorkingDirectory, sm.Path));
+					}
+				});
+			}
+
+			// If we are continuing the recursive operation, then
+			// recurse into nested submodules.
+			// Check submodules to see if they have their own submodules.
+			foreach (string submodule in submodules) {
+				RecursivelyCloneSubmodules (submodule, monitor);
+			}
 		}
 
 		protected override void OnRevert (FilePath[] localPaths, bool recurse, ProgressMonitor monitor)


### PR DESCRIPTION
This now reports that a loose object can not be found instead of crashing and shows checkout progress in the pad

Fixes VSTS #549721