### PR TITLE
[Ide][Mac] Allow to exit by closing the main IDE window

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -397,8 +397,6 @@ namespace MonoDevelop.MacIntegration
 
 			initedApp = true;
 
-			IdeApp.Workbench.RootWindow.DeleteEvent += HandleDeleteEvent;
-
 			if (MacSystemInformation.OsVersion >= MacSystemInformation.Lion) {
 				IdeApp.Workbench.RootWindow.Realized += (sender, args) => {
 					var win = GtkQuartz.GetWindow ((Gtk.Window) sender);
@@ -645,13 +643,6 @@ namespace MonoDevelop.MacIntegration
 					return path;
 			} while ((path = path.ParentDirectory).IsNotNull);
 			return null;
-		}
-
-		[GLib.ConnectBefore]
-		static void HandleDeleteEvent (object o, Gtk.DeleteEventArgs args)
-		{
-			args.RetVal = true;
-			NSApplication.SharedApplication.Hide (NSApplication.SharedApplication);
 		}
 
 		public static Gdk.Pixbuf GetPixbufFromNSImageRep (NSImageRep rep, int width, int height)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -719,13 +719,15 @@ namespace MonoDevelop.Ide.Gui
 			if (closing) 
 				return;
 			
-			// don't allow Gtk to close the workspace, in case Close() leaves the synchronization context
-			// Gtk.Application.Quit () will handle it for us.
+			// don't allow Gtk to close the workspace, in case IdeApp.Exit() leaves the synchronization context.
+			// IdeApp.Exit() will synchronize and call Gtk.Application.Quit () for us.
 			e.RetVal = true;
-			if (await Close ()) {
+			// We must use IdeApp.Exit () here, because on Mac the NSApplication termination
+			// relies on IdeApp.IsRunning to be unset on exit in order to terminate the application correctly.
+			// IdeApp.Exit () will call Workbench.Close() after updating its status.
+			if (await IdeApp.Exit ()) {
 				closing = true;
 				Destroy (); // default delete action
-				Gtk.Application.Quit ();
 			}
 		}
 		


### PR DESCRIPTION
I don't know why, but we don't exit if the user closes the main IDE window on Mac. Instead we just hide it (we event don't minimize with the typical animation).

This patch removes the DeleteEvent override on Mac and lets the main Window close as expected (handled by `DefaultWorkbench.OnClosing`). For this to work correctly we also need to loop the `IdeApp` into the closing process, because our [`NSApplication.SharedApplication.Delegate.Terminate` handler](https://github.com/mono/monodevelop/blob/fix561910-close-main-window-on-mac/main/src/addins/MacPlatform/MacPlatform.cs#L210) relies on `IdeApp.IsRunning` to be correctly set, in order to terminate MAC process correctly.

Fixes VSTS #561910