### PR TITLE
[A11y] Hide some invisible widgets from VoiceOver

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CodeGenerationPanel.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CodeGenerationPanel.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.CSharp.Project
 		void SetupAccessibility ()
 		{
 			label81.Accessible.Role = Atk.Role.Filler;
+			label73.Accessible.Role = Atk.Role.Filler;
 			generateOverflowChecksCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.OverflowChecks", "", 
 			                                                                    GettextCatalog.GetString ("Check this to enable overflow checking"));
 			enableOptimizationCheckButton.SetCommonAccessibilityAttributes ("CompilerOptions.Optimizations", "",

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
@@ -123,6 +123,8 @@ namespace MonoDevelop.CSharp.Project
 		void SetupAccessibility ()
 		{
 			label76.Accessible.Role = Atk.Role.Filler;
+			label75.Accessible.Role = Atk.Role.Filler;
+			label74.Accessible.Role = Atk.Role.Filler;
 			compileTargetCombo.SetCommonAccessibilityAttributes ("CodeGeneration.CompileTarget", label86,
 			                                                     GettextCatalog.GetString ("Select the compile target for the code generation"));
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/BaseDirectoryPanelWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/BaseDirectoryPanelWidget.cs
@@ -41,6 +41,8 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 		public BaseDirectoryPanelWidget()
 		{
 			this.Build();
+
+			label2.Accessible.SetShouldIgnore (true);
 			var a = folderentry.EntryAccessible;
 			a.SetTitleUIElement (label3.Accessible);
 			label3.Accessible.SetTitleFor (a);


### PR DESCRIPTION
VoiceOver was seeing some invisible spacer widgets because they hadn't been
hidden from accessibility.

Fixes VSTS #561850