### PR TITLE
[AOT] Fix the AOT profile not working on Mac.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ include main/monodevelop_version
 EXTRA_DIST = configure code_of_conduct.md
 SPACE := 
 SPACE +=  
-AOT_DIRECTORIES:=$(subst $(SPACE),:,$(shell find main/build/* -type d))
-MONO_AOT:=MONO_PATH=$(AOT_DIRECTORIES):$(MONO_PATH) mono64 --aot --debug --apply-bindings=main/build/bin/MonoDevelop.exe.config
+AOT_DIRECTORIES:=$(subst $(SPACE),:,$(shell find main/build/* -not -path "*azure-functions-cli*" -not -path "*.dSYM*" -not -path "main/build/tests*" -type d))
+MONO_AOT:=MONO_PATH=$(AOT_DIRECTORIES):/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin:$(MONO_PATH) mono64 --aot --debug --apply-bindings=main/build/bin/MonoDevelop.exe.config
 
 all: update_submodules all-recursive
 


### PR DESCRIPTION
Seems like AzureFunctions included a roslyn library, and it ended up being used when AOT-ing, causing mismatches with the core assembly