### PR TITLE
Fixed 'VSTS Bug 564268: Insert of two ' characters when pressing ' is…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
@@ -44,6 +44,8 @@ namespace MonoDevelop.SourceEditor
 
 		public override bool Handle (TextEditor editor, DocumentContext ctx, KeyDescriptor descriptor)
 		{
+			if (descriptor.KeyChar == '\'' && editor.MimeType == "text/fsharp")
+				return false;
 			int braceIndex = openBrackets.IndexOf (descriptor.KeyChar);
 			if (braceIndex < 0)
 				return false;


### PR DESCRIPTION
… incorrect for F# code'

Special cased f# files in the bracket handler.


---------------

In theory the f# binding would provide an AutoBracketHandler however that infrastructure is going to be replaced by the VS.NET one - so atm the best solution is just to hack out the f# case in the default handler until the infrastructure is replaced.

Any thoughts ?
