### PR TITLE
[Ide] Fixes a crash when activating no existent PathBar type / element

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
@@ -746,6 +746,10 @@ namespace MonoDevelop.CSharp
 				try {
 					root = await unit.GetRootAsync(cancellationToken).ConfigureAwait(false);
 					if (root.FullSpan.Length <= caretOffset) {
+						var prevPath = CurrentPath;
+						CurrentPath = new PathEntry [] { new PathEntry (GettextCatalog.GetString ("No selection")) { Tag = null } };
+						isPathSet = false;
+						OnPathChanged (new DocumentPathChangedEventArgs (prevPath));
 						return;
 					}
 					node = root.FindNode(TextSpan.FromBounds(caretOffset, caretOffset));


### PR DESCRIPTION
Issue: While having a "_pathed_" doc opened, when we (i.e.) do a `Select All` and `Cut`, (the doc's length becomes zero -empty-), the PathBar entries are not updated therefore when activating some element in the path bar's DropDownList it crashes.
Fix: Updates PathBar when PathedDoc root's length is equal or less than caret offset instead of just return;

Crash repro: https://www.dropbox.com/s/lwfrc21bm9zz2jv/vsformac%20bug.mov?dl=0