### PR TITLE
[Ide] Don't run the completion service query on the UI thread

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
@@ -41,6 +41,7 @@ using MonoDevelop.Core.Text;
 using Gtk;
 using System.Threading;
 using System.Threading.Tasks;
+using MonoDevelop.Ide.Editor.Highlighting;
 
 namespace MonoDevelop.SourceEditor
 {
@@ -57,23 +58,27 @@ namespace MonoDevelop.SourceEditor
 			var unit = analysisDocument.GetAst<SemanticModel> ();
 			if (unit == null)
 				return null;
-			
-			var root = unit.SyntaxTree.GetRoot (token);
-			SyntaxToken syntaxToken;
-			try {
-				syntaxToken = root.FindToken (offset);
-			} catch (ArgumentOutOfRangeException) {
-				return null;
-			}
-			if (!syntaxToken.Span.IntersectsWith (offset))
-				return null;
-			var node = GetBestFitResolveableNode (syntaxToken.Parent);
-			var symbolInfo = unit.GetSymbolInfo (node, token);
-			var symbol = symbolInfo.Symbol ?? unit.GetDeclaredSymbol (node, token);
-			var tooltipInformation = await CreateTooltip (symbol, syntaxToken, editor, ctx, offset);
-			if (tooltipInformation == null || string.IsNullOrEmpty (tooltipInformation.SignatureMarkup))
-				return null;
-			return new TooltipItem (tooltipInformation, syntaxToken.Span.Start, syntaxToken.Span.Length);
+
+			int caretOffset = editor.CaretOffset;
+			EditorTheme theme = editor.Options.GetEditorTheme ();
+			return await Task.Run (async () => {
+				var root = unit.SyntaxTree.GetRoot (token);
+				SyntaxToken syntaxToken;
+				try {
+					syntaxToken = root.FindToken (offset);
+				} catch (ArgumentOutOfRangeException) {
+					return null;
+				}
+				if (!syntaxToken.Span.IntersectsWith (offset))
+					return null;
+				var node = GetBestFitResolveableNode (syntaxToken.Parent);
+				var symbolInfo = unit.GetSymbolInfo (node, token);
+				var symbol = symbolInfo.Symbol ?? unit.GetDeclaredSymbol (node, token);
+				var tooltipInformation = await CreateTooltip (symbol, syntaxToken, caretOffset, theme, ctx, offset);
+				if (tooltipInformation == null || string.IsNullOrEmpty (tooltipInformation.SignatureMarkup))
+					return null;
+				return new TooltipItem (tooltipInformation, syntaxToken.Span.Start, syntaxToken.Span.Length);
+			});
 		}
 
 		static SyntaxNode GetBestFitResolveableNode (SyntaxNode node)
@@ -123,7 +128,7 @@ namespace MonoDevelop.SourceEditor
 			return result;
 		}
 
-		async Task<TooltipInformation> CreateTooltip (ISymbol symbol, SyntaxToken token, TextEditor editor, DocumentContext doc, int offset)
+		async Task<TooltipInformation> CreateTooltip (ISymbol symbol, SyntaxToken token, int caretOffset, EditorTheme theme, DocumentContext doc, int offset)
 		{
 			try {
 				TooltipInformation result;
@@ -139,7 +144,7 @@ namespace MonoDevelop.SourceEditor
 					return result;
 				
 				if (symbol != null) {
-					result = await QuickInfoProvider.GetQuickInfoAsync (editor, doc, symbol);
+					result = await QuickInfoProvider.GetQuickInfoAsync (caretOffset, theme, doc, symbol);
 				}
 				
 				return result;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/QuickInfoProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/QuickInfoProvider.cs
@@ -54,25 +54,24 @@ using System.Collections.Generic;
 using System.Text;
 using MonoDevelop.Ide.Fonts;
 using System.Linq;
+using MonoDevelop.Ide.Editor.Highlighting;
 
 namespace MonoDevelop.SourceEditor
 {
 	static class QuickInfoProvider
 	{
-		public static async Task<TooltipInformation> GetQuickInfoAsync(TextEditor editor, DocumentContext ctx, ISymbol symbol, CancellationToken cancellationToken = default(CancellationToken))
+		public static async Task<TooltipInformation> GetQuickInfoAsync (int caretOffset, EditorTheme theme, DocumentContext ctx, ISymbol symbol, CancellationToken cancellationToken = default (CancellationToken))
 		{
 			var tooltipInfo = new TooltipInformation ();
 
 			var model = await ctx.AnalysisDocument.GetSemanticModelAsync ();
 			var descriptionService = ctx.RoslynWorkspace.Services.GetLanguageServices (model.Language).GetService<ISymbolDisplayService> ();
 
-			var sections = await descriptionService.ToDescriptionGroupsAsync (ctx.RoslynWorkspace, model, editor.CaretOffset, new [] { symbol }.AsImmutable (), default (CancellationToken)).ConfigureAwait (false);
+			var sections = await descriptionService.ToDescriptionGroupsAsync (ctx.RoslynWorkspace, model, caretOffset, new [] { symbol }.AsImmutable (), default (CancellationToken)).ConfigureAwait (false);
 
 			ImmutableArray<TaggedText> parts;
 
 			var sb = new StringBuilder ();
-
-			var theme = editor.Options.GetEditorTheme ();
 
 			if (sections.TryGetValue (SymbolDescriptionGroups.MainDescription, out parts)) {
 				TaggedTextUtil.AppendTaggedText (sb, theme, parts);
@@ -84,7 +83,7 @@ namespace MonoDevelop.SourceEditor
 			}
 
 			var formatter = ctx.RoslynWorkspace.Services.GetLanguageServices (model.Language).GetService<IDocumentationCommentFormattingService> ();
-			var documentation = symbol.GetDocumentationParts (model, editor.CaretOffset, formatter, cancellationToken);
+			var documentation = symbol.GetDocumentationParts (model, caretOffset, formatter, cancellationToken);
 			sb.Append ("<span font='" + FontService.SansFontName + "' size='small'>");
 
 			if (documentation != null && documentation.Any ()) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
@@ -250,7 +250,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		public override async Task<TooltipInformation> CreateTooltipInformation (bool smartWrap, CancellationToken cancelToken)
 		{
-			var description = await completionService.GetDescriptionAsync (doc, CompletionItem);
+			var description = await Task.Run (() => completionService.GetDescriptionAsync (doc, CompletionItem)).ConfigureAwait (false);
 			var markup = new StringBuilder ();
 			var theme = DefaultSourceEditorOptions.Instance.GetEditorTheme ();
 			var taggedParts = description.TaggedParts;


### PR DESCRIPTION
The inner code in roslyn is thread safe, and we don't need to run the continuation on a bg thread either. Only sync back to UI context after the query is done

This amounts to 100ms out of 2000 of UI thread execution while moving the mouse