### PR TITLE
Structured build output Goto Log Build Output

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -189,34 +189,33 @@ namespace MonoDevelop.Ide.BuildOutputView
 			RaiseOutputChanged ();
 		}
 
-		public IEnumerable<BuildOutputNode> GetRootNodes ()
-		{
-			foreach (var proj in projects) {
-				foreach (var node in proj.RootNodes) {
-					yield return node;
-				}
-			}
-		}
-
 		internal void RaiseOutputChanged ()
 		{
 			OutputChanged?.Invoke (this, EventArgs.Empty);
 		}
 
-
-		public List<BuildOutputNode> GetTreeRootNodes (bool includeDiagnostics)
+		public List<BuildOutputNode> GetRootNodes (bool includeDiagnostics)
 		{
 			if (includeDiagnostics) {
-				return GetRootNodes ().ToList ();
+				return GetProjectRootNodes ().ToList ();
 			} else {
 				// If not including diagnostics, we need to filter the nodes,
 				// but instead of doing so now for all, we do it on the fly,
 				// as nodes are requested
 				var nodes = new List<BuildOutputNode> ();
-				foreach (var root in GetRootNodes ()) {
+				foreach (var root in GetProjectRootNodes ()) {
 					nodes.Add (new FilteredBuildOutputNode (root, null, includeDiagnostics));
 				}
 				return nodes;
+			}
+		}
+
+		IEnumerable<BuildOutputNode> GetProjectRootNodes ()
+		{
+			foreach (var proj in projects) {
+				foreach (var node in proj.RootNodes) {
+					yield return node;
+				}
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -417,6 +417,16 @@ namespace MonoDevelop.Ide.BuildOutputView
 		}
 
 		#endregion
+	}
+
+	class BuildOutputDataSearch
+	{
+		readonly List<BuildOutputNode> rootNodes;
+
+		public BuildOutputDataSearch (List<BuildOutputNode> rootNodes)
+		{
+			this.rootNodes = rootNodes;
+		}
 
 		#region Search functionality
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -40,58 +40,6 @@ using System.Linq;
 
 namespace MonoDevelop.Ide.BuildOutputView
 {
-	static class BuildOutputNodeExtensions
-	{
-		public static BuildOutputNode SearchFirstNode (this IEnumerable<BuildOutputNode> sender, BuildOutputNodeType type, string search)
-		{
-			BuildOutputNode tmp;
-			foreach (var item in sender) {
-				tmp = item.SearchFirstNode (type, search);
-				if (tmp != null) {
-					return tmp;
-				}
-			}
-			return null;
-		}
-
-		public static void Search (this BuildOutputNode node, List<BuildOutputNode> matches, string pattern)
-		{
-			if ((node.Message?.IndexOf (pattern, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
-				matches.Add (node);
-			}
-
-			if (node.HasChildren) {
-				foreach (var child in node.Children) {
-					Search (child, matches, pattern);
-				}
-			}
-		}
-
-		public static BuildOutputNode SearchFirstNode (this BuildOutputNode buildOutputNode, BuildOutputNodeType type, string search)
-		{
-			if (type == buildOutputNode.NodeType) {
-				if (search == buildOutputNode.Message) {
-					return buildOutputNode;
-				} else {
-					//We don't want deep recursive into children, change to next item
-					return null;
-				}
-			}
-
-			//iterating into children
-			if (buildOutputNode.Children != null) {
-				BuildOutputNode tmp;
-				for (int i = 0; i < buildOutputNode.Children.Count; ++i) {
-					tmp = SearchFirstNode (buildOutputNode.Children[i], type, search);
-					if (tmp != null) {
-						return tmp;
-					}
-				}
-			}
-			return null;
-		}
-	}
-
 	class BuildOutput : IDisposable
 	{
 		BuildOutputProgressMonitor progressMonitor;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -54,6 +54,18 @@ namespace MonoDevelop.Ide.BuildOutputView
 			return null;
 		}
 
+		public static void Search (this BuildOutputNode node, string pattern, List<BuildOutputNode> matches)
+		{
+			if ((node.Message ?? "").Equals (pattern, StringComparison.OrdinalIgnoreCase)) {
+				matches.Add (node);
+			}
+
+			for (int i = 0; i < node.Children.Count; ++i) {
+				var child = node.Children [i];
+				Search (child, pattern, matches);
+			}
+		}
+
 		public static BuildOutputNode SearchFirstNode (this BuildOutputNode buildOutputNode, BuildOutputNodeType type, string search)
 		{
 			if (type == buildOutputNode.NodeType) {
@@ -68,14 +80,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 			//iterating into children
 			if (buildOutputNode.Children != null) {
 				BuildOutputNode tmp;
-				foreach (var node in buildOutputNode.Children) {
-					tmp = SearchFirstNode (node, type, search);
+				for (int i = 0; i < buildOutputNode.Children.Count; ++i) {
+					tmp = SearchFirstNode (buildOutputNode.Children[i], type, search);
 					if (tmp != null) {
 						return tmp;
 					}
 				}
 			}
-
 			return null;
 		}
 	}
@@ -475,7 +486,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			// Perform search
 			foreach (var root in rootNodes) {
-				SearchInNodeAndChildren (root, currentSearchMatches, currentSearchPattern);
+				root.Search (currentSearchPattern, currentSearchMatches);
 			}
 
 			if (currentSearchMatches.Count > 0) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 	{
 		BuildOutputProgressMonitor progressMonitor;
 		readonly List<BuildOutputProcessor> projects = new List<BuildOutputProcessor> ();
+		List<BuildOutputNode> treeRootNodes;
 
 		public event EventHandler OutputChanged;
 
@@ -166,13 +167,30 @@ namespace MonoDevelop.Ide.BuildOutputView
 			OutputChanged?.Invoke (this, EventArgs.Empty);
 		}
 
+
+		public List<BuildOutputNode> GetTreeRootNodes (bool includeDiagnostics) 
+		{
+			if (includeDiagnostics) {
+				return GetRootNodes ().ToList ();
+			} else {
+				// If not including diagnostics, we need to filter the nodes,
+				// but instead of doing so now for all, we do it on the fly,
+				// as nodes are requested
+				var nodes = new List<BuildOutputNode> ();
+				foreach (var root in GetRootNodes ()) {
+					nodes.Add (new FilteredBuildOutputNode (root, null, includeDiagnostics));
+				}
+				return nodes;
+			}
+		}
+
 		public BuildOutputDataSource ToTreeDataSource (bool includeDiagnostics)
 		{
 			foreach (var p in projects) {
 				p.Process ();
 			}
-
-			return new BuildOutputDataSource (this, includeDiagnostics);
+			treeRootNodes = GetTreeRootNodes (includeDiagnostics);
+			return new BuildOutputDataSource (treeRootNodes);
 		}
 
 		bool disposed = false;
@@ -259,27 +277,14 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		BuildOutput buildOutput;
 		bool includeDiagnostics;
-		List<BuildOutputNode> rootNodes;
 		public IReadOnlyList<BuildOutputNode> RootNodes => this.rootNodes;
-
+		readonly List<BuildOutputNode> rootNodes;
 		public DataField<Xwt.Drawing.Image> ImageField = new DataField<Xwt.Drawing.Image> (0);
 		public DataField<string> LabelField = new DataField<string> (1);
 
-		public BuildOutputDataSource (BuildOutput output, bool includeDiagnostics)
+		public BuildOutputDataSource (List<BuildOutputNode> rootNodes)
 		{
-			buildOutput = output;
-			this.includeDiagnostics = includeDiagnostics;
-			if (includeDiagnostics) {
-				rootNodes = buildOutput.GetRootNodes ().ToList ();
-			} else {
-				// If not including diagnostics, we need to filter the nodes,
-				// but instead of doing so now for all, we do it on the fly,
-				// as nodes are requested
-				rootNodes = new List<BuildOutputNode> ();
-				foreach (var root in buildOutput.GetRootNodes ()) {
-					rootNodes.Add (new FilteredBuildOutputNode (root, null, includeDiagnostics));
-				}
-			}
+			this.rootNodes = rootNodes;
 		}
 
 		#region ITreeDataSource implementation

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -54,15 +54,16 @@ namespace MonoDevelop.Ide.BuildOutputView
 			return null;
 		}
 
-		public static void Search (this BuildOutputNode node, string pattern, List<BuildOutputNode> matches)
+		public static void Search (this BuildOutputNode node, List<BuildOutputNode> matches, string pattern)
 		{
-			if ((node.Message ?? "").Equals (pattern, StringComparison.OrdinalIgnoreCase)) {
+			if ((node.Message?.IndexOf (pattern, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
 				matches.Add (node);
 			}
 
-			for (int i = 0; i < node.Children.Count; ++i) {
-				var child = node.Children [i];
-				Search (child, pattern, matches);
+			if (node.HasChildren) {
+				foreach (var child in node.Children) {
+					Search (child, matches, pattern);
+				}
 			}
 		}
 
@@ -463,19 +464,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 		/// <value><c>true</c> if search wrapped; otherwise, <c>false</c>.</value>
 		public bool SearchWrapped { get; private set; }
 
-		static void SearchInNodeAndChildren (BuildOutputNode node, List<BuildOutputNode> matches, string pattern)
-		{
-			if ((node.Message?.IndexOf (pattern, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
-				matches.Add (node);
-			}
-
-			if (node.HasChildren) {
-				foreach (var child in node.Children) {
-					SearchInNodeAndChildren (child, matches, pattern);
-				}
-			}
-		}
-
 		public BuildOutputNode FirstMatch (string pattern)
 		{
 			// Initialize search data
@@ -486,7 +474,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			// Perform search
 			foreach (var root in rootNodes) {
-				root.Search (currentSearchPattern, currentSearchMatches);
+				root.Search (currentSearchMatches, currentSearchPattern);
 			}
 
 			if (currentSearchMatches.Count > 0) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -320,8 +320,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 		static readonly Xwt.Drawing.Image warningIcon = ImageService.GetIcon (Ide.Gui.Stock.Warning, Gtk.IconSize.Menu);
 		static readonly Xwt.Drawing.Image folderIcon = ImageService.GetIcon (Ide.Gui.Stock.OpenFolder, Gtk.IconSize.Menu);
 
-		BuildOutput buildOutput;
-		bool includeDiagnostics;
 		public IReadOnlyList<BuildOutputNode> RootNodes => this.rootNodes;
 		readonly List<BuildOutputNode> rootNodes;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
@@ -158,6 +158,55 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 	static class BuildOutputNodeExtensions
 	{
+		public static BuildOutputNode SearchFirstNode (this IEnumerable<BuildOutputNode> sender, BuildOutputNodeType type, string search)
+		{
+			BuildOutputNode tmp;
+			foreach (var item in sender) {
+				tmp = item.SearchFirstNode (type, search);
+				if (tmp != null) {
+					return tmp;
+				}
+			}
+			return null;
+		}
+
+		public static void Search (this BuildOutputNode node, List<BuildOutputNode> matches, string pattern)
+		{
+			if ((node.Message?.IndexOf (pattern, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
+				matches.Add (node);
+			}
+
+			if (node.HasChildren) {
+				foreach (var child in node.Children) {
+					Search (child, matches, pattern);
+				}
+			}
+		}
+
+		public static BuildOutputNode SearchFirstNode (this BuildOutputNode buildOutputNode, BuildOutputNodeType type, string search)
+		{
+			if (type == buildOutputNode.NodeType) {
+				if (search == buildOutputNode.Message) {
+					return buildOutputNode;
+				} else {
+					//We don't want deep recursive into children, change to next item
+					return null;
+				}
+			}
+
+			//iterating into children
+			if (buildOutputNode.Children != null) {
+				BuildOutputNode tmp;
+				for (int i = 0; i < buildOutputNode.Children.Count; ++i) {
+					tmp = SearchFirstNode (buildOutputNode.Children [i], type, search);
+					if (tmp != null) {
+						return tmp;
+					}
+				}
+			}
+			return null;
+		}
+
 		public static string GetDurationAsString (this BuildOutputNode node)
 		{
 			var duration = node.EndTime.Subtract (node.StartTime);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputProcessor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputProcessor.cs
@@ -37,7 +37,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 {
 	class BuildOutputProcessor : IDisposable
 	{
-		List<BuildOutputNode> rootNodes = new List<BuildOutputNode> ();
+		readonly List<BuildOutputNode> rootNodes = new List<BuildOutputNode> ();
 		BuildOutputNode currentNode;
 
 		public BuildOutputProcessor (string fileName, bool removeFileOnDispose)
@@ -59,7 +59,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		protected void Clear ()
 		{
 			currentNode = null;
-			rootNodes = new List<BuildOutputNode> ();
+			rootNodes.Clear ();
 			NeedsProcessing = true;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -49,16 +49,11 @@ namespace MonoDevelop.Ide.BuildOutputView
 			control.FileSaved += FileNameChanged;
 		}
 
-		public BuildOutputViewContent (BuildOutput buildOutput)
+		public BuildOutputViewContent (BuildOutputWidget widget)
 		{
-			ContentName = $"{GettextCatalog.GetString ("Build Output")} {DateTime.Now.ToString ("hh:mm:ss")}.binlog";
-			control = new BuildOutputWidget (buildOutput, ContentName);
+			ContentName = widget.ViewContentName;
+			control = widget;
 			control.FileSaved += FileNameChanged;
-		}
-
-		public Task ProcessLogs (bool showDiagnostics)
-		{
-			return control.ProcessLogs (showDiagnostics);
 		}
 
 		void FileNameChanged (object sender, string newName)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			this.filename = filename;
 			this.ContentName = filename;
 			control = new BuildOutputWidget (filename);
-			control.ProcessLogs (false);
+			control.ProcessLogsAsync (false);
 			control.FileSaved += FileNameChanged;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Commands;
 using MonoDevelop.Ide.Gui;
+using MonoDevelop.Ide.Tasks;
 
 namespace MonoDevelop.Ide.BuildOutputView
 {
@@ -99,6 +100,21 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			control.Dispose ();
 			base.Dispose ();
+		}
+
+		internal void GoToError (string description, string file, string project, string path)
+		{
+			control.GoToError (description, file, project, path);
+		}
+
+		internal void GoToWarning (string description, string file, string project, string path)
+		{
+			control.GoToWarning (description, file, project, path);
+		}
+
+		internal void GoToMessage (string description, string file, string project, string path)
+		{
+			control.GoToMessage (description, file, project, path);
 		}
 
 		[CommandHandler (SearchCommands.Find)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -102,19 +102,19 @@ namespace MonoDevelop.Ide.BuildOutputView
 			base.Dispose ();
 		}
 
-		internal void GoToError (string description, string file, string project, string path)
+		internal void GoToError (string description, string project)
 		{
-			control.GoToError (description, file, project, path);
+			control.GoToError (description, project);
 		}
 
-		internal void GoToWarning (string description, string file, string project, string path)
+		internal void GoToWarning (string description, string project)
 		{
-			control.GoToWarning (description, file, project, path);
+			control.GoToWarning (description, project);
 		}
 
-		internal void GoToMessage (string description, string file, string project, string path)
+		internal void GoToMessage (string description, string project)
 		{
-			control.GoToMessage (description, file, project, path);
+			control.GoToMessage (description, project);
 		}
 
 		[CommandHandler (SearchCommands.Find)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Threading.Tasks;
 using MonoDevelop.Components;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
@@ -43,6 +44,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			this.filename = filename;
 			this.ContentName = filename;
 			control = new BuildOutputWidget (filename);
+			control.ProcessLogs (false);
 			control.FileSaved += FileNameChanged;
 		}
 
@@ -51,6 +53,11 @@ namespace MonoDevelop.Ide.BuildOutputView
 			ContentName = $"{GettextCatalog.GetString ("Build Output")} {DateTime.Now.ToString ("hh:mm:ss")}.binlog";
 			control = new BuildOutputWidget (buildOutput, ContentName);
 			control.FileSaved += FileNameChanged;
+		}
+
+		public Task ProcessLogs (bool showDiagnostics)
+		{
+			return control.ProcessLogs (showDiagnostics);
 		}
 
 		void FileNameChanged (object sender, string newName)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -45,14 +45,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 			this.filename = filename;
 			this.ContentName = filename;
 			control = new BuildOutputWidget (filename);
-			control.ProcessLogsAsync (false);
 			control.FileSaved += FileNameChanged;
 		}
 
-		public BuildOutputViewContent (BuildOutputWidget widget)
+		public BuildOutputViewContent (BuildOutput buildOutput)
 		{
-			ContentName = widget.ViewContentName;
-			control = widget;
+			ContentName = $"{GettextCatalog.GetString ("Build Output")} {DateTime.Now.ToString ("hh:mm:ss")}.binlog";
+			control = new BuildOutputWidget (buildOutput, ContentName);
 			control.FileSaved += FileNameChanged;
 		}
 
@@ -97,19 +96,19 @@ namespace MonoDevelop.Ide.BuildOutputView
 			base.Dispose ();
 		}
 
-		internal void GoToError (string description, string project)
+		internal async Task GoToError (string description, string project)
 		{
-			control.GoToError (description, project);
+			await control.GoToError (description, project);
 		}
 
-		internal void GoToWarning (string description, string project)
+		internal async Task GoToWarning (string description, string project)
 		{
-			control.GoToWarning (description, project);
+			await control.GoToWarning (description, project);
 		}
 
-		internal void GoToMessage (string description, string project)
+		internal async Task GoToMessage (string description, string project)
 		{
-			control.GoToMessage (description, project);
+			await control.GoToMessage (description, project);
 		}
 
 		[CommandHandler (SearchCommands.Find)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -96,19 +96,19 @@ namespace MonoDevelop.Ide.BuildOutputView
 			base.Dispose ();
 		}
 
-		internal async Task GoToError (string description, string project)
+		internal Task GoToError (string description, string project)
 		{
-			await control.GoToError (description, project);
+			return control.GoToError (description, project);
 		}
 
-		internal async Task GoToWarning (string description, string project)
+		internal Task GoToWarning (string description, string project)
 		{
-			await control.GoToWarning (description, project);
+			return control.GoToWarning (description, project);
 		}
 
-		internal async Task GoToMessage (string description, string project)
+		internal Task GoToMessage (string description, string project)
 		{
-			await control.GoToMessage (description, project);
+			return control.GoToMessage (description, project);
 		}
 
 		[CommandHandler (SearchCommands.Find)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -209,7 +209,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			var projectNode = treeBuildOutputNodes.SearchFirstNode (BuildOutputNodeType.Project, project);
 			var node = projectNode.SearchFirstNode (nodeType, message);
-			Xwt.Application.InvokeAsync (() => MoveToMatch (node));
+			MoveToMatch (node);
 		}
 
 		void MoveToMatch (BuildOutputNode match)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -377,7 +377,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 				await Runtime.RunInMainThread (() => {
 
 					BuildOutput.ProcessProjects ();
-					treeBuildOutputNodes = BuildOutput.GetTreeRootNodes (showDiagnostics);
+					treeBuildOutputNodes = BuildOutput.GetRootNodes (showDiagnostics);
 					var buildOutputDataSource = new BuildOutputDataSource (treeBuildOutputNodes);
 					treeView.DataSource = buildOutputDataSource;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			BuildOutput = output;
 
-			BuildOutput.OutputChanged += (sender, e) => ProcessLogs (showDiagnosticsButton.Active);
+			BuildOutput.OutputChanged += (sender, e) => ProcessLogsAsync (showDiagnosticsButton.Active);
 
 			pathBar = new PathBar (this.CreatePathWidget) {
 				DrawBottomBorder = false
@@ -109,7 +109,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			showDiagnosticsButton.Accessible.Identifier = "BuildOutputWidget.ShowDiagnosticsButton";
 			showDiagnosticsButton.TooltipText = GettextCatalog.GetString ("Show full (diagnostics enabled) or reduced log");
 			showDiagnosticsButton.Accessible.Description = GettextCatalog.GetString ("Diagnostic log verbosity");
-			showDiagnosticsButton.Clicked += (sender, e) => ProcessLogs (showDiagnosticsButton.Active);
+			showDiagnosticsButton.Clicked += (sender, e) => ProcessLogsAsync (showDiagnosticsButton.Active);
 
 			saveButton = new Button (GettextCatalog.GetString ("Save"));
 			saveButton.Accessible.Identifier = "BuildOutputWidget.SaveButton";
@@ -368,7 +368,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 		}
 
-		public Task ProcessLogs (bool showDiagnostics)
+		public Task ProcessLogsAsync (bool showDiagnostics)
 		{
 			cts?.Cancel ();
 			cts = new CancellationTokenSource ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -190,17 +190,17 @@ namespace MonoDevelop.Ide.BuildOutputView
 			PackStart (scrolledWindow, expand: true, fill: true);
 		}
 
-		internal void GoToError (string description, string file, string project, string path)
+		internal void GoToError (string description, string project)
 		{
 			ExpandNode (project, BuildOutputNodeType.Error, description);
 		}
 
-		internal void GoToWarning (string description, string file, string project, string path)
+		internal void GoToWarning (string description, string project)
 		{
 			ExpandNode (project, BuildOutputNodeType.Warning, description);
 		}
 
-		internal void GoToMessage (string description, string file, string project, string path)
+		internal void GoToMessage (string description, string project)
 		{
 			ExpandNode (project, BuildOutputNodeType.Message, description);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -83,7 +83,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 		void SetupBuildOutput (BuildOutput output)
 		{
 			BuildOutput = output;
-			ProcessLogs (false);
 
 			BuildOutput.OutputChanged += (sender, e) => ProcessLogs (showDiagnosticsButton.Active);
 
@@ -336,12 +335,12 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 		}
 
-		void ProcessLogs (bool showDiagnostics)
+		public Task ProcessLogs (bool showDiagnostics)
 		{
 			cts?.Cancel ();
 			cts = new CancellationTokenSource ();
 
-			Task.Run (async () => {
+			return Task.Run (async () => {
 				await Runtime.RunInMainThread (() => {
 					var dataSource = BuildOutput.ToTreeDataSource (showDiagnostics);
 					treeView.DataSource = dataSource;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -398,28 +398,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 			searchEntry.Entry.GrabFocus ();
 		}
 
-		public void FindPrevious ()
-		{
-			var dataSource = treeView.DataSource as BuildOutputDataSource;
-			if (dataSource != null) {
-				var match = search.PreviousMatch ();
-				if (match != null) {
-					FocusRow (match);
-				}
-			}
-		}
-
-		public void FindNext ()
-		{
-			var dataSource = treeView.DataSource as BuildOutputDataSource;
-			if (dataSource != null) {
-				var match = search.NextMatch ();
-				if (match != null) {
-					FocusRow (match);
-				}
-			}
-		}
-
 		int currentIndex = -1;
 		public Control CreatePathWidget (int index)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -363,9 +363,10 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			Task.Run (async () => {
 				try {
-					await Runtime.RunInMainThread (() => {
+					BuildOutput.ProcessProjects ();
 
-						BuildOutput.ProcessProjects ();
+					await Runtime.RunInMainThread (() => {
+					
 						treeBuildOutputNodes = BuildOutput.GetRootNodes (showDiagnostics);
 						search = new BuildOutputDataSearch (treeBuildOutputNodes);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -434,7 +434,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 				TaskListEntry task = store.GetValue (iter, DataColumns.Task) as TaskListEntry;
 				if (task != null) {
-					await OpenBuildOutputViewDocument ().ConfigureAwait (false);
+					await OpenBuildOutputViewDocument ();
 					if (task.Severity == TaskSeverity.Error) {
 						buildOutputViewContent.GoToError (task.Message, task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Warning) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -434,13 +434,13 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 				TaskListEntry task = store.GetValue (iter, DataColumns.Task) as TaskListEntry;
 				if (task != null) {
-					await OpenBuildOutputViewDocument ();
+					OpenBuildOutputViewDocument ();
 					if (task.Severity == TaskSeverity.Error) {
-						buildOutputViewContent.GoToError (task.Message, task.GetProjectWithExtension ());
+						await buildOutputViewContent.GoToError (task.Message, task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Warning) {
-						buildOutputViewContent.GoToWarning (task.Message, task.GetProjectWithExtension ());
+						await buildOutputViewContent.GoToWarning (task.Message, task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Information) {
-						buildOutputViewContent.GoToMessage (task.Message, task.GetProjectWithExtension ());
+						await buildOutputViewContent.GoToMessage (task.Message, task.GetProjectWithExtension ());
 					}
 				}
 			}
@@ -949,21 +949,17 @@ namespace MonoDevelop.Ide.Gui.Pads
 		}
 
 		Document buildOutputDoc;
-		async void HandleLogBtnClicked (object sender, EventArgs e)
+		void HandleLogBtnClicked (object sender, EventArgs e)
 		{
-			await OpenBuildOutputViewDocument ().ConfigureAwait (false);
+			OpenBuildOutputViewDocument ();
 		}
 
-		async Task OpenBuildOutputViewDocument () 
+		void OpenBuildOutputViewDocument () 
 		{
 			if (buildOutputViewContent == null) {
-
-				var contentName = $"{GettextCatalog.GetString ("Build Output")} {DateTime.Now.ToString ("hh:mm:ss")}.binlog";
-				var widget = new BuildOutputWidget (buildOutput, contentName);
-				buildOutputViewContent = new BuildOutputViewContent (widget);
+				buildOutputViewContent = new BuildOutputViewContent (buildOutput);
 				buildOutputDoc = IdeApp.Workbench.OpenDocument (buildOutputViewContent, true);
 				buildOutputDoc.Closed += BuildOutputDocClosed;
-				await widget.ProcessLogsAsync (false);
 			} else if (buildOutputDoc != null) {
 				buildOutputDoc.Select ();
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -54,6 +54,7 @@ using System.Linq;
 using MonoDevelop.Components.AutoTest;
 using System.ComponentModel;
 using MonoDevelop.Ide.BuildOutputView;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.Gui.Pads
 {
@@ -940,12 +941,19 @@ namespace MonoDevelop.Ide.Gui.Pads
 		}
 
 		Document buildOutputDoc;
-		void HandleLogBtnClicked (object sender, EventArgs e)
+		async void HandleLogBtnClicked (object sender, EventArgs e)
+		{
+			await OpenBuildOutputViewDocument ().ConfigureAwait (false);
+		}
+
+		async Task OpenBuildOutputViewDocument () 
 		{
 			if (buildOutputViewContent == null) {
 				buildOutputViewContent = new BuildOutputViewContent (buildOutput);
 				buildOutputDoc = IdeApp.Workbench.OpenDocument (buildOutputViewContent, true);
 				buildOutputDoc.Closed += BuildOutputDocClosed;
+
+				await buildOutputViewContent.ProcessLogs (false);
 			} else if (buildOutputDoc != null) {
 				buildOutputDoc.Select ();
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -436,11 +436,11 @@ namespace MonoDevelop.Ide.Gui.Pads
 				if (task != null) {
 					await OpenBuildOutputViewDocument ().ConfigureAwait (false);
 					if (task.Severity == TaskSeverity.Error) {
-						buildOutputViewContent.GoToError (task.GetErrorDescription (), task.GetFile (), task.GetProjectWithExtension (), task.GetPath ());
+						buildOutputViewContent.GoToError (task.GetErrorDescription (), task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Warning) {
-						buildOutputViewContent.GoToWarning (task.GetErrorDescription (), task.GetFile (), task.GetProjectWithExtension (), task.GetPath ());
+						buildOutputViewContent.GoToWarning (task.GetErrorDescription (), task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Information) {
-						buildOutputViewContent.GoToMessage (task.GetErrorDescription (), task.GetFile (), task.GetProjectWithExtension (), task.GetPath ());
+						buildOutputViewContent.GoToMessage (task.GetErrorDescription (), task.GetProjectWithExtension ());
 					}
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -58,6 +58,35 @@ using System.Threading.Tasks;
 
 namespace MonoDevelop.Ide.Gui.Pads
 {
+	public static class TaskListEntryExtensions 
+	{
+		public static string GetPath (this TaskListEntry task)
+		{
+			if (task.WorkspaceObject != null)
+				return FileService.AbsoluteToRelativePath (task.WorkspaceObject.BaseDirectory, task.FileName);
+
+			return task.FileName;
+		}
+
+		public static string GetProject (this TaskListEntry task)
+		{
+			return (task != null && task.WorkspaceObject is SolutionFolderItem)? task.WorkspaceObject.Name: string.Empty;
+		}
+
+		public static string GetFile (this TaskListEntry task)
+		{
+			string tmpPath = "";
+			string fileName = "";
+			try {
+				tmpPath = GetPath (task);
+				fileName = Path.GetFileName (tmpPath);
+			} catch (Exception) {
+				fileName = tmpPath;
+			}
+			return fileName;
+		}
+	}
+
 	class ErrorListPad : PadContent
 	{
 		HPaned control;
@@ -626,25 +655,8 @@ namespace MonoDevelop.Ide.Gui.Pads
 				textRenderer.Text = "";
 				return;
 			}
-			
-			string tmpPath = "";
-			string fileName = "";
-			try {
-				tmpPath = GetPath (task);
-				fileName = Path.GetFileName (tmpPath);
-			} catch (Exception) { 
-				fileName =  tmpPath;
-			}
-			
-			SetText (textRenderer, model, iter, task, fileName);
-		}
-		
-		static string GetPath (TaskListEntry task)
-		{
-			if (task.WorkspaceObject != null)
-				return FileService.AbsoluteToRelativePath (task.WorkspaceObject.BaseDirectory, task.FileName);
-			
-			return task.FileName;
+
+			SetText (textRenderer, model, iter, task, task.GetFile ());
 		}
 		
 		static void ProjectDataFunc (Gtk.TreeViewColumn column, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter)
@@ -655,12 +667,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				textRenderer.Text = "";
 				return;
 			}
-			SetText (textRenderer, model, iter, task, GetProject(task));
-		}
-		
-		static string GetProject (TaskListEntry task)
-		{
-			return (task != null && task.WorkspaceObject is SolutionFolderItem)? task.WorkspaceObject.Name: string.Empty;
+			SetText (textRenderer, model, iter, task, task.GetProject ());
 		}
 		
 		static void PathDataFunc (Gtk.TreeViewColumn column, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter)
@@ -671,7 +678,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				textRenderer.Text = "";
 				return;
 			}
-			SetText (textRenderer, model, iter, task, GetPath (task));
+			SetText (textRenderer, model, iter, task, task.GetPath ());
 		}
 
 		static void CategoryDataFunc (Gtk.TreeViewColumn column, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter)
@@ -911,7 +918,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			     zTask = model.GetValue (z, DataColumns.Task) as TaskListEntry;
 			     
 			return (aTask != null && zTask != null) ?
-			       string.Compare (GetProject (aTask), GetProject (zTask), StringComparison.Ordinal) :
+			       string.Compare (aTask.GetProject (), zTask.GetProject (), StringComparison.Ordinal) :
 			       0;
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -436,11 +436,11 @@ namespace MonoDevelop.Ide.Gui.Pads
 				if (task != null) {
 					await OpenBuildOutputViewDocument ().ConfigureAwait (false);
 					if (task.Severity == TaskSeverity.Error) {
-						buildOutputViewContent.GoToError (task.GetErrorDescription (), task.GetProjectWithExtension ());
+						buildOutputViewContent.GoToError (task.Message, task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Warning) {
-						buildOutputViewContent.GoToWarning (task.GetErrorDescription (), task.GetProjectWithExtension ());
+						buildOutputViewContent.GoToWarning (task.Message, task.GetProjectWithExtension ());
 					} else if (task.Severity == TaskSeverity.Information) {
-						buildOutputViewContent.GoToMessage (task.GetErrorDescription (), task.GetProjectWithExtension ());
+						buildOutputViewContent.GoToMessage (task.Message, task.GetProjectWithExtension ());
 					}
 				}
 			}
@@ -1016,15 +1016,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 		public static string GetProjectWithExtension (this TaskListEntry task)
 		{
 			return (task != null && task.WorkspaceObject is SolutionItem) ? Path.GetFileName (((SolutionItem)task.WorkspaceObject).FileName) : string.Empty;
-		}
-
-		public static string GetErrorDescription (this TaskListEntry task)
-		{
-			var toRemove = $" ({task.Code})";
-			if (task.Description.EndsWith (toRemove, StringComparison.Ordinal)) {
-				return task.Description.Substring (0, task.Description.Length - toRemove.Length);
-			}
-			return task.Description;
 		}
 
 		public static string GetFile (this TaskListEntry task)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -957,11 +957,13 @@ namespace MonoDevelop.Ide.Gui.Pads
 		async Task OpenBuildOutputViewDocument () 
 		{
 			if (buildOutputViewContent == null) {
-				buildOutputViewContent = new BuildOutputViewContent (buildOutput);
+
+				var contentName = $"{GettextCatalog.GetString ("Build Output")} {DateTime.Now.ToString ("hh:mm:ss")}.binlog";
+				var widget = new BuildOutputWidget (buildOutput, contentName);
+				buildOutputViewContent = new BuildOutputViewContent (widget);
 				buildOutputDoc = IdeApp.Workbench.OpenDocument (buildOutputViewContent, true);
 				buildOutputDoc.Closed += BuildOutputDocClosed;
-
-				await buildOutputViewContent.ProcessLogs (false);
+				await widget.ProcessLogsAsync (false);
 			} else if (buildOutputDoc != null) {
 				buildOutputDoc.Select ();
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -996,7 +996,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 		}
 	}
 
-	public static class TaskListEntryExtensions
+	internal static class TaskListEntryExtensions
 	{
 		public static string GetPath (this TaskListEntry task)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
@@ -158,6 +158,7 @@ namespace MonoDevelop.Ide.Tasks
 									
 		public string Description {
 			get => description;
+			set => description = value;
 		}
 
 		public string Message {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskListEntry.cs
@@ -70,6 +70,8 @@ namespace MonoDevelop.Ide.Tasks
 		[ItemProperty (DefaultValue = "")]
 		string category = string.Empty;
 
+		string message = String.Empty;
+
 		object owner;
 		WorkspaceObject parentObject;
 		internal int SavedLine;
@@ -122,17 +124,19 @@ namespace MonoDevelop.Ide.Tasks
 			parentObject = error.SourceTarget as WorkspaceObject;
 			file = error.FileName;
 			this.owner = owner;
-			description = error.ErrorText;
+
 			column = error.Column;
 			line = error.Line;
-			if (!string.IsNullOrEmpty (error.ErrorNumber))
-				description += " (" + error.ErrorNumber + ")";
+			code = error.ErrorNumber;
+
+			SetMessage (error.ErrorText, code);
+
 			if (error.IsWarning)
 				severity = error.ErrorNumber == "COMMENT" ? TaskSeverity.Information : TaskSeverity.Warning;
 			else
 				severity = TaskSeverity.Error;
 			priority = TaskPriority.Normal;
-			code = error.ErrorNumber;
+
 			category = error.Subcategory;
 			helpKeyword = error.HelpKeyword;
 		}
@@ -153,12 +157,12 @@ namespace MonoDevelop.Ide.Tasks
 		}
 									
 		public string Description {
-			get {
-				return description;
-			}
-			set {
-				description = value;
-			}
+			get => description;
+		}
+
+		public string Message {
+			get => message;
+			set => SetMessage (value, code);
 		}
 		
 		public string Code {
@@ -237,6 +241,14 @@ namespace MonoDevelop.Ide.Tasks
 
 		public string DocumentationLink {
 			get; set;
+		}
+
+		void SetMessage (string value, string taskCode)
+		{
+			message = value;
+			description = message;
+			if (!string.IsNullOrEmpty (taskCode))
+				description += " (" + taskCode + ")";
 		}
 
 		public bool HasDocumentationLink ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/UserTasksView.cs
@@ -299,7 +299,7 @@ namespace MonoDevelop.Ide.Tasks
 			if (sortModel.GetIterFromString (out sortedIter, args.Path)) {
 				iter = sortModel.ConvertIterToChildIter (sortedIter);
 				TaskListEntry task = (TaskListEntry) sortModel.GetValue (sortedIter, (int)Columns.UserTask);
-				task.Description = args.NewText;
+				task.Message = args.NewText;
 				store.SetValue (iter, (int)Columns.Description, args.NewText);
 				TaskService.SaveUserTasks (task.WorkspaceObject);
 			}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
@@ -53,7 +53,8 @@ namespace MonoDevelop.Ide
 			monitor.Log.Write ("Custom project built");
 			monitor.LogObject (new ProjectFinishedProgressEvent ());
 
-			var dataSource = bo.ToTreeDataSource (true);
+			var nodes = bo.GetRootNodes (true);
+			var dataSource = new BuildOutputDataSource (nodes);
 			var child = dataSource.GetChild (dataSource.GetChild (null, 0), 0);
 
 			Assert.That (dataSource.GetChildrenCount (null), Is.EqualTo (1));
@@ -74,7 +75,8 @@ namespace MonoDevelop.Ide
 			monitor.Log.WriteLine ("Custom project built");
 			monitor.LogObject (new ProjectFinishedProgressEvent ());
 
-			var dataSource = bo.ToTreeDataSource (true);
+			var nodes = bo.GetRootNodes (true);
+			var dataSource = new BuildOutputDataSource (nodes);
 			int matches = 0;
 			var visited = new HashSet<BuildOutputNode> ();
 			for (var match = dataSource.FirstMatch ("Message "); match != null; match = dataSource.NextMatch ()) {

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.Ide
 		}
 
 		[Test]
-		public void CustomProject_SearchDataSource ()
+		public void CustomProject_DataSearch ()
 		{
 			var bo = new BuildOutput ();
 			var monitor = bo.GetProgressMonitor ();
@@ -77,9 +77,10 @@ namespace MonoDevelop.Ide
 
 			var nodes = bo.GetRootNodes (true);
 			var dataSource = new BuildOutputDataSource (nodes);
+			var search = new BuildOutputDataSearch (nodes);
 			int matches = 0;
 			var visited = new HashSet<BuildOutputNode> ();
-			for (var match = dataSource.FirstMatch ("Message "); match != null; match = dataSource.NextMatch ()) {
+			for (var match = search.FirstMatch ("Message "); match != null; match = search.NextMatch ()) {
 				if (visited.Contains (match)) {
 					break;
 				}


### PR DESCRIPTION
This feature allows go to selected error/warning/message in Log Build Output line from the ErrorListPad.

To jump into the error we need all the data loaded. I changed our current code to allow do this.
 