### PR TITLE
Fix #560350: Issue with adding a Style to Tags in cshtml views

### DIFF
--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -500,6 +500,10 @@ namespace MonoDevelop.Xml.Editor
 				if (!listWindow.AutoSelect && char.IsLetterOrDigit (descriptor.KeyChar)) {
 					listWindow.AutoSelect = true;
 				}
+				if (XmlEditorOptions.AutoInsertFragments && (descriptor.KeyChar == '=' || descriptor.KeyChar == '"')) {
+					keyAction = KeyActions.CloseWindow | KeyActions.Complete | KeyActions.Ignore;
+					return true;
+				}
 				keyAction = KeyActions.None;
 				return false;
 			}


### PR DESCRIPTION
Problem was that default code completion was triggering code completion on `=` and `"` which user typed but default implementation doesn't know that Xml extension already inserts this values(="") in case of `AutoInsertFragments=true`, hence we have to also specify `KeyActions.Ignore` so editor doesn't insert additional `=` and `"`. This is same behaviour as VS has.