### PR TITLE
[IDE] Make the folding margin keyboard accessible

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
@@ -43,7 +43,7 @@ namespace Mono.TextEditor
 		MonoTextEditor editor;
 		DocumentLine lineHover;
 		Pango.Layout layout;
-		
+
 		double foldSegmentSize = 8;
 		double marginWidth;
 		public override double Width {
@@ -283,12 +283,13 @@ namespace Mono.TextEditor
 			foldToggleMarkerBackground = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.FoldCrossBackground);
 			lineStateChangedGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.QuickDiffChanged);
 			lineStateDirtyGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.QuickDiffDirty);
-			
+			backgroundColor = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.IndicatorMargin);
+
 			marginWidth = editor.LineHeight  * 3 / 4;
 		}
 		
 		Cairo.Color foldBgGC, foldLineGC, foldLineHighlightedGC, foldLineHighlightedGCBg, foldToggleMarkerGC, foldToggleMarkerBackground;
-		Cairo.Color lineStateChangedGC, lineStateDirtyGC;
+		Cairo.Color lineStateChangedGC, lineStateDirtyGC, backgroundColor;
 		
 		public override void Dispose ()
 		{
@@ -364,7 +365,13 @@ namespace Mono.TextEditor
 
 			foldSegmentSize = marginWidth * 4 / 6;
 			foldSegmentSize -= (foldSegmentSize) % 2;
-			
+
+			if (HasFocus) {
+				cr.Rectangle (x, y, Width, lineHeight);
+				cr.SetSourceColor (backgroundColor);
+				cr.Fill ();
+			}
+
 			Cairo.Rectangle drawArea = new Cairo.Rectangle (x, y, marginWidth, lineHeight);
 			var state = editor.Document.GetLineState (lineSegment);
 
@@ -486,6 +493,96 @@ namespace Mono.TextEditor
 					}
 				}
 			}
+		}
+
+		FoldSegment[] focusSegments;
+		int focusedIndex;
+		protected internal override bool SupportsItemCommands => true;
+		protected internal override bool HandleItemCommand(ItemCommand command)
+		{
+			bool highlightFold = false;
+
+			switch (command) {
+			case ItemCommand.ActivateCurrentItem:
+				ActivateFold (focusSegments[focusedIndex]);
+				break;
+
+			case ItemCommand.FocusNextItem:
+				focusedIndex++;
+				if (focusedIndex >= focusSegments.Length) {
+					focusedIndex = focusSegments.Length - 1;
+				}
+
+				highlightFold = true;
+				break;
+
+			case ItemCommand.FocusPreviousItem:
+				focusedIndex--;
+				if (focusedIndex < 0) {
+					focusedIndex = 0;
+				}
+
+				highlightFold = true;
+				break;
+			}
+
+			if (highlightFold && focusSegments.Length > 0) {
+				var segment = focusSegments[focusedIndex];
+
+				HighlightFold (segment);
+			}
+
+			return base.HandleItemCommand(command);
+		}
+
+		protected internal override void FocusIn()
+		{
+			base.FocusIn();
+
+			focusSegments = editor.Document.FoldSegments.ToArray ();
+			focusedIndex = 0;
+
+			if (focusSegments.Length > 0) {
+				HighlightFold (focusSegments[0]);
+			}
+
+			editor.RedrawMargin (this);
+		}
+
+		protected internal override void FocusOut()
+		{
+			focusSegments = null;
+			focusedIndex = 0;
+
+			editor.TextViewMargin.BackgroundRenderer = null;
+			editor.QueueDraw ();
+			base.FocusOut();
+
+			editor.RedrawMargin (this);
+		}
+
+		void ActivateFold (FoldSegment segment)
+		{
+			segment.IsCollapsed = !segment.IsCollapsed;
+			editor.Document.InformFoldChanged (new FoldSegmentEventArgs (segment));
+
+			editor.SetAdjustments ();
+			editor.Caret.MoveCaretBeforeFoldings ();
+
+			// Collapsing the fold causes highlighting to disappear
+			HighlightFold (segment);
+		}
+
+		void HighlightFold (FoldSegment segment)
+		{
+			var line = segment.GetStartLine (editor.Document);
+			var list = new List<FoldSegment>(editor.Document.GetFoldingContaining (line));
+			list.Sort ((x, y) => x.Offset.CompareTo (y.Offset));
+
+			editor.TextViewMargin.DisposeLayoutDict ();
+			editor.TextViewMargin.BackgroundRenderer = new FoldingScreenbackgroundRenderer (editor, list);
+			editor.QueueDraw ();
+
 		}
 	}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
@@ -545,8 +545,6 @@ namespace Mono.TextEditor
 			if (focusSegments.Length > 0) {
 				HighlightFold (focusSegments[0]);
 			}
-
-			editor.RedrawMargin (this);
 		}
 
 		protected internal override void FocusOut()
@@ -581,8 +579,7 @@ namespace Mono.TextEditor
 
 			editor.TextViewMargin.DisposeLayoutDict ();
 			editor.TextViewMargin.BackgroundRenderer = new FoldingScreenbackgroundRenderer (editor, list);
-			editor.QueueDraw ();
-
+			editor.ScrollTo (line.LineNumber, 0);
 		}
 	}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
@@ -581,7 +581,9 @@ namespace Mono.TextEditor
 			editor.TextViewMargin.BackgroundRenderer = new FoldingScreenbackgroundRenderer (editor, list);
 			editor.ScrollTo (line.LineNumber, 0);
 
-			AtkCocoaExtensions.SetCurrentFocus (accessibles[segment].Accessible);
+			if (accessibles != null) {
+				AtkCocoaExtensions.SetCurrentFocus (accessibles[segment].Accessible);
+			}
 		}
 	}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
@@ -580,6 +580,8 @@ namespace Mono.TextEditor
 			editor.TextViewMargin.DisposeLayoutDict ();
 			editor.TextViewMargin.BackgroundRenderer = new FoldingScreenbackgroundRenderer (editor, list);
 			editor.ScrollTo (line.LineNumber, 0);
+
+			AtkCocoaExtensions.SetCurrentFocus (accessibles[segment].Accessible);
 		}
 	}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
@@ -264,7 +264,12 @@ namespace Mono.TextEditor
 			UpdateMarkers ();
 			focusedIndex = 0;
 
-			editor.RedrawMargin (this);
+			if (focusMarkers.Count == 0) {
+				return;
+			}
+
+			var marker = focusMarkers[0];
+			editor.CenterTo (marker.LineSegment.LineNumber, 1);
 		}
 
 		protected internal override void FocusOut()
@@ -298,22 +303,29 @@ namespace Mono.TextEditor
 				if (focusedIndex >= focusMarkers.Count) {
 					focusedIndex = focusMarkers.Count - 1;
 				}
+
+				editor.RedrawMargin (this);
 				break;
 
 			case ItemCommand.FocusNextItem:
 				focusedIndex++;
 
 				SanitizeFocusedIndex ();
+
+				marker = focusMarkers[focusedIndex] as MarginMarker;
+				editor.CenterTo (marker.LineSegment.LineNumber, 1);
 				break;
 
 			case ItemCommand.FocusPreviousItem:
 				focusedIndex--;
 
 				SanitizeFocusedIndex ();
+
+				marker = focusMarkers[focusedIndex] as MarginMarker;
+				editor.CenterTo (marker.LineSegment.LineNumber, 1);
 				break;
 			}
 
-			editor.RedrawMargin (this);
 			return true;
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
@@ -326,6 +326,12 @@ namespace Mono.TextEditor
 				break;
 			}
 
+			if (marker != null) {
+				var accessible = markerToAccessible[marker];
+				if (accessible != null) {
+					AtkCocoaExtensions.SetCurrentFocus (accessible.Accessible);
+				}
+			}
 			return true;
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
@@ -326,7 +326,7 @@ namespace Mono.TextEditor
 				break;
 			}
 
-			if (marker != null) {
+			if (marker != null && markerToAccessible != null) {
 				var accessible = markerToAccessible[marker];
 				if (accessible != null) {
 					AtkCocoaExtensions.SetCurrentFocus (accessible.Accessible);
@@ -354,6 +354,7 @@ namespace Mono.TextEditor
 
 			set {
 				metrics = value;
+
 				Accessible.FrameInGtkParent = new Rectangle ((int)metrics.X, (int)metrics.Y, (int)metrics.Width, (int)metrics.Height);
 
 				var halfParentHeight = margin.RectInParent.Height / 2.0f;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/IconMargin.cs
@@ -38,7 +38,7 @@ namespace Mono.TextEditor
 	class IconMargin : Margin
 	{
 		MonoTextEditor editor;
-		Cairo.Color backgroundColor, separatorColor;
+		Cairo.Color backgroundColor, separatorColor, focusedBackgroundColor, focusedMarkerColor;
 		const int marginWidth = 22;
 
 		public IconMargin (MonoTextEditor editor)
@@ -73,6 +73,8 @@ namespace Mono.TextEditor
 		internal protected override void OptionsChanged ()
 		{
 			backgroundColor = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.IndicatorMargin);
+			focusedBackgroundColor = backgroundColor.AddLight (-0.02);
+			focusedMarkerColor = backgroundColor.AddLight (-0.3);
 			separatorColor = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.IndicatorMarginSeparator);
 		}
 
@@ -131,18 +133,31 @@ namespace Mono.TextEditor
 		internal protected override void Draw (Cairo.Context cr, Cairo.Rectangle area, DocumentLine line, int lineNumber, double x, double y, double lineHeight)
 		{
 			bool backgroundIsDrawn = false;
+			bool lineMarkerIsSelected = false;
 			if (line != null) {
 				foreach (var marker in editor.Document.GetMarkersOrderedByInsertion (line)) {
 					var marginMarker = marker as MarginMarker;
-					if (marginMarker != null && marginMarker.CanDrawBackground (this)) {
-						backgroundIsDrawn = marginMarker.DrawBackground (editor, cr, new MarginDrawMetrics (this, area, line, lineNumber, x, y, lineHeight));
+					if (marginMarker != null) {
+						if (marginMarker.CanDrawBackground (this)) {
+							backgroundIsDrawn = marginMarker.DrawBackground (editor, cr, new MarginDrawMetrics (this, area, line, lineNumber, x, y, lineHeight));
+						}
+
+						if (focusMarkers != null) {
+							SanitizeFocusedIndex ();
+
+							lineMarkerIsSelected = (HasFocus && (marginMarker == focusMarkers[focusedIndex]));
+						}
 					}
 				}
 			}
 
 			if (!backgroundIsDrawn) {
 				cr.Rectangle (x, y, Width, lineHeight);
-				cr.SetSourceColor (backgroundColor);
+				if (HasFocus && lineMarkerIsSelected) {
+					cr.SetSourceColor (focusedMarkerColor);
+				} else {
+					cr.SetSourceColor (HasFocus ? focusedBackgroundColor : backgroundColor);
+				}
 				cr.Fill ();
 
 				cr.MoveTo (x + Width - 0.5, y);
@@ -187,6 +202,10 @@ namespace Mono.TextEditor
 			Accessible.AddAccessibleChild (proxy.Accessible);
 
 			markerToAccessible [e.TextMarker] = proxy;
+
+			if (focusMarkers != null) {
+				UpdateMarkers ();
+			}
 		}
 
 		void OnMarkerRemoved (object sender, TextMarkerEvent e)
@@ -206,6 +225,96 @@ namespace Mono.TextEditor
 
 			Accessible.RemoveAccessibleChild (proxy.Accessible);
 			markerToAccessible.Remove (e.TextMarker);
+
+			if (focusMarkers != null) {
+				UpdateMarkers ();
+			}
+		}
+
+		List<TextLineMarker> focusMarkers;
+		int focusedIndex;
+		protected internal override bool SupportsItemCommands => true;
+
+		void SanitizeFocusedIndex ()
+		{
+			if (focusMarkers == null) {
+				focusedIndex = 0;
+				return;
+			}
+
+			var count = focusMarkers.Count;
+			focusedIndex = focusedIndex < 0 ? 0 : focusedIndex >= count ? count - 1 : focusedIndex;
+		}
+
+		void UpdateMarkers ()
+		{
+			focusMarkers = new List<TextLineMarker> ();
+
+			for (int lineNumber = 0; lineNumber <= editor.Document.LineCount; lineNumber++) {
+				foreach (var marker in editor.Document.GetMarkersOrderedByInsertion (editor.GetLine (lineNumber))) {
+					focusMarkers.Add (marker);
+				}
+			}
+		}
+
+		protected internal override void FocusIn()
+		{
+			base.FocusIn();
+
+			UpdateMarkers ();
+			focusedIndex = 0;
+
+			editor.RedrawMargin (this);
+		}
+
+		protected internal override void FocusOut()
+		{
+			base.FocusOut();
+
+			focusMarkers = null;
+			focusedIndex = 0;
+
+			editor.RedrawMargin (this);
+		}
+
+		protected internal override bool HandleItemCommand(ItemCommand command)
+		{
+			if (focusMarkers.Count == 0) {
+				return false;
+			}
+
+			var marker = focusMarkers[focusedIndex] as MarginMarker;
+
+			if (marker == null) {
+				return false;
+			}
+
+			switch (command) {
+			case ItemCommand.ActivateCurrentItem:
+				var lineNumber = marker.LineSegment.LineNumber;
+				var y = editor.LineToY (lineNumber);
+				MousePressed (new MarginMouseEventArgs (editor, EventType.ButtonPress, 1, 0, y, ModifierType.None));
+
+				if (focusedIndex >= focusMarkers.Count) {
+					focusedIndex = focusMarkers.Count - 1;
+				}
+				break;
+
+			case ItemCommand.FocusNextItem:
+				focusedIndex++;
+
+				SanitizeFocusedIndex ();
+				break;
+
+			case ItemCommand.FocusPreviousItem:
+				focusedIndex--;
+
+				SanitizeFocusedIndex ();
+				break;
+			}
+
+			editor.RedrawMargin (this);
+			return true;
 		}
 
 		public EventHandler<BookmarkMarginDrawEventArgs> DrawEvent;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
@@ -158,7 +158,34 @@ namespace Mono.TextEditor
 			if (MouseLeave != null)
 				MouseLeave (this, EventArgs.Empty);
 		}
-		
+
+		internal protected virtual bool SupportsItemCommands {
+			get {
+				return false;
+			}
+		}
+		internal enum ItemCommand {
+			FocusNextItem,
+			FocusPreviousItem,
+			ActivateCurrentItem
+		};
+
+		internal protected virtual bool HandleItemCommand (ItemCommand command)
+		{
+			return false;
+		}
+
+		internal bool HasFocus { get; private set; }
+		internal protected virtual void FocusIn ()
+		{
+			HasFocus = true;
+		}
+
+		internal protected virtual void FocusOut ()
+		{
+			HasFocus = false;
+		}
+
 		public virtual void Dispose ()
 		{
 			cursor = cursor.Kill ();

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
@@ -179,11 +179,15 @@ namespace Mono.TextEditor
 		internal protected virtual void FocusIn ()
 		{
 			HasFocus = true;
+
+			// Set the margin as the current focused accessibility element
+			AtkCocoaExtensions.SetCurrentFocus (Accessible);
 		}
 
 		internal protected virtual void FocusOut ()
 		{
 			HasFocus = false;
+			AtkCocoaExtensions.SetCurrentFocus (null);
 		}
 
 		public virtual void Dispose ()

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -787,7 +787,10 @@ namespace Mono.TextEditor
 
 			if (margin != null) {
 				margin.FocusIn ();
+			} else if (currentFocus == FocusMargin.TextView) {
+				textViewMargin.FocusIn ();
 			}
+
 			return currentFocus != FocusMargin.None;
 		}
 
@@ -804,6 +807,7 @@ namespace Mono.TextEditor
 			var result = base.OnFocusInEvent (evnt);
 
 			currentFocus = FocusMargin.TextView;
+			textViewMargin.FocusIn ();
 			FocusIn ();
 
 			return result;
@@ -825,6 +829,7 @@ namespace Mono.TextEditor
 
 				TextViewMargin.StopCaretThread ();
 				Document.CommitLineUpdate (Caret.Line);
+				textViewMargin.FocusOut ();
 			} else if (currentFocus != FocusMargin.None){
 				var cm = GetMargin (currentFocus);
 				cm.FocusOut ();
@@ -847,6 +852,8 @@ namespace Mono.TextEditor
 				m.FocusOut ();
 			}
 			currentFocus = FocusMargin.TextView;
+			textViewMargin.FocusIn ();
+
 			base.OnFocusGrabbed();
 		}
 
@@ -1317,6 +1324,8 @@ namespace Mono.TextEditor
 				Margin margin = GetMarginAtX (e.X, out startPos);
 				if (margin == textViewMargin) {
 					currentFocus = FocusMargin.TextView;
+					textViewMargin.FocusIn ();
+
 					//main context menu
 					if (DoPopupMenu != null && e.TriggersContextMenu ()) {
 						DoClickedPopupMenu (e);

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -842,6 +842,10 @@ namespace Mono.TextEditor
 
 		protected override void OnFocusGrabbed()
 		{
+			if (currentFocus != FocusMargin.TextView && currentFocus != FocusMargin.None) {
+				var m = GetMargin (currentFocus);
+				m.FocusOut ();
+			}
 			currentFocus = FocusMargin.TextView;
 			base.OnFocusGrabbed();
 		}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -668,34 +668,182 @@ namespace Mono.TextEditor
 				preeditOffset = Caret.Offset;
 			}
 		}
-		
-		protected override bool OnFocusInEvent (EventFocus evnt)
+
+		enum FocusMargin {
+			None,
+			Icon,
+			Action,
+			Gutter,
+			FoldMarker,
+			TextView,
+		};
+
+		FocusMargin currentFocus = FocusMargin.None;
+
+		Margin GetMargin (FocusMargin margin)
 		{
-			var result = base.OnFocusInEvent (evnt);
+			switch (margin) {
+			case FocusMargin.None:
+				return null;
+
+			case FocusMargin.Icon:
+				return IconMargin;
+
+			case FocusMargin.Action:
+				return ActionMargin;
+
+			case FocusMargin.Gutter:
+				return GutterMargin;
+
+			case FocusMargin.FoldMarker:
+				return foldMarkerMargin;
+
+			case FocusMargin.TextView:
+				return TextViewMargin;
+
+			default:
+				return null;
+			}
+		}
+
+		FocusMargin GetNextMargin (FocusMargin current, DirectionType direction)
+		{
+			switch (direction) {
+			case DirectionType.TabForward:
+			case DirectionType.Right:
+				switch (current) {
+				case FocusMargin.None:
+					return FocusMargin.Icon;
+
+				case FocusMargin.Icon:
+					return FocusMargin.Action;
+
+				case FocusMargin.Action:
+					return FocusMargin.Gutter;
+
+				case FocusMargin.Gutter:
+					return FocusMargin.FoldMarker;
+
+				case FocusMargin.FoldMarker:
+					return FocusMargin.TextView;
+
+				case FocusMargin.TextView:
+					return FocusMargin.None;
+				}
+
+				break;
+
+			case DirectionType.TabBackward:
+			case DirectionType.Left:
+				switch (current) {
+				case FocusMargin.None:
+					return FocusMargin.TextView;
+
+				case FocusMargin.Icon:
+					return FocusMargin.None;
+
+				case FocusMargin.Action:
+					return FocusMargin.Icon;
+
+				case FocusMargin.Gutter:
+					return FocusMargin.Action;
+
+				case FocusMargin.FoldMarker:
+					return FocusMargin.Gutter;
+
+				case FocusMargin.TextView:
+					return FocusMargin.FoldMarker;
+				}
+
+				break;
+			}
+
+			return FocusMargin.None;
+		}
+
+		bool FocusNextMargin (Gtk.DirectionType direction)
+		{
+			FocusMargin nextFocus = currentFocus;
+			Margin margin = null;
+
+			while ((nextFocus = GetNextMargin (nextFocus, direction)) != FocusMargin.TextView) {
+				if (nextFocus == FocusMargin.None) {
+					break;
+				}
+
+				var m = GetMargin (nextFocus);
+
+				if (m.SupportsItemCommands) {
+					margin = m;
+					break;
+				}
+			}
+
+			var previousMargin = GetMargin (currentFocus);
+			if (previousMargin != null && previousMargin.SupportsItemCommands) {
+				previousMargin.FocusOut ();
+			}
+			currentFocus = nextFocus;
+
+			if (margin != null) {
+				margin.FocusIn ();
+			}
+			return currentFocus != FocusMargin.None;
+		}
+
+		void FocusIn ()
+		{
 			imContextNeedsReset = true;
 			IMContext.FocusIn ();
 			RequestResetCaretBlink ();
 			Document.CommitLineUpdate (Caret.Line);
+		}
+
+		protected override bool OnFocusInEvent (EventFocus evnt)
+		{
+			var result = base.OnFocusInEvent (evnt);
+
+			currentFocus = FocusMargin.TextView;
+			FocusIn ();
+
 			return result;
 		}
-		
+
+		void FocusOut ()
+		{
+			if (currentFocus == FocusMargin.TextView) {
+				imContextNeedsReset = true;
+				mouseButtonPressed = 0;
+				imContext.FocusOut ();
+
+				if (tipWindow != null && currentTooltipProvider != null) {
+					if (!currentTooltipProvider.IsInteractive (textEditorData.Parent, tipWindow))
+						DelayedHideTooltip ();
+				} else {
+					HideTooltip ();
+				}
+
+				TextViewMargin.StopCaretThread ();
+				Document.CommitLineUpdate (Caret.Line);
+			} else if (currentFocus != FocusMargin.None){
+				var cm = GetMargin (currentFocus);
+				cm.FocusOut ();
+			}
+		}
+
 		protected override bool OnFocusOutEvent (EventFocus evnt)
 		{
 			var result = base.OnFocusOutEvent (evnt);
-			imContextNeedsReset = true;
-			mouseButtonPressed = 0;
-			imContext.FocusOut ();
 
-			if (tipWindow != null && currentTooltipProvider != null) {
-				if (!currentTooltipProvider.IsInteractive (textEditorData.Parent, tipWindow))
-					DelayedHideTooltip ();
-			} else {
-				HideTooltip ();
-			}
+			FocusOut ();
 
-			TextViewMargin.StopCaretThread ();
-			Document.CommitLineUpdate (Caret.Line);
 			return result;
+		}
+
+		protected override void OnFocusGrabbed()
+		{
+			currentFocus = FocusMargin.TextView;
+			base.OnFocusGrabbed();
 		}
 
 		protected override void OnRealized ()
@@ -1047,59 +1195,97 @@ namespace Mono.TextEditor
 
 		protected override bool OnKeyPressEvent (Gdk.EventKey evt)
 		{
-			Gdk.Key key;
-			Gdk.ModifierType mod;
-			KeyboardShortcut[] accels;
-			GtkWorkarounds.MapKeys (evt, out key, out mod, out accels);
-			//HACK: we never call base.OnKeyPressEvent, so implement the popup key manually
-			if (key == Gdk.Key.Menu || (key == Gdk.Key.F10 && mod.HasFlag (ModifierType.ShiftMask))) {
-				OnPopupMenu ();
-				return true;
-			}
-			uint keyVal = (uint)key;
-			CurrentMode.SelectValidShortcut (accels, out key, out mod);
-			if (key == Gdk.Key.F1 && (mod & (ModifierType.ControlMask | ModifierType.ShiftMask)) == ModifierType.ControlMask) {
-				var p = LocationToPoint (Caret.Location);
-				ShowTooltip (Gdk.ModifierType.None, Caret.Offset, p.X, p.Y);
-				return true;
-			}
-			if (key == Gdk.Key.F2 && textViewMargin.IsCodeSegmentPreviewWindowShown) {
-				textViewMargin.OpenCodeSegmentEditor ();
-				return true;
-			}
-			
-			//FIXME: why are we doing this?
-			if ((key == Gdk.Key.space || key == Gdk.Key.parenleft || key == Gdk.Key.parenright) && (mod & Gdk.ModifierType.ShiftMask) == Gdk.ModifierType.ShiftMask)
-				mod = Gdk.ModifierType.None;
-			
-			uint unicodeChar = Gdk.Keyval.ToUnicode (keyVal);
-			
-			if (CurrentMode.WantsToPreemptIM || CurrentMode.PreemptIM (key, unicodeChar, mod)) {
-				ResetIMContext ();
-				//FIXME: should call base.OnKeyPressEvent when SimulateKeyPress didn't handle the event
-				SimulateKeyPress (key, unicodeChar, mod);
-				return true;
-			}
-			bool filter = IMFilterKeyPress (evt, key, unicodeChar, mod);
-			if (filter) {
-				imContextNeedsReset = false;
-				ResetIMContext ();
-				return true;
+			if (currentFocus == FocusMargin.TextView) {
+				Gdk.Key key;
+				Gdk.ModifierType mod;
+				KeyboardShortcut[] accels;
+				GtkWorkarounds.MapKeys (evt, out key, out mod, out accels);
+				//HACK: we never call base.OnKeyPressEvent, so implement the popup key manually
+				if (key == Gdk.Key.Menu || (key == Gdk.Key.F10 && mod.HasFlag (ModifierType.ShiftMask))) {
+					OnPopupMenu ();
+					return true;
+				}
+
+				if (key == Gdk.Key.Tab && mod.HasFlag (ModifierType.Mod1Mask)) {
+					currentFocus = FocusMargin.None;
+					return FocusNextMargin (Gtk.DirectionType.TabForward);
+				}
+
+				uint keyVal = (uint)key;
+				CurrentMode.SelectValidShortcut (accels, out key, out mod);
+				if (key == Gdk.Key.F1 && (mod & (ModifierType.ControlMask | ModifierType.ShiftMask)) == ModifierType.ControlMask) {
+					var p = LocationToPoint (Caret.Location);
+					ShowTooltip (Gdk.ModifierType.None, Caret.Offset, p.X, p.Y);
+					return true;
+				}
+				if (key == Gdk.Key.F2 && textViewMargin.IsCodeSegmentPreviewWindowShown) {
+					textViewMargin.OpenCodeSegmentEditor ();
+					return true;
+				}
+				
+				//FIXME: why are we doing this?
+				if ((key == Gdk.Key.space || key == Gdk.Key.parenleft || key == Gdk.Key.parenright) && (mod & Gdk.ModifierType.ShiftMask) == Gdk.ModifierType.ShiftMask)
+					mod = Gdk.ModifierType.None;
+				
+				uint unicodeChar = Gdk.Keyval.ToUnicode (keyVal);
+				
+				if (CurrentMode.WantsToPreemptIM || CurrentMode.PreemptIM (key, unicodeChar, mod)) {
+					ResetIMContext ();
+					//FIXME: should call base.OnKeyPressEvent when SimulateKeyPress didn't handle the event
+					SimulateKeyPress (key, unicodeChar, mod);
+					return true;
+				}
+				bool filter = IMFilterKeyPress (evt, key, unicodeChar, mod);
+				if (filter) {
+					imContextNeedsReset = false;
+					ResetIMContext ();
+					return true;
+				}
+
+				//FIXME: OnIMProcessedKeyPressEvent should return false when it didn't handle the event
+				if (editor.OnIMProcessedKeyPressEvent (key, unicodeChar, mod))
+					return true;
+			} else if (currentFocus != FocusMargin.None) {
+				return HandleMarginKeyCommand (evt);
 			}
 
-			//FIXME: OnIMProcessedKeyPressEvent should return false when it didn't handle the event
-			if (editor.OnIMProcessedKeyPressEvent (key, unicodeChar, mod))
-				return true;
-			
 			return base.OnKeyPressEvent (evt);
 		}
 		
+		bool HandleMarginKeyCommand (EventKey evnt)
+		{
+			var cm = GetMargin (currentFocus);
+			Gdk.Key key;
+			Gdk.ModifierType mod;
+			KeyboardShortcut[] accels;
+
+			GtkWorkarounds.MapKeys (evnt, out key, out mod, out accels);
+
+			if (key == Gdk.Key.space) {
+				cm.HandleItemCommand (Margin.ItemCommand.ActivateCurrentItem);
+			} else if (key == Gdk.Key.Up) {
+				cm.HandleItemCommand (Margin.ItemCommand.FocusPreviousItem);
+			} else if (key == Gdk.Key.Down) {
+				cm.HandleItemCommand (Margin.ItemCommand.FocusNextItem);
+			} else if (key == Gdk.Key.Tab || key == Gdk.Key.Right) {
+				return FocusNextMargin (Gtk.DirectionType.TabForward);
+			} else if (key == Gdk.Key.ISO_Left_Tab || key == Gdk.Key.Left) {
+				return FocusNextMargin (DirectionType.TabBackward);
+			} else {
+				return false;
+			}
+
+			return true;
+		}
 
 		protected override bool OnKeyReleaseEvent (EventKey evnt)
 		{
-			if (IMFilterKeyPress (evnt, 0, 0, ModifierType.None)) {
-				imContextNeedsReset = true;
+			if (currentFocus == FocusMargin.TextView) {
+				if (IMFilterKeyPress (evnt, 0, 0, ModifierType.None)) {
+					imContextNeedsReset = true;
+				}
 			}
+
 			return true;
 		}
 		
@@ -1126,6 +1312,7 @@ namespace Mono.TextEditor
 				double startPos;
 				Margin margin = GetMarginAtX (e.X, out startPos);
 				if (margin == textViewMargin) {
+					currentFocus = FocusMargin.TextView;
 					//main context menu
 					if (DoPopupMenu != null && e.TriggersContextMenu ()) {
 						DoClickedPopupMenu (e);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelper.cs
@@ -100,6 +100,13 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			w.Accessible.SetTitleUIElement (label.Accessible);
 			label.Accessible.SetTitleFor (w.Accessible);
 		}
+
+		public static void SetCurrentFocus (AccessibilityElementProxy focusElement)
+		{
+#if MAC
+			AtkCocoaMacExtensions.SetCurrentFocus (focusElement);
+#endif
+		}
 	}
 
 	// AtkCocoaHelper wraps NSAccessibilityElement to set NSAccessibility properties that aren't supported by Atk

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -81,6 +81,14 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			}
 		}
 
+		public static void SetCurrentFocus (AccessibilityElementProxy focusElement)
+		{
+			var element = focusElement != null ? focusElement.Proxy as NSObject : null;
+			NSApplication.SharedApplication.AccessibilityApplicationFocusedUIElement = element;
+			NSAccessibility.PostNotification (NSApplication.SharedApplication, NSAccessibilityNotifications.UIElementFocusedChangedNotification, 
+			                                  new NSDictionary (NSAccessibilityNotificationUserInfoKeys.UIElementsKey, NSArray.FromObject (element)));
+		}
+
 		public static void SetLabel (this Atk.Object o, string label)
 		{
 			var nsa = GetNSAccessibilityElement (o);


### PR DESCRIPTION
When in the text editor, use Alt-Tab to focus the margins.
Tab, Shift+Tab, Left or Right to select the focus margin (Only folding margin
accepts focus at the moment).
Up and Down selects the fold
Space folds or unfolds the selected fold

Fixes VSTS #515126