### PR TITLE
[NUnit] Fix being unable to use NUnit in a .NET Core test project

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
@@ -79,6 +79,9 @@ namespace MonoDevelop.UnitTesting.NUnit
 
 		public static NUnitProjectTestSuite CreateTest (DotNetProject project)
 		{
+			if (project.TargetFramework.Id.Identifier == ".NETCoreApp")
+				return null;
+
 			if (!project.ParentSolution.GetConfiguration (IdeApp.Workspace.ActiveConfiguration).BuildEnabledForItem (project))
 				return null;
 


### PR DESCRIPTION
The problem was that the NUnit test provider was finding a
PackageReference for NUnit, trying to load the tests for the .NET Core
project and failing. To fix this the NUnit test provider now ignores
.NET Core projects so the VS Test provider has a chance to load the
tests.

Fixes VSTS #565933