### PR TITLE
[Ide] When showing a result dialog, compute transientFor if possible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/BaseProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/BaseProgressMonitor.cs
@@ -40,13 +40,15 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 {
 	public static class ProgressHelper
 	{
-		public static void ShowResultDialog (this ProgressMonitor monitor)
+		public static void ShowResultDialog (this ProgressMonitor monitor) => ShowResultDialog (monitor, null);
+
+		public static void ShowResultDialog (this ProgressMonitor monitor, MonoDevelop.Components.Window parent)
 		{
 			if (monitor.Errors.Length == 1 && !monitor.HasWarnings) {
-				MessageService.ShowError (monitor.Errors [0].Message, monitor.Errors [0].Exception);
+				MessageService.ShowError (parent, monitor.Errors [0].Message, null, monitor.Errors [0].Exception);
 			}
 			else if (!monitor.HasErrors && monitor.Warnings.Length == 1) {
-				MessageService.ShowWarning (monitor.Warnings[0]);
+				MessageService.ShowWarning (parent, monitor.Warnings[0]);
 			}
 			else if (monitor.HasErrors || monitor.HasWarnings) {
 				using (var resultDialog = new MultiMessageDialog () {
@@ -56,7 +58,7 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 						resultDialog.AddError (m.DisplayMessage);
 					foreach (var m in monitor.Warnings)
 						resultDialog.AddWarning (m);
-					MessageService.ShowCustomDialog (resultDialog);
+					MessageService.ShowCustomDialog (resultDialog, parent);
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
@@ -137,8 +137,8 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 			
 			if (showDetails)
 				return;
-			
-			this.ShowResultDialog ();
+
+			this.ShowResultDialog (hideWhenDone ? MessageService.RootWindow : dialog);
 		}
 	}
 }


### PR DESCRIPTION
For some reason, when VCS finished checking out, the window that was chosen for the ShowError alert was not the root window, thus it would go behind.
That way, the IDE would be unusable until the user focuses out and back in and sees the dialog and clicks ok