### PR TITLE
[Structured build output] Few fixes:

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -419,14 +419,16 @@ namespace MonoDevelop.Ide.BuildOutputView
 			currentSearchPattern = pattern;
 			currentMatchIndex = -1;
 
-			// Perform search
-			foreach (var root in rootNodes) {
-				SearchInNodeAndChildren (root, currentSearchMatches, currentSearchPattern);
-			}
+			if (!string.IsNullOrEmpty (pattern)) {
+				// Perform search
+				foreach (var root in rootNodes) {
+					SearchInNodeAndChildren (root, currentSearchMatches, currentSearchPattern);
+				}
 
-			if (currentSearchMatches.Count > 0) {
-				currentMatchIndex = 0;
-				return currentSearchMatches [0];
+				if (currentSearchMatches.Count > 0) {
+					currentMatchIndex = 0;
+					return currentSearchMatches [0];
+				}
 			}
 
 			return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -128,7 +128,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		[CommandHandler (FileCommands.Save)]
 		public override Task Save ()
 		{
-			return control.Save ();
+			return control.SaveAs ();
 		}
 
 		[CommandUpdateHandler (FileCommands.Save)]
@@ -136,6 +136,5 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			cinfo.Enabled = control.IsDirty;
 		}
-
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Threading.Tasks;
 using MonoDevelop.Components;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
@@ -72,7 +73,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		public override bool IsFile {
 			get {
-				return System.IO.File.Exists (filename.FullPath);
+				return true;
 			}
 		}
 
@@ -123,5 +124,18 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			cinfo.Enabled = control.IsSearchInProgress;
 		}
+
+		[CommandHandler (FileCommands.Save)]
+		public override Task Save ()
+		{
+			return control.Save ();
+		}
+
+		[CommandUpdateHandler (FileCommands.Save)]
+		public void UpdateSaveHandler (CommandInfo cinfo)
+		{
+			cinfo.Enabled = control.IsDirty;
+		}
+
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -231,8 +231,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 			if (newIndex >= CurrentPath.Length)
 				return;
 
-			if (CurrentPath [newIndex].Tag != null) {
-				MoveToMatch (CurrentPath [newIndex].Tag as BuildOutputNode);
+			var node = CurrentPath [newIndex].Tag as BuildOutputNode;
+			if (node != null && node.HasChildren) {
+				MoveToMatch (node);
 			}
 		}
 
@@ -244,7 +245,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			var stack = new Stack<BuildOutputNode> ();
 
-			stack.Push (selectedNode);
+			if (selectedNode.HasChildren)
+				stack.Push (selectedNode);	
 			var parent = selectedNode.Parent;
 
 			while (parent != null) {
@@ -254,9 +256,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			var entries = new PathEntry [stack.Count];
 			var index = 0;
+			var dataSource = treeView.DataSource as BuildOutputDataSource;
 			while (stack.Count > 0) {
 				var node = stack.Pop ();
-				var dataSource = treeView.DataSource as BuildOutputDataSource;
 				var pathEntry = new PathEntry (dataSource.GetValue (node, 0) as Xwt.Drawing.Image, node.Message);
 				pathEntry.Tag = node;
 				entries [index] = pathEntry;
@@ -449,12 +451,27 @@ namespace MonoDevelop.Ide.BuildOutputView
 				this.widget = widget;
 				Reset ();
 
-				list = (node == null || node.Parent == null) ? DataSource.RootNodes : node.Parent.Children;
+				list = (node == null || node.Parent == null) ? DataSource.RootNodes : NodesWithChildren (node.Parent.Children);
+			}
+
+			IReadOnlyList<BuildOutputNode> NodesWithChildren(IEnumerable<BuildOutputNode> nodes)
+			{
+				var aux = new List<BuildOutputNode> ();
+				foreach (var node in nodes) {
+					if (node.HasChildren)
+						aux.Add (node);
+				}
+
+				return aux;
 			}
 
 			public int IconCount => list.Count;
 
-			public void ActivateItem (int n) => widget.MoveToMatch (list [n]);
+			public void ActivateItem (int n)
+			{
+				if (list [n].HasChildren)
+					widget.MoveToMatch (list [n]);
+			}
 
 			public Xwt.Drawing.Image GetIcon (int n) => DataSource.GetValue (list [n], 0) as Xwt.Drawing.Image;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -139,7 +139,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			searchEntry.Accessible.Description = GettextCatalog.GetString ("Search the build log");
 			searchEntry.WidthRequest = 200;
 			searchEntry.Visible = true;
-
+			searchEntry.EmptyMessage = GettextCatalog.GetString ("Search Build Output");
+			           
 			resultInformLabel = new Label ();
 			searchEntry.AddLabelWidget ((Gtk.Label) resultInformLabel.ToGtkWidget());
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -175,6 +175,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			treeView.HeadersVisible = false;
 			treeView.Accessible.Identifier = "BuildOutputWidget.TreeView";
 			treeView.Accessible.Description = GettextCatalog.GetString ("Structured build output");
+			treeView.HorizontalScrollPolicy = ScrollPolicy.Never;
 			treeView.SelectionChanged += TreeView_SelectionChanged;
 			var treeColumn = new ListViewColumn {
 				CanResize = false,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -167,7 +167,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			toolbar.AddSpace ();
 			toolbar.Add (searchEntry, false);
 			toolbar.Add (buttonSearchBackward.ToGtkWidget ());
-			toolbar.Add (buttonSearchForward.ToGtkWidget());
+			toolbar.Add (buttonSearchForward.ToGtkWidget ());
 
 			PackStart (toolbar.Container, expand: false, fill: true);
 
@@ -193,37 +193,24 @@ namespace MonoDevelop.Ide.BuildOutputView
 			PackStart (scrolledWindow, expand: true, fill: true);
 		}
 
-		async void SaveButtonClickedAsync (object sender, EventArgs e) => await Save ();
-
-		public async Task Save ()
-		{
-			if (filePathLocation == FilePath.Empty) {
-				await SaveAs ();
-			} else {
-				await Save (filePathLocation);
-			}
-		}
-
-		async Task Save (FilePath outputFile)
-		{
-			if (!outputFile.HasExtension (binLogExtension))
-				outputFile = outputFile.ChangeExtension (binLogExtension);
-
-			await BuildOutput.Save (outputFile);
-			FileSaved?.Invoke (this, outputFile.FileName);
-			filePathLocation = outputFile;
-			IsDirty = false;
-		}
+		async void SaveButtonClickedAsync (object sender, EventArgs e) => await SaveAs ();
 
 		FilePath filePathLocation;
-		async Task SaveAs ()
+		public async Task SaveAs ()
 		{
 			var dlg = new Gui.Dialogs.OpenFileDialog (GettextCatalog.GetString ("Save as..."), MonoDevelop.Components.FileChooserAction.Save) {
 				TransientFor = IdeApp.Workbench.RootWindow,
 				InitialFileName = ViewContentName
 			};
 			if (dlg.Run ()) {
-				await Save (dlg.SelectedFile);
+				var outputFile = dlg.SelectedFile;
+				if (!outputFile.HasExtension (binLogExtension))
+					outputFile = outputFile.ChangeExtension (binLogExtension);
+
+				await BuildOutput.Save (outputFile);
+				FileSaved?.Invoke (this, outputFile.FileName);
+				filePathLocation = outputFile;
+				IsDirty = false;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -94,6 +94,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			filePathLocation = filePath;
 			output.Load (filePath.FullPath, false);
 			SetupBuildOutput (output);
+			IsDirty = false;
 		}
 
 		void SetupBuildOutput (BuildOutput output)
@@ -375,6 +376,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			cts?.Cancel ();
 			cts = new CancellationTokenSource ();
 
+			IsDirty = true;
+
 			Task.Run (async () => {
 				await Runtime.RunInMainThread (() => {
 					var dataSource = BuildOutput.ToTreeDataSource (showDiagnostics);
@@ -389,8 +392,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 						treeView.ExpandRow (root, false);
 						ExpandChildrenWithErrors (treeView, dataSource, root);
 					}
-
-					IsDirty = true;
 				});
 			}, cts.Token);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -45,6 +45,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 {
 	class BuildOutputWidget : VBox, IPathedDocument
 	{
+		const string binLogExtension = "binlog";
+
 		TreeView treeView;
 		ScrollView scrolledWindow;
 		CheckBox showDiagnosticsButton;
@@ -64,7 +66,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		bool isDirty;
 		public bool IsDirty {
 			get => isDirty;
-			set {
+			private set {
 				if (isDirty == value)
 					return;
 				isDirty = value;
@@ -201,7 +203,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		async Task Save (FilePath outputFile)
 		{
-			const string binLogExtension = "binlog";
 			if (!outputFile.HasExtension (binLogExtension))
 				outputFile = outputFile.ChangeExtension (binLogExtension);
 
@@ -218,7 +219,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 				TransientFor = IdeApp.Workbench.RootWindow,
 				InitialFileName = ViewContentName
 			};
-			dlg.AddFilter (null, "*.binlog");
 			if (dlg.Run ()) {
 				await Save (dlg.SelectedFile);
 			}


### PR DESCRIPTION
- Implements File -> Save command handler
- Disables / Enabled Save button depending on IsDirty
- Removes SelectRow() and use MoveToMach() instead
- Enable / Disable search buttons depending on result matches
- When not matches, now displays "0 of 0" instead of "Not found"
- Implements missing PathChanged event
- Fixes: Save button should not show up when loading a log from a file (it is already saved)
- Adds a placeholder "Search Build Output";
- When pattern is null or empty, then FirstMatch returns null (This fixes -> Exclude output node itself in the breadcrumbs because they are too long. If the output element is selected, show just a parent in the breadcrumbs.)
- Removes nodes with no children in the pathBar  (Fixes: Exclude output node itself in the breadcrumbs because they are too long. If the output element is selected, show just a parent in the breadcrumbs.)
- Disables auto horizontal scrolling on the treeview