### PR TITLE
Fixed VSTS 525922: [Feedback] Renaming a class silently fails to

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
@@ -210,7 +210,7 @@ namespace MonoDevelop.Refactoring.Rename
 			if (ChangedDocuments != null) {
 				AlertButton result = null;
 				var msg = new QuestionMessage ();
-				msg.Buttons.Add (AlertButton.Yes);
+				msg.Buttons.Add (AlertButton.MakeWriteable);
 				msg.Buttons.Add (AlertButton.Cancel);
 				msg.AllowApplyToAll = true;
 
@@ -218,12 +218,13 @@ namespace MonoDevelop.Refactoring.Rename
 					try {
 						var attr = File.GetAttributes (path);
 						if (attr.HasFlag (FileAttributes.ReadOnly)) {
-							msg.Text = GettextCatalog.GetString ("File \"{0}\" is read only. Should it be made writeable?", path);
+							msg.Text = GettextCatalog.GetString ("File {0} is read-only", path);
+							msg.SecondaryText = GettextCatalog.GetString ("Would you like to make the file writable?");
 							result = MessageService.AskQuestion (msg);
 
 							if (result == AlertButton.Cancel) {
 								return;
-							} else if (result == AlertButton.Yes) {
+							} else if (result == AlertButton.MakeWriteable) {
 								try {
 									File.SetAttributes (path, attr & ~FileAttributes.ReadOnly);
 								} catch (Exception ex) {

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameItemDialog.cs
@@ -198,7 +198,6 @@ namespace MonoDevelop.Refactoring.Rename
 				};
 			}
 		}
-		static AlertButton YesToAllButton = new AlertButton (GettextCatalog.GetString ("Yes to All"));
 
 		async void OnOKClicked (object sender, EventArgs e)
 		{
@@ -206,18 +205,25 @@ namespace MonoDevelop.Refactoring.Rename
 			((Widget)this).Destroy ();
 			var changes = await this.rename (properties);
 			ProgressMonitor monitor = IdeApp.Workbench.ProgressMonitors.GetBackgroundProgressMonitor (Title, null);
+
+
 			if (ChangedDocuments != null) {
 				AlertButton result = null;
+				var msg = new QuestionMessage ();
+				msg.Buttons.Add (AlertButton.Yes);
+				msg.Buttons.Add (AlertButton.Cancel);
+				msg.AllowApplyToAll = true;
+
 				foreach (var path in ChangedDocuments) {
 					try {
 						var attr = File.GetAttributes (path);
 						if (attr.HasFlag (FileAttributes.ReadOnly)) {
-							if (result != YesToAllButton)
-								result = MessageService.AskQuestion (GettextCatalog.GetString ("File \"{0}\" is read only. Should it be made writeable?", path), AlertButton.Yes, YesToAllButton, AlertButton.Cancel);
+							msg.Text = GettextCatalog.GetString ("File \"{0}\" is read only. Should it be made writeable?", path);
+							result = MessageService.AskQuestion (msg);
 
 							if (result == AlertButton.Cancel) {
 								return;
-							} else if (result == AlertButton.Yes || result == YesToAllButton) {
+							} else if (result == AlertButton.Yes) {
 								try {
 									File.SetAttributes (path, attr & ~FileAttributes.ReadOnly);
 								} catch (Exception ex) {

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Rename/RenameRefactoring.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.Refactoring.Rename
 			var cts = new CancellationTokenSource ();
 			var newSolution = await MessageService.ExecuteTaskAndShowWaitDialog (Task.Run (() => Renamer.RenameSymbolAsync (currentSolution, symbol, "_" + symbol.Name + "_", ws.Options, cts.Token)), GettextCatalog.GetString ("Looking for all references"), cts);
 			var projectChanges = currentSolution.GetChanges (newSolution).GetProjectChanges ().ToList ();
-			var changedDocuments = new HashSet<string> ();
+			var changedDocuments = new List<string> ();
 			foreach (var change in projectChanges) {
 				foreach (var changedDoc in change.GetChangedDocuments ()) {
 					changedDocuments.Add (ws.CurrentSolution.GetDocument (changedDoc).FilePath);
@@ -95,8 +95,10 @@ namespace MonoDevelop.Refactoring.Rename
 			}
 
 			if (changedDocuments.Count > 1) {
-				using (var dlg = new RenameItemDialog (symbol, this))
+				using (var dlg = new RenameItemDialog (symbol, this)) {
+					dlg.ChangedDocuments = changedDocuments;
 					MessageService.ShowCustomDialog (dlg);
+				}
 				return;
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/IdeFileSystemExtensionExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/IdeFileSystemExtensionExtension.cs
@@ -63,8 +63,7 @@ namespace MonoDevelop.Ide.Projects
 			
 			string error = GettextCatalog.GetString ("File {0} is read-only", file.FileName);
 
-			var btn = new AlertButton (GettextCatalog.GetString ("Make Writable"));
-			var res = MessageService.AskQuestion (error, GettextCatalog.GetString ("Would you like {0} to attempt to make the file writable and try again?", BrandingService.ApplicationName), btn, AlertButton.Cancel);
+			var res = MessageService.AskQuestion (error, GettextCatalog.GetString ("Would you like {0} to attempt to make the file writable and try again?", BrandingService.ApplicationName), AlertButton.MakeWriteable, AlertButton.Cancel);
 			if (res == AlertButton.Cancel)
 				throw new UserException (error) { AlreadyReportedToUser = true };
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -91,7 +91,8 @@ namespace MonoDevelop.Ide
 
 		public static AlertButton OverwriteFile = new AlertButton (GettextCatalog.GetString ("_Overwrite file"));
 		public static AlertButton AddExistingFile = new AlertButton (GettextCatalog.GetString ("Add existing file"));
-		
+		public static AlertButton MakeWriteable = new AlertButton (GettextCatalog.GetString ("Make Writeable"));
+
 		
 		public string Label { get; set; }
 		public string Icon { get; set; }


### PR DESCRIPTION
update references in read-only files in Visual Studio for Mac 7.2
Preview

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/525922

The good old yes/no/cancel box solution.