### PR TITLE
[Core] Fix project capability test

### DIFF
--- a/main/Main.sln
+++ b/main/Main.sln
@@ -329,7 +329,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoDevelop.UnitTesting.Tests", "src\addins\MonoDevelop.UnitTesting\MonoDevelop.UnitTesting.Tests\MonoDevelop.UnitTesting.Tests.csproj", "{CD31F051-9012-487B-B7E8-4CDDEA68B3AF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoDevelop.Refactoring.Tests", "tests\MonoDevelop.Refactoring.Tests\MonoDevelop.Refactoring.Tests.csproj", "{BCC3A6AE-EC45-40AD-BA3E-59F6401D588C}"
+EndProject
 Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "po", "po\po.mdproj", "{AC7D119C-980B-4712-8811-5368C14412D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoDevelop.Core.Tests.Addin", "tests\MonoDevelop.Core.Tests.Addin\MonoDevelop.Core.Tests.Addin.csproj", "{CF789E43-7AAF-4690-BA32-ABD75DEEB087}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2152,6 +2155,26 @@ Global
 		{AC7D119C-980B-4712-8811-5368C14412D7}.ReleaseMac|Any CPU.ActiveCfg = ReleaseMac|Any CPU
 		{AC7D119C-980B-4712-8811-5368C14412D7}.ReleaseWin32|Any CPU.ActiveCfg = ReleaseWin32|Any CPU
 		{AC7D119C-980B-4712-8811-5368C14412D7}.ReleaseGnome|Any CPU.ActiveCfg = ReleaseGnome|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.DebugMac|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.DebugMac|Any CPU.Build.0 = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.DebugWin32|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.DebugWin32|Any CPU.Build.0 = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.DebugGnome|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.DebugGnome|Any CPU.Build.0 = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.ReleaseMac|Any CPU.ActiveCfg = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.ReleaseMac|Any CPU.Build.0 = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.ReleaseWin32|Any CPU.ActiveCfg = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.ReleaseWin32|Any CPU.Build.0 = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.ReleaseGnome|Any CPU.ActiveCfg = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.ReleaseGnome|Any CPU.Build.0 = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7525BB88-6142-4A26-93B9-A30C6983390A} = {9D360D43-0C05-49D6-84DB-4E7AB2F38F82}
@@ -2299,6 +2322,7 @@ Global
 		{FDA43CAA-1C2A-4593-8601-3E2EE06D9E03} = {78C10DAE-D3D7-44FC-93DF-831D8D54ECF9}
 		{CD31F051-9012-487B-B7E8-4CDDEA68B3AF} = {DE462010-393D-4655-A42C-2C78BB14D2FA}
 		{BCC3A6AE-EC45-40AD-BA3E-59F6401D588C} = {78C10DAE-D3D7-44FC-93DF-831D8D54ECF9}
+		{CF789E43-7AAF-4690-BA32-ABD75DEEB087} = {78C10DAE-D3D7-44FC-93DF-831D8D54ECF9}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/main/tests/MonoDevelop.Core.Tests.Addin/MonoDevelop.Core.Tests.Addin.csproj
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/MonoDevelop.Core.Tests.Addin.csproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CF789E43-7AAF-4690-BA32-ABD75DEEB087}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MonoDevelop.Core.Tests</RootNamespace>
+    <AssemblyName>MonoDevelop.Core.Tests.Addin</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\build\tests\MonoDevelop.Core.Tests.Addin\</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\build\tests\MonoDevelop.Core.Tests.Addin\</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AddinInfo.cs" />
+    <Compile Include="MonoDevelop.Core.Tests\TestCapabilityProjectExtension.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
+      <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
+      <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">
+      <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>
+      <Name>Mono.Addins</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Properties\MonoDevelop.Core.Tests.addin.xml">
+      <LogicalName>MonoDevelop.Core.Tests.addin.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+    <MakeDir Directories="..\..\..\local-config" />
+    <WriteLinesToFile File="..\..\..\local-config\$(AssemblyName).addins" Lines="%3CAddins%3E%3CDirectory include-subdirs='false'%3E$(MSBuildProjectDirectory)\$(OutputPath)%3C/Directory%3E%3C/Addins%3E" Overwrite="true" />
+  </Target>
+</Project>

--- a/main/tests/MonoDevelop.Core.Tests.Addin/MonoDevelop.Core.Tests/TestCapabilityProjectExtension.cs
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/MonoDevelop.Core.Tests/TestCapabilityProjectExtension.cs
@@ -1,0 +1,36 @@
+﻿//
+// TestCapabilityProjectExtension.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.Core.Tests
+{
+	[ExportProjectModelExtension]
+	[AppliesTo ("TestCapability")]
+	class TestCapabilityProjectExtension : DotNetProjectExtension
+	{
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests.Addin/Properties/AddinInfo.cs
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/Properties/AddinInfo.cs
@@ -1,0 +1,13 @@
+﻿
+using Mono.Addins;
+using Mono.Addins.Description;
+
+[assembly:Addin ("Core.Tests.Addin",
+                 Namespace = "MonoDevelop",
+                 Version = MonoDevelop.BuildInfo.Version,
+                 Category = "IDE extensions")]
+
+[assembly:AddinName ("MonoDevelop.Core.Tests addin")]
+[assembly:AddinDescription ("Test addin for MonoDevelop.Core.Tests")]
+
+[assembly:AddinDependency ("Core", MonoDevelop.BuildInfo.Version)]

--- a/main/tests/MonoDevelop.Core.Tests.Addin/Properties/AssemblyInfo.cs
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("MonoDevelop.Core.Tests.Addin")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/MonoDevelop.Core.Tests.Addin/Properties/MonoDevelop.Core.Tests.addin.xml
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/Properties/MonoDevelop.Core.Tests.addin.xml
@@ -1,0 +1,5 @@
+﻿<ExtensionModel>
+	<Runtime>
+		<Import assembly="MonoDevelop.Core.Tests.Addin.dll" />
+	</Runtime>
+</ExtensionModel>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -122,6 +122,11 @@
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
       <Name>GuiUnit_NET_4_5</Name>
     </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.Core.Tests.Addin\MonoDevelop.Core.Tests.Addin.csproj">
+      <Project>{CF789E43-7AAF-4690-BA32-ABD75DEEB087}</Project>
+      <Name>MonoDevelop.Core.Tests.Addin</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectCapabilityTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectCapabilityTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using MonoDevelop.Projects.Extensions;
 using NUnit.Framework;
@@ -49,6 +50,10 @@ namespace MonoDevelop.Projects
 		public void Teardown ()
 		{
 			WorkspaceObject.UnregisterCustomExtension (capaNode);
+
+			// Ensure MonoDevelop.Core.Tests addin is not registered in local-config after tests are run.
+			string localConfigFile = Path.Combine (Util.TestsRootDir, "..", "..", "local-config", "MonoDevelop.Core.Tests.Addin.addins");
+			File.Delete (localConfigFile);
 		}
 
 		List<string> defaultCapabilities;
@@ -119,13 +124,13 @@ namespace MonoDevelop.Projects
 			string solFile = Util.GetSampleProject ("project-capability-tests", "ConsoleProject.csproj");
 			var item = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), solFile);
 
-			string azureFunctionsProjectExtension = "AzureFunctionsProjectExtension";
-			Func<ProjectExtension, bool> isMatch = f => f.GetType ().Name == azureFunctionsProjectExtension;
+			string projectExtension = "TestCapabilityProjectExtension";
+			Func<ProjectExtension, bool> isMatch = f => f.GetType ().Name == projectExtension;
 			var ext = item.GetFlavors ().FirstOrDefault (isMatch);
 			Assert.IsNull (ext);
 
-			// Now activate "AzureFunctions" capability
-			var import = item.MSBuildProject.AddNewImport ("azurefunctions.targets");
+			// Now activate "TestCapability"
+			var import = item.MSBuildProject.AddNewImport ("testcapability.targets");
 			await item.ReevaluateProject (Util.GetMonitor ());
 
 			ext = item.GetFlavors ().FirstOrDefault (isMatch);

--- a/main/tests/test-projects/project-capability-tests/testcapability.targets
+++ b/main/tests/test-projects/project-capability-tests/testcapability.targets
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectCapability Include="AzureFunctions" />
+    <ProjectCapability Include="TestCapability" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The test was using the AzureFunctions project extension which has
been removed. Added a test addin that defines a custom project
extension using a test capability. This addin is registered by
adding an .addins file to the local-config directory. This file is
deleted after the test fixture completes to avoid including the addin
in the final packaged IDE.

The test is now passing on Wrench and VSTS. The Wrench dmg does not contain the test addin.