### PR TITLE
Fix mutable completion list filtering

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
@@ -259,7 +259,6 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			usingPreviewEntry = false;
 			previewCompletionEntryText = "";
-			StartOffset = 0;
 			HideWhenWordDeleted = false;
 			SelectedItemCompletionText = null;
 			ResetViewState();
@@ -407,8 +406,6 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			if (!object.ReferenceEquals (sender, mutableList))
 				return;
-			
-			ResetSizes ();
 
 			// Only hide the footer if it's finished changing
 			if (!mutableList.IsChanging)


### PR DESCRIPTION
The controller's ResetState method reset the StartOffset
to zero. Since this method is called when a mutable list
updates, the CompletionString used for filtering mutable
lists was the entire document up to the completion point,
which of course was so long and complex it matched nothing.

Also remove a redundant ResetSizes call that caused
unnecessary nontrivial work when updating mutable lists.