### PR TITLE
UI fixes rebased

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // BuildOutput.cs
 //
 // Author:
@@ -423,9 +423,10 @@ namespace MonoDevelop.Ide.BuildOutputView
 				root.Search (currentSearchMatches, currentSearchPattern);
 			}
 
-			if (currentSearchMatches.Count > 0) {
-				currentMatchIndex = 0;
-				return currentSearchMatches [0];
+				if (currentSearchMatches.Count > 0) {
+					currentMatchIndex = 0;
+					return currentSearchMatches [0];
+				}
 			}
 
 			return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -418,10 +418,11 @@ namespace MonoDevelop.Ide.BuildOutputView
 			currentSearchPattern = pattern;
 			currentMatchIndex = -1;
 
-			// Perform search
-			foreach (var root in rootNodes) {
-				root.Search (currentSearchMatches, currentSearchPattern);
-			}
+			if (!string.IsNullOrEmpty (pattern)) {
+				// Perform search
+				foreach (var root in rootNodes) {
+					root.Search (currentSearchMatches, currentSearchPattern);
+				}
 
 				if (currentSearchMatches.Count > 0) {
 					currentMatchIndex = 0;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -74,7 +74,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		public override bool IsFile {
 			get {
-				return System.IO.File.Exists (filename.FullPath);
+				return true;
 			}
 		}
 
@@ -140,5 +140,18 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			cinfo.Enabled = control.IsSearchInProgress;
 		}
+
+		[CommandHandler (FileCommands.Save)]
+		public override Task Save ()
+		{
+			return control.Save ();
+		}
+
+		[CommandUpdateHandler (FileCommands.Save)]
+		public void UpdateSaveHandler (CommandInfo cinfo)
+		{
+			cinfo.Enabled = control.IsDirty;
+		}
+
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -144,7 +144,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		[CommandHandler (FileCommands.Save)]
 		public override Task Save ()
 		{
-			return control.Save ();
+			return control.SaveAs ();
 		}
 
 		[CommandUpdateHandler (FileCommands.Save)]
@@ -152,6 +152,5 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			cinfo.Enabled = control.IsDirty;
 		}
-
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -249,17 +249,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 		}
 
-		void IndexChanged (int newIndex)
-		{
-			if (newIndex >= CurrentPath.Length)
-				return;
-
-			var node = CurrentPath [newIndex].Tag as BuildOutputNode;
-			if (node != null && node.HasChildren) {
-				FocusRow (node);
-			}
-		}
-
 		void TreeView_SelectionChanged (object sender, EventArgs e)
 		{
 			var selectedNode = treeView.SelectedRow as BuildOutputNode;
@@ -439,7 +428,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 		public Control CreatePathWidget (int index)
 		{
 			if (currentIndex != index) {
-				IndexChanged (index);
 				currentIndex = index;
 			}
 
@@ -456,7 +444,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			return window;
 		}
 
-		protected override void Dispose(bool disposing)
+		protected override void Dispose (bool disposing)
 		{
 			buttonSearchBackward.Clicked -= FindPrevious;
 			buttonSearchForward.Clicked -= FindNext;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -46,6 +46,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 {
 	class BuildOutputWidget : VBox, IPathedDocument
 	{
+		const string binLogExtension = "binlog";
+
 		TreeView treeView;
 		ScrollView scrolledWindow;
 		CheckBox showDiagnosticsButton;
@@ -67,7 +69,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		bool isDirty;
 		public bool IsDirty {
 			get => isDirty;
-			set {
+			private set {
 				if (isDirty == value)
 					return;
 				isDirty = value;
@@ -236,7 +238,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		async Task Save (FilePath outputFile)
 		{
-			const string binLogExtension = "binlog";
 			if (!outputFile.HasExtension (binLogExtension))
 				outputFile = outputFile.ChangeExtension (binLogExtension);
 
@@ -253,7 +254,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 				TransientFor = IdeApp.Workbench.RootWindow,
 				InitialFileName = ViewContentName
 			};
-			dlg.AddFilter (null, "*.binlog");
 			if (dlg.Run ()) {
 				await Save (dlg.SelectedFile);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -97,6 +97,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			filePathLocation = filePath;
 			output.Load (filePath.FullPath, false);
 			SetupBuildOutput (output);
+			IsDirty = false;
 		}
 
 		void SetupBuildOutput (BuildOutput output)
@@ -403,6 +404,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			cts?.Cancel ();
 			cts = new CancellationTokenSource ();
 			processingCompletion = new TaskCompletionSource<object> ();
+
+			IsDirty = true;
 
 			Task.Run (async () => {
 				try {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -228,7 +228,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 			treeView.FocusedRow = match;
 		}
 
-		async void SaveButtonClickedAsync (object sender, EventArgs e) => await Save ();
 		async void SaveButtonClickedAsync (object sender, EventArgs e) => await SaveAs ();
 
 		FilePath filePathLocation;
@@ -257,7 +256,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			var node = CurrentPath [newIndex].Tag as BuildOutputNode;
 			if (node != null && node.HasChildren) {
-				MoveToMatch (node);
+				FocusRow (node);
 			}
 		}
 
@@ -363,8 +362,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 			resultInformLabel.Show ();
 
-			buttonSearchForward.Sensitive = dataSource.MatchesCount > 0;
-			buttonSearchBackward.Sensitive = dataSource.MatchesCount > 0; 
+			buttonSearchForward.Sensitive = search.MatchesCount > 0;
+			buttonSearchBackward.Sensitive = search.MatchesCount > 0; 
 		}
 
 		static string GetShortcut (object commandId)
@@ -500,7 +499,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			public void ActivateItem (int n)
 			{
 				if (list [n].HasChildren)
-					widget.MoveToMatch (list [n]);
+					widget.FocusRow (list [n]);
 			}
 
 			public Xwt.Drawing.Image GetIcon (int n) => DataSource.GetValue (list [n], 0) as Xwt.Drawing.Image;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -144,7 +144,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			searchEntry.Accessible.Description = GettextCatalog.GetString ("Search the build log");
 			searchEntry.WidthRequest = 200;
 			searchEntry.Visible = true;
-
+			searchEntry.EmptyMessage = GettextCatalog.GetString ("Search Build Output");
+			           
 			resultInformLabel = new Label ();
 			searchEntry.AddLabelWidget ((Gtk.Label) resultInformLabel.ToGtkWidget());
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -173,7 +173,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			toolbar.AddSpace ();
 			toolbar.Add (searchEntry, false);
 			toolbar.Add (buttonSearchBackward.ToGtkWidget ());
-			toolbar.Add (buttonSearchForward.ToGtkWidget());
+			toolbar.Add (buttonSearchForward.ToGtkWidget ());
 
 			PackStart (toolbar.Container, expand: false, fill: true);
 
@@ -229,36 +229,24 @@ namespace MonoDevelop.Ide.BuildOutputView
 		}
 
 		async void SaveButtonClickedAsync (object sender, EventArgs e) => await Save ();
-
-		public async Task Save ()
-		{
-			if (filePathLocation == FilePath.Empty) {
-				await SaveAs ();
-			} else {
-				await Save (filePathLocation);
-			}
-		}
-
-		async Task Save (FilePath outputFile)
-		{
-			if (!outputFile.HasExtension (binLogExtension))
-				outputFile = outputFile.ChangeExtension (binLogExtension);
-
-			await BuildOutput.Save (outputFile);
-			FileSaved?.Invoke (this, outputFile.FileName);
-			filePathLocation = outputFile;
-			IsDirty = false;
-		}
+		async void SaveButtonClickedAsync (object sender, EventArgs e) => await SaveAs ();
 
 		FilePath filePathLocation;
-		async Task SaveAs ()
+		public async Task SaveAs ()
 		{
 			var dlg = new Gui.Dialogs.OpenFileDialog (GettextCatalog.GetString ("Save as..."), MonoDevelop.Components.FileChooserAction.Save) {
 				TransientFor = IdeApp.Workbench.RootWindow,
 				InitialFileName = ViewContentName
 			};
 			if (dlg.Run ()) {
-				await Save (dlg.SelectedFile);
+				var outputFile = dlg.SelectedFile;
+				if (!outputFile.HasExtension (binLogExtension))
+					outputFile = outputFile.ChangeExtension (binLogExtension);
+
+				await BuildOutput.Save (outputFile);
+				FileSaved?.Invoke (this, outputFile.FileName);
+				filePathLocation = outputFile;
+				IsDirty = false;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -181,6 +181,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			treeView.HeadersVisible = false;
 			treeView.Accessible.Identifier = "BuildOutputWidget.TreeView";
 			treeView.Accessible.Description = GettextCatalog.GetString ("Structured build output");
+			treeView.HorizontalScrollPolicy = ScrollPolicy.Never;
 			treeView.SelectionChanged += TreeView_SelectionChanged;
 			var treeColumn = new ListViewColumn {
 				CanResize = false,


### PR DESCRIPTION
- Implements File -> Save command handler
- Disables / Enabled Save button depending on IsDirty
- Removes SelectRow() and use MoveToMach() instead
- Enable / Disable search buttons depending on result matches
- When not matches, now displays "0 of 0" instead of "Not found"
- Implements missing PathChanged event
- Fixes: Save button should not show up when loading a log from a file (it is already saved)
- Adds a placeholder "Search Build Output";
- When pattern is null or empty, then FirstMatch returns null (This fixes -> Exclude output node itself in the breadcrumbs because they are too long. If the output element is selected, show just a parent in the breadcrumbs.)
- Removes nodes with no children in the pathBar  (Fixes: Exclude output node itself in the breadcrumbs because they are too long. If the output element is selected, show just a parent in the breadcrumbs.)
- Disables auto horizontal scrolling on the treeview