### PR TITLE
Simplify keeping track of the current search

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -379,9 +379,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 	class BuildOutputDataSearch
 	{
-		readonly List<BuildOutputNode> rootNodes;
+		readonly IReadOnlyList<BuildOutputNode> rootNodes;
 
-		public BuildOutputDataSearch (List<BuildOutputNode> rootNodes)
+		public BuildOutputDataSearch (IReadOnlyList<BuildOutputNode> rootNodes)
 		{
 			this.rootNodes = rootNodes;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -410,7 +410,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		/// <value><c>true</c> if search wrapped; otherwise, <c>false</c>.</value>
 		public bool SearchWrapped { get; private set; }
 
-		public BuildOutputNode FirstMatch (string pattern)
+		public Task<BuildOutputNode> FirstMatch (string pattern)
 		{
 			// Initialize search data
 			currentSearchMatches.Clear ();
@@ -418,19 +418,21 @@ namespace MonoDevelop.Ide.BuildOutputView
 			currentSearchPattern = pattern;
 			currentMatchIndex = -1;
 
-			if (!string.IsNullOrEmpty (pattern)) {
-				// Perform search
-				foreach (var root in rootNodes) {
-					root.Search (currentSearchMatches, currentSearchPattern);
+			return Task.Run (() => {
+				if (!string.IsNullOrEmpty (pattern)) {
+					// Perform search
+					foreach (var root in rootNodes) {
+						root.Search (currentSearchMatches, currentSearchPattern);
+					}
+
+					if (currentSearchMatches.Count > 0) {
+						currentMatchIndex = 0;
+						return currentSearchMatches [0];
+					}
 				}
 
-				if (currentSearchMatches.Count > 0) {
-					currentMatchIndex = 0;
-					return currentSearchMatches [0];
-				}
-			}
-
-			return null;
+				return null;
+			});
 		}
 
 		public BuildOutputNode PreviousMatch ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -289,14 +289,14 @@ namespace MonoDevelop.Ide.BuildOutputView
 			PathChanged?.Invoke (this, new DocumentPathChangedEventArgs (CurrentPath));
 		}
 
-		void FindFirst (object sender, EventArgs args)
+		async void FindFirst (object sender, EventArgs args)
 		{
 			var dataSource = treeView.DataSource as BuildOutputDataSource;
 			if (dataSource == null)
 				return;
 
 			currentSearch = new BuildOutputDataSearch (dataSource.RootNodes);
-			Find (currentSearch.FirstMatch (searchEntry.Entry.Text));
+			Find (await currentSearch.FirstMatch (searchEntry.Entry.Text));
 		}
 
 		public void FindNext (object sender, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -415,7 +415,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}, cts.Token);
 		}
 
-		public bool IsSearchInProgress => currentSearch != null;
+		public bool IsSearchInProgress => currentSearch != null && currentSearch.MatchesCount > 0;
 
 		public void FocusOnSearchEntry ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -58,8 +58,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		Button buttonSearchBackward;
 		Button buttonSearchForward;
 		Label resultInformLabel;
-		List<BuildOutputNode> treeBuildOutputNodes;
-		BuildOutputDataSearch search;
+		BuildOutputDataSearch currentSearch;
 
 		public string ViewContentName { get; private set; }
 		public BuildOutput BuildOutput { get; private set; }
@@ -213,8 +212,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		async Task ExpandNode (string project, BuildOutputNodeType nodeType, string message) 
 		{
+			var dataSource = treeView.DataSource as BuildOutputDataSource;
+			if (dataSource == null) {
+				return;
+			}
+
 			await processingCompletion.Task;
-			var projectNode = treeBuildOutputNodes.SearchFirstNode (BuildOutputNodeType.Project, project);
+			var projectNode = dataSource.RootNodes.SearchFirstNode (BuildOutputNodeType.Project, project);
 			var node = projectNode.SearchFirstNode (nodeType, message);
 			FocusRow (node);
 		}
@@ -291,18 +295,19 @@ namespace MonoDevelop.Ide.BuildOutputView
 			if (dataSource == null)
 				return;
 
-			Find (search.FirstMatch (searchEntry.Entry.Text));
+			currentSearch = new BuildOutputDataSearch (dataSource.RootNodes);
+			Find (currentSearch.FirstMatch (searchEntry.Entry.Text));
 		}
 
 		public void FindNext (object sender, EventArgs args)
 		{
-			var dataSource = treeView.DataSource as BuildOutputDataSource;
-			if (dataSource == null)
+			if (currentSearch == null) {
 				return;
+			}
 
-			Find (search.NextMatch ());
+			Find (currentSearch.NextMatch ());
 
-			if (search.SearchWrapped) {
+			if (currentSearch.SearchWrapped) {
 				IdeApp.Workbench.StatusBar.ShowMessage (
 					Gtk.Stock.Find, GettextCatalog.GetString ("Reached top, continued from bottom"));
 			} else {
@@ -312,13 +317,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		public void FindPrevious (object sender, EventArgs e)
 		{
-			var dataSource = treeView.DataSource as BuildOutputDataSource;
-			if (dataSource == null)
+			if (currentSearch == null) {
 				return;
+			}
 
-			Find (search.PreviousMatch ());
+			Find (currentSearch.PreviousMatch ());
 
-			if (search.SearchWrapped) {
+			if (currentSearch.SearchWrapped) {
 				IdeApp.Workbench.StatusBar.ShowMessage (
 					Gtk.Stock.Find, GettextCatalog.GetString ("Reached bottom, continued from top"));
 			} else {
@@ -331,13 +336,11 @@ namespace MonoDevelop.Ide.BuildOutputView
 			var dataSource = treeView.DataSource as BuildOutputDataSource;
 			if (dataSource == null)
 				return;
-			
-			IsSearchInProgress = node != null;
 
 			if (node != null) {
 				FocusRow (node);
 
-				resultInformLabel.Text = GettextCatalog.GetString ("{0} of {1}", search.CurrentAbsoluteMatchIndex, search.MatchesCount);
+				resultInformLabel.Text = GettextCatalog.GetString ("{0} of {1}", currentSearch.CurrentAbsoluteMatchIndex, currentSearch.MatchesCount);
 				resultInformLabel.TextColor = searchEntry.Style.Foreground (Gtk.StateType.Insensitive).ToXwtColor();
 			} else if (string.IsNullOrEmpty (searchEntry.Entry.Text)) {
 				resultInformLabel.Text = string.Empty;
@@ -348,8 +351,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 			resultInformLabel.Show ();
 
-			buttonSearchForward.Sensitive = search.MatchesCount > 0;
-			buttonSearchBackward.Sensitive = search.MatchesCount > 0; 
+			buttonSearchForward.Sensitive = currentSearch.MatchesCount > 0;
+			buttonSearchBackward.Sensitive = currentSearch.MatchesCount > 0; 
 		}
 
 		static string GetShortcut (object commandId)
@@ -389,11 +392,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 					BuildOutput.ProcessProjects ();
 
 					await Runtime.RunInMainThread (() => {
-					
-						treeBuildOutputNodes = BuildOutput.GetRootNodes (showDiagnostics);
-						search = new BuildOutputDataSearch (treeBuildOutputNodes);
+						currentSearch = null;
 
-						var buildOutputDataSource = new BuildOutputDataSource (treeBuildOutputNodes);
+						var buildOutputDataSource = new BuildOutputDataSource (BuildOutput.GetRootNodes (showDiagnostics));
 						treeView.DataSource = buildOutputDataSource;
 
 						(treeView.Columns [0].Views [0] as ImageCellView).ImageField = buildOutputDataSource.ImageField;
@@ -414,7 +415,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}, cts.Token);
 		}
 
-		public bool IsSearchInProgress { get; private set; } = false;
+		public bool IsSearchInProgress => currentSearch != null;
 
 		public void FocusOnSearchEntry ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -393,6 +393,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 					await Runtime.RunInMainThread (() => {
 						currentSearch = null;
+						searchEntry.Entry.Text = String.Empty;
+						Find (null);
 
 						var buildOutputDataSource = new BuildOutputDataSource (BuildOutput.GetRootNodes (showDiagnostics));
 						treeView.DataSource = buildOutputDataSource;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
@@ -81,7 +81,7 @@ namespace MonoDevelop.Ide
 		}
 
 		[Test]
-		public void CustomProject_DataSearch ()
+		public async Task CustomProject_DataSearch ()
 		{
 			var bo = new BuildOutput ();
 			var monitor = bo.GetProgressMonitor ();
@@ -98,7 +98,7 @@ namespace MonoDevelop.Ide
 			var search = new BuildOutputDataSearch (nodes);
 			int matches = 0;
 			var visited = new HashSet<BuildOutputNode> ();
-			for (var match = search.FirstMatch ("Message "); match != null; match = search.NextMatch ()) {
+			for (var match = await search.FirstMatch ("Message "); match != null; match = search.NextMatch ()) {
 				if (visited.Contains (match)) {
 					break;
 				}


### PR DESCRIPTION
Instead of creating a `BuildOutputDataSearch` instance for the whole lifetime of the `BuildOutputWidget`, just create it on demand, when a real search is started. And also, use this to keep track of whether we are in the middle of a search or not, instead of having to update a property.