### PR TITLE
[FSW] Fix FSW on Windows by also catching DllNotFoundException

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/FileSystemWatcher.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/FileSystemWatcher.cs
@@ -49,6 +49,8 @@ namespace MonoDevelop.FSW
 					_platform = Platform.OSX;
 					return;
 				}
+			} catch (DllNotFoundException) {
+			}
 			} catch (EntryPointNotFoundException) {
 			}
 


### PR DESCRIPTION
__Internal is a Mono-ism, it won't work on .NET.

Credits to @AngelCry for finding it.