### PR TITLE
Intellisense never auto-commits for F#, not even for '.'

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -46,6 +46,8 @@ type FSharpMemberCompletionData(name, icon, symbol:FSharpSymbolUse, overloads:FS
     override x.CreateTooltipInformation (_smartWrap, cancel) =
         Async.StartAsTask(SymbolTooltips.getTooltipInformation symbol, cancellationToken = cancel)
     
+    override x.IsCommitCharacter (_keyChar, _partialWord) = false
+
     type SimpleCategory(text) =
         inherit CompletionCategory(text, null)
         override x.CompareTo other =
@@ -782,6 +784,7 @@ type FSharpTextEditorCompletion() =
     let validCompletionChar c =
         c = '(' || c = ',' || c = '<'
 
+
     override x.CompletionLanguage = "F#"
     override x.Initialize() =
         do x.Editor.IndentationTracker <- FSharpIndentationTracker(x.Editor)
@@ -805,9 +808,6 @@ type FSharpTextEditorCompletion() =
     override x.HandleCodeCompletionAsync(context, triggerInfo, token) =
         let ctrlSpace = triggerInfo.CompletionTriggerReason = CompletionTriggerReason.CompletionCommand
         if IdeApp.Preferences.EnableAutoCodeCompletion.Value || ctrlSpace then
-            let computation =
-                Completion.codeCompletionCommandImpl(x.Editor, x.DocumentContext, context, ctrlSpace) 
-                        
             Async.StartAsTask (computation = computation, cancellationToken = token)
         else
             Task.FromResult null


### PR DESCRIPTION
Fixes vsts #563779 (#3798)

Determined that it is too difficult to detect all the occurrences of
identifiers in F# code for the time being, so it is hard to determine that the
popup should not be displayed. Given this, we should be far less aggressive
about auto-committing (even when "Complete with Space or Punctuation" is
switched on. This is a good default for C#, but a bad default for F#.)

This behaviour roughly matches both VS on Windows and VS Code