### PR TITLE
[Ide] Fix editor tooltip theme fitting

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
@@ -60,7 +60,7 @@ namespace MonoDevelop.SourceEditor
 				return null;
 
 			int caretOffset = editor.CaretOffset;
-			EditorTheme theme = editor.Options.GetEditorTheme ();
+			EditorTheme theme = SyntaxHighlightingService.GetIdeFittingTheme (editor.Options.GetEditorTheme ());
 			return await Task.Run (async () => {
 				var root = unit.SyntaxTree.GetRoot (token);
 				SyntaxToken syntaxToken;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/SignatureMarkupCreator.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/SignatureMarkupCreator.cs
@@ -79,14 +79,7 @@ namespace MonoDevelop.CSharp
 		public SignatureMarkupCreator (DocumentContext ctx, int offset)
 		{
 			this.offset = offset;
-			try {
-				this.colorStyle = SyntaxHighlightingService.GetEditorTheme (Ide.IdeApp.Preferences.ColorScheme);
-				if (!this.colorStyle.FitsIdeTheme (Ide.IdeApp.Preferences.UserInterfaceTheme))
-					this.colorStyle = SyntaxHighlightingService.GetDefaultColorStyle (Ide.IdeApp.Preferences.UserInterfaceTheme);
-			} catch (Exception e) {
-				LoggingService.LogError ("Error while getting the color style : " + Ide.IdeApp.Preferences.ColorScheme + " in ide theme : " + Ide.IdeApp.Preferences.UserInterfaceTheme, e);
-				this.colorStyle = SyntaxHighlightingService.DefaultColorStyle;
-			}
+			this.colorStyle = SyntaxHighlightingService.GetIdeFittingTheme ();
 			this.ctx = ctx;
 			if (ctx != null) {
 				this.options = ctx.GetOptionSet ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
@@ -275,7 +275,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			var description = await Task.Run (() => completionService.GetDescriptionAsync (doc, CompletionItem)).ConfigureAwait (false);
 			var markup = new StringBuilder ();
-			var theme = DefaultSourceEditorOptions.Instance.GetEditorTheme ();
+			var theme = SyntaxHighlightingService.GetIdeFittingTheme (DefaultSourceEditorOptions.Instance.GetEditorTheme ());
 			var taggedParts = description.TaggedParts;
 			int i = 0;
 			while (i < taggedParts.Length) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/SignatureHelpParameterHintingData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/SignatureHelpParameterHintingData.cs
@@ -75,7 +75,8 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			var tt = new TooltipInformation ();
 			var markup = new StringBuilder ();
-			var theme = DefaultSourceEditorOptions.Instance.GetEditorTheme ();
+			var theme = SyntaxHighlightingService.GetIdeFittingTheme (DefaultSourceEditorOptions.Instance.GetEditorTheme ());
+
 			markup.AppendTaggedText (theme, Item.PrefixDisplayParts);
 			var prefixLength = Item.PrefixDisplayParts.GetFullText ().Length;
 			var prefixSpacer = new string (' ', prefixLength);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
@@ -98,6 +98,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 				return GetEditorTheme (EditorTheme.DefaultDarkThemeName);
 			}
 		}
+
 		public static EditorTheme GetDefaultColorStyle (this Theme theme)
 		{
 			return GetEditorTheme (GetDefaultColorStyleName (theme));
@@ -133,6 +134,17 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			if (theme == Theme.Dark)
 				return (bgColor.L <= 0.5);
 			return (bgColor.L > 0.5);
+		}
+
+		public static EditorTheme GetIdeFittingTheme (EditorTheme userTheme = null)
+		{
+			try {
+				if (userTheme == null || !userTheme.FitsIdeTheme (Ide.IdeApp.Preferences.UserInterfaceTheme))
+					return GetDefaultColorStyle (Ide.IdeApp.Preferences.UserInterfaceTheme);
+			} catch (Exception e) {
+				LoggingService.LogError ("Error while getting the color style : " + Ide.IdeApp.Preferences.ColorScheme + " in ide theme : " + Ide.IdeApp.Preferences.UserInterfaceTheme, e);
+			}
+			return userTheme;
 		}
 
 		internal static IEnumerable<TmSetting> GetSettings (ScopeStack scope)


### PR DESCRIPTION
This fixes the issue #3437. We introduced a theme detection logic (with eeb7779276f8483d7202bb3812037f840ccdcebe) which checks whether the current highlighting theme fits the current IDE theme. If it doesn't fit, we fallback to the IDE default theme for the current IDE style. But recent editor changes didn't take that into account.