### PR TITLE
[C#] Add language version 7.2 to supported languages UI

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -397,6 +397,7 @@
     <Compile Include="MonoDevelop.CSharp.Completion\CSharpCompletionData.cs" />
     <Compile Include="MonoDevelop.CSharp.Completion\CompletionProvider\ProtocolMemberCompletionProvider.cs" />
     <Compile Include="MonoDevelop.CSharp.Tooltips\QuickInfoProvider.cs" />
+    <Compile Include="MonoDevelop.CSharp.Project\CSharpLanguageVersionHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpLanguageVersionHelper.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpLanguageVersionHelper.cs
@@ -1,0 +1,50 @@
+﻿//
+// CSharpLanguageVersionHelper.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.CSharp.Project
+{
+	class CSharpLanguageVersionHelper
+	{
+		public static IEnumerable<(string localized, LanguageVersion version)> GetKnownLanguageVersions ()
+		{
+			yield return (GettextCatalog.GetString ("Default"), LanguageVersion.Default);
+			yield return ("ISO-1", LanguageVersion.CSharp1);
+			yield return ("ISO-2", LanguageVersion.CSharp2);
+			yield return (GettextCatalog.GetString ("Version 3"), LanguageVersion.CSharp3);
+			yield return (GettextCatalog.GetString ("Version 4"), LanguageVersion.CSharp4);
+			yield return (GettextCatalog.GetString ("Version 5"), LanguageVersion.CSharp5);
+			yield return (GettextCatalog.GetString ("Version 6"), LanguageVersion.CSharp6);
+			yield return (GettextCatalog.GetString ("Version 7"), LanguageVersion.CSharp7);
+			yield return (GettextCatalog.GetString ("Version 7.1"), LanguageVersion.CSharp7_1);
+			yield return (GettextCatalog.GetString ("Version 7.2"), LanguageVersion.CSharp7_2);
+			yield return (GettextCatalog.GetString ("Latest"), LanguageVersion.Latest);
+		}
+	}
+}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
@@ -94,16 +94,9 @@ namespace MonoDevelop.CSharp.Project
 			noStdLibCheckButton.Active = compilerParameters.NoStdLib;
 
 			var langVerStore = new ListStore (typeof (string), typeof(LanguageVersion));
-			langVerStore.AppendValues (GettextCatalog.GetString ("Default"), LanguageVersion.Default);
-			langVerStore.AppendValues ("ISO-1", LanguageVersion.CSharp1);
-			langVerStore.AppendValues ("ISO-2", LanguageVersion.CSharp2);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Version 3"), LanguageVersion.CSharp3);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Version 4"), LanguageVersion.CSharp4);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Version 5"), LanguageVersion.CSharp5);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Version 6"), LanguageVersion.CSharp6);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Version 7"), LanguageVersion.CSharp7);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Version 7.1"), LanguageVersion.CSharp7_1);
-			langVerStore.AppendValues (GettextCatalog.GetString ("Latest"), LanguageVersion.Latest);
+			foreach (var (text, version) in CSharpLanguageVersionHelper.GetKnownLanguageVersions ()) {
+				langVerStore.AppendValues (text, version);
+			}
 			langVerCombo.Model = langVerStore;
 
 			TreeIter iter;

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -88,6 +88,10 @@
     </Reference>
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Features\ParameterHinting\ParameterHintingTests.cs" />
@@ -126,6 +130,7 @@
     <Compile Include="MonoDevelop.CSharpBinding\CSharpAutoInsertBracketHandlerTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\ExpandSelectionHandlerTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding.Parser\CSharpParsedDocumentTests.cs" />
+    <Compile Include="MonoDevelop.CSharpBinding\CSharpLanguageVersionHelperTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\addins\CSharpBinding\CSharpBinding.csproj">
@@ -195,6 +200,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="MonoDevelop.CSharpBinding\AutomaticBracketInsertionTests.cs" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.CSharpBinding.Parser\" />

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpLanguageVersionHelperTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpLanguageVersionHelperTests.cs
@@ -1,0 +1,48 @@
+﻿//
+// CSharpLanguageVersionTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+
+namespace MonoDevelop.CSharp.Project
+{
+	[TestFixture]
+	public class CSharpLanguageVersionHelperTests
+	{
+		[Test]
+		public void AssertWeHaveAllLanguagesInUI ()
+		{
+			var known = CSharpLanguageVersionHelper.GetKnownLanguageVersions().ToDictionary(x => x.version, x => x.localized);
+			var roslyn = Enum.GetValues (typeof (LanguageVersion)).Cast<LanguageVersion> ().ToArray ();
+
+			var toAdd = roslyn.Where (x => !known.ContainsKey (x)).ToArray ();
+
+			Assert.AreEqual (0, toAdd.Length, "Roslyn added new C# language versions: '{0}', add to CSharpLanguageVersionHelper.GetKnownLanguageVersions",
+							 string.Join (", ", toAdd));
+		}
+	}
+}

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/packages.config
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Also add an unit test that will fail every time roslyn adds a new language version.

The output of the test is:
1) AssertWeHaveAllLanguagesInUI (MonoDevelop.CSharp.Project.CSharpLanguageVersionHelperTests.AssertWeHaveAllLanguagesInUI)
     Roslyn added new C# language versions: 'CSharp7_2', add to CSharpLanguageVersionHelper.GetKnownLanguageVersions
  Expected: 0
  But was:  1

This will ensure that we never ship without adding these values to the UI.

Fixes VSTS #565692 Development with C# 7.2