### PR TITLE
Fixed VSTS Bug 567937: Completion after using keyword should be in su…

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -307,7 +307,7 @@ namespace MonoDevelop.CSharp.Completion
 				syntaxTree.GetContainingTypeOrEnumDeclaration (position, cancellationToken) is EnumDeclarationSyntax ||
 				syntaxTree.IsPreProcessorDirectiveContext (position, cancellationToken))
 				return;
-
+			
 			var extensionMethodImport = syntaxTree.IsRightOfDotOrArrowOrColonColon (position, cancellationToken);
 			ITypeSymbol extensionType = null;
 
@@ -334,7 +334,6 @@ namespace MonoDevelop.CSharp.Completion
 				syntaxTree.IsStatementContext (position, tokenLeftOfPosition, cancellationToken) ||
 				syntaxTree.IsTypeContext (position, cancellationToken) ||
 				syntaxTree.IsTypeDeclarationContext (position, tokenLeftOfPosition, cancellationToken) ||
-				syntaxTree.IsNamespaceContext (position, cancellationToken) ||
 				syntaxTree.IsMemberDeclarationContext (position, tokenLeftOfPosition, cancellationToken) ||
 				syntaxTree.IsLabelContext (position, cancellationToken)) {
 				var usedNamespaces = new HashSet<string> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
@@ -92,12 +92,12 @@ namespace MonoDevelop.Ide.CodeCompletion
 				var type = GetItemType ();
 				var hash = modifier | type << 16;
 				if (!IconIdCache.ContainsKey (hash))
-					IconIdCache [hash] = "md-" + modifierType[modifier] + completionType[type];
+					IconIdCache [hash] = "md-" + modifierType [modifier] + completionType [type];
 				return IconIdCache [hash];
 			}
 		}
 
-		static Dictionary<int, string> IconIdCache = new Dictionary<int, string>();
+		static Dictionary<int, string> IconIdCache = new Dictionary<int, string> ();
 
 		public RoslynCompletionData (Microsoft.CodeAnalysis.Document document, ITextSnapshot triggerSnapshot, CompletionService completionService, CompletionItem completionItem)
 		{
@@ -198,7 +198,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 			return 1;
 		}
 
-		string[] modifierType = {
+		string [] modifierType = {
 			"",
 			"private-",
 			"ProtectedOrInternal-",
@@ -257,7 +257,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 					editor.ReplaceText (mappedSpan.Start + 1, mappedSpan.Length - 1, completionChange.TextChange.NewText);
 				} else
 					editor.ReplaceText (mappedSpan.Start, mappedSpan.Length, completionChange.TextChange.NewText);
-			
+
 
 				if (completionChange.NewPosition.HasValue)
 					editor.CaretOffset = completionChange.NewPosition.Value;
@@ -297,6 +297,24 @@ namespace MonoDevelop.Ide.CodeCompletion
 				SignatureMarkup = markup.ToString ()
 			};
 		}
-	}
 
+		public override bool IsCommitCharacter (char keyChar, string partialWord)
+		{
+			foreach (var rule in CompletionItem.Rules.CommitCharacterRules) {
+				switch (rule.Kind) {
+				case CharacterSetModificationKind.Add:
+					if (rule.Characters.Contains (keyChar))
+						return true;
+					continue;
+				case CharacterSetModificationKind.Remove:
+					if (rule.Characters.Contains (keyChar))
+						return false;
+					continue;
+				case CharacterSetModificationKind.Replace:
+					return rule.Characters.Contains (keyChar);
+				}
+			}
+			return base.IsCommitCharacter (keyChar, partialWord);
+		}
+	}
 }

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompletionTextEditorTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompletionTextEditorTests.cs
@@ -209,8 +209,18 @@ namespace console61
 		public async Task TestVSTSBug568065 ()
 		{
 			IdeApp.Preferences.AddImportedItemsToCompletionList.Value = true;
-			await TestCompletion (@"$", list => Assert.AreEqual (1, list.Where (d => d.CompletionText == "Tuple").Count()));
+			await TestCompletion (@"$", list => Assert.AreEqual (1, list.Where (d => d.CompletionText == "Tuple").Count ()));
+		}
 
+
+		/// <summary>
+		/// Bug 567937: Completion after using keyword should be in suggestion mode
+		/// </summary>
+		[Test]
+		public async Task TestVSTSBug567937 ()
+		{
+			IdeApp.Preferences.AddImportedItemsToCompletionList.Value = true;
+			await TestCompletion (@"using S$", list => Assert.AreEqual (0, list.OfType<ImportSymbolCompletionData> ().Count ()));
 		}
 	}
 }


### PR DESCRIPTION
…ggestion mode

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/567937
We're now using the roslyn completion item commit system correctly and the import completion no longer shows up in the wrong context (namespace context).