### PR TITLE
[TextEditor] Always fetch the preedit string

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -482,10 +482,7 @@ namespace Mono.TextEditor
 
 		void PreeditStringChanged (object sender, EventArgs e)
 		{
-			if (imContextNeedsReset)
-				preeditString = null;
-			else
-				imContext.GetPreeditString (out preeditString, out preeditAttrs, out preeditCursorCharIndex);
+			imContext.GetPreeditString (out preeditString, out preeditAttrs, out preeditCursorCharIndex);
 			if (!string.IsNullOrEmpty (preeditString)) {
 				if (preeditOffset < 0) {
 					preeditOffset = Caret.Offset;


### PR DESCRIPTION
When the window first focuses imContextNeedsReset is always set to true,
so here we set preeditString to null and it won't be displayed correctly
for Japanese and Chinese users. There may be other situations where it
also is set to true and the preedit string will disappear in the middle
of typing.

Fixes VSTS #573925