### PR TITLE
Fixes VSTS 569813 'Find in Files' searches within hidden MacOS .DS_St…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -500,20 +500,7 @@ namespace MonoDevelop.Ide.FindInFiles
 				Visible = true,
 				Ready = true,
 			};
-			
-			var checkMenuItem = searchentryFileMask.AddFilterOption (0, GettextCatalog.GetString ("Include binary files"));
-			checkMenuItem.DrawAsRadio = false;
-			checkMenuItem.Active = properties.Get ("IncludeBinaryFiles", false);
-			checkMenuItem.Toggled += delegate {
-				properties.Set ("IncludeBinaryFiles", checkMenuItem.Active);
-			};
-			
-			var checkMenuItem1 = searchentryFileMask.AddFilterOption (1, GettextCatalog.GetString ("Include hidden files and directories"));
-			checkMenuItem1.DrawAsRadio = false;
-			checkMenuItem1.Active = properties.Get ("IncludeHiddenFiles", false);
-			checkMenuItem1.Toggled += delegate {
-				properties.Set ("IncludeHiddenFiles", checkMenuItem1.Active);
-			};
+
 			
 			searchentryFileMask.Query = properties.Get ("MonoDevelop.FindReplaceDialogs.FileMask", "");
 			
@@ -793,15 +780,12 @@ namespace MonoDevelop.Ide.FindInFiles
 					return null;
 				}
 				
-				scope = new DirectoryScope (comboboxentryPath.Entry.Text, checkbuttonRecursively.Active) {
-					IncludeHiddenFiles = properties.Get ("IncludeHiddenFiles", false)
-				};
+				scope = new DirectoryScope (comboboxentryPath.Entry.Text, checkbuttonRecursively.Active);
 				break;
 			default:
 				throw new ApplicationException ("Unknown scope:" + comboboxScope.Active);
 			}
 			
-			scope.IncludeBinaryFiles = properties.Get ("IncludeBinaryFiles", false);
 			return scope;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -39,11 +39,6 @@ namespace MonoDevelop.Ide.FindInFiles
 {
 	public abstract class Scope
 	{
-		public bool IncludeBinaryFiles {
-			get;
-			set;
-		}
-
 		public virtual PathMode PathMode {
 			get {
 				var workspace = IdeApp.Workspace;
@@ -145,7 +140,7 @@ namespace MonoDevelop.Ide.FindInFiles
 							  () => new List<FileProvider> (),
 							  (folder, loop, providers) => {
 								  foreach (var file in folder.Files.Where (f => filterOptions.NameMatches (f.FileName) && File.Exists (f.FullPath))) {
-									  if (!IncludeBinaryFiles && !DesktopService.GetFileIsText (file.FullPath))
+									  if (!DesktopService.GetFileIsText (file.FullPath))
 										  continue;
 									  lock (alreadyVisited) {
 										  if (alreadyVisited.Contains (file.FullPath))
@@ -171,7 +166,7 @@ namespace MonoDevelop.Ide.FindInFiles
 								  foreach (ProjectFile file in project.GetSourceFilesAsync (conf).Result.Where (f => filterOptions.NameMatches (f.Name) && File.Exists (f.Name))) {
 									  if ((file.Flags & ProjectItemFlags.Hidden) == ProjectItemFlags.Hidden)
 										  continue;
-									  if (!IncludeBinaryFiles && !DesktopService.GetFileIsText (file.FilePath))
+									  if (!DesktopService.GetFileIsText (file.FilePath))
 										  continue;
 
 									  lock (alreadyVisited) {
@@ -227,7 +222,7 @@ namespace MonoDevelop.Ide.FindInFiles
 				foreach (ProjectFile file in project.GetSourceFilesAsync (conf).Result.Where (f => filterOptions.NameMatches (f.Name) && File.Exists (f.Name))) {
 					if ((file.Flags & ProjectItemFlags.Hidden) == ProjectItemFlags.Hidden)
 						continue;
-					if (!IncludeBinaryFiles && !DesktopService.GetFileIsText (file.Name))
+					if (!DesktopService.GetFileIsText (file.Name))
 						continue;
 					if (alreadyVisited.Contains (file.FilePath.FullPath))
 						continue;
@@ -280,10 +275,6 @@ namespace MonoDevelop.Ide.FindInFiles
 			get { return PathMode.Absolute; }
 		}
 
-		public bool IncludeHiddenFiles {
-			get;
-			set;
-		}
 
 		FileProvider[] fileNames;
 		public override int GetTotalWork (FilterOptions filterOptions)
@@ -315,33 +306,29 @@ namespace MonoDevelop.Ide.FindInFiles
 				}
 
 				foreach (string fileName in Directory.EnumerateFiles (curPath, "*")) {
-					if (!IncludeHiddenFiles) {
-						if (Platform.IsWindows) {
-							var attr = File.GetAttributes (fileName);
-							if (attr.HasFlag (FileAttributes.Hidden))
-								continue;
-						}
-						if (Path.GetFileName (fileName).StartsWith (".", StringComparison.Ordinal))
+					if (Platform.IsWindows) {
+						var attr = File.GetAttributes (fileName);
+						if (attr.HasFlag (FileAttributes.Hidden))
 							continue;
 					}
+					if (Path.GetFileName (fileName).StartsWith (".", StringComparison.Ordinal))
+						continue;
 					if (!filterOptions.NameMatches (fileName))
 						continue;
-					if (!IncludeBinaryFiles && !DesktopService.GetFileIsText (fileName))
+					if (!DesktopService.GetFileIsText (fileName))
 						continue;
 					yield return fileName;
 				}
 
 				if (recurse) {
 					foreach (string directoryName in Directory.EnumerateDirectories (curPath)) {
-						if (!IncludeHiddenFiles) {
-							if (Platform.IsWindows) {
-								var attr = File.GetAttributes (directoryName);
-								if (attr.HasFlag (FileAttributes.Hidden))
-									continue;
-							}
-							if (Path.GetFileName (directoryName).StartsWith (".", StringComparison.Ordinal))
+						if (Platform.IsWindows) {
+							var attr = File.GetAttributes (directoryName);
+							if (attr.HasFlag (FileAttributes.Hidden))
 								continue;
 						}
+						if (Path.GetFileName (directoryName).StartsWith (".", StringComparison.Ordinal))
+							continue;
 						directoryStack.Push (directoryName);
 					}
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -39,6 +39,12 @@ namespace MonoDevelop.Ide.FindInFiles
 {
 	public abstract class Scope
 	{
+		[Obsolete ("Unused - will be removed")]
+		public bool IncludeBinaryFiles {
+			get;
+			set;
+		}
+
 		public virtual PathMode PathMode {
 			get {
 				var workspace = IdeApp.Workspace;
@@ -275,6 +281,11 @@ namespace MonoDevelop.Ide.FindInFiles
 			get { return PathMode.Absolute; }
 		}
 
+		[Obsolete ("Unused - will be removed")]
+		public bool IncludeHiddenFiles {
+			get;
+			set;
+		}
 
 		FileProvider[] fileNames;
 		public override int GetTotalWork (FilterOptions filterOptions)


### PR DESCRIPTION
…ore files.

https://devdiv.visualstudio.com/DevDiv/_workitems?id=569813

The binary & hidden files flag was not used in the UI in any way so it's better to remove it. For VS4Mac it doesn't make sense to include non source code files so they're not useful at all.
The default is not to search in binary or hidden files - that fixes the .DS_Store issue as well.