### PR TITLE
Add TypeScript content type to RoslynCompletionPresenter

### DIFF
--- a/main/src/addins/CSharpBinding/Razor/RoslynCompletionPresenter.cs
+++ b/main/src/addins/CSharpBinding/Razor/RoslynCompletionPresenter.cs
@@ -67,6 +67,9 @@ namespace MonoDevelop.Ide.CodeCompletion
             else if (contentType.IsOfType ("CSharp")) {
                 languageName = LanguageNames.CSharp;
             }
+            else if (contentType.IsOfType ("TypeScript")) {
+                languageName = "TypeScript";
+            }
             else {
                 languageName = null;
             }


### PR DESCRIPTION
This is necessary for TypeScript completions to work in the editorFeatures branch.