### PR TITLE
[Ide] Ensured that the document parsed event is called on UI thread.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/ProjectedDocumentContext.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/ProjectedDocumentContext.cs
@@ -30,6 +30,7 @@ using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.TypeSystem;
 using System.Threading.Tasks;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Editor.Projection
 {
@@ -101,7 +102,7 @@ namespace MonoDevelop.Ide.Editor.Projection
 			ReparseDocumentInternal ();
 		}
 
-		Task ReparseDocumentInternal ()
+		async Task ReparseDocumentInternal ()
 		{
 			var options = new ParseOptions {
 				FileName = projectedEditor.FileName,
@@ -110,8 +111,9 @@ namespace MonoDevelop.Ide.Editor.Projection
 				RoslynDocument = projectedDocument,
 				OldParsedDocument = parsedDocument
 			}; 
-			return TypeSystemService.ParseFile (options, projectedEditor.MimeType).ContinueWith (t => {
-				parsedDocument = t.Result;
+			var result = await TypeSystemService.ParseFile (options, projectedEditor.MimeType).ConfigureAwait (false);
+			await Runtime.RunInMainThread (delegate {
+				parsedDocument = result;
 				base.OnDocumentParsed (EventArgs.Empty);
 			});
 		}


### PR DESCRIPTION
If ReparseDocument was called from a background thread the parsed event was called on the same thread. This should be fixed.

Fixes VSTS 572820