### PR TITLE
Fix possible crash in close all files

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -203,10 +203,11 @@ namespace MonoDevelop.AnalysisCore.Gui
 			if (doc == null || DocumentContext.IsAdHocProject)
 				return;
 
-			if (DocumentContext.AnalysisDocument == null)
+			var ad = DocumentContext.AnalysisDocument;
+			if (ad == null || ad.Project == null)
 				return;
 			
-			if (e.DocumentId != DocumentContext.AnalysisDocument.Id || e.ProjectId != DocumentContext.AnalysisDocument.Project.Id)
+			if (e.DocumentId != DocumentContext.AnalysisDocument.Id || e.ProjectId != ad.Project.Id)
 				return;
 
 			var token = CancelUpdateTimeout (e.Id);

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -203,11 +203,11 @@ namespace MonoDevelop.AnalysisCore.Gui
 			if (doc == null || DocumentContext.IsAdHocProject)
 				return;
 
-			var ad = DocumentContext.AnalysisDocument;
-			if (ad == null || ad.Project == null)
+			var cad = DocumentContext.AnalysisDocument;
+			if (cad == null || cad.Project == null)
 				return;
 			
-			if (e.DocumentId != DocumentContext.AnalysisDocument.Id || e.ProjectId != ad.Project.Id)
+			if (e.DocumentId != cad.Id || e.ProjectId != cad.Project.Id)
 				return;
 
 			var token = CancelUpdateTimeout (e.Id);


### PR DESCRIPTION
```
[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.AnalysisCore.Gui.ResultsEditorExtension+<OnDiagnosticsUpdated>d__15.MoveNext () [0x0007f] in /Users/davidkarlas/GIT/MD1/monodevelop/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs:209 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:152 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__6_1 (System.Object state) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:1034 
  at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context (System.Object state) [0x0000d] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1306 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:957 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:904 
  at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00021] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1283 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:856 
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1211 
```