### PR TITLE
[Ide] Fix double Dispose in BuildOutputWidget

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -87,10 +87,15 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 		}
 
+		bool disposed = false;
+
 		public override void Dispose ()
 		{
-			control.FileSaved -= FileNameChanged;
-			control.Dispose ();
+			if (!disposed) {
+				control.FileSaved -= FileNameChanged;
+				control.Dispose ();
+				disposed = true;
+			}
 			base.Dispose ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -530,13 +530,15 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		protected override void Dispose (bool disposing)
 		{
-			buttonSearchBackward.Clicked -= FindPrevious;
-			buttonSearchForward.Clicked -= FindNext;
-			searchEntry.Entry.Changed -= FindFirst;
-			searchEntry.Entry.Activated -= FindNext;
-			saveButton.Clicked -= SaveButtonClickedAsync;
-			treeView.SelectionChanged -= TreeView_SelectionChanged;
-			treeView.ButtonPressed -= TreeView_ButtonPressed;
+			if (disposing) {
+				buttonSearchBackward.Clicked -= FindPrevious;
+				buttonSearchForward.Clicked -= FindNext;
+				searchEntry.Entry.Changed -= FindFirst;
+				searchEntry.Entry.Activated -= FindNext;
+				saveButton.Clicked -= SaveButtonClickedAsync;
+				treeView.SelectionChanged -= TreeView_SelectionChanged;
+				treeView.ButtonPressed -= TreeView_ButtonPressed;
+			}
 
 			base.Dispose (disposing);
 		}


### PR DESCRIPTION
This exception:

```ERROR [2018-02-27 13:59:03Z]: An unhandled exception has occured. Terminating Visual Studio? False
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object
  at Xwt.GtkBackend.TableViewBackend.DisableEvent (System.Object eventId) [0x00017] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs:135
  at Xwt.GtkBackend.TreeViewBackend.DisableEvent (System.Object eventId) [0x00000] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs:69
  at Xwt.Backends.BackendHost.OnDisableEvent (System.Object eventId) [0x00000] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt/Xwt.Backends/BackendHost.cs:189
  at Xwt.Backends.EventHost.OnAfterEventRemove (System.Object eventId, System.Delegate eventDelegate) [0x00011] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt/Xwt.Backends/EventHost.cs:127
  at Xwt.TreeView.remove_SelectionChanged (System.EventHandler value) [0x00017] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt/Xwt/TreeView.cs:517
  at (wrapper remoting-invoke-with-check) Xwt.TreeView.remove_SelectionChanged(System.EventHandler)
  at MonoDevelop.Ide.BuildOutputView.BuildOutputWidget.Dispose (System.Boolean disposing) [0x0007d] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs:512
  at System.ComponentModel.Component.Dispose () [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System/compmod/system/componentmodel/Component.cs:119
  at (wrapper remoting-invoke-with-check) System.ComponentModel.Component.Dispose()
  at MonoDevelop.Ide.BuildOutputView.BuildOutputViewContent.Dispose () [0x00017] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs:93
  at MonoDevelop.Ide.Gui.SdiWorkspaceWindow.OnDestroyed () [0x0001d] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs:522
  at Gtk.Object.NativeDestroy (System.Object o, System.EventArgs args) [0x00014] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/gtk/generated/Object.custom:85
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
   --- End of inner exception stack trace ---
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00043] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/MonoMethod.cs:313
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/reflection/methodbase.cs:229
  at System.Delegate.DynamicInvokeImpl (System.Object[] args) [0x000e1] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/corlib/System/Delegate.cs:461
  at System.MulticastDelegate.DynamicInvokeImpl (System.Object[] args) [0x00008] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/corlib/System/MulticastDelegate.cs:67
  at System.Delegate.DynamicInvoke (System.Object[] args) [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/corlib/System/Delegate.cs:406
  at GLib.Signal.ClosureInvokedCB (System.Object o, GLib.ClosureInvokedArgs args) [0x0007f] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/glib/Signal.cs:207
  at GLib.Signal+SignalClosure.Invoke (GLib.ClosureInvokedArgs args) [0x00019] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/glib/SignalClosure.cs:114
  at GLib.Signal+SignalClosure.MarshalCallback (System.IntPtr raw_closure, GLib.Value* return_val, System.UInt32 n_param_vals, GLib.Value* param_values, System.IntPtr invocation_hint, System.IntPtr marshal_data) [0x00053] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/glib/SignalClosure.cs:143
ERROR [2018-02-27 13:59:09Z]: An unhandled exception has occured. Terminating Visual Studio? False
System.NullReferenceException: Object reference not set to an instance of an object
  at Xwt.GtkBackend.TreeViewBackend.SetSource (Xwt.ITreeDataSource source, Xwt.Backends.IBackend sourceBackend) [0x0001d] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs:202
  at Xwt.TreeView.set_DataSource (Xwt.ITreeDataSource value) [0x00009] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/external/xwt/Xwt/Xwt/TreeView.cs:186
  at (wrapper remoting-invoke-with-check) Xwt.TreeView.set_DataSource(Xwt.ITreeDataSource)
  at MonoDevelop.Ide.BuildOutputView.BuildOutputWidget+<>c__DisplayClass62_0.<ProcessLogs>b__1 () [0x0004e] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs:459
  at MonoDevelop.Core.Runtime+<>c.<RunInMainThread>b__39_0 (System.Object state) [0x00013] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs:337
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:152
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x00037] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:187
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:156
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:128
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:113
  at MonoDevelop.Ide.BuildOutputView.BuildOutputWidget+<>c__DisplayClass62_0+<<ProcessLogs>b__0>d.MoveNext () [0x0004e] in /Users/builder/data/lanes/5691/e9bbd224/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs:453```

was being thrown when closing any BuildOutput tab, as BuildOutputWidget's Dispose
was being called twice.