### PR TITLE
Better quick info content formatting.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/BaseWpfToolTipPresenter.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/BaseWpfToolTipPresenter.cs
@@ -72,7 +72,7 @@
             if (this.popup != null)
             {
                 this.popup.Closed -= this.OnPopupClosed;
-				this.popup.Visible = false;
+                this.popup.Visible = false;
                 //this.popup.Content = null;
                 this.isDismissed = true;
                 this.obscuringTipManager.RemoveTip(this.textView, this);
@@ -108,12 +108,11 @@
                 this.Dismiss();
                 return;
             }
-			
 
             this.Update(content);
 
             this.popup.Closed += this.OnPopupClosed;
-
+            this.popup.Padding = 4.0;
             this.popup.Visible = true;
            //todo this.popup.BringIntoView();
             this.obscuringTipManager.PushTip(this.textView, this);
@@ -127,18 +126,13 @@
                     this.textView, item))
                     .Where(item => item != null);
 
-			//var control = new WpfToolTipControl (this.WpfTextView) {
-			//	// Translate intermediate to UI.
-			//	DataContext = new WpfToolTipViewModel (
-			//		this.parameters,
-			//		contentViewElements,
-			//		this.presenterStyle)
-			//};
-			var vbox = new Xwt.VBox ();
-			foreach (var view in contentViewElements) {
-				vbox.PackStart (view);
-			}
-			this.popup.Content = vbox;
+            var vbox = new Xwt.VBox ();
+            foreach (var view in contentViewElements)
+            {
+                vbox.PackStart (view);
+            }
+            vbox.Margin = 4.0;
+            this.popup.Content = vbox;
         }
 
         protected ITrackingSpan PresentationSpan

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/ViewElementFactories/WpfClassifiedTextElementViewElementFactory.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/ViewElementFactories/WpfClassifiedTextElementViewElementFactory.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
 				var classy = textRunClassification.Classification;
 				var color = classy.GetHashCode ().ToString ("X");
 				color = color.Substring (2);
-				markup.AppendLine ($"<span foreground=\"#{color}\">{run.Text}</span>");
+				markup.Append ($"<span foreground=\"#{color}\">{run.Text}</span>");
 			}
 			textBlock.Markup = markup.ToString ();
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/ViewElementFactories/WpfContainerElementViewElementFactory.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/ViewElementFactories/WpfContainerElementViewElementFactory.cs
@@ -3,13 +3,13 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
     using System;
     using System.ComponentModel.Composition;
     using System.Text;
-	using UIElement = Xwt.Widget;
+    using UIElement = Xwt.Widget;
     using Microsoft.VisualStudio.Text.Adornments;
     using Microsoft.VisualStudio.Text.Editor;
     using Microsoft.VisualStudio.Utilities;
-	using Xwt;
+    using Xwt;
 
-	[Export(typeof(IViewElementFactory))]
+    [Export(typeof(IViewElementFactory))]
     [Name("default ContainerElement to UIElement")]
     [TypeConversion(from: typeof(ContainerElement), to: typeof(UIElement))]
     [Order]
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
                 throw new ArgumentException($"Invalid type conversion. Unsupported {nameof(model)} or {nameof(TView)} type");
             }
 
-            VBox containerControl;
+            Box containerControl;
 
             if (container.Style == ContainerElementStyle.Stacked)
             {
@@ -34,13 +34,11 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
             }
             else
             {
-                containerControl = new VBox ();//TODO
+                containerControl = new HBox();
             }
 
-			containerControl.HorizontalPlacement = WidgetPlacement.Start;
-			containerControl.VerticalPlacement = WidgetPlacement.Start;
-
-            var automationNameBuffer = new StringBuilder();
+            containerControl.HorizontalPlacement = WidgetPlacement.Start;
+            containerControl.VerticalPlacement = WidgetPlacement.Start;
 
             foreach (var element in container.Elements)
             {


### PR DESCRIPTION
- This PR tweaks the UX and adds padding and support for horizontal quick info layouts to make UI more consistent with VS for Windows.
- Addresses issue #4001

**VS for Windows**
![image](https://user-images.githubusercontent.com/5387680/36823415-e44e716c-1cb1-11e8-8dda-deacf533e5b5.png)


**Before:**
![image](https://user-images.githubusercontent.com/5387680/36823636-eedf23aa-1cb2-11e8-988c-1dd23213d4bd.png)

**After:**
![image](https://user-images.githubusercontent.com/5387680/36823329-84ff1bee-1cb1-11e8-8236-dfdbf5910cd2.png)

If desired I can share a repro extension project once I have it cleaned up.

**NOTE:** quick info is unusable at the moment due to #3999