### PR TITLE
[Ide] Fix errors/warnings count in summary node

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -160,8 +160,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 						result [node.Message] = new AggregatedBuildOutputNode (node);
 					}
 
-					errorCount += node.ErrorCount;
-					warningCount += node.WarningCount;
+					errorCount += node.Children.Sum (x => x.ErrorCount);
+					warningCount += node.Children.Sum (x => x.WarningCount);
 				}
 			}
 


### PR DESCRIPTION
Because we change the parent on nodes when aggregating them in
AggregatedBuildOutputNode, the summary node was, sometimes (depending
on when the full tree was requested), not summing up the errors and
warnings correctly, so use the aggregated nodes' values instead.