### PR TITLE
Fix mutable completion list filtering

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
@@ -259,7 +259,6 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			usingPreviewEntry = false;
 			previewCompletionEntryText = "";
-			StartOffset = 0;
 			HideWhenWordDeleted = false;
 			SelectedItemCompletionText = null;
 			ResetViewState();
@@ -407,8 +406,6 @@ namespace MonoDevelop.Ide.CodeCompletion
 		{
 			if (!object.ReferenceEquals (sender, mutableList))
 				return;
-			
-			ResetSizes ();
 
 			// Only hide the footer if it's finished changing
 			if (!mutableList.IsChanging)


### PR DESCRIPTION
Fixes mutable completion lists again. Without this, PackageReference IntelliSense in the MSBuild extension will regress and be completely broken.