### PR TITLE
Change the GetService call to not pass in the buffer. If the buffer i…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/VsCompletionTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/VsCompletionTextEditorExtension.cs
@@ -65,7 +65,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 		{
 			base.Initialize ();
 			view = Editor.TextView;
-			editorCommandHandlerService = CompositionManager.GetExportedValue<IEditorCommandHandlerServiceFactory> ().GetService (view, view.TextBuffer);
+			editorCommandHandlerService = CompositionManager.GetExportedValue<IEditorCommandHandlerServiceFactory> ().GetService (view);
 		}
 
 		public override bool IsValidInContext (DocumentContext context)


### PR DESCRIPTION
…s passed in, the buffer graph isn't fully walked, which is what we need for projection files.