### PR TITLE
[d15-7][VCS] Make the authors before command label less ambiguous

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
@@ -193,7 +193,7 @@
 		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowLog"
 			_label = "S_how Log"/>
 		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowBlameBefore"
-			_label = "Show _Authors Before"/>
+			_label = "Show _Authors prior to this change"/>
 		</Category>
 	</Extension>
 


### PR DESCRIPTION
Fixes VSTS #574214 [loc][query][DevDiv][XamarinStudio_GIT] Please clarify strings in " md-addins.po...." // Show _Authors Before