### PR TITLE
Fix japanse translation

### DIFF
--- a/main/po/ja.po
+++ b/main/po/ja.po
@@ -26345,7 +26345,7 @@ msgstr ""
 
 #: ../external/mono-addins/Mono.Addins.Gui/Mono.Addins.Gui/InstallDialog.cs:138
 msgid "The following packages will be installed:"
-msgstr "次のパッケージがアンインストールされます:"
+msgstr "次のパッケージがインストールされます:"
 
 #: ../external/mono-addins/Mono.Addins.Gui/Mono.Addins.Gui/InstallDialog.cs:142
 msgid " (in user directory)"


### PR DESCRIPTION
I changed the message that we get it when we install extensions.

This is a fix of translation:
- **インストール** means **install**
- **アンインストール** means **uninstall**

Thank you.