### PR TITLE
Fixes VSTS 572337: Saving changes causes the ViewContent to be reloaded

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -746,7 +746,6 @@ namespace MonoDevelop.SourceEditor
 				}
 			}
 
-			DocumentRegistry.SkipNextChange (fileName);
 			try {
 				object attributes = null;
 				if (File.Exists (fileName)) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -431,6 +431,7 @@ namespace MonoDevelop.Ide.Gui
                             await Window.ViewContent.Save (fileName + "~");
 							FileService.NotifyFileChanged (fileName + "~");
 						}
+						DocumentRegistry.SkipNextChange (fileName);
 						await Window.ViewContent.Save (fileName);
 						FileService.NotifyFileChanged (fileName);
                         OnSaved(EventArgs.Empty);


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/Xamarin%20VS%20for%20Mac/_workitems/edit/572337

Moving the file registry to central point requires to set the skip change to that point as well otherwise all other view content implementations are broken.