### PR TITLE
[d15-6] Add Xwt Name to various buttons and elements in PackageManagement dialogs

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.UI.cs
@@ -86,6 +86,7 @@ namespace MonoDevelop.PackageManagement
 			topHBox.PackStart (packageSourceComboBox);
 
 			packageSearchEntry = new SearchTextEntry ();
+			packageSearchEntry.Name = "addPackagesDialogSearchEntry";
 			packageSearchEntry.WidthRequest = 187;
 			topHBox.PackEnd (packageSearchEntry);
 
@@ -349,16 +350,19 @@ namespace MonoDevelop.PackageManagement
 			mainVBox.PackStart (bottomHBox);
 
 			showPrereleaseCheckBox = new CheckBox ();
+			showPrereleaseCheckBox.Name = "addPackagesDialogShowPreReleaseCheckBox";
 			showPrereleaseCheckBox.Label = Catalog.GetString ("Show pre-release packages");
 			bottomHBox.PackStart (showPrereleaseCheckBox);
 
 			addPackagesButton = new Button ();
+			addPackagesButton.Name = "addPackagesDialogAddPackageButton";
 			addPackagesButton.MinWidth = 120;
 			addPackagesButton.MinHeight = 25;
 			addPackagesButton.Label = Catalog.GetString ("Add Package");
 			bottomHBox.PackEnd (addPackagesButton);
 
 			var closeButton = new Button ();
+			closeButton.Name = "addPackagesDialogCloseButton";
 			closeButton.MinWidth = 120;
 			closeButton.MinHeight = 25;
 			closeButton.Label = Catalog.GetString ("Close");


### PR DESCRIPTION
Backport from master https://github.com/mono/monodevelop/pull/4064

Needed so that we don't have to maintain two different codebase or branching for automated tests. The change itself is extremely low risk as it just adds the name to various widgets
