### PR TITLE
[NuGet] Ensure generated files available to type system after install

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProject.cs
@@ -84,6 +84,14 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public IMSBuildEvaluatedPropertyCollection EvaluatedProperties {
 			get { return FakeEvaluatedProperties; }
 		}
+
+		public bool IsReevaluated;
+
+		public Task ReevaluateProject (ProgressMonitor monitor)
+		{
+			IsReevaluated = true;
+			return Task.FromResult (0);
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
@@ -823,6 +823,72 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsTrue (info.IsUninstallPending);
 			Assert.IsFalse (info.IsRestorePending);
 		}
+
+		[Test]
+		public void Run_ImportRemoved_ProjectBuilderDisposed ()
+		{
+			CreateRunner ();
+			var project = new FakeDotNetProject ();
+			var solution = new FakeSolution ();
+			solution.Projects.Add (project);
+			project.ParentSolution = solution;
+			AddInstallActionWithCustomExecuteAction (() => {
+				packageManagementEvents.OnImportRemoved (project, "Test.targets");
+			});
+
+			Run ();
+
+			Assert.IsTrue (project.IsProjectBuilderDisposed);
+		}
+
+		[Test]
+		public void Run_ImportRemoved_ProjectIsReevaluated ()
+		{
+			CreateRunner ();
+			var project = new FakeDotNetProject ();
+			var solution = new FakeSolution ();
+			solution.Projects.Add (project);
+			project.ParentSolution = solution;
+			AddInstallActionWithCustomExecuteAction (() => {
+				packageManagementEvents.OnImportRemoved (project, "Test.targets");
+			});
+
+			Run ();
+
+			Assert.IsTrue (project.IsReevaluated);
+		}
+
+		[Test]
+		public void Run_ImportAdded_ProjectIsReevaluated ()
+		{
+			CreateRunner ();
+			var project = new FakeDotNetProject ();
+			var solution = new FakeSolution ();
+			solution.Projects.Add (project);
+			project.ParentSolution = solution;
+			AddInstallActionWithCustomExecuteAction (() => {
+				packageManagementEvents.OnImportAdded (project, "Test.targets");
+			});
+
+			Run ();
+
+			Assert.IsTrue (project.IsReevaluated);
+		}
+
+		[Test]
+		public void Run_NoImportAddedOrRemoved_ProjectIsNotReevaluated ()
+		{
+			CreateRunner ();
+			var project = new FakeDotNetProject ();
+			var solution = new FakeSolution ();
+			solution.Projects.Add (project);
+			project.ParentSolution = solution;
+			AddInstallActionWithCustomExecuteAction (() => {});
+
+			Run ();
+
+			Assert.IsFalse (project.IsReevaluated);
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/MonoDevelopProjectSystemTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/MonoDevelopProjectSystemTests.cs
@@ -1174,6 +1174,28 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
+		public void AddImport_ImportAlreadyAddedToBottomOfProject_ImportAddedEventIsFired ()
+		{
+			CreateTestProject (@"d:\projects\MyProject\MyProject\MyProject.csproj");
+			CreateProjectSystem (project);
+			string targetPath = @"d:\projects\MyProject\packages\Foo.0.1\build\Foo.targets".ToNativePath ();
+			projectSystem.AddImport (targetPath, ImportLocation.Bottom);
+			const string expectedImportAdded = @"..\packages\Foo.0.1\build\Foo.targets";
+			DotNetProjectImportEventArgs eventArgs = null;
+			projectSystem.PackageManagementEvents.ImportAdded += (sender, e) => {
+				eventArgs = e;
+			};
+
+			projectSystem.AddImport (targetPath, ImportLocation.Bottom);
+
+			AssertLastMSBuildChildElementHasProjectAttributeValue (@"..\packages\Foo.0.1\build\Foo.targets");
+			AssertLastImportHasImportLocation (ImportLocation.Bottom);
+			Assert.IsFalse (project.IsProjectBuilderDisposed);
+			Assert.AreEqual (project, eventArgs.Project);
+			Assert.AreEqual (expectedImportAdded, eventArgs.Import);
+		}
+
+		[Test]
 		public async Task AddReferenceAsync_AddReferenceToNUnitFramework_ReferenceAddingEventIsFired ()
 		{
 			CreateTestProject ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageManagementEvents.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPackageManagementEvents.cs
@@ -46,6 +46,7 @@ namespace MonoDevelop.PackageManagement
 		event EventHandler UpdatedPackagesAvailable;
 		event EventHandler<DotNetProjectReferenceEventArgs> ReferenceAdding;
 		event EventHandler<DotNetProjectReferenceEventArgs> ReferenceRemoving;
+		event EventHandler<DotNetProjectImportEventArgs> ImportAdded;
 		event EventHandler<DotNetProjectImportEventArgs> ImportRemoved;
 		event EventHandler<PackageManagementEventArgs> PackageInstalled;
 		event EventHandler<PackageManagementEventArgs> PackageUninstalling;
@@ -63,6 +64,7 @@ namespace MonoDevelop.PackageManagement
 		bool OnFileRemoving (string path);
 		void OnReferenceAdding (ProjectReference reference);
 		void OnReferenceRemoving (ProjectReference reference);
+		void OnImportAdded (IDotNetProject project, string import);
 		void OnImportRemoved (IDotNetProject project, string import);
 		void OnNoUpdateFound (IDotNetProject project);
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IProject.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.PackageManagement
 		IMSBuildEvaluatedPropertyCollection EvaluatedProperties { get; }
 
 		Task SaveAsync ();
+		Task ReevaluateProject (ProgressMonitor monitor);
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopMSBuildNuGetProjectSystem.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopMSBuildNuGetProjectSystem.cs
@@ -226,6 +226,8 @@ namespace MonoDevelop.PackageManagement
 					handler.AddImportIfMissing (relativeTargetPath, condition, location);
 					await project.SaveAsync ();
 				}
+
+				packageManagementEvents.OnImportAdded (project, relativeTargetPath);
 			});
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementEvents.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementEvents.cs
@@ -141,6 +141,13 @@ namespace MonoDevelop.PackageManagement
 			}
 		}
 
+		public event EventHandler<DotNetProjectImportEventArgs> ImportAdded;
+
+		public void OnImportAdded (IDotNetProject project, string import)
+		{
+			ImportAdded?.Invoke (this, new DotNetProjectImportEventArgs (project, import));
+		}
+
 		public event EventHandler<DotNetProjectImportEventArgs> ImportRemoved;
 
 		public void OnImportRemoved (IDotNetProject project, string import)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectProxy.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectProxy.cs
@@ -35,7 +35,7 @@ namespace MonoDevelop.PackageManagement
 {
 	internal class ProjectProxy : IProject
 	{
-		Project project;
+		readonly Project project;
 
 		public ProjectProxy (Project project)
 		{
@@ -79,6 +79,29 @@ namespace MonoDevelop.PackageManagement
 			using (var monitor = new ProgressMonitor ()) {
 				await project.SaveAsync (monitor);
 			}
+		}
+
+		public Task ReevaluateProject (ProgressMonitor monitor)
+		{
+			return project.ReevaluateProject (monitor);
+		}
+
+		public override int GetHashCode ()
+		{
+			return project.GetHashCode ();
+		}
+
+		public override bool Equals (object obj)
+		{
+			return Equals (obj as ProjectProxy);
+		}
+
+		public bool Equals (ProjectProxy other)
+		{
+			if (other != null) {
+				return other.project == project;
+			}
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
Installing a NuGet package such as Refit, which extends the
CoreCompileDependsOn to generate a C# file, the generated file would
not be available to the type system until the solution was closed
and re-opened again. The problem was that the result of running
the targets that are in the CoreCompileDependsOn property are
cached. When Refit is installed the cached result is returned so
the generated C# file is not available to the type system when it
calls Project.GetSourceFilesAsync. To fix this the NuGet addin
will now re-evaluate the project if an MSBuild import is added or
removed. Re-evaluation will result in the ResetCachedCompileItems
being called which clears the CoreCompileDependsOn cache. Note
that projects that use PackageReferences were unaffected since these
re-evaluate the project. Only projects that use a packages.config
file were affected.

Fixes VSTS #528487