### PR TITLE
[F#] Fix exception in Android previewer

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -263,7 +263,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			var workspace = await GetWorkspaceAsync (parentSolution, cancellationToken);
 			var projectId = workspace.GetProjectId (project);
 			if (projectId == null)
-				throw new Exception ("Project not part of workspace");
+				return null;
 			var proj = workspace.CurrentSolution.GetProject (projectId);
 			if (proj != null)
 				return proj;


### PR DESCRIPTION
Don't throw an exception if we don't have a Roslyn workspace, e.g. F#
fixes vsts #579690 (#4062)