### PR TITLE
[d15-7][Core] Fix zero package dependencies cached when call is cancelled.

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1084,6 +1084,11 @@ namespace MonoDevelop.Projects
 				if (result == null)
 					return new List<PackageDependency> ();
 
+				if (monitor.CancellationToken.IsCancellationRequested && !result.Items.Any ()) {
+					// Avoid caching 0 items which can happen if a cancellation occurs.
+					return new List<PackageDependency> ();
+				}
+
 				packageDependencies = result.Items.Select (i => PackageDependency.Create (i)).Where (dependency => dependency != null).ToList ();
 
 				packageDependenciesCache = packageDependenciesCache .SetItem (confId, packageDependencies);


### PR DESCRIPTION
Fixes VSTS #577272 - Unable to expand SDK dependencies in Solution
window for .NET Core projects

On creating a new ASP.NET Core Web App project after the NuGet packages
have restored it was sometimes not possible to expand the dependencies
under the NuGet folder or SDK folder in the Solution window. The
problem was that the initial call to Project.GetPackageDependencies
was cancelled and that could cause the RemoveProjectBuilder to return
a build result with an error and no items. This list of zero items
was then cached resulting in the Dependencies folder only showing
the dependencies it found in the project directly.