### PR TITLE
[StressTest] Use sorted visitor when processing MLPDs

### DIFF
--- a/main/tests/StressTest/MonoDevelop.StressTest/ProfilerProcessor.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/ProfilerProcessor.cs
@@ -76,7 +76,7 @@ namespace MonoDevelop.StressTest
 				}
 				using (var fs = new FileStream (Options.MlpdOutputPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
 				using (var logStream = new NeverEndingLogStream (fs, cts.Token)) {
-					processor = new LogProcessor (logStream, new Visitor (this), null);
+					processor = new LogProcessor (logStream, null, new Visitor (this));
 					processor.Process (cts.Token);
 				}
 			} catch (OperationCanceledException) { } catch (Exception ex) {


### PR DESCRIPTION
Using the immediate visitor doesn't guarantee the order of the events,
which results in crashes in HeapObjectEvent visitor if the class event
for the object in the snapshot hasn't arrived yet.