### PR TITLE
[d15-7][Core] Ensure generated files available to type system

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
@@ -68,12 +68,18 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public string Project {
 			get { return target; }
-			set { AssertCanModify (); target = value; NotifyChanged (); }
+			set { AssertCanModify (); target = value; NotifyImportChanged (); }
 		}
 
 		public string Sdk {
 			get { return sdk; }
-			set { AssertCanModify (); sdk = value; NotifyChanged (); }
+			set { AssertCanModify (); sdk = value; NotifyImportChanged (); }
+		}
+
+		void NotifyImportChanged ()
+		{
+			if (ParentProject != null)
+				ParentProject.NotifyImportChanged ();
 		}
 
 		internal override void Write (XmlWriter writer, WriteContext context)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -432,6 +432,18 @@ namespace MonoDevelop.Projects.MSBuild
 			changeStamp++;
 		}
 
+		internal void NotifyImportChanged ()
+		{
+			NotifyChanged ();
+
+			ImportChanged?.Invoke (this, EventArgs.Empty);
+		}
+
+		/// <summary>
+		/// Occurs when an import has changed, is added or removed.
+		/// </summary>
+		internal event EventHandler ImportChanged;
+
 		/// <summary>
 		/// Gets or sets a value indicating whether this project uses the msbuild engine for evaluation.
 		/// </summary>
@@ -613,7 +625,7 @@ namespace MonoDevelop.Projects.MSBuild
 				ChildNodes = ChildNodes.Add (import);
 
 			import.ResetIndent (false);
-			NotifyChanged ();
+			NotifyImportChanged ();
 			return import;
 		}
 
@@ -629,7 +641,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (i != null) {
 				i.RemoveIndent ();
 				ChildNodes = ChildNodes.Remove (i);
-				NotifyChanged ();
+				NotifyImportChanged ();
 			}
 		}
 
@@ -642,7 +654,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (import.ParentObject == this) {
 				import.RemoveIndent ();
 				ChildNodes = ChildNodes.Remove (import);
-				NotifyChanged ();
+				NotifyImportChanged ();
 			} else
 				((MSBuildImportGroup)import.ParentObject).RemoveImport (import);
 		}

--- a/main/tests/test-projects/project-with-corecompiledepends/consoleproject-import.targets
+++ b/main/tests/test-projects/project-with-corecompiledepends/consoleproject-import.targets
@@ -1,0 +1,14 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CoreCompileDependsOn>
+      $(CoreCompileDependsOn);
+      GenerateFiles;
+    </CoreCompileDependsOn>
+  </PropertyGroup>
+  <Target Name="GenerateFiles" BeforeTargets="CoreCompile">
+    <WriteLinesToFile File="GeneratedFile.g.cs" Lines="hello" Overwrite="true" />
+    <ItemGroup Condition="Exists('GeneratedFile.g.cs')">
+        <Compile Include="GeneratedFile.g.cs" />
+    </ItemGroup>    
+  </Target>
+</Project>

--- a/main/tests/test-projects/project-with-corecompiledepends/consoleproject.csproj
+++ b/main/tests/test-projects/project-with-corecompiledepends/consoleproject.csproj
@@ -1,0 +1,37 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Installing a NuGet package such as Refit, which extends the
CoreCompileDependsOn to generate a C# file, the generated file would
not be available to the type system until the solution was closed
and re-opened again. The problem was that the result of running the
targets that are in the CoreCompileDependsOn property are cached.
When Refit is installed the cached result is returned so the
generated C# file is not available to the type system when it calls
Project.GetSourceFilesAsync. To fix this the project will be
re-evaluated before getting the CoreCompileDependsOn property if an
MSBuild import is added or removed. Note that projects that use
PackageReferences were unaffected since these projects are
re-evaluated by the NuGet addin. Only projects that use a
packages.config file were affected.

Fixes VSTS #528487