### PR TITLE
[529478][Ide] Fix Light search result highlight color

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/LightStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/LightStyle.json
@@ -29,7 +29,7 @@
 	"colors": [
 		{ "name": "Background(Read Only)", "color": "white" },
 
-		{ "name": "Search result background", "color": "#fffeb7" },
+		{ "name": "Search result background", "color": "#fcff54" },
 		{ "name": "Search result background (highlighted)", "color": "#fffc38" },
 
 		{ "name": "Column Ruler", "color": "#eeeeee" },


### PR DESCRIPTION
This changes the search result highlighting color in the `Light` syntax highlighting theme to `#fcff54`.

Fixes VSTS #529478