### PR TITLE
Fixes VSTS 577393 Quick Fix: Move Add string.IsNull... checks up in t…

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
@@ -54,29 +54,6 @@ namespace MonoDevelop.CodeActions
 {
 	internal static class CodeFixMenuService
 	{
-		static readonly Dictionary<string, int> CodeActionUsages = new Dictionary<string, int> ();
-
-		static CodeFixMenuService ()
-		{
-			var usages = PropertyService.Get ("CodeActionUsages", new Properties ());
-			foreach (var key in usages.Keys) {
-				CodeActionUsages [key] = usages.Get<int> (key);
-			}
-		}
-
-		static void ConfirmUsage (string id)
-		{
-			if (id == null)
-				return;
-			if (!CodeActionUsages.ContainsKey (id)) {
-				CodeActionUsages [id] = 1;
-			} else {
-				CodeActionUsages [id]++;
-			}
-			var usages = PropertyService.Get ("CodeActionUsages", new Properties ());
-			usages.Set (id, CodeActionUsages [id]);
-		}
-
 		static MonoDevelopWorkspaceDiagnosticAnalyzerProviderService.OptionsTable options =
 			((MonoDevelopWorkspaceDiagnosticAnalyzerProviderService)Ide.Composition.CompositionManager.GetExportedValue<IWorkspaceDiagnosticAnalyzerProviderService> ()).Options;
 		public static async Task<CodeFixMenu> CreateFixMenu (TextEditor editor, CodeActionContainer fixes, CancellationToken cancellationToken = default(CancellationToken))
@@ -98,7 +75,7 @@ namespace MonoDevelop.CodeActions
 			var configureLabel = GettextCatalog.GetString ("_Options");
 			var configureMenu = new CodeFixMenu (configureLabel);
 
-			foreach (var cfa in fixes.CodeFixActions.OrderByDescending (x => x.Fixes.Max(y => GetUsage (y.Action.EquivalenceKey)))) {
+			foreach (var cfa in fixes.CodeFixActions) {
 				var state = cfa.FixAllState;
 				var scopes = cfa.SupportedScopes;
 
@@ -202,7 +179,6 @@ namespace MonoDevelop.CodeActions
 			var label = mnemonic < 0 ? fix.Title : CreateLabel (fix.Title, ref mnemonic);
 			var item = new CodeFixMenuEntry (label, async delegate {
 				await new ContextActionRunner (editor, fix).Run ();
-				ConfirmUsage (fix.EquivalenceKey);
 			});
 
 			item.ShowPreviewTooltip = delegate (Xwt.Rectangle rect) {
@@ -247,14 +223,6 @@ namespace MonoDevelop.CodeActions
 #else
 			return (mnemonic <= 10) ? "_" + mnemonic++ % 10 + " \u2013 " + escapedLabel : "  " + escapedLabel;
 #endif
-		}
-
-		static int GetUsage (string id)
-		{
-			int result;
-			if (id == null || !CodeActionUsages.TryGetValue (id, out result))
-				return 0;
-			return result;
 		}
 
 		internal class ContextActionRunner


### PR DESCRIPTION
…he context menu

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/577393

The issue was caused by the on usage ordering. That's a left over from old nrefactory - now roslyn sorts the actions.