### PR TITLE
Report the version of Xamarin.Mac that's used at runtime by the IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ Thumbs.db
 /main/build/MacOSX/*.o
 /main/external/fsharpbinding/.paket
 /main/external/fsharpbinding/paket-files
+/main/external/Xamarin.Mac.buildinfo
 /main/external/Xamarin.Mac.registrar.full.a
 /main/external/Xamarin.Mac.dll*
 /main/external/libxammac.dylib

--- a/main/external/Makefile.am
+++ b/main/external/Makefile.am
@@ -1,23 +1,27 @@
 TARBALL_PATH=../../tarballs/external
-XAMMAC_PATH=/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib
-XAMMAC_PDB=$(XAMMAC_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.pdb
+XAMMAC_PATH=/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
+XAMMAC_LIB_PATH=$(XAMMAC_PATH)/lib
+XAMMAC_PDB=$(XAMMAC_LIB_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.pdb
 all:
 
 clean:
 
 if ENABLE_MACPLATFORM
-all: Xamarin.Mac.dll Xamarin.Mac.registrar.full.a libxammac.dylib
+all: Xamarin.Mac.dll Xamarin.Mac.registrar.full.a libxammac.dylib Xamarin.Mac.buildinfo
 	$(MAKE) -C monomac/src
 
-Xamarin.Mac.dll: $(XAMMAC_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.dll
+Xamarin.Mac.dll: $(XAMMAC_LIB_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.dll
 	cp -p $< $@
 	if [[ -f $<.mdb ]]; then cp -p $<.mdb $@.mdb; fi;
 	if [[ -f $(XAMMAC_PDB) ]]; then cp -p $(XAMMAC_PDB) Xamarin.Mac.pdb; fi;
 
-Xamarin.Mac.registrar.full.a: $(XAMMAC_PATH)/mmp/Xamarin.Mac.registrar.full.a
+Xamarin.Mac.registrar.full.a: $(XAMMAC_LIB_PATH)/mmp/Xamarin.Mac.registrar.full.a
 	cp -p $< $@
 
-libxammac.dylib: $(XAMMAC_PATH)/libxammac.dylib
+libxammac.dylib: $(XAMMAC_LIB_PATH)/libxammac.dylib
+	cp -p $< $@
+
+Xamarin.Mac.buildinfo: $(XAMMAC_PATH)/buildinfo
 	cp -p $< $@
 
 clean:

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -225,6 +225,10 @@
     <EmbeddedResource Include="icons\status-stop-16~dark%402x.png">
       <LogicalName>status-stop-16~dark@2x.png</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\..\..\external\Xamarin.Mac.buildinfo">
+      <Link>Xamarin.Mac.buildinfo</Link>
+      <LogicalName>Xamarin.Mac.buildinfo</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Dialogs\" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -576,6 +576,11 @@ namespace MonoDevelop.Ide.Desktop
 		}
 
 		public static bool AccessibilityInUse { get; protected set; }
+
+		internal virtual string GetNativeRuntimeDescription ()
+		{
+			return null;
+		}
 	}
 
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -400,5 +400,7 @@ namespace MonoDevelop.Ide
 				return PlatformService.AccessibilityInUse;
 			}
 		}
+
+		internal static string GetNativeRuntimeDescription () => PlatformService.GetNativeRuntimeDescription ();
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
@@ -131,6 +131,13 @@ namespace MonoDevelop.Ide
 					sb.Append (" (").Append (gtkTheme).AppendLine (" theme)");
 				else
 					sb.AppendLine ();
+
+				var nativeRuntime = DesktopService.GetNativeRuntimeDescription ();
+				if (!string.IsNullOrEmpty (nativeRuntime)) {
+					sb.Append ('\t');
+					sb.AppendLine (nativeRuntime);
+				}
+
 				if (Platform.IsWindows && !IsMono ()) {
 					using (var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey (@"SOFTWARE\Xamarin\GtkSharp\Version")) {
 						Version ver;


### PR DESCRIPTION
Fixes VSTS #577285 Report version of Xamarin.Mac that's used at runtime