### PR TITLE
Bump Roslyn to 2.8.0-beta2-62708-11 (#4101)

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -5,8 +5,8 @@
     <PackagesDirectory>$(RootDirectory)packages</PackagesDirectory>
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
-    <NuGetVersionRoslyn>2.7.0-beta3-62509-03</NuGetVersionRoslyn>
-    <NuGetVersionVSEditor>15.6.241-preview</NuGetVersionVSEditor>
+    <NuGetVersionRoslyn>2.8.0-beta2-62708-11</NuGetVersionRoslyn>
+    <NuGetVersionVSEditor>15.6.281-preview</NuGetVersionVSEditor>
   </PropertyGroup>
 
 </Project>

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
@@ -169,8 +169,7 @@ namespace MonoDevelop.CSharp.Project
 			if (configuration != null)
 				symbols = symbols.Concat (configuration.GetDefineSymbols ()).Distinct ();
 
-			LanguageVersion lv;
-			TryParseLanguageVersion (langVersion, out lv);
+			langVersion.TryParse (out LanguageVersion lv);
 
 			return new CSharpParseOptions (
 				lv,
@@ -183,8 +182,7 @@ namespace MonoDevelop.CSharp.Project
 
 		public LanguageVersion LangVersion {
 			get {
-				LanguageVersion val;
-				if (!TryParseLanguageVersion (langVersion, out val)) {
+				if (!langVersion.TryParse (out LanguageVersion val)) {
 					throw new Exception ("Unknown LangVersion string '" + langVersion + "'");
 				}
 				return val;
@@ -376,66 +374,8 @@ namespace MonoDevelop.CSharp.Project
 			case LanguageVersion.CSharp2: return "ISO-2";
 			case LanguageVersion.CSharp7_1: return "7.1";
 			case LanguageVersion.CSharp7_2: return "7.2";
+			case LanguageVersion.CSharp7_3: return "7.3";
 			default: return ((int)value).ToString ();
-			}
-		}
-
-		// From https://github.com/dotnet/roslyn/blob/f60facc9f40ddc40f85411372f5b8dde9dd5e3b4/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
-		// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-		static bool TryParseLanguageVersion (string str, out LanguageVersion version)
-		{
-			if (str == null) {
-				version = LanguageVersion.Default;
-				return true;
-			}
-
-			switch (str.ToLowerInvariant ()) {
-			case "iso-1":
-				version = LanguageVersion.CSharp1;
-				return true;
-
-			case "iso-2":
-				version = LanguageVersion.CSharp2;
-				return true;
-
-			case "7":
-				version = LanguageVersion.CSharp7;
-				return true;
-
-			case "7.1":
-				version = LanguageVersion.CSharp7_1;
-				return true;
-				
-			case "7.2":
-				version = LanguageVersion.CSharp7_2;
-				return true;
-
-			case "default":
-				version = LanguageVersion.Default;
-				return true;
-
-			case "latest":
-				version = LanguageVersion.Latest;
-				return true;
-
-			default:
-				// We are likely to introduce minor version numbers after C# 7, thus breaking the
-				// one-to-one correspondence between the integers and the corresponding
-				// LanguageVersion enum values. But for compatibility we continue to accept any
-				// integral value parsed by int.TryParse for its corresponding LanguageVersion enum
-				// value for language version C# 6 and earlier (e.g. leading zeros are allowed)
-				int versionNumber;
-				if (int.TryParse (str, NumberStyles.None, CultureInfo.InvariantCulture, out versionNumber) &&
-					//HACK: IsValid isn't accessible, do our own check here
-					//&& versionNumber <= 6 && ((LanguageVersion)versionNumber).IsValid ())
-					versionNumber > 0 && versionNumber <= 6)
-				{
-					version = (LanguageVersion)versionNumber;
-					return true;
-				}
-
-				version = LanguageVersion.Default;
-				return false;
 			}
 		}
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpLanguageVersionHelper.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpLanguageVersionHelper.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.CSharp.Project
 			yield return (GettextCatalog.GetString ("Version 7"), LanguageVersion.CSharp7);
 			yield return (GettextCatalog.GetString ("Version 7.1"), LanguageVersion.CSharp7_1);
 			yield return (GettextCatalog.GetString ("Version 7.2"), LanguageVersion.CSharp7_2);
+			yield return (GettextCatalog.GetString ("Version 7.3"), LanguageVersion.CSharp7_3);
 			yield return (GettextCatalog.GetString ("Latest"), LanguageVersion.Latest);
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -1,37 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis" version="2.7.0-beta3-62509-03" targetFramework="net461" />
+  <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis" version="2.8.0-beta2-62708-11" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.2.0-beta2" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.7.0-beta3-62509-03" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.8.0-beta2-62708-11" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Elfie" version="1.0.0-rc9" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Features" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.7.0-beta3-62509-03" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.7.0-beta3-62509-03" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Features" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.8.0-beta2-62708-11" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.8.0-beta2-62708-11" targetFramework="net461" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net461" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.CodingConventions" version="1.1.20180226.4" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Composition" version="15.3.38" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Language" version="15.6.241-preview" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Data" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Internal" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Logic" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.UI" version="15.6.241-preview" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.6.241-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Composition" version="15.6.36" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Language" version="15.6.281-preview" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Internal" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="15.6.281-preview" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.6.281-preview" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Implementation" version="15.1.0-pre" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net461" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -128,20 +128,24 @@ namespace MonoDevelop.Ide.Composition
 
 			var discoveryErrors = catalog.DiscoveredParts.DiscoveryErrors;
 			if (!discoveryErrors.IsEmpty) {
-				throw new ApplicationException ($"MEF catalog scanning errors encountered.\n{string.Join ("\n", discoveryErrors)}");
+				foreach	(var error in discoveryErrors) {
+					LoggingService.LogInfo ("MEF discovery error", error);
+				}
+				
+				// throw new ApplicationException ("MEF discovery errors");
 			}
 
 			CompositionConfiguration configuration = CompositionConfiguration.Create (catalog);
 
 			if (!configuration.CompositionErrors.IsEmpty) {
 				// capture the errors in an array for easier debugging
-				var errors = configuration.CompositionErrors.ToArray ();
+				var errors = configuration.CompositionErrors.SelectMany (e => e).ToArray ();
+				foreach	(var error in errors) {
+					LoggingService.LogInfo ("MEF composition error: " + error.Message);
+				}
 
 				// For now while we're still transitioning to VSMEF it's useful to work
 				// even if the composition has some errors. TODO: re-enable this.
-				//var messages = errors.SelectMany (e => e).Select (e => e.Message);
-				//var text = string.Join (Environment.NewLine, messages);
-				//Xwt.Clipboard.SetText (text);
 				//configuration.ThrowOnErrors ();
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/EditorThemeColors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/EditorThemeColors.cs
@@ -139,22 +139,45 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 		public static readonly string UserTypesDelegates = "entity.name.delegate";
 		public static readonly string UserTypesMutable = "entity.name.mutable";
 
+		public static readonly string UserField = "entity.name.field";
+		[Obsolete ("Use UserField")]
 		public static readonly string UserFieldDeclaration = "entity.name.field";
-		public static readonly string UserFieldUsage = "entity.name.field.usage";
+		[Obsolete ("Use UserField")]
+		public static readonly string UserFieldUsage = "entity.name.field";
 
+		public static readonly string UserEnumMember = "entity.name.enummember";
+		public static readonly string UserConstant = "entity.name.constant";
+
+		public static readonly string UserProperty = "entity.name.property";
+		[Obsolete ("Use UserProperty")]
 		public static readonly string UserPropertyDeclaration = "entity.name.property";
-		public static readonly string UserPropertyUsage = "entity.name.property.usage";
+		[Obsolete ("Use UserProperty")]
+		public static readonly string UserPropertyUsage = "entity.name.property";
 
+
+		public static readonly string UserEvent = "entity.name.event";
+		[Obsolete ("Use UserEvent")]
 		public static readonly string UserEventDeclaration = "entity.name.event";
+		[Obsolete ("Use UserEvent")]
 		public static readonly string UserEventUsage = "entity.name.event.usage";
 
+		public static readonly string UserMethod = "entity.name.function";
+		public static readonly string UserExtensionMethod = "entity.name.extensionmethod";
+		[Obsolete ("Use UserMethod")]
 		public static readonly string UserMethodDeclaration = "entity.name.function";
+		[Obsolete ("Use UserMethod")]
 		public static readonly string UserMethodUsage = "entity.name.function.usage";
 
+		public static readonly string UserParameter = "entity.name.parameter";
+		[Obsolete ("Use UserParameter")]
 		public static readonly string UserParameterDeclaration = "entity.name.parameter";
+		[Obsolete ("Use UserParameter")]
 		public static readonly string UserParameterUsage = "entity.name.parameter.usage";
 
+		public static readonly string UserLocal = "entity.name.local";
+		[Obsolete ("Use UserLocal")]
 		public static readonly string UserVariableDeclaration = "entity.name.local";
+		[Obsolete ("Use UserLocal")]
 		public static readonly string UserVariableUsage = "entity.name.local.usage";
 	}
 	

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/OldFormat.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/OldFormat.cs
@@ -259,18 +259,16 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			settings.Add (new ThemeSetting ("User Types(Delegates)", new List<string> { EditorThemeColors.UserTypesDelegates }, ConvertChunkStyle (colorScheme.UserTypesDelegates)));
 			settings.Add (new ThemeSetting ("User Types(Mutable)", new List<string> { EditorThemeColors.UserTypesMutable }, ConvertChunkStyle (colorScheme.UserTypesMutable)));
 
-			settings.Add (new ThemeSetting ("User Field(Declaration)", new List<string> { EditorThemeColors.UserFieldDeclaration }, ConvertChunkStyle (colorScheme.UserFieldDeclaration)));
-			settings.Add (new ThemeSetting ("User Field(Usage)", new List<string> { EditorThemeColors.UserFieldUsage }, ConvertChunkStyle (colorScheme.UserFieldUsage)));
-			settings.Add (new ThemeSetting ("User Property(Declaration)", new List<string> { EditorThemeColors.UserPropertyDeclaration }, ConvertChunkStyle (colorScheme.UserPropertyDeclaration)));
-			settings.Add (new ThemeSetting ("User Property(Usage)", new List<string> { EditorThemeColors.UserPropertyUsage }, ConvertChunkStyle (colorScheme.UserPropertyUsage)));
-			settings.Add (new ThemeSetting ("User Event(Declaration)", new List<string> { EditorThemeColors.UserEventDeclaration }, ConvertChunkStyle (colorScheme.UserEventDeclaration)));
-			settings.Add (new ThemeSetting ("User Event(Usage)", new List<string> { EditorThemeColors.UserEventUsage }, ConvertChunkStyle (colorScheme.UserEventUsage)));
-			settings.Add (new ThemeSetting ("User Method(Declaration)", new List<string> { EditorThemeColors.UserMethodDeclaration }, ConvertChunkStyle (colorScheme.UserMethodDeclaration)));
-			settings.Add (new ThemeSetting ("User Method(Usage)", new List<string> { EditorThemeColors.UserMethodUsage }, ConvertChunkStyle (colorScheme.UserMethodUsage)));
-			settings.Add (new ThemeSetting ("User Parameter(Declaration)", new List<string> { EditorThemeColors.UserParameterDeclaration }, ConvertChunkStyle (colorScheme.UserParameterDeclaration)));
-			settings.Add (new ThemeSetting ("User Parameter(Usage)", new List<string> { EditorThemeColors.UserParameterUsage }, ConvertChunkStyle (colorScheme.UserParameterUsage)));
-			settings.Add (new ThemeSetting ("User Variable(Declaration)", new List<string> { EditorThemeColors.UserVariableDeclaration }, ConvertChunkStyle (colorScheme.UserVariableDeclaration)));
-			settings.Add (new ThemeSetting ("User Variable(Usage)", new List<string> { EditorThemeColors.UserVariableUsage }, ConvertChunkStyle (colorScheme.UserVariableUsage)));
+			settings.Add (new ThemeSetting ("User Field", new List<string> { EditorThemeColors.UserField }, ConvertChunkStyle (colorScheme.UserFieldDeclaration)));
+			settings.Add (new ThemeSetting ("User Enum Member", new List<string> { EditorThemeColors.UserField }, ConvertChunkStyle (colorScheme.UserFieldDeclaration)));
+			settings.Add (new ThemeSetting ("User Constant", new List<string> { EditorThemeColors.UserConstant }, ConvertChunkStyle (colorScheme.UserFieldDeclaration)));
+
+			settings.Add (new ThemeSetting ("User Property", new List<string> { EditorThemeColors.UserProperty }, ConvertChunkStyle (colorScheme.UserPropertyDeclaration)));
+			settings.Add (new ThemeSetting ("User Event", new List<string> { EditorThemeColors.UserEvent }, ConvertChunkStyle (colorScheme.UserEventDeclaration)));
+			settings.Add (new ThemeSetting ("User Method", new List<string> { EditorThemeColors.UserMethod }, ConvertChunkStyle (colorScheme.UserMethodDeclaration)));
+			settings.Add (new ThemeSetting ("User Extension Method", new List<string> { EditorThemeColors.UserExtensionMethod }, ConvertChunkStyle (colorScheme.UserMethodDeclaration)));
+			settings.Add (new ThemeSetting ("User Parameter", new List<string> { EditorThemeColors.UserParameter }, ConvertChunkStyle (colorScheme.UserParameterDeclaration)));
+			settings.Add (new ThemeSetting ("User Variable", new List<string> { EditorThemeColors.UserLocal }, ConvertChunkStyle (colorScheme.UserVariableDeclaration)));
 
 			settings.Add (new ThemeSetting ("CSS Comment", new List<string> { "comment.block.css" }, ConvertChunkStyle (colorScheme.CssComment)));
 			settings.Add (new ThemeSetting ("CSS Keyword", new List<string> { "keyword.other.css" }, ConvertChunkStyle (colorScheme.CssKeyword)));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RoslynClassificationHighlighting.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RoslynClassificationHighlighting.cs
@@ -82,6 +82,16 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 				[ClassificationTypeNames.StructName] = MakeScope ("entity.name.struct." + defaultScope),
 				[ClassificationTypeNames.TypeParameterName] = MakeScope ("entity.name.typeparameter." + defaultScope),
 
+				[ClassificationTypeNames.FieldName] = MakeScope ("entity.name.field." + defaultScope),
+				[ClassificationTypeNames.EnumMemberName] = MakeScope ("entity.name.enummember." + defaultScope),
+				[ClassificationTypeNames.ConstantName] = MakeScope ("entity.name.constant." + defaultScope),
+				[ClassificationTypeNames.LocalName] = MakeScope ("entity.name.local." + defaultScope),
+				[ClassificationTypeNames.ParameterName] = MakeScope ("entity.name.parameter." + defaultScope),
+				[ClassificationTypeNames.ExtensionMethodName] = MakeScope ("entity.name.extensionmethod." + defaultScope),
+				[ClassificationTypeNames.MethodName] = MakeScope ("entity.name.function." + defaultScope),
+				[ClassificationTypeNames.PropertyName] = MakeScope ("entity.name.property." + defaultScope),
+				[ClassificationTypeNames.EventName] = MakeScope ("entity.name.event." + defaultScope),
+
 				[ClassificationTypeNames.XmlDocCommentAttributeName] = MakeScope ("comment.line.documentation." + defaultScope),
 				[ClassificationTypeNames.XmlDocCommentAttributeQuotes] = MakeScope ("comment.line.documentation." + defaultScope),
 				[ClassificationTypeNames.XmlDocCommentAttributeValue] = MakeScope ("comment.line.documentation." + defaultScope),

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -135,14 +135,14 @@
     <Reference Include="Microsoft.TemplateEngine.Utils">
       <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Utils.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Utils.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Composition.15.3.38\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Composition, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Composition.15.6.36\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Threading.15.4.4\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Validation.15.3.32\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cairo" />

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -108,43 +108,43 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.Features" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.EditorFeatures.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces.Desktop" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic.Features" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -161,6 +161,10 @@
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.Text.UI" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-15.6.0.0" newVersion="15.6.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
+++ b/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
-   <ItemGroup>
+  <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
       <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
@@ -133,7 +133,7 @@
       <Name>MonoDevelop.SourceEditor</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\external\RefactoringEssentials\RefactoringEssentials\RefactoringEssentials.csproj">
+    <ProjectReference Include="..\..\external\RefactoringEssentials\RefactoringEssentials\RefactoringEssentials.csproj">
       <Project>{C465A5DC-AD28-49A2-89C0-F81838814A7E}</Project>
       <Name>RefactoringEssentials</Name>
       <Private>True</Private>


### PR DESCRIPTION
* Bump Roslyn to 2.8.0-beta2-62708-11

* port persistent storage to 2.8 API

* Update Roslyn binding redirects to 2.8.0.0.

* Update VSMEF to 15.6.

* Fix ProjectReference relative path.

Fix Threading version.

Fix threading binding redirect.

* Temporarily comment out throwing on VSMEF composition errors.

Pending Roslyn bug https://github.com/dotnet/roslyn/issues/25211

* Add C# 7.3 language version.

* [C#] Reuse roslyn extensions for parsing string to language version

* Fix compiler options unit test

* Fixes issue #3436 Syntax highlighting regression

https://github.com/mono/monodevelop/issues/3436#issuecomment-372545839

* Don't use persistent storage for an adhoc workspace

* Log VSMEF errors to log file.

* Log MEF errors individually.