### PR TITLE
[15.7] [Editor] Commit and clear preedit string when changing lines

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -648,6 +648,11 @@ namespace Mono.TextEditor
 			textArea.ResetIMContext ();
 		}
 
+		internal void CommitPreedit ()
+		{
+			textArea.CommitPreedit ();
+		}
+
 		internal bool ContainsPreedit (int offset, int length)
 		{
 			return textArea.ContainsPreedit (offset, length);

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -630,6 +630,17 @@ namespace Mono.TextEditor
 			oldSelection = selection;
 			OnSelectionChanged (EventArgs.Empty);
 		}
+
+		internal void CommitPreedit ()
+		{
+			CommitString (preeditString);
+
+			preeditOffset = -1;
+			preeditString = null;
+			preeditAttrs = null;
+			preeditCursorCharIndex = 0;
+			imContextNeedsReset = true;
+		}
 		
 		internal void ResetIMContext ()
 		{
@@ -638,35 +649,39 @@ namespace Mono.TextEditor
 				imContextNeedsReset = false;
 			}
 		}
-		
-		void IMCommit (object sender, Gtk.CommitArgs ca)
+
+		void CommitString (string str)
 		{
 			if (!IsRealized || !IsFocus)
 				return;
-			
-			//this, if anywhere, is where we should handle UCS4 conversions
-			for (int i = 0; i < ca.Str.Length; i++) {
+
+			for (int i = 0; i < str.Length; i++) {
 				int utf32Char;
-				if (char.IsHighSurrogate (ca.Str, i)) {
-					utf32Char = char.ConvertToUtf32 (ca.Str, i);
+				if (char.IsHighSurrogate (str, i)) {
+					utf32Char = char.ConvertToUtf32 (str, i);
 					i++;
 				} else {
-					utf32Char = (int)ca.Str [i];
+					utf32Char = (int)str [i];
 				}
-				
+
 				//include the other pre-IM state *if* the post-IM char matches the pre-IM (key-mapped) one
-				 if (lastIMEventMappedChar == utf32Char && lastIMEventMappedChar == (uint)lastIMEventMappedKey) {
+				if (lastIMEventMappedChar == utf32Char && lastIMEventMappedChar == (uint)lastIMEventMappedKey) {
 					editor.OnIMProcessedKeyPressEvent (lastIMEventMappedKey, lastIMEventMappedChar, lastIMEventMappedModifier);
 				} else {
 					editor.OnIMProcessedKeyPressEvent ((Gdk.Key)0, (uint)utf32Char, Gdk.ModifierType.None);
 				}
 			}
-			
+
 			//the IME can commit while there's still a pre-edit string
 			//since we cached the pre-edit offset when it started, need to update it
 			if (preeditOffset > -1) {
 				preeditOffset = Caret.Offset;
 			}
+		}
+
+		void IMCommit (object sender, Gtk.CommitArgs ca)
+		{
+			CommitString (ca.Str);
 		}
 		
 		protected override bool OnFocusInEvent (EventFocus evnt)

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -2366,6 +2366,9 @@ namespace Mono.TextEditor
 						Caret.PreserveSelection = false;
 					} else {
 						textEditor.ClearSelection ();
+						if (Caret.Location.Line != clickLocation.Line && !String.IsNullOrEmpty (textEditor.preeditString)) {
+							textEditor.CommitPreedit ();
+						}
 						Caret.Location = clickLocation;
 						InSelectionDrag = true;
 						textEditor.MainSelection = new MonoDevelop.Ide.Editor.Selection (clickLocation, clickLocation);


### PR DESCRIPTION
This fixes weird issues that happened when the user typed into a preedit
on an otherwise empty line and then clicked to another line in the
editor. Committing the preedit string and clearing the IM also seems to
be more like what other editors like Xcode and TextEdit do.

Fixes VSTS #569890