### PR TITLE
[Tests] Improve project capability tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ obj/
 /main/.nuget/
 pull-package.exe
 /main/tests/StressTest/TestProject/bin
+/main/tests/MonoDevelop.Core.Tests.Addin/bin/
 
 #VS writes these sometimes even when it doesn't change anything
 /main/_UpgradeReport_Files

--- a/main/tests/MonoDevelop.Core.Tests.Addin/MonoDevelop.Core.Tests.Addin.csproj
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/MonoDevelop.Core.Tests.Addin.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\build\tests\MonoDevelop.Core.Tests.Addin\</OutputPath>
+    <OutputPath>bin</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\build\tests\MonoDevelop.Core.Tests.Addin\</OutputPath>
+    <OutputPath>bin</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -52,8 +52,4 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <MakeDir Directories="..\..\..\local-config" />
-    <WriteLinesToFile File="..\..\..\local-config\$(AssemblyName).addins" Lines="%3CAddins%3E%3CDirectory include-subdirs='false'%3E$(MSBuildProjectDirectory)\$(OutputPath)%3C/Directory%3E%3C/Addins%3E" Overwrite="true" />
-  </Target>
 </Project>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectCapabilityTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectCapabilityTests.cs
@@ -26,6 +26,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Mono.Addins;
 using MonoDevelop.Projects.Extensions;
 using NUnit.Framework;
 using UnitTests;
@@ -38,12 +39,22 @@ namespace MonoDevelop.Projects
 	public class ProjectCapabilityTests : TestBase
 	{
 		CustomCapabilityNode capaNode;
+		string testAddinAssemblyPath;
 
 		[TestFixtureSetUp]
 		public void SetUp ()
 		{
 			capaNode = new CustomCapabilityNode ();
 			WorkspaceObject.RegisterCustomExtension (capaNode);
+
+			// Register test addin.
+			if (!Directory.Exists (AddinManager.Registry.DefaultAddinsFolder))
+				Directory.CreateDirectory (AddinManager.Registry.DefaultAddinsFolder);
+
+			string testAddinBuildPath = Path.Combine (Util.TestsRootDir, "MonoDevelop.Core.Tests.Addin", "bin", "MonoDevelop.Core.Tests.Addin.dll");
+			testAddinAssemblyPath = Path.Combine (AddinManager.Registry.DefaultAddinsFolder, "MonoDevelop.Core.Tests.Addin.dll");
+			File.Copy (testAddinBuildPath, testAddinAssemblyPath);
+			AddinManager.Registry.Update (null);
 		}
 	
 		[TestFixtureTearDown]
@@ -51,9 +62,9 @@ namespace MonoDevelop.Projects
 		{
 			WorkspaceObject.UnregisterCustomExtension (capaNode);
 
-			// Ensure MonoDevelop.Core.Tests addin is not registered in local-config after tests are run.
-			string localConfigFile = Path.Combine (Util.TestsRootDir, "..", "..", "local-config", "MonoDevelop.Core.Tests.Addin.addins");
-			File.Delete (localConfigFile);
+			// Unregister test addin.
+			File.Delete (testAddinAssemblyPath);
+			AddinManager.Registry.Update (null);
 		}
 
 		List<string> defaultCapabilities;


### PR DESCRIPTION
Register the MonoDevelop.Core.Tests.Addin in the project capability
tests and unregister it afterwards. This is instead of registering
the addin using an .addins file generated in the local-config folder
at build time and then deleting it after the test is run.