### PR TITLE
[Core] Fix file watcher argument null exception

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4188,7 +4188,14 @@ namespace MonoDevelop.Projects
 			}
 
 			string include = MSBuildProjectService.ToMSBuildPath (ItemDirectory, fileName);
-			foreach (var it in sourceProject.FindGlobItemsIncludingFile (include).Where (it => it.Metadata.GetProperties ().Count () == 0)) {
+			var globItems = sourceProject.FindGlobItemsIncludingFile (include);
+			if (globItems == null) {
+				// If the MSBuildEngine no glob items can be found.
+				LoggingService.LogWarning ("File created externally not processed. {0}", fileName);
+				return;
+			}
+
+			foreach (var it in globItems.Where (it => it.Metadata.GetProperties ().Count () == 0)) {
 				var eit = CreateFakeEvaluatedItem (sourceProject, it, include, null);
 				var pi = CreateProjectItem (eit);
 				pi.Read (this, eit);


### PR DESCRIPTION
Opening a .NET Core project would sometimes log an unhandled
ArgumentNullException. When calling the MSBuildProject's
FindGlobItemsIncludingFile the MSBuildEngine is sometimes null so
a null was being returned. This is now handled. The files being
created on project load are typically in the obj folder so would be
ignored by the default file globs.

An unhandled exception has occured. Terminating Visual Studio? False
System.ArgumentNullException: Value cannot be null.
Parameter name: source
  at System.Linq.Enumerable.Where[TSource]
  in corefx/src/System.Linq/src/System/Linq/Where.cs:42
  at MonoDevelop.Projects.Project.OnFileCreatedExternally
in src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs:4041

Fixes VSTS #567569 Opening a solution with NetStandard library throws
System.ArgumentNullException