### PR TITLE
[Ide] Fix file template API break

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/DirectoryTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/DirectoryTemplate.cs
@@ -105,6 +105,25 @@ namespace MonoDevelop.Ide.Templates
 			return addedSomething;
 		}
 
+		[Obsolete ("Use public Task<bool> AddToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string entryName).")]
+		public override bool AddToProject (SolutionFolderItem policyParent, Project project,
+		                                   string language, string directory, string name)
+		{
+			bool addedSomething = false;
+			directory = Path.Combine (directory, dirName);
+			if (templates.Count == 0) {
+				string relPath = FileService.AbsoluteToRelativePath (project.BaseDirectory, directory);
+				if (project.AddDirectory (relPath) != null)
+					addedSomething = true;
+			}
+
+			foreach (FileDescriptionTemplate t in templates) {
+				if (t.EvaluateCreateCondition ())
+					addedSomething |= t.AddToProject (policyParent, project, language, directory, name);
+			}
+			return addedSomething;
+		}
+
 		internal override void SetProjectTagModel (MonoDevelop.Core.StringParsing.IStringTagModel tagModel)
 		{
 			base.SetProjectTagModel (tagModel);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplate.cs
@@ -323,7 +323,7 @@ namespace MonoDevelop.Ide.Templates
 					throw new InvalidOperationException ("Single file template expected");
 
 				if (directory != null) {
-					string fileName = await singleFile.SaveFile (policyParent, project, language, directory, name);
+					string fileName = await singleFile.SaveFileAsync (policyParent, project, language, directory, name);
 					if (fileName != null) {
 						IdeApp.Workbench.OpenDocument (fileName, project);
 						return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplateReference.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/FileTemplateReference.cs
@@ -80,7 +80,27 @@ namespace MonoDevelop.Ide.Templates
 			
 			foreach (FileDescriptionTemplate fdt in innerTemplate.Files) {
 				if (fdt.EvaluateCreateCondition ()) {
-					if (!await fdt.AddToProjectAsync (policyParent, project, language, directory, substName) || !fdt.AddToProject (policyParent, project, language, directory, substName))
+					if (!await fdt.AddToProjectAsync (policyParent, project, language, directory, substName))
+						return false;
+				}
+			}
+			return true;
+		}
+
+		[Obsolete ("Use public Task<bool> AddToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string entryName).")]
+		public override bool AddToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string entryName)
+		{
+			string[,] customTags = new string[,] {
+				{"ProjectName", project.Name},
+				{"EntryName", entryName},
+				{"EscapedProjectName", GetDotNetIdentifier (project.Name) }
+			};
+
+			string substName = StringParserService.Parse (this.name, customTags);
+
+			foreach (FileDescriptionTemplate fdt in innerTemplate.Files) {
+				if (fdt.EvaluateCreateCondition ()) {
+					if (!fdt.AddToProject (policyParent, project, language, directory, substName))
 						return false;
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectDescriptor.cs
@@ -177,7 +177,7 @@ namespace MonoDevelop.Ide.Templates
 				try {
 					if (!projectCreateInformation.ShouldCreate (resourceTemplate.CreateCondition))
 						continue;
-					var projectFile = new ProjectFile (await resourceTemplate.SaveFile (policyParent, project, defaultLanguage, project.BaseDirectory, null));
+					var projectFile = new ProjectFile (await resourceTemplate.SaveFileAsync (policyParent, project, defaultLanguage, project.BaseDirectory, null));
 					projectFile.BuildAction = BuildAction.EmbeddedResource;
 					project.Files.Add (projectFile);
 				} catch (Exception ex) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/PropertyDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/PropertyDescriptionTemplate.cs
@@ -71,12 +71,18 @@ namespace MonoDevelop.Ide.Templates
 
 		public override Task<bool> AddToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
 		{
+			AddToProject (policyParent, project, language, directory, name);
+			return Task.FromResult(true);
+		}
+
+		public override bool AddToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
+		{
 			var model = CombinedTagModel.GetTagModel (ProjectTagModel, policyParent, project, language, name, null);
 			var fileName = StringParserService.Parse (name, model);
 
 			project.ProjectProperties.SetValue (typeAtt.Value, string.IsNullOrEmpty (fileName) ? propertyInnerText : string.Concat (fileName, extension));
 
-			return Task.FromResult(true);
+			return true;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ResourceFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ResourceFileDescriptionTemplate.cs
@@ -54,9 +54,21 @@ namespace MonoDevelop.Ide.Templates
 			}
 		}
 		
+		[Obsolete("Use public Task<ProjectFile> AddFileToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name).")]
+		public override bool AddToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
+		{
+			ProjectFile file = template.AddFileToProject (policyParent, project, language, directory, name);
+			if (file != null) {
+				file.BuildAction = BuildAction.EmbeddedResource;
+				return true;
+			}
+			else
+				return false;
+		}
+
 		public override async Task<bool> AddToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
 		{
-			ProjectFile file = await template.AddFileToProject (policyParent, project, language, directory, name);
+			ProjectFile file = await template.AddFileToProjectAsync (policyParent, project, language, directory, name);
 			if (file != null) {
 				file.BuildAction = BuildAction.EmbeddedResource;
 				return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
@@ -115,12 +115,12 @@ namespace MonoDevelop.Ide.Templates
 		
 		public sealed override async Task<bool> AddToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
 		{
-			return await AddFileToProject (policyParent, project, language, directory, name) != null;
+			return await AddFileToProjectAsync (policyParent, project, language, directory, name) != null;
 		}
 		
-		public async Task<ProjectFile> AddFileToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
+		public async Task<ProjectFile> AddFileToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
 		{
-			generatedFile = await SaveFile (policyParent, project, language, directory, name);
+			generatedFile = await SaveFileAsync (policyParent, project, language, directory, name);
 			if (generatedFile != null) {		
 				string buildAction = this.buildAction ?? project.GetDefaultBuildAction (generatedFile);
 				ProjectFile projectFile = project.AddFile (generatedFile, buildAction);
@@ -154,6 +154,54 @@ namespace MonoDevelop.Ide.Templates
 					}
 				}
 				
+				return projectFile;
+			} else
+				return null;
+		}
+
+		[Obsolete ("Use public sealed Task<bool> AddToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name).")]
+		public sealed override bool AddToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
+		{
+			return AddFileToProject (policyParent, project, language, directory, name) != null;
+		}
+
+		[Obsolete ("Use public Task<ProjectFile> AddFileToProjectAsync (SolutionFolderItem policyParent, Project project, string language, string directory, string name).")]
+		public ProjectFile AddFileToProject (SolutionFolderItem policyParent, Project project, string language, string directory, string name)
+		{
+			generatedFile = SaveFile (policyParent, project, language, directory, name);
+			if (generatedFile != null) {
+				string buildAction = this.buildAction ?? project.GetDefaultBuildAction (generatedFile);
+				ProjectFile projectFile = project.AddFile (generatedFile, buildAction);
+
+				if (!string.IsNullOrEmpty (dependsOn)) {
+					var model = CombinedTagModel.GetTagModel (ProjectTagModel, policyParent, project, language, name, generatedFile);
+					string parsedDepName = StringParserService.Parse (dependsOn, model);
+					if (projectFile.DependsOn != parsedDepName)
+						projectFile.DependsOn = parsedDepName;
+				}
+
+				if (!string.IsNullOrEmpty (customTool))
+					projectFile.Generator = customTool;
+
+				if (!string.IsNullOrEmpty (customToolNamespace)) {
+					var model = CombinedTagModel.GetTagModel (ProjectTagModel, policyParent, project, language, name, generatedFile);
+					projectFile.CustomToolNamespace = StringParserService.Parse (customToolNamespace, model);
+				}
+
+				if (!string.IsNullOrEmpty (subType))
+					projectFile.ContentType = subType;
+
+				DotNetProject netProject = project as DotNetProject;
+				if (netProject != null) {
+					// Add required references
+					foreach (string aref in references) {
+						string res = netProject.AssemblyContext.GetAssemblyFullName (aref, netProject.TargetFramework);
+						res = netProject.AssemblyContext.GetAssemblyNameForVersion (res, netProject.TargetFramework);
+						if (!ContainsReference (netProject, res))
+							netProject.References.Add (ProjectReference.CreateAssemblyReference (aref));
+					}
+				}
+
 				return projectFile;
 			} else
 				return null;
@@ -203,7 +251,7 @@ namespace MonoDevelop.Ide.Templates
 		
 		// Creates a file and saves it to disk. Returns the path to the new file
 		// All parameters are optional (can be null)
-		public async Task<string> SaveFile (SolutionFolderItem policyParent, Project project, string language, string baseDirectory, string entryName)
+		public async Task<string> SaveFileAsync (SolutionFolderItem policyParent, Project project, string language, string baseDirectory, string entryName)
 		{
 			string file = GetFileName (policyParent, project, language, baseDirectory, entryName);
 			AlertButton questionResult = null;
@@ -222,7 +270,64 @@ namespace MonoDevelop.Ide.Templates
 				Directory.CreateDirectory (Path.GetDirectoryName (file));
 
 			if (questionResult == null || questionResult == AlertButton.OverwriteFile) {
-				Stream stream = CreateFileContent (policyParent, project, language, file, entryName) ?? await CreateFileContentAsync (policyParent, project, language, file, entryName);
+				Stream stream = CreateFileContentFromDerivedClass (policyParent, project, language, file, entryName) ?? await CreateFileContentAsync (policyParent, project, language, file, entryName);
+
+				byte [] buffer = new byte [2048];
+				int nr;
+				FileStream fs = null;
+				try {
+					fs = File.Create (file);
+					while ((nr = stream.Read (buffer, 0, 2048)) > 0)
+						fs.Write (buffer, 0, nr);
+				} finally {
+					stream.Close ();
+					if (fs != null)
+						fs.Close ();
+				}
+			}
+			return file;
+		}
+
+		bool createFileContentFromDerivedClass;
+
+		/// <summary>
+		/// Allows a derived class's CreateFileContent to be called. Need to ensure that if the derived
+		/// class does not implement CreateFileContent then the SingleFileDescriptionTemplate's
+		/// CreateFileContentAsync is used instead of CreateFileContent.
+		/// </summary>
+		Stream CreateFileContentFromDerivedClass (SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier)
+		{
+			createFileContentFromDerivedClass = true;
+			try {
+				return CreateFileContent (policyParent, project, language, fileName, identifier);
+			} finally {
+				createFileContentFromDerivedClass = false;
+			}
+		}
+
+		// Creates a file and saves it to disk. Returns the path to the new file
+		// All parameters are optional (can be null)
+		[Obsolete ("Use public Task<string> SaveFileAsync (SolutionFolderItem policyParent, Project project, string language, string baseDirectory, string entryName).")]
+		public string SaveFile (SolutionFolderItem policyParent, Project project, string language, string baseDirectory, string entryName)
+		{
+			string file = GetFileName (policyParent, project, language, baseDirectory, entryName);
+			AlertButton questionResult = null;
+
+			if (File.Exists (file)) {
+				questionResult = MessageService.AskQuestion (GettextCatalog.GetString ("File already exists"),
+				                                             GettextCatalog.GetString ("File {0} already exists.\nDo you want to overwrite the existing file or add it to the project?", file),
+				                                             AlertButton.Cancel,
+				                                             AlertButton.AddExistingFile,
+				                                             AlertButton.OverwriteFile);
+				if (questionResult == AlertButton.Cancel)
+					return null;
+			}
+
+			if (!Directory.Exists (Path.GetDirectoryName (file)))
+				Directory.CreateDirectory (Path.GetDirectoryName (file));
+
+			if (questionResult == null || questionResult == AlertButton.OverwriteFile) {
+				Stream stream = CreateFileContent (policyParent, project, language, file, entryName);
 
 				byte [] buffer = new byte [2048];
 				int nr;
@@ -280,10 +385,66 @@ namespace MonoDevelop.Ide.Templates
 			return StringParserService.Parse (content, tags);
 		}
 
-		[Obsolete("Use public virtual async Task<Stream> CreateFileContentAsync (SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier).")]
+		// Returns a stream with the content of the file.
+		// project and language parameters are optional
+		[Obsolete ("Use public virtual async Task<Stream> CreateFileContentAsync (SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier).")]
 		public virtual Stream CreateFileContent (SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier)
 		{
-			return null;
+			if (createFileContentFromDerivedClass)
+				return null;
+
+			var model = CombinedTagModel.GetTagModel (ProjectTagModel, policyParent, project, language, identifier, fileName);
+
+			//HACK: for API compat, CreateContent just gets the override, not the base model
+			// but ProcessContent gets the entire model
+			string content = CreateContent (project, model.OverrideTags, language);
+
+			content = ProcessContent (content, model);
+
+			string mime = DesktopService.GetMimeTypeForUri (fileName);
+			var formatter = !string.IsNullOrEmpty (mime) ? CodeFormatterService.GetFormatter (mime) : null;
+
+			if (formatter != null) {
+				var formatted = formatter.FormatText (policyParent != null ? policyParent.Policies : null, content);
+				if (formatted != null)
+					content = formatted;
+			}
+
+			var ms = new MemoryStream ();
+
+			var bom = Encoding.UTF8.GetPreamble ();
+			ms.Write (bom, 0, bom.Length);
+
+			byte[] data;
+			if (AddStandardHeader) {
+				string header = StandardHeaderService.GetHeader (policyParent, fileName, true);
+				data = System.Text.Encoding.UTF8.GetBytes (header);
+				ms.Write (data, 0, data.Length);
+			}
+
+			var doc = TextEditorFactory.CreateNewDocument ();
+			doc.Text = content;
+
+			TextStylePolicy textPolicy = policyParent != null ? policyParent.Policies.Get<TextStylePolicy> (mime ?? "text/plain")
+				: MonoDevelop.Projects.Policies.PolicyService.GetDefaultPolicy<TextStylePolicy> (mime ?? "text/plain");
+			string eolMarker = TextStylePolicy.GetEolMarker (textPolicy.EolMarker);
+			byte[] eolMarkerBytes = System.Text.Encoding.UTF8.GetBytes (eolMarker);
+
+			var tabToSpaces = textPolicy.TabsToSpaces? new string (' ', textPolicy.TabWidth) : null;
+
+			foreach (var line in doc.GetLines ()) {
+				var lineText = doc.GetTextAt (line.Offset, line.Length);
+				if (tabToSpaces != null)
+					lineText = lineText.Replace ("\t", tabToSpaces);
+				if (line.LengthIncludingDelimiter > 0) {
+					data = System.Text.Encoding.UTF8.GetBytes (lineText);
+					ms.Write (data, 0, data.Length);
+					ms.Write (eolMarkerBytes, 0, eolMarkerBytes.Length);
+				}
+			}
+
+			ms.Position = 0;
+			return ms;
 		}
 
 		// Returns a stream with the content of the file.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/TextFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/TextFileDescriptionTemplate.cs
@@ -109,5 +109,12 @@ namespace MonoDevelop.Ide.Templates
 		{
 			return Task.FromResult<Stream>(File.OpenRead (contentSrcFile));
 		}
+
+		[Obsolete ("Use public Task<Stream> CreateFileContentAsync (SolutionFolderItem policyParent, Project project, string language, string fileName, string identifier).")]
+		public override Stream CreateFileContent (SolutionFolderItem policyParent, Project project, string language,
+			string fileName, string identifier)
+		{
+			return File.OpenRead (contentSrcFile);
+		}
 	}
 }


### PR DESCRIPTION
Fixed SingleFileDescription's public methods being removed.
Ensure that code that uses the obsolete non-async methods still
work by adding back the original code for these methods.