### PR TITLE
[15.7][Mac] Fix crasher in MDMenu that happens if the command is not regist…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.Components.Mac
 					continue;
 				}
 
-				Command cmd = manager.GetCommand (ce.CommandId);
+				Command cmd = ce.GetCommand (manager);
 				if (cmd == null) {
 					LoggingService.LogError ("MacMenu: '{0}' maps to null command", ce.CommandId);
 					continue;


### PR DESCRIPTION
…ered before showing the menu

The code change is so that we use the virtual method on CommandEntry to get the actual command,
as that bit of code also registers the command in the command manager. (this is what the gtk backend
used to do)

Without doing that, we can end up having a commandentry for a command that has not been registered yet,
thus it will throw when trying to query the CommandInfo of a given command entry.

Fixes VSTS #584923 [Feedback] Using meny items crashes Visual Studio Mac

System.InvalidOperationException: Invalid action command id: MonoDevelop.Ide.CodeFormatting.CodeFormattingCommands.FormatBuffer
  at MonoDevelop.Components.Commands.CommandManager.GetCommandInfo (System.Object commandId, MonoDevelop.Components.Commands.CommandTargetRoute targetRoute, System.Threading.CancellationToken cancelToken) [0x001f9] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1718
  at MonoDevelop.Components.Commands.CommandManager.GetCommandInfo (System.Object commandId, MonoDevelop.Components.Commands.CommandTargetRoute targetRoute) [0x00000] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1608
  at MonoDevelop.Components.Mac.MDMenuItem.Update (MonoDevelop.Components.Mac.MDMenu parent, System.Int32& index) [0x00000] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs:114
  at MonoDevelop.Components.Mac.MDMenu.UpdateCommands () [0x00037] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs:157
  at MonoDevelop.Components.Mac.MDSubMenuItem.Update (MonoDevelop.Components.Mac.MDMenu parent, System.Int32& index) [0x00000] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDSubMenuItem.cs:48
  at MonoDevelop.Components.Mac.MDMenu.UpdateCommands () [0x00037] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs:157
  at MonoDevelop.Components.Mac.MDMenu.MenuNeedsUpdate (AppKit.NSMenu menu) [0x00019] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenu.cs:199
--- End of stack trace from previous location where exception was thrown ---
  at (wrapper managed-to-native) Gtk.Application.gtk_main()
  at Gtk.Application.Run () [0x00001] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:145
  at MonoDevelop.Ide.IdeApp.Run () [0x00006] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs:404
  at MonoDevelop.Ide.IdeStartup.Run (MonoDevelop.Ide.MonoDevelopOptions options) [0x00764] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:300
  at MonoDevelop.Ide.IdeStartup.Main (System.String[] args, MonoDevelop.Ide.Extensions.IdeCustomizer customizer) [0x0008f] in /Users/builder/data/lanes/5810/05399106/source/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:619