### PR TITLE
[Mac] Fix Add Files dialog being broken on High Sierra

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MDAccessoryViewBox.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MDAccessoryViewBox.cs
@@ -1,0 +1,84 @@
+﻿//
+// MacAccessoryViewBox.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AppKit;
+using CoreGraphics;
+
+using MonoDevelop.Core;
+using MonoDevelop.Ide;
+using MonoDevelop.Ide.Extensions;
+using MonoDevelop.MacInterop;
+
+namespace MonoDevelop.MacIntegration
+{
+	class MDAccessoryViewBox : MDBox
+	{
+		readonly List<MDAlignment> labels = new List<MDAlignment> ();
+		readonly List<MDAlignment> controls = new List<MDAlignment> ();
+
+		public MDAccessoryViewBox () : base (LayoutDirection.Vertical, 2, 2)
+		{
+		}
+
+		public void AddControl (NSControl control, string text)
+		{
+			int minWidth = string.IsNullOrEmpty (text) ? 0 : 200;
+			var labelAlignment = new MDAlignment (new MDLabel (text) { Alignment = NSTextAlignment.Right }, true);
+			labels.Add (labelAlignment);
+
+			var controlAlignment = new MDAlignment (control, true) { MinWidth = minWidth };
+			controls.Add (controlAlignment);
+
+			Add (new MDBox (LayoutDirection.Horizontal, 2, 0) {
+				{ labelAlignment },
+				{ controlAlignment },
+			});
+		}
+
+		public override void Layout ()
+		{
+			if (labels.Count > 0) {
+				float w = labels.Max (l => l.MinWidth);
+				foreach (var l in labels) {
+					l.MinWidth = w;
+					l.XAlign = LayoutAlign.Begin;
+				}
+			}
+
+			if (controls.Count > 0) {
+				float w = controls.Max (c => c.MinWidth);
+				foreach (var c in controls) {
+					c.MinWidth = w;
+					c.XAlign = LayoutAlign.Begin;
+				}
+			}
+
+			base.Layout ();
+		}
+	}
+}

--- a/main/src/addins/MacPlatform/Dialogs/MDBox.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MDBox.cs
@@ -62,16 +62,10 @@ namespace MonoDevelop.MacIntegration
 			ownsView = unownedView == null;
 		}
 		
-		public void Layout ()
+		public virtual void Layout ()
 		{
 			var request = BeginLayout ();
 			EndLayout (request, CGPoint.Empty, request.Size);
-		}
-		
-		public void Layout (CGSize allocation)
-		{
-			var request = BeginLayout ();
-			EndLayout (request, CGPoint.Empty, allocation);
 		}
 		
 		public void Add (NSView view)

--- a/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
@@ -49,21 +49,12 @@ namespace MonoDevelop.MacIntegration
 
 				var labels = new List<MDAlignment> ();
 				var controls = new List<MDAlignment> ();
-				
+
+				var accessoryBox = new MDAccessoryViewBox ();
+
 				var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
-				MDBox accessoryBox = new MDBox (LayoutDirection.Vertical, 2, 2);
 				if (filterPopup != null) {
-					var filterLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Show Files:")) { Alignment = NSTextAlignment.Right }, true);
-					labels.Add (filterLabel);
-
-					var filterPopupAlignment = new MDAlignment (filterPopup, true) { MinWidth = 200 };
-					controls.Add (filterPopupAlignment);
-					var filterBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-						{ filterLabel },
-						{ filterPopupAlignment }
-					};
-
-					accessoryBox.Add (filterBox);
+					accessoryBox.AddControl (filterPopup, GettextCatalog.GetString ("Show Files:"));
 				}
 
 				var popup = new NSPopUpButton (new CGRect (0, 0, 200, 28), false);
@@ -77,38 +68,11 @@ namespace MonoDevelop.MacIntegration
 						popup.AddItem (b);
 				}
 
-				var dropdownLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Override build action:")) { Alignment = NSTextAlignment.Right }, true);
-				labels.Add (dropdownLabel);
-
-				var dropdownAlignment = new MDAlignment (popup, true) { MinWidth = 200 };
-				controls.Add (dropdownAlignment);
-
-				var dropdownBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-					dropdownLabel,
-					dropdownAlignment,
-				};
-
-				accessoryBox.Add (dropdownBox);
-
-				if (labels.Count > 0) {
-					float w = labels.Max (l => l.MinWidth);
-					foreach (var l in labels) {
-						l.MinWidth = w;
-						l.XAlign = LayoutAlign.Begin;
-					}
-				}
-
-				if (controls.Count > 0) {
-					float w = controls.Max (c => c.MinWidth);
-					foreach (var c in controls) {
-						c.MinWidth = w;
-						c.XAlign = LayoutAlign.Begin;
-					}
-				}
+				accessoryBox.AddControl (popup, GettextCatalog.GetString ("Override build action:"));
 
 				accessoryBox.Layout ();
 				panel.AccessoryView = accessoryBox.View;
-				
+
 				if (panel.RunModal () == 0) {
 					GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 					return false;

--- a/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
@@ -37,42 +37,19 @@ using MonoDevelop.MacInterop;
 
 namespace MonoDevelop.MacIntegration
 {
-	class MacAddFileDialogHandler : IAddFileDialogHandler
+	class MacAddFileDialogHandler : MacCommonFileDialogHandler<AddFileDialogData, NSPopUpButton>, IAddFileDialogHandler
 	{
-		public bool Run (AddFileDialogData data)
+		protected override NSSavePanel OnCreatePanel (AddFileDialogData data)
 		{
-			using (var panel = new NSOpenPanel {
+			return new NSOpenPanel {
 				CanChooseDirectories = false,
 				CanChooseFiles = true,
-			}) {
-				MacSelectFileDialogHandler.SetCommonPanelProperties (data, panel);
+			};
+		}
 
-				var labels = new List<MDAlignment> ();
-				var controls = new List<MDAlignment> ();
-
-				var accessoryBox = new MDAccessoryViewBox ();
-
-				var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
-				if (filterPopup != null) {
-					accessoryBox.AddControl (filterPopup, GettextCatalog.GetString ("Show Files:"));
-				}
-
-				var popup = new NSPopUpButton (new CGRect (0, 0, 200, 28), false);
-				popup.AddItem (GettextCatalog.GetString ("(Default)"));
-				popup.Menu.AddItem (NSMenuItem.SeparatorItem);
-
-				foreach (var b in data.BuildActions) {
-					if (b == "--")
-						popup.Menu.AddItem (NSMenuItem.SeparatorItem);
-					else
-						popup.AddItem (b);
-				}
-
-				accessoryBox.AddControl (popup, GettextCatalog.GetString ("Override build action:"));
-
-				accessoryBox.Layout ();
-				panel.AccessoryView = accessoryBox.View;
-
+		public bool Run (AddFileDialogData data)
+		{
+			using (var panel = CreatePanel (data, out NSPopUpButton popup)) {
 				if (panel.RunModal () == 0) {
 					GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 					return false;
@@ -87,6 +64,25 @@ namespace MonoDevelop.MacIntegration
 				GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 				return true;
 			}
+		}
+
+		protected override IEnumerable<(NSControl control, string text)> OnGetAccessoryBoxControls (AddFileDialogData data, NSSavePanel panel, out NSPopUpButton saveState)
+		{
+			var popup = saveState = new NSPopUpButton (new CGRect (0, 0, 200, 28), false);
+
+			popup.AddItem (GettextCatalog.GetString ("(Default)"));
+			popup.Menu.AddItem (NSMenuItem.SeparatorItem);
+
+			foreach (var b in data.BuildActions) {
+				if (b == "--")
+					popup.Menu.AddItem (NSMenuItem.SeparatorItem);
+				else
+					popup.AddItem (b);
+			}
+
+			return new (NSControl, string) [] {
+				(popup, GettextCatalog.GetString ("Override build action:")),
+			};
 		}
 	}
 }

--- a/main/src/addins/MacPlatform/Dialogs/MacCommonFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacCommonFileDialogHandler.cs
@@ -1,0 +1,100 @@
+﻿//
+// MacCommonFileDialogHandler.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using AppKit;
+using Foundation;
+using MonoDevelop.Components;
+using MonoDevelop.Components.Extensions;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.MacIntegration
+{
+	abstract class MacCommonFileDialogHandler<TData, TState> where TData:SelectFileDialogData
+	{
+		protected abstract NSSavePanel OnCreatePanel (TData data);
+
+		protected NSSavePanel CreatePanel (TData data, out TState saveState)
+		{
+			var panel = OnCreatePanel (data);
+
+			SetCommonPanelProperties (data, panel);
+
+			CreateAccessoryBox (data, panel, out saveState);
+			return panel;
+		}
+
+		bool ShouldCreateAccessoryBox (TData data) => (data.Action & FileChooserAction.FileFlags) != 0;
+		MDAccessoryViewBox CreateAccessoryBox (TData data, NSSavePanel panel, out TState saveState)
+		{
+			saveState = default(TState);
+			if (!ShouldCreateAccessoryBox (data))
+				return null;
+			
+			var box = new MDAccessoryViewBox ();
+
+			var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
+			if (filterPopup != null) {
+				box.AddControl (filterPopup, GettextCatalog.GetString ("Show Files:"));
+			}
+
+			foreach (var item in OnGetAccessoryBoxControls (data, panel, out saveState)) {
+				box.AddControl (item.control, item.text);
+			}
+
+			box.Layout ();
+			panel.AccessoryView = box.View;
+			return box;
+		}
+
+		protected virtual IEnumerable<(NSControl control, string text)> OnGetAccessoryBoxControls (TData data, NSSavePanel panel, out TState saveState)
+		{
+			saveState = default(TState);
+			return Array.Empty<(NSControl, string)> ();
+		}
+
+		static void SetCommonPanelProperties (TData data, NSSavePanel panel)
+		{
+			panel.TreatsFilePackagesAsDirectories = true;
+
+			if (!string.IsNullOrEmpty (data.Title))
+				panel.Title = data.Title;
+
+			if (!string.IsNullOrEmpty (data.InitialFileName))
+				panel.NameFieldStringValue = data.InitialFileName;
+
+			if (!string.IsNullOrEmpty (data.CurrentFolder))
+				panel.DirectoryUrl = new NSUrl (data.CurrentFolder, true);
+
+			panel.ParentWindow = NSApplication.SharedApplication.KeyWindow ?? NSApplication.SharedApplication.MainWindow;
+
+			if (panel is NSOpenPanel openPanel) {
+				openPanel.AllowsMultipleSelection = data.SelectMultiple;
+				openPanel.ShowsHiddenFiles = data.ShowHidden;
+			}
+		}
+	}
+}

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -79,40 +79,21 @@ namespace MonoDevelop.MacIntegration
 				NSPopUpButton viewerSelector = null;
 				NSButton closeSolutionButton = null;
 				
-				var box = new MDBox (LayoutDirection.Vertical, 2, 2);
+				var box = new MDAccessoryViewBox ();
 				
 				List<FileViewer> currentViewers = null;
-				var labels = new List<MDAlignment> ();
-				var controls = new List<MDAlignment> ();
-				
+
 				if ((data.Action & FileChooserAction.FileFlags) != 0) {
 					var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
-
 					if (filterPopup != null) {
-						var filterLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Show Files:")) { Alignment = NSTextAlignment.Right }, true);
-						var filterPopupAlignment = new MDAlignment (filterPopup, true) { MinWidth = 200 };
-						var filterBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-							{ filterLabel },
-							{ filterPopupAlignment }
-						};
-						labels.Add (filterLabel);
-						controls.Add (filterPopupAlignment);
-						box.Add (filterBox);
+						box.AddControl (filterPopup, GettextCatalog.GetString ("Show Files:"));
 					}
 
 					if (data.ShowEncodingSelector) {
 						encodingSelector = new SelectEncodingPopUpButton (data.Action != FileChooserAction.Save);
 						encodingSelector.SelectedEncodingId = data.Encoding != null ? data.Encoding.CodePage : 0;
-						
-						var encodingLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Encoding:")) { Alignment = NSTextAlignment.Right }, true);
-						var encodingSelectorAlignment = new MDAlignment (encodingSelector, true) { MinWidth = 200 };
-						var encodingBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-							{ encodingLabel },
-							{ encodingSelectorAlignment }
-						};
-						labels.Add (encodingLabel);
-						controls.Add (encodingSelectorAlignment);
-						box.Add (encodingBox);
+
+						box.AddControl (encodingSelector, GettextCatalog.GetString ("Encoding:"));
 					}
 					
 					if (data.ShowViewerSelector && panel is NSOpenPanel) {
@@ -146,44 +127,10 @@ namespace MonoDevelop.MacIntegration
 							closeSolutionButton.SetButtonType (NSButtonType.Switch);
 							closeSolutionButton.SizeToFit ();
 
-							var closeSolutionLabelBox = new MDAlignment (new MDLabel (string.Empty), true);
-							var closeSolutionButtonAlignment = new MDAlignment (closeSolutionButton, true);
-							var closeSolutionBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-								{ closeSolutionLabelBox },
-								{ closeSolutionButtonAlignment }
-							};
-
-							labels.Add (closeSolutionLabelBox);
-							controls.Add (closeSolutionButtonAlignment);
-							box.Add (closeSolutionBox);
+							box.AddControl (closeSolutionButton, string.Empty);
 						}
 
-						var viewSelLabel = new MDAlignment (new MDLabel (GettextCatalog.GetString ("Open With:")) { Alignment = NSTextAlignment.Right }, true);
-						var viewSelectorAlignemnt = new MDAlignment (viewerSelector, true) { MinWidth = 200 };
-						var viewSelBox = new MDBox (LayoutDirection.Horizontal, 2, 0) {
-							{ viewSelLabel },
-							{ viewSelectorAlignemnt }
-						};
-
-						labels.Add (viewSelLabel);
-						controls.Add (viewSelectorAlignemnt);
-						box.Add (viewSelBox);
-					}
-				}
-				
-				if (labels.Count > 0) {
-					float w = labels.Max (l => l.MinWidth);
-					foreach (var l in labels) {
-						l.MinWidth = w;
-						l.XAlign = LayoutAlign.Begin;
-					}
-				}
-
-				if (controls.Count > 0) {
-					float w = controls.Max (c => c.MinWidth);
-					foreach (var c in controls) {
-						c.MinWidth = w;
-						c.XAlign = LayoutAlign.Begin;
+						box.AddControl (viewerSelector, GettextCatalog.GetString ("Open With:"));
 					}
 				}
 				

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -41,145 +41,154 @@ using MonoDevelop.MacInterop;
 
 namespace MonoDevelop.MacIntegration
 {
-	class MacOpenFileDialogHandler : IOpenFileDialogHandler
+	class MacOpenFileDialogHandler : MacCommonFileDialogHandler<OpenFileDialogData, MacOpenFileDialogHandler.SaveState>, IOpenFileDialogHandler
 	{
+		internal class SaveState
+		{
+			public SelectEncodingPopUpButton EncodingSelector { get; }
+			public NSPopUpButton ViewerSelector { get; }
+			public NSButton CloseSolutionButton { get; }
+			public List<FileViewer> CurrentViewers { get; }
+
+			public SaveState (SelectEncodingPopUpButton encodingSelector, NSPopUpButton viewerSelector, NSButton closeSolutionButton, List<FileViewer> currentViewers)
+			{
+				EncodingSelector = encodingSelector;
+				ViewerSelector = viewerSelector;
+				CloseSolutionButton = closeSolutionButton;
+				CurrentViewers = currentViewers;
+			}
+		}
+
+		protected override NSSavePanel OnCreatePanel (OpenFileDialogData data)
+		{
+			if (data.Action == FileChooserAction.Save) {
+				return new NSSavePanel ();
+			}
+
+			return new NSOpenPanel {
+				CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
+				CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
+			};
+		}
+
 		public bool Run (OpenFileDialogData data)
 		{
-			NSSavePanel panel = null;
-			
 			try {
-				if (data.Action == FileChooserAction.Save) {
-					panel = new NSSavePanel ();
-				} else {
-					panel = new NSOpenPanel {
-						CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
-						CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
+				using (var panel = CreatePanel (data, out var state)) {
+					bool pathAlreadySet = false;
+					panel.DidChangeToDirectory += (sender, e) => {
+						var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
+						if (string.IsNullOrEmpty (directoryPath))
+							return;
+						var selectedPath = data.OnDirectoryChanged (this, directoryPath);
+						if (selectedPath.IsNull)
+							return;
+						data.SelectedFiles = new FilePath [] { selectedPath };
+						pathAlreadySet = true;
+
+						// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
+						// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
+						// in that case calling .Cancel() leaves dialog in weird state...
+						// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
+						System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate { panel.Cancel (panel); }, Runtime.MainTaskScheduler);
 					};
-				}
-				bool pathAlreadySet = false;
-				panel.DidChangeToDirectory += (sender, e) => {
-					var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
-					if (string.IsNullOrEmpty (directoryPath))
-						return;
-					var selectedPath = data.OnDirectoryChanged (this, directoryPath);
-					if (selectedPath.IsNull)
-						return;
-					data.SelectedFiles = new FilePath [] { selectedPath };
-					pathAlreadySet = true;
 
-					// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
-					// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
-					// in that case calling .Cancel() leaves dialog in weird state...
-					// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
-					System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate { panel.Cancel (panel); }, Runtime.MainTaskScheduler);
-				};
-				MacSelectFileDialogHandler.SetCommonPanelProperties (data, panel);
-				
-				SelectEncodingPopUpButton encodingSelector = null;
-				NSPopUpButton viewerSelector = null;
-				NSButton closeSolutionButton = null;
-				
-				var box = new MDAccessoryViewBox ();
-				
-				List<FileViewer> currentViewers = null;
+					panel.SelectionDidChange += delegate {
+						var selection = MacSelectFileDialogHandler.GetSelectedFiles (panel);
+						bool slnViewerSelected = false;
+						if (state.ViewerSelector != null) {
+							slnViewerSelected = FillViewers (state.CurrentViewers, state.ViewerSelector, state.CloseSolutionButton, selection);
+							if (state.CloseSolutionButton != null) {
+								state.CloseSolutionButton.Enabled = slnViewerSelected;
+								state.CloseSolutionButton.State = slnViewerSelected ? NSCellStateValue.On : NSCellStateValue.Off;
+							}
+						}
+						if (state.EncodingSelector != null)
+							state.EncodingSelector.Enabled = !slnViewerSelected;
+					};
 
-				if ((data.Action & FileChooserAction.FileFlags) != 0) {
-					var filterPopup = MacSelectFileDialogHandler.CreateFileFilterPopup (data, panel);
-					if (filterPopup != null) {
-						box.AddControl (filterPopup, GettextCatalog.GetString ("Show Files:"));
+					if (panel.RunModal () == 0 && !pathAlreadySet) {
+						GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
+						return false;
+					}
+					if (!pathAlreadySet)
+						data.SelectedFiles = MacSelectFileDialogHandler.GetSelectedFiles (panel);
+
+					if (state.EncodingSelector != null)
+						data.Encoding = state.EncodingSelector.SelectedEncodingId > 0 ? Encoding.GetEncoding (state.EncodingSelector.SelectedEncodingId) : null;
+
+					if (state.ViewerSelector != null) {
+						if (state.CloseSolutionButton != null)
+							data.CloseCurrentWorkspace = state.CloseSolutionButton.State != NSCellStateValue.Off;
+						data.SelectedViewer = state.ViewerSelector.IndexOfSelectedItem >= 0 ?
+							state.CurrentViewers [(int)state.ViewerSelector.IndexOfSelectedItem] : null;
 					}
 
-					if (data.ShowEncodingSelector) {
-						encodingSelector = new SelectEncodingPopUpButton (data.Action != FileChooserAction.Save);
-						encodingSelector.SelectedEncodingId = data.Encoding != null ? data.Encoding.CodePage : 0;
-
-						box.AddControl (encodingSelector, GettextCatalog.GetString ("Encoding:"));
-					}
-					
-					if (data.ShowViewerSelector && panel is NSOpenPanel) {
-						currentViewers = new List<FileViewer> ();
-						viewerSelector = new NSPopUpButton {
-							Enabled = false,
-						};
-
-						if (encodingSelector != null || IdeApp.Workspace.IsOpen) {
-							viewerSelector.Activated += delegate {
-								var idx = viewerSelector.IndexOfSelectedItem;
-								bool workbenchViewerSelected = idx == 0 && currentViewers [0] == null;
-								if (encodingSelector != null)
-									encodingSelector.Enabled = !workbenchViewerSelected;
-								if (closeSolutionButton != null) {
-									if (closeSolutionButton.Enabled != workbenchViewerSelected) {
-										closeSolutionButton.Enabled = workbenchViewerSelected;
-										closeSolutionButton.State = workbenchViewerSelected ? NSCellStateValue.On : NSCellStateValue.Off;
-									}
-								}
-							};
-						}
-
-						if (IdeApp.Workspace.IsOpen) {
-							closeSolutionButton = new NSButton {
-								Title = GettextCatalog.GetString ("Close current workspace"),
-								Enabled = false,
-								State = NSCellStateValue.Off,
-							};
-
-							closeSolutionButton.SetButtonType (NSButtonType.Switch);
-							closeSolutionButton.SizeToFit ();
-
-							box.AddControl (closeSolutionButton, string.Empty);
-						}
-
-						box.AddControl (viewerSelector, GettextCatalog.GetString ("Open With:"));
-					}
-				}
-				
-				if (box.Count > 0) {
-					box.Layout ();
-					panel.AccessoryView = box.View;
-				}
-				
-				panel.SelectionDidChange += delegate {
-					var selection = MacSelectFileDialogHandler.GetSelectedFiles (panel);
-					bool slnViewerSelected = false;
-					if (viewerSelector != null) {
-						slnViewerSelected = FillViewers (currentViewers, viewerSelector, closeSolutionButton, selection);
-						if (closeSolutionButton != null) {
-							closeSolutionButton.Enabled = slnViewerSelected;
-							closeSolutionButton.State = slnViewerSelected ? NSCellStateValue.On : NSCellStateValue.Off;
-						}
-					} 
-					if (encodingSelector != null)
-						encodingSelector.Enabled = !slnViewerSelected;
-				};
-
-				if (panel.RunModal () == 0 && !pathAlreadySet) {
 					GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
-					return false;
 				}
-				if (!pathAlreadySet)
-					data.SelectedFiles = MacSelectFileDialogHandler.GetSelectedFiles (panel);
-				
-				if (encodingSelector != null)
-					data.Encoding = encodingSelector.SelectedEncodingId > 0 ? Encoding.GetEncoding (encodingSelector.SelectedEncodingId) : null;
-				
-				if (viewerSelector != null ) {
-					if (closeSolutionButton != null)
-						data.CloseCurrentWorkspace = closeSolutionButton.State != NSCellStateValue.Off;
-					data.SelectedViewer = viewerSelector.IndexOfSelectedItem >= 0 ?
-						currentViewers[(int)viewerSelector.IndexOfSelectedItem] : null;
-				}
-				
-				GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 			} catch (Exception ex) {
 				LoggingService.LogInternalError ("Error in Open File dialog", ex);
-			} finally {
-				if (panel != null)
-					panel.Dispose ();
 			}
 			return true;
 		}
-		
+
+		protected override IEnumerable<(NSControl control, string text)> OnGetAccessoryBoxControls (OpenFileDialogData data, NSSavePanel panel, out SaveState saveState)
+		{
+			List<(NSControl, string)> controls = new List<(NSControl, string)> ();
+			SelectEncodingPopUpButton encodingSelector = null;
+			NSPopUpButton viewerSelector = null;
+			NSButton closeSolutionButton = null;
+			List<FileViewer> currentViewers = null;
+
+			if (data.ShowEncodingSelector) {
+				encodingSelector = new SelectEncodingPopUpButton (data.Action != FileChooserAction.Save) {
+					SelectedEncodingId = data.Encoding != null ? data.Encoding.CodePage : 0
+				};
+
+				controls.Add ((encodingSelector, GettextCatalog.GetString ("Encoding:")));
+			}
+
+			if (data.ShowViewerSelector && panel is NSOpenPanel) {
+				currentViewers = new List<FileViewer> ();
+				viewerSelector = new NSPopUpButton {
+					Enabled = false,
+				};
+
+				if (encodingSelector != null || IdeApp.Workspace.IsOpen) {
+					viewerSelector.Activated += delegate {
+						var idx = viewerSelector.IndexOfSelectedItem;
+						bool workbenchViewerSelected = idx == 0 && currentViewers [0] == null;
+						if (encodingSelector != null)
+							encodingSelector.Enabled = !workbenchViewerSelected;
+						if (closeSolutionButton != null) {
+							if (closeSolutionButton.Enabled != workbenchViewerSelected) {
+								closeSolutionButton.Enabled = workbenchViewerSelected;
+								closeSolutionButton.State = workbenchViewerSelected ? NSCellStateValue.On : NSCellStateValue.Off;
+							}
+						}
+					};
+				}
+
+				if (IdeApp.Workspace.IsOpen) {
+					closeSolutionButton = new NSButton {
+						Title = GettextCatalog.GetString ("Close current workspace"),
+						Enabled = false,
+						State = NSCellStateValue.Off,
+					};
+
+					closeSolutionButton.SetButtonType (NSButtonType.Switch);
+					closeSolutionButton.SizeToFit ();
+
+					controls.Add ((closeSolutionButton, string.Empty));
+				}
+
+				controls.Add ((viewerSelector, GettextCatalog.GetString ("Open With:")));
+			}
+			saveState = new SaveState (encodingSelector, viewerSelector, closeSolutionButton, currentViewers);
+
+			return controls;
+		}
+
 		static bool FillViewers (List<FileViewer> currentViewers, NSPopUpButton button, NSButton closeSolutionButton, FilePath[] filenames)
 		{
 			button.Menu.RemoveAllItems ();

--- a/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
@@ -42,33 +42,24 @@ using MonoDevelop.MacInterop;
 
 namespace MonoDevelop.MacIntegration
 {
-	class MacSelectFileDialogHandler : ISelectFileDialogHandler
+	class MacSelectFileDialogHandler : MacCommonFileDialogHandler<SelectFileDialogData, object>, ISelectFileDialogHandler
 	{
+		protected override NSSavePanel OnCreatePanel (SelectFileDialogData data)
+		{
+			if (data.Action == FileChooserAction.Save)
+				return new NSSavePanel ();
+
+			return new NSOpenPanel {
+				CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
+				CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
+				CanCreateDirectories = (data.Action & FileChooserAction.CreateFolder) != 0,
+				ResolvesAliases = false,
+			};
+		}
+
 		public bool Run (SelectFileDialogData data)
 		{
-			NSSavePanel panel = null;
-			
-			try {
-				if (data.Action == FileChooserAction.Save) {
-					panel = new NSSavePanel ();
-				} else {
-					panel = new NSOpenPanel {
-						CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
-						CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
-						CanCreateDirectories = (data.Action & FileChooserAction.CreateFolder) != 0,
-						ResolvesAliases = false,
-					};
-				}
-				
-				SetCommonPanelProperties (data, panel);
-				
-				if ((data.Action & FileChooserAction.FileFlags) != 0) {
-					var popup = CreateFileFilterPopup (data, panel);
-					if (popup != null) {
-						panel.AccessoryView = popup;
-					}
-				}
-				
+			using (var panel = CreatePanel (data, out var saveState)) {
 				if (panel.RunModal () == 0) {
 					GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 					return false;
@@ -77,12 +68,9 @@ namespace MonoDevelop.MacIntegration
 				data.SelectedFiles = GetSelectedFiles (panel);
 				GtkQuartz.FocusWindow (data.TransientFor ?? MessageService.RootWindow);
 				return true;
-			} finally {
-				if (panel != null)
-					panel.Dispose ();
 			}
 		}
-		
+
 		internal static FilePath[] GetSelectedFiles (NSSavePanel panel)
 		{
 			var openPanel = panel as NSOpenPanel;
@@ -93,28 +81,7 @@ namespace MonoDevelop.MacIntegration
 				return url != null ? new FilePath[] { panel.Url.Path } : new FilePath[0];
 			}
 		}
-		
-		internal static void SetCommonPanelProperties (SelectFileDialogData data, NSSavePanel panel)
-		{
-			panel.TreatsFilePackagesAsDirectories = true;
-			
-			if (!string.IsNullOrEmpty (data.Title))
-				panel.Title = data.Title;
 
-			if (!string.IsNullOrEmpty (data.InitialFileName))
-				panel.NameFieldStringValue = data.InitialFileName;
-			
-			if (!string.IsNullOrEmpty (data.CurrentFolder))
-				panel.DirectoryUrl = new NSUrl (data.CurrentFolder, true);
-			
-			panel.ParentWindow = NSApplication.SharedApplication.KeyWindow ?? NSApplication.SharedApplication.MainWindow;
-
-			var openPanel = panel as NSOpenPanel;
-			if (openPanel != null) {
-				openPanel.AllowsMultipleSelection = data.SelectMultiple;
-				openPanel.ShowsHiddenFiles = data.ShowHidden;
-			}
-		}
 		
 		static NSOpenSavePanelUrl GetFileFilter (SelectFileDialogFilter filter)
 		{

--- a/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
@@ -204,48 +204,6 @@ namespace MonoDevelop.MacIntegration
 			
 			return popup;
 		}
-		
-		internal static NSView CreateLabelledDropdown (string label, float popupWidth, out NSPopUpButton popup)
-		{
-			popup = new NSPopUpButton (new CGRect (0, 6, popupWidth, 18), false) {
-				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.MaxXMargin,
-			};
-			return LabelControl (label, 200, popup);
-		}
-		
-		internal static NSView LabelControl (string label, float controlWidth, NSControl control)
-		{
-			var view = new NSView (new CGRect (0, 0, controlWidth, 28)) {
-				AutoresizesSubviews = true,
-				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.MaxXMargin,
-			};
-			
-			var text = new NSTextField (new CGRect (0, 6, 100, 20)) {
-				StringValue = label,
-				DrawsBackground = false,
-				Bordered = false,
-				Editable = false,
-				Selectable = false
-			};
-			text.SizeToFit ();
-			var textWidth = text.Frame.Width;
-			var textHeight = text.Frame.Height;
-			
-			control.SizeToFit ();
-			var rect = control.Frame;
-			var controlHeight = rect.Height;
-			control.Frame = new CGRect (textWidth + 5, 0, controlWidth, rect.Height);
-			
-			rect = view.Frame;
-			rect.Width = control.Frame.Width + textWidth + 5;
-			rect.Height = NMath.Max (controlHeight, textHeight);
-			view.Frame = rect;
-			
-			view.AddSubview (text);
-			view.AddSubview (control);
-			
-			return view;
-		}
 	}
 }
 

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -135,6 +135,7 @@
     <Compile Include="MimeMapLoader.cs" />
     <Compile Include="ScreenMonitor.cs" />
     <Compile Include="MainToolbar\NSFocusButton.cs" />
+    <Compile Include="Dialogs\MDAccessoryViewBox.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -55,6 +55,11 @@
       <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cairo" />
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
@@ -136,9 +141,11 @@
     <Compile Include="ScreenMonitor.cs" />
     <Compile Include="MainToolbar\NSFocusButton.cs" />
     <Compile Include="Dialogs\MDAccessoryViewBox.cs" />
+    <Compile Include="Dialogs\MacCommonFileDialogHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/src/addins/MacPlatform/packages.config
+++ b/main/src/addins/MacPlatform/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
This uses the same fix as a4bbb0989b9c9767766e6b16a83f0c07c406d0c2
to fix this dialog being broken on High Sierra. Don't layout
after setting the accessory view

Fixes VSTS #585364 Add File/[Options] UI is not shown