### PR TITLE
[Registrar] Register all assemblies loaded in the appdomain after the…

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -237,6 +237,14 @@ namespace MonoDevelop.MacIntegration
 			System.Reflection.Assembly.LoadFrom (Path.Combine (path, "Xwt.XamMac.dll"));
 			var loaded = Xwt.Toolkit.Load (Xwt.ToolkitType.XamMac);
 
+			// Register all the assemblies that are not loaded at this point manually.
+			// The static registrar initialization tells the runtime that it should
+			// find the assembly in there, thus it would fail to for any addins
+			// that are loaded after the fact and not in the static registrar.
+			AppDomain.CurrentDomain.AssemblyLoad += (o, args) => {
+				ObjCRuntime.Runtime.RegisterAssembly (args.LoadedAssembly);
+			};
+
 			loaded.RegisterBackend<Xwt.Backends.IDialogBackend, ThemedMacDialogBackend> ();
 			loaded.RegisterBackend<Xwt.Backends.IWindowBackend, ThemedMacWindowBackend> ();
 			loaded.RegisterBackend<Xwt.Backends.IAlertDialogBackend, ThemedMacAlertDialogBackend> ();


### PR DESCRIPTION
… app is initialized (#4135)

Should fix issues like Macaque not working.