### PR TITLE
Fixes VSTS 586125: Alt+Up at beginning of the document results in an

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/MiscActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/MiscActions.cs
@@ -372,6 +372,8 @@ namespace Mono.TextEditor
 				//int relCaretOffset = data.Caret.Offset - startLine.Offset;
 				
 				Mono.TextEditor.DocumentLine prevLine = data.Document.GetLine (lineStart - 1);
+				if (prevLine == null)
+					return;
 				string text = data.Document.GetTextAt (prevLine.Offset, prevLine.Length);
 				List<TextLineMarker> prevLineMarkers = new List<TextLineMarker> (data.Document.GetMarkers (prevLine));
 				data.Document.ClearMarkers (prevLine);

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests.DefaultEditActions/MiscActionsTest.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests.DefaultEditActions/MiscActionsTest.cs
@@ -281,6 +281,18 @@ dddddd$dddd
 eeeeeeeeee
 ffffffffff");
 		}
+
+		/// <summary>
+		/// Bug 586125: Alt+Up at beginning of the document results in an exception
+		/// </summary>
+		[Test ()]
+		public void TestBug586125 ()
+		{
+			TextEditorData data = Create (@"$1234567890
+1234567890");
+			MiscActions.MoveBlockUp (data);
+			Assert.AreEqual (new DocumentLocation (3, 6), data.Caret.Location);
+		}
 	}
 }
 


### PR DESCRIPTION
exception

MoveBlockDown doesn't have that bug. It's not a big one - doesn't
crash the IDE - just visible in the log file.