### PR TITLE
[DotNetCore] Allow .NET Core location to be configured 

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationPanel.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationPanel.cs
@@ -47,10 +47,7 @@ namespace MonoDevelop.DotNetCore.Gui
 
 		public FilePath LoadSdkLocationSetting ()
 		{
-			if (DotNetCoreRuntime.IsInstalled) {
-				return DotNetCoreRuntime.FileName;
-			}
-			return FilePath.Null;
+			return DotNetCoreRuntime.FileName;
 		}
 
 		public void SaveSdkLocationSetting (FilePath location)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationPanel.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationPanel.cs
@@ -1,0 +1,115 @@
+﻿//
+// DotNetCoreSdkLocationPanel.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Components;
+using MonoDevelop.Core;
+using MonoDevelop.Ide;
+using MonoDevelop.Ide.Gui.Dialogs;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.DotNetCore.Gui
+{
+	class DotNetCoreSdkLocationPanel : OptionsPanel
+	{
+		DotNetCoreSdkLocationWidget widget;
+
+		public override Control CreatePanelWidget ()
+		{
+			widget = new DotNetCoreSdkLocationWidget (this);
+			return widget.ToGtkWidget ();
+		}
+
+		public FilePath LoadSdkLocationSetting ()
+		{
+			if (DotNetCoreRuntime.IsInstalled) {
+				return DotNetCoreRuntime.FileName;
+			}
+			return FilePath.Null;
+		}
+
+		public void SaveSdkLocationSetting (FilePath location)
+		{
+			if (location == DotNetCoreRuntime.FileName) {
+				return;
+			}
+
+			var path = new DotNetCorePath (location);
+			DotNetCoreSdkPaths sdkPaths = GetSdkPaths (path);
+
+			DotNetCoreSdk.Update (sdkPaths);
+			DotNetCoreRuntime.Update (path);
+
+			// All open .NET Core projects need to be re-evaluated so the correct
+			// SDK MSBuild imports are used.
+			ReevaluateAllOpenDotNetCoreProjects ().Ignore ();
+		}
+
+		public DotNetCoreSdkPaths SdkPaths { get; private set; }
+		public DotNetCorePath DotNetCorePath { get; private set; }
+		public DotNetCoreVersion[] RuntimeVersions { get; private set; }
+
+		public void ValidateSdkLocation (FilePath location)
+		{
+			if (!location.IsNullOrEmpty) {
+				DotNetCorePath = new DotNetCorePath (location);
+				SdkPaths = GetSdkPaths (DotNetCorePath);
+				RuntimeVersions = DotNetCoreRuntimeVersions.GetInstalledVersions (DotNetCorePath.FileName).ToArray ();
+			} else {
+				DotNetCorePath = null;
+				SdkPaths = new DotNetCoreSdkPaths ();
+				RuntimeVersions = Array.Empty<DotNetCoreVersion> ();
+			}
+		}
+
+		static DotNetCoreSdkPaths GetSdkPaths (DotNetCorePath path)
+		{
+			var sdkPaths = new DotNetCoreSdkPaths ();
+			sdkPaths.FindMSBuildSDKsPath (path.FileName);
+			return sdkPaths;
+		}
+
+		async Task ReevaluateAllOpenDotNetCoreProjects ()
+		{
+			if (!IdeApp.Workspace.IsOpen)
+				return;
+
+			var progressMonitor = new ProgressMonitor ();
+			foreach (var project in IdeApp.Workspace.GetAllItems<DotNetProject> ()) {
+				if (project.HasFlavor<DotNetCoreProjectExtension> ()) {
+					await project.ReevaluateProject (progressMonitor);
+				}
+			}
+		}
+
+		public override void ApplyChanges ()
+		{
+			widget.ApplyChanges ();
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
@@ -1,0 +1,183 @@
+﻿//
+// DotNetCoreSdkLocationWidget.UI.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Xwt;
+using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.DotNetCore.Gui
+{
+	partial class DotNetCoreSdkLocationWidget : Widget
+	{
+		FileSelector locationFileSelector;
+		Label commandLineFoundLabel;
+		ImageView commandLineFoundIcon;
+		Label sdkFoundLabel;
+		ImageView sdkFoundIcon;
+		Label sdkVersionsFoundLabel;
+		ScrollView sdkVersionsScrollView;
+		Label runtimeFoundLabel;
+		ImageView runtimeFoundIcon;
+		Label runtimeVersionsFoundLabel;
+		ScrollView runtimeVersionsScrollView;
+		Label runtimeVersionsFoundScrollViewLabel;
+
+		void Build ()
+		{
+			var mainVBox = new VBox ();
+			mainVBox.Spacing = 12;
+
+			// .NET Core command line section.
+			var titleLabel = new Label ();
+			titleLabel.Markup = GetBoldMarkup (GettextCatalog.GetString (".NET Core Command Line"));
+			mainVBox.PackStart (titleLabel);
+
+			var commandLineVBox = new VBox ();
+			commandLineVBox.Spacing = 6;
+			commandLineVBox.MarginLeft = 24;
+			mainVBox.PackStart (commandLineVBox);
+
+			var commandLineFoundHBox = new HBox ();
+			commandLineFoundHBox.Spacing = 6;
+			commandLineVBox.PackStart (commandLineFoundHBox, false, false);
+
+			commandLineFoundIcon = new ImageView ();
+			commandLineFoundHBox.PackStart (commandLineFoundIcon, false, false);
+
+			commandLineFoundLabel = new Label ();
+			commandLineFoundHBox.PackStart (commandLineFoundLabel, true, true);
+
+			var locationBox = new HBox ();
+			locationBox.Spacing = 6;
+			commandLineVBox.PackStart (locationBox, false, false);
+
+			var locationLabel = new Label ();
+			locationLabel.Text = GettextCatalog.GetString ("Location:");
+			locationBox.PackStart (locationLabel, false, false);
+
+			locationFileSelector = new FileSelector ();
+			locationBox.PackStart (locationFileSelector, true, true);
+
+			// .NET Core runtime section
+			var runtimeVersionsTitleLabel = new Label ();
+			runtimeVersionsTitleLabel.Markup = GetBoldMarkup (GettextCatalog.GetString (".NET Core Runtime"));
+			mainVBox.PackStart (runtimeVersionsTitleLabel);
+
+			var runtimeVersionsVBox = new VBox ();
+			runtimeVersionsVBox.Spacing = 6;
+			runtimeVersionsVBox.MarginLeft = 24;
+			mainVBox.PackStart (runtimeVersionsVBox, false, false);
+
+			var runtimeFoundHBox = new HBox ();
+			runtimeFoundHBox.Spacing = 6;
+			runtimeFoundHBox.MarginBottom = 6;
+			runtimeVersionsVBox.PackStart (runtimeFoundHBox, false, false);
+
+			runtimeFoundIcon = new ImageView ();
+			runtimeFoundHBox.PackStart (runtimeFoundIcon, false, false);
+
+			runtimeFoundLabel = new Label ();
+			runtimeFoundHBox.PackStart (runtimeFoundLabel, false, false);
+
+			runtimeVersionsFoundLabel = new Label ();
+
+			runtimeVersionsVBox.PackStart (runtimeVersionsFoundLabel, false, false);
+
+			runtimeVersionsFoundScrollViewLabel = new Label ();
+			var runtimeVersionsScrollViewVBox = new VBox ();
+			runtimeVersionsScrollViewVBox.PackStart (runtimeVersionsFoundScrollViewLabel, false, false);
+
+			runtimeVersionsScrollView = new ScrollView ();
+			runtimeVersionsScrollView.HorizontalScrollPolicy = ScrollPolicy.Never;
+			runtimeVersionsScrollView.BorderVisible = false;
+			runtimeVersionsScrollView.Content = runtimeVersionsScrollViewVBox;
+			runtimeVersionsVBox.PackStart (runtimeVersionsScrollView, false, false);
+
+			// .NET Core SDK section.
+			var sdkVersionsTitleLabel = new Label ();
+			sdkVersionsTitleLabel.Markup = GetBoldMarkup (GettextCatalog.GetString (".NET Core SDK"));
+			mainVBox.PackStart (sdkVersionsTitleLabel);
+
+			var sdkVersionsVBox = new VBox ();
+			sdkVersionsVBox.Spacing = 6;
+			sdkVersionsVBox.MarginLeft = 24;
+			mainVBox.PackStart (sdkVersionsVBox, true, true);
+
+			var sdkFoundHBox = new HBox ();
+			sdkFoundHBox.Spacing = 6;
+			sdkFoundHBox.MarginBottom = 6;
+			sdkVersionsVBox.PackStart (sdkFoundHBox, false, false);
+
+			sdkFoundIcon = new ImageView ();
+			sdkFoundHBox.PackStart (sdkFoundIcon, false, false);
+
+			sdkFoundLabel = new Label ();
+			sdkFoundHBox.PackStart (sdkFoundLabel, false, false);
+
+			sdkVersionsFoundLabel = new Label ();
+
+			var sdkVersionsScrollViewVBox = new VBox ();
+			sdkVersionsScrollViewVBox.PackStart (sdkVersionsFoundLabel, false, false);
+
+			sdkVersionsScrollView = new ScrollView ();
+			sdkVersionsScrollView.HorizontalScrollPolicy = ScrollPolicy.Never;
+			sdkVersionsScrollView.BorderVisible = false;
+			sdkVersionsScrollView.Content = sdkVersionsScrollViewVBox;
+			sdkVersionsVBox.PackStart (sdkVersionsScrollView, true, true);
+
+			Content = mainVBox;
+		}
+
+		static string GetBoldMarkup (string text)
+		{
+			return "<b>" + GLib.Markup.EscapeText (text) + "</b>";
+		}
+
+		void UpdateSdkIconAccessibility (bool found)
+		{
+			sdkFoundIcon.SetCommonAccessibilityAttributes (
+				"DotNetCoreSdkFoundImage",
+				found ? GettextCatalog.GetString ("A Tick") : GettextCatalog.GetString ("A Cross"),
+				found ? GettextCatalog.GetString ("The .NET Core SDK was found") : GettextCatalog.GetString ("The .NET Core SDK was not found"));
+		}
+
+		void UpdateCommandLineIconAccessibility (bool found)
+		{
+			sdkFoundIcon.SetCommonAccessibilityAttributes (
+				"DotNetCoreCommandLineFoundImage",
+				found ? GettextCatalog.GetString ("A Tick") : GettextCatalog.GetString ("A Cross"),
+				found ? GettextCatalog.GetString ("The .NET Core command line was found") : GettextCatalog.GetString ("The .NET Core command line was not found"));
+		}
+
+		void UpdateRuntimeIconAccessibility (bool found)
+		{
+			runtimeFoundIcon.SetCommonAccessibilityAttributes (
+				"DotNetCoreRuntimeFoundImage",
+				found ? GettextCatalog.GetString ("A Tick") : GettextCatalog.GetString ("A Cross"),
+				found ? GettextCatalog.GetString ("A .NET Core runtime was found") : GettextCatalog.GetString ("A .NET Core runtime was not found"));
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
@@ -37,13 +37,10 @@ namespace MonoDevelop.DotNetCore.Gui
 		ImageView commandLineFoundIcon;
 		Label sdkFoundLabel;
 		ImageView sdkFoundIcon;
-		Label sdkVersionsFoundLabel;
-		ScrollView sdkVersionsScrollView;
+		ListBox sdkVersionsListBox;
 		Label runtimeFoundLabel;
 		ImageView runtimeFoundIcon;
-		Label runtimeVersionsFoundLabel;
-		ScrollView runtimeVersionsScrollView;
-		Label runtimeVersionsFoundScrollViewLabel;
+		ListBox runtimeVersionsListBox;
 
 		void Build ()
 		{
@@ -81,41 +78,6 @@ namespace MonoDevelop.DotNetCore.Gui
 			locationFileSelector = new FileSelector ();
 			locationBox.PackStart (locationFileSelector, true, true);
 
-			// .NET Core runtime section
-			var runtimeVersionsTitleLabel = new Label ();
-			runtimeVersionsTitleLabel.Markup = GetBoldMarkup (GettextCatalog.GetString (".NET Core Runtime"));
-			mainVBox.PackStart (runtimeVersionsTitleLabel);
-
-			var runtimeVersionsVBox = new VBox ();
-			runtimeVersionsVBox.Spacing = 6;
-			runtimeVersionsVBox.MarginLeft = 24;
-			mainVBox.PackStart (runtimeVersionsVBox, false, false);
-
-			var runtimeFoundHBox = new HBox ();
-			runtimeFoundHBox.Spacing = 6;
-			runtimeFoundHBox.MarginBottom = 6;
-			runtimeVersionsVBox.PackStart (runtimeFoundHBox, false, false);
-
-			runtimeFoundIcon = new ImageView ();
-			runtimeFoundHBox.PackStart (runtimeFoundIcon, false, false);
-
-			runtimeFoundLabel = new Label ();
-			runtimeFoundHBox.PackStart (runtimeFoundLabel, false, false);
-
-			runtimeVersionsFoundLabel = new Label ();
-
-			runtimeVersionsVBox.PackStart (runtimeVersionsFoundLabel, false, false);
-
-			runtimeVersionsFoundScrollViewLabel = new Label ();
-			var runtimeVersionsScrollViewVBox = new VBox ();
-			runtimeVersionsScrollViewVBox.PackStart (runtimeVersionsFoundScrollViewLabel, false, false);
-
-			runtimeVersionsScrollView = new ScrollView ();
-			runtimeVersionsScrollView.HorizontalScrollPolicy = ScrollPolicy.Never;
-			runtimeVersionsScrollView.BorderVisible = false;
-			runtimeVersionsScrollView.Content = runtimeVersionsScrollViewVBox;
-			runtimeVersionsVBox.PackStart (runtimeVersionsScrollView, false, false);
-
 			// .NET Core SDK section.
 			var sdkVersionsTitleLabel = new Label ();
 			sdkVersionsTitleLabel.Markup = GetBoldMarkup (GettextCatalog.GetString (".NET Core SDK"));
@@ -137,16 +99,32 @@ namespace MonoDevelop.DotNetCore.Gui
 			sdkFoundLabel = new Label ();
 			sdkFoundHBox.PackStart (sdkFoundLabel, false, false);
 
-			sdkVersionsFoundLabel = new Label ();
+			sdkVersionsListBox = new ListBox ();
+			sdkVersionsVBox.PackStart (sdkVersionsListBox, true, true);
 
-			var sdkVersionsScrollViewVBox = new VBox ();
-			sdkVersionsScrollViewVBox.PackStart (sdkVersionsFoundLabel, false, false);
+			// .NET Core runtime section
+			var runtimeVersionsTitleLabel = new Label ();
+			runtimeVersionsTitleLabel.Markup = GetBoldMarkup (GettextCatalog.GetString (".NET Core Runtime"));
+			mainVBox.PackStart (runtimeVersionsTitleLabel);
 
-			sdkVersionsScrollView = new ScrollView ();
-			sdkVersionsScrollView.HorizontalScrollPolicy = ScrollPolicy.Never;
-			sdkVersionsScrollView.BorderVisible = false;
-			sdkVersionsScrollView.Content = sdkVersionsScrollViewVBox;
-			sdkVersionsVBox.PackStart (sdkVersionsScrollView, true, true);
+			var runtimeVersionsVBox = new VBox ();
+			runtimeVersionsVBox.Spacing = 6;
+			runtimeVersionsVBox.MarginLeft = 24;
+			mainVBox.PackStart (runtimeVersionsVBox, true, true);
+
+			var runtimeFoundHBox = new HBox ();
+			runtimeFoundHBox.Spacing = 6;
+			runtimeFoundHBox.MarginBottom = 6;
+			runtimeVersionsVBox.PackStart (runtimeFoundHBox, false, false);
+
+			runtimeFoundIcon = new ImageView ();
+			runtimeFoundHBox.PackStart (runtimeFoundIcon, false, false);
+
+			runtimeFoundLabel = new Label ();
+			runtimeFoundHBox.PackStart (runtimeFoundLabel, false, false);
+
+			runtimeVersionsListBox = new ListBox ();
+			runtimeVersionsVBox.PackStart (runtimeVersionsListBox, true, true);
 
 			Content = mainVBox;
 		}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
@@ -1,0 +1,180 @@
+﻿//
+// DotNetCoreSdkLocationWidget.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MonoDevelop.Core;
+using MonoDevelop.Ide;
+using Xwt.Drawing;
+
+namespace MonoDevelop.DotNetCore.Gui
+{
+	partial class DotNetCoreSdkLocationWidget
+	{
+		DotNetCoreSdkLocationPanel panel;
+
+		public DotNetCoreSdkLocationWidget (DotNetCoreSdkLocationPanel panel)
+		{
+			this.panel = panel;
+
+			Build ();
+
+			string location = panel.LoadSdkLocationSetting ();
+			locationFileSelector.FileName = location ?? string.Empty;
+
+			locationFileSelector.FileChanged += LocationChanged;
+
+			Validate ();
+		}
+
+		void LocationChanged (object sender, EventArgs e)
+		{
+			Validate ();
+		}
+
+		void Validate ()
+		{
+			FilePath location = CleanPath (locationFileSelector.FileName);
+			panel.ValidateSdkLocation (location);
+
+			ShowDotNetCoreInformation ();
+		}
+
+		FilePath CleanPath (FilePath path)
+		{
+			if (path.IsNullOrEmpty) {
+				return null;
+			}
+
+			try {
+				return path.FullPath;
+			} catch {
+				return null;
+			}
+		}
+
+		public void ApplyChanges ()
+		{
+			panel.SaveSdkLocationSetting (CleanPath (locationFileSelector.FileName));
+		}
+
+		void ShowDotNetCoreInformation ()
+		{
+			if (panel.DotNetCorePath?.Exists == true) {
+				commandLineFoundLabel.Text = GettextCatalog.GetString ("Found");
+				commandLineFoundIcon.Image = GetIcon (Gtk.Stock.Apply);
+				UpdateCommandLineIconAccessibility (true);
+			} else {
+				commandLineFoundLabel.Text = GettextCatalog.GetString ("Not found");
+				commandLineFoundIcon.Image = GetIcon (Gtk.Stock.Cancel);
+				UpdateCommandLineIconAccessibility (false);
+			}
+
+			if (panel.SdkPaths.Exist) {
+				ShowSdkInformation (panel.SdkPaths.SdkVersions);
+			} else {
+				ShowNoSdkFound ();
+			}
+
+			if (panel.RuntimeVersions.Any ()) {
+				ShowRuntimes (panel.RuntimeVersions);
+			} else {
+				ShowNoRuntimesFound ();
+			}
+		}
+
+		void ShowSdkInformation (DotNetCoreVersion[] versions)
+		{
+			sdkFoundLabel.Text = GettextCatalog.GetPluralString ("SDK found", "SDKs found", versions.Length);
+			sdkFoundIcon.Image = GetIcon (Gtk.Stock.Apply);
+			UpdateSdkIconAccessibility (true);
+
+			sdkVersionsFoundLabel.Text = GetVersionsText (versions);
+			sdkVersionsScrollView.Visible = true;
+		}
+
+		static Image GetIcon (string name)
+		{
+			return ImageService.GetIcon (name, Gtk.IconSize.Menu);
+		}
+
+		static string GetVersionsText (IEnumerable<DotNetCoreVersion> versions)
+		{
+			var versionText = new StringBuilder ();
+
+			foreach (var version in versions) {
+				versionText.AppendLine (version.OriginalString);
+			}
+
+			return versionText.ToString ().Trim ();
+		}
+
+		void ShowNoSdkFound ()
+		{
+			sdkFoundLabel.Text = GettextCatalog.GetString ("Not found");
+			sdkFoundIcon.Image = GetIcon (Gtk.Stock.Cancel);
+			UpdateSdkIconAccessibility (false);
+
+			sdkVersionsScrollView.Visible = false;
+		}
+
+		void ShowRuntimes (DotNetCoreVersion[] versions)
+		{
+			runtimeFoundLabel.Text = GettextCatalog.GetPluralString ("Runtime found", "Runtimes found", versions.Length);
+			runtimeFoundIcon.Image = GetIcon (Gtk.Stock.Apply);
+			UpdateRuntimeIconAccessibility (true);
+
+			// HACK - Use scrollview if there more than 5 runtime versions.
+			// Using the scrollview for a single runtime version adds too much space in the UI
+			// even though it is set to not expand nor fill.
+			if (versions.Length > 5) {
+				runtimeVersionsFoundLabel.Text = string.Empty;
+				runtimeVersionsFoundLabel.Visible = false;
+
+				runtimeVersionsFoundScrollViewLabel.Text = GetVersionsText (versions);
+				runtimeVersionsScrollView.Visible = true;
+			} else {
+				runtimeVersionsFoundLabel.Text = GetVersionsText (versions);
+				runtimeVersionsFoundLabel.Visible = true;
+
+				runtimeVersionsFoundScrollViewLabel.Text = string.Empty;
+				runtimeVersionsScrollView.Visible = false;
+			}
+		}
+
+		void ShowNoRuntimesFound ()
+		{
+			runtimeFoundLabel.Text = GettextCatalog.GetString ("Not found");
+			runtimeFoundIcon.Image = GetIcon (Gtk.Stock.Cancel);
+			UpdateRuntimeIconAccessibility (false);
+
+			runtimeVersionsFoundLabel.Visible = false;
+			runtimeVersionsScrollView.Visible = false;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
@@ -49,12 +49,13 @@ namespace MonoDevelop.DotNetCore.Gui
 
 			locationFileSelector.FileChanged += LocationChanged;
 
-			Validate ();
+			LocationChanged (null, null);
 		}
 
 		void LocationChanged (object sender, EventArgs e)
 		{
 			Validate ();
+			UpdateFileSelectorDirectory ();
 		}
 
 		void Validate ()
@@ -63,6 +64,16 @@ namespace MonoDevelop.DotNetCore.Gui
 			panel.ValidateSdkLocation (location);
 
 			ShowDotNetCoreInformation ();
+		}
+
+		void UpdateFileSelectorDirectory ()
+		{
+			FilePath location = CleanPath (locationFileSelector.FileName);
+			if (location.IsNull) {
+				locationFileSelector.CurrentFolder = null;
+			} else {
+				locationFileSelector.CurrentFolder = location.ParentDirectory;
+			}
 		}
 
 		FilePath CleanPath (FilePath path)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
@@ -114,8 +114,11 @@ namespace MonoDevelop.DotNetCore.Gui
 			sdkFoundIcon.Image = GetIcon (Gtk.Stock.Apply);
 			UpdateSdkIconAccessibility (true);
 
-			sdkVersionsFoundLabel.Text = GetVersionsText (versions);
-			sdkVersionsScrollView.Visible = true;
+			sdkVersionsListBox.Items.Clear ();
+
+			foreach (var version in versions) {
+				sdkVersionsListBox.Items.Add (version.OriginalString);
+			}
 		}
 
 		static Image GetIcon (string name)
@@ -123,24 +126,12 @@ namespace MonoDevelop.DotNetCore.Gui
 			return ImageService.GetIcon (name, Gtk.IconSize.Menu);
 		}
 
-		static string GetVersionsText (IEnumerable<DotNetCoreVersion> versions)
-		{
-			var versionText = new StringBuilder ();
-
-			foreach (var version in versions) {
-				versionText.AppendLine (version.OriginalString);
-			}
-
-			return versionText.ToString ().Trim ();
-		}
-
 		void ShowNoSdkFound ()
 		{
 			sdkFoundLabel.Text = GettextCatalog.GetString ("Not found");
 			sdkFoundIcon.Image = GetIcon (Gtk.Stock.Cancel);
+			sdkVersionsListBox.Items.Clear ();
 			UpdateSdkIconAccessibility (false);
-
-			sdkVersionsScrollView.Visible = false;
 		}
 
 		void ShowRuntimes (DotNetCoreVersion[] versions)
@@ -149,21 +140,10 @@ namespace MonoDevelop.DotNetCore.Gui
 			runtimeFoundIcon.Image = GetIcon (Gtk.Stock.Apply);
 			UpdateRuntimeIconAccessibility (true);
 
-			// HACK - Use scrollview if there more than 5 runtime versions.
-			// Using the scrollview for a single runtime version adds too much space in the UI
-			// even though it is set to not expand nor fill.
-			if (versions.Length > 5) {
-				runtimeVersionsFoundLabel.Text = string.Empty;
-				runtimeVersionsFoundLabel.Visible = false;
+			runtimeVersionsListBox.Items.Clear ();
 
-				runtimeVersionsFoundScrollViewLabel.Text = GetVersionsText (versions);
-				runtimeVersionsScrollView.Visible = true;
-			} else {
-				runtimeVersionsFoundLabel.Text = GetVersionsText (versions);
-				runtimeVersionsFoundLabel.Visible = true;
-
-				runtimeVersionsFoundScrollViewLabel.Text = string.Empty;
-				runtimeVersionsScrollView.Visible = false;
+			foreach (var version in versions) {
+				runtimeVersionsListBox.Items.Add (version.OriginalString);
 			}
 		}
 
@@ -171,10 +151,8 @@ namespace MonoDevelop.DotNetCore.Gui
 		{
 			runtimeFoundLabel.Text = GettextCatalog.GetString ("Not found");
 			runtimeFoundIcon.Image = GetIcon (Gtk.Stock.Cancel);
+			runtimeVersionsListBox.Items.Clear ();
 			UpdateRuntimeIconAccessibility (false);
-
-			runtimeVersionsFoundLabel.Visible = false;
-			runtimeVersionsScrollView.Visible = false;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.cs
@@ -96,7 +96,7 @@ namespace MonoDevelop.DotNetCore.Gui
 
 		void ShowDotNetCoreInformation ()
 		{
-			if (panel.DotNetCorePath?.Exists == true) {
+			if (panel.DotNetCorePath?.Exists == true && panel.RuntimeVersions.Any ()) {
 				commandLineFoundLabel.Text = GettextCatalog.GetString ("Found");
 				commandLineFoundIcon.Image = GetIcon (Gtk.Stock.Apply);
 				UpdateCommandLineIconAccessibility (true);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeBuilderExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DotNetCoreProjectNodeBuilderExtension.cs
@@ -26,6 +26,7 @@
 
 using System;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 using MonoDevelop.Ide.Gui.Components;
 using MonoDevelop.Ide.Tasks;
 using MonoDevelop.Projects;
@@ -34,6 +35,28 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 {
 	class DotNetCoreProjectNodeBuilderExtension : NodeBuilderExtension
 	{
+		protected override void Initialize ()
+		{
+			base.Initialize ();
+			DotNetCoreRuntime.Changed += DotNetCoreRuntimeChanged;
+		}
+
+		public override void Dispose ()
+		{
+			DotNetCoreRuntime.Changed -= DotNetCoreRuntimeChanged;
+			base.Dispose ();
+		}
+
+		void DotNetCoreRuntimeChanged (object sender, EventArgs e)
+		{
+			foreach (DotNetProject project in IdeApp.Workspace.GetAllItems<DotNetProject> ()) {
+				if (project.HasFlavor<DotNetCoreProjectExtension> ()) {
+					ITreeBuilder builder = Context.GetTreeBuilder (project);
+					builder?.Update ();
+				}
+			}
+		}
+
 		public override bool CanBuildNode (Type dataType)
 		{
 			return typeof (DotNetProject).IsAssignableFrom (dataType);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -125,6 +125,11 @@
     <Compile Include="MonoDevelop.DotNetCore\MSBuildSdksPathGlobalPropertyProvider.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCoreShortTargetFramework.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Templating\DotNetCoreProjectTemplateStringTagProvider.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Gui\DotNetCoreSdkLocationPanel.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Gui\DotNetCoreSdkLocationWidget.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Gui\DotNetCoreSdkLocationWidget.UI.cs">
+      <DependentUpon>DotNetCoreSdkLocationWidget.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.DotNetCore\" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCorePath.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCorePath.cs
@@ -35,20 +35,35 @@ namespace MonoDevelop.DotNetCore
 		public DotNetCorePath ()
 		{
 			FileName = GetDotNetFileName ();
+			Exists = !IsMissing;
+		}
+
+		public DotNetCorePath (string fileName)
+		{
+			FileName = fileName;
+			Exists = File.Exists (fileName);
+			IsMissing = !Exists;
 		}
 
 		public string FileName { get; private set; }
 		public bool IsMissing { get; private set; }
+		public bool Exists { get; private set; }
+
+		public string ParentDirectory {
+			get {
+				if (!string.IsNullOrEmpty (FileName)) {
+					return Path.GetDirectoryName (FileName);
+				}
+				return null;
+			}
+		}
 
 		string GetDotNetFileName ()
 		{
 			if (Platform.IsWindows) {
 				return GetDotNetFileNameOnWindows ();
 			} else {
-				string dotnetFileName = "/usr/local/share/dotnet/dotnet";
-				if (Platform.IsLinux)
-					dotnetFileName = "/usr/share/dotnet/dotnet";
-
+				string dotnetFileName = GetDefaultPath ();
 				if (File.Exists (dotnetFileName)) {
 					return dotnetFileName;
 				}
@@ -84,6 +99,25 @@ namespace MonoDevelop.DotNetCore
 			IsMissing = true;
 
 			return executableName;
+		}
+
+		public bool IsDefault ()
+		{
+			FilePath defaultPath = GetDefaultPath ();
+			var currentPath = new FilePath (FileName);
+			return currentPath == defaultPath;
+		}
+
+		static string GetDefaultPath ()
+		{
+			if (Platform.IsMac)
+				return "/usr/local/share/dotnet/dotnet";
+
+			if (Platform.IsLinux)
+				return "/usr/share/dotnet/dotnet";
+
+			// Windows.
+			return "dotnet.exe";
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
@@ -62,6 +62,10 @@ namespace MonoDevelop.DotNetCore
 				.OrderByDescending (version => version)
 				.ToArray ();
 
+			// If there are no runtimes then do not consider the runtime to be installed.
+			if (!Versions.Any ())
+				IsInstalled = false;
+
 			// Used by the DotNetMSBuildSdkResolver to find the .NET Core SDK.
 			// Not sure this is needed - seems to work without it.
 			Environment.SetEnvironmentVariable ("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", path.ParentDirectory);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // DotNetCoreRuntime.cs
 //
 // Author:
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MonoDevelop.Core;
@@ -32,9 +33,28 @@ namespace MonoDevelop.DotNetCore
 {
 	public static class DotNetCoreRuntime
 	{
+		internal static readonly string DotNetCoreRuntimeFileNameProperty = "DotNetCoreRuntimeFileName";
+
 		static DotNetCoreRuntime ()
 		{
-			var path = new DotNetCorePath ();
+			Init (GetDotNetCorePath ());
+
+			if (!IsInstalled)
+				LoggingService.LogInfo (".NET Core runtime not found.");
+		}
+
+		static DotNetCorePath GetDotNetCorePath ()
+		{
+			string fileName = PropertyService.Get<string> (DotNetCoreRuntimeFileNameProperty);
+
+			if (!string.IsNullOrEmpty (fileName))
+				return new DotNetCorePath (fileName);
+
+			return new DotNetCorePath ();
+		}
+
+		static void Init (DotNetCorePath path)
+		{
 			IsInstalled = !path.IsMissing;
 			FileName = path.FileName;
 
@@ -42,8 +62,32 @@ namespace MonoDevelop.DotNetCore
 				.OrderByDescending (version => version)
 				.ToArray ();
 
-			if (!IsInstalled)
-				LoggingService.LogInfo (".NET Core runtime not found.");
+			// Used by the DotNetMSBuildSdkResolver to find the .NET Core SDK.
+			// Not sure this is needed - seems to work without it.
+			Environment.SetEnvironmentVariable ("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", path.ParentDirectory);
+		}
+
+		internal static void Update (DotNetCorePath path)
+		{
+			if (path.FileName == FileName)
+				return;
+
+			Init (path);
+
+			if (path.IsDefault ()) {
+				PropertyService.Set (DotNetCoreRuntimeFileNameProperty, null);
+			} else {
+				PropertyService.Set (DotNetCoreRuntimeFileNameProperty, path.FileName);
+			}
+
+			OnChanged ();
+		}
+
+		static internal event EventHandler Changed;
+
+		static void OnChanged ()
+		{
+			Changed?.Invoke (null, EventArgs.Empty);
 		}
 
 		public static string FileName { get; private set; }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntimeVersions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntimeVersions.cs
@@ -37,6 +37,14 @@ namespace MonoDevelop.DotNetCore
 			if (dotNetCorePath.IsMissing)
 				return Enumerable.Empty<DotNetCoreVersion> ();
 
+			return GetInstalledVersions (dotNetCorePath.FileName);
+		}
+
+		public static IEnumerable<DotNetCoreVersion> GetInstalledVersions (string dotNetCorePath)
+		{
+			if (string.IsNullOrEmpty (dotNetCorePath))
+				return Enumerable.Empty<DotNetCoreVersion> ();
+
 			string runtimePath = GetDotNetCoreRuntimePath (dotNetCorePath);
 			if (!Directory.Exists (runtimePath))
 				return Enumerable.Empty<DotNetCoreVersion> ();
@@ -46,9 +54,9 @@ namespace MonoDevelop.DotNetCore
 				.Where (version => version != null);
 		}
 
-		static string GetDotNetCoreRuntimePath (DotNetCorePath dotNetCorePath)
+		static string GetDotNetCoreRuntimePath (string fileName)
 		{
-			string rootDirectory = Path.GetDirectoryName (dotNetCorePath.FileName);
+			string rootDirectory = Path.GetDirectoryName (fileName);
 			return Path.Combine (rootDirectory, "shared", "Microsoft.NETCore.App");
 		}
 	}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntimeVersions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntimeVersions.cs
@@ -51,7 +51,8 @@ namespace MonoDevelop.DotNetCore
 
 			return Directory.EnumerateDirectories (runtimePath)
 				.Select (directory => DotNetCoreVersion.GetDotNetCoreVersionFromDirectory (directory))
-				.Where (version => version != null);
+				.Where (version => version != null)
+				.OrderByDescending (version => version);
 		}
 
 		static string GetDotNetCoreRuntimePath (string fileName)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // DotNetCoreSdk.cs
 //
 // Author:
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MonoDevelop.Core;
 using MonoDevelop.Core.Assemblies;
+using MonoDevelop.Projects.MSBuild;
 
 namespace MonoDevelop.DotNetCore
 {
@@ -39,16 +40,34 @@ namespace MonoDevelop.DotNetCore
 			var sdkPaths = new DotNetCoreSdkPaths ();
 			sdkPaths.FindMSBuildSDKsPath ();
 
-			SdkRootPath = sdkPaths.SdkRootPath;
+			Update (sdkPaths);
+		}
+
+		internal static void Update (DotNetCoreSdkPaths sdkPaths)
+		{
+			RegisterProjectImportSearchPath (MSBuildSDKsPath, sdkPaths.MSBuildSDKsPath);
+
 			MSBuildSDKsPath = sdkPaths.MSBuildSDKsPath;
+			SdkRootPath = sdkPaths.SdkRootPath;
 			IsInstalled = !string.IsNullOrEmpty (MSBuildSDKsPath);
-			Versions = sdkPaths.SdkVersions ?? new DotNetCoreVersion [0];
+			Versions = sdkPaths.SdkVersions ?? Array.Empty<DotNetCoreVersion> ();
 
 			if (!IsInstalled)
 				LoggingService.LogInfo (".NET Core SDK not found.");
 
 			if (IsInstalled)
 				SetFSharpShims ();
+		}
+
+		static void RegisterProjectImportSearchPath (string oldPath, string newPath)
+		{
+			const string propertyName = "MSBuildSDKsPath";
+
+			if (!string.IsNullOrEmpty (oldPath))
+				MSBuildProjectService.UnregisterProjectImportSearchPath (propertyName, oldPath);
+
+			if (!string.IsNullOrEmpty (newPath))
+				MSBuildProjectService.RegisterProjectImportSearchPath (propertyName, newPath);
 		}
 
 		public static bool IsInstalled { get; private set; }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -32,6 +32,16 @@ namespace MonoDevelop.DotNetCore
 {
 	internal class DotNetCoreSdkInstalledCondition : ConditionType
 	{
+		public DotNetCoreSdkInstalledCondition ()
+		{
+			DotNetCoreRuntime.Changed += OnLocationChanged;
+		}
+
+		void OnLocationChanged (object sender, EventArgs e)
+		{
+			NotifyChanged ();
+		}
+
 		/// <summary>
 		/// The SDK version check is not quite correct. It currently only checks the
 		/// latest installed version when it should check all versions installed.

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -29,7 +29,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using MonoDevelop.Core;
-using MonoDevelop.Projects.MSBuild;
 
 namespace MonoDevelop.DotNetCore
 {
@@ -40,12 +39,18 @@ namespace MonoDevelop.DotNetCore
 
 		public void FindMSBuildSDKsPath ()
 		{
-			var dotNetCorePath = new DotNetCorePath ();
-			if (dotNetCorePath.IsMissing)
+			if (DotNetCoreRuntime.IsInstalled)
+				FindMSBuildSDKsPath (DotNetCoreRuntime.FileName);
+		}
+
+		public void FindMSBuildSDKsPath (string dotNetCorePath)
+		{
+			if (string.IsNullOrEmpty (dotNetCorePath))
 				return;
 
-			string rootDirectory = Path.GetDirectoryName (dotNetCorePath.FileName);
+			string rootDirectory = Path.GetDirectoryName (dotNetCorePath);
 			sdkRootPath = Path.Combine (rootDirectory, "sdk");
+
 			if (!Directory.Exists (sdkRootPath))
 				return;
 
@@ -61,8 +66,7 @@ namespace MonoDevelop.DotNetCore
 				return;
 
 			msbuildSDKsPath = Path.Combine (SdksParentDirectory, "Sdks");
-
-			MSBuildProjectService.RegisterProjectImportSearchPath ("MSBuildSDKsPath", MSBuildSDKsPath);
+			Exist = true;
 		}
 
 		public void FindSdkPaths (string sdk)

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -602,4 +602,14 @@
 			id="DotNetCoreMSBuildSdksPathPropertyProvider"
 			class="MonoDevelop.DotNetCore.MSBuildSdksPathGlobalPropertyProvider" />
 	</Extension>
+
+	<Extension path="/MonoDevelop/Ide/GlobalOptionsDialog/Projects/SdkLocations">
+		<Section id="DotNetCore" _label=".NET Core" icon="md-platform-netcore">
+			<Panel
+				id="DotNetCoreSdkSettings"
+				_label=".NET Core"
+				fill="true"
+				class="MonoDevelop.DotNetCore.Gui.DotNetCoreSdkLocationPanel" />
+		</Section>
+	</Extension>
 </ExtensionModel>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
@@ -63,9 +63,7 @@ namespace MonoDevelop.Ide.Templates
 			UpdateCache ();
 		}
 
-		static List<TemplateExtensionNode> projectTemplateNodes = new List<TemplateExtensionNode> ();
 		static List<MicrosoftTemplateEngineSolutionTemplate> projectTemplates = new List<MicrosoftTemplateEngineSolutionTemplate> ();
-		static List<ItemTemplateExtensionNode> itemTemplateNodes = new List<ItemTemplateExtensionNode> ();
 		static List<MicrosoftTemplateEngineItemTemplate> itemTemplates = new List<MicrosoftTemplateEngineItemTemplate> ();
 
 		static void UpdateCache ()
@@ -76,6 +74,8 @@ namespace MonoDevelop.Ide.Templates
 			// Prevent a TypeInitializationException in when calling SettingsLoader.Save when no templates
 			// are available, which throws an exception, by returning here. This prevents the MonoDevelop.Ide addin
 			// from loading. In practice this should not happen unless the .NET Core addin is disabled.
+			var projectTemplateNodes = AddinManager.GetExtensionNodes<TemplateExtensionNode> ("/MonoDevelop/Ide/Templates");
+			var itemTemplateNodes = AddinManager.GetExtensionNodes<ItemTemplateExtensionNode> ("/MonoDevelop/Ide/ItemTemplates");
 			if (!projectTemplateNodes.Any () && !itemTemplateNodes.Any ())
 				return;
 
@@ -129,53 +129,12 @@ namespace MonoDevelop.Ide.Templates
 
 		static void OnProjectTemplateExtensionChanged (object sender, ExtensionNodeEventArgs args)
 		{
-			var node = (TemplateExtensionNode)args.ExtensionNode;
-
-			OnExtensionChanged (projectTemplateNodes, node, args.Change);
+			UpdateCache ();
 		}
 
 		static void OnItemTemplateExtensionChanged (object sender, ExtensionNodeEventArgs args)
 		{
-			var node = (ItemTemplateExtensionNode)args.ExtensionNode;
-
-			OnExtensionChanged (itemTemplateNodes, node, args.Change);
-		}
-
-		static void OnExtensionChanged<T> (List<T> extensionNodes, T node, ExtensionChange change)
-			where T : ExtensionNode
-		{
-			if (change == ExtensionChange.Add) {
-				try {
-					extensionNodes.Add (node);
-				} catch (Exception ex) {
-					LogExtensionChangedError (ex, node);
-				}
-			} else {
-				foreach (var existingNode in extensionNodes) {
-					if (existingNode.Id == node.Id) {
-						extensionNodes.Remove (existingNode);
-						break;
-					}
-				}
-			}
-
 			UpdateCache ();
-		}
-
-		static void LogExtensionChangedError (Exception ex, ExtensionNode node)
-		{
-			string extId = null;
-			string addinId = null;
-
-			if (node != null) {
-				if (node.HasId)
-					extId = node.Id;
-				if (node.Addin != null)
-					addinId = node.Addin.Id;
-			}
-
-			LoggingService.LogError ("Error loading template id {0} in addin {1}:\n{2}",
-				extId ?? "(null)", addinId ?? "(null)", ex.ToString ());
 		}
 
 		public static IEnumerable<SolutionTemplate> GetProjectTemplates ()


### PR DESCRIPTION
Fixes VSTS #566365 Support .NET Core SDK being installed in
non-standard location

In Preferences there is now a Projects - SDK Locations - .NET Core
section that can be used to configure the location of the .NET Core
command line tool (dotnet). This can be used to point to a different
non-standard install location of the .NET Core SDK. After this is
switched the MSBuild hosts are recycled and all .NET Core projects
are re-evaluated to ensure the new locations of any MSBuild targets
is used.

<img width="957" alt="dotnetcorefound" src="https://user-images.githubusercontent.com/372361/37650089-d4b6e570-2c2b-11e8-91c9-b032a021bc78.png">

<img width="956" alt="dotnetcorenotfound" src="https://user-images.githubusercontent.com/372361/37650094-dae9c138-2c2b-11e8-9a3d-e3c0dfdd85da.png">
