### PR TITLE
[529478][Ide] Fix Light search result highlight color in FallbackStyle

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/FallbackStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/FallbackStyle.json
@@ -29,7 +29,7 @@
 	"colors": [
 		{ "name": "Background(Read Only)", "color": "white" },
 
-		{ "name": "Search result background", "color": "#fffeb7" },
+		{ "name": "Search result background", "color": "#fcff54" },
 		{ "name": "Search result background (highlighted)", "color": "#fffc38" },
 
 		{ "name": "Column Ruler", "color": "#eeeeee" },


### PR DESCRIPTION
This changes the search result highlighting color in the Fallback syntax highlighting theme to `#fcff54`, as requested by @vancura  in https://github.com/mono/monodevelop/pull/4140#pullrequestreview-103751898

Fixes VSTS #529478

(cherry picked from commit b44f84c8d05a22ba45218594d18ab5400d27796e)