### PR TITLE
[Core] Improve .NET Core project load times for project with project files

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngine.cs
@@ -68,6 +68,10 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 		}
 
+		public virtual void Evaluate (object projectInstance, bool onlyEvaluateProperties)
+		{
+		}
+
 		public abstract bool GetItemHasMetadata (object item, string name);
 
 		public abstract string GetItemMetadata (object item, string name);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -477,7 +477,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		object readLock = new object ();
 
-		internal MSBuildProjectInstanceInfo LoadNativeInstance ()
+		internal MSBuildProjectInstanceInfo LoadNativeInstance (bool evaluateItems)
 		{
 			lock (readLock) {
 				var supportsMSBuild = UseMSBuildEngine && GetGlobalPropertyGroup ().GetValue ("UseMSBuildEngine", true);
@@ -514,8 +514,10 @@ namespace MonoDevelop.Projects.MSBuild
 						};
 						var xml = SaveToString (ctx);
 
-						foreach (var it in GetAllItems ())
-							it.EvaluatedItemCount = 0;
+						if (evaluateItems) {
+							foreach (var it in GetAllItems ())
+								it.EvaluatedItemCount = 0;
+						}
 
 						nativeProjectInfo.Project = e.LoadProject (this, xml, FileName);
 					} catch (Exception ex) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (projectInstance != null)
 				engine.DisposeProjectInstance (projectInstance);
 
-			info = msproject.LoadNativeInstance ();
+			info = msproject.LoadNativeInstance (!OnlyEvaluateProperties);
 
 			engine = info.Engine;
 			projectInstance = engine.CreateProjectInstance (info.Project);
@@ -103,7 +103,7 @@ namespace MonoDevelop.Projects.MSBuild
 				foreach (var prop in globalProperties)
 					engine.SetGlobalProperty (projectInstance, prop.Key, prop.Value);
 
-				engine.Evaluate (projectInstance);
+				engine.Evaluate (projectInstance, OnlyEvaluateProperties);
 
 				SyncBuildProject (info.ItemMap, info.Engine, projectInstance);
 			} catch (Exception ex) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
@@ -86,6 +86,17 @@ namespace MonoDevelop.Projects
 				OnItemsRemoved (removedItems);
 		}
 
+		internal void SetItems (IEnumerable<T> items, IEnumerable<T> newItems, IEnumerable<T> removedItems)
+		{
+			AssertCanWrite ();
+
+			list = ImmutableList<T>.Empty.AddRange (items);
+			if (newItems.Any ())
+				OnItemsAdded (newItems);
+			if (removedItems.Any ())
+				OnItemsRemoved (removedItems);
+		}
+
 		IEnumerable<T> ReuseExistingItems (IEnumerable<T> items)
 		{
 			var updatedItems = new List<T> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2915,12 +2915,12 @@ namespace MonoDevelop.Projects
 				loadedItems.Clear ();
 
 			HashSet<ProjectItem> unusedItems = null;
-			Dictionary<string, ProjectItem> lookupItems = null;
-			List<ProjectItem> newItems = null;
+			Dictionary<(string Name, string Include), ProjectItem> lookupItems = null;
+			ImmutableList<ProjectItem>.Builder newItems = null;
 			if (IsReevaluating) {
 				unusedItems = new HashSet<ProjectItem> (Items);
-				lookupItems = new Dictionary<string, ProjectItem> ();
-				newItems = new List<ProjectItem> ();
+				lookupItems = new Dictionary<(string Name, string Include), ProjectItem> ();
+				newItems = ImmutableList.CreateBuilder<ProjectItem> ();
 
 				// Improve ReadItem performance by creating a dictionary of items that can be
 				// searched faster than using Items.FirstOrDefault. Building this dictionary takes ~15ms
@@ -2961,9 +2961,9 @@ namespace MonoDevelop.Projects
 				Items.AddRange (localItems);
 		}
 
-		static string GetProjectItemLookupKey (IMSBuildItemEvaluated item)
+		static (string Name, string Include) GetProjectItemLookupKey (IMSBuildItemEvaluated item)
 		{
-			return $"{item.Name}-{item.Include}";
+			return (item.Name, item.Include);
 		}
 
 		protected override void OnSetFormat (MSBuildFileFormat format)
@@ -2983,7 +2983,7 @@ namespace MonoDevelop.Projects
 				productVersion = FileFormat.DefaultProductVersion;
 		}
 
-		internal (ProjectItem Item, bool IsNew) ReadItem (IMSBuildItemEvaluated buildItem, Dictionary<string, ProjectItem> lookupItems)
+		internal (ProjectItem Item, bool IsNew) ReadItem (IMSBuildItemEvaluated buildItem, Dictionary<(string Name, string Include), ProjectItem> lookupItems)
 		{
 			if (IsReevaluating) {
 				// If this item already exists in the current collection of items, reuse it


### PR DESCRIPTION
Fixes VSTS #524077 - Performance: Opening .NET Core project with many
files that are not excluded

Two parts two to this change:

 1. Improve re-evaluation performance
 2. Improve initial project load time

Timinges for .NET Core console project that has a node_modules directory
containing 17150 files:

  - Initial project load time down from ~70-80 seconds down to ~20 seconds.
  - Re-evaluation time from ~110 seconds down to ~20 seconds.