### PR TITLE
[AspNetCore] Fix ASP.NET Core file templates modifying project file

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewImportsPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewImportsPage.xft.xml
@@ -19,6 +19,6 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml" src="MVCViewImportsPage.cshtml" />
+		<File name="${Name}.cshtml" src="MVCViewImportsPage.cshtml" BuildAction="Content" />
 	</TemplateFiles>
 </Template>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewLayoutPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewLayoutPage.xft.xml
@@ -19,6 +19,6 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml" src="MVCViewLayoutPage.cshtml" />
+		<File name="${Name}.cshtml" src="MVCViewLayoutPage.cshtml" BuildAction="Content" />
 	</TemplateFiles>
 </Template>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewPage.xft.xml
@@ -19,6 +19,6 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml" src="MVCViewPage.cshtml" />
+		<File name="${Name}.cshtml" src="MVCViewPage.cshtml" BuildAction="Content" />
 	</TemplateFiles>
 </Template>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewStartPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewStartPage.xft.xml
@@ -19,6 +19,6 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml" src="MVCViewStartPage.cshtml" />
+		<File name="${Name}.cshtml" src="MVCViewStartPage.cshtml" BuildAction="Content" />
 	</TemplateFiles>
 </Template>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/RazorPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/RazorPage.xft.xml
@@ -19,6 +19,6 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml" src="RazorPage.cshtml" />
+		<File name="${Name}.cshtml" src="RazorPage.cshtml" BuildAction="Content" />
 	</TemplateFiles>
 </Template>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/RazorPageWithPageModel.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/RazorPageWithPageModel.xft.xml
@@ -19,7 +19,7 @@
 	
 	<!-- Template Content -->
 	<TemplateFiles>
-		<File name="${Name}.cshtml" src="RazorPageWithPageModel.cshtml" />
-		<File name="${Name}.cshtml.cs" src="RazorPageWithPageModel.cshtml.cs" DependsOn="${Name}.cshtml"  />
+		<File name="${Name}.cshtml" src="RazorPageWithPageModel.cshtml" BuildAction="Content" />
+		<File name="${Name}.cshtml.cs" src="RazorPageWithPageModel.cshtml.cs" />
 	</TemplateFiles>
 </Template>


### PR DESCRIPTION
Adding a new .cshtml file from a file template to an ASP.NET Core
project would modify the project file (.csproj) when it should not be
modified. The problem was the files were added as None items whilst
.cshtml are Content items. The project file would contain the
following after adding a new cshtml file from a template:

<ItemGroup>
  <Content Remove="Views\Index.cshtml" />
</ItemGroup>
<ItemGroup>
  <None Include="Views\Index.cshtml" />
</ItemGroup>

Another problem was that the Razor Page with view model file
template specifies a DependentUpon property so this is added to the
project file and the .cshtml and .cs files are nested where as
the other .cshtml and .cs files created with the initial ASP.NET
Core project template are not nested. The project file would include
the following:

<ItemGroup>
  <Compile Update="Views\Index.cshtml.cs">
    <DependentUpon>Index.cshtml</DependentUpon>
  </Compile>
</ItemGroup>

Note that the .NET Core SDK does not indicate that .cshtml and .cs
files are dependent on each other so they are not currently nested
in the Solution window. New .cshtml files created from these updated
file templates will not be nested in Solution window.

Fixes VSTS #585219 Only new Razor Pages are nested