### PR TITLE
Fix VSTS 581051 - Value cannot be null. Parameter name: context

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -409,6 +409,11 @@ namespace MonoDevelop.Core
 		}
 
 		/// <summary>
+		/// The main UI thread of the application. Needed to initialize the JoinableTaskContext.
+		/// </summary>
+		public static Thread MainThread => mainThread;
+
+		/// <summary>
 		/// Returns true if current thread is GUI thread.
 		/// </summary>
 		public static bool IsMainThread

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/JoinableTaskContextHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/JoinableTaskContextHost.cs
@@ -43,10 +43,7 @@ namespace MonoDevelop.Ide.Composition
 		[ImportingConstructor]
 		public JoinableTaskContextHost ()
 		{
-			Runtime.RunInMainThread (() => {
-				var joinableTaskContext = new JoinableTaskContext ();
-				this.JoinableTaskContext = joinableTaskContext;
-			});
+			JoinableTaskContext = new JoinableTaskContext (Runtime.MainThread, Runtime.MainSynchronizationContext);
 		}
 	}
 }


### PR DESCRIPTION
Fix VSTS 581051 - Value cannot be null. Parameter name: context

Fixes https://developercommunity.visualstudio.com/content/problem/210744/value-cannot-be-null-1.html

When opening a .json file (such as appsettings.json in an ASP.NET Core Web app) you get a fatal error message: Value cannot be null. Parameter name: context.

We think this is because of a race condition, where if someone first requests the JoinableTaskContext from a background thread, the importing constructor of JoinableTaskContextHost runs and returns, because we do not await the task spawned by the constructor. And so we grab the value of JoinableTaskContext property, which is still null, before it is being assigned by the UI thread task that we've started in the constructor.

The solution is to expose the MainThread from the runtime and forcibly initialize the JoinableTaskContext to the already known values of UI thread and SyncContext.

Stack:
System.ArgumentNullException: Value cannot be null.
Parameter name: context
  at Microsoft.VisualStudio.Utilities.JoinableTaskHelper..ctor (Microsoft.VisualStudio.Threading.JoinableTaskContext context) [0x00039] in C:\vs-editor-api\src\Text\Def\Internal\TextData\JoinableTaskHelper.cs:31 
  at Microsoft.VisualStudio.Text.Tagging.Implementation.TagAggregator`1[T]..ctor (Microsoft.VisualStudio.Text.Tagging.Implementation.TagAggregatorFactoryService factory, Microsoft.VisualStudio.Text.Editor.ITextView textView, Microsoft.VisualStudio.Text.Projection.IBufferGraph bufferGraph, Microsoft.VisualStudio.Text.Tagging.TagAggregatorOptions options) [0x00023] in C:\vs-editor-api\src\Text\Impl\TagAggregator\TagAggregator.cs:52 
