### PR TITLE
Fixes issue #4267 Multi-line comment classification not working properly

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RoslynClassificationHighlighting.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RoslynClassificationHighlighting.cs
@@ -150,16 +150,18 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			ScopeStack scopeStack;
 
 			foreach (var curSpan in classifications) {
-				if (curSpan.TextSpan.Start < lastClassifiedOffsetEnd) // Work around for : https://github.com/dotnet/roslyn/issues/25648
+				var start = Math.Max (offset, curSpan.TextSpan.Start);
+				if (start < lastClassifiedOffsetEnd) { // Work around for : https://github.com/dotnet/roslyn/issues/25648
 					continue;
-				if (curSpan.TextSpan.Start > lastClassifiedOffsetEnd) {
+				}
+				if (start > lastClassifiedOffsetEnd) {
 					scopeStack = userScope;
-					ColoredSegment whitespaceSegment = new ColoredSegment (lastClassifiedOffsetEnd - offset, curSpan.TextSpan.Start - lastClassifiedOffsetEnd, scopeStack);
+					ColoredSegment whitespaceSegment = new ColoredSegment (lastClassifiedOffsetEnd - offset, start - lastClassifiedOffsetEnd, scopeStack);
 					coloredSegments.Add (whitespaceSegment);
 				}
 
 				scopeStack = GetStyleScopeStackFromClassificationType (curSpan.ClassificationType);
-				ColoredSegment curColoredSegment = new ColoredSegment (curSpan.TextSpan.Start - offset, curSpan.TextSpan.Length, scopeStack);
+				ColoredSegment curColoredSegment = new ColoredSegment (start - offset, curSpan.TextSpan.Length, scopeStack);
 				coloredSegments.Add (curColoredSegment);
 
 				lastClassifiedOffsetEnd = curSpan.TextSpan.End;


### PR DESCRIPTION
Side effect of last fix. Seems the roslyn classifier can give back a span with a start prior to the requested classification area in case of multi line spans.

It's arguable if this is a bug or not - but anyways that's now handled.