### PR TITLE
[d15-7][UnitTesting] Update Newtonsoft.Json version and do not local copy

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -72,10 +72,12 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
       <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>

--- a/main/src/addins/MonoDevelop.UnitTesting/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.TestPlatform" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.5.0-preview-20170919-04" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Use the same Newtonsoft.Json verson 10.0.3 as used everywhere else.
Also prevent a local copy of the Newtonsoft.Json.dll being copied
to the addin directory.