### PR TITLE
Fix 541368: MSTest not supported in .NET Framework library project

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
@@ -65,6 +65,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			return "<RunSettings>" + new Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration () {
 				TargetFrameworkVersion = Framework.FromString ((project as DotNetProject)?.TargetFramework?.Id?.ToString ()),
 				DisableAppDomain = true,
+				ResultsDirectory = project.BaseIntermediateOutputPath.Combine (Constants.ResultsDirectoryName),
 				ShouldCollectSourceInformation = false,
 				TestAdaptersPaths = GetTestAdapters (project),
 				TestSessionTimeout = 60000,


### PR DESCRIPTION
Problem was very obscure to debug because problem was 2 processes away... Basically when running locally VSfM ResultDirectory was set to `/Path/To/Current/Path/Of/Process/TestResults/` but when VSfM is started via `Finder` or `open /Application/Visual Studio.app/`, `Directory.GetCurrentDirectory()` returns empty, resulting in `/TestResults/` folder and test runner doesn't have permissions to access that folder, hence it failed. Now from VSfM always set ResultDirectory to project `obj/TestResults` folder.