### PR TITLE
Include MonoDevelop.Core.Tests.Addin in SUBDIRS

### DIFF
--- a/main/configure.ac
+++ b/main/configure.ac
@@ -386,6 +386,7 @@ tests/TestRunner/Makefile
 tests/Ide.Tests/Makefile
 tests/MacPlatform.Tests/Makefile
 tests/MonoDevelop.Core.Tests/Makefile
+tests/MonoDevelop.Core.Tests.Addin/Makefile
 tests/MonoDevelop.CSharpBinding.Tests/Makefile
 tests/MonoDevelop.Refactoring.Tests/Makefile
 tests/WindowsPlatform.Tests/Makefile

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/xbuild.include
 
-SUBDIRS=UnitTests MacPlatform.Tests UserInterfaceTests TestRunner Ide.Tests MonoDevelop.CSharpBinding.Tests WindowsPlatform.Tests MonoDevelop.Core.Tests MonoDevelop.Refactoring.Tests
+SUBDIRS=UnitTests MacPlatform.Tests UserInterfaceTests TestRunner Ide.Tests MonoDevelop.CSharpBinding.Tests WindowsPlatform.Tests MonoDevelop.Core.Tests MonoDevelop.Core.Tests.Addin MonoDevelop.Refactoring.Tests
 
 MONO=mono$(SGEN_SUFFIX)
 RUN_TEST=$(MDTOOL_RUN) run-md-tests

--- a/main/tests/MonoDevelop.Core.Tests.Addin/Makefile.am
+++ b/main/tests/MonoDevelop.Core.Tests.Addin/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include


### PR DESCRIPTION
Fixes tarball build. It's smaller than last time!