### PR TITLE
[Ide] Add an internal method to allow reloading extensions attached to a document

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -673,7 +673,19 @@ namespace MonoDevelop.Ide.Gui
 
 			if (window is SdiWorkspaceWindow)
 				((SdiWorkspaceWindow)window).AttachToPathedDocument (GetContent<MonoDevelop.Ide.Gui.Content.IPathedDocument> ());
+		}
 
+		/* In some situation, a document can be associated with an editor
+		 * outside of the normal document opening process. This happens
+		 * for instance with the designers where a single view content
+		 * can host multiple text editor instances. In that case we need
+		 * a way to tell the underlying document both that extensions needs
+		 * to be re-registered and that previous GetContent calls may now
+		 * be out of date. This method serves that purpose.
+		 */
+		internal void ReloadExtensions ()
+		{
+			InitializeExtensionChain ();
 		}
 
 		void InitializeEditor ()


### PR DESCRIPTION
Context: https://github.com/mono/monodevelop/issues/3870

This commits adds an internal method that we can call to reload the extension chain and allow the pathbar widget to be updated when a view content changes the underlying text editor instances it uses (and thus alter the value that can be returned from GetContent).

Note that it's likely still profitable to add a ContentChanged event of some sort in the future to handle the use case described in the issue but that can be done on a longer term effort to support those. In the meantime that method is an acceptable workaround for the subset of features we care about.