### PR TITLE
Fix 581032: Debugger session not properly exited

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -106,7 +106,21 @@ namespace MonoDevelop.Debugger
 				// Refresh the evaluators list
 				evaluators = null;
 			});
+			IdeApp.Exiting += IdeApp_Exiting;
 		}
+
+		static void IdeApp_Exiting (object sender, ExitEventArgs args)
+		{
+			if (!IsDebugging)
+				return;
+			if (MessageService.Confirm (GettextCatalog.GetString (
+						"The debugger is currently running and will have to be stopped. Do you want to stop debugging?"),
+						new AlertButton (GettextCatalog.GetString ("Stop Debugging")))) {
+				Stop ();
+			} else
+				args.Cancel = true;
+		}
+
 
 		public static IExecutionHandler GetExecutionHandler ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -534,13 +534,22 @@ namespace MonoDevelop.Ide
 				DispatchIdleActions (500);
 		}
 
-		
+
 		internal static bool OnExit ()
 		{
-			if (Exiting != null) {
-				ExitEventArgs args = new ExitEventArgs ();
-				Exiting (null, args);
-				return !args.Cancel;
+			var exiting = Exiting;
+			if (exiting != null) {
+				bool haveAnyCancelled = false;
+				var args = new ExitEventArgs ();
+				foreach (ExitEventHandler handler in exiting.GetInvocationList ()) {
+					try {
+						handler (null, args);
+						haveAnyCancelled |= args.Cancel;
+					} catch (Exception ex) {
+						LoggingService.LogError ("Exception processing IdeApp.Exiting handler.", ex);
+					}
+				}
+				return !haveAnyCancelled;
 			}
 			return true;
 		}


### PR DESCRIPTION
Main issue here was that when Attaching to process and user Quiting IDE, it didn't ask user for confirmation, we usually do this when debugging specific project when unloading that project, but we can't do that when attached...
Also modified  IdeApp.Exiting event execution to fix possible issue with different handlers setting Cancel=true, Cancel=false same as 6873f00665b1885a8095454de148075ee678fd68