### PR TITLE
[15.7] [Editor] Fix color of preedit string

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -1186,8 +1186,9 @@ namespace Mono.TextEditor
 					}
 				}
 				if (containsPreedit) {
+					var byteLength = Encoding.UTF8.GetByteCount (textEditor.preeditString);
 					var si = TranslateToUTF8Index (lineText, (uint)(textEditor.preeditOffset - offset), ref curIndex, ref byteIndex);
-					var ei = TranslateToUTF8Index (lineText, (uint)(textEditor.preeditOffset - offset + preeditLength), ref curIndex, ref byteIndex);
+					var ei = TranslateToUTF8Index (lineText, (uint)(textEditor.preeditOffset - offset + byteLength), ref curIndex, ref byteIndex);
 
 					if (textEditor.GetTextEditorData ().IsCaretInVirtualLocation) {
 						uint len = (uint)textEditor.GetTextEditorData ().GetIndentationString (textEditor.Caret.Location).Length;


### PR DESCRIPTION
We're computing the byte indices when we update the color of the preedit
string, but we're using the length of the preedit string instead of the
byte count. For multibyte languages this makes it difficult to see the
entire preedit string, and especially when "highlight current line" is
enabled then part of the string is completely invisible.

Fixes VSTS #591143

Example of the issue:

<img width="291" alt="screen shot 2018-03-28 at 11 26 05 am" src="https://user-images.githubusercontent.com/2041/38043034-882d324e-327b-11e8-924c-0068f87099d8.png">


* VSTS Story/Issue link https://devdiv.visualstudio.com/DevDiv/_workitems/edit/591143

### Tasks

- [x] Draft release notes updated [here](https://github.com/xamarin/studio/wiki)

### Review

- [x] Assign code reviewers.

FWIW, here is a screenshot of the fix:
<img width="285" alt="screen shot 2018-03-28 at 2 42 49 pm" src="https://user-images.githubusercontent.com/2041/38052306-6bf2e23e-3296-11e8-90cd-da92a9747e83.png">
