### PR TITLE
[Editor] Fix color of preedit string

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -1186,8 +1186,9 @@ namespace Mono.TextEditor
 					}
 				}
 				if (containsPreedit) {
+					var byteLength = Encoding.UTF8.GetByteCount (textEditor.preeditString);
 					var si = TranslateToUTF8Index (lineText, (uint)(textEditor.preeditOffset - offset), ref curIndex, ref byteIndex);
-					var ei = TranslateToUTF8Index (lineText, (uint)(textEditor.preeditOffset - offset + preeditLength), ref curIndex, ref byteIndex);
+					var ei = TranslateToUTF8Index (lineText, (uint)(textEditor.preeditOffset - offset + byteLength), ref curIndex, ref byteIndex);
 
 					if (textEditor.GetTextEditorData ().IsCaretInVirtualLocation) {
 						uint len = (uint)textEditor.GetTextEditorData ().GetIndentationString (textEditor.Caret.Location).Length;


### PR DESCRIPTION
We're computing the byte indices when we update the color of the preedit
string, but we're using the length of the preedit string instead of the
byte count. For multibyte languages this makes it difficult to see the
entire preedit string, and especially when "highlight current line" is
enabled then part of the string is completely invisible.

Fixes VSTS #591143

This is https://github.com/mono/monodevelop/pull/4352 but for master