### PR TITLE
Fixes VSTS 590492: [Feedback] Intellisense in Shared Projects seems b…

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtension.cs
@@ -146,10 +146,7 @@ namespace MonoDevelop.CSharp.ClassOutline
 				JumpToDeclaration (true);
 			};
 
-			var analysisDocument = DocumentContext.ParsedDocument;
-			if (analysisDocument != null)
-				lastCU = analysisDocument.GetAst<SemanticModel> ();
-
+			UpdateDocumentOutline (this, EventArgs.Empty);
 			outlineTreeView.Realized += delegate { RefillOutlineStore (); };
 			UpdateSorting ();
 
@@ -283,12 +280,12 @@ namespace MonoDevelop.CSharp.ClassOutline
 		}
 
 		uint refillOutlineStoreId;
-		void UpdateDocumentOutline (object sender, EventArgs args)
+		async void UpdateDocumentOutline (object sender, EventArgs args)
 		{
-			var analysisDocument = DocumentContext.ParsedDocument;
+			var analysisDocument = DocumentContext.AnalysisDocument;
 			if (analysisDocument == null)
 				return;
-			lastCU = analysisDocument.GetAst<SemanticModel> ();
+			lastCU = await analysisDocument.GetSemanticModelAsync ();
 			//limit update rate to 3s
 			if (!refreshingOutline) {
 				refreshingOutline = true;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/CodeGenerationOptions.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/CodeGenerationOptions.cs
@@ -102,8 +102,8 @@ namespace MonoDevelop.CodeGeneration
 		{
 			Editor = editor;
 			DocumentContext = ctx;
-			if (ctx.ParsedDocument != null)
-				CurrentState = ctx.ParsedDocument.GetAst<SemanticModel> ();
+			if (ctx.AnalysisDocument != null)
+				CurrentState = ctx.AnalysisDocument.GetSemanticModelAsync ().WaitAndGetResult ();
 			offset = editor.CaretOffset;
 			var tree = CurrentState.SyntaxTree;
 			EnclosingPart = tree.GetContainingTypeDeclaration (offset, default(CancellationToken));

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -220,11 +220,7 @@ namespace MonoDevelop.CSharp.Completion
 
 		void HandleDocumentParsed (object sender, EventArgs e)
 		{
-			var parsedDocument = DocumentContext.ParsedDocument;
-			if (parsedDocument == null)
-				return;
-			var semanticModel = parsedDocument.GetAst<SemanticModel> ();
-			if (semanticModel == null)
+			if (DocumentContext.AnalysisDocument == null)
 				return;
 			TypeSegmentTreeUpdated?.Invoke (this, EventArgs.Empty);
 		}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
@@ -131,10 +131,9 @@ namespace MonoDevelop.CSharp.Completion
 			ka |= KeyActions.Ignore;
 		}
 
-		static void AddGlobalNamespaceImport (MonoDevelop.Ide.Editor.TextEditor editor, DocumentContext context, string nsName)
+		static async void AddGlobalNamespaceImport (MonoDevelop.Ide.Editor.TextEditor editor, DocumentContext context, string nsName)
 		{
-			var parsedDocument = context.ParsedDocument;
-			var unit = parsedDocument.GetAst<SemanticModel> ();
+			var unit = await context.AnalysisDocument.GetSemanticModelAsync ();
 			if (unit == null)
 				return;
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextEditorIndentation.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextEditorIndentation.cs
@@ -567,8 +567,6 @@ namespace MonoDevelop.CSharp.Formatting
 			SafeUpdateIndentEngine (Editor.CaretOffset);
 			bool skipFormatting = stateTracker.IsInsideOrdinaryCommentOrString;
 			if (!skipFormatting && !(stateTracker.IsInsideComment || stateTracker.IsInsideString)) {
-				if (DocumentContext.ParsedDocument == null || DocumentContext.ParsedDocument.GetAst<SemanticModel> () == null)
-					return;
 				var document = DocumentContext.AnalysisDocument;
 				if (document == null)
 					return;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpCodeGenerator.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpCodeGenerator.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.CSharp.Refactoring
 			public SemanticModel SemanticModel {
 				get {
 					if (semanticModel == null) {
-						var model = DocumentContext.ParsedDocument.GetAst<SemanticModel> ();
+						var model = DocumentContext.AnalysisDocument.GetSemanticModelAsync ().WaitAndGetResult ();
 						return model;
 					}
 					return semanticModel;
@@ -104,7 +104,7 @@ namespace MonoDevelop.CSharp.Refactoring
 				if (DocumentContext == null || Editor == null || SemanticModel == null || DocumentContext.ParsedDocument == null)
 					return ns + "." + name;
 
-				var model = DocumentContext.ParsedDocument.GetAst<SemanticModel>();
+				var model = DocumentContext.AnalysisDocument.GetSemanticModelAsync ().WaitAndGetResult ();
 
 				if (model == null)
 					return ns + "." + name;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFeaturesTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFeaturesTextEditorExtension.cs
@@ -116,7 +116,7 @@ namespace MonoDevelop.CSharp.Refactoring
 			var doc = IdeApp.Workbench.ActiveDocument;
 			if (doc == null || doc.FileName == FilePath.Null)
 				return;
-			if (doc.ParsedDocument == null || doc.ParsedDocument.GetAst<SemanticModel> () == null) {
+			if (DocumentContext.AnalysisDocument == null) {
 				ci.Enabled = false;
 				return;
 			}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/ExtractMethodCommandHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/ExtractMethodCommandHandler.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.CSharp.Refactoring
 		protected override void Update (CommandInfo info)
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
-			info.Enabled = doc != null && doc.ParsedDocument != null && doc.ParsedDocument.GetAst<SemanticModel> () != null;
+			info.Enabled = doc != null && doc.AnalysisDocument != null;
 		}
 
 		public async static Task Run (MonoDevelop.Ide.Gui.Document doc)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/FindReferencesHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/FindReferencesHandler.cs
@@ -126,8 +126,7 @@ namespace MonoDevelop.CSharp.Refactoring
 				info.Enabled = false;
 				return;
 			}
-			var pd = doc.ParsedDocument.GetAst<SemanticModel> ();
-			info.Enabled = pd != null;
+			info.Enabled = doc.AnalysisDocument != null;
 		}
 
 		public void Run (object data)
@@ -169,8 +168,7 @@ namespace MonoDevelop.CSharp.Refactoring
 				info.Enabled = false;
 				return;
 			}
-			var pd = doc.ParsedDocument.GetAst<SemanticModel> ();
-			info.Enabled = pd != null;
+			info.Enabled = doc.AnalysisDocument != null;
 		}
 
 		public void Run (object data)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
@@ -56,18 +56,15 @@ namespace MonoDevelop.CSharp.Refactoring
 				del ();
 		}
 
-		protected override void Update (CommandArrayInfo ainfo)
+		protected override async Task UpdateAsync (CommandArrayInfo ainfo, CancellationToken cancelToken)
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
-			if (doc == null || doc.FileName == FilePath.Null || doc.ParsedDocument == null)
+			if (doc == null || doc.FileName == FilePath.Null || doc.AnalysisDocument == null)
 				return;
-			var semanticModel = doc.ParsedDocument.GetAst<SemanticModel> ();
+			var semanticModel = await doc.AnalysisDocument.GetSemanticModelAsync (cancelToken);
 			if (semanticModel == null)
 				return;
-			var task = RefactoringSymbolInfo.GetSymbolInfoAsync (doc, doc.Editor);
-			if (!task.Wait (2000))
-				return;
-			var info = task.Result;
+			var info = await RefactoringSymbolInfo.GetSymbolInfoAsync (doc, doc.Editor);
 			bool added = false;
 
 			var ext = doc.GetContent<CodeActionEditorExtension> ();

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RenameHandler.cs
@@ -50,7 +50,7 @@ namespace MonoDevelop.CSharp.Refactoring
 			var doc = IdeApp.Workbench.ActiveDocument;
 			if (doc == null || doc.FileName == FilePath.Null)
 				return;
-			ci.Enabled = doc.ParsedDocument != null && doc.ParsedDocument.GetAst<SemanticModel> () != null;
+			ci.Enabled = doc.AnalysisDocument != null;
 		}
 
 		internal static bool CanRename (ISymbol symbol)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/DebuggerExpressionResolver.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/DebuggerExpressionResolver.cs
@@ -55,10 +55,7 @@ namespace MonoDevelop.CSharp.Resolver
 				result = GetInfo (compilationUnit, null, offset, default(CancellationToken));
 			} else {
 				compilationUnit = await analysisDocument.GetCSharpSyntaxRootAsync (cancellationToken).ConfigureAwait (false);
-				var semantic = document.ParsedDocument?.GetAst<SemanticModel> ();
-				if (semantic == null) {
-					semantic = await analysisDocument.GetSemanticModelAsync (cancellationToken).ConfigureAwait (false);
-				}
+				var semantic = await analysisDocument.GetSemanticModelAsync (cancellationToken);
 				result = GetInfo (compilationUnit, semantic, offset, default(CancellationToken));
 			}
 			if (result.IsDefault || !result.Span.Contains(offset)) {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/TextEditorResolverProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Resolver/TextEditorResolverProvider.cs
@@ -27,6 +27,7 @@ using MonoDevelop.Ide.Gui.Content;
 using Microsoft.CodeAnalysis;
 using MonoDevelop.Ide.Editor;
 using System.Linq;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.CSharp.Resolver
 {
@@ -37,10 +38,10 @@ namespace MonoDevelop.CSharp.Resolver
 		public ISymbol GetLanguageItem (MonoDevelop.Ide.Gui.Document document, int offset, out DocumentRegion expressionRegion)
 		{
 			expressionRegion = DocumentRegion.Empty;
-			var parsedDocument = document.ParsedDocument;
+			var parsedDocument = document.AnalysisDocument;
 			if (parsedDocument == null)
 				return null;
-			var model = parsedDocument.GetAst<SemanticModel> ();
+			var model = parsedDocument.GetSemanticModelAsync ().WaitAndGetResult ();
 			if (model == null)
 				return null;
 			foreach (var symbol in model.LookupSymbols (offset)) {
@@ -57,9 +58,9 @@ namespace MonoDevelop.CSharp.Resolver
 
 		public ISymbol GetLanguageItem (MonoDevelop.Ide.Gui.Document document, int offset, string identifier)
 		{
-			if (document.ParsedDocument == null)
+			if (document.AnalysisDocument == null)
 				return null;
-			var model = document.ParsedDocument.GetAst<SemanticModel> ();
+			var model = document.AnalysisDocument.GetSemanticModelAsync ().WaitAndGetResult ();
 			if (model == null)
 				return null;
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
@@ -52,10 +52,10 @@ namespace MonoDevelop.SourceEditor
 		{
 			if (ctx == null)
 				return null;
-			var analysisDocument = ctx.ParsedDocument;
+			var analysisDocument = ctx.AnalysisDocument;
 			if (analysisDocument == null)
 				return null;
-			var unit = analysisDocument.GetAst<SemanticModel> ();
+			var unit = await analysisDocument.GetSemanticModelAsync (token);
 			if (unit == null)
 				return null;
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpNavigationTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpNavigationTextEditorExtension.cs
@@ -45,10 +45,10 @@ namespace MonoDevelop.CSharp
 
 		protected override async Task<IEnumerable<NavigationSegment>> RequestLinksAsync (int offset, int length, CancellationToken token)
 		{
-			var parsedDocument = DocumentContext.ParsedDocument;
-			if (parsedDocument == null)
+			var analysisDocument = DocumentContext.AnalysisDocument;
+			if (analysisDocument == null)
 				return Enumerable.Empty<NavigationSegment> ();
-			var model = parsedDocument.GetAst<SemanticModel> ();
+			var model = await analysisDocument.GetSemanticModelAsync(token);
 			if (model == null)
 				return Enumerable.Empty<NavigationSegment> ();
 			return await Task.Run (async delegate {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/ExpandSelectionHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/ExpandSelectionHandler.cs
@@ -78,13 +78,13 @@ namespace MonoDevelop.CSharp
 			Run (doc);
 		}
 
-		internal static void Run (Ide.Gui.Document doc)
+		internal static async void Run (Ide.Gui.Document doc)
 		{
 			var selectionRange = doc.Editor.SelectionRange;
-			var parsedDocument = doc.ParsedDocument;
-			if (parsedDocument == null)
+			var analysisDocument = doc.AnalysisDocument;
+			if (analysisDocument == null)
 				return;
-			var model = parsedDocument.GetAst<SemanticModel> ();
+			var model = await analysisDocument.GetSemanticModelAsync ();
 			if (model == null)
 				return;
 			var unit = model.SyntaxTree.GetRoot ();

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
@@ -724,15 +724,15 @@ namespace MonoDevelop.CSharp
 			Update ();
 		}
 
-		void Update()
+		async void Update()
 		{
 			if (DocumentContext == null)
 				return;
-			var parsedDocument = DocumentContext.ParsedDocument;
-			if (parsedDocument == null)
+			var analysisDocument = DocumentContext.AnalysisDocument;
+			if (analysisDocument == null)
 				return;
 			var caretOffset = Editor.CaretOffset;
-			var model = parsedDocument.GetAst<SemanticModel>();
+			var model = await analysisDocument.GetSemanticModelAsync ();
 			if (model == null)
 				return;
 			CancelUpdatePath ();
@@ -766,7 +766,6 @@ namespace MonoDevelop.CSharp
 				var curType = node != null ? node.AncestorsAndSelf ().FirstOrDefault (IsType) : null;
 
 				var curProject = ownerProjects != null && ownerProjects.Count > 1 ? DocumentContext.Project : null;
-
 				if (curType == curMember || curType is DelegateDeclarationSyntax)
 					curMember = null;
 				if (isPathSet && curType == lastType && curMember == lastMember && curProject == lastProject) {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/SignatureMarkupCreator.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/SignatureMarkupCreator.cs
@@ -48,6 +48,7 @@ using ICSharpCode.NRefactory6.CSharp;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.CSharp.Completion;
 using System.Threading;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.CSharp
 {
@@ -131,9 +132,9 @@ namespace MonoDevelop.CSharp
 			if (ctx != null) {
 				SemanticModel model = SemanticModel;
 				if (model == null) {
-					var parsedDocument = ctx.ParsedDocument;
-					if (parsedDocument != null) {
-						model = parsedDocument.GetAst<SemanticModel> () ?? ctx.AnalysisDocument?.GetSemanticModelAsync ().Result;
+					var analysisDocument = ctx.AnalysisDocument;
+					if (analysisDocument != null) {
+						model = analysisDocument.GetSemanticModelAsync ().WaitAndGetResult ();
 					}
 				}
 				//Math.Min (model.SyntaxTree.Length, offset)) is needed in case parsedDocument.GetAst<SemanticModel> () is outdated

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/ParsedDocument.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/ParsedDocument.cs
@@ -120,7 +120,9 @@ namespace MonoDevelop.Ide.TypeSystem
 			get;
 			set;
 		}
-		
+
+
+		[Obsolete("Do not use this system anymore. Use the analysisDocument.GetSemanticModelAsync () instead.")]
 		public T GetAst<T> () where T : class
 		{
 			return Ast as T;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/TaskUtil.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/TaskUtil.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Ide
 			public static readonly Task<IEnumerable<T>> EmptyEnumerable = Task.FromResult<IEnumerable<T>>(new T[0]);
 		}
 
-		public static T WaitAndGetResult<T> (this Task<T> task, CancellationToken cancellationToken)
+		public static T WaitAndGetResult<T> (this Task<T> task, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			task.Wait (cancellationToken);
 			return task.Result;

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/GenerateNewMemberTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/GenerateNewMemberTests.cs
@@ -128,7 +128,7 @@ namespace MonoDevelop.CSharpBinding.Refactoring
 			content.Project = project;
 			doc.SetProject (project);
 			var parsedFile = await doc.UpdateParseDocument ();
-			var model = parsedFile.GetAst<SemanticModel> ();
+			var model = await doc.AnalysisDocument.GetSemanticModelAsync ();
 			var sym = model?.GetEnclosingSymbol (data.Text.IndexOf ('{'));
 			var type = sym as INamedTypeSymbol ?? sym?.ContainingType;
 			if (type != null) {


### PR DESCRIPTION
…roken in latest Visual Studio for Mac

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/590492

The GetAst infrastructure is incompatible with roslyn and broke in the shared project context - so I removed the usages there.
It has only historically been used for nrefactory.