### PR TITLE
Fixes VSTS 591385: [Feedback] Visual Studio Mac Community, find

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
@@ -157,7 +157,7 @@ namespace MonoDevelop.CSharp.Refactoring
 
 			if (typeId.Length < reminder)
 				return null;
-			if (string.CompareOrdinal (documentationCommentId, reminder, typeId, reminder, idx - reminder - 1) == 0) {
+			if (string.CompareOrdinal (documentationCommentId, reminder, typeId + ".", reminder, idx - reminder) == 0) {
 				if (typeId.Length > idx)
 					return null;
 				foreach (var subType in current.GetTypeMembers ()) {

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpFindReferencesProviderTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpFindReferencesProviderTests.cs
@@ -123,5 +123,29 @@ public void Foo(int i, int j) {}
 			Assert.AreEqual (2, refs.Count);
 		}
 
+		/// <summary>
+		/// Bug 591385: [Feedback] Visual Studio Mac Community, find reference stops working in some classes.
+		/// </summary>
+		[Test]
+		public async Task TestBug591385 ()
+		{
+			var refs = await GatherReferences (@"
+public class RefBug {
+    public int xxx;
+    public void Meth() { xxx++; }
+}
+
+public class RefBug2
+{
+    public int xxx;
+    public void Meth() { xxx++; }
+}
+
+", project => {
+				var provider = new CSharpFindReferencesProvider ();
+				return provider.FindAllReferences ("F:RefBug2.xxx", project, default (CancellationToken));
+			});
+			Assert.AreEqual (2, refs.Count);
+		}
 	}
 }


### PR DESCRIPTION
reference stops working in some classes.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/591385