### PR TITLE
[Performance] Only calculate the DocumentLocation once per mouse move

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
@@ -232,7 +232,12 @@ namespace Mono.TextEditor
 			get;
 			private set;
 		}
-		
+
+		public DocumentLocation Location {
+			get;
+			internal set;
+		}
+
 		public bool TriggersContextMenu ()
 		{
 			var evt = RawEvent as Gdk.EventButton;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1652,8 +1652,6 @@ namespace Mono.TextEditor
 			mx = x - textViewMargin.XOffset;
 			my = y;
 
-			ShowTooltip (state);
-
 			double startPos;
 			Margin margin;
 			if (textViewMargin.InSelectionDrag) {
@@ -1672,12 +1670,18 @@ namespace Mono.TextEditor
 				}
 			}
 
+			var location = textViewMargin.PointToLocation (x - startPos, y, snapCharacters: true);
 			if (oldMargin != margin && oldMargin != null)
 				oldMargin.MouseLeft ();
-			
-			if (margin != null) 
-				margin.MouseHover (new MarginMouseEventArgs (textEditorData.Parent, EventType.MotionNotify,
-					mouseButtonPressed, x - startPos, y, state));
+
+			ShowTooltip (state, location);
+			if (margin != null) {
+				var args = new MarginMouseEventArgs (textEditorData.Parent, EventType.MotionNotify,
+				                                     mouseButtonPressed, x - startPos, y, state);
+				args.Location = location;
+				margin.MouseHover (args);
+			}
+
 			oldMargin = margin;
 		}
 
@@ -3075,28 +3079,27 @@ namespace Mono.TextEditor
 		Gdk.ModifierType nextTipModifierState = ModifierType.None;
 		DateTime nextTipScheduledTime; // Time at which we want the tooltip to show
 		
-		void ShowTooltip (Gdk.ModifierType modifierState)
+		void ShowTooltip (Gdk.ModifierType modifierState, DocumentLocation location)
 		{
 			if (mx < TextViewMargin.TextStartPosition) {
 				HideTooltip ();
 				return;
 			}
 
-			var loc = PointToLocation (mx, my, true);
-			if (loc.IsEmpty) {
+			if (location.IsEmpty) {
 				HideTooltip ();
 				return;
 			}
 
 			// Hide editor tooltips for text marker extended regions (message bubbles)
-			double y = LineToY (loc.Line);
+			double y = LineToY (location.Line);
 			if (y + LineHeight < my) {
 				HideTooltip ();
 				return;
 			}
 			
 			ShowTooltip (modifierState, 
-			             Document.LocationToOffset (loc),
+			             Document.LocationToOffset (location),
 			             (int)mx,
 			             (int)my);
 		}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -2693,7 +2693,7 @@ namespace Mono.TextEditor
 
 		protected internal override void MouseHover (MarginMouseEventArgs args)
 		{
-			var loc = PointToLocation (args.X, args.Y, snapCharacters: true);
+			var loc = args.Location;
 			if (loc.Line < DocumentLocation.MinLine || loc.Column < DocumentLocation.MinColumn)
 				return;
 			var line = Document.GetLine (loc.Line);


### PR DESCRIPTION
PointToLocation was being called once in TextViewMargin.MouseHover and once in
ShowTooltip, both called from TextArea.FireMotionEvent. Calculate the
DocumentLocation once in FireMotionEvent and pass it to the sub methods

Fixes GH #4380 