### PR TITLE
Supply SortText to preserve protocol methods in the completion list

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CompletionProvider/ProtocolMemberCompletionProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CompletionProvider/ProtocolMemberCompletionProvider.cs
@@ -157,7 +157,7 @@ namespace MonoDevelop.CSharp.Completion.Provider
 				pDict = pDict.Add ("DeclarationBegin", declarationBegin.ToString());
 
 				var tags = ImmutableArray<string>.Empty.Add ("NewMethod");
-				var completionData = CompletionItem.Create (m.Name, properties: pDict, rules: ProtocolCompletionRules, tags: tags);
+				var completionData = CompletionItem.Create (m.Name, sortText: m.ToSignatureDisplayString (), properties: pDict, rules: ProtocolCompletionRules, tags: tags);
 				context.AddItem (completionData);
 			}
 		}


### PR DESCRIPTION
This PR is an attempt to fix the following issues:
* https://github.com/xamarin/xamarin-macios/issues/3762
* https://devdiv.visualstudio.com/DevDiv/_workitems/edit/585126
* https://github.com/mono/monodevelop/issues/4216

Essentially the problem boils down to iOS/Mac protocol method overloads not showing up in the completion list.

The fix description:

When we generate completion items in `ProtocolMemberCompletionProvider`, methods with the same name (but different signature) get similar completion info. Specifically, they get the same `SortText` and `Span`.

These two properties are then used by Roslyn to remove duplicates when merging multiple completion contexts. Refer to this code for more details:
https://github.com/dotnet/roslyn/blob/master/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs#L360

If two completion items have the same `DisplayName`, `SortText`, and `Span` the completion service will consider removing one of those items from the list. This is precisely the root cause of https://github.com/xamarin/xamarin-macios/issues/3762

By changing the `SortText` property of protocol methods we will help the completion service to distinct similar items and remove only duplicates that have the same name, span, and signature.

How it worked before:
![categorycompletion](https://user-images.githubusercontent.com/1524073/38102682-f2384864-3351-11e8-9e4c-22313b729e88.gif)

How it works now:
![categorycompletion](https://user-images.githubusercontent.com/1524073/38102501-73dc25bc-3351-11e8-8dba-6e77fde98b2d.gif)