### PR TITLE
[d15-7][Forms] Use dotnet templating project templates 

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -377,6 +377,7 @@
     <InternalsVisibleTo Include="DotNetCore.Debugger" />
     <InternalsVisibleTo Include="MonoDevelop.UnitTesting" />
     <InternalsVisibleTo Include="MonoDevelop.DotNetCore.Tests" />
+    <InternalsVisibleTo Include="Xamarin.Forms.Addin" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/FinalProjectConfigurationPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/FinalProjectConfigurationPage.cs
@@ -42,6 +42,8 @@ namespace MonoDevelop.Ide.Projects
 		bool projectNameIsReadOnly;
 		bool? createProjectDirectoryInsideSolutionDirectory;
 		bool createProjectDirectoryInsideSolutionDirectoryEnabled = true;
+		bool? createGitIgnoreFile;
+		bool gitIgnoreEnabled = true;
 
 		public FinalProjectConfigurationPage (NewProjectConfiguration config)
 		{
@@ -140,7 +142,12 @@ namespace MonoDevelop.Ide.Projects
 		}
 
 		public bool CreateGitIgnoreFile {
-			get { return config.CreateGitIgnoreFile; }
+			get {
+				if (createGitIgnoreFile.HasValue) {
+					return createGitIgnoreFile.Value;
+				}
+				return config.CreateGitIgnoreFile;
+			}
 			set { config.CreateGitIgnoreFile = value; }
 		}
 
@@ -172,7 +179,7 @@ namespace MonoDevelop.Ide.Projects
 		}
 
 		public bool IsGitIgnoreEnabled {
-			get { return config.UseGit && IsUseGitEnabled; }
+			get { return config.UseGit && IsUseGitEnabled && gitIgnoreEnabled; }
 		}
 
 		public bool IsUseGitEnabled { get; set; }
@@ -238,11 +245,20 @@ namespace MonoDevelop.Ide.Projects
 			ProjectName = Parameters ["ProjectName"];
 			projectNameIsReadOnly = Parameters.GetBoolValue ("IsProjectNameReadOnly", false);
 
-			string value = Parameters ["CreateProjectDirectoryInsideSolutionDirectory"];
-			if (!string.IsNullOrEmpty (value)) {
-				createProjectDirectoryInsideSolutionDirectory = Parameters.GetBoolValue ("CreateProjectDirectoryInsideSolutionDirectory", config.CreateProjectDirectoryInsideSolutionDirectory);
-			}
+			createProjectDirectoryInsideSolutionDirectory = GetParameterValue ("CreateProjectDirectoryInsideSolutionDirectory");
 			createProjectDirectoryInsideSolutionDirectoryEnabled = Parameters. GetBoolValue ("IsCreateProjectDirectoryInsideSolutionDirectoryEnabled", true);
+
+			createGitIgnoreFile = GetParameterValue ("CreateGitIgnoreFile");
+			gitIgnoreEnabled = Parameters.GetBoolValue ("IsGitIgnoreEnabled", true);
+		}
+
+		bool? GetParameterValue (string name)
+		{
+			string value = Parameters [name];
+			if (!string.IsNullOrEmpty (value)) {
+				return Parameters.GetBoolValue (name);
+			}
+			return null;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/FinalProjectConfigurationPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/FinalProjectConfigurationPage.cs
@@ -40,6 +40,8 @@ namespace MonoDevelop.Ide.Projects
 		SolutionTemplate template;
 		bool valid;
 		bool projectNameIsReadOnly;
+		bool? createProjectDirectoryInsideSolutionDirectory;
+		bool createProjectDirectoryInsideSolutionDirectoryEnabled = true;
 
 		public FinalProjectConfigurationPage (NewProjectConfiguration config)
 		{
@@ -148,7 +150,12 @@ namespace MonoDevelop.Ide.Projects
 		}
 
 		public bool CreateProjectDirectoryInsideSolutionDirectory {
-			get { return config.CreateProjectDirectoryInsideSolutionDirectory; }
+			get {
+				if (createProjectDirectoryInsideSolutionDirectory.HasValue) {
+					return createProjectDirectoryInsideSolutionDirectory.Value;
+				}
+				return config.CreateProjectDirectoryInsideSolutionDirectory;
+			}
 			set { config.CreateProjectDirectoryInsideSolutionDirectory = value; }
 		}
 
@@ -161,7 +168,7 @@ namespace MonoDevelop.Ide.Projects
 		}
 
 		public bool IsCreateProjectDirectoryInsideSolutionDirectoryEnabled {
-			get { return HasProjects && IsNewSolution; }
+			get { return HasProjects && IsNewSolution && createProjectDirectoryInsideSolutionDirectoryEnabled; }
 		}
 
 		public bool IsGitIgnoreEnabled {
@@ -230,6 +237,12 @@ namespace MonoDevelop.Ide.Projects
 		{
 			ProjectName = Parameters ["ProjectName"];
 			projectNameIsReadOnly = Parameters.GetBoolValue ("IsProjectNameReadOnly", false);
+
+			string value = Parameters ["CreateProjectDirectoryInsideSolutionDirectory"];
+			if (!string.IsNullOrEmpty (value)) {
+				createProjectDirectoryInsideSolutionDirectory = Parameters.GetBoolValue ("CreateProjectDirectoryInsideSolutionDirectory", config.CreateProjectDirectoryInsideSolutionDirectory);
+			}
+			createProjectDirectoryInsideSolutionDirectoryEnabled = Parameters. GetBoolValue ("IsCreateProjectDirectoryInsideSolutionDirectoryEnabled", true);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
@@ -247,7 +247,7 @@ namespace MonoDevelop.Ide.Projects
 			solutionNameTextBox.Sensitive = projectConfiguration.IsSolutionNameEnabled;
 			projectNameTextBox.Sensitive = projectConfiguration.IsProjectNameEnabled;
 			createProjectWithinSolutionDirectoryCheckBox.Sensitive = projectConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled;
-			createProjectWithinSolutionDirectoryCheckBox.Active = projectConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled ? projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory : true;
+			createProjectWithinSolutionDirectoryCheckBox.Active = projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory;
 			useGitCheckBox.Sensitive = projectConfiguration.IsUseGitEnabled;
 			useGitCheckBox.Active = projectConfiguration.UseGit;
 			createGitIgnoreFileCheckBox.Sensitive = projectConfiguration.IsGitIgnoreEnabled;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -59,8 +59,8 @@ namespace MonoDevelop.Ide.Projects
 		string configureYourWorkspaceBannerText = GettextCatalog.GetString ("Configure your new workspace");
 		string configureYourSolutionBannerText = GettextCatalog.GetString ("Configure your new solution");
 
-		const string UseGitPropertyName = "Dialogs.NewProjectDialog.UseGit";
-		const string CreateGitIgnoreFilePropertyName = "Dialogs.NewProjectDialog.CreateGitIgnoreFile";
+		internal const string UseGitPropertyName = "Dialogs.NewProjectDialog.UseGit";
+		internal const string CreateGitIgnoreFilePropertyName = "Dialogs.NewProjectDialog.CreateGitIgnoreFile";
 		internal const string CreateProjectSubDirectoryPropertyName = "MonoDevelop.Core.Gui.Dialogs.NewProjectDialog.AutoCreateProjectSubdir";
 		const string NewSolutionLastSelectedCategoryPropertyName = "Dialogs.NewProjectDialog.LastSelectedCategoryPath";
 		const string NewSolutionLastSelectedTemplatePropertyName = "Dialogs.NewProjectDialog.LastSelectedTemplate";
@@ -270,7 +270,9 @@ namespace MonoDevelop.Ide.Projects
 		void UpdateDefaultGitSettings ()
 		{
 			PropertyService.Set (UseGitPropertyName, projectConfiguration.UseGit);
-			PropertyService.Set (CreateGitIgnoreFilePropertyName, projectConfiguration.CreateGitIgnoreFile);
+
+			if (finalConfigurationPage.IsGitIgnoreEnabled)
+				PropertyService.Set (CreateGitIgnoreFilePropertyName, projectConfiguration.CreateGitIgnoreFile);
 		}
 
 		protected virtual INewProjectDialogBackend CreateNewProjectDialog ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -204,7 +204,7 @@ namespace MonoDevelop.Ide.Projects
 		void UpdateDefaultSettings ()
 		{
 			UpdateDefaultGitSettings ();
-			if (IsNewSolution)
+			if (IsNewSolution && finalConfigurationPage.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled)
 				PropertyService.Set (CreateProjectSubDirectoryPropertyName, projectConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
 			PropertyService.Set (SelectedLanguagePropertyName, GetLanguageForTemplateProcessing ());
 			DefaultSelectedCategoryPath = GetSelectedCategoryPath ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
@@ -333,25 +333,11 @@ namespace MonoDevelop.Ide.Templates
 
 		class MyTemplateEngineHost : DefaultTemplateEngineHost
 		{
-			public MyTemplateEngineHost ()
-				: base (BrandingService.ApplicationName, BuildInfo.CompatVersion, "en-US", new Dictionary<string, string> { { "dotnet-cli-version", "0" } }, new Dictionary<Guid, Func<Type>>
-			{
-				{ new Guid("0C434DF7-E2CB-4DEE-B216-D7C58C8EB4B3"), () => typeof(RunnableProjectGenerator) },
-				{ new Guid("3147965A-08E5-4523-B869-02C8E9A8AAA1"), () => typeof(BalancedNestingConfig) },
-				{ new Guid("3E8BCBF0-D631-45BA-A12D-FBF1DE03AA38"), () => typeof(ConditionalConfig) },
-				{ new Guid("A1E27A4B-9608-47F1-B3B8-F70DF62DC521"), () => typeof(FlagsConfig) },
-				{ new Guid("3FAE1942-7257-4247-B44D-2DDE07CB4A4A"), () => typeof(IncludeConfig) },
-				{ new Guid("3D33B3BF-F40E-43EB-A14D-F40516F880CD"), () => typeof(RegionConfig) },
-				{ new Guid("62DB7F1F-A10E-46F0-953F-A28A03A81CD1"), () => typeof(ReplacementConfig) },
-				{ new Guid("370996FE-2943-4AED-B2F6-EC03F0B75B4A"), () => typeof(ConstantMacro) },
-				{ new Guid("BB625F71-6404-4550-98AF-B2E546F46C5F"), () => typeof(EvaluateMacro) },
-				{ new Guid("10919008-4E13-4FA8-825C-3B4DA855578E"), () => typeof(GuidMacro) },
-				{ new Guid("F2B423D7-3C23-4489-816A-41D8D2A98596"), () => typeof(NowMacro) },
-				{ new Guid("011E8DC1-8544-4360-9B40-65FD916049B7"), () => typeof(RandomMacro) },
-				{ new Guid("8A4D4937-E23F-426D-8398-3BDBD1873ADB"), () => typeof(RegexMacro) },
-				{ new Guid("B57D64E0-9B4F-4ABE-9366-711170FD5294"), () => typeof(SwitchMacro) },
-				{ new Guid("10919118-4E13-4FA9-825C-3B4DA855578E"), () => typeof(CaseChangeMacro) }
-			}.ToList ())
+			static readonly AssemblyComponentCatalog builtIns = new AssemblyComponentCatalog (new[] {
+				typeof (RunnableProjectGenerator).Assembly,
+			});
+
+			public MyTemplateEngineHost () : base (BrandingService.ApplicationName, BuildInfo.CompatVersion, "en-US", new Dictionary<string, string> { { "dotnet-cli-version", "0" } }, builtIns)
 			{
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -118,22 +118,22 @@
       <HintPath>..\..\..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170615.10\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Abstractions">
-      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Abstractions.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Abstractions.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Abstractions.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Core">
-      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Core.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Core.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Core.Contracts">
-      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Core.Contracts.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Core.Contracts.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Core.Contracts.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Core.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Edge">
-      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Edge.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Edge.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Edge.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Edge.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects">
-      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Utils">
-      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Utils.1.0.0-beta2-20170523-241\lib\net45\Microsoft.TemplateEngine.Utils.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Utils.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Composition, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Composition.15.6.36\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.TemplateEngine.Abstractions" version="1.0.0-beta2-20170523-241" targetFramework="net461" />
-  <package id="Microsoft.TemplateEngine.Core" version="1.0.0-beta2-20170523-241" targetFramework="net461" />
-  <package id="Microsoft.TemplateEngine.Core.Contracts" version="1.0.0-beta2-20170523-241" targetFramework="net461" />
-  <package id="Microsoft.TemplateEngine.Edge" version="1.0.0-beta2-20170523-241" targetFramework="net461" />
-  <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta2-20170523-241" targetFramework="net461" />
-  <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta2-20170523-241" targetFramework="net461" />
+  <package id="Microsoft.TemplateEngine.Abstractions" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
+  <package id="Microsoft.TemplateEngine.Core" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
+  <package id="Microsoft.TemplateEngine.Core.Contracts" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
+  <package id="Microsoft.TemplateEngine.Edge" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
+  <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
+  <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
@@ -35,6 +35,8 @@ namespace MonoDevelop.Ide.Projects
 	{
 		TestableNewProjectDialogController controller;
 		bool createProjectDirectoryOriginalValue;
+		bool useGitOriginalValue;
+		bool useGitIgnoreOriginalValue;
 
 		[TestFixtureSetUp]
 		public void SetUp ()
@@ -44,6 +46,9 @@ namespace MonoDevelop.Ide.Projects
 			createProjectDirectoryOriginalValue = PropertyService.Get (
 				NewProjectDialogController.CreateProjectSubDirectoryPropertyName,
 				true);
+
+			useGitOriginalValue = PropertyService.Get (NewProjectDialogController.UseGitPropertyName, false);
+			useGitIgnoreOriginalValue = PropertyService.Get (NewProjectDialogController.CreateGitIgnoreFilePropertyName, true);
 		}
 
 		public override void TearDown ()
@@ -52,6 +57,9 @@ namespace MonoDevelop.Ide.Projects
 			PropertyService.Set (
 				NewProjectDialogController.CreateProjectSubDirectoryPropertyName,
 				createProjectDirectoryOriginalValue);
+
+			PropertyService.Set (NewProjectDialogController.UseGitPropertyName, useGitOriginalValue);
+			PropertyService.Set (NewProjectDialogController.CreateGitIgnoreFilePropertyName, useGitIgnoreOriginalValue);
 		}
 
 		void CreateDialog ()
@@ -217,6 +225,87 @@ namespace MonoDevelop.Ide.Projects
 
 			Assert.IsFalse (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
 			Assert.IsFalse (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+		}
+
+		[TestCase (true, true)]
+		[TestCase (true, false)]
+		[TestCase (false, true)]
+		[TestCase (false, false)]
+		public void Git_NewSolution_FinalConfigurationPage (bool useGit, bool createGitIgnore)
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			PropertyService.Set (NewProjectDialogController.UseGitPropertyName, useGit);
+			PropertyService.Set (NewProjectDialogController.CreateGitIgnoreFilePropertyName, createGitIgnore);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			Assert.AreEqual (useGit, controller.FinalConfiguration.UseGit);
+			Assert.AreEqual (createGitIgnore, controller.FinalConfiguration.CreateGitIgnoreFile);
+			Assert.AreEqual (useGit, controller.FinalConfiguration.IsGitIgnoreEnabled);
+			Assert.IsTrue (controller.FinalConfiguration.IsUseGitEnabled);
+		}
+
+		[TestCase (true, true)]
+		[TestCase (true, false)]
+		[TestCase (false, true)]
+		[TestCase (false, false)]
+		public void Git_ExistingSolution_FinalConfigurationPage (bool useGit, bool createGitIgnore)
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			UseExistingSolution ();
+			PropertyService.Set (NewProjectDialogController.UseGitPropertyName, useGit);
+			PropertyService.Set (NewProjectDialogController.CreateGitIgnoreFilePropertyName, createGitIgnore);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			Assert.AreEqual (useGit, controller.FinalConfiguration.UseGit);
+			Assert.AreEqual (createGitIgnore, controller.FinalConfiguration.CreateGitIgnoreFile);
+			Assert.IsFalse (controller.FinalConfiguration.IsGitIgnoreEnabled);
+			Assert.IsFalse (controller.FinalConfiguration.IsUseGitEnabled);
+		}
+
+		[TestCase (true, true)]
+		[TestCase (true, false)]
+		[TestCase (false, true)]
+		[TestCase (false, false)]
+		public void Git_NewSolution_OverriddenGitIgnoreSettings_FinalConfigurationPage (bool useGit, bool createGitIgnore)
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			PropertyService.Set (NewProjectDialogController.UseGitPropertyName, useGit);
+			PropertyService.Set (NewProjectDialogController.CreateGitIgnoreFilePropertyName, createGitIgnore);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			controller.FinalConfiguration.Parameters ["CreateGitIgnoreFile"] = bool.TrueString;
+			controller.FinalConfiguration.Parameters ["IsGitIgnoreEnabled"] = bool.FalseString;
+			controller.FinalConfiguration.UpdateFromParameters ();
+
+			Assert.IsTrue (controller.FinalConfiguration.CreateGitIgnoreFile);
+			Assert.IsFalse (controller.FinalConfiguration.IsGitIgnoreEnabled);
+			Assert.IsTrue (controller.FinalConfiguration.IsUseGitEnabled);
+
+			controller.FinalConfiguration.Parameters ["CreateGitIgnoreFile"] = bool.FalseString;
+			controller.FinalConfiguration.Parameters ["IsGitIgnoreEnabled"] = bool.FalseString;
+			controller.FinalConfiguration.UpdateFromParameters ();
+
+			Assert.IsFalse (controller.FinalConfiguration.CreateGitIgnoreFile);
+			Assert.IsFalse (controller.FinalConfiguration.IsGitIgnoreEnabled);
+			Assert.IsTrue (controller.FinalConfiguration.IsUseGitEnabled);
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/NewProjectDialogTests.cs
@@ -162,5 +162,61 @@ namespace MonoDevelop.Ide.Projects
 			Assert.IsTrue (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
 			Assert.IsFalse (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
 		}
+
+		[Test]
+		public void FinalPage_ProjectNameTests ()
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			PropertyService.Set (NewProjectDialogController.CreateProjectSubDirectoryPropertyName, true);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+			controller.FinalConfiguration.UpdateFromParameters ();
+			controller.FinalConfiguration.ProjectName = "Test";
+
+			Assert.IsTrue (controller.FinalConfiguration.IsProjectNameEnabled);
+			Assert.AreEqual ("Test", controller.FinalConfiguration.ProjectName);
+
+			controller.FinalConfiguration.Parameters ["ProjectName"] = "ChangedName";
+			controller.FinalConfiguration.Parameters ["IsProjectNameReadOnly"] = bool.TrueString;
+
+			controller.FinalConfiguration.UpdateFromParameters ();
+
+			Assert.IsFalse (controller.FinalConfiguration.IsProjectNameEnabled);
+			Assert.AreEqual ("ChangedName", controller.FinalConfiguration.ProjectName);
+		}
+
+		[TestCase (true)]
+		[TestCase (false)]
+		public void CreateProjectDirectorySetting_WizardOverridesProperty (bool createProjectSubDirectory)
+		{
+			CreateDialog ();
+			CSharpLibraryTemplateSelectedByDefault ();
+			PropertyService.Set (NewProjectDialogController.CreateProjectSubDirectoryPropertyName, createProjectSubDirectory);
+
+			controller.Backend.OnShowDialogCalled = () => {
+				controller.MoveToNextPage ();
+			};
+
+			controller.Show ();
+
+			controller.FinalConfiguration.Parameters ["CreateProjectDirectoryInsideSolutionDirectory"] = bool.TrueString;
+			controller.FinalConfiguration.Parameters ["IsCreateProjectDirectoryInsideSolutionDirectoryEnabled"] = bool.TrueString;
+			controller.FinalConfiguration.UpdateFromParameters ();
+
+			Assert.IsTrue (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			Assert.IsTrue (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+
+			controller.FinalConfiguration.Parameters ["CreateProjectDirectoryInsideSolutionDirectory"] = bool.FalseString;
+			controller.FinalConfiguration.Parameters ["IsCreateProjectDirectoryInsideSolutionDirectoryEnabled"] = bool.FalseString;
+			controller.FinalConfiguration.UpdateFromParameters ();
+
+			Assert.IsFalse (controller.FinalConfiguration.CreateProjectDirectoryInsideSolutionDirectory);
+			Assert.IsFalse (controller.FinalConfiguration.IsCreateProjectDirectoryInsideSolutionDirectoryEnabled);
+		}
 	}
 }

--- a/main/tests/Ide.Tests/ProjectTemplateTests.cs
+++ b/main/tests/Ide.Tests/ProjectTemplateTests.cs
@@ -266,6 +266,46 @@ namespace MonoDevelop.Ide
 				Assert.AreEqual (expectedXml, xml);
 			}
 		}
+
+		/// <summary>
+		/// Support new lines in a description that is a single line.
+		/// </summary>
+		[Test]
+		public void MicrosoftTemplateEngine_DescriptionParsing ()
+		{
+			string result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription ("test");
+			Assert.AreEqual ("test", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"test\n");
+			Assert.AreEqual ("test" + Environment.NewLine, result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"\ntest");
+			Assert.AreEqual (Environment.NewLine + "test", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"t\nest");
+			Assert.AreEqual ("t" + Environment.NewLine + "est", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"t\n\nest");
+			Assert.AreEqual ("t" + Environment.NewLine + Environment.NewLine + "est", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"test\\n");
+			Assert.AreEqual (@"test\n", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"\\ntest");
+			Assert.AreEqual (@"\ntest", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"test\");
+			Assert.AreEqual (@"test\", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"te\st");
+			Assert.AreEqual (@"te\st", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (@"te\\st");
+			Assert.AreEqual (@"te\\st", result);
+
+			result = MicrosoftTemplateEngineSolutionTemplate.ParseDescription (null);
+			Assert.IsNull (result);
+		}
 	}
 }
 


### PR DESCRIPTION
 - Updated the templating engine to fix problems with @ characters in file names being incorrectly encoded on creating the project.
 - Support new lines in descriptions for templates using new templating engine.
 - Allow options on the final page to be configured from a project template wizard.
    - Gitignore
    - Create project directory

VSTS #521689

Backport of  #3912 without any change to the version-checks. It can be merged without the Xamarin.Forms project template changes, whilst #589649 is not yet resolved.