### PR TITLE
[VSTS] Bring in support for a local resolve directory for gtk

### DIFF
--- a/main/Directory.Build.targets
+++ b/main/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <!-- Coverity runs on VSTS resolves gtk# from a local directory -->
+  <Target Name="BeforeResolveReferences" Condition=" '$(COVERITY_GTK)' != '' ">
+    <CreateProperty Value="$(MSBuildThisFileDirectory)\$(COVERITY_GTK);$(AssemblySearchPaths)">
+      <Output TaskParameter="Value" PropertyName="AssemblySearchPaths" />
+    </CreateProperty>
+  </Target>
+</Project>


### PR DESCRIPTION
Instead of installing support libraries, we just download a zip
with the files and unpack it in the repo.

This way we can resolve assemblies from a local directory