### PR TITLE
Fixes VSTS 592988: Code colors flicker black when typing

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -945,7 +945,7 @@ namespace Mono.TextEditor
 				get;
 				private set;
 			}
-			readonly TextDocument doc;
+			protected readonly TextDocument doc;
 			protected LineDescriptor (TextDocument doc, DocumentLine line, int offset, int length)
 			{
 				this.Offset = offset;
@@ -962,6 +962,8 @@ namespace Mono.TextEditor
 
 		class LayoutDescriptor : LineDescriptor, IDisposable
 		{
+			readonly ITextSourceVersion version;
+
 			public LayoutWrapper Layout {
 				get;
 				private set;
@@ -979,6 +981,7 @@ namespace Mono.TextEditor
 
 			public LayoutDescriptor (TextDocument doc, DocumentLine line, int offset, int length, LayoutWrapper layout, int selectionStart, int selectionEnd) : base(doc, line, offset, length)
 			{
+				this.version = doc.Version;
 				this.Layout = layout;
 				if (selectionEnd >= 0) {
 					this.SelectionStart = selectionStart;
@@ -1001,7 +1004,9 @@ namespace Mono.TextEditor
 					selStart = selectionStart;
 					selEnd = selectionEnd;
 				}
-				return base.Equals (line, offset, length) && selStart == this.SelectionStart && selEnd == this.SelectionEnd;
+				if (selStart != this.SelectionStart || selEnd != this.SelectionEnd || Length != length || MarkerLength != doc.GetMarkers (line).Count ())
+					return false;
+				return doc.Version.MoveOffsetTo (version, offset) == Offset;
 			}
 
 			public override bool Equals (object obj)
@@ -1315,7 +1320,6 @@ namespace Mono.TextEditor
 				descriptor.Dispose ();
 				layoutDict.Remove (lineNumber);
 			}
-			cachedLines.Remove (lineNumber);
 		}
 
 		internal void DisposeLayoutDict ()
@@ -1327,7 +1331,6 @@ namespace Mono.TextEditor
 			layoutDict.Clear ();
 			cacheSrc.Cancel ();
 			cacheSrc = new CancellationTokenSource ();
-			cachedLines.Clear ();
 		}
 		public void PurgeLayoutCache ()
 		{
@@ -1340,12 +1343,6 @@ namespace Mono.TextEditor
 				if (descr.Key >= lineNumber) {
 					descr.Value.Dispose ();
 					layoutDict.Remove (descr.Key);
-				}
-			}
-
-			foreach (var descr in cachedLines.ToArray()) {
-				if (descr.Key >= lineNumber) {
-					cachedLines.Remove (descr.Key);
 				}
 			}
 		}
@@ -1362,16 +1359,10 @@ namespace Mono.TextEditor
 				this.Chunk = chunk;
 			}
 		}
-		Dictionary<int, HighlightedLine> cachedLines = new Dictionary<int, HighlightedLine> ();
 		CancellationTokenSource cacheSrc = new CancellationTokenSource ();
 		Tuple<List<ColoredSegment>, bool> GetCachedChunks (TextDocument doc, DocumentLine line, int offset, int length)
 		{
-			HighlightedLine result;
 			var lineNumber = line.LineNumber;
-			if (cachedLines.TryGetValue (lineNumber, out result)) {
-				if (result.TextSegment.Length == line.Length && result.TextSegment.Offset == line.Offset)
-					return Tuple.Create (TrimChunks (result.Segments, offset - line.Offset, length), true);
-			}
 			var token = cacheSrc.Token;
 			var task = doc.SyntaxMode.GetHighlightedLineAsync (line, token);
 			switch (task.Status)  {
@@ -1380,38 +1371,14 @@ namespace Mono.TextEditor
 				break;
 			case TaskStatus.RanToCompletion:
 				if (task.Result != null) {
-					UpdateLineHighlight (lineNumber, result, task.Result);
 					return Tuple.Create (TrimChunks (task.Result.Segments, offset - line.Offset, length), true);
 				}
 				break;
 			default:
-				task.ContinueWith (t => {
-					if (t.Status == TaskStatus.Faulted) {
-						LoggingService.LogError ("Error while highlighting line " + lineNumber, t.Exception);
-						return;
-					}
-					if (t.Result == null)
-						return;
-					if (UpdateLineHighlight (lineNumber, result, t.Result)) {
-						RemoveCachedLine (lineNumber);
-						Document.CommitLineUpdate (line);
-					}
-				}, Runtime.MainTaskScheduler);
-				break;
+				var taskResult = task.WaitAndGetResult (default (CancellationToken));
+				return Tuple.Create (TrimChunks (taskResult.Segments, offset - line.Offset, length), true);
 			}
 			return Tuple.Create (new List<ColoredSegment> (new [] { new ColoredSegment (0, line.Length, ScopeStack.Empty) }), false);
-		}
-
-		bool UpdateLineHighlight (int lineNumber, HighlightedLine oldLine, HighlightedLine newLine)
-		{
-			if (oldLine != null && ShouldUpdateSpan (oldLine, newLine)) {
-				PurgeLayoutCacheAfter (lineNumber);
-				cachedLines [lineNumber] = newLine;
-				textEditor.QueueDraw ();
-				return false;
-			}
-			cachedLines [lineNumber] = newLine;
-			return true;
 		}
 
 		static bool ShouldUpdateSpan (HighlightedLine line1, HighlightedLine line2)


### PR DESCRIPTION
It's needed to run the highlighting on the UI thread. Note this also
fixes a problem that popped up in conjunction with github issue #4346.