### PR TITLE
[Ide] Fix Gtk warnings caused by unsupported locale

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Gettext.cs
@@ -47,6 +47,11 @@ namespace MonoDevelop.Core
 
 		const int LOCALE_CUSTOM_UNSPECIFIED = 4096;
 
+		public static void Initialize ()
+		{
+			// no-op, triggers static ctor.
+		}
+
 		static Dictionary<string, string> localeToCulture = new Dictionary<string, string> {
 			{ "cs", "cs-CZ" },
 			{ "de", "de-DE" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -80,6 +80,7 @@ namespace MonoDevelop.Ide
 
 			//ensure native libs initialized before we hit anything that p/invokes
 			Platform.Initialize ();
+			GettextCatalog.Initialize ();
 
 			LoggingService.LogInfo ("Operating System: {0}", SystemInformation.GetOperatingSystemDescription ());
 


### PR DESCRIPTION
Fixes VSTS #594227 "GTK warning at startup about unsupported locale"

WARNING [2018-04-03 11:59:27Z]: Gtk-Warning: Locale not supported by C library.
	Using the fallback 'C' locale.
Stack trace:
  at Gtk.Application.gtk_init (System.Int32& , System.IntPtr& ) [0x00000] in <13dfc6c534074eb08a8f382a81e605d5>:0
  at Gtk.Application.do_init (System.String progname, System.String[]& args, System.Boolean check) [0x0004d] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:102
  at Gtk.Application.Init (System.String progname, System.String[]& args) [0x0000e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:131