### PR TITLE
Split content view

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -256,6 +256,11 @@ namespace MonoDevelop.Components
 			}
 		}
 
+		public void HandlePathChange (object sender, MonoDevelop.Ide.Gui.Content.DocumentPathChangedEventArgs args)
+		{ 
+			SetPath (((Ide.Gui.Content.IPathedDocument)sender).CurrentPath);
+		}
+
 		public void SetPath (PathEntry[] path)
 		{
 			if (ArrSame (this.leftPath, path))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
@@ -352,7 +352,7 @@ namespace MonoDevelop.Components
 			get { return Label == "|"; }
 		}
 		
-		public object Tag {
+		public BaseViewContent[] ViewsSelection {
 			get;
 			set;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Content/IMultipleTabs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Content/IMultipleTabs.cs
@@ -1,0 +1,68 @@
+﻿//
+// IMultipleTabs.cs
+//
+// Author:
+//       David Karlaš <david.karlas@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoDevelop.Ide.Gui.Content
+{
+	/// <summary>
+	/// ContentView can implement this interface to show multiple tabs below content
+	/// e.g. "Designer" and "Split" tabs. Beside specifing multiple tabs each tab can specify
+	/// one or two content views to be shown when that tab is activated(clicked by user).
+	/// </summary>
+	public interface IMultipleTabs
+	{
+		/// <summary>
+		/// Gets the tab page infos see this interface documentation and
+		/// <see cref="T:MonoDevelop.Ide.Gui.Content.TabPageInfo"/> constructor for more information.
+		/// </summary>
+		IEnumerable<TabPageInfo> GetTabPageInfos ();
+	}
+
+	public class TabPageInfo
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:MonoDevelop.Ide.Gui.Content.TabPageInfo"/> class.
+		/// </summary>
+		/// <param name="label">Label is text displayed in tab.</param>
+		/// <param name="accessibilityDescription">Accessibility description is used to give more context about tab to visually impaired users.</param>
+		/// <param name="viewsSelection">Views selection can either be one or two content views to be displayed when this tab is activated.</param>
+		public TabPageInfo (string label, string accessibilityDescription, BaseViewContent [] viewsSelection)
+		{
+			Label = label;
+			AccessibilityDescription = accessibilityDescription;
+			var count = viewsSelection.Count ();
+			if (count < 1 || count > 2)
+				throw new ArgumentOutOfRangeException ($"{nameof (viewsSelection)} argument must contain one or two content views.");
+			ViewsSelection = viewsSelection;
+		}
+
+		public string Label { get; }
+		public string AccessibilityDescription { get; }
+		public BaseViewContent [] ViewsSelection { get; }
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BaseViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BaseViewContent.cs
@@ -159,24 +159,6 @@ namespace MonoDevelop.Ide.Gui
 		/// </summary>
 		/// <value>The display binding used to create this view.</value>
 		public IDisplayBinding Binding { get; internal set; }
-
-		public virtual IEnumerable<TabPageInfo> GetTabPageInfos() {
-			return new [] { new TabPageInfo (TabPageLabel, TabAccessibilityDescription, new [] { this }) };
-		}
-	}
-
-	public class TabPageInfo
-	{
-		public TabPageInfo (string label, string accessibilityDescription, BaseViewContent [] viewsSelection)
-		{
-			Label = label;
-			AccessibilityDescription = accessibilityDescription;
-			ViewsSelection = viewsSelection;
-		}
-
-		public string Label { get; set; }
-		public string AccessibilityDescription { get; set; }
-		public BaseViewContent [] ViewsSelection { get; set; }
 	}
 
 	public enum ProjectReloadCapability

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BaseViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BaseViewContent.cs
@@ -159,6 +159,24 @@ namespace MonoDevelop.Ide.Gui
 		/// </summary>
 		/// <value>The display binding used to create this view.</value>
 		public IDisplayBinding Binding { get; internal set; }
+
+		public virtual IEnumerable<TabPageInfo> GetTabPageInfos() {
+			return new [] { new TabPageInfo (TabPageLabel, TabAccessibilityDescription, new [] { this }) };
+		}
+	}
+
+	public class TabPageInfo
+	{
+		public TabPageInfo (string label, string accessibilityDescription, BaseViewContent [] viewsSelection)
+		{
+			Label = label;
+			AccessibilityDescription = accessibilityDescription;
+			ViewsSelection = viewsSelection;
+		}
+
+		public string Label { get; set; }
+		public string AccessibilityDescription { get; set; }
+		public BaseViewContent [] ViewsSelection { get; set; }
 	}
 
 	public enum ProjectReloadCapability

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -592,8 +592,6 @@ namespace MonoDevelop.Ide.Gui
 			UnsubscribeAnalysisDocument ();
 			UnsubscribeRoslynWorkspace ();
 			UnloadAdhocProject ();
-			if (window is SdiWorkspaceWindow)
-				((SdiWorkspaceWindow)window).DetachFromPathedDocument ();
 			window.Closed -= OnClosed;
 			window.ActiveViewContentChanged -= OnActiveViewContentChanged;
 			if (IdeApp.Workspace != null)
@@ -602,7 +600,7 @@ namespace MonoDevelop.Ide.Gui
 			// Unsubscribe project events
 			if (window.ViewContent.Project != null)
 				window.ViewContent.Project.Modified -= HandleProjectModified;
-			window.ViewsChanged += HandleViewsChanged;
+			window.ViewsChanged -= HandleViewsChanged;
 			MonoDevelopWorkspace.LoadingFinished -= ReloadAnalysisDocumentHandler;
 
 			window = null;
@@ -672,7 +670,7 @@ namespace MonoDevelop.Ide.Gui
 			Editor.InitializeExtensionChain (this);
 
 			if (window is SdiWorkspaceWindow)
-				((SdiWorkspaceWindow)window).AttachToPathedDocument (GetContent<MonoDevelop.Ide.Gui.Content.IPathedDocument> ());
+				((SdiWorkspaceWindow)window).UpdatePathedDocument ();
 
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -673,14 +673,22 @@ namespace MonoDevelop.Ide.Gui
 			// If this is the current displayed document we need to add the control immediately as the tab is already active.
 			if (addedContent)
 				SetCurrentViews (new [] { viewContent });
-			foreach (var tabInfo in viewContent.GetTabPageInfos ()) {
+			var tabIndex = index;
+			IEnumerable<TabPageInfo> tabPageInfos;
+			if (viewContent is IMultipleTabs multipleTabs) {
+				tabPageInfos = multipleTabs.GetTabPageInfos ();
+			} else {
+				tabPageInfos = new [] { new TabPageInfo (viewContent.TabPageLabel, viewContent.TabAccessibilityDescription, new [] { viewContent }) };
+			}
+
+			foreach (var tabInfo in tabPageInfos) {
 				var newTab = new Tab (subViewToolbar, tabInfo.Label) {
 					ViewsSelection = tabInfo.ViewsSelection
 				};
 				if (newTab.Accessible != null) {
 					newTab.Accessible.Help = tabInfo.AccessibilityDescription;
 				}
-				subViewToolbar.InsertTab (index, newTab);
+				subViewToolbar.InsertTab (tabIndex++, newTab);
 				newTab.Activated += (sender, e) => {
 					SetCurrentViews (((Tab)sender).ViewsSelection);
 				};

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=2920248e9f9025e2c8986963891ed8cd3976fc69
-DEP_BRANCH_AND_REMOTE[0]="master origin/master"
+DEP_NEEDED_VERSION[0]=d9920e81c5a7aeef2f30062cf8f003f3eb6c310c
+DEP_BRANCH_AND_REMOTE[0]="splitContentView origin/splitContentView"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
Change on designer side is here: https://github.com/xamarin/designer/pull/767
This two PRs change the way Xamarin.Forms Previewer operates with TextEditor, before this PRs Previewer AddIn created PreviewerContentView which had EditorWidget embedded inside HPaned widget and optionally on side when Preview button was pressed Preview appeared. There were multiple bugs with this approach because editor was just Widget not actual EditorContentView which meant Previewer had to take care of Loading/Saving file content setting IsDirty state, beside this problems and bugs, Cmd+-/Cmd++ didn't work for TextEditor, Pathbar for code part of .xaml not appearing...
This also fixes most of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/558175 (need to sync Pathbar and Toolbar heights).
Old view:
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/774791/38306290-62622980-3810-11e8-85ff-6ec00f42ad0b.png">

New in Preview:
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/774791/38306351-94ee4f46-3810-11e8-9567-3b6b579a311d.png">

New in Source:
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/774791/38306356-9d11d8d2-3810-11e8-81be-c1dbc4b47ae5.png">

