### PR TITLE
[Refactoring,Editor] Allow for 0-length diagnostic spans to be drawn

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -352,8 +352,13 @@ namespace MonoDevelop.AnalysisCore.Gui
 					if (currentResult.InspectionMark != IssueMarker.None) {
 						int start = currentResult.Region.Start;
 						int end = currentResult.Region.End;
-						if (start >= end)
+						if (start > end)
 							continue;
+
+						// In case a diagnostic has a 0 length span, force it to 1.
+						if (start == end)
+							end = end + 1;
+						
 						var marker = TextMarkerFactory.CreateGenericTextSegmentMarker (editor, GetSegmentMarkerEffect (currentResult.InspectionMark), TextSegment.FromBounds (start, end));
 						marker.Tag = currentResult;
 						marker.IsVisible = currentResult.Underline;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/TextMarker/WavedLineMarker.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/TextMarker/WavedLineMarker.cs
@@ -89,8 +89,12 @@ namespace MonoDevelop.SourceEditor
 			
 			drawFrom = Math.Max (drawFrom, editor.TextViewMargin.XOffset);
 			drawTo = Math.Max (drawTo, editor.TextViewMargin.XOffset);
-			if (drawFrom >= drawTo)
+
+			if (drawFrom > drawTo)
 				return;
+
+			if (drawFrom == drawTo)
+				drawTo += editor.TextViewMargin.charWidth;
 			
 			double height = editor.LineHeight / 5;
 			cr.SetSourceColor (Color);

--- a/main/tests/MonoDevelop.Refactoring.Tests/ResultsEditorExtensionTests.cs
+++ b/main/tests/MonoDevelop.Refactoring.Tests/ResultsEditorExtensionTests.cs
@@ -114,6 +114,10 @@ class MyClass
 	}
 ";
 		static readonly ExpectedDiagnostic[] OneFromEachDiagnostics = {
+			// Compiler diagnostics
+			new ExpectedDiagnostic (251, DiagnosticSeverity.Error, "; expected"),
+			new ExpectedDiagnostic (254, DiagnosticSeverity.Error, "} expected"),
+
 			new ExpectedDiagnostic (68, DiagnosticSeverity.Hidden, "Accessibility modifiers required"),
 			new ExpectedDiagnostic (248, DiagnosticSeverity.Error, "The name 'cls' does not exist in the current context"),
 			new ExpectedDiagnostic (144, DiagnosticSeverity.Info, "Empty constructor is redundant"),
@@ -157,7 +161,7 @@ class MyClass
 
 				Assert.AreEqual (OneFromEachDiagnostics.Length, diagnostics.Length);
 
-				for (int i = 0; i < 3; ++i) {
+				for (int i = 0; i < diagnostics.Length; ++i) {
 					AssertExpectedDiagnostic (OneFromEachDiagnostics [i], diagnostics [i]);
 				}
 			} finally {
@@ -177,17 +181,21 @@ class MyClass
 				var tuple = await GatherDiagnosticsNoDispose<bool> (OneFromEach, (ext, tcs) => {
 					--expectedUpdates;
 					if (expectedUpdates == 4) {
-						Assert.AreEqual (0, ext.QuickTasks.Length);
+						Assert.AreEqual (2, ext.QuickTasks.Length);
+						for (int i = 0; i < ext.QuickTasks.Length; ++i) {
+							AssertExpectedDiagnostic (OneFromEachDiagnostics [i], ext.QuickTasks [i]);
+						}
 					}
 
 					if (expectedUpdates == 1) {
 						IdeApp.Preferences.EnableSourceAnalysis.Value = false;
 
-						Assert.AreEqual (3, ext.QuickTasks.Length);
-						for (int i = 0; i < 3; ++i) {
+						Assert.AreEqual (5, ext.QuickTasks.Length);
+						for (int i = 0; i < ext.QuickTasks.Length; ++i) {
 							AssertExpectedDiagnostic (OneFromEachDiagnostics [i], ext.QuickTasks [i]);
 						}
 					}
+
 					if (expectedUpdates == 0) {
 						Assert.AreEqual (0, ext.QuickTasks.Length);
 						tcs.SetResult (true);


### PR DESCRIPTION
Force them to have a length of 1.

Fixes VSTS #594665 Removing curly braces in text editor does not display any error or red squiggle
Fixes VSTS #592144 [Feedback] Syntax highlighting doesn't detect missing ; in c# editor