### PR TITLE
[Refactoring,Editor] Allow for 0-length diagnostic spans to be drawn

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -352,8 +352,13 @@ namespace MonoDevelop.AnalysisCore.Gui
 					if (currentResult.InspectionMark != IssueMarker.None) {
 						int start = currentResult.Region.Start;
 						int end = currentResult.Region.End;
-						if (start >= end)
+						if (start > end)
 							continue;
+
+						// In case a diagnostic has a 0 length span, force it to 1.
+						if (start == end)
+							end = end + 1;
+						
 						var marker = TextMarkerFactory.CreateGenericTextSegmentMarker (editor, GetSegmentMarkerEffect (currentResult.InspectionMark), TextSegment.FromBounds (start, end));
 						marker.Tag = currentResult;
 						marker.IsVisible = currentResult.Underline;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/TextMarker/WavedLineMarker.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/TextMarker/WavedLineMarker.cs
@@ -89,8 +89,12 @@ namespace MonoDevelop.SourceEditor
 			
 			drawFrom = Math.Max (drawFrom, editor.TextViewMargin.XOffset);
 			drawTo = Math.Max (drawTo, editor.TextViewMargin.XOffset);
-			if (drawFrom >= drawTo)
+
+			if (drawFrom > drawTo)
 				return;
+
+			if (drawFrom == drawTo)
+				drawTo += editor.TextViewMargin.charWidth;
 			
 			double height = editor.LineHeight / 5;
 			cr.SetSourceColor (Color);


### PR DESCRIPTION
Force them to have a length of 1.

Fixes VSTS #594665 Removing curly braces in text editor does not display any error or red squiggle
Fixes VSTS #592144 [Feedback] Syntax highlighting doesn't detect missing ; in c# editor