### PR TITLE
[59012][Mac] Fix IsModalDialogRunning for native dialogs

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1049,6 +1049,9 @@ namespace MonoDevelop.MacIntegration
 
 		public override bool IsModalDialogRunning ()
 		{
+			if (NSApplication.SharedApplication.ModalWindow != null)
+				return true;
+
 			var toplevels = GtkQuartz.GetToplevels ();
 
 			// Check GtkWindow's Modal flag or for a visible NSPanel


### PR DESCRIPTION
The original implementation checks Gtk toplevels only and does not take real native modal windows into account.

Fixes bxc #59012 - [VSfM] Menu Bar Options are available to user even if Pop Ups are Over IDE