### PR TITLE
Fix queued sheets

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -218,7 +218,12 @@ namespace MonoDevelop.MacIntegration
 							NSApplication.SharedApplication.StopModal ();
 						});
 
-						NSApplication.SharedApplication.RunModalForWindow (alert.Window);
+						// pass parent and not alert so that the Runloop will change
+						// and processing will stop until the sheet is closed.
+						// If we pass alert, then it will run until a second alert is created
+						// which will be shown as a dialog and then the runloop changes and
+						// processing stops
+						NSApplication.SharedApplication.RunModalForWindow (parent);
 					}
 				}
 


### PR DESCRIPTION
[Mac] Correctly queue modal sheets

If you change the current branch outside of Monodevelop and certain files change then `ProjectOperations.AllowSave` will be called and it will display a sheet. Sometimes however, if multiple files change, the first sheet is shown, and the second is shown at the same time as a dialog.

The sheet is shown in `MacAlertDialogHandler` using `BeginSheet`
`BeginSheet` starts a modal sheet, but does it without changing the Runloop. To
block for a response we need to call `NSApplication.RunModalForWindow`.

It seems like when `RunModalForWindow` is called on a sheet, it does not stop processing the mainloop because when `AllowSave` still creates a second sheet. This sheet is then queued for showing once the first sheet is closed.

According to the documentation

> If it is not already visible, the window is centered on the screen using the value in its center method and made visible

Because the second sheet has been queued for display, `RunModalForWindow` decides to show it, and it appears as a dialog. This time, because `RunModalForWindow` has shown a dialog, the runloop is changed and processing stops showing any more dialogs until this one is shown.

So instead of calling `RunModalForWindow` with the new `NSAlert` calling it with
the main application window changes the runloop and stops processing until the sheet is closed.

> Fixes VSTS #937831