### PR TITLE
Fixes issue #4489 Virtual indentation handling broken

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -1108,7 +1108,7 @@ namespace Mono.TextEditor
 						goto restart;
 					}
 					var theme = textEditor.GetTextEditorData ().EditorTheme;
-					var chunkStyle = theme.GetChunkStyle(chunk.ScopeStack);
+					var chunkStyle = theme.GetChunkStyle (chunk.ScopeStack);
 					foreach (TextLineMarker marker in textEditor.Document.GetMarkers (line))
 						chunkStyle = marker.GetStyle (chunkStyle);
 
@@ -1742,8 +1742,6 @@ namespace Mono.TextEditor
 			if (text.IndexOf (spaceOrTab) == -1)
 				return;
 			var chunks = layout.Chunks;
-			if (chunks == null)
-				return;
 
 			uint curIndex = 0, byteIndex = 0;
 			bool first = true, oldSelected = false;
@@ -1764,9 +1762,6 @@ namespace Mono.TextEditor
 			}
 
 			var showOnlySelected = textEditor.Options.ShowWhitespaces != ShowWhitespaces.Always;
-
-			var lastColor = new Cairo.Color ();
-			bool firstDraw = true;
 			var foregroundColor = SyntaxHighlightingService.GetColor (textEditor.EditorTheme, EditorThemeColors.Foreground);
 
 			int lastIndex = -1;
@@ -1797,38 +1792,26 @@ namespace Mono.TextEditor
 				lastPosX = posX;
 				lastIndex = i + 1;
 				double xpos2 = x + posX / Pango.Scale.PangoScale;
-				var col = new Cairo.Color (0, 0, 0);
-				//if (SelectionColor.TransparentForeground) {
-				while (curchunk + 1 < chunks.Count && chunks [curchunk].Offset < offset + i)
-					curchunk++;
-					/*if (curchunk != null && curchunk.SpanStack.Count > 0 && curchunk.SpanStack.Peek ().Color != "Plain Text") {
-						var chunkStyle = ColorStyle.GetChunkStyle (curchunk.SpanStack.Peek ().Color);
-						if (chunkStyle != null)
-							col = ColorStyle.GetForeground (chunkStyle);
-					} else */{
-					col = foregroundColor;
+				var col = (Cairo.Color)foregroundColor;
+				if (chunks != null) {
+					while (curchunk + 1 < chunks.Count) {
+						if (offset + i < chunks [curchunk].EndOffset)
+							break;
+						curchunk++;
+					}
+					if (curchunk < chunks.Count) {
+						var chunkStyle = EditorTheme.GetChunkStyle (chunks [curchunk].ScopeStack);
+						col = chunkStyle.Foreground;
+					}
 				}
-				// } else {
-				//	col = selected ? SelectionColor.Foreground : foregroundColor;
-				// }
-
-				if (firstDraw || (lastColor.R != col.R && lastColor.G != col.G && lastColor.B != col.B)) {
-					ctx.SetSourceRGBA (col.R, col.G, col.B, whitespaceMarkerAlpha);
-					lastColor = col;
-					firstDraw = false;
-				}
+				ctx.SetSourceRGBA (col.R, col.G, col.B, whitespaceMarkerAlpha);
 
 				if (spaceOrTab == ' ') {
 					ctx.Rectangle (xpos + (xpos2 - xpos - dotThickness) / 2, ypos, dotThickness, dotThickness);
+					ctx.Fill ();
 				} else {
 					ctx.MoveTo (0.5 + xpos, ypos);
 					ctx.LineTo (0.5 + xpos2 - charWidth / 2, ypos);
-				}
-			}
-			if (!firstDraw) {//Atleast one draw was called
-				if (spaceOrTab == ' ') {
-					ctx.Fill ();
-				} else {
 					ctx.Stroke ();
 				}
 			}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
@@ -648,11 +648,7 @@ namespace Mono.TextEditor
 		/// </summary>
 		public void FixVirtualIndentation ()
 		{
-			if (!HasIndentationTracker || Options.IndentStyle != IndentStyle.Virtual)
-				return;
-			var line = Document.GetLine (Caret.Line);
-			if (line != null && line.Length > 0 && GetIndentationString (caret.Line - 1, int.MaxValue) == Document.GetTextAt (line.Offset, line.Length))
-				Remove (line.Offset, line.Length);
+			FixVirtualIndentation (Caret.Line);
 		}
 
 		public void FixVirtualIndentation (int lineNumber)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RoslynClassificationHighlighting.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/RoslynClassificationHighlighting.cs
@@ -167,7 +167,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 					continue;
 				}
 				if (start > lastClassifiedOffsetEnd) {
-					scopeStack = userScope;
+					scopeStack = defaultScope;
 					ColoredSegment whitespaceSegment = new ColoredSegment (lastClassifiedOffsetEnd - offset, start - lastClassifiedOffsetEnd, scopeStack);
 					coloredSegments.Add (whitespaceSegment);
 				}
@@ -179,7 +179,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			}
 
 			if (offset + length > lastClassifiedOffsetEnd) {
-				scopeStack = userScope;
+				scopeStack = defaultScope;
 				ColoredSegment whitespaceSegment = new ColoredSegment (lastClassifiedOffsetEnd - offset, offset + length - lastClassifiedOffsetEnd, scopeStack);
 				coloredSegments.Add (whitespaceSegment);
 			}

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SmartIndentModeTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SmartIndentModeTests.cs
@@ -40,6 +40,7 @@ namespace Mono.TextEditor.Tests
 		internal class TestIndentTracker : IndentationTracker
 		{
 			string indentString;
+			Dictionary<int, string> definedIndents = new Dictionary<int, string> ();
 
 			public override IndentationTrackerFeatures SupportedFeatures {
 				get {
@@ -54,7 +55,14 @@ namespace Mono.TextEditor.Tests
 
 			public override string GetIndentationString (int lineNumber)
 			{
+				if (definedIndents.TryGetValue (lineNumber, out string result))
+					return result;
 				return indentString;
+			}
+
+			public void SetIndent(int lineNumber, string indentationString)
+			{
+				definedIndents [lineNumber] = indentationString;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/VirtualIndentModeTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/VirtualIndentModeTests.cs
@@ -568,6 +568,22 @@ namespace Mono.TextEditor.Tests
 			Assert.AreEqual (new DocumentLocation (2, 6), data.Caret.Location);
 			Assert.AreEqual ("\n\t\tFooBar", data.Document.Text);
 		}
+
+		/// <summary>
+		/// Virtual indentation handling broken #4489 
+		/// https://github.com/mono/monodevelop/issues/4489
+		/// </summary>
+		[Test]
+		public void TestIssue4489 ()
+		{
+			var data = CreateDataWithSpaces ("\n\t\t\n\n");
+			var tracker = new SmartIndentModeTests.TestIndentTracker ();
+			tracker.SetIndent (1, "    ");
+			data.IndentationTracker = tracker;
+			data.Caret.Location = new DocumentLocation (2, 2);
+			data.FixVirtualIndentation ();
+			Assert.AreEqual ("\n\n\n", data.Document.Text);
+		}
 	}
 }
 


### PR DESCRIPTION
https://github.com/mono/monodevelop/issues/4489

It was caused by FixVirtualIndentation taking caret.line - 1 for the
correct indentation check. The FixVirtualIndentation (int lineNumber)
method doesn't have that flaw so delegating to that fixes the issue.
That the whitespaces were not drawn was just a visual display bug
which got fixed as well.