### PR TITLE
[MSBuild] Fix unsaved project xml not cleared in remote build engine

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.v4.0.cs
@@ -79,6 +79,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal void UnloadProject (string file)
 		{
+			lock (unsavedProjects) {
+				unsavedProjects.Remove (file);
+			}
+
 			RunSTA (delegate
 			{
 				// Unloading projects modifies the collection, so copy it
@@ -86,10 +90,6 @@ namespace MonoDevelop.Projects.MSBuild
 
 				if (loadedProjects.Length == 0)
 					return;
-
-				lock (unsavedProjects) {
-					unsavedProjects.Remove (file);
-				}
 
 				var rootElement = loadedProjects[0].Xml;
 


### PR DESCRIPTION
Running the TestCreateBuildBlankFormsSharedAndroidIOS automation
test sometimes fails to build. The build fails due to various
missing Android assembly references from the NuGet packages that are
installed when the project is created. The project file itself has
the correct reference information but the MSBuild engine host was
building an old version of the project.

The problem was that the project was modified in memory which
results in the unsaved project xml being given to the remote build
engine host and whilst a refresh was requested when the project file
is saved the old unsaved project xml was being used when building.
This could happen if the remote build engine had not loaded any
projects. Now the unsaved project information is removed even if
there are no loaded projects.

Fixes VSTS #582975 - Getting errors while building Multiplaform forms
application