### PR TITLE
[Core] Fix files not re-opened on opening a solution

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -423,7 +423,7 @@ namespace MonoDevelop.Projects
 
 		public FilePath GetPreferencesDirectory ()
 		{
-			return BaseDirectory.Combine (".vs", Name, "xs");
+			return FileName.ParentDirectory.Combine (".vs", Name, "xs");
 		}
 
 		internal string GetPreferencesFileName ()

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/UserPreferencesTests.cs
@@ -127,5 +127,30 @@ namespace MonoDevelop.Ide
 			using (var solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), fileName))
 				Assert.AreEqual ("Test-Value-Updated", solution.UserProperties.GetValue<string> ("Test"));
 		}
+
+		[Test]
+		public async Task UserPreferences_SolutionHasCustomBaseDirectory ()
+		{
+			FilePath directory = Util.CreateTmpDir ("MySolution");
+			var customSolutionBaseDirectory = directory.Combine ("Custom");
+			Directory.CreateDirectory (customSolutionBaseDirectory);
+
+			var fileName = directory.Combine ("MySolution.sln");
+			using (var solution = new Solution ()) {
+				solution.FileName = fileName;
+				solution.BaseDirectory = customSolutionBaseDirectory;
+				solution.UserProperties.SetValue ("Test", "Test-Value");
+
+				// Create a user prefs file.
+				await solution.SaveAsync (Util.GetMonitor ());
+
+				Assert.IsTrue (File.Exists (solution.GetPreferencesFileName ()));
+			}
+
+			// Ensure that saved user preference is available when re-loading a solution with a custom base directory
+			using (var solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), fileName)) {
+				Assert.AreEqual ("Test-Value", solution.UserProperties.GetValue<string> ("Test"));
+			}
+		}
 	}
 }


### PR DESCRIPTION
If the solution used a custom BaseDirectory then the user preferences
were saved inside the custom base directory and then not loaded on
re-opening the solution. A custom base directory can be configured
in solution preferences - General - Main Settings and then changing
the Root Directory. This then adds a section to the solution file:

GlobalSection(MonoDevelopProperties) = preSolution
	BaseDirectory = ..
EndGlobalSection

Now the user preferences are always stored in a .vs directory
relative to the solution file itself instead of using the Solution's
BaseDirectory.

Fixes VSTS #598545 When opening a solution, last files are not
re-opened correctly