### PR TITLE
Fix VSTS 586152: Preserve documents on project reload

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -608,7 +608,7 @@ namespace MonoDevelop.Ide.TypeSystem
 						continue;
 					documents.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));
 				} else {
-					var id = projectData.GetOrCreateDocumentId (f.Name, projectData);
+					var id = projectData.GetOrCreateDocumentId (f.Name, oldProjectData);
 					if (!duplicates.Add (id))
 						continue;
 					additionalDocuments.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));


### PR DESCRIPTION
DotNetProject.OnReevaluateProject causes a LoadProject call where we attempt to incrementally preserve documents from the previous project. The CreateDocuments call incorrectly passed the current projectData to GetOrCreateDocumentId, and the document was not found there and was recreated from scratch.

Simple fix is to pass the oldProjectData so we preserve the DocumentId and other info from the previous project data.

Symptoms included lack of classification when a .cshtml document was opened on project open.