### PR TITLE
Build speed improvements

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -6,9 +6,11 @@
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
+    <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
+    <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>
   </PropertyGroup>
 
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -12,6 +12,7 @@
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
+    <!-- Also edit the ReferencesSharpZipLib.props file when modifying this to set the right assembly version -->
     <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>
     <NuGetVersionSystemCollectionsImmutable>1.3.1</NuGetVersionSystemCollectionsImmutable>
     <NuGetVersionSystemValueTuple>4.4.0</NuGetVersionSystemValueTuple>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -21,6 +21,7 @@
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSCodingConventions>1.1.20180226.4</NuGetVersionVSCodingConventions>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
+    <NuGetVersionVSEditorTextImplementation>15.2.0-pre</NuGetVersionVSEditorTextImplementation>
     <NuGetVersionVSThreading>15.6.46</NuGetVersionVSThreading>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
     <!-- Also edit the ReferencesSharpZipLib.props file when modifying this to set the right assembly version -->

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -6,7 +6,9 @@
 
     <ReferencesMonoDoc>$(RootDirectory)\msbuild\ReferencesMonoDoc.props</ReferencesMonoDoc>
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
+    <ReferencesVSCodingConventions>$(RootDirectory)\msbuild\ReferencesVSCodingConventions.props</ReferencesVSCodingConventions>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
+    <ReferencesVSThreading>$(RootDirectory)\msbuild\ReferencesVSThreading.props</ReferencesVSThreading>
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
     <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
     <ReferencesSystemComposition>$(RootDirectory)\msbuild\ReferencesSystemComposition.props</ReferencesSystemComposition>
@@ -16,7 +18,9 @@
 
     <NuGetVersionMonoDoc>5.6.3</NuGetVersionMonoDoc>
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
+    <NuGetVersionVSCodingConventions>1.1.20180226.4</NuGetVersionVSCodingConventions>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
+    <NuGetVersionVSThreading>15.6.46</NuGetVersionVSThreading>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
     <!-- Also edit the ReferencesSharpZipLib.props file when modifying this to set the right assembly version -->
     <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -5,8 +5,10 @@
     <PackagesDirectory>$(RootDirectory)packages</PackagesDirectory>
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
+    <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
+    <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
   </PropertyGroup>
 
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -8,11 +8,13 @@
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
     <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
     <ReferencesSystemCollectionsImmutable>$(RootDirectory)\msbuild\ReferencesSystemCollectionsImmutable.props</ReferencesSystemCollectionsImmutable>
+    <ReferencesSystemValueTuple>$(RootDirectory)\msbuild\ReferencesSystemValueTuple.props</ReferencesSystemValueTuple>
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
     <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>
     <NuGetVersionSystemCollectionsImmutable>1.3.1</NuGetVersionSystemCollectionsImmutable>
+    <NuGetVersionSystemValueTuple>4.4.0</NuGetVersionSystemValueTuple>
   </PropertyGroup>
 
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -9,7 +9,9 @@
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
     <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
+    <ReferencesSystemComposition>$(RootDirectory)\msbuild\ReferencesSystemComposition.props</ReferencesSystemComposition>
     <ReferencesSystemCollectionsImmutable>$(RootDirectory)\msbuild\ReferencesSystemCollectionsImmutable.props</ReferencesSystemCollectionsImmutable>
+    <ReferencesSystemReflectionMetadata>$(RootDirectory)\msbuild\ReferencesSystemReflectionMetadata.props</ReferencesSystemReflectionMetadata>
     <ReferencesSystemValueTuple>$(RootDirectory)\msbuild\ReferencesSystemValueTuple.props</ReferencesSystemValueTuple>
 
     <NuGetVersionMonoDoc>5.6.3</NuGetVersionMonoDoc>
@@ -18,8 +20,12 @@
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
     <!-- Also edit the ReferencesSharpZipLib.props file when modifying this to set the right assembly version -->
     <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>
+    <NuGetVersionSystemComposition>1.0.31</NuGetVersionSystemComposition>
     <NuGetVersionSystemCollectionsImmutable>1.3.1</NuGetVersionSystemCollectionsImmutable>
+    <NuGetVersionSystemReflectionMetadata>1.4.2</NuGetVersionSystemReflectionMetadata>
     <NuGetVersionSystemValueTuple>4.4.0</NuGetVersionSystemValueTuple>
+
+    <AssemblyVersionSystemComposition>1.0.31.0</AssemblyVersionSystemComposition>
   </PropertyGroup>
 
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -7,10 +7,12 @@
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
     <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
+    <ReferencesSystemCollectionsImmutable>$(RootDirectory)\msbuild\ReferencesSystemCollectionsImmutable.props</ReferencesSystemCollectionsImmutable>
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
     <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>
+    <NuGetVersionSystemCollectionsImmutable>1.3.1</NuGetVersionSystemCollectionsImmutable>
   </PropertyGroup>
 
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -10,6 +10,7 @@
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <ReferencesVSThreading>$(RootDirectory)\msbuild\ReferencesVSThreading.props</ReferencesVSThreading>
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
+    <ReferencesJson>$(RootDirectory)\msbuild\ReferencesJson.props</ReferencesJson>
     <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
     <ReferencesSystemComposition>$(RootDirectory)\msbuild\ReferencesSystemComposition.props</ReferencesSystemComposition>
     <ReferencesSystemCollectionsImmutable>$(RootDirectory)\msbuild\ReferencesSystemCollectionsImmutable.props</ReferencesSystemCollectionsImmutable>
@@ -23,6 +24,7 @@
     <NuGetVersionVSThreading>15.6.46</NuGetVersionVSThreading>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>
     <!-- Also edit the ReferencesSharpZipLib.props file when modifying this to set the right assembly version -->
+    <NuGetVersionJson>10.0.3</NuGetVersionJson>
     <NuGetVersionSharpZipLib>0.87.20170615.10</NuGetVersionSharpZipLib>
     <NuGetVersionSystemComposition>1.0.31</NuGetVersionSystemComposition>
     <NuGetVersionSystemCollectionsImmutable>1.3.1</NuGetVersionSystemCollectionsImmutable>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -3,12 +3,16 @@
   <PropertyGroup>
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>
     <PackagesDirectory>$(RootDirectory)packages</PackagesDirectory>
+
+    <ReferencesMonoDoc>$(RootDirectory)\msbuild\ReferencesMonoDoc.props</ReferencesMonoDoc>
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <ReferencesCecil>$(RootDirectory)\msbuild\ReferencesCecil.props</ReferencesCecil>
     <ReferencesSharpZipLib>$(RootDirectory)\msbuild\ReferencesSharpZipLib.props</ReferencesSharpZipLib>
     <ReferencesSystemCollectionsImmutable>$(RootDirectory)\msbuild\ReferencesSystemCollectionsImmutable.props</ReferencesSystemCollectionsImmutable>
     <ReferencesSystemValueTuple>$(RootDirectory)\msbuild\ReferencesSystemValueTuple.props</ReferencesSystemValueTuple>
+
+    <NuGetVersionMonoDoc>5.6.3</NuGetVersionMonoDoc>
     <NuGetVersionRoslyn>2.8.0-beta3-62728-05</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.7.153-preview-g7d0635149a</NuGetVersionVSEditor>
     <NuGetVersionCecil>0.10.0-beta7</NuGetVersionCecil>

--- a/main/external/Makefile.am
+++ b/main/external/Makefile.am
@@ -2,33 +2,36 @@ TARBALL_PATH=../../tarballs/external
 XAMMAC_PATH=/Library/Frameworks/Xamarin.Mac.framework/Versions/Current
 XAMMAC_LIB_PATH=$(XAMMAC_PATH)/lib
 XAMMAC_PDB=$(XAMMAC_LIB_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.pdb
-all:
-
-clean:
 
 if ENABLE_MACPLATFORM
 all: Xamarin.Mac.dll Xamarin.Mac.registrar.full.a libxammac.dylib Xamarin.Mac.buildinfo
 	$(MAKE) -C monomac/src
 
 Xamarin.Mac.dll: $(XAMMAC_LIB_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.dll
-	cp -p $< $@
-	if [[ -f $<.mdb ]]; then cp -p $<.mdb $@.mdb; fi;
-	if [[ -f $(XAMMAC_PDB) ]]; then cp -p $(XAMMAC_PDB) Xamarin.Mac.pdb; fi;
+	cp $< $@
+	if [[ -f $<.mdb ]]; then cp $<.mdb $@.mdb; fi;
+	if [[ -f $(XAMMAC_PDB) ]]; then cp $(XAMMAC_PDB) Xamarin.Mac.pdb; fi;
 
 Xamarin.Mac.registrar.full.a: $(XAMMAC_LIB_PATH)/mmp/Xamarin.Mac.registrar.full.a
-	cp -p $< $@
+	cp $< $@
 
 libxammac.dylib: $(XAMMAC_LIB_PATH)/libxammac.dylib
-	cp -p $< $@
+	cp $< $@
 
 Xamarin.Mac.buildinfo: $(XAMMAC_PATH)/buildinfo
-	cp -p $< $@
+	cp $< $@
 
 clean:
 	$(MAKE) -C monomac/src clean
 	rm -f Xamarin.Mac.Registrar.full.a
 	rm -f Xamarin.Mac.dll*
 	rm -f libxammac.dylib
+
+else
+all:
+
+clean:
+
 endif
 
 install:
@@ -53,4 +56,3 @@ dist-clean:
 		fi \
 	done
 
-.PHONY: Xamarin.Mac.dll 

--- a/main/external/Makefile.am
+++ b/main/external/Makefile.am
@@ -8,23 +8,24 @@ all: Xamarin.Mac.dll Xamarin.Mac.registrar.full.a libxammac.dylib Xamarin.Mac.bu
 	$(MAKE) -C monomac/src
 
 Xamarin.Mac.dll: $(XAMMAC_LIB_PATH)/@MAC_ARCHITECTURE@/full/Xamarin.Mac.dll
-	cp $< $@
-	if [[ -f $<.mdb ]]; then cp $<.mdb $@.mdb; fi;
-	if [[ -f $(XAMMAC_PDB) ]]; then cp $(XAMMAC_PDB) Xamarin.Mac.pdb; fi;
+	cp -p $< $@
+	if [[ -f $<.mdb ]]; then cp -p $<.mdb $@.mdb; fi;
+	if [[ -f $(XAMMAC_PDB) ]]; then cp -p $(XAMMAC_PDB) Xamarin.Mac.pdb; fi;
 
 Xamarin.Mac.registrar.full.a: $(XAMMAC_LIB_PATH)/mmp/Xamarin.Mac.registrar.full.a
-	cp $< $@
+	cp -p $< $@
 
 libxammac.dylib: $(XAMMAC_LIB_PATH)/libxammac.dylib
-	cp $< $@
+	cp -p $< $@
 
 Xamarin.Mac.buildinfo: $(XAMMAC_PATH)/buildinfo
-	cp $< $@
+	cp -p $< $@
 
 clean:
 	$(MAKE) -C monomac/src clean
 	rm -f Xamarin.Mac.Registrar.full.a
 	rm -f Xamarin.Mac.dll*
+	rm -f Xamarin.Mac.pdb
 	rm -f libxammac.dylib
 
 else

--- a/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/app.config
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/app.config
@@ -6,6 +6,18 @@
 					<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
 					<bindingRedirect oldVersion="2.0.0.0-4.4.3.0" newVersion="4.4.3.0"/>
 				</dependentAssembly>
+				<dependentAssembly>
+					<assemblyIdentity name="System" publicKeyToken="b77a5c561934e089" culture="neutral"/>
+					<bindingRedirect oldVersion="2.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+				</dependentAssembly>
+				<dependentAssembly>
+					<assemblyIdentity name="mscorlib" publicKeyToken="b77a5c561934e089" culture="neutral"/>
+					<bindingRedirect oldVersion="2.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+				</dependentAssembly>
+				<dependentAssembly>
+					<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+					<bindingRedirect oldVersion="1.2.0.0-1.2.1.0" newVersion="1.2.1.0"/>
+				</dependentAssembly>
 			</assemblyBinding>
 	</runtime>
 </configuration>

--- a/main/msbuild/ReferencesCecil.props
+++ b/main/msbuild/ReferencesCecil.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <ReferencesCecilCopyToOutput Condition="$(ReferencesCecilCopyToOutput) == ''">false</ReferencesCecilCopyToOutput>
+    <ReferencesCecilCopyToOutput Condition="'$(ReferencesCecilCopyToOutput)' == ''">false</ReferencesCecilCopyToOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/main/msbuild/ReferencesCecil.props
+++ b/main/msbuild/ReferencesCecil.props
@@ -1,0 +1,26 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesCecilCopyToOutput Condition="$(ReferencesCecilCopyToOutput) == ''">false</ReferencesCecilCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Mono.Cecil">
+      <HintPath>$(PackagesDirectory)\Mono.Cecil.$(NuGetVersionCecil)\lib\net40\Mono.Cecil.dll</HintPath>
+      <Private>$(ReferencesCecilCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>$(PackagesDirectory)\Mono.Cecil.$(NuGetVersionCecil)\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>$(ReferencesCecilCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>$(PackagesDirectory)\Mono.Cecil.$(NuGetVersionCecil)\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>$(ReferencesCecilCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>$(PackagesDirectory)\Mono.Cecil.$(NuGetVersionCecil)\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <Private>$(ReferencesCecilCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesJson.props
+++ b/main/msbuild/ReferencesJson.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesJsonCopyToOutput Condition="'$(ReferencesJsonCopyToOutput)' == ''">false</ReferencesJsonCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(PackagesDirectory)\Newtonsoft.Json.$(NuGetVersionJson)\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>$(ReferencesJsonCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>
+

--- a/main/msbuild/ReferencesMonoDoc.props
+++ b/main/msbuild/ReferencesMonoDoc.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesMonoDocCopyToOutput Condition="$(ReferencesMonoDocCopyToOutput) == ''">false</ReferencesMonoDocCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="monodoc">
+      <HintPath>$(PackagesDirectory)\mdoc.$(NuGetVersionMonoDoc)\tools\monodoc.dll</HintPath>
+      <Private>$(ReferencesMonoDocCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesMonoDoc.props
+++ b/main/msbuild/ReferencesMonoDoc.props
@@ -2,12 +2,16 @@
 
   <PropertyGroup>
     <ReferencesMonoDocCopyToOutput Condition="'$(ReferencesMonoDocCopyToOutput)' == ''">false</ReferencesMonoDocCopyToOutput>
+    <!-- HACK! Force it to false until we get a monodoc compliant with what SharpZipLib we use -->
+    <ReferencesMonoDocCopyToOutput">false</ReferencesMonoDocCopyToOutput>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="monodoc">
+<!-- Disabled until we get a monodoc compliant with what SharpZipLib we use
       <HintPath>$(PackagesDirectory)\mdoc.$(NuGetVersionMonoDoc)\tools\monodoc.dll</HintPath>
       <Private>$(ReferencesMonoDocCopyToOutput)</Private>
+-->
     </Reference>
   </ItemGroup>
 

--- a/main/msbuild/ReferencesMonoDoc.props
+++ b/main/msbuild/ReferencesMonoDoc.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ReferencesMonoDocCopyToOutput Condition="'$(ReferencesMonoDocCopyToOutput)' == ''">false</ReferencesMonoDocCopyToOutput>
     <!-- HACK! Force it to false until we get a monodoc compliant with what SharpZipLib we use -->
-    <ReferencesMonoDocCopyToOutput">false</ReferencesMonoDocCopyToOutput>
+    <ReferencesMonoDocCopyToOutput>false</ReferencesMonoDocCopyToOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/main/msbuild/ReferencesMonoDoc.props
+++ b/main/msbuild/ReferencesMonoDoc.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <ReferencesMonoDocCopyToOutput Condition="$(ReferencesMonoDocCopyToOutput) == ''">false</ReferencesMonoDocCopyToOutput>
+    <ReferencesMonoDocCopyToOutput Condition="'$(ReferencesMonoDocCopyToOutput)' == ''">false</ReferencesMonoDocCopyToOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/main/msbuild/ReferencesSharpZipLib.props
+++ b/main/msbuild/ReferencesSharpZipLib.props
@@ -9,6 +9,7 @@
     <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6375.31400">
       <HintPath>$(PackagesDirectory)\JetBrains.SharpZipLib.Stripped.$(NuGetVersionSharpZipLib)\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>$(ReferencesSharpZipLibCopyToOutput)</Private>
+      <SpecificVersion>true</SpecificVersion>
     </Reference>
   </ItemGroup>
 

--- a/main/msbuild/ReferencesSharpZipLib.props
+++ b/main/msbuild/ReferencesSharpZipLib.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <ReferencesSharpZipLibCopyToOutput Condition="$(ReferencesSharpZipLibCopyToOutput) == ''">false</ReferencesSharpZipLibCopyToOutput>
+    <ReferencesSharpZipLibCopyToOutput Condition="'$(ReferencesSharpZipLibCopyToOutput)' == ''">false</ReferencesSharpZipLibCopyToOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/main/msbuild/ReferencesSharpZipLib.props
+++ b/main/msbuild/ReferencesSharpZipLib.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesSharpZipLibCopyToOutput Condition="$(ReferencesSharpZipLibCopyToOutput) == ''">false</ReferencesSharpZipLibCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>$(PackagesDirectory)\JetBrains.SharpZipLib.Stripped.$(NuGetVersionSharpZipLib)\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>$(ReferencesSharpZipLibCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesSharpZipLib.props
+++ b/main/msbuild/ReferencesSharpZipLib.props
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib">
+    <!-- Modify this every time the library is bumped -->
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6375.31400">
       <HintPath>$(PackagesDirectory)\JetBrains.SharpZipLib.Stripped.$(NuGetVersionSharpZipLib)\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>$(ReferencesSharpZipLibCopyToOutput)</Private>
     </Reference>

--- a/main/msbuild/ReferencesSystemCollectionsImmutable.props
+++ b/main/msbuild/ReferencesSystemCollectionsImmutable.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesSystemCollectionsImmutableCopyToOutput Condition="$(ReferencesSystemCollectionsImmutableCopyToOutput) == ''">false</ReferencesSystemCollectionsImmutableCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(PackagesDirectory)\System.Collections.Immutable.$(NuGetVersionSystemCollectionsImmutable)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>$(ReferencesSystemCollectionsImmutableCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesSystemComposition.props
+++ b/main/msbuild/ReferencesSystemComposition.props
@@ -1,0 +1,30 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesSystemCompositionCopyToOutput Condition="$(ReferencesSystemCompositionCopyToOutput) == ''">false</ReferencesSystemCompositionCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Composition.AttributedModel, Version=$(AssemblyVersionSystemComposition), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(PackagesDirectory)\System.Composition.AttributedModel.$(NuGetVersionSystemComposition)\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>$(ReferencesSystemCompositionCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=$(AssemblyVersionSystemComposition), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(PackagesDirectory)\System.Composition.Convention.$(NuGetVersionSystemComposition)\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>$(ReferencesSystemCompositionCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=$(AssemblyVersionSystemComposition), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(PackagesDirectory)\System.Composition.Hosting.$(NuGetVersionSystemComposition)\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>$(ReferencesSystemCompositionCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=$(AssemblyVersionSystemComposition), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(PackagesDirectory)\System.Composition.Runtime.$(NuGetVersionSystemComposition)\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>$(ReferencesSystemCompositionCopyToOutput)</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=$(AssemblyVersionSystemComposition), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(PackagesDirectory)\System.Composition.TypedParts.$(NuGetVersionSystemComposition)\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>$(ReferencesSystemCompositionCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesSystemReflectionMetadata.props
+++ b/main/msbuild/ReferencesSystemReflectionMetadata.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesSystemReflectionMetadataCopyToOutput Condition="$(ReferencesSystemReflectionMetadataCopyToOutput) == ''">false</ReferencesSystemReflectionMetadataCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Reflection.Metadata">
+      <!-- NOTE: NuGet installs the PCL version of SRM by default, but it is Windows-specific. Use netstandard instead.
+-->
+      <HintPath>$(PackagesDirectory)\System.Reflection.Metadata.$(NuGetVersionSystemReflectionMetadata)\lib\netstandard1.1\System.Reflection.Metadata.dll</HintPath>
+      <Private>$(ReferencesSystemReflectionMetadataCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesSystemValueTuple.props
+++ b/main/msbuild/ReferencesSystemValueTuple.props
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <Reference Include="System.ValueTuple">
-      <HintPath>$(PackagesDirectory)\System.ValueTuple.$(NuGetVersionSystemValueTuple)\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>$(PackagesDirectory)\System.ValueTuple.$(NuGetVersionSystemValueTuple)\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>$(ReferencesSystemValueTupleCopyToOutput)</Private>
     </Reference>
   </ItemGroup>

--- a/main/msbuild/ReferencesSystemValueTuple.props
+++ b/main/msbuild/ReferencesSystemValueTuple.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesSystemValueTupleCopyToOutput Condition="$(ReferencesSystemValueTupleCopyToOutput) == ''">false</ReferencesSystemValueTupleCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(PackagesDirectory)\System.ValueTuple.$(NuGetVersionSystemValueTuple)\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>$(ReferencesSystemValueTupleCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesVSCodingConventions.props
+++ b/main/msbuild/ReferencesVSCodingConventions.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesVSCodingConventionsCopyToOutput Condition="$(ReferencesVSCodingConventionsCopyToOutput) == ''">false</ReferencesVSCodingConventionsCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.CodingConventions">
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.CodingConventions.$(NuGetVersionVSCodingConventions)\lib\netstandard1.3\Microsoft.VisualStudio.CodingConventions.dll</HintPath>
+      <Private>$(ReferencesVSCodingConventionsCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/msbuild/ReferencesVSEditor.props
+++ b/main/msbuild/ReferencesVSEditor.props
@@ -34,7 +34,7 @@
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Implementation">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.2.0-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.$(NuGetVersionVSEditorTextImplementation)\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
   </ItemGroup>

--- a/main/msbuild/ReferencesVSThreading.props
+++ b/main/msbuild/ReferencesVSThreading.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <ReferencesVSThreadingCopyToOutput Condition="$(ReferencesVSThreadingCopyToOutput) == ''">false</ReferencesVSThreadingCopyToOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Threading">
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Threading.$(NuGetVersionVSThreading)\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <Private>$(ReferencesVSThreadingCopyToOutput)</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -132,10 +133,6 @@
       <Name>ICSharpCode.NRefactory</Name>
       <Private>False</Private>
     </ProjectReference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Mono.TextTemplating">
       <HintPath>..\..\..\packages\Mono.TextTemplating.1.3.1\lib\net45\Mono.TextTemplating.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
+++ b/main/src/addins/AspNet/MonoDevelop.AspNet.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -132,26 +134,6 @@
     </ProjectReference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.TextTemplating">

--- a/main/src/addins/AspNet/Tests/MonoDevelop.AspNet.Tests.csproj
+++ b/main/src/addins/AspNet/Tests/MonoDevelop.AspNet.Tests.csproj
@@ -42,18 +42,6 @@
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Razor\Dom\RazorCodeBlockParsingTests.cs" />

--- a/main/src/addins/AspNet/Tests/MonoDevelop.AspNet.Tests.csproj
+++ b/main/src/addins/AspNet/Tests/MonoDevelop.AspNet.Tests.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,10 +43,6 @@
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">

--- a/main/src/addins/AspNet/Tests/MonoDevelop.AspNet.Tests.csproj
+++ b/main/src/addins/AspNet/Tests/MonoDevelop.AspNet.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,10 +42,6 @@
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -1,5 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesVSCodingConventions)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
@@ -141,10 +142,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="Microsoft.VisualStudio.CodingConventions">
-      <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.CodingConventions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="templates\ConsoleProject.xpt.xml">

--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -143,10 +144,6 @@
     </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ValueTuple">

--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -3,7 +3,9 @@
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -139,14 +141,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.CodingConventions">
       <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.CodingConventions.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -144,10 +145,6 @@
     </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CodingConventions">
@@ -378,7 +375,6 @@
   <ItemGroup>
     <None Include="Makefile.am" />
     <None Include="MonoDevelop.CSharp.CodeRefactorings\ConvertToEnum\ConvertToEnumCodeRefactoringProvider.cs" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.Ide.Tests" />

--- a/main/src/addins/CSharpBinding/packages.config
+++ b/main/src/addins/CSharpBinding/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.csproj
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSharpZipLib)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -90,7 +91,6 @@
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib" />
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.csproj
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSharpZipLib)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -90,10 +91,6 @@
     </Reference>
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -55,10 +56,6 @@
       <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cairo" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
@@ -145,7 +142,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/main/src/addins/MacPlatform/packages.config
+++ b/main/src/addins/MacPlatform/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,10 +39,6 @@
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="Mono.Posix" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoDevelop.AspNetCore.Templating\AspNetCoreFileTemplateCondition.cs" />

--- a/main/src/addins/MonoDevelop.AspNetCore/packages.config
+++ b/main/src/addins/MonoDevelop.AspNetCore/packages.config
@@ -1,6 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="Microsoft.DotNet.Web.ProjectTemplates.1.x" version="1.0.0-beta2-20170430-208" targetFramework="net46" />
   <package id="Microsoft.DotNet.Web.ProjectTemplates.2.0" version="1.0.0-beta2-20170727-301" targetFramework="net46" />
 </packages>

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -79,22 +80,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -180,8 +165,5 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="Gui\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
@@ -69,7 +70,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -72,10 +73,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
@@ -72,10 +73,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -71,10 +72,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/packages.config
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.Autotools/MonoDevelop.Autotools.csproj
+++ b/main/src/addins/MonoDevelop.Autotools/MonoDevelop.Autotools.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -87,10 +88,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
+++ b/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemComposition)" />
@@ -49,10 +50,6 @@
     </Reference>
     <Reference Include="ICSharpCode.NRefactory.CSharp">
       <HintPath>..\..\..\build\bin\ICSharpCode.NRefactory.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -142,7 +139,6 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="ReadMe.md" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
+++ b/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemComposition)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -48,10 +49,6 @@
     </Reference>
     <Reference Include="ICSharpCode.NRefactory.CSharp">
       <HintPath>..\..\..\build\bin\ICSharpCode.NRefactory.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
+++ b/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
@@ -1,6 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -40,10 +41,6 @@
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="Mono.Cairo" />
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="ICSharpCode.NRefactory">
       <HintPath>..\..\..\build\bin\ICSharpCode.NRefactory.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
+++ b/main/src/addins/MonoDevelop.ConnectedServices/MonoDevelop.ConnectedServices.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -51,30 +52,6 @@
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/main/src/addins/MonoDevelop.ConnectedServices/packages.config
+++ b/main/src/addins/MonoDevelop.ConnectedServices/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.csproj
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.csproj
@@ -1,6 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -43,22 +44,6 @@
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/packages.config
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol.csproj
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -31,10 +32,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shared.VSCodeDebugProtocol">
       <HintPath>..\..\..\..\packages\Microsoft.VisualStudio.Shared.VsCodeDebugProtocol.15.0.10815.1\lib\net45\Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.dll</HintPath>
     </Reference>

--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/packages.config
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/packages.config
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" version="15.0.10815.1" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/MonoDevelop.Debugger.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/MonoDevelop.Debugger.Tests.csproj
@@ -80,6 +80,7 @@
     <ProjectReference Include="..\..\..\..\external\debugger-libs\Mono.Debugging.Soft\Mono.Debugging.Soft.csproj">
       <Project>{DE40756E-57F6-4AF2-B155-55E3A88CCED8}</Project>
       <Name>Mono.Debugging.Soft</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -95,10 +96,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
@@ -96,18 +97,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Drawing" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -95,10 +96,6 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -108,10 +109,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -717,8 +714,5 @@
     <Folder Include="MonoDevelop.Debugger.Converters\" />
     <Folder Include="icons\mac\" />
     <Folder Include="Gui\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/main/src/addins/MonoDevelop.Debugger/packages.config
+++ b/main/src/addins/MonoDevelop.Debugger/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
@@ -67,10 +68,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -67,10 +68,6 @@
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -66,10 +67,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
-  <Import Projepct="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Projepct="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -74,22 +75,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -266,7 +251,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/addins/MonoDevelop.DesignerSupport/packages.config
+++ b/main/src/addins/MonoDevelop.DesignerSupport/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.csproj
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
@@ -47,22 +48,6 @@
     <Reference Include="Mono.Posix" />
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.csproj
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -46,10 +47,6 @@
     <Reference Include="Mono.Posix" />
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.csproj
+++ b/main/src/addins/MonoDevelop.DocFood/MonoDevelop.DocFood.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -47,10 +48,6 @@
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,10 +36,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -34,10 +35,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.DotNetCore/packages.config
+++ b/main/src/addins/MonoDevelop.DotNetCore/packages.config
@@ -4,5 +4,4 @@
   <package id="Microsoft.DotNet.Common.ProjectTemplates.2.0" version="1.0.0-beta2-20170727-301" targetFramework="net46" />
   <package id="Microsoft.DotNet.Test.ProjectTemplates.1.x" version="1.0.0-beta2-20170430-208" targetFramework="net46" />
   <package id="Microsoft.DotNet.Test.ProjectTemplates.2.0" version="1.0.0-beta2-20170727-301" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
 </packages>

--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.csproj
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -62,10 +63,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.csproj
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
@@ -62,10 +63,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.csproj
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -61,10 +62,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -92,10 +93,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -93,10 +94,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -108,22 +109,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
@@ -93,18 +94,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.GtkCore/libsteticui/libsteticui.csproj
+++ b/main/src/addins/MonoDevelop.GtkCore/libsteticui/libsteticui.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -65,22 +66,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libstetic\libstetic.csproj">

--- a/main/src/addins/MonoDevelop.GtkCore/libsteticui/packages.config
+++ b/main/src/addins/MonoDevelop.GtkCore/libsteticui/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net40" />
-</packages>

--- a/main/src/addins/MonoDevelop.GtkCore/packages.config
+++ b/main/src/addins/MonoDevelop.GtkCore/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <ProjectGuid>{2645C9F3-9ED5-4806-AB09-DAD9BE90C67B}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -92,10 +93,6 @@
     </Reference>
     <Reference Include="NuGet.LibraryModel">
       <HintPath>..\..\..\..\external\nuget-binary\NuGet.LibraryModel.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="NuGet.Commands">
       <HintPath>..\..\..\..\external\nuget-binary\NuGet.Commands.dll</HintPath>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <ProjectGuid>{2645C9F3-9ED5-4806-AB09-DAD9BE90C67B}</ProjectGuid>
@@ -84,9 +85,6 @@
     </Reference>
     <Reference Include="NuGet.Resolver">
       <HintPath>..\..\..\..\external\nuget-binary\NuGet.Resolver.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.ProjectModel">
       <HintPath>..\..\..\..\external\nuget-binary\NuGet.ProjectModel.dll</HintPath>
@@ -236,8 +234,5 @@
   <ItemGroup>
     <Folder Include="MonoDevelop.PackageManagement.Tests\" />
     <Folder Include="MonoDevelop.PackageManagement.Tests.Helpers\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/packages.config
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <ProjectGuid>{F218643D-2E74-4309-820E-206A54B7133F}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -120,10 +121,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
@@ -118,10 +119,6 @@
     </Reference>
     <Reference Include="NuGet.Indexing">
       <HintPath>..\..\..\external\nuget-binary\NuGet.Indexing.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -606,7 +603,6 @@
       <Link>NuGet-LICENSE.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.DotNetCore" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <ProjectGuid>{F218643D-2E74-4309-820E-206A54B7133F}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -119,10 +120,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ValueTuple">

--- a/main/src/addins/MonoDevelop.PackageManagement/packages.config
+++ b/main/src/addins/MonoDevelop.PackageManagement/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-</packages>

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
@@ -75,6 +75,7 @@
     <ProjectReference Include="..\..\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.Tests\MonoDevelop.PackageManagement.Tests.csproj">
       <Project>{2645C9F3-9ED5-4806-AB09-DAD9BE90C67B}</Project>
       <Name>MonoDevelop.PackageManagement.Tests</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\MonoDevelop.DotNetCore\MonoDevelop.DotNetCore.csproj">
       <Project>{6868153E-41EA-43A4-A81A-C1E7256373F7}</Project>

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -33,10 +34,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -112,10 +113,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.EditorFeatures">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Composition.TypedParts">

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -81,54 +83,6 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="Xamarin.Mac" Condition=" '$(Configuration)' == 'DebugMac' Or '$(Configuration)' == 'ReleaseMac' ">
       <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Composition.Runtime">
-      <HintPath>..\..\..\build\bin\System.Composition.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Features">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Features.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Composition.TypedParts">
-      <HintPath>..\..\..\build\bin\System.Composition.TypedParts.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Composition.Hosting">
-      <HintPath>..\..\..\build\bin\System.Composition.Hosting.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -87,10 +88,6 @@
     </Reference>
     <Reference Include="System.Composition.Runtime">
       <HintPath>..\..\..\build\bin\System.Composition.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">

--- a/main/src/addins/MonoDevelop.RegexToolkit/MonoDevelop.RegexToolkit.csproj
+++ b/main/src/addins/MonoDevelop.RegexToolkit/MonoDevelop.RegexToolkit.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
@@ -64,22 +65,6 @@
     </Reference>
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/MonoDevelop.RegexToolkit/MonoDevelop.RegexToolkit.csproj
+++ b/main/src/addins/MonoDevelop.RegexToolkit/MonoDevelop.RegexToolkit.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -81,10 +82,6 @@
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.RegexToolkit/MonoDevelop.RegexToolkit.csproj
+++ b/main/src/addins/MonoDevelop.RegexToolkit/MonoDevelop.RegexToolkit.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -78,10 +79,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -128,11 +128,6 @@
       <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.Threading.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Implementation">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Posix" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -156,10 +157,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
-  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSThreading)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -156,10 +157,6 @@
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -165,10 +166,6 @@
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
@@ -268,7 +265,6 @@
     <Compile Include="Mono.TextEditor.Theatrics\SingleActorStage.cs" />
     <Compile Include="Mono.TextEditor.Theatrics\SmartScrolledWindow.cs" />
     <Compile Include="Mono.TextEditor.Theatrics\Stage.cs" />
-    <None Include="packages.config" />
     <Compile Include="MonoDevelop.SourceEditor\TextMarker\LineSeparatorMarker.cs" />
     <Compile Include="MonoDevelop.SourceEditor.QuickTasks\QuickTaskOverviewMode.IndicatorDrawingCache.cs" />
     <Compile Include="MonoDevelop.SourceEditor.QuickTasks\QuickTaskOverviewMode.IdleUpdater.cs" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesVSThreading)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
@@ -117,7 +119,7 @@
     <ProjectReference Include="..\..\..\external\debugger-libs\Mono.Debugging\Mono.Debugging.csproj">
       <Project>{90C99ADB-7D4B-4EB4-98C2-40BD1B14C7D2}</Project>
       <Name>Mono.Debugging</Name>
-      <Private>False</Private>
+      <private>false</private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\external\xwt\Xwt.Gtk\Xwt.Gtk.csproj">
       <Project>{C3887A93-B2BD-4097-8E2F-3A063EFF32FD}</Project>
@@ -126,11 +128,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.Threading.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Posix" />
@@ -157,10 +154,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="mscorlib" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorWidget.cs
@@ -391,8 +391,8 @@ namespace MonoDevelop.SourceEditor
 				return child;
 			}
 		}
-		
-		public SourceEditorWidget (SourceEditorView view, TextDocument doc)
+
+		public SourceEditorWidget (SourceEditorView view, Mono.TextEditor.TextDocument doc)
 		{
 			this.view = view;
 			vbox.SetSizeRequest (32, 32);

--- a/main/src/addins/MonoDevelop.SourceEditor2/packages.config
+++ b/main/src/addins/MonoDevelop.SourceEditor2/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -44,10 +45,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnit3Runner.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnit3Runner.csproj
@@ -64,6 +64,7 @@
     <Compile Include="EventListenerWrapper.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnit3Runner.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnit3Runner.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -47,10 +48,6 @@
       <HintPath>..\..\..\..\packages\NUnit.Engine.3.0.1\lib\nunit-agent-x86.exe</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/app.config
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/app.config
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<runtime>
+	<!-- DO NOT TRUST CORECLR PACKAGE VERSIONS. LOOK AT THE ASSEMBLY VERSION OF THE ASSEMBLY, NOT THE PACKAGE VERSION -->
+		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="mscorlib" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Configuration" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitRunner.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitRunner.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -49,10 +50,6 @@
     </Reference>
     <Reference Include="nunit.util">
       <HintPath>..\..\..\..\packages\NUnit.Runners.2.6.4\tools\lib\nunit.util.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitRunner.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnitRunner/NUnitRunner.csproj
@@ -69,5 +69,8 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="..\NUnit3Runner\app.config">
+      <Link>app.config</Link>
+    </None>
   </ItemGroup>
 </Project>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
@@ -65,6 +65,7 @@
     <ProjectReference Include="..\..\..\..\tests\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
@@ -79,6 +80,7 @@
     <ProjectReference Include="..\MonoDevelop.UnitTesting.csproj">
       <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>
       <Name>MonoDevelop.UnitTesting</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\MonoDevelop.DotNetCore\MonoDevelop.DotNetCore.csproj">
       <Project>{6868153E-41EA-43A4-A81A-C1E7256373F7}</Project>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -49,9 +50,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicTests.cs" />

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -48,9 +49,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/packages.config
@@ -1,7 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
@@ -38,13 +38,13 @@ namespace MonoDevelop.UnitTesting.VsTest
 {
 	class VsTestUnitTest : UnitTest, IVsTestTestProvider
 	{
-		public Project Project { get; private set; }
+		public MonoDevelop.Projects.Project Project { get; private set; }
 		TestCase test;
 		IVsTestTestRunner testRunner;
 		string name;
 		SourceCodeLocation sourceCodeLocation;
 
-		public VsTestUnitTest (IVsTestTestRunner testRunner, TestCase test, Project project)
+		public VsTestUnitTest (IVsTestTestRunner testRunner, TestCase test, MonoDevelop.Projects.Project project)
 			: base (test.DisplayName)
 		{
 			this.Project = project;

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -333,8 +333,8 @@
     </VsTestConsoleExtensions>
   </ItemGroup>
   <Target Name="CopyTestAdapters" BeforeTargets="Build">
-    <Copy SourceFiles="@(VsTestConsole)" DestinationFolder="$(OutputPath)\VsTestConsole\%(RecursiveDir)" />
-    <Copy SourceFiles="@(VsTestConsoleExtensions)" DestinationFolder="$(OutputPath)\VsTestConsole\Extensions\" />
+    <Copy SourceFiles="@(VsTestConsole)" DestinationFolder="$(OutputPath)\VsTestConsole\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(VsTestConsoleExtensions)" DestinationFolder="$(OutputPath)\VsTestConsole\Extensions\" SkipUnchangedFiles="true" />
   </Target>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -78,10 +79,6 @@
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
       <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
@@ -64,10 +65,6 @@
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="mscorlib" />
     <Reference Include="System.Configuration" />

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -77,10 +78,6 @@
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
       <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Reflection.Metadata">

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
@@ -70,10 +71,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
       <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>False</Private>
@@ -301,7 +298,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.UnitTesting.VsTest\" />

--- a/main/src/addins/MonoDevelop.UnitTesting/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/packages.config
@@ -3,6 +3,5 @@
   <package id="Microsoft.TestPlatform" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.5.0-preview-20170919-04" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/main/src/addins/MonoDevelop.UnitTesting/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/packages.config
@@ -4,6 +4,5 @@
   <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/main/src/addins/MonoDevelop.UnitTesting/packages.config
+++ b/main/src/addins/MonoDevelop.UnitTesting/packages.config
@@ -1,10 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.TestPlatform" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.5.0-preview-20170919-04" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.csproj
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -66,10 +67,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/PerformanceDiagnosticsAddIn.csproj
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/PerformanceDiagnosticsAddIn.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -36,10 +37,6 @@
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="Xamarin.Mac">
       <HintPath>..\..\..\..\external\Xamarin.Mac.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Posix" />
@@ -81,9 +78,6 @@
       <Project>{3FDB97B5-916E-4817-8098-41659687A8FF}</Project>
       <Name>UIThreadMonitorDaemon</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/packages.config
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.csproj
+++ b/main/src/addins/TextTemplating/MonoDevelop.TextTemplating/MonoDevelop.TextTemplating.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -75,10 +76,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Mono.TextTemplating">
       <HintPath>..\..\..\..\packages\Mono.TextTemplating.1.3.1\lib\net45\Mono.TextTemplating.dll</HintPath>
     </Reference>

--- a/main/src/addins/VBNetBinding/VBNetBinding.csproj
+++ b/main/src/addins/VBNetBinding/VBNetBinding.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -78,22 +79,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/main/src/addins/VBNetBinding/VBNetBinding.csproj
+++ b/main/src/addins/VBNetBinding/VBNetBinding.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -91,10 +92,6 @@
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
@@ -133,6 +133,7 @@
     <ProjectReference Include="..\..\..\..\external\libgit2sharp\LibGit2Sharp\LibGit2Sharp.csproj">
       <Project>{EE6ED99F-CB12-4683-B055-D28FC7357A34}</Project>
       <Name>LibGit2Sharp</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
       <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -108,10 +109,6 @@
     <Reference Include="Mono.Cairo" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
@@ -108,14 +110,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI">
-      <HintPath>..\..\..\..\build\bin\Microsoft.VisualStudio.Text.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="icons\added-overlay-16.png">

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -107,10 +108,6 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cairo" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>

--- a/main/src/addins/VersionControl/Subversion.Win32.Tests/VersionControl.Subversion.Win32.Tests.csproj
+++ b/main/src/addins/VersionControl/Subversion.Win32.Tests/VersionControl.Subversion.Win32.Tests.csproj
@@ -51,6 +51,7 @@
     <ProjectReference Include="..\Subversion.Win32\VersionControl.Subversion.Win32.csproj">
       <Project>{1038FBD8-750E-4081-BC65-D89FFED3C881}</Project>
       <Name>VersionControl.Subversion.Win32</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>

--- a/main/src/addins/Xml/MonoDevelop.Xml.csproj
+++ b/main/src/addins/Xml/MonoDevelop.Xml.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -68,10 +69,6 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/Xml/MonoDevelop.Xml.csproj
+++ b/main/src/addins/Xml/MonoDevelop.Xml.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -69,10 +70,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/Xml/Tests/MonoDevelop.Xml.Tests.csproj
+++ b/main/src/addins/Xml/Tests/MonoDevelop.Xml.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -66,10 +67,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Parser\ActiveElementStartPathTestFixture.cs" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -7,6 +7,7 @@
     <ReferencesVSEditorCopyToOutput>true</ReferencesVSEditorCopyToOutput>
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
+    <ReferencesJsonCopyToOutput>true</ReferencesJsonCopyToOutput>
     <ReferencesSharpZipLibCopyToOutput>true</ReferencesSharpZipLibCopyToOutput>
     <ReferencesSystemCompositionCopyToOutput>true</ReferencesSystemCompositionCopyToOutput>
     <ReferencesSystemCollectionsImmutableCopyToOutput>true</ReferencesSystemCollectionsImmutableCopyToOutput>
@@ -17,6 +18,7 @@
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesSharpZipLib)" />
   <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
@@ -165,9 +167,6 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext">
       <HintPath>..\..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -1,12 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <PropertyGroup>
     <ReferencesVSEditorCopyToOutput>true</ReferencesVSEditorCopyToOutput>
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
+    <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
   </PropertyGroup>
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesCecil)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -161,18 +163,6 @@
     <Reference Include="Microsoft.Build.Tasks.Core">
       <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.Tasks.Core.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="mscorlib" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <PropertyGroup>
+    <ReferencesMonoDocCopyToOutput>true</ReferencesMonoDocCopyToOutput>
     <ReferencesVSEditorCopyToOutput>true</ReferencesVSEditorCopyToOutput>
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
@@ -9,6 +10,7 @@
     <ReferencesSystemCollectionsImmutableCopyToOutput>true</ReferencesSystemCollectionsImmutableCopyToOutput>
     <ReferencesSystemValueTupleCopyToOutput>true</ReferencesSystemValueTupleCopyToOutput>
   </PropertyGroup>
+  <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
@@ -149,7 +151,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
     <Reference Include="System.ServiceModel" />
@@ -170,7 +171,6 @@
       <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.Tasks.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesVSCodingConventions)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesJson)" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -7,7 +7,9 @@
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
     <ReferencesSharpZipLibCopyToOutput>true</ReferencesSharpZipLibCopyToOutput>
+    <ReferencesSystemCompositionCopyToOutput>true</ReferencesSystemCompositionCopyToOutput>
     <ReferencesSystemCollectionsImmutableCopyToOutput>true</ReferencesSystemCollectionsImmutableCopyToOutput>
+    <ReferencesSystemReflectionMetadataCopyToOutput>true</ReferencesSystemReflectionMetadataCopyToOutput>
     <ReferencesSystemValueTupleCopyToOutput>true</ReferencesSystemValueTupleCopyToOutput>
   </PropertyGroup>
   <Import Project="$(ReferencesMonoDoc)" />
@@ -15,7 +17,9 @@
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSharpZipLib)" />
+  <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -132,18 +136,6 @@
       <HintPath>..\..\..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.9\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Posix" />
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Composition.AttributedModel.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Composition.Hosting.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Composition.Runtime.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\netstandard1.0\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>true</Private>
@@ -198,10 +190,6 @@
       <HintPath>..\..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />
-    <!-- NOTE: NuGet installs the PCL version of System.Reflection.Metadata by default but it is windows-specific. Use netstandard version instead. -->
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\netstandard1.1\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
       <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -6,11 +6,13 @@
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
     <ReferencesSharpZipLibCopyToOutput>true</ReferencesSharpZipLibCopyToOutput>
+    <ReferencesSystemCollectionsImmutableCopyToOutput>true</ReferencesSystemCollectionsImmutableCopyToOutput>
   </PropertyGroup>
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSharpZipLib)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -174,9 +176,6 @@
     <Reference Include="System" />
     <Reference Include="System.AppContext">
       <HintPath>..\..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Console">
       <HintPath>..\..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -134,6 +134,10 @@
     <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\netstandard1.0\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <PropertyGroup>
     <ReferencesMonoDocCopyToOutput>true</ReferencesMonoDocCopyToOutput>
+    <ReferencesVSCodingConventionsCopyToOutput>true</ReferencesVSCodingConventionsCopyToOutput>
     <ReferencesVSEditorCopyToOutput>true</ReferencesVSEditorCopyToOutput>
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
@@ -222,9 +223,6 @@
     </Reference>
     <Reference Include="System.Xml.XPath.XDocument">
       <HintPath>..\..\..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.CodingConventions">
-      <HintPath>..\..\..\packages\Microsoft.VisualStudio.CodingConventions.1.1.20180226.4\lib\netstandard1.3\Microsoft.VisualStudio.CodingConventions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -5,10 +5,12 @@
     <ReferencesVSEditorCopyToOutput>true</ReferencesVSEditorCopyToOutput>
     <ReferencesRoslynCopyToOutput>true</ReferencesRoslynCopyToOutput>
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
+    <ReferencesSharpZipLibCopyToOutput>true</ReferencesSharpZipLibCopyToOutput>
   </PropertyGroup>
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesSharpZipLib)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -7,12 +7,14 @@
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
     <ReferencesSharpZipLibCopyToOutput>true</ReferencesSharpZipLibCopyToOutput>
     <ReferencesSystemCollectionsImmutableCopyToOutput>true</ReferencesSystemCollectionsImmutableCopyToOutput>
+    <ReferencesSystemValueTupleCopyToOutput>true</ReferencesSystemValueTupleCopyToOutput>
   </PropertyGroup>
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSharpZipLib)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -220,9 +222,6 @@
     </Reference>
     <Reference Include="System.Threading.Thread">
       <HintPath>..\..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.ReaderWriter">
       <HintPath>..\..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/HelpService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/HelpService.cs
@@ -77,6 +77,18 @@ namespace MonoDevelop.Projects
 				Counters.HelpServiceInitialization.BeginTiming ();
 				
 				try {
+					// Temporary hack to make monodoc work from nuget
+					var type = Type.GetType ("Mono.Runtime");
+					if (type != null) {
+						// We need to get from corlib to monodoc
+						// "/Library/Frameworks/Mono.framework/Versions/5.12.0/lib/mono/4.5/mscorlib.dll"
+						// "/Library/Frameworks/Mono.framework/Versions/5.12.0/lib/monodoc"
+						var mscorlib = type.Assembly.Location;
+						var monoLib = Path.GetDirectoryName (Path.GetDirectoryName (Path.GetDirectoryName (mscorlib)));
+						var monodocPath = Path.Combine (monoLib, "monodoc");
+						Config.AppSettings.Add ("docPath", monodocPath);
+					}
+
 					helpTree = RootTree.LoadTree ();
 					
 					foreach (var node in AddinManager.GetExtensionNodes ("/MonoDevelop/ProjectModel/MonoDocSources"))

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -99,6 +99,7 @@
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Timer" version="4.0.1" targetFramework="net461" />

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ICSharpCode.Decompiler" version="3.0.0.3403-beta4" targetFramework="net461" />
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net461" />
+  <package id="ICSharpCode.Decompiler" version="3.0.0.3403-beta4" targetFramework="net461" />
+  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
+  <package id="mdoc" version="5.6.3" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis" version="2.8.0-beta3-62728-05" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.2.0-beta2" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.8.0-beta3-62728-05" targetFramework="net461" />
@@ -27,18 +29,17 @@
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Data" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.2.0-pre" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Internal" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.7.153-preview-g7d0635149a" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.2.0-pre" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0-beta7" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_e_sqlite3" version="1.1.9" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.9" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.9" targetFramework="net461" />

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -38,7 +38,7 @@
   <package id="Mono.Cecil" version="0.10.0-beta7" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_e_sqlite3" version="1.1.9" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.9" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.9" targetFramework="net461" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -182,7 +182,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression">
+      <HintPath>..\..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\netstandard1.1\System.Reflection.Metadata.dll</HintPath>
     </Reference>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -190,6 +190,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\netstandard1.0\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Services" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -1,8 +1,13 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <PropertyGroup>
+    <ReferencesVSThreadingCopyToOutput>true</ReferencesVSThreadingCopyToOutput>
+  </PropertyGroup>
   <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesVSCodingConventions)" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesVSThreading)" />
   <Import Project="$(ReferencesSharpZipLib)" />
   <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
@@ -141,9 +146,6 @@
     <Reference Include="Microsoft.VisualStudio.Composition, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Composition.15.6.36\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Validation.15.3.32\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
@@ -189,10 +191,6 @@
     </Reference>
     <Reference Include="YamlDotNet">
       <HintPath>..\..\..\packages\YamlDotNet.Signed.4.0.1-pre291\lib\net35\YamlDotNet.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.CodingConventions">
-      <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.CodingConventions.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -212,10 +212,12 @@
     <ProjectReference Include="..\..\..\external\xwt\Xwt\Xwt.csproj">
       <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>
       <Name>Xwt</Name>
+      <Private>true</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\external\xwt\Xwt.Gtk\Xwt.Gtk.csproj">
       <Project>{C3887A93-B2BD-4097-8E2F-3A063EFF32FD}</Project>
       <Name>Xwt.Gtk</Name>
+      <Private>true</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">
       <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSharpZipLib)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -204,10 +205,6 @@
     </Reference>
     <Reference Include="YamlDotNet">
       <HintPath>..\..\..\packages\YamlDotNet.Signed.4.0.1-pre291\lib\net35\YamlDotNet.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CodingConventions">
       <HintPath>..\..\..\build\bin\Microsoft.VisualStudio.CodingConventions.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9705,7 +9705,6 @@
     <InternalsVisibleTo Include="MonoDevelop.SourceEditor" />
     <InternalsVisibleTo Include="MonoDevelop.SourceEditor2" />
     <InternalsVisibleTo Include="MonoDevelop.AssemblyBrowser" />
-    <InternalsVisibleTo Include="MonoDevelop.AspNet" />
     <InternalsVisibleTo Include="Xamarin.Sketches" />
     <InternalsVisibleTo Include="MonoDevelop.CSharpBinding.AspNet" />
     <InternalsVisibleTo Include="MonoDevelop.GtkCore" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4,7 +4,9 @@
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSharpZipLib)" />
+  <Import Project="$(ReferencesSystemComposition)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -160,30 +162,12 @@
     <Reference Include="PresentationFramework" Condition=" '$(Configuration)' == 'DebugWin32' Or '$(Configuration)' == 'ReleaseWin32' " />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\..\packages\System.Composition.AttributedModel.1.0.31\lib\netstandard1.0\System.Composition.AttributedModel.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Convention">
-      <HintPath>..\..\..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Hosting">
-      <HintPath>..\..\..\packages\System.Composition.Hosting.1.0.31\lib\netstandard1.0\System.Composition.Hosting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.Runtime">
-      <HintPath>..\..\..\packages\System.Composition.Runtime.1.0.31\lib\netstandard1.0\System.Composition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.TypedParts">
-      <HintPath>..\..\..\packages\System.Composition.TypedParts.1.0.31\lib\netstandard1.0\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression">
       <HintPath>..\..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\netstandard1.1\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <ReferencesVSThreadingCopyToOutput>true</ReferencesVSThreadingCopyToOutput>
   </PropertyGroup>
+  <Import Project="$(ReferencesJson)" />
   <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSCodingConventions)" />
@@ -153,10 +154,6 @@
     <Reference Include="Mono.Cairo" />
     <Reference Include="Mono.Posix" />
     <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -190,7 +190,6 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\netstandard1.0\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Services" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSharpZipLib)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -157,9 +158,6 @@
     <Reference Include="PresentationCore" Condition=" '$(Configuration)' == 'DebugWin32' Or '$(Configuration)' == 'ReleaseWin32' " />
     <Reference Include="PresentationFramework" Condition=" '$(Configuration)' == 'DebugWin32' Or '$(Configuration)' == 'ReleaseWin32' " />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\..\packages\System.Composition.AttributedModel.1.0.31\lib\netstandard1.0\System.Composition.AttributedModel.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
+  <Import Project="$(ReferencesSharpZipLib)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -113,9 +114,6 @@
     </Reference>
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170615.10\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TemplateEngine.Abstractions">
       <HintPath>..\..\..\packages\Microsoft.TemplateEngine.Abstractions.1.0.0-beta3-20171117-314\lib\net45\Microsoft.TemplateEngine.Abstractions.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -1,5 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesMonoDoc)" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesVSEditor)" />
   <Import Project="$(ReferencesSharpZipLib)" />
@@ -147,7 +148,6 @@
     </Reference>
     <Reference Include="Mono.Cairo" />
     <Reference Include="Mono.Posix" />
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -7,7 +7,6 @@
   <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -7,7 +7,6 @@
   <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170615.10" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.TemplateEngine.Abstractions" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Microsoft.TemplateEngine.Core" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
@@ -10,6 +10,5 @@
   <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="YamlDotNet.Signed" version="4.0.1-pre291" targetFramework="net45" />
 </packages>

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -11,7 +11,6 @@
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
-  <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="YamlDotNet.Signed" version="4.0.1-pre291" targetFramework="net45" />
 </packages>

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -6,7 +6,6 @@
   <package id="Microsoft.TemplateEngine.Edge" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
   <package id="YamlDotNet.Signed" version="4.0.1-pre291" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -7,7 +7,6 @@
   <package id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Microsoft.TemplateEngine.Utils" version="1.0.0-beta3-20171117-314" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
   <package id="YamlDotNet.Signed" version="4.0.1-pre291" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Ide/packages.config
+++ b/main/src/core/MonoDevelop.Ide/packages.config
@@ -11,6 +11,7 @@
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Composition" version="1.0.31" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks.DataFlow" version="4.7.0" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="YamlDotNet.Signed" version="4.0.1-pre291" targetFramework="net45" />
 </packages>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.csproj
@@ -52,7 +52,6 @@
     <Compile Include="AssemblyInfo.v4.0.cs" />
   </ItemGroup>
   <Import Project="MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems" Label="Shared" Condition="Exists('MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems')" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
   </ItemGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,10 +39,6 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
@@ -54,9 +51,6 @@
   <Import Project="MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems" Label="Shared" Condition="Exists('MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems')" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v15.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.dotnet.v15.0.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -81,10 +82,6 @@
       <HintPath>$(MSBuild_OSS_BinDir)Microsoft.Build.Utilities.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release' ">
     <None Include="app.v15.0.config">
@@ -105,9 +102,6 @@
     <Compile Include="AssemblyInfo.v15.0.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="MonoDevelop.Projects.Formats.MSBuild\MSBuildLoggerAdapter.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems" Label="Shared" Condition="Exists('MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -55,7 +55,6 @@
     <Compile Include="AssemblyInfo.v12.0.cs" />
   </ItemGroup>
   <Import Project="MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems" Label="Shared" Condition="Exists('MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems')" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
   </ItemGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v12.0.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -41,10 +42,6 @@
     <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0" />
     <Reference Include="Microsoft.Build.Utilities.v12.0" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
@@ -63,7 +60,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -55,7 +55,6 @@
     <Compile Include="AssemblyInfo.v14.0.cs" />
   </ItemGroup>
   <Import Project="MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems" Label="Shared" Condition="Exists('MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems')" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
   </ItemGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v14.0.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -41,10 +42,6 @@
     <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0" />
     <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
@@ -63,7 +60,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v4.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v4.0.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -41,10 +42,6 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
@@ -63,7 +60,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MonoDevelop.Projects.Formats.MSBuild.exe.config</Link>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v4.0.csproj
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild.v4.0.csproj
@@ -55,7 +55,6 @@
     <Compile Include="AssemblyInfo.v4.0.cs" />
   </ItemGroup>
   <Import Project="MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems" Label="Shared" Condition="Exists('MonoDevelop.Projects.MSBuild.Shared\MonoDevelop.Projects.MSBuild.Shared.projitems')" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="MonoDevelop.Projects.Formats.MSBuild\" />
   </ItemGroup>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.v15.0.config
@@ -28,6 +28,10 @@
 				<assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="1.2.0.0-1.2.1.0" newVersion="1.2.1.0" />
+			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 	<msbuildToolsets default="15.0">

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/packages.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
-</packages>

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -5,6 +5,26 @@
 		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="mscorlib" PublicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System" PublicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Core" PublicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="3.5.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Utilities.Core" PublicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="12.0.0.0-14.0.0.0" newVersion="15.1.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Build.Framework" PublicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="12.0.0.0-14.0.0.0" newVersion="15.1.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="1.0.6375.31400" />
 				<bindingRedirect oldVersion="2.84.0.0-4.84.0.0" newVersion="1.0.6375.31400" />

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -6,15 +6,15 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="mscorlib" publicKeyToken="b77a5c561934e089" culture="neutral" />
-				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+				<bindingRedirect oldVersion="2.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System" publicKeyToken="b77a5c561934e089" culture="neutral" />
-				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
+				<bindingRedirect oldVersion="2.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Core" publicKeyToken="b77a5c561934e089" culture="neutral" />
-				<bindingRedirect oldVersion="3.5.0.0" newVersion="4.0.0.0" />
+				<bindingRedirect oldVersion="3.5.0.0-4.0.0.0" newVersion="4.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -8,6 +8,8 @@
 				<assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="1.0.6375.31400" />
 				<bindingRedirect oldVersion="2.84.0.0-4.84.0.0" newVersion="1.0.6375.31400" />
+				<!-- Temporary hack for monodoc -->
+				<bindingRedirect oldVersion="1.0.6670.36949" newVersion="1.0.6375.31400" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -5,23 +5,23 @@
 		<AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="mscorlib" PublicKeyToken="b77a5c561934e089" culture="neutral" />
+				<assemblyIdentity name="mscorlib" publicKeyToken="b77a5c561934e089" culture="neutral" />
 				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System" PublicKeyToken="b77a5c561934e089" culture="neutral" />
+				<assemblyIdentity name="System" publicKeyToken="b77a5c561934e089" culture="neutral" />
 				<bindingRedirect oldVersion="2.0.0.0" newVersion="4.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Core" PublicKeyToken="b77a5c561934e089" culture="neutral" />
+				<assemblyIdentity name="System.Core" publicKeyToken="b77a5c561934e089" culture="neutral" />
 				<bindingRedirect oldVersion="3.5.0.0" newVersion="4.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Build.Utilities.Core" PublicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="12.0.0.0-14.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Build.Framework" PublicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="12.0.0.0-14.0.0.0" newVersion="15.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>

--- a/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
@@ -97,10 +97,12 @@
     <ProjectReference Include="..\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
       <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
       <Name>MonoDevelop.Ide</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -111,6 +111,7 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
       <Name>MonoDevelop.Ide</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -42,10 +43,6 @@
     <Reference Include="Microsoft.CodeAnalysis">
       <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
@@ -185,8 +182,5 @@
     <Folder Include="MonoDevelop.Components.PropertyGrid\" />
     <Folder Include="MonoDevelop.SourceEditor\" />
     <Folder Include="MonoDevelop.Components\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -45,6 +45,7 @@
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
       <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,18 +41,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ProjectTemplateTests.cs" />
@@ -122,7 +111,6 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
       <Name>MonoDevelop.Ide</Name>
-      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
@@ -136,6 +124,7 @@
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\xwt\Xwt\Xwt.csproj">
       <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>

--- a/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
+++ b/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
@@ -56,6 +56,7 @@
     <ProjectReference Include="..\..\src\addins\MacPlatform\MacPlatform.csproj">
       <Project>{50D6768C-C072-4E79-AFC5-C1C40767EF45}</Project>
       <Name>MacPlatform</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>

--- a/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
+++ b/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
@@ -56,7 +56,6 @@
     <ProjectReference Include="..\..\src\addins\MacPlatform\MacPlatform.csproj">
       <Project>{50D6768C-C072-4E79-AFC5-C1C40767EF45}</Project>
       <Name>MacPlatform</Name>
-      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
@@ -74,6 +73,7 @@
     </ProjectReference>
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
+      <Private>False</Private>
       <Name>UnitTests</Name>
     </ProjectReference>
     <ProjectReference Include="..\MonoDevelop.Core.Tests\MonoDevelop.Core.Tests.csproj">
@@ -84,6 +84,7 @@
     <ProjectReference Include="..\Ide.Tests\MonoDevelop.Ide.Tests.csproj">
       <Project>{73D4CC8B-BAB9-4A29-841B-F25C6311F067}</Project>
       <Name>MonoDevelop.Ide.Tests</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -90,6 +90,7 @@
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.ValueTuple">
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="mscorlib" />
   </ItemGroup>

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -107,6 +107,7 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
       <Name>MonoDevelop.Ide</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
@@ -114,19 +115,23 @@
     </ProjectReference>
     <ProjectReference Include="..\..\external\xwt\Xwt\Xwt.csproj">
       <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>
+      <Private>False</Private>
       <Name>Xwt</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
       <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\RefactoringEssentials\RefactoringEssentials\RefactoringEssentials.csproj">
       <Project>{C465A5DC-AD28-49A2-89C0-F81838814A7E}</Project>
       <Name>RefactoringEssentials</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\addins\MonoDevelop.Debugger\MonoDevelop.Debugger.csproj">
       <Project>{2357AABD-08C7-4808-A495-8FF2D3CDFDB0}</Project>
       <Name>MonoDevelop.Debugger</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Ide.Tests\MonoDevelop.Ide.Tests.csproj">
       <Project>{73D4CC8B-BAB9-4A29-841B-F25C6311F067}</Project>
@@ -146,6 +151,7 @@
     <ProjectReference Include="..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">
       <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>
       <Name>Mono.Addins</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\addins\MonoDevelop.UnitTesting\MonoDevelop.UnitTesting.csproj">
       <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -88,10 +89,6 @@
     </Reference>
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
@@ -202,7 +199,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="MonoDevelop.CSharpBinding\AutomaticBracketInsertionTests.cs" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.CSharpBinding.Parser\" />

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -4,6 +4,8 @@
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemComposition)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,23 +40,11 @@
     <Reference Include="System.ComponentModel.Composition">
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Composition.Runtime">
-      <HintPath>..\..\build\bin\System.Composition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Composition.TypedParts">
-      <HintPath>..\..\build\bin\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Cairo" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -103,6 +103,7 @@
     <ProjectReference Include="..\..\src\addins\CSharpBinding\CSharpBinding.csproj">
       <Project>{07CC7654-27D6-421D-A64C-0FFA40456FA2}</Project>
       <Name>CSharpBinding</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -33,18 +35,6 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition">
       <Private>True</Private>
     </Reference>
@@ -57,25 +47,13 @@
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="System.Composition.TypedParts">
       <HintPath>..\..\build\bin\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Features">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Features">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Features.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cairo" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/packages.config
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -104,6 +104,7 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
       <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">
       <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -4,6 +4,7 @@
     <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
   </PropertyGroup>
   <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
@@ -36,10 +37,6 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.$(NuGetVersionRoslyn)\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -1,5 +1,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesCecil)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemValueTuple)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -28,30 +31,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.$(NuGetVersionRoslyn)\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -140,9 +124,6 @@
       <Name>MonoDevelop.Core.Tests.Addin</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -1,5 +1,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <PropertyGroup>
+    <ReferencesCecilCopyToOutput>true</ReferencesCecilCopyToOutput>
+  </PropertyGroup>
   <Import Project="$(ReferencesCecil)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <Import Project="$(ReferencesSystemValueTuple)" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -104,7 +104,6 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
       <Name>MonoDevelop.Core</Name>
-      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">
       <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>
@@ -114,6 +113,7 @@
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Mono.Cecil">
       <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.dll</HintPath>

--- a/main/tests/MonoDevelop.Core.Tests/packages.config
+++ b/main/tests/MonoDevelop.Core.Tests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.10.0-beta7" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>

--- a/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
+++ b/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
@@ -110,7 +110,7 @@
     <ProjectReference Include="..\..\external\RefactoringEssentials\RefactoringEssentials\RefactoringEssentials.csproj">
       <Project>{C465A5DC-AD28-49A2-89C0-F81838814A7E}</Project>
       <Name>RefactoringEssentials</Name>
-      <Private>True</Private>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
+++ b/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesRoslyn)" />
   <Import Project="$(ReferencesSystemCollectionsImmutable)" />
+  <Import Project="$(ReferencesSystemComposition)" />
+  <Import Project="$(ReferencesSystemReflectionMetadata)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -37,23 +39,11 @@
     <Reference Include="System.ComponentModel.Composition">
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Composition.Runtime">
-      <HintPath>..\..\build\bin\System.Composition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\build\bin\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Composition.TypedParts">
-      <HintPath>..\..\build\bin\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Cairo" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>

--- a/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
+++ b/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
@@ -61,6 +61,7 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
       <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
       <Name>MonoDevelop.Ide</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
@@ -69,14 +70,17 @@
     <ProjectReference Include="..\..\external\xwt\Xwt\Xwt.csproj">
       <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>
       <Name>Xwt</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
       <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\addins\MonoDevelop.Debugger\MonoDevelop.Debugger.csproj">
       <Project>{2357AABD-08C7-4808-A495-8FF2D3CDFDB0}</Project>
       <Name>MonoDevelop.Debugger</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Ide.Tests\MonoDevelop.Ide.Tests.csproj">
       <Project>{73D4CC8B-BAB9-4A29-841B-F25C6311F067}</Project>
@@ -91,10 +95,12 @@
     <ProjectReference Include="..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">
       <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>
       <Name>Mono.Addins</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\addins\MonoDevelop.Refactoring\MonoDevelop.Refactoring.csproj">
       <Project>{100568FC-F4E8-439B-94AD-41D11724E45B}</Project>
       <Name>MonoDevelop.Refactoring</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\addins\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
       <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>

--- a/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
+++ b/main/tests/MonoDevelop.Refactoring.Tests/MonoDevelop.Refactoring.Tests.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesRoslyn)" />
+  <Import Project="$(ReferencesSystemCollectionsImmutable)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -32,18 +34,6 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\build\bin\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition">
       <Private>True</Private>
     </Reference>
@@ -56,25 +46,13 @@
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\build\bin\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="System.Composition.TypedParts">
       <HintPath>..\..\build\bin\System.Composition.TypedParts.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Features">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Features">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Features.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cairo" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -44,22 +44,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -119,10 +119,12 @@
     <ProjectReference Include="..\..\src\addins\VersionControl\MonoDevelop.VersionControl\MonoDevelop.VersionControl.csproj">
       <Project>{19DE0F35-D204-4FD8-A553-A19ECE05E24D}</Project>
       <Name>MonoDevelop.VersionControl</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\addins\VersionControl\MonoDevelop.VersionControl.Git\MonoDevelop.VersionControl.Git.csproj">
       <Project>{0413DB7D-8B35-423F-9752-D75C9225E7DE}</Project>
       <Name>MonoDevelop.VersionControl.Git</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
+++ b/main/tests/UserInterfaceTests/UserInterfaceTests.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\MonoDevelop.props" />
+  <Import Project="$(ReferencesJson)" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -66,10 +67,6 @@
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="UITestBase.cs" />

--- a/main/tests/UserInterfaceTests/packages.config
+++ b/main/tests/UserInterfaceTests/packages.config
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
+++ b/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="..\..\src\addins\WindowsPlatform\WindowsPlatform\WindowsPlatform.csproj">
       <Project>{459868D2-54DC-415B-B1AB-BE39BDBD352F}</Project>
       <Name>WindowsPlatform</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>

--- a/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
+++ b/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
@@ -45,7 +45,6 @@
     <ProjectReference Include="..\..\src\addins\WindowsPlatform\WindowsPlatform\WindowsPlatform.csproj">
       <Project>{459868D2-54DC-415B-B1AB-BE39BDBD352F}</Project>
       <Name>WindowsPlatform</Name>
-      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
@@ -54,10 +53,12 @@
     <ProjectReference Include="..\MonoDevelop.Core.Tests\MonoDevelop.Core.Tests.csproj">
       <Project>{fda43caa-1c2a-4593-8601-3e2ee06d9e03}</Project>
       <Name>MonoDevelop.Core.Tests</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>

--- a/main/xbuild.include
+++ b/main/xbuild.include
@@ -27,7 +27,7 @@ endif
 
 XBUILD=msbuild
 XBUILD_VERBOSITY ?= normal
-XBUILD_ARGS=/verbosity:$(XBUILD_VERBOSITY) /nologo /property:CodePage=65001
+XBUILD_ARGS=/verbosity:$(XBUILD_VERBOSITY) /nologo /property:CodePage=65001 /property:RestorePackages=false /property:DownloadPaket=false
 XBUILD_PROFILE=/property:Configuration=$(PROFILE_NAME)
 
 # Figure out how far we are from top_builddir


### PR DESCRIPTION
This is the first part of fixing the build so it's snappy.

Right now, projects cause ResolveAssemblyReferences to be re-evaluated a lot of times and this just works towards fixing NOP builds to not compile anything.

Will add a CI based test that verifies that `make` does not contain targets we should be skipping.

TODO:

* [ ] Integrate with CI so we assert that things don't get rebuilt - maybe integrate a binlog parser and some msbuild task that automates this process
* [x] ~Fix md-addins~ - Will do in a later step to unblock this
* [x] Figure out why RAR takes a long time - Seems like nugets which contain references to shims happen to cause issues with resolving assemblies from the GAC. System.Runtime versions from nugets do not match the versions in the Mono GAC, so mono ends up probing a lot of directories trying to find the right versions.
* [ ] Remove tests local copies of MD assemblies, they should be loaded from mdtool/vstool
* [ ] Revert monodoc change for now.

Edit:
# What is this mastodon PR?

This PR tries to fix some common problems we have in how our projects reference eachother and nugets, avoiding issues with incremental builds.

It tries to consolidate nuget versions into props files and only MonoDevelop.Core has to do the NuGet restore step.

It also fixes issues with mismatched versions by adding some binding redirects.

Unifies assembly references and only local copies from where it should be.

# What do we gain?

Better incrementality.

We removed the system dependency on monodoc, we now get it from nuget, but it's a bit hacky:
https://github.com/mono/api-doc-tools/issues/229
https://github.com/mono/api-doc-tools/issues/228
https://github.com/mono/api-doc-tools/issues/227

# There are some missing changes

I reverted the changes in F# until we have a consensus about switching from Paket to this model.

I haven't opened PRs yet to mono-addins, debugger-libs and NRefactory

# Current issues

PackageReference would solve a lot of our issues, and we'd only need to have versions defined, and not manual references to different assemblies, right now, I used what nuget added to the csproj files.

