### PR TITLE
Invalidate cached line upon TextArea.RedrawLine

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1084,6 +1084,9 @@ namespace Mono.TextEditor
 		{
 			if (isDisposed || logicalLine > LineCount || logicalLine < DocumentLocation.MinLine)
 				return;
+
+			textViewMargin.RemoveCachedLine(logicalLine);
+
 			double y = LineToY (logicalLine) - this.textEditorData.VAdjustment.Value;
 			double h = GetLineHeight (logicalLine);
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -142,9 +142,9 @@ namespace Microsoft.VisualStudio.Platform
                 int startLineIndex = this.textDocument.OffsetToLineNumber (args.ChangeSpan.Start);
                 int endLineIndex = this.textDocument.OffsetToLineNumber (args.ChangeSpan.End);
 
-                IEnumerable<IDocumentLine> documentLines = this.textDocument.GetLinesBetween (startLineIndex, endLineIndex);
-                foreach(IDocumentLine documentLine in documentLines)
+                for (int curLineIndex = startLineIndex; curLineIndex <= endLineIndex; curLineIndex++)
                 {
+                    IDocumentLine documentLine = this.textDocument.GetLine(curLineIndex);
                     handler(this, new LineEventArgs(documentLine));
                 }
             }


### PR DESCRIPTION
DO NOT MERGE. This PR is strictly to demonstrate a fix I have locally that fixes some colorization issues.

The commented out code in TagBasedSyntaxHighlighting is what I was doing if I wanted to keep this as a tactical fix just for VS classifications (and the textarea.cs change wouldn't be necessary). There is a more widespread issue in colorization outside razor that I can reproduce in c#.

C# repro:
 Create a new class.
 In a different file, reference that class (notice it colorizes correctly)
 Go back to new class file and modify the class name.
 Go back to referencing file and notice that it still colorizes the old class name as if it were an existing type.
