### PR TITLE
[529478][Editor] Fix search marker fallback color

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
@@ -900,18 +900,11 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 		void DrawSearchResults (Cairo.Context cr, IndicatorDrawingState state, int i)
 		{
-			var color = SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.FindHighlight);
+			bool isSelected = i == state.MainSelection;
+			var color = SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, isSelected ? EditorThemeColors.Selection : EditorThemeColors.FindHighlight);
 			if (Math.Abs (HslColor.Brightness (color) - HslColor.Brightness (SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.Background))) < 0.1)
-				color = Styles.Editor.SearchMarkerFallbackColor;
-
-			if (i == state.MainSelection) {
-				// TODO: EditorTheme does that look ok ?
-				if (HslColor.Brightness (color) < 0.5) {
-					color = color.AddLight (0.1);
-				} else {
-					color = color.AddLight (-0.1);
-				}
-			}
+				color = isSelected ? Styles.Editor.SearchMarkerSelectedFallbackColor : Styles.Editor.SearchMarkerFallbackColor;
+			
 			cr.SetSourceColor (color);
 			cr.Rectangle (barPadding, state.SearchResultIndicators[i], Allocation.Width - barPadding * 2, 2);
 			cr.Fill ();

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
@@ -901,6 +901,9 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 		void DrawSearchResults (Cairo.Context cr, IndicatorDrawingState state, int i)
 		{
 			var color = SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.FindHighlight);
+			if (Math.Abs (HslColor.Brightness (color) - HslColor.Brightness (SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.Background))) < 0.1)
+				color = Styles.Editor.SearchMarkerFallbackColor;
+
 			if (i == state.MainSelection) {
 				// TODO: EditorTheme does that look ok ?
 				if (HslColor.Brightness (color) < 0.5) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HslColor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HslColor.cs
@@ -129,6 +129,11 @@ namespace MonoDevelop.Components
 			return new Xwt.Drawing.Color (r, g, b, hsl.Alpha);
 		}
 
+		public static implicit operator HslColor (Xwt.Drawing.Color color)
+		{
+			return new HslColor (color.Red, color.Green, color.Blue, color.Alpha);
+		}
+
 		public static implicit operator HslColor (Color color)
 		{
 			return new HslColor (color);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -271,6 +271,7 @@ namespace MonoDevelop.Ide.Gui
 			public static Color SmartTagMarkerColorLight { get; internal set; }
 			public static Color SmartTagMarkerColorDark { get; internal set; }
 			public static Color SearchErrorForegroundColor { get; internal set; }
+			public static Color SearchMarkerFallbackColor { get; internal set; }
 		}
 
 		public static class KeyBindingsPanel
@@ -431,6 +432,8 @@ namespace MonoDevelop.Ide.Gui
 			Editor.SmartTagMarkerColorLight = Color.FromName ("#ff70fe").WithAlpha (.5);
 			Editor.SmartTagMarkerColorDark = Color.FromName ("#ffffff").WithAlpha (.5);
 			Editor.SearchErrorForegroundColor = ErrorForegroundColor;
+			// TODO: FINAL COLOR!
+			Editor.SearchMarkerFallbackColor = Color.FromName ("#ff00ff");
 
 			// Key Bindings Preferences
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -272,6 +272,7 @@ namespace MonoDevelop.Ide.Gui
 			public static Color SmartTagMarkerColorDark { get; internal set; }
 			public static Color SearchErrorForegroundColor { get; internal set; }
 			public static Color SearchMarkerFallbackColor { get; internal set; }
+			public static Color SearchMarkerSelectedFallbackColor { get; internal set; }
 		}
 
 		public static class KeyBindingsPanel
@@ -433,6 +434,8 @@ namespace MonoDevelop.Ide.Gui
 			Editor.SmartTagMarkerColorDark = Color.FromName ("#ffffff").WithAlpha (.5);
 			Editor.SearchErrorForegroundColor = ErrorForegroundColor;
 			Editor.SearchMarkerFallbackColor = Color.FromName ("#f3da2d");
+			// TODO: FINAL COLOR!
+			Editor.SearchMarkerSelectedFallbackColor = Color.FromName ("#ff00ff");
 
 			// Key Bindings Preferences
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -432,8 +432,7 @@ namespace MonoDevelop.Ide.Gui
 			Editor.SmartTagMarkerColorLight = Color.FromName ("#ff70fe").WithAlpha (.5);
 			Editor.SmartTagMarkerColorDark = Color.FromName ("#ffffff").WithAlpha (.5);
 			Editor.SearchErrorForegroundColor = ErrorForegroundColor;
-			// TODO: FINAL COLOR!
-			Editor.SearchMarkerFallbackColor = Color.FromName ("#ff00ff");
+			Editor.SearchMarkerFallbackColor = Color.FromName ("#f3da2d");
 
 			// Key Bindings Preferences
 


### PR DESCRIPTION
This is a possible fix for less visible search result markers. If the search result highlighting color of the current editor theme is not visible enough, a default marker color will be used instead.

TODO:
* Final marker color (same for dark/light IDE?)
* Needs a better color visibility detection than brightness comparison?

NOTE: making the theme color brighter based on the current background is too complex. We have simple (brightness based) calculation in [`SearchResultWidget`](https://github.com/mono/monodevelop/blob/fix529478-editor-search-marker-fallback-color/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchResultWidget.cs#L318), but it tends to calculate black/white colors for most themes, which doesn't look really good.