### PR TITLE
Fix 597220: No IntelliSense for pages deriving from a custom ContentPage

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -1921,7 +1921,7 @@ namespace MonoDevelop.SourceEditor
 
 			// for named arguments invoke(arg:<Expr>);
 			if (completeWord.EndsWith (":", StringComparison.Ordinal)) {
-				if (data.GetCharAt (triggerOffset + length) == ':')
+				if (data.Length > triggerOffset + length && data.GetCharAt (triggerOffset + length) == ':')
 					length++;
 			}
 

--- a/main/src/addins/Xml/Parser/XmlNameState.cs
+++ b/main/src/addins/Xml/Parser/XmlNameState.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.Xml.Parser
 			if (namedObject == null || namedObject.Name.Prefix != null)
 				throw new InvalidOperationException ("Invalid state");
 			
-			Debug.Assert (context.CurrentStateLength > 1 || IsValidNameStart (c), 
+			Debug.Assert (context.CurrentStateLength > 1 || IsValidNameStart (c) || XmlChar.IsWhitespace (c), 
 				"First character pushed to a XmlTagNameState must be a letter.");
 			Debug.Assert (context.CurrentStateLength > 1 || context.KeywordBuilder.Length == 0,
 				"Keyword builder must be empty when state begins.");
@@ -54,6 +54,7 @@ namespace MonoDevelop.Xml.Parser
 				rollback = string.Empty;
 				if (context.KeywordBuilder.Length == 0) {
 					context.LogError ("Zero-length name.");
+					namedObject.Name = new XName (c.ToString ());
 				} else {
 					string s = context.KeywordBuilder.ToString ();
 					int i = s.IndexOf (':');

--- a/main/src/addins/Xml/Parser/XmlRootState.cs
+++ b/main/src/addins/Xml/Parser/XmlRootState.cs
@@ -127,7 +127,7 @@ namespace MonoDevelop.Xml.Parser
 					return null;
 				} else if (c == '/') {
 					return this.ClosingTagState;
-				} else if (char.IsLetter (c) || c == '_') {
+				} else if (char.IsLetter (c) || c == '_' || char.IsWhiteSpace (c)) {
 					rollback = string.Empty;
 					return TagState;
 				}

--- a/main/src/addins/Xml/Parser/XmlTagState.cs
+++ b/main/src/addins/Xml/Parser/XmlTagState.cs
@@ -68,6 +68,10 @@ namespace MonoDevelop.Xml.Parser
 				element = new XElement (context.LocationMinus (2)); // 2 == < + current char
 				element.Parent = parent;
 				context.Nodes.Push (element);
+				if (context.BuildTree) {
+					var parentContainer = (XContainer)context.Nodes.Peek (element.IsClosed ? 0 : 1);
+					parentContainer.AddChildNode (element);
+				}
 			}
 			
 			if (c == '<') {
@@ -126,7 +130,7 @@ namespace MonoDevelop.Xml.Parser
 
 			context.StateTag = OK;
 
-			if (!element.IsNamed && XmlChar.IsFirstNameChar (c)) {
+			if (!element.IsNamed && (XmlChar.IsFirstNameChar (c) || XmlChar.IsWhitespace (c))) {
 				rollback = string.Empty;
 				return NameState;
 			}
@@ -151,10 +155,6 @@ namespace MonoDevelop.Xml.Parser
 				context.Nodes.Pop ();
 
 			element.End (location);
-			if (context.BuildTree) {
-				var parent = (XContainer)context.Nodes.Peek (element.IsClosed ? 0 : 1);
-				parent.AddChildNode (element);
-			}
 		}
 	}
 }

--- a/main/src/addins/Xml/Tests/Parser/AttributeNameTestFixture.cs
+++ b/main/src/addins/Xml/Tests/Parser/AttributeNameTestFixture.cs
@@ -47,6 +47,12 @@ namespace MonoDevelop.Xml.Tests.Parser
 		}	
 		
 		[Test]
+		public void SuccessTest7()
+		{
+			AssertAttributeName ("< foo=$", "foo");
+		}
+		
+		[Test]
 		public void FailureTest1()
 		{
 			NotAttribute ("foo=$");
@@ -67,7 +73,10 @@ namespace MonoDevelop.Xml.Tests.Parser
 		[Test]
 		public void FailureTest4()
 		{
-			NotAttribute ("< a$");
+			// It's ok if we are already in attribute naming state at this point
+			// even if element is not named yet, but until = is written, attribute
+			// is not named yet, hence null
+			AssertAttributeName ("< a$", null);
 		}	
 		
 		[Test]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Util/SimpleBracketMatcher.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Util/SimpleBracketMatcher.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Ide.Editor.Util
 				result = SearchMatchingBracketForward (document, offset + 1, closingBrackets [bracket], openBrackets [bracket], cancellationToken);
 			} else {
 				bracket = closingBrackets.IndexOf (ch);
-				if (bracket >= 0) {
+				if (bracket >= 0 && offset > 0) {
 					result = SearchMatchingBracketBackward (document, offset - 1, openBrackets [bracket], closingBrackets [bracket], cancellationToken);
 				} else {
 					result = -1;


### PR DESCRIPTION
This is just MonoDevelop part of fix, what I did here is update XmlName/Root and Tag states to support having `< xmlns="formsNamespace"` and parse this as element with attributes, because until now this was not element element yet(because it doesn't have name) so attributes also were not parsed, resulting in Forms extension not being aware of referenced namespaces, hence code completion not working...

I included also 2 unrelated fixes in SourceEditorView.cs and SimpleBracketMatcher.cs which deal with file edge cases that I found while working on this.