### PR TITLE
[d15-7][Core] Support facade assemblies from a custom location

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -972,17 +972,31 @@ namespace MonoDevelop.Projects
 			}
 
 			if (addFacadeAssemblies) {
-				var runtime = TargetRuntime ?? MonoDevelop.Core.Runtime.SystemAssemblyService.DefaultRuntime;
-				var facades = runtime.FindFacadeAssembliesForPCL (TargetFramework);
-				foreach (var facade in facades) {
-					if (!File.Exists (facade))
-						continue;
-					var ar = new AssemblyReference (facade);
-					if (!result.Contains (ar))
-						result.Add (ar);
+				var facades = await ProjectExtension.OnGetFacadeAssemblies ();
+				if (facades != null) {
+					foreach (var facade in facades) {
+						if (!result.Contains (facade))
+							result.Add (facade);
+					}
 				}
 			}
 			return result;
+		}
+
+		internal protected virtual Task<List<AssemblyReference>> OnGetFacadeAssemblies ()
+		{
+			List<AssemblyReference> result = null;
+			var runtime = TargetRuntime ?? Runtime.SystemAssemblyService.DefaultRuntime;
+			var facades = runtime.FindFacadeAssembliesForPCL (TargetFramework);
+			foreach (var facade in facades) {
+				if (!File.Exists (facade))
+					continue;
+				if (result == null)
+					result = new List<AssemblyReference> ();
+				var ar = new AssemblyReference (facade);
+				result.Add (ar);
+			}
+			return Task.FromResult (result);
 		}
 
 		AsyncCriticalSection referenceCacheLock = new AsyncCriticalSection ();
@@ -2028,6 +2042,11 @@ namespace MonoDevelop.Projects
 			internal protected override IEnumerable<DotNetProject> OnGetReferencedAssemblyProjects (ConfigurationSelector configuration)
 			{
 				return Project.OnGetReferencedAssemblyProjects (configuration);
+			}
+
+			internal protected override Task<List<AssemblyReference>> OnGetFacadeAssemblies ()
+			{
+				return Project.OnGetFacadeAssemblies ();
 			}
 
 #pragma warning disable 672 // Member overrides obsolete member

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectExtension.cs
@@ -88,6 +88,11 @@ namespace MonoDevelop.Projects
 			return next.OnGetReferencedAssemblyProjects (configuration);
 		}
 
+		internal protected virtual Task<List<AssemblyReference>> OnGetFacadeAssemblies ()
+		{
+			return next.OnGetFacadeAssemblies ();
+		}
+
 		[Obsolete("User overload that takes a RunConfiguration")]
 		internal protected virtual ExecutionCommand OnCreateExecutionCommand (ConfigurationSelector configSel, DotNetProjectConfiguration configuration)
 		{

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=748c8c7805c929d94f2057d9298c1d0c20d413f3
-DEP_BRANCH_AND_REMOTE[0]="d15-7 origin/d15-7"
+DEP_NEEDED_VERSION[0]=65b87d32fb2f7275b8bee47dc8f37af176987b87
+DEP_BRANCH_AND_REMOTE[0]="d15-7-xamarin-mac-resolve-facades-directory origin/d15-7-xamarin-mac-resolve-facades-directory"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
Added a OnGetFacadeAssemblies method to the DotNetProjectExtension
that allows a project extension to provide the facade assemblies
for a project if the default behaviour does not work for the project.
This can be used by the Xamarin.Mac project extension to provide
the facade assemblies when the project uses Xamarin.Mac full. A
Xamarin.Mac full project will use a custom facades directory at
build time but the project has a target framework of .NET Framework
so the default facades assembly resolution logic will return the
wrong facade assemblies that are included with Mono.