### PR TITLE
[529478][Editor] Fix search marker fallback color with final colors

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -434,8 +434,7 @@ namespace MonoDevelop.Ide.Gui
 			Editor.SmartTagMarkerColorDark = Color.FromName ("#ffffff").WithAlpha (.5);
 			Editor.SearchErrorForegroundColor = ErrorForegroundColor;
 			Editor.SearchMarkerFallbackColor = Color.FromName ("#f3da2d");
-			// TODO: FINAL COLOR!
-			Editor.SearchMarkerSelectedFallbackColor = Color.FromName ("#ff00ff");
+			Editor.SearchMarkerSelectedFallbackColor = Color.FromName ("#ffaf45");
 
 			// Key Bindings Preferences
 


### PR DESCRIPTION
Continuing https://github.com/mono/monodevelop/pull/4531#event-1572839415: now with final colors.