### PR TITLE
[AspNetCore] SDK Preview 2 Changes

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreCertificateManager.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreCertificateManager.cs
@@ -93,12 +93,6 @@ namespace MonoDevelop.AspNetCore
 		public static async Task TrustDevelopmentCertificate (ProgressMonitor monitor)
 		{
 			try {
-				if (!DotNetCoreDevCertsTool.IsInstalled ()) {
-					if (!await DotNetCoreDevCertsTool.Install (monitor.CancellationToken)) {
-						return;
-					}
-				}
-
 				CertificateCheckResult result = await DotNetCoreDevCertsTool.CheckCertificate (monitor.CancellationToken);
 				if (result == CertificateCheckResult.OK) {
 					IsDevelopmentCertificateTrusted = true;

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
@@ -72,15 +72,23 @@ namespace MonoDevelop.AspNetCore
 		{
 			var applicationUrl = settings?.GetValue ("applicationUrl")?.Value<string> ();
 			if (applicationUrl != null)
-				return applicationUrl;
+				return GetFirstUrl (applicationUrl);
 
 			if (environmentVariables.TryGetValue ("ASPNETCORE_URLS", out string applicationUrls)) {
-				applicationUrl = applicationUrls.Split (';').FirstOrDefault ();
+				applicationUrl = GetFirstUrl (applicationUrls);
 				if (applicationUrl != null)
 					return applicationUrl;
 			}
 
 			return "http://localhost:5000";
+		}
+
+		static string GetFirstUrl (string url)
+		{
+			if (string.IsNullOrEmpty (url) || !url.Contains (';'))
+				return url;
+
+			return url.Split (';').FirstOrDefault ();
 		}
 
 		protected override void Read (IPropertySet pset)


### PR DESCRIPTION
 - Do not install dev-certs tool. This is pre-installed with the .NET Core SDK 2.1 preview 2.
 - Fix browser not opened when running an ASP.NET Core 2.1 preview 2 project. The applicationUrl launchSetting.json property now stores multiple urls which was not being handled.