### PR TITLE
Fix 591345: [Updater] "Updates have been downloaded and are ready to …

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Setup/UpdateChannel.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Setup/UpdateChannel.cs
@@ -60,7 +60,7 @@ namespace MonoDevelop.Core.Setup
 				return false;
 			}
 
-			return a.Idx == Idx;
+			return a.Id == Id;
 		}
 
 		public bool Equals (UpdateChannel a)
@@ -68,7 +68,7 @@ namespace MonoDevelop.Core.Setup
 			if ((object)a == null) {
 				return false;
 			}
-			return (a.Idx == Idx);
+			return (a.Id == Id);
 		}
 
 		public static bool operator == (UpdateChannel a, UpdateChannel b)
@@ -79,7 +79,7 @@ namespace MonoDevelop.Core.Setup
 			if (Object.ReferenceEquals (a, null) || Object.ReferenceEquals (b, null)) {
 				return false;
 			}
-			return a.Idx == b.Idx;
+			return a.Id == b.Id;
 		}
 
 		public static bool operator != (UpdateChannel a, UpdateChannel b)
@@ -90,7 +90,7 @@ namespace MonoDevelop.Core.Setup
 			if (Object.ReferenceEquals (a, null) || Object.ReferenceEquals (b, null)) {
 				return true;
 			}
-			return a.Idx != b.Idx;
+			return a.Id != b.Id;
 		}
 
 		public static bool operator <= (UpdateChannel a, UpdateChannel b)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateService.cs
@@ -89,7 +89,17 @@ namespace MonoDevelop.Ide.Updater
 				var updateChannelId = PropertyService.Get<string> ("MonoDevelop.Ide.AddinUpdater.UpdateChannel");
 				if (string.IsNullOrEmpty (updateChannelId))
 					return UpdateChannel.FromUpdateLevel (PropertyService.Get ("MonoDevelop.Ide.AddinUpdater.UpdateLevel", UpdateLevel.Stable));
-				return new UpdateChannel (updateChannelId, updateChannelId, "", 0);
+				if (UpdateChannel.Stable.Id == updateChannelId)
+					return UpdateChannel.Stable;
+				else if (UpdateChannel.Beta.Id == updateChannelId)
+					return UpdateChannel.Beta;
+				else if (UpdateChannel.Alpha.Id == updateChannelId)
+					return UpdateChannel.Alpha;
+				else if (UpdateChannel.Test.Id == updateChannelId)
+					return UpdateChannel.Test;
+				else
+					//idx matters in .Equals() so we can't do `new UpdateChannel (updateChannelId, updateChannelId, "", 0);`
+					throw new NotImplementedException ($"Unknown update channel id:{updateChannelId}");
 			}
 			set {
 				PropertyService.Set ("MonoDevelop.Ide.AddinUpdater.UpdateChannel", value.Id);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateService.cs
@@ -98,8 +98,7 @@ namespace MonoDevelop.Ide.Updater
 				else if (UpdateChannel.Test.Id == updateChannelId)
 					return UpdateChannel.Test;
 				else
-					//idx matters in .Equals() so we can't do `new UpdateChannel (updateChannelId, updateChannelId, "", 0);`
-					throw new NotImplementedException ($"Unknown update channel id:{updateChannelId}");
+					return new UpdateChannel (updateChannelId, updateChannelId, "", 0);
 			}
 			set {
 				PropertyService.Set ("MonoDevelop.Ide.AddinUpdater.UpdateChannel", value.Id);


### PR DESCRIPTION
…install" still shown after updating to Alpha

Problem was with changes around MonoDevelop.Ide.AddinUpdater.UpdateChannel/UpdateLevel migration where `idx` was not set for each channel resulting in UpdateChannel.Equals returning wrong values causing https://github.com/xamarin/md-addins/blob/5b4c8d9/Xamarin.Ide/Xamarin.Ide/Xamarin.Ide.Updater/UpdatesDialog.cs#L278 to not execute and update list of updatable items.