### PR TITLE
[600128][Mac] Disallow window tabbing mode

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -294,6 +294,10 @@ namespace MonoDevelop.MacIntegration
 				Gtk.Rc.ParseString ("style \"radio-or-check-box\" { engine \"xamarin\" { focusstyle = 2 } } ");
 			}
 
+			// Disallow window tabbing globally
+			if (MacSystemInformation.OsVersion >= MacSystemInformation.Sierra)
+				NSWindow.AllowsAutomaticWindowTabbing = false;
+
 			return loaded;
 		}
 
@@ -454,6 +458,8 @@ namespace MonoDevelop.MacIntegration
 				IdeApp.Workbench.RootWindow.Realized += (sender, args) => {
 					var win = GtkQuartz.GetWindow ((Gtk.Window) sender);
 					win.CollectionBehavior |= NSWindowCollectionBehavior.FullScreenPrimary;
+					if (MacSystemInformation.OsVersion >= MacSystemInformation.Sierra)
+						win.TabbingMode = NSWindowTabbingMode.Disallowed;
 				};
 			}
 


### PR DESCRIPTION
This should hopefully fix the rare case when Sierra decides to enable tabbing for the main IDE window described in https://developercommunity.visualstudio.com/content/problem/227348/cursor-position-is-shifted-because-of-the-bar-with.html.

Fixes VSTS #600128 – [Feedback] Cursor position is shifted because of the bar with project name, opened file name and Visual Studio IDE type