### PR TITLE
[Core] Fix MSBuild items added for globs with link metadata

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildValueType.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildValueType.cs
@@ -45,6 +45,7 @@ namespace MonoDevelop.Projects.MSBuild
 	class PathValueType: MSBuildValueType
 	{
 		static readonly char [] pathSep = { '\\' };
+		static string currentDirectoryPrefix = @".\";
 
 		public override bool Equals (string ob1, string ob2)
 		{
@@ -52,6 +53,10 @@ namespace MonoDevelop.Projects.MSBuild
 				return true;
 			if (ob1 == null || ob2 == null)
 				return string.IsNullOrEmpty (ob1) && string.IsNullOrEmpty (ob2);//Empty or null path is same thing
+			if (ob1.StartsWith (currentDirectoryPrefix, StringComparison.OrdinalIgnoreCase))
+				ob1 = ob1.Substring (currentDirectoryPrefix.Length);
+			if (ob2.StartsWith (currentDirectoryPrefix, StringComparison.OrdinalIgnoreCase))
+				ob2 = ob2.Substring (currentDirectoryPrefix.Length);
 			return ob1.TrimEnd (pathSep) == ob2.TrimEnd (pathSep);
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3823,6 +3823,8 @@ namespace MonoDevelop.Projects
 				if (p2 == null || !p.ValueType.Equals (p.Value, p2.UnevaluatedValue)) {
 					if (generateNewUpdateItem)
 						continue;
+					if (p2?.UnevaluatedValue != null && p2.UnevaluatedValue.Contains ('%') && p.ValueType.Equals (p.Value, p2.Value))
+						continue;
 					if (updateItem == null) {
 						updateItems = FindUpdateItemsForItem (globItem, item.Include).ToList ();
 						updateItem = updateItems.LastOrDefault ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3780,7 +3780,6 @@ namespace MonoDevelop.Projects
 		{
 			// Compare only metadata, since item name and include can't change
 
-			MSBuildEvaluationContext context = null;
 			var n = 0;
 			foreach (var p in item.Metadata.GetProperties ()) {
 				var p2 = evalItem.Metadata.GetProperty (p.Name);
@@ -3789,12 +3788,7 @@ namespace MonoDevelop.Projects
 				if (!p.ValueType.Equals (p.Value, p2.UnevaluatedValue)) {
 					if (p2.UnevaluatedValue != null && p2.UnevaluatedValue.Contains ('%')) {
 						// Check evaluated value is a match.
-						if (context == null) {
-							context = new MSBuildEvaluationContext ();
-							context.InitEvaluation (MSBuildProject);
-						}
-						string value = context.Evaluate (p.UnevaluatedValue);
-						if (!p.ValueType.Equals (p.Value, value))
+						if (!p.ValueType.Equals (p.Value, p2.Value))
 							return false;
 					} else
 						return false;

--- a/main/tests/test-projects/msbuild-glob-tests/glob-file-link-test2.sln
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-file-link-test2.sln
@@ -1,0 +1,20 @@
+
+Microsoft Visual Studio Solution File, Format Version 9.00
+# Visual Studio 2005
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GlobTest", "glob-file-link\glob-file-link-test2.csproj", "{109A0AFA-67E0-4FF4-A942-78A545367EBD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/msbuild-glob-tests/glob-file-link/glob-file-link-test2.csproj
+++ b/main/tests/test-projects/msbuild-glob-tests/glob-file-link/glob-file-link-test2.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{109A0AFA-67E0-4FF4-A942-78A545367EBD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GlobTest</RootNamespace>
+    <AssemblyName>GlobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\**\*.cs" Exclude="*9.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
A project containing the following MSBuild file globs would have
extra MSBuild items added when the project file was saved.

```
<ItemGroup>
  <Compile Include="..\**\*.cs">
    <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
  </Compile>
</ItemGroup>
```

On saving the project Compile Update items would be added for each
file included by the file glob.

```
<ItemGroup>
  <Compile Update="..\Test\Class1.cs">
    <Link>Class1.cs</Link>
  </Compile>
</ItemGroup>
```

Fixes VSTS #527721 - Overriding globs

Also re-worked the fix for VSTS #569295 - Projects that includes files using wildcards will expand (and remove) wildcards upon save. Now no evaluation of the MSBuild property is done on saving the project.