### PR TITLE
[d15-7][Templates] Added ItemTemplate.GetImage() for loading themed images

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ItemTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ItemTemplate.cs
@@ -45,17 +45,12 @@ namespace MonoDevelop.Ide.Templates
 
 		public virtual Stream GetStream (string path)
 		{
-			return null;
+			return File.OpenRead (path);
 		}
 
 		public virtual Image GetImage (string path)
 		{
-			var stream = GetStream (path);
-
-			if (stream == null)
-				return null;
-
-			return Image.FromStream (stream);
+			return Image.FromFile (path);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ItemTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ItemTemplate.cs
@@ -27,6 +27,8 @@
 using System;
 using System.IO;
 
+using Xwt.Drawing;
+
 namespace MonoDevelop.Ide.Templates
 {
 	public class ItemTemplate
@@ -44,6 +46,16 @@ namespace MonoDevelop.Ide.Templates
 		public virtual Stream GetStream (string path)
 		{
 			return null;
+		}
+
+		public virtual Image GetImage (string path)
+		{
+			var stream = GetStream (path);
+
+			if (stream == null)
+				return null;
+
+			return Image.FromStream (stream);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
@@ -279,6 +279,16 @@ namespace MonoDevelop.Ide.Templates
 			return null;
 		}
 
+		public static Xwt.Drawing.Image GetImage (ITemplateInfo template, string path)
+		{
+			var settingsLoader = (SettingsLoader) environmentSettings.SettingsLoader;
+			var loader = new MicrosoftTemplateEngineImageLoader (settingsLoader, template);
+
+			path = NormalizePath (template, path);
+
+			return Xwt.Drawing.Image.FromCustomLoader (loader, path);
+		}
+
 		static string NormalizePath (ITemplateInfo template, string path)
 		{
 			path = NormalizePath (path);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineImageLoader.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineImageLoader.cs
@@ -1,0 +1,89 @@
+﻿//
+// MicrosoftTemplateEngineImageLoader.cs
+//
+// Author:
+//       Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+using Xwt;
+using Xwt.Drawing;
+
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Edge.Settings;
+
+namespace MonoDevelop.Ide.Templates
+{
+	public class MicrosoftTemplateEngineImageLoader : IImageLoader
+	{
+		static char[] DirectorySeparators = new [] { Path.DirectorySeparatorChar };
+		readonly SettingsLoader settings;
+		readonly ITemplateInfo template;
+
+		public MicrosoftTemplateEngineImageLoader (SettingsLoader settingsLoader, ITemplateInfo templateInfo)
+		{
+			settings = settingsLoader;
+			template = templateInfo;
+		}
+
+		public IEnumerable<string> GetAlternativeFiles (string fileName, string baseName, string ext)
+		{
+			IMountPoint mountPoint;
+			IDirectory dir;
+
+			if (!settings.TryGetMountPointFromId (template.ConfigMountPointId, out mountPoint))
+				yield break;
+
+			dir = mountPoint.Root;
+
+			var path = baseName.Split (DirectorySeparators, StringSplitOptions.RemoveEmptyEntries);
+			for (int i = 0; i < path.Length - 1; i++) {
+				dir = dir.EnumerateDirectories (path[i], SearchOption.TopDirectoryOnly).FirstOrDefault ();
+
+				if (dir == null)
+					yield break;
+			}
+
+			var pattern = string.Format ("{0}*{1}", path[path.Length - 1], ext);
+			foreach (var entry in dir.EnumerateFiles (pattern, SearchOption.TopDirectoryOnly))
+				yield return entry.FullPath;
+
+			yield break;
+		}
+
+		public Stream LoadImage (string fileName)
+		{
+			IMountPoint mountPoint;
+			IFile file;
+
+			if (!settings.TryGetFileFromIdAndPath (template.ConfigMountPointId, fileName, out file, out mountPoint))
+				return null;
+
+			return file.OpenRead ();
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineImageLoader.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineImageLoader.cs
@@ -38,7 +38,7 @@ using Microsoft.TemplateEngine.Edge.Settings;
 
 namespace MonoDevelop.Ide.Templates
 {
-	public class MicrosoftTemplateEngineImageLoader : IImageLoader
+	class MicrosoftTemplateEngineImageLoader : IImageLoader
 	{
 		static char[] DirectorySeparators = new [] { Path.DirectorySeparatorChar };
 		readonly SettingsLoader settings;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineItemTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineItemTemplate.cs
@@ -25,6 +25,11 @@
 // THE SOFTWARE.
 
 using System.IO;
+using System.Collections.Generic;
+
+using Xwt;
+using Xwt.Drawing;
+
 using Microsoft.TemplateEngine.Abstractions;
 using MonoDevelop.Ide.Codons;
 
@@ -45,6 +50,11 @@ namespace MonoDevelop.Ide.Templates
 		public override Stream GetStream (string path)
 		{
 			return MicrosoftTemplateEngine.GetStream (TemplateInfo, path);
+		}
+
+		public override Image GetImage (string path)
+		{
+			return MicrosoftTemplateEngine.GetImage (TemplateInfo, path);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9653,6 +9653,7 @@
     <Compile Include="MonoDevelop.Ide.Templates\NewItemConfiguration.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\ItemTemplatePackageInstaller.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\TemplatePackageReference.cs" />
+    <Compile Include="MonoDevelop.Ide.Templates\MicrosoftTemplateEngineImageLoader.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />


### PR DESCRIPTION
This is needed by the new Azure Functions templates so that the
"New Function" dialog can render theme-appropriate icons based
on the icons shipped with the Azure templates.