### PR TITLE
[CSharp] Add captures information to QuickInfo output

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/QuickInfoProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/QuickInfoProvider.cs
@@ -113,6 +113,13 @@ namespace MonoDevelop.SourceEditor
 					TaggedTextUtil.AppendTaggedText (sb, theme, parts);
 				}
 			}
+
+			if (sections.TryGetValue (SymbolDescriptionGroups.Captures, out parts)) {
+				if (!parts.IsDefaultOrEmpty) {
+					sb.AppendLine ();
+					TaggedTextUtil.AppendTaggedText (sb, theme, parts);
+				}
+			}
 			sb.Append ("</span>");
 
 			tooltipInfo.SignatureMarkup = StringBuilderCache.ReturnAndFree (sb);


### PR DESCRIPTION
When hovering over a lambda or anonymous function this commit adds variable captured in the scope to the tooltip. This helps debugging potential performance issues (lambda that do not reference external variables are efficiently cached).

Before:
<img width="215" alt="screen shot 2018-04-13 at 11 17 28 pm" src="https://user-images.githubusercontent.com/104105/38763821-df3ae83a-3f71-11e8-9321-7a2b0d946d67.png">

After:

<img width="383" alt="screen shot 2018-04-13 at 11 20 22 pm" src="https://user-images.githubusercontent.com/104105/38763825-e99f4000-3f71-11e8-9ac4-4ba89fd1d6d3.png">
