### PR TITLE
Fixes issue #4393 Error in text editor The original error should be

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/BounceFadePopupWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/BounceFadePopupWindow.cs
@@ -27,6 +27,7 @@
 
 using System;
 using Gdk;
+using MonoDevelop.Core;
 
 namespace Mono.TextEditor.Theatrics
 {
@@ -349,7 +350,7 @@ namespace Mono.TextEditor.Theatrics
 					Draw (cr, userspaceArea);
 				}
 			} catch (Exception e) {
-				Console.WriteLine ("Exception in animation:" + e);
+				LoggingService.LogError ("Exception in animation:" + e);
 			}
 			return true;
 		}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/BounceFadePopupWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/BounceFadePopupWindow.cs
@@ -350,7 +350,7 @@ namespace Mono.TextEditor.Theatrics
 					Draw (cr, userspaceArea);
 				}
 			} catch (Exception e) {
-				LoggingService.LogError ("Exception in animation:" + e);
+				LoggingService.LogError ("Exception in animation:", e);
 			}
 			return true;
 		}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -193,7 +193,7 @@ namespace Mono.TextEditor
 					try {
 						textEditorData.HeightTree.SetLineHeight (lineNumber, GetLineHeight (e.Line));
 					} catch (Exception ex) {
-						Console.WriteLine (ex);
+						LoggingService.LogError ("HandleTextEditorDataDocumentMarkerChange error", ex);
 					}
 				}
 			}
@@ -461,7 +461,7 @@ namespace Mono.TextEditor
 			try {
 				action (GetTextEditorData ());
 			} catch (Exception e) {
-				Console.WriteLine ("Error while executing " + action + " :" + e);
+				LoggingService.LogError ("Error while executing " + action + " :" + e);
 			}
 		}
 
@@ -2193,7 +2193,7 @@ namespace Mono.TextEditor
 					try {
 						margin.Draw (margin == textViewMargin ? textViewCr : cr, cairoRectangle, line, logicalLineNumber, margin.XOffset, curY, lineHeight);
 					} catch (Exception e) {
-						System.Console.WriteLine (e);
+						LoggingService.LogError ("Error while drawing margin " + margin, e);
 					}
 				}
 				// take the line real render width from the text view margin rendering (a line can consist of more than 
@@ -3176,8 +3176,7 @@ namespace Mono.TextEditor
 					item = await tp.GetItem (editor, nextTipOffset, token);
 				} catch (OperationCanceledException) {
 				} catch (Exception e) {
-					System.Console.WriteLine ("Exception in tooltip provider " + tp + " GetItem:");
-					System.Console.WriteLine (e);
+					LoggingService.LogError ("Exception in tooltip provider " + tp + " GetItem:", e);
 				}
 				if (token.IsCancellationRequested) {
 					return;
@@ -3204,8 +3203,7 @@ namespace Mono.TextEditor
 					if (tw != null)
 						provider.ShowTooltipWindow (editor, tw, nextTipOffset, nextTipModifierState, tipX + (int) TextViewMargin.XOffset, tipY, item);
 				} catch (Exception e) {
-					Console.WriteLine ("-------- Exception while creating tooltip: " + provider);
-					Console.WriteLine (e);
+					LoggingService.LogError ("-------- Exception while creating tooltip: " + provider, e);
 				}
 				if (tw == tipWindow)
 					return;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -461,7 +461,7 @@ namespace Mono.TextEditor
 			try {
 				action (GetTextEditorData ());
 			} catch (Exception e) {
-				LoggingService.LogError ("Error while executing " + action + " :" + e);
+				LoggingService.LogError ("Error while executing " + action, e);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -430,7 +430,7 @@ namespace Mono.TextEditor
 				try {
 					result = args.Engine.SearchForward (worker, args, offset);
 				} catch (Exception ex) {
-					Console.WriteLine ("Got exception while search forward:" + ex);
+					LoggingService.LogError ("Got exception while search forward",  ex);
 					break;
 				}
 				if (worker.CancellationPending)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Wrappers/SemanticHighlightingSyntaxMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Wrappers/SemanticHighlightingSyntaxMode.cs
@@ -160,7 +160,7 @@ namespace MonoDevelop.SourceEditor.Wrappers
 					SyntaxHighlighting.ReplaceSegment (segments, semanticSegment);
 				}
 			} catch (Exception e) {
-				LoggingService.LogError ("Error in semantic highlighting: " + e);
+				LoggingService.LogError ("Error in semantic highlighting: ", e);
 				return syntaxLine;
 			}
 			return new HighlightedLine (line, segments);

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorPrintOperation.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorPrintOperation.cs
@@ -292,7 +292,7 @@ namespace MonoDevelop.SourceEditor
 			try {
 				Font = Pango.FontDescription.FromString (DefaultSourceEditorOptions.Instance.FontName);
 			} catch {
-				Console.WriteLine ("Could not load font: {0}", DefaultSourceEditorOptions.Instance.FontName);
+				LoggingService.LogWarning ("Could not load font: {0}", DefaultSourceEditorOptions.Instance.FontName);
 			}
 			if (Font == null || String.IsNullOrEmpty (Font.Family))
 				Font = Pango.FontDescription.FromString (TextEditorOptions.DEFAULT_FONT);

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Highlighting/XmlReadHelper.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Highlighting/XmlReadHelper.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using MonoDevelop.Core;
 
 namespace Mono.TextEditor.Highlighting
 {
@@ -81,7 +82,7 @@ namespace Mono.TextEditor.Highlighting
 				case XmlNodeType.EndElement:
 					if (endNodes.Contains (reader.LocalName)) 
 						return;
-					Console.WriteLine ("Unknown end node: " + reader.LocalName + " valid end nodes are: " + ConcatString (endNodes));
+					LoggingService.LogWarning ("Unknown end node: " + reader.LocalName + " valid end nodes are: " + ConcatString (endNodes));
 					break;
 				case XmlNodeType.Element:
 					if (!didReadStartNode && endNodes.Contains (reader.LocalName)) {
@@ -90,7 +91,7 @@ namespace Mono.TextEditor.Highlighting
 					}
 					bool validNode = callback (data);
 					if (!validNode) 
-						Console.WriteLine ("Unknown node: " + reader.LocalName);
+						LoggingService.LogWarning ("Unknown node: " + reader.LocalName);
 					if (data.SkipNextRead) 
 						goto skip;
 					break;

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
@@ -214,7 +214,7 @@ namespace Mono.TextEditor
 							try {
 								copyData = pasteHandler.GetCopyData (segment.Offset, segment.Length);
 							} catch (Exception e) {
-								Console.WriteLine ("Exception while getting copy data:" + e);
+								LoggingService.LogError ("Exc eption while getting copy data:" + e);
 							}
 						}
 						break;

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
@@ -214,7 +214,7 @@ namespace Mono.TextEditor
 							try {
 								copyData = pasteHandler.GetCopyData (segment.Offset, segment.Length);
 							} catch (Exception e) {
-								LoggingService.LogError ("Exc eption while getting copy data:" + e);
+								LoggingService.LogError ("Exception while getting copy data", e);
 							}
 						}
 						break;

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DiffTracker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DiffTracker.cs
@@ -86,7 +86,7 @@ namespace Mono.TextEditor
 					var lineNumber = startLine.LineNumber;
 					lineStates.RemoveRange (lineNumber, endRemoveLine.LineNumber - lineNumber);
 				} catch (Exception ex) {
-					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanging:" + ex);
+					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanging", ex);
 				}
 			}
 		}
@@ -113,7 +113,7 @@ namespace Mono.TextEditor
 					if (trackDocument != null)
 						trackDocument.CommitMultipleLineUpdate (lineNumber, lineNumber + insertedLines);
 				} catch (Exception ex) {
-					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanged:" + ex);
+					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanged", ex);
 				}
 			}
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DiffTracker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DiffTracker.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using Mono.TextEditor.Utils;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor;
 
 namespace Mono.TextEditor
@@ -85,7 +86,7 @@ namespace Mono.TextEditor
 					var lineNumber = startLine.LineNumber;
 					lineStates.RemoveRange (lineNumber, endRemoveLine.LineNumber - lineNumber);
 				} catch (Exception ex) {
-					Console.WriteLine ("error while DiffTracker.TrackDocument_TextChanging:" + ex);
+					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanging:" + ex);
 				}
 			}
 		}
@@ -112,7 +113,7 @@ namespace Mono.TextEditor
 					if (trackDocument != null)
 						trackDocument.CommitMultipleLineUpdate (lineNumber, lineNumber + insertedLines);
 				} catch (Exception ex) {
-					Console.WriteLine ("error while DiffTracker.TrackDocument_TextChanged:" + ex);
+					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanged:" + ex);
 				}
 			}
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/EditMode.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/EditMode.cs
@@ -229,7 +229,7 @@ namespace Mono.TextEditor
 				var sb = new System.Text.StringBuilder ("Error while executing actions ");
 				foreach (var action in actions)
 					sb.AppendFormat (" {0}", action);
-				LoggingService.LogError (sb.ToString () + ": " + e);
+				LoggingService.LogError (sb.ToString (), e);
 			}
 		
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/EditMode.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/EditMode.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using Gdk;
 using MonoDevelop.Components;
 using MonoDevelop.Ide.Editor;
+using MonoDevelop.Core;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Mono.TextEditor
@@ -228,7 +229,7 @@ namespace Mono.TextEditor
 				var sb = new System.Text.StringBuilder ("Error while executing actions ");
 				foreach (var action in actions)
 					sb.AppendFormat (" {0}", action);
-				Console.WriteLine (sb.ToString () + ": " + e);
+				LoggingService.LogError (sb.ToString () + ": " + e);
 			}
 		
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
@@ -1419,7 +1419,7 @@ namespace Mono.TextEditor
 				try {
 					newText = TextPasteHandler.FormatPlainText (offset, text, copyData);
 				} catch (Exception e) {
-					LoggingService.LogError ("Text paste handler exception:" + e);
+					LoggingService.LogError ("Text paste handler exception", e);
 					newText = text;
 				}
 				if (newText != text) {

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
@@ -31,6 +31,7 @@ using System.IO;
 using System.Diagnostics;
 using Mono.TextEditor.Highlighting;
 using Xwt.Drawing;
+using MonoDevelop.Core;
 using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide.Editor.Extension;
@@ -1418,7 +1419,7 @@ namespace Mono.TextEditor
 				try {
 					newText = TextPasteHandler.FormatPlainText (offset, text, copyData);
 				} catch (Exception e) {
-					Console.WriteLine ("Text paste handler exception:" + e);
+					LoggingService.LogError ("Text paste handler exception:" + e);
 					newText = text;
 				}
 				if (newText != text) {

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Diagnostics;
+using MonoDevelop.Core;
 using Mono.TextEditor.Highlighting;
 using MonoDevelop.Ide.Editor.Highlighting;
 
@@ -396,7 +397,7 @@ namespace Mono.TextEditor
 					try {
 						font = Pango.FontDescription.FromString (FontName);
 					} catch {
-						Console.WriteLine ("Could not load font: {0}", FontName);
+						LoggingService.LogError ("Could not load font: {0}", FontName);
 					}
 					if (font == null || String.IsNullOrEmpty (font.Family))
 						font = Pango.FontDescription.FromString (DEFAULT_FONT);
@@ -427,7 +428,7 @@ namespace Mono.TextEditor
 						if (!string.IsNullOrEmpty (GutterFontName))
 							gutterFont = Pango.FontDescription.FromString (GutterFontName);
 					} catch {
-						Console.WriteLine ("Could not load gutter font: {0}", GutterFontName);
+						LoggingService.LogError ("Could not load gutter font: {0}", GutterFontName);
 					}
 					if (gutterFont == null || String.IsNullOrEmpty (gutterFont.Family))
 						gutterFont = Gtk.Widget.DefaultStyle.FontDescription.Copy ();

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorOptions.cs
@@ -396,8 +396,8 @@ namespace Mono.TextEditor
 				if (font == null) {
 					try {
 						font = Pango.FontDescription.FromString (FontName);
-					} catch {
-						LoggingService.LogError ("Could not load font: {0}", FontName);
+					} catch (Exception e) {
+						LoggingService.LogError ("Could not load font: " + FontName, e);
 					}
 					if (font == null || String.IsNullOrEmpty (font.Family))
 						font = Pango.FontDescription.FromString (DEFAULT_FONT);
@@ -427,8 +427,8 @@ namespace Mono.TextEditor
 					try {
 						if (!string.IsNullOrEmpty (GutterFontName))
 							gutterFont = Pango.FontDescription.FromString (GutterFontName);
-					} catch {
-						LoggingService.LogError ("Could not load gutter font: {0}", GutterFontName);
+					} catch (Exception e) {
+						LoggingService.LogError ("Could not load gutter font: " + GutterFontName, e);
 					}
 					if (gutterFont == null || String.IsNullOrEmpty (gutterFont.Family))
 						gutterFont = Gtk.Widget.DefaultStyle.FontDescription.Copy ();


### PR DESCRIPTION
already fixed (the line numbers indicate it). However the text editor
errors should be printed to the log and not the console. This had
historical reasons because the editor was stand alone and had no
connection to the Core/Ide and no own logging capabilities.