### PR TITLE
Fixes issue #4566 Enabling code folding by default

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/Actor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/Actor.cs
@@ -40,10 +40,11 @@ namespace Mono.TextEditor.Theatrics
         private double percent;
         private bool can_expire = true;
 
-        public Actor (T target, uint duration)
+        public Actor (T target, uint duration, double percent)
         {
             this.target = target;
             this.duration = duration;
+			this.percent = percent;
             Reset ();
         }
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/Stage.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor.Theatrics/Stage.cs
@@ -80,14 +80,14 @@ namespace Mono.TextEditor.Theatrics
             }
         }
 
-        public Actor<T> Add (T target, uint duration)
+		public Actor<T> Add (T target, uint duration, double percent = 1.0)
         {
             lock (this) {
                 if (Contains (target)) {
                     throw new InvalidOperationException ("Stage already contains this actor");
                 }
 
-                Actor<T> actor = new Actor<T> (target, duration);
+				Actor<T> actor = new Actor<T> (target, duration, percent);
                 actors.Add (target, actor);
 
                 CheckTimeout ();
@@ -231,7 +231,7 @@ namespace Mono.TextEditor.Theatrics
             }
         }
 
-        public void Exeunt ()
+		public void Exeunt ()
         {
             lock (this) {
                 actors.Clear ();

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.FoldMarkerMarginDrawer.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.FoldMarkerMarginDrawer.cs
@@ -1,0 +1,140 @@
+﻿// FoldMarkerMargin.cs
+//
+// Author:
+//   Mike Krüger <mkrueger@novell.com>
+//
+// Copyright (c) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+
+using System.Linq;
+using System.Collections.Generic;
+using Cairo;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Editor.Highlighting;
+
+namespace Mono.TextEditor
+{
+	partial class FoldMarkerMargin
+	{
+		abstract class FoldMarkerMarginDrawer
+		{
+			readonly FoldMarkerMargin margin;
+
+			public FoldMarkerMargin Margin => margin;
+			public MonoTextEditor Editor => margin.editor;
+			public abstract bool AutoHide { get; }
+			public double FoldMarkerOcapitiy { get; set; }
+
+			protected FoldMarkerMarginDrawer (FoldMarkerMargin margin)
+			{
+				this.margin = margin;
+			}
+
+			public abstract void OptionsChanged ();
+
+			public abstract void Draw (Cairo.Context cr, Cairo.Rectangle area, DocumentLine line, int lineNumber, double x, double y, double lineHeight);
+
+			protected MarginMarker GetMarginMarker (DocumentLine line)
+			{
+				if (line != null) {
+					foreach (var m in Editor.Document.GetMarkers (line)) {
+						var mm = m as MarginMarker;
+						if (mm != null && mm.CanDraw (Margin)) {
+							return mm;
+						}
+					}
+				}
+				return null;
+			}
+
+			protected bool IsMouseHover (IEnumerable<FoldSegment> foldings)
+			{
+				return foldings.Any (s => Margin.lineHover == s.GetStartLine (Editor.Document));
+			}
+		}
+
+		abstract class LineStateFoldMarkerMarginDrawer : FoldMarkerMarginDrawer
+		{
+			Color lineStateChangedGC, lineStateDirtyGC, backgroundColor;
+
+			protected LineStateFoldMarkerMarginDrawer (FoldMarkerMargin margin) : base (margin)
+			{
+			}
+
+			public override void OptionsChanged ()
+			{
+				lineStateChangedGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.QuickDiffChanged);
+				lineStateDirtyGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.QuickDiffDirty);
+				backgroundColor = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.Background);
+			}
+
+			public override void Draw (Context cr, Rectangle area, DocumentLine line, int lineNumber, double x, double y, double lineHeight)
+			{
+				MarginMarker marker = GetMarginMarker (line);
+				bool hasDrawn = false;
+				if (marker != null) {
+					hasDrawn = marker.DrawBackground (Editor, cr, new MarginDrawMetrics (Margin, area, line, lineNumber, x, y, lineHeight));
+				}
+
+				if (!hasDrawn) {
+					if (Editor.GetTextEditorData ().HighlightCaretLine && Editor.Caret.Line == lineNumber) {
+						Editor.TextViewMargin.DrawCaretLineMarker (cr, x, y, Margin.Width, lineHeight);
+					} else {
+						cr.Rectangle (x, y, Margin.Width, lineHeight);
+						cr.SetSourceColor (backgroundColor);
+						cr.Fill ();
+					}
+				}
+
+				var state = Editor.Document.GetLineState (line);
+
+				if (Editor.Options.EnableQuickDiff && state != TextDocument.LineState.Unchanged) {
+					var prevState = line?.PreviousLine != null ? Editor.Document.GetLineState (line.PreviousLine) : TextDocument.LineState.Unchanged;
+					var nextState = line?.NextLine != null ? Editor.Document.GetLineState (line.NextLine) : TextDocument.LineState.Unchanged;
+
+					if (state == TextDocument.LineState.Changed) {
+						cr.SetSourceColor (lineStateChangedGC);
+					} else if (state == TextDocument.LineState.Dirty) {
+						cr.SetSourceColor (lineStateDirtyGC);
+					}
+
+					if ((prevState == TextDocument.LineState.Unchanged && prevState != state ||
+						 nextState == TextDocument.LineState.Unchanged && nextState != state)) {
+						FoldingScreenbackgroundRenderer.DrawRoundRectangle (
+							cr,
+							prevState == TextDocument.LineState.Unchanged,
+							nextState == TextDocument.LineState.Unchanged,
+							x + 1,
+							y,
+							lineHeight / 4,
+							Margin.Width / 4,
+							lineHeight
+						);
+					} else {
+						cr.Rectangle (x + 1, y, Margin.Width / 4, lineHeight);
+					}
+					cr.Fill ();
+				}
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.VSCodeFoldMarkerMarginDrawer.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.VSCodeFoldMarkerMarginDrawer.cs
@@ -1,0 +1,114 @@
+﻿// FoldMarkerMargin.cs
+//
+// Author:
+//   Mike Krüger <mkrueger@novell.com>
+//
+// Copyright (c) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+
+using System.Linq;
+using System.Collections.Generic;
+using Cairo;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Editor.Highlighting;
+
+namespace Mono.TextEditor
+{
+	partial class FoldMarkerMargin
+	{
+		sealed class VSCodeFoldMarkerMarginDrawer : LineStateFoldMarkerMarginDrawer
+		{
+			double foldSegmentSize = 8;
+			Color background, foreground, foldLine;
+
+			List<FoldSegment> startFoldings = new List<FoldSegment> ();
+
+			public override bool AutoHide { get => true; }
+
+			internal VSCodeFoldMarkerMarginDrawer (FoldMarkerMargin margin) : base (margin)
+			{
+			}
+
+			public override void OptionsChanged ()
+			{
+				base.OptionsChanged ();
+				background = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.Background);
+				foreground = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.Foreground);
+				foldLine = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.FoldLine);
+
+				foldSegmentSize = Margin.Width * 4 / 6;
+				foldSegmentSize -= (foldSegmentSize) % 2;
+			}
+
+			public override void Draw (Context cr, Rectangle area, DocumentLine line, int lineNumber, double x, double y, double lineHeight)
+			{
+				base.Draw (cr, area, line, lineNumber, x, y, lineHeight);
+				if (!Editor.Options.ShowFoldMargin || lineNumber > Editor.Document.LineCount || line == null || FoldMarkerOcapitiy <= 0)
+					return;
+				startFoldings.Clear ();
+
+				foreach (var segment in Editor.Document.GetFoldingContaining (line)) {
+					if (segment.GetStartLine (Editor.Document)?.Offset == line.Offset)
+						startFoldings.Add (segment);
+				}
+				if (startFoldings.Count == 0)
+					return;
+
+				bool isVisible = true;
+				bool isStartSelected = Margin.lineHover != null && IsMouseHover (startFoldings);
+
+				foreach (FoldSegment foldSegment in startFoldings) {
+					if (foldSegment.IsCollapsed) {
+						isVisible = false;
+					} 
+				}
+				DrawFoldSegment (cr, x, y, isVisible, isStartSelected);
+			}
+
+			void DrawFoldSegment (Cairo.Context ctx, double x, double y, bool isOpen, bool isSelected)
+			{
+				var drawArea = new Cairo.Rectangle (System.Math.Floor (x + (Margin.Width - foldSegmentSize) / 2) + 0.5,
+													System.Math.Floor (y + (Editor.LineHeight - foldSegmentSize) / 2) + 0.5, foldSegmentSize, foldSegmentSize);
+				ctx.Rectangle (drawArea);
+				ctx.SetSourceColor (background);
+				ctx.FillPreserve ();
+				ctx.SetSourceColor (foldLine);
+				ctx.Stroke ();
+
+				ctx.DrawLine (foreground,
+							  drawArea.X + drawArea.Width * 2 / 10,
+							  drawArea.Y + drawArea.Height / 2,
+							  drawArea.X + drawArea.Width - drawArea.Width * 2 / 10,
+							  drawArea.Y + drawArea.Height / 2);
+
+				if (!isOpen)
+					ctx.DrawLine (foreground,
+								  drawArea.X + drawArea.Width / 2,
+								  drawArea.Y + drawArea.Height * 2 / 10,
+								  drawArea.X + drawArea.Width / 2,
+								  drawArea.Y + drawArea.Height - drawArea.Height * 2 / 10);
+			}
+
+		}
+
+	}
+}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.VSNetFoldMarkerMarginDrawer.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.VSNetFoldMarkerMarginDrawer.cs
@@ -1,0 +1,175 @@
+﻿// FoldMarkerMargin.cs
+//
+// Author:
+//   Mike Krüger <mkrueger@novell.com>
+//
+// Copyright (c) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+
+using System.Linq;
+using System.Collections.Generic;
+using Cairo;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Editor.Highlighting;
+
+namespace Mono.TextEditor
+{
+	partial class FoldMarkerMargin
+	{
+		sealed class VSNetFoldMarkerMarginDrawer : LineStateFoldMarkerMarginDrawer
+		{
+			double foldSegmentSize = 8;
+
+			Color foldBgGC, foldLineGC, foldLineHighlightedGC, foldLineHighlightedGCBg, foldToggleMarkerGC, foldToggleMarkerBackground;
+			List<FoldSegment> startFoldings = new List<FoldSegment> ();
+			List<FoldSegment> containingFoldings = new List<FoldSegment> ();
+			List<FoldSegment> endFoldings        = new List<FoldSegment> ();
+
+			public override bool AutoHide { get => true; }
+
+			internal VSNetFoldMarkerMarginDrawer (FoldMarkerMargin margin) : base (margin)
+			{
+			}
+
+			public override void OptionsChanged ()
+			{
+				base.OptionsChanged ();
+				foldBgGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.Background);
+				foldLineGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.FoldLine);
+				foldLineHighlightedGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.Foreground);
+
+				HslColor hslColor = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.Background);
+				double brightness = HslColor.Brightness (hslColor);
+				if (brightness < 0.5) {
+					hslColor.L = hslColor.L * 0.85 + hslColor.L * 0.25;
+				} else {
+					hslColor.L = hslColor.L * 0.9;
+				}
+
+				foldLineHighlightedGCBg = hslColor;
+				foldToggleMarkerGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.FoldCross);
+				foldToggleMarkerBackground = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.FoldCrossBackground);
+				foldSegmentSize = Margin.Width * 4 / 6;
+				foldSegmentSize -= (foldSegmentSize) % 2;
+			}
+
+			void DrawFoldSegment (Cairo.Context ctx, double x, double y, bool isOpen, bool isSelected)
+			{
+				var drawArea = new Cairo.Rectangle (System.Math.Floor (x + (Margin.Width - foldSegmentSize) / 2) + 0.5,
+													System.Math.Floor (y + (Editor.LineHeight - foldSegmentSize) / 2) + 0.5, foldSegmentSize, foldSegmentSize);
+				ctx.Rectangle (drawArea);
+				ctx.SetSourceColor (isOpen ? foldBgGC : foldToggleMarkerBackground);
+				ctx.FillPreserve ();
+				ctx.SetSourceColor (isSelected ? foldLineHighlightedGC : foldLineGC);
+				ctx.Stroke ();
+
+				ctx.DrawLine (isSelected ? foldLineHighlightedGC : foldToggleMarkerGC,
+							  drawArea.X + drawArea.Width * 2 / 10,
+							  drawArea.Y + drawArea.Height / 2,
+							  drawArea.X + drawArea.Width - drawArea.Width * 2 / 10,
+							  drawArea.Y + drawArea.Height / 2);
+
+				if (!isOpen)
+					ctx.DrawLine (isSelected ? foldLineHighlightedGC : foldToggleMarkerGC,
+								  drawArea.X + drawArea.Width / 2,
+								  drawArea.Y + drawArea.Height * 2 / 10,
+								  drawArea.X + drawArea.Width / 2,
+								  drawArea.Y + drawArea.Height - drawArea.Height * 2 / 10);
+			}
+
+			public override void Draw (Context cr, Rectangle area, DocumentLine line, int lineNumber, double x, double y, double lineHeight)
+			{
+				base.Draw (cr, area, line, lineNumber, x, y, lineHeight);
+				if (!Editor.Options.ShowFoldMargin || lineNumber > Editor.Document.LineCount || line == null)
+					return;
+
+				Cairo.Rectangle drawArea = new Cairo.Rectangle (x, y, Margin.Width, lineHeight);
+
+				bool isFoldStart = false;
+				bool isContaining = false;
+				bool isFoldEnd = false;
+
+				bool isStartSelected = false;
+				bool isContainingSelected = false;
+				bool isEndSelected = false;
+
+				startFoldings.Clear ();
+				containingFoldings.Clear ();
+				endFoldings.Clear ();
+				foreach (FoldSegment segment in Editor.Document.GetFoldingContaining (line)) {
+					if (segment.GetStartLine (Editor.Document)?.Offset == line.Offset) {
+						startFoldings.Add (segment);
+					} else if (segment.GetEndLine (Editor.Document)?.Offset == line.Offset) {
+						endFoldings.Add (segment);
+					} else {
+						containingFoldings.Add (segment);
+					}
+				}
+
+				isFoldStart = startFoldings.Count > 0;
+				isContaining = containingFoldings.Count > 0;
+				isFoldEnd = endFoldings.Count > 0;
+
+				isStartSelected = Margin.lineHover != null && IsMouseHover (startFoldings);
+				isContainingSelected = Margin.lineHover != null && IsMouseHover (containingFoldings);
+				isEndSelected = Margin.lineHover != null && IsMouseHover (endFoldings);
+
+				double foldSegmentYPos = y + System.Math.Floor (Editor.LineHeight - foldSegmentSize) / 2;
+				double xPos = x + System.Math.Floor (Margin.Width / 2) + 0.5;
+
+				if (isFoldStart) {
+					bool isVisible = true;
+					bool moreLinedOpenFold = false;
+					foreach (FoldSegment foldSegment in startFoldings) {
+						if (foldSegment.IsCollapsed) {
+							isVisible = false;
+						} else {
+							moreLinedOpenFold = foldSegment.GetEndLine (Editor.Document).Offset > foldSegment.GetStartLine (Editor.Document).Offset;
+						}
+					}
+					bool isFoldEndFromUpperFold = false;
+					foreach (FoldSegment foldSegment in endFoldings) {
+						if (foldSegment.GetEndLine (Editor.Document).Offset > foldSegment.GetStartLine (Editor.Document).Offset && !foldSegment.IsCollapsed)
+							isFoldEndFromUpperFold = true;
+					}
+					DrawFoldSegment (cr, x, y, isVisible, isStartSelected);
+
+					if (isContaining || isFoldEndFromUpperFold)
+						cr.DrawLine (isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, drawArea.Y, xPos, foldSegmentYPos - 2);
+					if (isContaining || moreLinedOpenFold)
+						cr.DrawLine (isEndSelected || (isStartSelected && isVisible) || isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, foldSegmentYPos + foldSegmentSize + 2, xPos, drawArea.Y + drawArea.Height);
+				} else {
+					if (isFoldEnd) {
+						double yMid = System.Math.Floor (drawArea.Y + drawArea.Height / 2) + 0.5;
+						cr.DrawLine (isEndSelected ? foldLineHighlightedGC : foldLineGC, xPos, yMid, x + Margin.Width - 2, yMid);
+						cr.DrawLine (isContainingSelected || isEndSelected ? foldLineHighlightedGC : foldLineGC, xPos, drawArea.Y, xPos, yMid);
+
+						if (isContaining)
+							cr.DrawLine (isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, yMid, xPos, drawArea.Y + drawArea.Height);
+					} else if (isContaining) {
+						cr.DrawLine (isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, drawArea.Y, xPos, drawArea.Y + drawArea.Height);
+					}
+				}
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.VSNetFoldMarkerMarginDrawer.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.VSNetFoldMarkerMarginDrawer.cs
@@ -68,8 +68,6 @@ namespace Mono.TextEditor
 				foldLineHighlightedGCBg = hslColor;
 				foldToggleMarkerGC = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.FoldCross);
 				foldToggleMarkerBackground = SyntaxHighlightingService.GetColor (Editor.EditorTheme, EditorThemeColors.FoldCrossBackground);
-				foldSegmentSize = Margin.Width * 4 / 6;
-				foldSegmentSize -= (foldSegmentSize) % 2;
 			}
 
 			void DrawFoldSegment (Cairo.Context ctx, double x, double y, bool isOpen, bool isSelected)
@@ -101,6 +99,8 @@ namespace Mono.TextEditor
 				base.Draw (cr, area, line, lineNumber, x, y, lineHeight);
 				if (!Editor.Options.ShowFoldMargin || lineNumber > Editor.Document.LineCount || line == null)
 					return;
+				foldSegmentSize = Margin.Width * 4 / 6;
+				foldSegmentSize -= (foldSegmentSize) % 2;
 
 				Cairo.Rectangle drawArea = new Cairo.Rectangle (x, y, Margin.Width, lineHeight);
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
@@ -33,18 +33,20 @@ using System.Timers;
 using MonoDevelop.Components;
 using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.Editor;
-using MonoDevelop.Ide.Editor.Highlighting;
 using MonoDevelop.Core;
 
 namespace Mono.TextEditor
 {
-	class FoldMarkerMargin : Margin
+	partial class FoldMarkerMargin : Margin
 	{
+		const int HoverTimer = 100;
+		uint hoverTimerId;
+
+		FoldMarkerMarginDrawer drawer;
 		MonoTextEditor editor;
 		DocumentLine lineHover;
 		Pango.Layout layout;
 
-		double foldSegmentSize = 8;
 		double marginWidth;
 		public override double Width {
 			get {
@@ -75,8 +77,47 @@ namespace Mono.TextEditor
 			editor.Caret.PositionChanged += HandleEditorCaretPositionChanged;
 			editor.Document.FoldTreeUpdated += HandleEditorDocumentFoldTreeUpdated;
 			editor.Caret.PositionChanged += EditorCarethandlePositionChanged;
-
+			editor.TextArea.MouseHover += TextArea_MouseHover;
+			editor.TextArea.MouseLeft += TextArea_MouseLeft; 
+			drawer = new VSCodeFoldMarkerMarginDrawer (this);
 			UpdateAccessibility ();
+		}
+
+		void TextArea_MouseLeft (object sender, EventArgs e)
+		{
+			if (!drawer.AutoHide)
+				return;
+			StopHoverTimer ();
+			drawer.FoldMarkerOcapitiy = 0;
+			editor.RedrawMargin (this);
+		}
+
+		void TextArea_MouseHover (object sender, MarginEventArgs e)
+		{
+			if (!drawer.AutoHide)
+				return;
+			if (e.Margin == editor.TextViewMargin) {
+				StopHoverTimer ();
+				drawer.FoldMarkerOcapitiy = 0;
+				editor.RedrawMargin (this);
+			} else {
+				if (hoverTimerId != 0)
+					return;
+				hoverTimerId = GLib.Timeout.Add (HoverTimer, delegate {
+					drawer.FoldMarkerOcapitiy = 1.0;
+					editor.RedrawMargin (this);
+					hoverTimerId = 0;
+					return false;
+				});
+			}
+		}
+
+		private void StopHoverTimer ()
+		{
+			if (hoverTimerId == 0)
+				return;
+			GLib.Source.Remove (hoverTimerId);
+			hoverTimerId = 0;
 		}
 
 		void EditorCarethandlePositionChanged (object sender, DocumentLocationEventArgs e)
@@ -266,41 +307,23 @@ namespace Mono.TextEditor
 		
 		internal protected override void OptionsChanged ()
 		{
-			foldBgGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.Background);
-			foldLineGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.FoldLine);
-			foldLineHighlightedGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.Foreground);
-			
-			HslColor hslColor = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.Background);
-			double brightness = HslColor.Brightness (hslColor);
-			if (brightness < 0.5) {
-				hslColor.L = hslColor.L * 0.85 + hslColor.L * 0.25;
-			} else {
-				hslColor.L = hslColor.L * 0.9;
-			}
-			
-			foldLineHighlightedGCBg = hslColor;
-			foldToggleMarkerGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.FoldCross);
-			foldToggleMarkerBackground = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.FoldCrossBackground);
-			lineStateChangedGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.QuickDiffChanged);
-			lineStateDirtyGC = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.QuickDiffDirty);
-			backgroundColor = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.IndicatorMargin);
+			drawer.OptionsChanged ();
 
 			marginWidth = editor.LineHeight  * 3 / 4;
 		}
-		
-		Cairo.Color foldBgGC, foldLineGC, foldLineHighlightedGC, foldLineHighlightedGCBg, foldToggleMarkerGC, foldToggleMarkerBackground;
-		Cairo.Color lineStateChangedGC, lineStateDirtyGC, backgroundColor;
 		
 		public override void Dispose ()
 		{
 			base.Dispose ();
 			StopTimer ();
+			editor.TextArea.MouseHover -= TextArea_MouseHover;
+			editor.TextArea.MouseLeft -= TextArea_MouseLeft; 
 			editor.Caret.PositionChanged -= HandleEditorCaretPositionChanged;
 			editor.Caret.PositionChanged -= EditorCarethandlePositionChanged;
 			editor.Document.FoldTreeUpdated -= HandleEditorDocumentFoldTreeUpdated;
 			layout = layout.Kill ();
 			foldings = null;
-			startFoldings = containingFoldings = endFoldings = null;
+			drawer = null;
 
 			if (accessibles != null) {
 				foreach (var a in accessibles.Values) {
@@ -311,188 +334,10 @@ namespace Mono.TextEditor
 			}
 		}
 		
-		void DrawFoldSegment (Cairo.Context ctx, double x, double y, bool isOpen, bool isSelected)
+
+		internal protected override void Draw (Cairo.Context cr, Cairo.Rectangle area, DocumentLine line, int lineNumber, double x, double y, double lineHeight)
 		{
-			var drawArea = new Cairo.Rectangle (System.Math.Floor (x + (Width - foldSegmentSize) / 2) + 0.5, 
-			                                    System.Math.Floor (y + (editor.LineHeight - foldSegmentSize) / 2) + 0.5, foldSegmentSize, foldSegmentSize);
-			ctx.Rectangle (drawArea);
-			ctx.SetSourceColor (isOpen ? foldBgGC : foldToggleMarkerBackground);
-			ctx.FillPreserve ();
-			ctx.SetSourceColor (isSelected ? foldLineHighlightedGC  : foldLineGC);
-			ctx.Stroke ();
-			
-			ctx.DrawLine (isSelected ? foldLineHighlightedGC  : foldToggleMarkerGC,
-			              drawArea.X  + drawArea.Width * 2 / 10,
-			              drawArea.Y + drawArea.Height / 2,
-			              drawArea.X + drawArea.Width - drawArea.Width * 2 / 10,
-			              drawArea.Y + drawArea.Height / 2);
-			
-			if (!isOpen)
-				ctx.DrawLine (isSelected ? foldLineHighlightedGC  : foldToggleMarkerGC,
-				              drawArea.X + drawArea.Width / 2,
-				              drawArea.Y + drawArea.Height * 2 / 10,
-				              drawArea.X  + drawArea.Width / 2,
-				              drawArea.Y + drawArea.Height - drawArea.Height * 2 / 10);
-		}
-		
-		bool IsMouseHover (IEnumerable<FoldSegment> foldings)
-		{
-			return foldings.Any (s => this.lineHover == s.GetStartLine  (editor.Document));
-		}
-		
-		List<FoldSegment> startFoldings      = new List<FoldSegment> ();
-		List<FoldSegment> containingFoldings = new List<FoldSegment> ();
-		List<FoldSegment> endFoldings        = new List<FoldSegment> ();
-		
-		internal protected override void Draw (Cairo.Context cr, Cairo.Rectangle area, DocumentLine lineSegment, int line, double x, double y, double lineHeight)
-		{
-			MarginMarker marker = null;
-			if (lineSegment != null) {
-				foreach (var m in editor.Document.GetMarkers (lineSegment)) {
-					var mm = m as MarginMarker;
-					if (mm != null && mm.CanDraw (this)) {
-						marker = mm;
-						break;
-					}
-				}
-			}
-
-			if (marker != null) {
-				bool hasDrawn = marker.DrawBackground (editor, cr, new MarginDrawMetrics (this, area, lineSegment, line, x, y, lineHeight));
-				if (!hasDrawn)
-					marker = null;
-			}
-
-			foldSegmentSize = marginWidth * 4 / 6;
-			foldSegmentSize -= (foldSegmentSize) % 2;
-
-			if (HasFocus) {
-				cr.Rectangle (x, y, Width, lineHeight);
-				cr.SetSourceColor (backgroundColor);
-				cr.Fill ();
-			}
-
-			Cairo.Rectangle drawArea = new Cairo.Rectangle (x, y, marginWidth, lineHeight);
-			var state = editor.Document.GetLineState (lineSegment);
-
-			bool isFoldStart = false;
-			bool isContaining = false;
-			bool isFoldEnd = false;
-			
-			bool isStartSelected = false;
-			bool isContainingSelected = false;
-			bool isEndSelected = false;
-			
-			if (editor.Options.ShowFoldMargin && line <= editor.Document.LineCount) {
-				startFoldings.Clear ();
-				containingFoldings.Clear ();
-				endFoldings.Clear ();
-				if (lineSegment != null) {
-					foreach (FoldSegment segment in editor.Document.GetFoldingContaining (lineSegment)) {
-						if (segment.GetStartLine (editor.Document)?.Offset == lineSegment.Offset) {
-							startFoldings.Add (segment);
-						} else if (segment.GetEndLine (editor.Document)?.Offset == lineSegment.Offset) {
-							endFoldings.Add (segment);
-						} else {
-							containingFoldings.Add (segment);
-						}
-					}
-				}
-				
-				isFoldStart = startFoldings.Count > 0;
-				isContaining = containingFoldings.Count > 0;
-				isFoldEnd = endFoldings.Count > 0;
-				
-				isStartSelected = this.lineHover != null && IsMouseHover (startFoldings);
-				isContainingSelected = this.lineHover != null && IsMouseHover (containingFoldings);
-				isEndSelected = this.lineHover != null && IsMouseHover (endFoldings);
-			}
-
-			if (marker == null) {
-				if (editor.GetTextEditorData ().HighlightCaretLine && editor.Caret.Line == line) {
-					editor.TextViewMargin.DrawCaretLineMarker (cr, x, y, Width, lineHeight);
-				} else {
-					var bgGC = foldBgGC;
-					if (editor.TextViewMargin.BackgroundRenderer != null) {
-						if (isContainingSelected || isStartSelected || isEndSelected) {
-							bgGC = foldBgGC;
-						} else {
-							bgGC = foldLineHighlightedGCBg;
-						}
-					}
-					
-					cr.Rectangle (drawArea);
-					cr.SetSourceColor (bgGC);
-					cr.Fill ();
-				}
-			}
-
-			if (editor.Options.EnableQuickDiff && state != TextDocument.LineState.Unchanged) {
-				var prevState = lineSegment?.PreviousLine != null ? editor.Document.GetLineState (lineSegment.PreviousLine) : TextDocument.LineState.Unchanged;
-				var nextState = lineSegment?.NextLine != null ? editor.Document.GetLineState (lineSegment.NextLine) : TextDocument.LineState.Unchanged;
-
-				if (state == TextDocument.LineState.Changed) {
-					cr.SetSourceColor (lineStateChangedGC);
-				} else if (state == TextDocument.LineState.Dirty) {
-					cr.SetSourceColor (lineStateDirtyGC);
-				}
-
-				if ((prevState == TextDocument.LineState.Unchanged  && prevState != state ||
-				     nextState == TextDocument.LineState.Unchanged  && nextState != state)) {
-					FoldingScreenbackgroundRenderer.DrawRoundRectangle (
-						cr, 
-						prevState == TextDocument.LineState.Unchanged, 
-						nextState == TextDocument.LineState.Unchanged,
-						x + 1, 
-						y, 
-						lineHeight / 4,
-						marginWidth / 4, 
-						lineHeight
-					);
-				} else {
-					cr.Rectangle (x + 1, y, marginWidth / 4, lineHeight);
-				}
-				cr.Fill ();
-			}
-
-			if (editor.Options.ShowFoldMargin && line <= editor.Document.LineCount) {
-				double foldSegmentYPos = y + System.Math.Floor (editor.LineHeight - foldSegmentSize) / 2;
-				double xPos = x + System.Math.Floor (marginWidth / 2) + 0.5;
-				
-				if (isFoldStart) {
-					bool isVisible         = true;
-					bool moreLinedOpenFold = false;
-					foreach (FoldSegment foldSegment in startFoldings) {
-						if (foldSegment.IsCollapsed) {
-							isVisible = false;
-						} else {
-							moreLinedOpenFold = foldSegment.GetEndLine (editor.Document).Offset > foldSegment.GetStartLine (editor.Document).Offset;
-						}
-					}
-					bool isFoldEndFromUpperFold = false;
-					foreach (FoldSegment foldSegment in endFoldings) {
-						if (foldSegment.GetEndLine (editor.Document).Offset > foldSegment.GetStartLine (editor.Document).Offset && !foldSegment.IsCollapsed) 
-							isFoldEndFromUpperFold = true;
-					}
-					DrawFoldSegment (cr, x, y, isVisible, isStartSelected);
-					
-					if (isContaining || isFoldEndFromUpperFold)
-						cr.DrawLine (isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, drawArea.Y, xPos, foldSegmentYPos - 2);
-					if (isContaining || moreLinedOpenFold) 
-						cr.DrawLine (isEndSelected || (isStartSelected && isVisible) || isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, foldSegmentYPos + foldSegmentSize + 2, xPos, drawArea.Y + drawArea.Height);
-				} else {
-					if (isFoldEnd) {
-						double yMid = System.Math.Floor (drawArea.Y + drawArea.Height / 2) + 0.5;
-						cr.DrawLine (isEndSelected ? foldLineHighlightedGC : foldLineGC, xPos, yMid, x + marginWidth - 2, yMid);
-						cr.DrawLine (isContainingSelected || isEndSelected ? foldLineHighlightedGC : foldLineGC, xPos, drawArea.Y, xPos, yMid);
-						
-						if (isContaining) 
-							cr.DrawLine (isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, yMid, xPos, drawArea.Y + drawArea.Height);
-					} else if (isContaining) {
-						cr.DrawLine (isContainingSelected ? foldLineHighlightedGC : foldLineGC, xPos, drawArea.Y, xPos, drawArea.Y + drawArea.Height);
-					}
-				}
-			}
+			drawer.Draw (cr, area, line, lineNumber, x, y, lineHeight);
 		}
 
 		FoldSegment[] focusSegments;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/Margin.cs
@@ -200,7 +200,17 @@ namespace Mono.TextEditor
 		public event EventHandler<MarginMouseEventArgs> MouseMoved;
 		public event EventHandler MouseLeave;
 	}
-	
+
+	class MarginEventArgs : EventArgs
+	{
+		public Margin Margin { get; private set; }
+
+		public MarginEventArgs (Margin margin)
+		{
+			Margin = margin;
+		}
+	}
+
 	class MarginMouseEventArgs : EventArgs
 	{
 		public double X {

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1696,9 +1696,10 @@ namespace Mono.TextEditor
 				args.Location = location;
 				margin.MouseHover (args);
 			}
-
+			MouseHover?.Invoke (this, new MarginEventArgs (margin));
 			oldMargin = margin;
 		}
+		internal event EventHandler<MarginEventArgs> MouseHover;
 
 		#region CustomDrag (for getting dnd data from toolbox items for example)
 		string     customText;
@@ -1745,9 +1746,11 @@ namespace Mono.TextEditor
 				SetCursor (null);
 			if (oldMargin != null)
 				oldMargin.MouseLeft ();
-			
+			MouseLeft?.Invoke (this, EventArgs.Empty);
 			return base.OnLeaveNotifyEvent (e); 
 		}
+
+		internal event EventHandler MouseLeft;
 
 		public double LineHeight {
 			get {

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -359,6 +359,9 @@
     <Compile Include="Gui\MonoDevelop.SourceEditor.SearchWidget.cs" />
     <Compile Include="MonoDevelop.SourceEditor\TextMarker\BackgroundTextMarker.cs" />
     <Compile Include="Mono.TextEditor\Gui\TextViewMargin.SpanUpdateListener.cs" />
+    <Compile Include="Mono.TextEditor\Gui\FoldMarkerMargin.FoldMarkerMarginDrawer.cs" />
+    <Compile Include="Mono.TextEditor\Gui\FoldMarkerMargin.VSNetFoldMarkerMarginDrawer.cs" />
+    <Compile Include="Mono.TextEditor\Gui\FoldMarkerMargin.VSCodeFoldMarkerMarginDrawer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.SourceEditor.addin.xml">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
@@ -596,7 +596,7 @@ namespace MonoDevelop.Ide.Editor
 			}
 		}
 		
-		ConfigurationProperty<bool> showFoldMargin = ConfigurationProperty.Create ("ShowFoldMargin", false);
+		ConfigurationProperty<bool> showFoldMargin = ConfigurationProperty.Create ("ShowFoldMargin", true);
 		public bool ShowFoldMargin {
 			get {
 				return showFoldMargin;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
@@ -595,14 +595,14 @@ namespace MonoDevelop.Ide.Editor
 					OnChanged (EventArgs.Empty);
 			}
 		}
-		
-		ConfigurationProperty<bool> showFoldMargin = ConfigurationProperty.Create ("ShowFoldMargin", true);
+
+		ConfigurationProperty<bool> hideFoldMargin = ConfigurationProperty.Create ("HideFoldMargin", false);
 		public bool ShowFoldMargin {
 			get {
-				return showFoldMargin;
+				return !hideFoldMargin;
 			}
 			set {
-				if (showFoldMargin.Set (value))
+				if (hideFoldMargin.Set (!value))
 					OnChanged (EventArgs.Empty);
 			}
 		}


### PR DESCRIPTION
https://github.com/mono/monodevelop/issues/4566

Should match the VS.NET default options.