### PR TITLE
[Debugger] Add logpoints to the icon margin

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.addin.xml
@@ -126,6 +126,9 @@
 				defaultHandler = "MonoDevelop.Debugger.NewCatchpointHandler"
 				_label = "New Exception Catchpoint"
 				icon = "md-catchpoint-new" />
+		<Command id = "MonoDevelop.Debugger.DebugCommands.ToggleLogpoint"
+				 defaultHandler = "MonoDevelop.Debugger.ToggleLogpointHandler"
+				 _label = "Toggle Logpoint" />
 		<Command id = "MonoDevelop.Debugger.DebugCommands.ShowBreakpoints"
 				defaultHandler = "MonoDevelop.Debugger.ShowBreakpointsHandler"
 				_label = "View Breakpoints"

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
@@ -131,16 +131,15 @@
 	<Extension path = "/MonoDevelop/SourceEditor2/IconContextMenu/Editor">
 		<CommandItem id = "MonoDevelop.Ide.Editor.MessageBubbleCommands.Toggle" />
 		<SeparatorItem id = "Separator1" />
+		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.ToggleLogpoint" />
 		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.ToggleBreakpoint" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.ToggleBookmark" />
 		<SeparatorItem id = "Separator1" />
-		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.NewBreakpoint" />
 		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.ShowBreakpointProperties" />
 		<SeparatorItem id = "Separator1" />
 		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.EnableDisableBreakpoint" />
 		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.DisableAllBreakpoints" />
 		<SeparatorItem id = "Separator1" />
-		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.RemoveBreakpoint" />
 		<CommandItem id = "MonoDevelop.Debugger.DebugCommands.ClearAllBreakpoints" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.ClearBookmarks" />
 	</Extension>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
@@ -554,7 +554,6 @@ namespace MonoDevelop.Ide.Gui
 		#endregion
 		
 		#region Bookmarks
-		[CommandUpdateHandler (SearchCommands.ToggleBookmark)]
 		[CommandUpdateHandler (SearchCommands.PrevBookmark)]
 		[CommandUpdateHandler (SearchCommands.NextBookmark)]
 		[CommandUpdateHandler (SearchCommands.ClearBookmarks)]
@@ -562,7 +561,18 @@ namespace MonoDevelop.Ide.Gui
 		{
 			info.Enabled = GetContent <IBookmarkBuffer> () != null;
 		}
-		
+
+		[CommandUpdateHandler (SearchCommands.ToggleBookmark)]
+		protected void UpdateToggleBookmark (CommandInfo info)
+		{
+			info.Enabled = GetContent <IBookmarkBuffer> () != null;
+			var markBuffer = GetContent <IBookmarkBuffer> ();
+			Debug.Assert (markBuffer != null);
+			int position = markBuffer.CursorPosition;
+
+			info.Text = markBuffer.IsBookmarked (position) ? GettextCatalog.GetString ("Remove Bookmark") : GettextCatalog.GetString ("New Bookmark");
+		}
+
 		[CommandHandler (SearchCommands.ToggleBookmark)]
 		public void ToggleBookmark ()
 		{


### PR DESCRIPTION
A log point is a breakpoint that just prints a message and continues. Add
support for them to the icon margin.

Requires https://github.com/mono/debugger-libs/pull/182