### PR TITLE
[DotNetCore] Handle .NET Core 2.1 SDK not installed

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkTests.cs
@@ -52,6 +52,22 @@ namespace MonoDevelop.DotNetCore.Tests
 		[TestCase (".NETFramework", "2.0", new [] { "2.0.0" }, false, true)] // Allow other non-.NET Core frameworks to be supported.
 		[TestCase (".NETCoreApp", "1.1", new [] { "2.0.0" }, false, true)] // v2.0 SDK can compile v1 projects
 		[TestCase (".NETStandard", "1.6", new [] { "2.0.0" }, false, true)] // v2.0 SDK can compile v1 projects
+		[TestCase (".NETStandard", "2.0", new [] { "2.1.101" }, false, true)] // v2.1.101 supports .NET Standard 2.0
+		[TestCase (".NETStandard", "2.0", new [] { "2.1.4" }, false, true)] // v2.1.4 supports .NET Standard 2.0
+		[TestCase (".NETCoreApp", "2.0", new [] { "2.1.101" }, false, true)] // v2.1.101 supports .NET Core  2.0
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.4" }, false, false)] // v2.1.4 does not support .NET Core 2.1
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.101" }, false, false)] // v2.1.101 does not support .NET Core 2.1
+		[TestCase (".NETCoreApp", "2.0", new [] { "2.1.299" }, false, true)]
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.299" }, false, false)]
+		[TestCase (".NETCoreApp", "1.0", new [] { "2.1.300" }, false, true)]
+		[TestCase (".NETCoreApp", "1.1", new [] { "2.1.300" }, false, true)]
+		[TestCase (".NETCoreApp", "2.0", new [] { "2.1.300" }, false, true)] // v2.1.300 supports .NET Core  2.0
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.300" }, false, true)] // v2.1.300 supports .NET Core  2.1
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.300" }, false, true)] // v2.1.300 supports .NET Core  2.1
+		[TestCase (".NETStandard", "2.0", new [] { "2.1.300" }, false, true)]
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.300-preview2-008530" }, true, true)] // v2.1 preview 2 supports .NET Core  2.1
+		[TestCase (".NETStandard", "2.0", new [] { "2.1.300-preview2-008530" }, true, true)] // v2.1 preview 2 supports .NET Core  2.1
+		[TestCase (".NETCoreApp", "2.1", new [] { "2.1.400" }, false, true)] // v2.1.400 will support .NET Core  2.1
 		public void IsSupportedTargetFramework (
 			string frameworkIdentifier,
 			string frameworkVersion,

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
@@ -35,10 +35,12 @@ namespace MonoDevelop.DotNetCore
 	{
 		public static readonly string DotNetCoreDownloadUrl = "https://aka.ms/vs/mac/install-netcore";
 		public static readonly string DotNetCore20DownloadUrl = "https://aka.ms/vs/mac/install-netcore2";
+		public static readonly string DotNetCore21DownloadUrl = "https://aka.ms/vs/mac/install-netcore21";
 
 		static readonly string defaultMessage = GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build and run .NET Core projects.");
 		static readonly string unsupportedMessage = GettextCatalog.GetString ("The .NET Core SDK installed is not supported. Please install a more recent version.");
 		static readonly string dotNetCore20Message = GettextCatalog.GetString (".NET Core 2.0 SDK is not installed. This is required to build and run .NET Core 2.0 projects.");
+		static readonly string dotNetCore21Message = GettextCatalog.GetString (".NET Core 2.1 SDK is not installed. This is required to build and run .NET Core 2.1 projects.");
 
 		GenericMessage message;
 		AlertButton downloadButton;
@@ -82,6 +84,9 @@ namespace MonoDevelop.DotNetCore
 			else if (RequiresDotNetCore20) {
 				Message = dotNetCore20Message;
 				downloadUrl = DotNetCore20DownloadUrl;
+			} else if (RequiresDotNetCore21) {
+				Message = dotNetCore21Message;
+				downloadUrl = DotNetCore21DownloadUrl;
 			}
 
 			MessageService.GenericAlert (message);
@@ -94,5 +99,6 @@ namespace MonoDevelop.DotNetCore
 
 		public bool IsUnsupportedVersion { get; set; }
 		public bool RequiresDotNetCore20 { get; set; }
+		public bool RequiresDotNetCore21 { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -233,6 +233,7 @@ namespace MonoDevelop.DotNetCore
 
 				using (var dialog = new DotNetCoreNotInstalledDialog ()) {
 					dialog.IsUnsupportedVersion = unsupportedSdkVersion;
+					dialog.RequiresDotNetCore21 = Project.TargetFramework.IsNetCoreApp21 ();
 					dialog.RequiresDotNetCore20 = Project.TargetFramework.IsNetStandard20OrNetCore20 ();
 					dialog.Show ();
 				}
@@ -335,7 +336,7 @@ namespace MonoDevelop.DotNetCore
 			if (ProjectNeedsRestore ()) {
 				return CreateNuGetRestoreRequiredBuildResult ();
 			} else if (HasSdk && !IsDotNetCoreSdkInstalled ()) {
-				return CreateDotNetCoreSdkRequiredBuildResult (sdkPaths.IsUnsupportedSdkVersion);
+				return CreateDotNetCoreSdkRequiredBuildResult ();
 			}
 			return null;
 		}
@@ -363,25 +364,26 @@ namespace MonoDevelop.DotNetCore
 			return result;
 		}
 
-		BuildResult CreateDotNetCoreSdkRequiredBuildResult (bool isUnsupportedVersion)
+		BuildResult CreateDotNetCoreSdkRequiredBuildResult ()
 		{
-			bool requiresDotNetCoreSdk20 = Project.TargetFramework.IsNetStandard20OrNetCore20 ();
-			return CreateBuildError (GetDotNetCoreSdkRequiredBuildErrorMessage (isUnsupportedVersion, requiresDotNetCoreSdk20));
+			return CreateBuildError (GetDotNetCoreSdkRequiredMessage ());
 		}
 
 		internal string GetDotNetCoreSdkRequiredMessage ()
 		{
 			return GetDotNetCoreSdkRequiredBuildErrorMessage (
 				IsUnsupportedDotNetCoreSdkInstalled (),
-				Project.TargetFramework.IsNetStandard20OrNetCore20 ());
+				Project.TargetFramework);
 		}
 
-		static string GetDotNetCoreSdkRequiredBuildErrorMessage (bool isUnsupportedVersion, bool requiresDotNetCoreSdk20)
+		static string GetDotNetCoreSdkRequiredBuildErrorMessage (bool isUnsupportedVersion, TargetFramework targetFramework)
 		{
 			if (isUnsupportedVersion)
 				return GettextCatalog.GetString ("The .NET Core SDK installed is not supported. Please install a more recent version. {0}", DotNetCoreNotInstalledDialog.DotNetCoreDownloadUrl);
-			else if (requiresDotNetCoreSdk20)
+			else if (targetFramework.IsNetStandard20OrNetCore20 ())
 				return GettextCatalog.GetString (".NET Core 2.0 SDK is not installed. This is required to build .NET Core 2.0 projects. {0}", DotNetCoreNotInstalledDialog.DotNetCore20DownloadUrl);
+			else if (targetFramework.IsNetCoreApp21 ())
+				return GettextCatalog.GetString (".NET Core 2.1 SDK is not installed. This is required to build .NET Core 2.1 projects. {0}", DotNetCoreNotInstalledDialog.DotNetCore21DownloadUrl);
 
 			return GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build .NET Core projects. {0}", DotNetCoreNotInstalledDialog.DotNetCoreDownloadUrl);
 		}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -113,7 +113,7 @@ namespace MonoDevelop.DotNetCore
 
 			var projectFrameworkVersion = Version.Parse (projectFramework.Version);
 
-			if (versions.Any (sdkVersion => IsSupported (projectFrameworkVersion, sdkVersion)))
+			if (versions.Any (sdkVersion => IsSupported (projectFramework, projectFrameworkVersion, sdkVersion)))
 				return true;
 
 			// .NET Core 1.x is supported by the MSBuild .NET Core SDKs if they are installed with Mono.
@@ -130,14 +130,33 @@ namespace MonoDevelop.DotNetCore
 		///
 		/// .NET Core SDK 1.0.4 supports .NET Core 1.0 and 1.1
 		/// .NET Core SDK 1.0.4 supports .NET Standard 1.0 to 1.6
-		/// .NET Core SDK 2.0 supports 1.0, 1.1 and 2.0
+		/// .NET Core SDK 2.0 supports .NET Core 1.0, 1.1 and 2.0
 		/// .NET Core SDK 2.0 supports .NET Standard 1.0 to 1.6 and 2.0
-		/// .NET Core SDK 2.1 supports 1.0, 1.1 and 2.0
-		/// .NET Core SDK 2.1 supports .NET Standard 1.0 to 1.6 and 2.0
+		/// .NET Core SDK 2.1.x (x &lt; 300) supports .NET Core 1.0, 1.1 and 2.0
+		/// .NET Core SDK 2.1.x (x &lt; 300) supports .NET Standard 1.0 to 1.6 and 2.0
+		/// .NET Core 2.1.300 supports .NET Core 1.0, 1.1, 2.0 and 2.1
+		/// .NET Core 2.1.300 supports .NET Standard 1.0 to 1.6, and 2.0, 2.1
 		/// </summary>
-		static bool IsSupported (Version projectFrameworkVersion, DotNetCoreVersion sdkVersion)
+		static bool IsSupported (TargetFrameworkMoniker projectFramework, Version projectFrameworkVersion, DotNetCoreVersion sdkVersion)
 		{
+			// Special case .NET Core 2.1.
+			if (IsNetCore21 (projectFramework, projectFrameworkVersion) && !SupportsNetCore21 (sdkVersion))
+				return false;
+
 			return sdkVersion.Major >= projectFrameworkVersion.Major;
+		}
+
+		static bool IsNetCore21 (TargetFrameworkMoniker framework, Version version)
+		{
+			return framework.IsNetCoreApp () && version.Major == 2 && version.Minor == 1;
+		}
+
+		/// <summary>
+		/// .NET Core 2.1.300 SDK is the lowest version that supports .NET Core App 2.1
+		/// </summary>
+		static bool SupportsNetCore21 (DotNetCoreVersion version)
+		{
+			return version.Major >= 2 && version.Minor >= 1 && version.Patch >= 300;
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.DotNetCore
 
 		public static bool IsNetStandard20OrNetCore20 (this TargetFramework framework)
 		{
-			return framework.IsNetStandard20 () || framework.IsNetCoreApp ();
+			return framework.IsNetStandard20 () || framework.IsNetCoreApp20 ();
 		}
 
 		public static string GetDisplayName (this TargetFramework framework)


### PR DESCRIPTION
If a .NET Core 2.1 project is opened and .NET Core SDK 2.1.300 or
above is not installed then a dialog is shown allowing the SDK to
be downloaded. The project in the Solution window will show an error
icon with the same information about .NET Core 2.1 not being
installed. Currently the download link goes to the preview 2 page
- https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2
the url is shortened and can be redirected later without changing
the code once .NET Core 2.1 SDK final is released.

Fixes VSTS #573785 - Prompt to install .NET Core 2.1 SDK if .NET Core
2.1 project opened