### PR TITLE
Switch Assembly References to be resolved using Design Time targets

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1026,13 +1026,13 @@ namespace MonoDevelop.Projects
 
 				var monitor = new ProgressMonitor ();
 
-				var context = new TargetEvaluationContext ();
-				context.ItemsToEvaluate.Add ("ReferencePath");
+				var context = new TargetEvaluationContext (designTime: true);
+				context.ItemsToEvaluate.Add ("_ReferencesFromRAR");
 				context.BuilderQueue = BuilderQueue.ShortOperations;
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 
-				var result = await RunTarget (monitor, "ResolveAssemblyReferences", configuration, context);
+				var result = await RunTarget (monitor, "ResolveAssemblyReferencesDesignTime", configuration, context);
 
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1028,11 +1028,14 @@ namespace MonoDevelop.Projects
 
 				var context = new TargetEvaluationContext (designTime: true);
 				context.ItemsToEvaluate.Add ("_ReferencesFromRAR");
+				context.ItemsToEvaluate.Add ("_ProjectReferencesFromRAR");
+				context.ItemsToEvaluate.Add ("_ResolvedNativeProjectReferencePaths");
+
 				context.BuilderQueue = BuilderQueue.ShortOperations;
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 
-				var result = await RunTarget (monitor, "ResolveAssemblyReferencesDesignTime", configuration, context);
+				var result = await RunTarget (monitor, "ResolveAssemblyReferencesDesignTime;ResolveProjectReferencesDesignTime", configuration, context);
 
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/TargetEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/TargetEvaluationContext.cs
@@ -33,11 +33,19 @@ namespace MonoDevelop.Projects
 	{
 		List<MSBuildLogger> loggers = new List<MSBuildLogger> ();
 
-		public TargetEvaluationContext ()
+		public TargetEvaluationContext () : this (false)
+		{
+		}
+
+		public TargetEvaluationContext (bool designTime)
 		{
 			PropertiesToEvaluate = new HashSet<string> ();
 			ItemsToEvaluate = new HashSet<string> ();
 			LogVerbosity = MSBuildProjectService.DefaultMSBuildVerbosity;
+
+			if (designTime) {
+				GlobalProperties.SetValue ("DesignTimeBuild", "true");
+			}
 		}
 
 		public TargetEvaluationContext (OperationContext other): this ()

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/BuildEngine.v4.0.cs
@@ -36,7 +36,7 @@ namespace MonoDevelop.Projects.MSBuild
 	{
 		static CultureInfo uiCulture;
 		readonly Dictionary<string, string> unsavedProjects = new Dictionary<string, string> ();
-		readonly ProjectCollection engine = new ProjectCollection { DefaultToolsVersion = MSBuildConsts.Version };
+		readonly ProjectCollection engine = ProjectCollection.GlobalProjectCollection;
 		MSBuildLoggerAdapter loggerAdapter;
 
 		IEngineLogWriter sessionLogWriter;

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -85,7 +85,6 @@ namespace MonoDevelop.Projects.MSBuild
 							foreach (var p in globalProperties)
 								project.SetGlobalProperty (p.Key, p.Value);
 						}
-						project.ReevaluateIfNecessary ();
 					}
 
 					// Building the project will create items and alter properties, so we use a new instance
@@ -134,7 +133,6 @@ namespace MonoDevelop.Projects.MSBuild
 							project.RemoveGlobalProperty (p.Key);
 						foreach (var p in originalGlobalProperties)
 							project.SetGlobalProperty (p.Key, p.Value);
-						project.ReevaluateIfNecessary ();
 					}
 				}
 			});
@@ -197,15 +195,12 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 
-			bool reevaluate = false;
-
 			if (p.GetPropertyValue ("Configuration") != configuration || (p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
 				p.SetGlobalProperty ("Configuration", configuration);
 				if (!string.IsNullOrEmpty (platform))
 					p.SetGlobalProperty ("Platform", platform);
 				else
 					p.RemoveGlobalProperty ("Platform");
-				reevaluate = true;
 			}
 
 			// The CurrentSolutionConfigurationContents property only needs to be set once
@@ -214,11 +209,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			if (!buildEngine.BuildOperationStarted && this.file == file && p.GetPropertyValue ("CurrentSolutionConfigurationContents") != slnConfigContents) {
 				p.SetGlobalProperty ("CurrentSolutionConfigurationContents", slnConfigContents);
-				reevaluate = true;
 			}
-
-			if (reevaluate)
-				p.ReevaluateIfNecessary ();
 
 			return p;
 		}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -188,8 +188,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 					// Use the engine's default tools version to load the project. We want to build with the latest
 					// tools version.
-					string toolsVersion = engine.DefaultToolsVersion;
-					p = new Project (projectRootElement, engine.GlobalProperties, toolsVersion, engine);
+					p = new Project (projectRootElement, engine.GlobalProperties, MSBuildConsts.Version, engine);
 				}
 			}
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -183,7 +183,12 @@ namespace MonoDevelop.Projects.MSBuild
 				else {
 					if (!string.IsNullOrEmpty (projectDir) && Directory.Exists (projectDir))
 						Environment.CurrentDirectory = projectDir;
-					var projectRootElement = ProjectRootElement.Create (new XmlTextReader (new StringReader (content)));
+
+					var settings = new XmlReaderSettings {
+						DtdProcessing = DtdProcessing.Ignore,
+						IgnoreWhitespace = true,
+					};
+					var projectRootElement = ProjectRootElement.Create (XmlReader.Create (new StringReader (content), settings), engine);
 					projectRootElement.FullPath = file;
 
 					// Use the engine's default tools version to load the project. We want to build with the latest


### PR DESCRIPTION
This PR aims to optimize MSBuild builders actual evaluation and target running:

* https://github.com/mono/monodevelop/issues/4502
* https://github.com/mono/monodevelop/issues/4501

The first commit aims to fix root element caching:

* Don't use a custom project collection, but use the actual global collection provided by msbuild. We won't use multiple collections in the same builder anyway.

The second commit adds root caching for unsaved content files:

* This adds unsaved content elements cached into the root project collection, and changes the reader to not preserve formatting and ignore dtd, similar to how msbuild does it.

The third commit removes the `ReevaluateIfNecessary()` calls that are not needed. Creating a ProjectInstance re-evaluates the project if it needs to: http://source.dot.net/#Microsoft.Build/Definition/Project.cs,2604

The fourth commit a simple way to initialize a evaluation context for design time builds.

WIP from here:
The fifth and so on switch actual GetReferencedAssemblies calls to use design time targets, instead of actual targets to resolve files to compile and so on.