### PR TITLE
Clean up MSBuildFileFormat

### DIFF
--- a/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.Gui/SourcesZipEditorWidget.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.Gui/SourcesZipEditorWidget.cs
@@ -34,8 +34,8 @@ namespace MonoDevelop.Deployment.Gui
 			
 			int sel = 0;
 			for (int n=0; n<formats.Length; n++) {
-				comboFormat.AppendText (formats[n].Name);
-				if (formats[n].Name == selectedFormat.Name)
+				comboFormat.AppendText (formats[n].ProductDescription);
+				if (formats[n].ProductDescription == selectedFormat.ProductDescription)
 					sel = n;
 			}
 

--- a/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.Targets/SourcesZipPackageBuilder.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/MonoDevelop.Deployment.Targets/SourcesZipPackageBuilder.cs
@@ -138,7 +138,7 @@ namespace MonoDevelop.Deployment.Targets
 		public override string DefaultName {
 			get {
 				if (FileFormat != null)
-					return GettextCatalog.GetString ("{0} Sources", FileFormat.Name);
+					return GettextCatalog.GetString ("MSBuild Sources");
 				else
 					return base.DefaultName;
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
@@ -67,21 +67,19 @@ namespace MonoDevelop.Projects.MSBuild
 			return GetSupportedFormats ().Where (f => f.CanWriteFile (targetItem));
 		}
 
-		public static MSBuildFileFormat DefaultFormat {
-			get { return VS2012; }
-		}
+		public static MSBuildFileFormat DefaultFormat => VS2012;
 		
-		public string Name {
-			get { return "MSBuild"; }
-		}
+		[Obsolete ("Use ProductDescription or ID")]
+		public string Name => "MSBuild";
 
+		[Obsolete]
 		public abstract Version Version { get; }
 
 		internal SlnFileFormat SlnFileFormat {
 			get { return slnFileFormat; }
 		}
 		
-		public bool SupportsMonikers { get { return SupportedFrameworks == null; } }
+		public bool SupportsMonikers => SupportedFrameworks == null;
 
 		public static bool ToolsSupportMonikers (string toolsVersion)
 		{
@@ -198,7 +196,15 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public virtual string DefaultSchemaVersion { get { return null; } }
 
+		/// <summary>
+		/// Product description for display in UI
+		/// </summary>
 		public abstract string ProductDescription { get; }
+
+		/// <summary>
+		/// Product description for comment in new sln files
+		/// </summary>
+		public virtual string ProductDescriptionComment => ProductDescription;
 
 		public virtual TargetFrameworkMoniker[] SupportedFrameworks {
 			get { return null; }
@@ -226,49 +232,39 @@ namespace MonoDevelop.Projects.MSBuild
 		
 		public abstract string Id { get; }
 	}
-	
-	class MSBuildFileFormatVS05: MSBuildFileFormat
+
+	class MSBuildFileFormatVS05 : MSBuildFileFormat
 	{
-		static readonly TargetFrameworkMoniker[] supportedFrameworks = {
+		public override string Id => "MSBuild05";
+
+		[Obsolete("Unused")]
+		public override Version Version => new Version ("2005");
+
+		public override string DefaultProductVersion => "8.0.50727";
+		public override string DefaultToolsVersion => "2.0";
+		public override string DefaultSchemaVersion => "2.0";
+		public override string SlnVersion => "9.00";
+		public override string ProductDescription => "Visual Studio 2005";
+
+		public override TargetFrameworkMoniker [] SupportedFrameworks { get; } = {
 			TargetFrameworkMoniker.NET_2_0,
 		};
-
-		public override string Id {
-			get { return "MSBuild05"; }
-		}
-
-		public override Version Version {
-			get { return new Version ("2005"); }
-		}
-
-		public override string DefaultProductVersion {
-			get { return "8.0.50727"; }
-		}
-
-		public override string DefaultToolsVersion {
-			get { return "2.0"; }
-		}
-
-		public override string DefaultSchemaVersion {
-			get { return "2.0"; }
-		}
-
-		public override string SlnVersion {
-			get { return "9.00"; }
-		}
-
-		public override string ProductDescription {
-			get { return "Visual Studio 2005"; }
-		}
-
-		public override TargetFrameworkMoniker[] SupportedFrameworks {
-			get { return supportedFrameworks; }
-		}
 	}
 	
 	class MSBuildFileFormatVS08: MSBuildFileFormat
 	{
-		static readonly TargetFrameworkMoniker[] supportedFrameworks = {
+		public override string Id => "MSBuild08";
+
+		[Obsolete ("Unused")]
+		public override Version Version => new Version ("2008");
+
+		public override string DefaultProductVersion => "9.0.21022";
+		public override string DefaultToolsVersion => "3.5";
+		public override string DefaultSchemaVersion => "2.0";
+		public override string SlnVersion => "10.00";
+		public override string ProductDescription => "Visual Studio 2008";
+
+		public override TargetFrameworkMoniker [] SupportedFrameworks { get; } = {
 			TargetFrameworkMoniker.NET_2_0,
 			TargetFrameworkMoniker.NET_3_0,
 			TargetFrameworkMoniker.NET_3_5,
@@ -277,97 +273,45 @@ namespace MonoDevelop.Projects.MSBuild
 			TargetFrameworkMoniker.MONOTOUCH_1_0,
 		};
 
-		public override string Id {
-			get { return "MSBuild08"; }
-		}
-
-		public override Version Version {
-			get { return new Version ("2008"); }
-		}
-
-		public override string DefaultProductVersion {
-			get { return "9.0.21022"; }
-		}
-
-		public override string DefaultToolsVersion {
-			get { return "3.5"; }
-		}
-
-		public override string DefaultSchemaVersion {
-			get { return "2.0"; }
-		}
-
-		public override string SlnVersion {
-			get { return "10.00"; }
-		}
-
-		public override string ProductDescription {
-			get { return "Visual Studio 2008"; }
-		}
-
-		public override TargetFrameworkMoniker[] SupportedFrameworks {
-			get { return supportedFrameworks; }
-		}
 	}
 	
 	class MSBuildFileFormatVS10: MSBuildFileFormat
 	{
-		public override string Id {
-			get { return "MSBuild10"; }
-		}
+		public override string Id => "MSBuild10";
 
-		public override Version Version {
-			get { return new Version ("2010"); }
-		}
+		[Obsolete ("Unused")]
+		public override Version Version => new Version ("2010");
 
-		//WTF VS
-		public override string DefaultProductVersion {
-			get { return "8.0.30703"; }
-		}
-
-		public override string DefaultSchemaVersion {
-			get { return "2.0"; }
-		}
-
-		public override string DefaultToolsVersion {
-			get { return "4.0"; }
-		}
-
-		public override string SlnVersion {
-			get { return "11.00"; }
-		}
-
-		public override string ProductDescription {
-			get { return "Visual Studio 2010"; }
-		}
+		public override string DefaultProductVersion => "8.0.30703";
+		public override string DefaultSchemaVersion => "2.0";
+		public override string DefaultToolsVersion => "4.0";
+		public override string SlnVersion => "11.00";
+		public override string ProductDescription => "Visual Studio 2010";
 	}
 
 	// this is actually VS2010 SP1 and later
 	class MSBuildFileFormatVS12: MSBuildFileFormat
 	{
-		public override string Id {
-			get { return "MSBuild12"; }
-		}
+		public override string Id => "MSBuild12";
 
-		public override Version Version {
-			get { return new Version ("2012"); }
-		}
+		[Obsolete ("Unused")]
+		public override Version Version => new Version ("2012");
 
-		public override string DefaultToolsVersion {
-			get { return "4.0"; }
-		}
+		// This is mostly irrelevant, the builder always uses the latest
+		// tools version. It's only used for new projects created with
+		// the old project template engine.
+		public override string DefaultToolsVersion => "4.0";
 
-		public override string SlnVersion {
-			get { return "12.00"; }
-		}
+		public override string SlnVersion => "12.00";
 
-		public override string ProductDescription {
-			get { return "Visual Studio 15"; }
-		}
+		public override string ProductDescription => "Visual Studio 2012+";
+
+		// This matches the value used by VS 2017
+		public override string ProductDescriptionComment => "Visual Studio 15";
 
 		protected override bool SupportsToolsVersion (string version)
 		{
-			return version == "4.0" || version == "12.0" || version == "14.0" || version == "15.0";
+			return Version.TryParse (version, out Version v) && v <= new Version (15, 0);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SlnFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SlnFileFormat.cs
@@ -113,9 +113,9 @@ namespace MonoDevelop.Projects.MSBuild
 
 			sln.FormatVersion = format.SlnVersion;
 
-			// Don't modify the product description if it already has a value
+			// Don't modify the product description comment if it already has a value
 			if (string.IsNullOrEmpty (sln.ProductDescription))
-				sln.ProductDescription = format.ProductDescription;
+				sln.ProductDescription = format.ProductDescriptionComment;
 
 			solution.WriteSolution (monitor, sln);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConvertTool.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectConvertTool.cs
@@ -62,18 +62,18 @@ namespace MonoDevelop.Projects
 			
 			string projectFile = null;
 			string destPath = null;
-			string formatName = null;
+			string formatId = null;
 			bool formatList = false;
 			List<string> projects = new List<string> ();
 			string[] itemsToExport = null;
 			
 			foreach (string s in arguments)
 			{
-				if (s.StartsWith ("-d:"))
+				if (s.StartsWith ("-d:", StringComparison.Ordinal))
 					destPath = s.Substring (3);
-				else if (s.StartsWith ("-f:"))
-					formatName = s.Substring (3);
-				else if (s.StartsWith ("-p:"))
+				else if (s.StartsWith ("-f:", StringComparison.Ordinal))
+					formatId = s.Substring (3);
+				else if (s.StartsWith ("-p:", StringComparison.Ordinal))
 					projects.Add (s.Substring (3));
 				else if (s == "-l")
 					formatList = true;
@@ -142,11 +142,11 @@ namespace MonoDevelop.Projects
 			
 			MSBuildFileFormat format = null;
 			
-			if (formatName == null || formatList) {
+			if (formatId == null || formatList) {
 				Console.WriteLine ();
 				Console.WriteLine ("Target formats:");
 				for (int n=0; n<formats.Length; n++)
-					Console.WriteLine ("  {0}. {1}", n + 1, formats [n].Name);
+					Console.WriteLine ("  {0}. {1} ({2})", n + 1, formats [n].Id, formats [n].ProductDescription);
 				Console.WriteLine ();
 				if (formatList)
 					return 0;
@@ -167,11 +167,11 @@ namespace MonoDevelop.Projects
 			}
 			else {
 				foreach (var f in formats) {
-					if (f.Name == formatName)
+					if (f.Id == formatId)
 						format = f;
 				}
 				if (format == null) {
-					Console.WriteLine ("Unknown file format: " + formatName);
+					Console.WriteLine ("Unknown file format: " + formatId);
 					return 1;
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/SelectFileFormatDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/SelectFileFormatDialog.cs
@@ -47,10 +47,10 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			
 			labelWarnings.Text = warning;
 			labelMessage.Text = string.Format (labelMessage.Text, item.Name);
-			labelCurrentFormat.Text = item.FileFormat.Name;
+			labelCurrentFormat.Text = item.FileFormat.ProductDescription;
 			
 			foreach (MSBuildFileFormat format in MSBuildFileFormat.GetSupportedFormats (item)) {
-				comboNewFormat.AppendText (format.Name);
+				comboNewFormat.AppendText (format.ProductDescription);
 				formats.Add (format);
 			}
 			comboNewFormat.Active = 0;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/ExportSolutionDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/ExportSolutionDialog.cs
@@ -43,11 +43,11 @@ namespace MonoDevelop.Ide.Projects
 		{
 			this.Build();
 			
-			labelNewFormat.Text = GetFormatText (item.FileFormat);
+			labelNewFormat.Text = selectedFormat.ProductDescription;
 			
 			formats = MSBuildFileFormat.GetSupportedFormats (item).ToArray ();
 			foreach (var format in formats) {
-				comboFormat.AppendText (GetFormatText (format));
+				comboFormat.AppendText (format.ProductDescription);
 			}
 
 			int sel = Array.IndexOf (formats, selectedFormat);
@@ -69,13 +69,6 @@ namespace MonoDevelop.Ide.Projects
 			
 			folderEntry.Path = item.ItemDirectory;
 			UpdateControls ();
-		}
-
-		static string GetFormatText (MSBuildFileFormat format)
-		{
-			if (!string.IsNullOrEmpty (format.ProductDescription))
-				return string.Format ("{0} ({1})", format.Name, format.ProductDescription);
-			return format.Name;
 		}
 		
 		public MSBuildFileFormat Format {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/TestProjectsChecks.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/TestProjectsChecks.cs
@@ -247,11 +247,11 @@ namespace Foo {
 		{
 			Solution sol = new Solution ();
 			sol.ConvertToFormat (format);
-			string dir = Util.CreateTmpDir ("generic-item-" + format.Name);
+			string dir = Util.CreateTmpDir ("generic-item");
 			sol.FileName = Path.Combine (dir, "TestGenericItem");
 			sol.Name = "TheItem";
 
-			MonoDevelop.Projects.MSBuild.MSBuildProjectService.RegisterGenericProjectType ("GenericItem", typeof(GenericItem));
+			MSBuildProjectService.RegisterGenericProjectType ("GenericItem", typeof(GenericItem));
 			
 			GenericItem it = new GenericItem ();
 			it.SomeValue = "hi";
@@ -278,7 +278,7 @@ namespace Foo {
 			
 			Solution sol = new Solution ();
 			sol.ConvertToFormat (fileFormat);
-			string dir = Util.CreateTmpDir ("solution-folders-" + fileFormat.Name);
+			string dir = Util.CreateTmpDir ("solution-folders");
 			sol.FileName = Path.Combine (dir, "TestSolutionFolders");
 			sol.Name = "TheSolution";
 			

--- a/main/tests/test-projects/project-includes-props/ConsoleProject/ConsoleProject.csproj
+++ b/main/tests/test-projects/project-includes-props/ConsoleProject/ConsoleProject.csproj
@@ -3,6 +3,8 @@
     <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FrameworkAlias>Mac</FrameworkAlias>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="Common.props" />
 


### PR DESCRIPTION
Clean up MSBuildFileFormat to obsolete unused and invalid members, and fix various places in the code that depended on these invalid values.

As an example, here's what project export looked like before the patch:

```
mikayla@neptune:~/code/monodevelop$ /Applications/Visual\ Studio.app/Contents/MacOS/vstool project-export -l ~/Projects/HelloConsole/HelloConsole.sln 

Target formats:
  1. MSBuild
  2. MSBuild
  3. MSBuild
  4. MSBuild
  5. MSBuild
```

Here's what it looks like after the patch:

```
mikayla@neptune:~/code/monodevelop$ mono main/build/bin/mdtool.exe project-export -l ~/Projects/HelloConsole/HelloConsole.sln 

Target formats:
  1. MSBuild12 (Visual Studio 2012+)
  2. MSBuild10 (Visual Studio 2010)
  3. MSBuild08 (Visual Studio 2008)
  4. MSBuild05 (Visual Studio 2005)
```

This also adds a distinction between the product description shown in the UI, and the product description written to the sln comment:

```
ProductDescription => "Visual Studio 2012+";
ProductDescriptionComment => "Visual Studio 15";
```
