### PR TITLE
Improve AutoInsertBracketHandler extension filtering

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -344,7 +344,7 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/AutoInsertBracketHandler">
-		<Class class="MonoDevelop.CSharp.Features.AutoInsertBracket.CSharpAutoInsertBracketHandler" insertbefore="Default"/>
+		<Handler class="MonoDevelop.CSharp.Features.AutoInsertBracket.CSharpAutoInsertBracketHandler" mimeType = "text/x-csharp" />
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/TypeService/MefHostServices">

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/CSharpAutoInsertBracketHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/CSharpAutoInsertBracketHandler.cs
@@ -33,12 +33,6 @@ namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 {
 	class CSharpAutoInsertBracketHandler : AutoInsertBracketHandler
 	{
-		public override bool CanHandle (TextEditor editor)
-		{
-
-			return editor.MimeType == CSharpFormatter.MimeType;
-		}
-
 		public override bool Handle (TextEditor editor, DocumentContext ctx, KeyDescriptor descriptor)
 		{
 			if (ctx.AnalysisDocument == null)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
@@ -172,7 +172,7 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/AutoInsertBracketHandler">
-		<Class id = "Default" class="MonoDevelop.SourceEditor.DefaultAutoInsertBracketHandler" />
+		<Handler id = "Default" class="MonoDevelop.SourceEditor.DefaultAutoInsertBracketHandler" />
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Core/UserDataMigration">

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
@@ -37,11 +37,6 @@ namespace MonoDevelop.SourceEditor
 		const string openBrackets = "{[('\"";
 		const string closingBrackets = "}])'\"";
 
-		public override bool CanHandle (TextEditor editor)
-		{
-			return true;
-		}
-
 		public override bool Handle (TextEditor editor, DocumentContext ctx, KeyDescriptor descriptor)
 		{
 			if (descriptor.KeyChar == '\'' && editor.MimeType == "text/fsharp")

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -95,7 +95,7 @@
 	
 	<ExtensionPoint path = "/MonoDevelop/Ide/TextEditorExtensions" name = "Text editor extensions" defaultInsertAfter = "MidStep">
 		<Description>Extensions to the text editor. Classes must be a subclass of TextEditorExtension.</Description>
-		<ExtensionNode name="Class" type="MonoDevelop.Ide.Extensions.TextEditorExtensionNode"/>
+		<ExtensionNode name="Class" type="MonoDevelop.Ide.Extensions.TextEditorExtensionNode" objectType="MonoDevelop.Ide.Editor.Extension.TextEditorExtension" />
 	</ExtensionPoint>
 
 	<ExtensionPoint path = "/MonoDevelop/Ide/CompletionCharacters" name = "Code completion commit characters">
@@ -213,7 +213,7 @@
 
 	<ExtensionPoint path = "/MonoDevelop/Ide/AutoInsertBracketHandler" name = "Automatic bracket handler">
 		<Description>Algorithm for providing automatic bracket insertion.</Description>
-		<ExtensionNode name="Class"/>
+		<ExtensionNode name="Handler" type="MonoDevelop.Ide.Extensions.TextEditorExtensionNode" objectType="MonoDevelop.Ide.Editor.Extension.AutoInsertBracketHandler" />
 	</ExtensionPoint>
 
 	<ExtensionPoint path = "/MonoDevelop/Ide/ErrorDocumentationProvider" name = "Link to documentation">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/AutoInsertBracketTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/AutoInsertBracketTextEditorExtension.cs
@@ -25,35 +25,46 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Mono.Addins;
+using MonoDevelop.Ide.Extensions;
 
 namespace MonoDevelop.Ide.Editor.Extension
 {
 	public abstract class AutoInsertBracketHandler
 	{
-		public abstract bool CanHandle (TextEditor editor);
-
+		public virtual bool CanHandle (TextEditor editor) => true;
 		public abstract bool Handle (TextEditor editor, DocumentContext ctx, KeyDescriptor descriptor);
 	}
 
 	class AutoInsertBracketTextEditorExtension : TextEditorExtension
 	{
-		static List<AutoInsertBracketHandler> allHandlers = new List<AutoInsertBracketHandler> ();
+		const string extensionPoint = "/MonoDevelop/Ide/AutoInsertBracketHandler";
+		List<AutoInsertBracketHandler> handlers;
 
-		public AutoInsertBracketTextEditorExtension ()
+		protected override void Initialize ()
 		{
-			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/AutoInsertBracketHandler", delegate (object sender, ExtensionNodeEventArgs args) {
-				var newHandler = (AutoInsertBracketHandler)args.ExtensionObject;
-				switch (args.Change) {
-				case ExtensionChange.Add:
-					allHandlers.Add (newHandler);
-					break;
-				case ExtensionChange.Remove:
-					allHandlers.Remove (newHandler);
-					break;
-				}
-			});
+			base.Initialize ();
+
+			//whenever the mimetype or the extension context has changed, refilter handlers
+			Editor.MimeTypeChanged += ContextChanged;
+			Editor.ExtensionContext.ExtensionChanged += ContextChanged;
+		}
+
+		void ContextChanged (object sender, EventArgs e)
+		{
+			handlers = new List<AutoInsertBracketHandler> (
+				GetEditorExtensions (Editor, extensionPoint)
+				.Select (ext => (AutoInsertBracketHandler) ext.CreateInstance())
+			);
+		}
+
+		public override void Dispose ()
+		{
+			Editor.MimeTypeChanged -= ContextChanged;
+			Editor.ExtensionContext.ExtensionChanged -= ContextChanged;
+			base.Dispose ();
 		}
 
 		public override bool KeyPress (KeyDescriptor descriptor)
@@ -61,11 +72,56 @@ namespace MonoDevelop.Ide.Editor.Extension
 			var result = base.KeyPress (descriptor);
 
 			if (DefaultSourceEditorOptions.Instance.AutoInsertMatchingBracket && !Editor.IsSomethingSelected) {
-				var handler = allHandlers.FirstOrDefault(h => h.CanHandle (Editor));
+				var handler = handlers.FirstOrDefault (h => h.CanHandle (Editor));
 				if (handler != null && handler.Handle (Editor, DocumentContext, descriptor))
 					return false;
 			}
 			return result;
+		}
+
+		//returns all valid extensions in order of most to least specific
+		static IEnumerable<TextEditorExtensionNode> GetEditorExtensions (TextEditor editor, string extensionPoint)
+		{
+			var returned = new HashSet<TextEditorExtensionNode> ();
+
+			//get the nodes from the extensioncontext rather than the addinmanager
+			//so that custom conditions supported by the editor are respected
+			var nodes = editor.ExtensionContext.GetExtensionNodes<TextEditorExtensionNode> (extensionPoint);
+
+			//file extensions are cheaper to check than mimetypes, check them first
+			//this means exact file extensions take precedence over mimetypes regardless
+			//of node ordering but it's not a big deal
+			var extension = string.IsNullOrEmpty (editor.FileName) ? null : Path.GetExtension (editor.FileName);
+			foreach (var node in nodes) {
+				if (MatchAny (extension, node.FileExtensions)) {
+					returned.Add (node);
+					yield return node;
+				}
+			}
+
+			//check mimetypes, from most to least specific
+			var mimeChain = DesktopService.GetMimeTypeInheritanceChain (editor.MimeType);
+			foreach (var mime in mimeChain) {
+				foreach (var node in nodes) {
+					if (!returned.Contains (node) && MatchAny (mime, node.MimeTypes)) {
+						returned.Add (node);
+						yield return node;
+					}
+				}
+			}
+
+			//finally, return any remaining nodes that don't have restrictions at all
+			foreach (var node in nodes) {
+				if (!returned.Contains (node) && NullOrEmpty (node.MimeTypes) && NullOrEmpty (node.FileExtensions)) {
+					yield return node;
+				}
+			}
+
+			bool MatchAny (string value, string [] matches) =>
+				matches != null && matches.Length > 0
+					&& matches.Any (m => string.Equals (m, value, StringComparison.OrdinalIgnoreCase));
+
+			bool NullOrEmpty (string [] arr) => arr == null || arr.Length == 0;
 		}
 	}
 }


### PR DESCRIPTION
There's now a first pass filter using the file extension and mimetype, avoiding loading assemblies/types until needed. More specific matches are preferred over less specific matches, so there's less need to worry about node ordering.

The extension point now respects conditions on the editor context, and automatically refreshes when the mimetypes or the context change.