### PR TITLE
[TextEditor] Handled line cache removal in redraw methods.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -604,14 +604,14 @@ namespace Mono.TextEditor
 			textArea.RedrawPosition (logicalLine, logicalColumn);
 		}
 
-		internal void RedrawLine (int line)
+		internal void RedrawLine (int line, bool removeLineCache = true)
 		{
-			textArea.RedrawLine (line);
+			textArea.RedrawLine (line, removeLineCache);
 		}
 
-		internal void RedrawLines (int start, int end)
+		internal void RedrawLines (int start, int end, bool removeLineCache = true)
 		{
-			textArea.RedrawLines (start, end);
+			textArea.RedrawLines (start, end, removeLineCache);
 		}
 
 		internal string preeditString {

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentUpdateRequest.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentUpdateRequest.cs
@@ -59,7 +59,9 @@ namespace Mono.TextEditor
 	class LineUpdate : DocumentUpdateRequest
 	{
 		int line;
-		
+
+		public bool RemoveLineCache { get; set; }
+
 		public LineUpdate (int line)
 		{
 			this.line = line;
@@ -67,7 +69,7 @@ namespace Mono.TextEditor
 		
 		public override void Update (MonoTextEditor editor)
 		{
-			editor.RedrawLine (line);
+			editor.RedrawLine (line, RemoveLineCache);
 		}
 	}
 	
@@ -86,16 +88,9 @@ namespace Mono.TextEditor
 		public override void Update (MonoTextEditor editor)
 		{
 			if (start == end) {
-				if (RemoveLineCache)
-					editor.TextViewMargin.RemoveCachedLine (start);
-				editor.RedrawLine (start);
+				editor.RedrawLine (start, RemoveLineCache);
 			} else {
-				if (RemoveLineCache) {
-					for (int i = start; i <= end; i++) {
-						editor.TextViewMargin.RemoveCachedLine (i);
-					}
-				}
-				editor.RedrawLines (start, end);
+				editor.RedrawLines (start, end, RemoveLineCache);
 			}
 		}
 	}


### PR DESCRIPTION
This way the caller can choose not to remove the line cache - removing
the line cache is always more costly and most of the time not needed.