### PR TITLE
[TextEditor] Handled line cache removal in redraw methods.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -604,14 +604,14 @@ namespace Mono.TextEditor
 			textArea.RedrawPosition (logicalLine, logicalColumn);
 		}
 
-		internal void RedrawLine (int line)
+		internal void RedrawLine (int line, bool removeLineCache = true)
 		{
-			textArea.RedrawLine (line);
+			textArea.RedrawLine (line, removeLineCache);
 		}
 
-		internal void RedrawLines (int start, int end)
+		internal void RedrawLines (int start, int end, bool removeLineCache = true)
 		{
-			textArea.RedrawLines (start, end);
+			textArea.RedrawLines (start, end, removeLineCache);
 		}
 
 		internal string preeditString {

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1080,7 +1080,7 @@ namespace Mono.TextEditor
 			return (int)margin.Width;
 		}
 		
-		internal void RedrawLine (int logicalLine)
+		internal void RedrawLine (int logicalLine, bool removeLineCache = true)
 		{
 			if (isDisposed || logicalLine > LineCount || logicalLine < DocumentLocation.MinLine)
 				return;
@@ -1089,6 +1089,9 @@ namespace Mono.TextEditor
 
 			double y = LineToY (logicalLine) - this.textEditorData.VAdjustment.Value;
 			double h = GetLineHeight (logicalLine);
+
+			if (removeLineCache)
+				textViewMargin.RemoveCachedLine (logicalLine);
 
 			if (y + h > 0)
 				QueueDrawArea (0, (int)y, this.Allocation.Width, (int)h);
@@ -1117,7 +1120,7 @@ namespace Mono.TextEditor
 			if (isDisposed)
 				return;
 //				Console.WriteLine ("Redraw position: logicalLine={0}, logicalColumn={1}", logicalLine, logicalColumn);
-			RedrawLine (logicalLine);
+			RedrawLine (logicalLine, false);
 		}
 		
 		public void RedrawMarginLines (Margin margin, int start, int end)
@@ -1133,7 +1136,7 @@ namespace Mono.TextEditor
 			QueueDrawArea ((int)margin.XOffset, (int)visualStart, GetMarginWidth (margin), (int)(visualEnd - visualStart));
 		}
 			
-		internal void RedrawLines (int start, int end)
+		internal void RedrawLines (int start, int end, bool removeLineCache = true)
 		{
 //			Console.WriteLine ("redraw lines: start={0}, end={1}", start, end);
 			if (isDisposed)
@@ -1143,6 +1146,11 @@ namespace Mono.TextEditor
 			double visualStart = -this.textEditorData.VAdjustment.Value +  LineToY (start);
 			if (end < 0)
 				end = Document.LineCount;
+			if (removeLineCache) {
+				for (int i = start; i <= end; i++) {
+					editor.TextViewMargin.RemoveCachedLine (i);
+				}
+			}
 			double visualEnd   = -this.textEditorData.VAdjustment.Value + LineToY (end) + GetLineHeight (end);
 			QueueDrawArea (0, (int)visualStart, this.Allocation.Width, (int)(visualEnd - visualStart));
 		}
@@ -1530,9 +1538,9 @@ namespace Mono.TextEditor
 				Gdk.Drag.Status (context, (context.Actions & DragAction.Move) == DragAction.Move ? DragAction.Move : DragAction.Copy, time);
 				Caret.Location = dragCaretPos; 
 			}
-			this.RedrawLine (oldLocation.Line);
+			this.RedrawLine (oldLocation.Line, false);
 			if (oldLocation.Line != Caret.Line)
-				this.RedrawLine (Caret.Line);
+				this.RedrawLine (Caret.Line, false);
 			Caret.PreserveSelection = false;
 			return base.OnDragMotion (context, x, y, time);
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentUpdateRequest.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentUpdateRequest.cs
@@ -59,7 +59,9 @@ namespace Mono.TextEditor
 	class LineUpdate : DocumentUpdateRequest
 	{
 		int line;
-		
+
+		public bool RemoveLineCache { get; set; }
+
 		public LineUpdate (int line)
 		{
 			this.line = line;
@@ -67,7 +69,7 @@ namespace Mono.TextEditor
 		
 		public override void Update (MonoTextEditor editor)
 		{
-			editor.RedrawLine (line);
+			editor.RedrawLine (line, RemoveLineCache);
 		}
 	}
 	
@@ -86,16 +88,9 @@ namespace Mono.TextEditor
 		public override void Update (MonoTextEditor editor)
 		{
 			if (start == end) {
-				if (RemoveLineCache)
-					editor.TextViewMargin.RemoveCachedLine (start);
-				editor.RedrawLine (start);
+				editor.RedrawLine (start, RemoveLineCache);
 			} else {
-				if (RemoveLineCache) {
-					for (int i = start; i <= end; i++) {
-						editor.TextViewMargin.RemoveCachedLine (i);
-					}
-				}
-				editor.RedrawLines (start, end);
+				editor.RedrawLines (start, end, RemoveLineCache);
 			}
 		}
 	}


### PR DESCRIPTION
This way the caller can choose not to remove the line cache - removing
the line cache is always more costly and most of the time not needed.