### PR TITLE
Fix 587803: [Feedback] Find References command is slow 

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
@@ -678,9 +678,9 @@ type FSharpJumpToDeclarationHandler () =
 type FSharpFindReferencesProvider () =
     inherit FindReferencesProvider ()
 
-    override x.FindReferences(documentationCommentId, _hintProject, token) =
+    override x.FindReferences(documentationCommentId, _hintProject, monitor) =
         async {
-            return
+            monitor.ReportResults(
                 Search.getAllSymbolsInAllProjects()
                 |> AsyncSeq.toSeq
                 |> Seq.toArray
@@ -688,13 +688,13 @@ type FSharpFindReferencesProvider () =
                 |> Array.filter (fun symbol -> symbol.Symbol.XmlDocSig = documentationCommentId)
                 |> Array.map (fun symbol -> let (filename, startOffset, endOffset) = Symbols.getOffsetsTrimmed symbol.Symbol.DisplayName symbol
                                             SearchResult (FileProvider (filename), startOffset, endOffset-startOffset))
-                |> Array.toSeq
+                |> Array.toSeq)
         }
-        |> StartAsyncAsTask token
+        |> StartAsyncAsTask monitor.CancellationToken :> Task
 
-    override x.FindAllReferences(_documentationCommentId, _hintProject, _token) =
+    override x.FindAllReferences(_documentationCommentId, _hintProject, monitor) =
         //TODO:
-        Task.FromResult Seq.empty
+        Task.CompletedTask
 
 type FSharpCommandsTextEditorExtension () =
     inherit Editor.Extension.TextEditorExtension ()

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
@@ -50,19 +50,21 @@ namespace MonoDevelop.CSharp.Refactoring
 
 			public bool Success { get; private set; }
 			public ISymbol Symbol { get; private set; }
-			public Solution Solution { get; private set; }
+			public Solution Solution { get => Project.Solution; }
+			public SymbolAndProjectId SymbolAndProjectId { get => SymbolAndProjectId.Create (Symbol, Project.Id); }
 			public MonoDevelop.Projects.Project MonoDevelopProject { get; internal set; }
+			public Microsoft.CodeAnalysis.Project Project { get; private set; }
 			public Compilation Compilation { get; private set; }
 
 			public LookupResult ()
 			{
 			}
 
-			public LookupResult (ISymbol symbol, Solution solution, Compilation compilation)
+			public LookupResult (ISymbol symbol, Microsoft.CodeAnalysis.Project project, Compilation compilation)
 			{
 				this.Success = true;
 				this.Symbol = symbol;
-				this.Solution = solution;
+				this.Project = project;
 				this.Compilation = compilation;
 			}
 		}
@@ -81,7 +83,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					return LookupResult.Failure;
 				if (searchNs) {
 					if (current.GetDocumentationCommentId () == documentationCommentId)
-						return new LookupResult (current, prj.Solution, comp);
+						return new LookupResult (current, prj, comp);
 					return LookupResult.Failure;
 				}
 				INamedTypeSymbol type = null;
@@ -91,7 +93,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					type = LookupType (documentationCommentId, reminderIndex, t, token);
 					if (type != null) {
 						if (searchType) {
-							return new LookupResult (type, prj.Solution, comp);
+							return new LookupResult (type, prj, comp);
 						}
 						break;
 					}
@@ -103,7 +105,7 @@ namespace MonoDevelop.CSharp.Refactoring
 						return LookupResult.Failure;
 
 					if (member.GetDocumentationCommentId () == documentationCommentId) {
-						return new LookupResult (member, prj.Solution, comp);
+						return new LookupResult (member, prj, comp);
 					}
 				}
 				return LookupResult.Failure;
@@ -200,131 +202,56 @@ namespace MonoDevelop.CSharp.Refactoring
 			return current;
 		}
 
-		public override Task<IEnumerable<SearchResult>> FindReferences (string documentationCommentId, MonoDevelop.Projects.Project hintProject, CancellationToken token)
+		public override Task FindReferences (string documentationCommentId, Projects.Project hintProject, SearchProgressMonitor monitor)
 		{
 			return Task.Run (async delegate {
 				var result = new List<SearchResult> ();
-				var antiDuplicatesSet = new HashSet<SearchResult> (new SearchResultComparer ());
-				var lookup = await TryLookupSymbol (documentationCommentId, hintProject, token);
+				var lookup = await TryLookupSymbol (documentationCommentId, hintProject, monitor.CancellationToken);
 				if (lookup == null || !lookup.Success)
 					return Enumerable.Empty<SearchResult> ();
 
 				var workspace = TypeSystemService.AllWorkspaces.FirstOrDefault (w => w.CurrentSolution == lookup.Solution) as MonoDevelopWorkspace;
 				if (workspace == null)
 					return Enumerable.Empty<SearchResult> ();
-				foreach (var sym in await GatherSymbols (lookup.Symbol, lookup.Solution, token)) {
-					foreach (var loc in sym.Locations) {
-						if (token.IsCancellationRequested)
-							break;
-
-						if (!loc.IsInSource)
-							continue;
-						var fileName = loc.SourceTree.FilePath;
-						var offset = loc.SourceSpan.Start;
-						string projectedName;
-						int projectedOffset;
-						if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-							fileName = projectedName;
-							offset = projectedOffset;
-						}
-						var sr = new MemberReference (sym, fileName, offset, loc.SourceSpan.Length);
-						sr.ReferenceUsageType = ReferenceUsageType.Declaration;
-						antiDuplicatesSet.Add (sr);
-						result.Add (sr);
-					}
-
-					foreach (var mref in await SymbolFinder.FindReferencesAsync (sym, lookup.Solution, token).ConfigureAwait (false)) {
-						foreach (var loc in mref.Locations) {
-							if (token.IsCancellationRequested)
-								break;
-							var fileName = loc.Document.FilePath;
-							var offset = loc.Location.SourceSpan.Start;
-							string projectedName;
-							int projectedOffset;
-							if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-								fileName = projectedName;
-								offset = projectedOffset;
-							}
-							var sr = new MemberReference (sym, fileName, offset, loc.Location.SourceSpan.Length);
-
-
-							if (antiDuplicatesSet.Add (sr)) {
-								var root = loc.Location.SourceTree.GetRoot ();
-								var node = root.FindNode (loc.Location.SourceSpan);
-								var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
-								sr.ReferenceUsageType = HighlightUsagesExtension.GetUsage (node);
-								result.Add (sr);
-							}
-						}
-					}
-				}
+				await FindReferencesHandler.FindRefs ((await GatherSymbols (lookup.SymbolAndProjectId, lookup.Solution, monitor.CancellationToken)).ToArray (), lookup.Solution, monitor);
 				return (IEnumerable<SearchResult>)result;
 			});
 		}
 
-		public static async Task<IEnumerable<ISymbol>> GatherSymbols (ISymbol symbol, Solution solution, CancellationToken token)
+		public static async Task<IEnumerable<SymbolAndProjectId>> GatherSymbols (SymbolAndProjectId symbol, Microsoft.CodeAnalysis.Solution solution, CancellationToken token)
 		{
 			var implementations = await SymbolFinder.FindImplementationsAsync (symbol, solution, null, token);
-			var result = new List<ISymbol> ();
+			var result = new List<SymbolAndProjectId> ();
 			result.Add (symbol);
 			result.AddRange (implementations);
 			return result;
 		}
 
-		public override Task<IEnumerable<SearchResult>> FindAllReferences (string documentationCommentId, MonoDevelop.Projects.Project hintProject, CancellationToken token)
+		public override Task FindAllReferences (string documentationCommentId, Projects.Project hintProject, SearchProgressMonitor monitor)
 		{
 			return Task.Run (async delegate {
-				var antiDuplicatesSet = new HashSet<SearchResult> (new SearchResultComparer ());
-				var result = new List<SearchResult> ();
-				var lookup = await TryLookupSymbol (documentationCommentId, hintProject, token);
+				var lookup = await TryLookupSymbol (documentationCommentId, hintProject, monitor.CancellationToken);
 				if (!lookup.Success)
-					return result;
+					return;
 				var workspace = TypeSystemService.AllWorkspaces.FirstOrDefault (w => w.CurrentSolution == lookup.Solution) as MonoDevelopWorkspace;
 				if (workspace == null)
-					return Enumerable.Empty<SearchResult> ();
+					return;
 				if (lookup.Symbol.Kind == SymbolKind.Method) {
+					var symbolsToLookup = new List<SymbolAndProjectId> ();
 					foreach (var curSymbol in lookup.Symbol.ContainingType.GetMembers ().Where (m => m.Kind == lookup.Symbol.Kind && m.Name == lookup.Symbol.Name)) {
 						foreach (var sym in SymbolFinder.FindSimilarSymbols (curSymbol, lookup.Compilation)) {
-							foreach (var simSym in await GatherSymbols (sym, lookup.Solution, token)) {
-								await FindSymbolReferencesAsync (antiDuplicatesSet, result, lookup, workspace, simSym);
+							//assumption here is, that FindSimilarSymbols returns symbols inside same project
+							foreach (var simSym in await GatherSymbols (SymbolAndProjectId.Create (sym, lookup.Project.Id), lookup.Solution, monitor.CancellationToken)) {
+								symbolsToLookup.Add (simSym);
 							}
 						}
 					}
+					await FindReferencesHandler.FindRefs (symbolsToLookup.ToArray (), lookup.Solution, monitor);
 				} else {
-					await FindSymbolReferencesAsync (antiDuplicatesSet, result, lookup, workspace, lookup.Symbol);
+					await FindReferencesHandler.FindRefs (new [] { lookup.SymbolAndProjectId }, lookup.Solution, monitor);
 				}
-				return (IEnumerable<SearchResult>)result;
+				return;
 			});
-		}
-
-		static async Task FindSymbolReferencesAsync (HashSet<SearchResult> antiDuplicatesSet, List<SearchResult> result, LookupResult lookup, MonoDevelopWorkspace workspace, ISymbol simSym)
-		{
-			foreach (var loc in simSym.Locations) {
-				if (!loc.IsInSource)
-					continue;
-				var sr = new SearchResult (new FileProvider (loc.SourceTree.FilePath), loc.SourceSpan.Start, loc.SourceSpan.Length);
-				if (antiDuplicatesSet.Add (sr)) {
-					result.Add (sr);
-				}
-			}
-
-			foreach (var mref in await SymbolFinder.FindReferencesAsync (simSym, lookup.Solution).ConfigureAwait (false)) {
-				foreach (var loc in mref.Locations) {
-					var fileName = loc.Document.FilePath;
-					var offset = loc.Location.SourceSpan.Start;
-					string projectedName;
-					int projectedOffset;
-					if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-						fileName = projectedName;
-						offset = projectedOffset;
-					}
-
-					var sr = new SearchResult (new FileProvider (fileName), offset, loc.Location.SourceSpan.Length);
-					if (antiDuplicatesSet.Add (sr)) {
-						result.Add (sr);
-					}
-				}
-			}
 		}
 	}
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/FindReferencesHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/FindReferencesHandler.cs
@@ -38,69 +38,147 @@ using MonoDevelop.Ide;
 using MonoDevelop.Ide.FindInFiles;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Refactoring;
+using Roslyn.Utilities;
+using System.Threading;
 
 namespace MonoDevelop.CSharp.Refactoring
 {
 	class FindReferencesHandler
 	{
-		internal static void FindRefs (ISymbol symbol, Solution solution)
+		class StreamingFindReferencesProgress : IStreamingFindReferencesProgress
 		{
-			var monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
+			ConcurrentSet<SearchResult> antiDuplicatesSet = new ConcurrentSet<SearchResult> (new SearchResultComparer ());
+			private SearchProgressMonitor monitor;
+			private MonoDevelopWorkspace workspace;
+
+			object reportingLock = new object ();
+
+			private int reportedCurrent;
+			private int currentMaximum;
+
+			public StreamingFindReferencesProgress (SearchProgressMonitor monitor, MonoDevelopWorkspace workspace)
+			{
+				this.monitor = monitor;
+				this.workspace = workspace;
+			}
+
+			public Task OnCompletedAsync ()
+			{
+				if (!monitor.CancellationToken.IsCancellationRequested)
+					monitor.ReportResults (antiDuplicatesSet);
+				return Task.CompletedTask;
+			}
+
+			public Task OnDefinitionFoundAsync (SymbolAndProjectId symbolAndProjectId)
+			{
+				foreach (var loc in symbolAndProjectId.Symbol.Locations) {
+					if (!loc.IsInSource)
+						continue;
+					var fileName = loc.SourceTree.FilePath;
+					var offset = loc.SourceSpan.Start;
+					string projectedName;
+					int projectedOffset;
+					if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
+						fileName = projectedName;
+						offset = projectedOffset;
+					}
+					var sr = new MemberReference (symbolAndProjectId.Symbol, fileName, offset, loc.SourceSpan.Length);
+					sr.ReferenceUsageType = ReferenceUsageType.Declaration;
+					antiDuplicatesSet.Add (sr);
+				}
+				return Task.CompletedTask;
+			}
+
+			public Task OnFindInDocumentCompletedAsync (Document document)
+			{
+				return Task.CompletedTask;
+			}
+
+			public Task OnFindInDocumentStartedAsync (Document document)
+			{
+				return Task.CompletedTask;
+			}
+
+			public Task OnReferenceFoundAsync (SymbolAndProjectId symbolAndProjectId, ReferenceLocation loc)
+			{
+				var fileName = loc.Document.FilePath;
+				var offset = loc.Location.SourceSpan.Start;
+				string projectedName;
+				int projectedOffset;
+				if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
+					fileName = projectedName;
+					offset = projectedOffset;
+				}
+				var sr = new MemberReference (symbolAndProjectId.Symbol, fileName, offset, loc.Location.SourceSpan.Length);
+				if (antiDuplicatesSet.Add (sr)) {
+					var root = loc.Location.SourceTree.GetRoot ();
+					var node = root.FindNode (loc.Location.SourceSpan);
+					var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
+					sr.ReferenceUsageType = HighlightUsagesExtension.GetUsage (node);
+				}
+				return Task.CompletedTask;
+			}
+
+			public Task OnStartedAsync ()
+			{
+				return Task.CompletedTask;
+			}
+
+			internal double Progress;
+			internal Action ProgressUpdated;
+
+			public Task ReportProgressAsync (int current, int maximum)
+			{
+				Progress = (double)current / maximum;
+				ProgressUpdated?.Invoke ();
+				return Task.CompletedTask;
+			}
+		}
+
+		internal static Task FindRefs (SymbolAndProjectId[] symbolAndProjectIds, Solution solution, SearchProgressMonitor monitor = null)
+		{
+			bool owningMonitor = false;
+			if (monitor == null) {
+				monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true);
+				owningMonitor = true;
+			}
 			var workspace = TypeSystemService.Workspace as MonoDevelopWorkspace;
 			if (workspace == null)
-				return;
-			Task.Run (async delegate {
+				return Task.CompletedTask;
+			return Task.Run (async delegate {
 				ITimeTracker timer = null;
 				var metadata = MonoDevelop.Refactoring.Counters.CreateFindReferencesMetadata ();
 
 				try {
 					timer = MonoDevelop.Refactoring.Counters.FindReferences.BeginTiming (metadata);
+					monitor.BeginTask (GettextCatalog.GetString ("Searching..."), 100);
 
-					var antiDuplicatesSet = new HashSet<SearchResult> (new SearchResultComparer ());
-					foreach (var loc in symbol.Locations) {
-						if (monitor.CancellationToken.IsCancellationRequested)
-							return;
-
-						if (!loc.IsInSource)
-							continue;
-						var fileName = loc.SourceTree.FilePath;
-						var offset = loc.SourceSpan.Start;
-						string projectedName;
-						int projectedOffset;
-						if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-							fileName = projectedName;
-							offset = projectedOffset;
-						}
-						var sr = new MemberReference (symbol, fileName, offset, loc.SourceSpan.Length);
-						sr.ReferenceUsageType = ReferenceUsageType.Declaration;
-						antiDuplicatesSet.Add (sr);
-						monitor.ReportResult (sr);
-					}
-
-					foreach (var mref in await SymbolFinder.FindReferencesAsync (symbol, solution, monitor.CancellationToken).ConfigureAwait (false)) {
-						foreach (var loc in mref.Locations) {
-							if (monitor.CancellationToken.IsCancellationRequested)
-								return;
-							var fileName = loc.Document.FilePath;
-							var offset = loc.Location.SourceSpan.Start;
-							string projectedName;
-							int projectedOffset;
-							if (workspace.TryGetOriginalFileFromProjection (fileName, offset, out projectedName, out projectedOffset)) {
-								fileName = projectedName;
-								offset = projectedOffset;
+					var streamingProgresses = new StreamingFindReferencesProgress [symbolAndProjectIds.Length];
+					var tasks = new Task [symbolAndProjectIds.Length];
+					int reportedProgress = 0;
+					for (int i = 0; i < symbolAndProjectIds.Length; i++) {
+						var reportingProgress = new StreamingFindReferencesProgress (monitor, workspace);
+						reportingProgress.ProgressUpdated = delegate {
+							double sumOfProgress = 0;
+							for (int j = 0; j < streamingProgresses.Length; j++) {
+								sumOfProgress += streamingProgresses [j].Progress;
 							}
-							var sr = new MemberReference (symbol, fileName, offset, loc.Location.SourceSpan.Length);
-							if (antiDuplicatesSet.Add (sr)) {
-
-								var root = loc.Location.SourceTree.GetRoot ();
-								var node = root.FindNode (loc.Location.SourceSpan);
-								var trivia = root.FindTrivia (loc.Location.SourceSpan.Start);
-								sr.ReferenceUsageType = HighlightUsagesExtension.GetUsage (node);
-
-								monitor.ReportResult (sr);
+							int newProgress = (int)((sumOfProgress / streamingProgresses.Length) * 100);
+							if (newProgress > reportedProgress) {
+								lock (streamingProgresses) {
+									if (newProgress > reportedProgress) {
+										monitor.Step (newProgress - reportedProgress);
+										reportedProgress = newProgress;
+									}
+								}
 							}
-						}
+						};
+						streamingProgresses [i] = reportingProgress;
 					}
+					for (int i = 0; i < tasks.Length; i++) {
+						tasks [i] = SymbolFinder.FindReferencesAsync (symbolAndProjectIds [i], solution, streamingProgresses [i], null, monitor.CancellationToken);
+					}
+					await Task.WhenAll (tasks);
 				} catch (OperationCanceledException) {
 				} catch (Exception ex) {
 					MonoDevelop.Refactoring.Counters.SetFailure (metadata);
@@ -109,7 +187,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					else
 						LoggingService.LogError ("Error finding references", ex);
 				} finally {
-					if (monitor != null)
+					if (owningMonitor)
 						monitor.Dispose ();
 					if (monitor.CancellationToken.IsCancellationRequested)
 						MonoDevelop.Refactoring.Counters.SetUserCancel (metadata);
@@ -139,9 +217,9 @@ namespace MonoDevelop.CSharp.Refactoring
 			var sym = info.Symbol ?? info.DeclaredSymbol;
 			if (sym != null) {
 				if (sym.Kind == SymbolKind.Local || sym.Kind == SymbolKind.Parameter || sym.Kind == SymbolKind.TypeParameter) {
-					FindRefs (sym, doc.AnalysisDocument.Project.Solution);
+					FindRefs (new [] { SymbolAndProjectId.Create (sym, doc.AnalysisDocument.Project.Id) }, doc.AnalysisDocument.Project.Solution).Ignore ();
 				} else {
-					RefactoringService.FindReferencesAsync (FilterSymbolForFindReferences (sym).GetDocumentationCommentId ());
+					RefactoringService.FindReferencesAsync (FilterSymbolForFindReferences (sym).GetDocumentationCommentId ()).Ignore ();
 				}
 			}
 		}
@@ -156,11 +234,8 @@ namespace MonoDevelop.CSharp.Refactoring
 		}
 	}
 
-	
-
 	class FindAllReferencesHandler
 	{
-
 		public void Update (CommandInfo info)
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
@@ -181,9 +256,9 @@ namespace MonoDevelop.CSharp.Refactoring
 			var sym = info.Symbol ?? info.DeclaredSymbol;
 			if (sym != null) {
 				if (sym.Kind == SymbolKind.Local || sym.Kind == SymbolKind.Parameter || sym.Kind == SymbolKind.TypeParameter) {
-					FindReferencesHandler.FindRefs (sym, doc.AnalysisDocument.Project.Solution);
+					FindReferencesHandler.FindRefs (new [] { SymbolAndProjectId.Create (sym, doc.AnalysisDocument.Project.Id) }, doc.AnalysisDocument.Project.Solution).Ignore ();
 				} else {
-					RefactoringService.FindAllReferencesAsync (FindReferencesHandler.FilterSymbolForFindReferences (sym).GetDocumentationCommentId ());
+					RefactoringService.FindAllReferencesAsync (FindReferencesHandler.FilterSymbolForFindReferences (sym).GetDocumentationCommentId ()).Ignore ();
 				}
 			}
 		}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
@@ -44,6 +44,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.FindSymbols;
 
 namespace MonoDevelop.CSharp.Refactoring
 {
@@ -117,9 +118,9 @@ namespace MonoDevelop.CSharp.Refactoring
 				ainfo.Add (IdeApp.CommandService.GetCommandInfo (RefactoryCommands.FindReferences), new System.Action (() => {
 
 					if (sym.Kind == SymbolKind.Local || sym.Kind == SymbolKind.Parameter || sym.Kind == SymbolKind.TypeParameter) {
-						FindReferencesHandler.FindRefs (sym, doc.AnalysisDocument.Project.Solution);
+						FindReferencesHandler.FindRefs (new [] { SymbolAndProjectId.Create (sym, doc.AnalysisDocument.Project.Id) }, doc.AnalysisDocument.Project.Solution).Ignore ();
 					} else {
-						RefactoringService.FindReferencesAsync (FindReferencesHandler.FilterSymbolForFindReferences (sym).GetDocumentationCommentId ());
+						RefactoringService.FindReferencesAsync (FindReferencesHandler.FilterSymbolForFindReferences (sym).GetDocumentationCommentId ()).Ignore ();
 					}
 
 				}));

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/FindReferencesProvider.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/FindReferencesProvider.cs
@@ -35,8 +35,8 @@ namespace MonoDevelop.Refactoring
 {
 	abstract class FindReferencesProvider
 	{
-		public abstract Task<IEnumerable<SearchResult>> FindReferences (string documentationCommentId, Project hintProject, CancellationToken token = default(CancellationToken));
-		public abstract Task<IEnumerable<SearchResult>> FindAllReferences (string documentationCommentId, Project hintProject, CancellationToken token = default(CancellationToken));
+		public abstract Task FindReferences (string documentationCommentId, Project hintProject, SearchProgressMonitor monitor);
+		public abstract Task FindAllReferences (string documentationCommentId, Project hintProject, SearchProgressMonitor monitor);
 	}
 }
 

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -249,9 +249,7 @@ namespace MonoDevelop.Refactoring
 				timer = Counters.FindReferences.BeginTiming (metadata);
 				foreach (var provider in findReferencesProvider) {
 					try {
-						foreach (var result in await provider.FindReferences (documentIdString, hintProject, monitor.CancellationToken)) {
-							monitor.ReportResult (result);
-						}
+						await provider.FindReferences (documentIdString, hintProject, monitor);
 					} catch (OperationCanceledException) {
 						Counters.SetUserCancel (metadata);
 						return;
@@ -282,9 +280,7 @@ namespace MonoDevelop.Refactoring
 				timer = Counters.FindReferences.BeginTiming (metadata);
 				foreach (var provider in findReferencesProvider) {
 					try {
-						foreach (var result in await provider.FindAllReferences (documentIdString, hintProject, monitor.CancellationToken)) {
-							monitor.ReportResult (result);
-						}
+						await provider.FindAllReferences (documentIdString, hintProject, monitor);
 					} catch (OperationCanceledException) {
 						Counters.SetUserCancel (metadata);
 						return;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -247,7 +247,7 @@ namespace MonoDevelop.Refactoring
 			try {
 				var metadata = Counters.CreateFindReferencesMetadata ();
 				timer = Counters.FindReferences.BeginTiming (metadata);
-				var tasks = new List<(Task task, FindReferencesProvider provider)> ();
+				var tasks = new List<(Task task, FindReferencesProvider provider)> (findReferencesProvider.Count);
 				foreach (var provider in findReferencesProvider) {
 					try {
 						tasks.Add ((provider.FindReferences (documentIdString, hintProject, monitor), provider));
@@ -293,7 +293,7 @@ namespace MonoDevelop.Refactoring
 			try {
 				var metadata = Counters.CreateFindReferencesMetadata ();
 				timer = Counters.FindReferences.BeginTiming (metadata);
-				var tasks = new List<(Task task, FindReferencesProvider provider)> ();
+				var tasks = new List<(Task task, FindReferencesProvider provider)> (findReferencesProvider.Count);
 				foreach (var provider in findReferencesProvider) {
 					try {
 						tasks.Add ((provider.FindAllReferences (documentIdString, hintProject, monitor), provider));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
@@ -45,6 +45,9 @@ namespace MonoDevelop.Ide.FindInFiles
 			}
 		}
 
+		// Used for unit testing
+		internal SearchProgressMonitor() { }
+
 		internal SearchProgressMonitor (Pad pad, CancellationTokenSource cancellationTokenSource = null) : base (Runtime.MainSynchronizationContext, cancellationTokenSource)
 		{
 			var stMon = IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (GettextCatalog.GetString ("Searching..."), Stock.StatusSearch, false, true, false, pad, true);
@@ -60,7 +63,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			set { Runtime.RunInMainThread (delegate { outputPad.PathMode = value; }); }
 		}
 
-		public void ReportResult (SearchResult result)
+		public virtual void ReportResult (SearchResult result)
 		{
 			Runtime.RunInMainThread (delegate {
 				try {
@@ -72,7 +75,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			});
 		}
 		
-		public void ReportResults (IEnumerable<SearchResult> results)
+		public virtual void ReportResults (IEnumerable<SearchResult> results)
 		{
 			Runtime.RunInMainThread (delegate {
 				try {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/SearchProgressMonitor.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			set { Runtime.RunInMainThread (delegate { outputPad.PathMode = value; }); }
 		}
 
-		public virtual void ReportResult (SearchResult result)
+		protected virtual void OnReportResult (SearchResult result)
 		{
 			Runtime.RunInMainThread (delegate {
 				try {
@@ -74,8 +74,13 @@ namespace MonoDevelop.Ide.FindInFiles
 				}
 			});
 		}
+
+		public void ReportResult (SearchResult result)
+		{
+			OnReportResult (result);
+		}
 		
-		public virtual void ReportResults (IEnumerable<SearchResult> results)
+		protected virtual void OnReportResults (IEnumerable<SearchResult> results)
 		{
 			Runtime.RunInMainThread (delegate {
 				try {
@@ -84,6 +89,11 @@ namespace MonoDevelop.Ide.FindInFiles
 					LoggingService.LogError ("Error adding search results.", ex.ToString ());
 				}
 			});
+		}
+
+		public void ReportResults (IEnumerable<SearchResult> results)
+		{
+			OnReportResults (results);
 		}
 		
 		public void ReportStatus (string resultMessage)

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpFindReferencesProviderTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpFindReferencesProviderTests.cs
@@ -44,6 +44,7 @@ using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Projects;
 using MonoDevelop.Projects.Policies;
 using NUnit.Framework;
+using System.Collections.Concurrent;
 
 namespace MonoDevelop.CSharp.Refactoring
 {
@@ -85,12 +86,29 @@ namespace MonoDevelop.CSharp.Refactoring
 			}
 		}
 
+		class MockSearchProgressMonitor : SearchProgressMonitor
+		{
+			internal ConcurrentBag<SearchResult> Results = new ConcurrentBag<SearchResult> ();
+			public override void ReportResults (IEnumerable<SearchResult> results)
+			{
+				foreach (var result in results)
+					ReportResult (result);
+			}
+
+			public override void ReportResult (SearchResult result)
+			{
+				Results.Add (result);
+			}
+		}
+
 		[Test]
 		public async Task TestFindReferences ()
 		{
-			var refs = await GatherReferences (@"class FooBar {}", project => {
+			var refs = await GatherReferences (@"class FooBar {}", async project => {
 				var provider = new CSharpFindReferencesProvider ();
-				return provider.FindReferences ("T:FooBar", project, default (CancellationToken));
+				var monitor = new MockSearchProgressMonitor ();
+				await provider.FindReferences ("T:FooBar", project, monitor);
+				return monitor.Results;
 			});
 			Assert.AreEqual (1, refs.Count);
 		}
@@ -103,9 +121,11 @@ public void Foo() {}
 public void Foo(int i) {}
 public void Foo(string s) {}
 public void Foo(int i, int j) {}
- }", project => {
+ }", async project => {
 				var provider = new CSharpFindReferencesProvider ();
-				return provider.FindAllReferences ("M:FooBar.Foo", project, default (CancellationToken));
+				var monitor = new MockSearchProgressMonitor ();
+				await provider.FindAllReferences ("M:FooBar.Foo", project, monitor);
+				return monitor.Results;
 			});
 			Assert.AreEqual (4, refs.Count);
 		}
@@ -116,9 +136,11 @@ public void Foo(int i, int j) {}
 		[Test]
 		public async Task TestBug58060 ()
 		{
-			var refs = await GatherReferences (@"class FooBar { FooBar fb; }", project => {
+			var refs = await GatherReferences (@"class FooBar { FooBar fb; }", async project => {
 				var provider = new CSharpFindReferencesProvider ();
-				return  provider.FindAllReferences ("T:FooBar", project, default (CancellationToken));
+				var monitor = new MockSearchProgressMonitor ();
+				await provider.FindAllReferences ("T:FooBar", project, monitor);
+				return monitor.Results;
 			});
 			Assert.AreEqual (2, refs.Count);
 		}
@@ -141,9 +163,11 @@ public class RefBug2
     public void Meth() { xxx++; }
 }
 
-", project => {
+", async project => {
 				var provider = new CSharpFindReferencesProvider ();
-				return provider.FindAllReferences ("F:RefBug2.xxx", project, default (CancellationToken));
+				var monitor = new MockSearchProgressMonitor ();
+				await provider.FindAllReferences ("F:RefBug2.xxx", project, monitor);
+				return monitor.Results;
 			});
 			Assert.AreEqual (2, refs.Count);
 		}

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpFindReferencesProviderTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpFindReferencesProviderTests.cs
@@ -89,13 +89,13 @@ namespace MonoDevelop.CSharp.Refactoring
 		class MockSearchProgressMonitor : SearchProgressMonitor
 		{
 			internal ConcurrentBag<SearchResult> Results = new ConcurrentBag<SearchResult> ();
-			public override void ReportResults (IEnumerable<SearchResult> results)
+			protected override void OnReportResults (IEnumerable<SearchResult> results)
 			{
 				foreach (var result in results)
 					ReportResult (result);
 			}
 
-			public override void ReportResult (SearchResult result)
+			protected override void OnReportResult (SearchResult result)
 			{
 				Results.Add (result);
 			}


### PR DESCRIPTION
I'm not 100% this will fix it, because I can't reproduce so long searches but switching to `IStreamingFindReferencesProgress` and making it parallel and avoiding `.ReportResult` one by one, should help.
But also progress bar in main status should help user get better idea of how much longer it will take to finish, or if it's stuck.