### PR TITLE
[VB] Fix incorrect compilation constant separator

### DIFF
--- a/main/src/addins/VBNetBinding/Project/VBCompilerParameters.cs
+++ b/main/src/addins/VBNetBinding/Project/VBCompilerParameters.cs
@@ -104,11 +104,14 @@ namespace MonoDevelop.VBNetBinding
 		[ItemProperty ("AdditionalParameters")]
 		string additionalParameters = String.Empty;
 
+		/// <summary>
+		/// VB.NET compiler does not support ';' as symbol separators so use ','
+		/// </summary>
 		public override void AddDefineSymbol (string symbol)
 		{
 			var symbols = new List<string> (GetDefineSymbols ());
 			symbols.Add (symbol);
-			definesymbols = string.Join (";", symbols) + ";";
+			definesymbols = string.Join (",", symbols) + ",";
 		}
 		
 		public override void RemoveDefineSymbol (string symbol)
@@ -118,14 +121,14 @@ namespace MonoDevelop.VBNetBinding
 			symbols.Remove (symbol);
 			
 			if (symbols.Count > 0)
-				definesymbols = string.Join (";", symbols) + ";";
+				definesymbols = string.Join (",", symbols) + ",";
 			else
 				definesymbols = string.Empty;
 		}
 
 		public override IEnumerable<string> GetDefineSymbols ()
 		{
-			foreach (var s in definesymbols.Split (new [] { ';' }))
+			foreach (var s in definesymbols.Split (new [] { ',' }))
 				if (!string.IsNullOrEmpty (s))
 					yield return s;
 		}


### PR DESCRIPTION
VB.NET projects would fail to build with an error:

vbc : error BC31030: Conditional compilation constant 'DEBUG ^^ ^^ '
is not valid: Character is not valid.

The VB.NET addin was using ';' as the separator for the constants
but the VB.NET compiler only supports ',' as the separator.

VB.NET project build support requires Mono 5.12 to be installed.

Fixes VSTS #602648 - Incorrect compilation constants separator used
for VB.NET