### PR TITLE
Fix VSTS 586112: ignore TextChange events with no Changes

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -263,7 +263,7 @@ namespace Mono.TextEditor
 
 		void OnTextBufferChanged(object sender, Microsoft.VisualStudio.Text.TextContentChangedEventArgs args)
 		{
-			if (args.Changes == null)
+			if (args.Changes == null || args.Changes.Count == 0)
 				return;
 			var changes = new List<TextChange> ();
 			foreach (var change in args.Changes) {


### PR DESCRIPTION
We are already checking for args.Changes == null, but we're not checking for args.Changes.Count == 0. As a result we were adding UndoOperations where changes list was empty.

The symptom was then in Undo when this code was throwing ArgumentOutOfRange:
((UndoOperation)op).Changes[0].OldPosition;

because it assumed that the Changes list is non-empty.