### PR TITLE
[Core] Fix SolutionItemExtension.OnModified not being called

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolderItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolderItem.cs
@@ -437,7 +437,16 @@ namespace MonoDevelop.Projects
 		/// </param>
 		public void NotifyModified (string hint)
 		{
-			OnModified (new SolutionItemModifiedEventArgs (this, hint));
+			OnNotifyModified (new SolutionItemModifiedEventArgs (this, hint));
+		}
+
+		/// <summary>
+		/// Notifies that this solution folder item has been modified
+		/// </summary>
+		/// <param name="args">Arguments.</param>
+		internal virtual void OnNotifyModified (SolutionItemModifiedEventArgs args)
+		{
+			OnModified (args);
 		}
 		
 		/// <summary>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -195,6 +195,18 @@ namespace MonoDevelop.Projects
 		}
 
 		/// <summary>
+		/// Notifies the extensions that this solution item has been modified
+		/// </summary>
+		/// <param name="args">Arguments.</param>
+		internal override void OnNotifyModified (SolutionItemModifiedEventArgs args)
+		{
+			if (IsExtensionChainCreated)
+				ItemExtension.OnModified (args);
+			else
+				base.OnModified (args);
+		}
+
+		/// <summary>
 		/// Called when a load operation for this solution item has finished
 		/// </summary>
 		protected virtual void OnEndLoad ()


### PR DESCRIPTION
When the Project's NotifyModifed method is called now the project
extension's OnModified method is called if the extension chain is
initialized.

The Android addin was using the project extension's OnModified to
set the project's target framework to the latest and this method was
not being called which resulted in the wrong Android project having
the wrong target framework when use latest frameworkwas enabled.

Fixes VSTS #602708 - Incorrect Android target framework version stored
in project.assets.json

For d15-7 we may want to use a less riskier fix and just change the Android addin to directly use the Project.Modified event. I implemented an alternative fix in the md-addins/android-fix-target-framework-not-set-to-latest branch.

The project extension's OnModified event is currently used by the Android addin in two places:
  1. Main project extension to change the Project.TargetFramework if use latest is set.
  2. Android sdk manager service to check the api is installed. This check is not being called currently since OnModified is not called. The code seems like it can be removed since there is a check made just before the project is compiled. The code in OnModified seems incorrect to me since it only checks the api if use latest is configured. It should be checking if the target framework has changed - not just when use latest is configured. But I think it can be removed completely and instead just check the api before compiling the project.