### PR TITLE
Fixes VSTS 599407: C# classification doesn't update when compilation

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentUpdateRequest.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DocumentUpdateRequest.cs
@@ -50,8 +50,12 @@ namespace Mono.TextEditor
 	
 	class UpdateAll : DocumentUpdateRequest
 	{
+		public bool RemoveLineCache { get; set; }
+
 		public override void Update (MonoTextEditor editor)
 		{
+			if (RemoveLineCache)
+				editor.TextViewMargin.PurgeLayoutCache ();
 			editor.QueueDraw ();
 		}
 	}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -160,7 +160,11 @@ namespace Mono.TextEditor
 
 		void SyntaxMode_HighlightingStateChanged (object sender, MonoDevelop.Ide.Editor.LineEventArgs e)
 		{
-			CommitMultipleLineUpdate (e.Line.LineNumber, e.Line.LineNumber);
+			if (e == MonoDevelop.Ide.Editor.LineEventArgs.AllLines) {
+				CommitUpdateAll (true);
+			} else { 
+				CommitMultipleLineUpdate (e.Line.LineNumber, e.Line.LineNumber, true);
+			}
 		}
 
 		void OnSyntaxModeChanged (SyntaxModeChangeEventArgs e)
@@ -1877,6 +1881,13 @@ namespace Mono.TextEditor
 		public void CommitUpdateAll ()
 		{
 			RequestUpdate (new UpdateAll ());
+			CommitDocumentUpdate ();
+		}
+
+		// TODO: Merge with CommitUpdateAll (ABI break!)
+		public void CommitUpdateAll (bool removeLineCache)
+		{
+			RequestUpdate (new UpdateAll () { RemoveLineCache = removeLineCache});
 			CommitDocumentUpdate ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/LineEventArgs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/LineEventArgs.cs
@@ -29,6 +29,8 @@ namespace MonoDevelop.Ide.Editor
 {
 	public class LineEventArgs : System.EventArgs
 	{
+		public readonly static LineEventArgs AllLines = new LineEventArgs ();
+
 		readonly IDocumentLine line;
 
 		public IDocumentLine Line {
@@ -37,11 +39,13 @@ namespace MonoDevelop.Ide.Editor
 			}
 		}
 
+		LineEventArgs () 
+		{
+		}
+
 		public LineEventArgs (IDocumentLine line)
 		{
-			if (line == null)
-				throw new ArgumentNullException ("line");
-			this.line = line;
+			this.line = line ?? throw new ArgumentNullException (nameof (line));
 		}
 	}
 }


### PR DESCRIPTION
changes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/599407

Use ISemanticChangeNotificationService to update the highlighting
info.