### PR TITLE
[NuGet] Restore PackageReference project after target framework changed

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -96,9 +96,14 @@ namespace MonoDevelop.PackageManagement
 			get { return msbuildProjectPath; }
 		}
 
+		public static bool CanCreate (DotNetProject project)
+		{
+			return project.MSBuildProject.Sdk != null;
+		}
+
 		public static NuGetProject Create (DotNetProject project)
 		{
-			if (project.MSBuildProject.Sdk != null)
+			if (CanCreate (project))
 				return new DotNetCoreNuGetProject (project);
 
 			return null;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageCompatibilityHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageCompatibilityHandler.cs
@@ -24,9 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using MonoDevelop.PackageManagement;
-using MonoDevelop.Ide;
+using MonoDevelop.PackageManagement.Commands;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -42,6 +40,11 @@ namespace MonoDevelop.PackageManagement
 			if (e.Project.HasPackagesConfig ()) {
 				var runner = new PackageCompatibilityRunner (e.Project);
 				runner.Run ();
+			} else if (DotNetCoreNuGetProject.CanCreate (e.Project.DotNetProject)) {
+				// Ignore - .NET Core project target framework changes are handled
+				// by the DotNetCoreProjectExtension.
+			} else if (PackageReferenceNuGetProject.CanCreate (e.Project.DotNetProject)) {
+				RestorePackagesInProjectHandler.Run (e.Project.DotNetProject);
 			}
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -91,9 +91,14 @@ namespace MonoDevelop.PackageManagement
 			get { return msbuildProjectPath; }
 		}
 
+		public static bool CanCreate (DotNetProject project)
+		{
+			return project.HasPackageReferences () || project.HasPackageReferenceRestoreProjectStyle ();
+		}
+
 		public static NuGetProject Create (DotNetProject project)
 		{
-			if (project.HasPackageReferences () || project.HasPackageReferenceRestoreProjectStyle ())
+			if (CanCreate (project))
 				return new PackageReferenceNuGetProject (project);
 
 			return null;


### PR DESCRIPTION
When the target framework version in project options is changed and
the project uses PackageReferences a restore is now run after the
project file is saved. This ensures the PackageReferences work with
the new target framework and re-generates the project.assets.json file
to ensure the build is using the correct references. Without this
changing the target framework to use latest for an Android project
can result in the build failing since the project.assets.json file
is out of sync with the project until a restore was run again.

Fixes VSTS #603274 - PackageReference project not restored after
target framework changed