### PR TITLE
[NuGet] Initial work for NuGet Sdk Resolver support

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -248,7 +248,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			if (!string.IsNullOrEmpty (pi.Project.Sdk)) {
 				var rootProject = pi.GetRootMSBuildProject ();
-				var sdkPaths = pi.Project.Sdk.Replace ('/', '\\')
+				var sdkPaths = pi.Project.Sdk
 				                 .Split (sdkPathSeparator, StringSplitOptions.RemoveEmptyEntries)
 				                 .Select (s => s.Trim ())
 				                 .Where (s => s.Length > 0)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
@@ -66,7 +66,8 @@ namespace MonoDevelop.Projects.MSBuild
 							return result.Path;
 						}
 
-						results.Add (result);
+						if (result != null)
+							results.Add (result);
 					} catch (Exception e) {
 						logger.LogFatalBuildError (buildEventContext, e, projectFile);
 					}


### PR DESCRIPTION
 - [Core] Fix null reference on opening .NET Core project with sdk version

Opening a SDK style project that used a Sdk attribute with a version
would show an error message "Error while trying to load project:
Object reference not set to an instance of an object". The problem
was that an SdkResolver will can return null from the Resolve method.
These null results were added to a list and then an attempt was made
to log the result warnings on a null result.

    <Project Sdk="Microsoft.NET.Sdk.Razor/2.1.0-preview2-final">

This allows the project to load but no files are shown in the
Solution window and a warning about the project not having any
valid configurations is also shown since the sdk cannot be resolved.

- [Core] Fix .NET Core Sdk version not being parsed from Sdk attribute

The Sdk attribute was having the forward slash / replaced with a
backslash \ which meant the SdkReference.TryParse was creating an
SdkReference with the wrong name, for example:

    Microsoft.NET.Sdk.Razor\2.1.0-preview2-final

Instead of having Microsoft.NET.Sdk.Razor as the name and the
version being found.

The NuGet Sdk resolver returns a result now but contains an error
about failing to find the NuGet.Version assembly. This assembly
is in a higher folder next to the MSBuild assemblies shipped with
Mono. Another problem here is that the NuGet addin and the NuGet
assemblies used with the NuGet Sdk resolver will need to match.
Different NuGet assembly versions being used will break the NuGet
addin. Unless something like ILRepack is used this will mean the
IDE is tied to a particular Mono version.
