### PR TITLE
Fix VSTS 602848: Project Reload doesn't work

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1495,6 +1495,8 @@ namespace MonoDevelop.Ide.TypeSystem
 				MetadataReferenceCache.RemoveReferences (id);
 
 				UnloadMonoProject (project);
+
+				OnProjectRemoved (id);
 			}
 		}
 


### PR DESCRIPTION
In this commit https://github.com/mono/monodevelop/commit/88afb8bc3257cde9e500fcbb193615c851eb7e68#diff-a93bf3423c7fe66c6f8e07d45a997a72 we have regressed the Unload and Reload behavior where manually reloading a project would result in errors.

The problem is that we didn't find an oldProject because the ReplacedItem was an UnloadedSolutionItem and not the original project.

This change attempts to recover the actual project that was previously unloaded and passes it to LoadProject, so that LoadProject can properly diff against it.

Also adding a call to Workspace.OnProjectRemoved to remove a Roslyn project from the workspace when the MonoDevelop project was removed.