### PR TITLE
[NuGet] Fix restore check on solution load using UI thread

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackageManagementStartupHandler.cs
@@ -40,7 +40,6 @@ namespace MonoDevelop.PackageManagement.Commands
 	{
 		protected override void Run ()
 		{
-			ClearUpdatedPackages ();
 			IdeApp.Workspace.SolutionLoaded += SolutionLoaded;
 			IdeApp.Workspace.SolutionUnloaded += SolutionUnloaded;
 			IdeApp.Workspace.ItemUnloading += WorkspaceItemUnloading;
@@ -48,13 +47,18 @@ namespace MonoDevelop.PackageManagement.Commands
 			FileService.FileChanged += FileChanged;
 		}
 
-		async void SolutionLoaded (object sender, SolutionEventArgs e)
+		void SolutionLoaded (object sender, SolutionEventArgs e)
+		{
+			Task.Run (() => OnSolutionLoaded (e.Solution)).Ignore ();
+		}
+
+		async Task OnSolutionLoaded (Solution solution)
 		{
 			try {
 				if (ShouldRestorePackages) {
-					await RestoreAndCheckForUpdates (e.Solution);
-				} else if (ShouldCheckForUpdates && AnyProjectHasPackages (e.Solution)) {
-					CheckForUpdates (e.Solution);
+					await RestoreAndCheckForUpdates (solution);
+				} else if (ShouldCheckForUpdates && AnyProjectHasPackages (solution)) {
+					CheckForUpdates (solution);
 				}
 			} catch (Exception ex) {
 				LoggingService.LogError ("PackageManagementStartupHandler error", ex);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopNuGetProjectFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopNuGetProjectFactory.cs
@@ -66,8 +66,6 @@ namespace MonoDevelop.PackageManagement
 
 		public NuGetProject CreateNuGetProject (DotNetProject project, INuGetProjectContext context)
 		{
-			Runtime.AssertMainThread ();
-
 			var nugetAwareProject = project as INuGetAwareProject;
 			if (nugetAwareProject != null)
 				return nugetAwareProject.CreateNuGetProject ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopSolutionManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopSolutionManager.cs
@@ -114,9 +114,7 @@ namespace MonoDevelop.PackageManagement
 		public IEnumerable<NuGetProject> GetNuGetProjects ()
 		{
 			if (projects == null) {
-				Runtime.RunInMainThread (() => {
-					projects = GetNuGetProjects (Solution, Settings).ToList ();
-				}).Wait ();
+				projects = GetNuGetProjects (Solution, Settings).ToList ();
 			}
 			return projects;
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreAndCheckForUpdatesAction.cs
@@ -58,8 +58,7 @@ namespace MonoDevelop.PackageManagement
 			this.solution = solution;
 			packageManagementEvents = PackageManagementServices.PackageManagementEvents;
 
-			solutionManager = PackageManagementServices.Workspace.GetSolutionManager (solution);
-			solutionManager.ClearProjectCache ();
+			solutionManager = new MonoDevelopSolutionManager (solution);
 			nugetProjects = solutionManager.GetNuGetProjects ().ToList ();
 
 			// Use the same source repository provider for all restores and updates to prevent


### PR DESCRIPTION
Use the solution load event to start a task which does the restore
and check for updates instead of having the work done on the UI
thread.

Fixes VSTS #59385 - NuGet restore checker does work on the UI thread
on solution load