### PR TITLE
[NuGet] Allow NuGet SDK resolver to find NuGet assemblies

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementServices.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementServices.cs
@@ -26,6 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.IO;
+
 namespace MonoDevelop.PackageManagement
 {
 	public static class PackageManagementServices
@@ -65,6 +68,8 @@ namespace MonoDevelop.PackageManagement
 			credentialService = new PackageManagementCredentialService ();
 			credentialService.Initialize ();
 
+			ConfigureNuGetSdkResolver ();
+
 			PackageManagementBackgroundDispatcher.Initialize ();
 
 			nuGetConfigFileChangedMonitor.MonitorFileChanges ();
@@ -76,6 +81,17 @@ namespace MonoDevelop.PackageManagement
 		internal static void InitializeCredentialService ()
 		{
 			credentialService.Initialize ();
+		}
+
+		/// <summary>
+		/// Tell the NuGet SDK resolver included with MSBuild to look at the NuGet addin directory when
+		/// resolving the NuGet assemblies. The NuGet SDK resolver will download NuGet packages for
+		/// .NET Core projects that use SDKs provided by a NuGet package.
+		/// </summary>
+		static void ConfigureNuGetSdkResolver ()
+		{
+			string directory = Path.GetDirectoryName (typeof (PackageManagementServices).Assembly.Location);
+			Environment.SetEnvironmentVariable ("MSBUILD_NUGET_PATH", directory);
 		}
 
 		internal static PackageManagementOptions Options {


### PR DESCRIPTION
The NuGet SDK resolver will download and install SDKs for .NET Core
projects if they are missing. The NuGet SDK resolver was failing to
find the NuGet assemblies previously. The NuGet SDK resolver supports
a MSBUILD_NUGET_PATH environment variable which can be set to the
directory containing the NuGet assemblies that are included with
the NuGet addin. This is now set by the NuGet addin which allows
the NuGet SDK resolver to work.