### PR TITLE
[SourceEditor] Allow debug value tooltips for documents without parser

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueTooltipProvider.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DebugValueTooltipProvider.cs
@@ -93,15 +93,14 @@ namespace MonoDevelop.SourceEditor
 				startOffset = ed.SelectionRange.Offset;
 				expression = ed.SelectedText;
 			} else {
-				var doc = ctx;
-				if (doc == null || doc.ParsedDocument == null)
+				if (ctx == null)
 					return null;
 
-				var resolver = doc.GetContent<IDebuggerExpressionResolver> ();
-				var data = doc.GetContent<SourceEditorView> ();
+				var resolver = ctx.GetContent<IDebuggerExpressionResolver> ();
+				var data = ctx.GetContent<SourceEditorView> ();
 
 				if (resolver != null) {
-					var result = await resolver.ResolveExpressionAsync (editor, doc, offset, token);
+					var result = await resolver.ResolveExpressionAsync (editor, ctx, offset, token);
 					expression = result.Text;
 					startOffset = result.Span.Start;
 				} else {


### PR DESCRIPTION
Remove the null check for the DocumentContext.ParsedDocument. This
allows tooltips to be shown when the document does not have an
associated parser. This makes it possible for a text editor extension
to implement the IDebuggerExpressionResolver and provide debug value
tooltips without having to provide a dummy ParsedDocument or implement
the debug value tooltip UI itself.

Also changed the code since it was creating a local variable for a
parameter that was passed into the method so the local variable was
not needed. The code when it was originally created was using the
workbench's active document so a local variable was needed then.