### PR TITLE
Fixes issue #4655 Text editor corrupts when you navigate to a file

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/CSharpParsedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Parser/CSharpParsedDocument.cs
@@ -64,6 +64,7 @@ namespace MonoDevelop.CSharp.Parser
 		public CSharpParsedDocument (Ide.TypeSystem.ParseOptions options,  string fileName) : base (fileName)
 		{
 			isAdHocProject = options.IsAdhocProject;
+			Flags |= ParsedDocumentFlags.SkipFoldings;
 		}
 		
 


### PR DESCRIPTION
from the search window

Turns off c# parsed document folding - that now done by roslyn block
structure folding.