### PR TITLE
[d15-7][Perf] Optimize startup by doing MEF composition query on idle

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -56,7 +56,11 @@ namespace MonoDevelop.Ide.Composition
 		public static CompositionManager Instance {
 			get {
 				if (instance == null) {
-					instance = InitializeAsync ().Result;
+					var task = InitializeAsync ();
+					if (!task.IsCompleted && Runtime.IsMainThread) {
+						LoggingService.LogInfo ("UI thread queried MEF while it was still being built:{0}{1}", Environment.NewLine, Environment.StackTrace);
+					}
+					instance = task.Result;
 				}
 
 				return instance;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -163,8 +163,6 @@ namespace MonoDevelop.Ide
 			Counters.Initialization.Trace ("Initializing Runtime");
 			Runtime.Initialize (true);
 
-			Composition.CompositionManager.InitializeAsync ().Ignore ();
-
 			IdeApp.Customizer.OnCoreInitialized ();
 
 			Counters.Initialization.Trace ("Initializing theme");
@@ -300,6 +298,7 @@ namespace MonoDevelop.Ide
 			startupTimer.Stop ();
 			Counters.Startup.Inc (GetStartupMetadata (startupInfo));
 
+			GLib.Idle.Add (OnIdle);
 			IdeApp.Run ();
 
 			IdeApp.Customizer.OnIdeShutdown ();
@@ -317,6 +316,12 @@ namespace MonoDevelop.Ide
 			MonoDevelop.Components.GtkWorkarounds.Terminate ();
 			
 			return 0;
+		}
+
+		static bool OnIdle ()
+		{
+			Composition.CompositionManager.InitializeAsync ().Ignore ();
+			return false;
 		}
 
 		static DateTime lastIdle;


### PR DESCRIPTION
What happens here is that our Composition Catalog uses Mono.Addins behind the scenes
to gather all the assemblies to load for composition.

On the other hand, that _also_ loads the addins into the current engine.

That means that MEF holds the addin lock, so IDE startup is inconsistent
across sessions, depending on who gets to hold the lock first.

This should fix the startup of the IDE by a big margin