### PR TITLE
Improve startup time by optimizing MEF composition

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.AnalysisCore.Gui
 	public class ResultsEditorExtension : TextEditorExtension, IQuickTaskProvider
 	{
 		bool disposed;
-		static IDiagnosticService diagService = Ide.Composition.CompositionManager.GetExportedValue<IDiagnosticService> ();
+		IDiagnosticService diagService = Ide.Composition.CompositionManager.GetExportedValue<IDiagnosticService> ();
 		
 		protected override void Initialize ()
 		{

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -123,8 +123,8 @@ namespace MonoDevelop.CodeActions
 			}
 		}
 
-		static ICodeFixService codeFixService = Ide.Composition.CompositionManager.GetExportedValue<ICodeFixService> ();
-		static ICodeRefactoringService codeRefactoringService = Ide.Composition.CompositionManager.GetExportedValue<ICodeRefactoringService> ();
+		ICodeFixService codeFixService = Ide.Composition.CompositionManager.GetExportedValue<ICodeFixService> ();
+		ICodeRefactoringService codeRefactoringService = Ide.Composition.CompositionManager.GetExportedValue<ICodeRefactoringService> ();
 		internal Task<CodeActionContainer> GetCurrentFixesAsync (CancellationToken cancellationToken)
 		{
 			var loc = Editor.CaretOffset;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -41,6 +41,9 @@ namespace MonoDevelop.Ide.Composition
 {
 	public partial class CompositionManager
 	{
+		/// <summary>
+		/// Used by tests to inject changes into the cache data in memory so it asserts whether caching can be used.
+		/// </summary>
 		internal interface ICachingFaultInjector
 		{
 			void FaultAssemblyInfo (MefControlCacheAssemblyInfo info);
@@ -119,10 +122,10 @@ namespace MonoDevelop.Ide.Composition
 					// Validate that the assemblies match and we have the same time stamps on them.
 					var currentAssemblies = new HashSet<string> (Assemblies.Select (asm => asm.Location));
 					foreach (var assemblyInfo in controlCache.AssemblyInfos) {
+						cachingFaultInjector?.FaultAssemblyInfo (assemblyInfo);
 						if (!currentAssemblies.Contains (assemblyInfo.Location))
 							return false;
 
-						cachingFaultInjector?.FaultAssemblyInfo (assemblyInfo);
 						if (File.GetLastWriteTimeUtc (assemblyInfo.Location) != assemblyInfo.LastWriteTimeUtc)
 							return false;
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -1,0 +1,160 @@
+﻿//
+// CompositionManager.Caching.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.VisualStudio.Composition;
+using Mono.Addins;
+using MonoDevelop.Core;
+using MonoDevelop.Core.AddIns;
+using MonoDevelop.Core.Instrumentation;
+
+namespace MonoDevelop.Ide.Composition
+{
+	public partial class CompositionManager
+	{
+		internal class Caching
+		{
+			Task saveTask;
+			public HashSet<Assembly> Assemblies { get; }
+			readonly string mefCacheFile;
+			readonly string mefCacheControlFile;
+
+			public Caching (HashSet<Assembly> assemblies, Func<string, string> getCacheFilePath = null)
+			{
+				Assemblies = assemblies;
+
+				getCacheFilePath = getCacheFilePath ?? (file => Path.Combine (AddinManager.CurrentAddin.PrivateDataPath, file));
+				mefCacheFile = getCacheFilePath ("mef-cache");
+				mefCacheControlFile = getCacheFilePath ("mef-cache-control");
+			}
+
+			void IdeApp_Exiting (object sender, ExitEventArgs args)
+			{
+				// As of the time this code was written, serializing the cache takes 200ms.
+				// Maybe show a dialog and progress bar here that we're closing after save.
+				// We cannot cancel the save, vs-mef doesn't use the cancellation tokens in the API.
+				saveTask?.Wait ();
+			}
+
+			internal Stream OpenCacheStream () => File.Open (mefCacheFile, FileMode.Open);
+
+			internal bool CanUse ()
+			{
+				// If we don't have a control file, bail early
+				if (!File.Exists (mefCacheControlFile))
+					return false;
+
+				using (var timer = Counters.CompositionCacheControl.BeginTiming ()) {
+					// Read the cache from disk
+					var serializer = new XmlSerializer (typeof (MefControlCache));
+					MefControlCache controlCache;
+					using (var fs = File.Open (mefCacheControlFile, FileMode.Open)) {
+						controlCache = (MefControlCache)serializer.Deserialize (fs);
+					}
+
+					// Short-circuit on number of assemblies change
+					if (controlCache.AssemblyInfos.Length != Assemblies.Count)
+						return false;
+
+					// Validate that the assemblies match and we have the same time stamps on them.
+					var currentAssemblies = new HashSet<string> (Assemblies.Select (asm => asm.Location));
+					foreach (var assemblyInfo in controlCache.AssemblyInfos) {
+						if (!currentAssemblies.Contains (assemblyInfo.Location))
+							return false;
+
+						if (File.GetLastWriteTimeUtc (assemblyInfo.Location) != assemblyInfo.LastWriteTimeUtc)
+							return false;
+					}
+				}
+
+				return true;
+			}
+
+			internal Task Write (RuntimeComposition runtimeComposition, CachedComposition cacheManager)
+			{
+				IdeApp.Exiting += IdeApp_Exiting;
+
+				return saveTask = Task.Run (() => WriteMefCache (runtimeComposition, cacheManager)).ContinueWith (t => {
+					IdeApp.Exiting -= IdeApp_Exiting;
+					saveTask = null;
+
+					if (t.IsFaulted) {
+						LoggingService.LogError ("Failed to write MEF cached", t.Exception.Flatten ());
+					}
+				});
+			}
+
+			internal async Task WriteMefCache (RuntimeComposition runtimeComposition, CachedComposition cacheManager)
+			{
+				using (var timer = Counters.CompositionSave.BeginTiming ()) {
+					WriteMefCacheControl (timer);
+
+					// Serialize the MEF cache.
+					using (var stream = File.Open (mefCacheFile, FileMode.Create)) {
+						await cacheManager.SaveAsync (runtimeComposition, stream);
+					}
+				}
+			}
+
+			void WriteMefCacheControl (ITimeTracker timer)
+			{
+				// Create cache control data.
+				var controlCache = new MefControlCache {
+					AssemblyInfos = Assemblies.Select (asm => new MefControlCacheAssemblyInfo {
+						Location = asm.Location,
+						LastWriteTimeUtc = File.GetLastWriteTimeUtc (asm.Location),
+					}).ToArray (),
+				};
+
+				// Serialize it to disk
+				var serializer = new XmlSerializer (typeof (MefControlCache));
+				using (var fs = File.Open (mefCacheControlFile, FileMode.Create)) {
+					serializer.Serialize (fs, controlCache);
+				}
+				timer.Trace ("Composition control file written");
+			}
+		}
+
+		// FIXME: Don't ship these as public
+		[Serializable]
+		public class MefControlCache
+		{
+			public MefControlCacheAssemblyInfo [] AssemblyInfos;
+		}
+
+		[Serializable]
+		public class MefControlCacheAssemblyInfo
+		{
+			public string Location;
+			public DateTime LastWriteTimeUtc;
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -128,16 +128,20 @@ namespace MonoDevelop.Ide.Composition
 
 			internal Task Write (RuntimeComposition runtimeComposition, CachedComposition cacheManager)
 			{
-				IdeApp.Exiting += IdeApp_Exiting;
+				return Runtime.RunInMainThread (async () => {
+					IdeApp.Exiting += IdeApp_Exiting;
 
-				return saveTask = Task.Run (async () => {
-					try {
-						await WriteMefCache (runtimeComposition, cacheManager);
-						IdeApp.Exiting -= IdeApp_Exiting;
-						saveTask = null;
-					} catch (Exception ex) {
-						LoggingService.LogError ("Failed to write MEF cache", ex);
-					}
+					saveTask = Task.Run (async () => {
+						try {
+							await WriteMefCache (runtimeComposition, cacheManager);
+						} catch (Exception ex) {
+							LoggingService.LogError ("Failed to write MEF cache", ex);
+						}
+					});
+					await saveTask;
+
+					IdeApp.Exiting -= IdeApp_Exiting;
+					saveTask = null;
 				});
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -47,6 +47,7 @@ namespace MonoDevelop.Ide.Composition
 
 		internal class Caching
 		{
+			internal static bool writeCache;
 			ICachingFaultInjector cachingFaultInjector;
 			Task saveTask;
 			public HashSet<Assembly> Assemblies { get; }
@@ -89,7 +90,7 @@ namespace MonoDevelop.Ide.Composition
 			internal bool CanUse ()
 			{
 				// If we don't have a control file, bail early
-				if (!File.Exists (MefCacheControlFile))
+				if (!File.Exists (MefCacheControlFile) || !File.Exists (MefCacheFile))
 					return false;
 
 				using (var timer = Counters.CompositionCacheControl.BeginTiming ()) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -115,12 +115,13 @@ namespace MonoDevelop.Ide.Composition
 						return false;
 					}
 
+					var currentAssemblies = new HashSet<string> (Assemblies.Select (asm => asm.Location));
+
 					// Short-circuit on number of assemblies change
-					if (controlCache.AssemblyInfos.Length != Assemblies.Count)
+					if (controlCache.AssemblyInfos.Length != currentAssemblies.Count)
 						return false;
 
 					// Validate that the assemblies match and we have the same time stamps on them.
-					var currentAssemblies = new HashSet<string> (Assemblies.Select (asm => asm.Location));
 					foreach (var assemblyInfo in controlCache.AssemblyInfos) {
 						cachingFaultInjector?.FaultAssemblyInfo (assemblyInfo);
 						if (!currentAssemblies.Contains (assemblyInfo.Location))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -56,7 +56,11 @@ namespace MonoDevelop.Ide.Composition
 		public static CompositionManager Instance {
 			get {
 				if (instance == null) {
-					instance = InitializeAsync ().Result;
+					var task = InitializeAsync ();
+					if (!task.IsCompleted && Runtime.IsMainThread) {
+						LoggingService.LogInfo ("UI thread queried MEF while it was still being built:{0}{1}", Environment.NewLine, Environment.StackTrace);
+					}
+					instance = task.Result;
 				}
 
 				return instance;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -51,6 +51,9 @@ namespace MonoDevelop.Ide.Composition
 		static Task<CompositionManager> creationTask;
 		static CompositionManager instance;
 
+		// Test helper so MEF cache does not get corrupted when run for tests.
+		internal static bool DisableCacheWrite;
+
 		static readonly Resolver StandardResolver = Resolver.DefaultInstance;
 		static readonly PartDiscovery Discovery = PartDiscovery.Combine (
 			new AttributedPartDiscoveryV1 (StandardResolver),
@@ -132,8 +135,11 @@ namespace MonoDevelop.Ide.Composition
 			// Otherwise fallback to runtime discovery.
 			if (RuntimeComposition == null) {
 				RuntimeComposition = await CreateRuntimeCompositionFromDiscovery (caching);
-				CachedComposition cacheManager = new CachedComposition ();
-				caching.Write (RuntimeComposition, cacheManager).Ignore ();
+
+				if (!DisableCacheWrite) {
+					CachedComposition cacheManager = new CachedComposition ();
+					caching.Write (RuntimeComposition, cacheManager).Ignore ();
+				}
 			}
 
 			ExportProviderFactory = RuntimeComposition.CreateExportProviderFactory ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -51,9 +51,6 @@ namespace MonoDevelop.Ide.Composition
 		static Task<CompositionManager> creationTask;
 		static CompositionManager instance;
 
-		// Test helper so MEF cache does not get corrupted when run for tests.
-		internal static bool DisableCacheWrite;
-
 		static readonly Resolver StandardResolver = Resolver.DefaultInstance;
 		static readonly PartDiscovery Discovery = PartDiscovery.Combine (
 			new AttributedPartDiscoveryV1 (StandardResolver),
@@ -136,10 +133,8 @@ namespace MonoDevelop.Ide.Composition
 			if (RuntimeComposition == null) {
 				RuntimeComposition = await CreateRuntimeCompositionFromDiscovery (caching);
 
-				if (!DisableCacheWrite) {
-					CachedComposition cacheManager = new CachedComposition ();
-					caching.Write (RuntimeComposition, cacheManager).Ignore ();
-				}
+				CachedComposition cacheManager = new CachedComposition ();
+				caching.Write (RuntimeComposition, cacheManager).Ignore ();
 			}
 
 			ExportProviderFactory = RuntimeComposition.CreateExportProviderFactory ();
@@ -224,7 +219,7 @@ namespace MonoDevelop.Ide.Composition
 							timer.Trace ("Start: " + id);
 							// Make sure the add-in that registered the assembly is loaded, since it can bring other
 							// other assemblies required to load this one
-							AddinManager.LoadAddin (null, assemblyNode.Addin.Id);
+							AddinManager.LoadAddin (null, id);
 
 							var assemblyFilePath = assemblyNode.Addin.GetFilePath (assemblyNode.FileName);
 							var assembly = Runtime.SystemAssemblyService.LoadAssemblyFrom (assemblyFilePath);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -119,13 +119,15 @@ namespace MonoDevelop.Ide.Composition
 			return compositionManager;
 		}
 
+		const string cacheEnabledVar = "MONODEVELOP_ENABLE_MEF_CACHE";
+		static bool cacheEnabled = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable (cacheEnabledVar));
 		async Task InitializeInstanceAsync ()
 		{
 			var assemblies = ReadAssembliesFromAddins ();
 			var caching = new Caching (assemblies);
 
 			// Try to use cached MEF data
-			if (caching.CanUse ()) {
+			if (cacheEnabled && caching.CanUse ()) {
 				RuntimeComposition = await TryCreateRuntimeCompositionFromCache (caching);
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -130,8 +130,11 @@ namespace MonoDevelop.Ide.Composition
 			}
 
 			// Otherwise fallback to runtime discovery.
-			if (RuntimeComposition == null)
+			if (RuntimeComposition == null) {
 				RuntimeComposition = await CreateRuntimeCompositionFromDiscovery (caching);
+				CachedComposition cacheManager = new CachedComposition ();
+				caching.Write (RuntimeComposition, cacheManager).Ignore ();
+			}
 
 			ExportProviderFactory = RuntimeComposition.CreateExportProviderFactory ();
 			ExportProvider = ExportProviderFactory.CreateExportProvider ();
@@ -192,8 +195,6 @@ namespace MonoDevelop.Ide.Composition
 				timer.Trace ("Composition configured");
 
 				var runtimeComposition = RuntimeComposition.CreateRuntimeComposition (configuration);
-				CachedComposition cacheManager = new CachedComposition ();
-				caching.Write (runtimeComposition, cacheManager).Ignore ();
 				return runtimeComposition;
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TagCommentsTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TagCommentsTextEditorExtension.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 {
 	class TagCommentsTextEditorExtension : TextEditorExtension, IQuickTaskProvider
 	{
-		static ITodoListProvider todoListProvider = Ide.Composition.CompositionManager.GetExportedValue<ITodoListProvider> ();
+		ITodoListProvider todoListProvider = Ide.Composition.CompositionManager.GetExportedValue<ITodoListProvider> ();
 		CancellationTokenSource src = new CancellationTokenSource ();
 		bool isDisposed;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
@@ -46,11 +46,14 @@ namespace MonoDevelop.Ide.Tasks
 
 		static CommentTasksProvider()
 		{
-			IdeApp.Workspace.SolutionLoaded += OnSolutionLoaded;
-			IdeApp.Workspace.WorkspaceItemClosed += OnWorkspaceItemClosed;
-			CommentTag.SpecialCommentTagsChanged += OnSpecialTagsChanged;
+			IdeApp.Initialized += (sender, args) => {
+				IdeApp.Workspace.SolutionLoaded += OnSolutionLoaded;
+				IdeApp.Workspace.WorkspaceItemClosed += OnWorkspaceItemClosed;
 
-			Legacy.Initialize ();
+				Legacy.Initialize ();
+			};
+
+			CommentTag.SpecialCommentTagsChanged += OnSpecialTagsChanged;
 		}
 
 		static bool TryGetDocument (Microsoft.CodeAnalysis.Common.UpdatedEventArgs args, out Document doc, out MonoDevelop.Projects.Project project)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
@@ -38,17 +38,17 @@ namespace MonoDevelop.Ide.Tasks
 {
 	static partial class CommentTasksProvider
 	{
-		static ITodoListProvider todoListProvider;
+		internal static void Initialize ()
+		{
+			var todoListProvider = Composition.CompositionManager.GetExportedValue<ITodoListProvider> ();
+			todoListProvider.TodoListUpdated += OnTodoListUpdated;
+		}
 
 		static CommentTasksProvider()
 		{
-			todoListProvider = Ide.Composition.CompositionManager.GetExportedValue<ITodoListProvider> ();
-
 			IdeApp.Workspace.SolutionLoaded += OnSolutionLoaded;
 			IdeApp.Workspace.WorkspaceItemClosed += OnWorkspaceItemClosed;
 			CommentTag.SpecialCommentTagsChanged += OnSpecialTagsChanged;
-
-			todoListProvider.TodoListUpdated += OnTodoListUpdated;
 
 			Legacy.Initialize ();
 		}
@@ -146,10 +146,6 @@ namespace MonoDevelop.Ide.Tasks
 			TaskService.InformCommentTasks (new CommentTasksChangedEventArgs (new [] { change }));
 		}
 
-		public static void Initialize ()
-		{
-		}
-
 		static async void OnSolutionLoaded (object sender, SolutionEventArgs args)
 		{
 			var ws = await TypeSystemService.GetWorkspaceAsync (args.Solution);
@@ -181,11 +177,6 @@ namespace MonoDevelop.Ide.Tasks
 		{
 			foreach (var ws in TypeSystemService.AllWorkspaces)
 				UpdateWorkspaceOptions (ws);
-		}
-
-		public static ImmutableArray<TodoItem> GetTodoItems (Microsoft.CodeAnalysis.Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
-		{
-			return todoListProvider.GetTodoItems (workspace, documentId, cancellationToken);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskService.cs
@@ -57,7 +57,7 @@ namespace MonoDevelop.Ide.Tasks
 			if (IdeApp.Workspace != null) {
 				IdeApp.Workspace.WorkspaceItemLoaded += OnWorkspaceItemLoaded;
 				IdeApp.Workspace.WorkspaceItemUnloaded += OnWorkspaceItemUnloaded;
-				CommentTasksProvider.Initialize ();
+				CommentTasksProvider.Legacy.Initialize ();
 			}
 			errors.ItemName = GettextCatalog.GetString ("Warning/Error");
 			userTasks.ItemName = GettextCatalog.GetString ("User Task");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -81,6 +81,7 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		static MonoDevelopWorkspace ()
 		{
+			Tasks.CommentTasksProvider.Initialize ();
 			Logger.SetLogger (AggregateLogger.Create (
 				new RoslynLogger (),
 				Logger.GetLogger ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9639,6 +9639,7 @@
     <Compile Include="MonoDevelop.Ide.Tasks\CommentTasksProvider.cs" />
     <Compile Include="MonoDevelop.Ide.Tasks\CommentTasksProvider.Legacy.cs" />
     <Compile Include="MonoDevelop.Ide.Editor.Extension\TagCommentsTextEditorExtension.cs" />
+    <Compile Include="MonoDevelop.Ide.Composition\CompositionManager.Caching.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -58,11 +58,11 @@ namespace MonoDevelop.Ide
 		internal static TimerCounter SaveAllTimer = InstrumentationService.CreateTimerCounter ("Save all documents", "IDE", id:"Ide.Shell.SaveAll");
 		internal static TimerCounter CloseWorkspaceTimer = InstrumentationService.CreateTimerCounter ("Workspace closed", "IDE", id:"Ide.Shell.CloseWorkspace");
 		internal static Counter Startup = InstrumentationService.CreateTimerCounter ("IDE Startup", "IDE", id:"Ide.Startup");
-		internal static TimerCounter CompositionAddinLoad = InstrumentationService.CreateTimerCounter ("MEF Composition Addin Load", "IDE", id: "Ide.Startup.Composition.ExtensionLoad", logMessages: true);
-		internal static TimerCounter CompositionDiscovery = InstrumentationService.CreateTimerCounter ("MEF Composition From Discovery", "IDE", id:"Ide.Startup.Composition.Discovery", logMessages:true);
-		internal static TimerCounter CompositionCacheControl = InstrumentationService.CreateTimerCounter ("MEF Composition Control Cache", "IDE", id: "Ide.Startup.Composition.ControlCache", logMessages: true);
-		internal static TimerCounter CompositionCache = InstrumentationService.CreateTimerCounter ("MEF Composition From Cache", "IDE", id: "Ide.Startup.Composition.Cache", logMessages: true);
-		internal static TimerCounter CompositionSave = InstrumentationService.CreateTimerCounter ("MEF Composition Save", "IDE", id: "Ide.CompositionSave", logMessages: true);
+		internal static TimerCounter CompositionAddinLoad = InstrumentationService.CreateTimerCounter ("MEF Composition Addin Load", "IDE", id: "Ide.Startup.Composition.ExtensionLoad");
+		internal static TimerCounter CompositionDiscovery = InstrumentationService.CreateTimerCounter ("MEF Composition From Discovery", "IDE", id:"Ide.Startup.Composition.Discovery");
+		internal static TimerCounter CompositionCacheControl = InstrumentationService.CreateTimerCounter ("MEF Composition Control Cache", "IDE", id: "Ide.Startup.Composition.ControlCache");
+		internal static TimerCounter CompositionCache = InstrumentationService.CreateTimerCounter ("MEF Composition From Cache", "IDE", id: "Ide.Startup.Composition.Cache");
+		internal static TimerCounter CompositionSave = InstrumentationService.CreateTimerCounter ("MEF Composition Save", "IDE", id: "Ide.CompositionSave");
 		internal static TimerCounter ProcessCodeCompletion = InstrumentationService.CreateTimerCounter ("Process Code Completion", "IDE", id: "Ide.ProcessCodeCompletion", logMessages:false);
 
 		internal static class ParserService {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -58,7 +58,11 @@ namespace MonoDevelop.Ide
 		internal static TimerCounter SaveAllTimer = InstrumentationService.CreateTimerCounter ("Save all documents", "IDE", id:"Ide.Shell.SaveAll");
 		internal static TimerCounter CloseWorkspaceTimer = InstrumentationService.CreateTimerCounter ("Workspace closed", "IDE", id:"Ide.Shell.CloseWorkspace");
 		internal static Counter Startup = InstrumentationService.CreateTimerCounter ("IDE Startup", "IDE", id:"Ide.Startup");
-		internal static TimerCounter Composition = InstrumentationService.CreateTimerCounter ("MEF Composition", "IDE", id:"Ide.Startup.Composition", logMessages:true);
+		internal static TimerCounter CompositionAddinLoad = InstrumentationService.CreateTimerCounter ("MEF Composition Addin Load", "IDE", id: "Ide.Startup.Composition.ExtensionLoad", logMessages: true);
+		internal static TimerCounter CompositionDiscovery = InstrumentationService.CreateTimerCounter ("MEF Composition From Discovery", "IDE", id:"Ide.Startup.Composition.Discovery", logMessages:true);
+		internal static TimerCounter CompositionCacheControl = InstrumentationService.CreateTimerCounter ("MEF Composition Control Cache", "IDE", id: "Ide.Startup.Composition.ControlCache", logMessages: true);
+		internal static TimerCounter CompositionCache = InstrumentationService.CreateTimerCounter ("MEF Composition From Cache", "IDE", id: "Ide.Startup.Composition.Cache", logMessages: true);
+		internal static TimerCounter CompositionSave = InstrumentationService.CreateTimerCounter ("MEF Composition Save", "IDE", id: "Ide.CompositionSave", logMessages: true);
 		internal static TimerCounter ProcessCodeCompletion = InstrumentationService.CreateTimerCounter ("Process Code Completion", "IDE", id: "Ide.ProcessCodeCompletion", logMessages:false);
 
 		internal static class ParserService {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.Ide
 		internal static TimerCounter SaveAllTimer = InstrumentationService.CreateTimerCounter ("Save all documents", "IDE", id:"Ide.Shell.SaveAll");
 		internal static TimerCounter CloseWorkspaceTimer = InstrumentationService.CreateTimerCounter ("Workspace closed", "IDE", id:"Ide.Shell.CloseWorkspace");
 		internal static Counter Startup = InstrumentationService.CreateTimerCounter ("IDE Startup", "IDE", id:"Ide.Startup");
-
+		internal static TimerCounter Composition = InstrumentationService.CreateTimerCounter ("MEF Composition", "IDE", id:"Ide.Startup.Composition", logMessages:true);
 		internal static TimerCounter ProcessCodeCompletion = InstrumentationService.CreateTimerCounter ("Process Code Completion", "IDE", id: "Ide.ProcessCodeCompletion", logMessages:false);
 
 		internal static class ParserService {

--- a/main/tests/Ide.Tests/IdeTestBase.cs
+++ b/main/tests/Ide.Tests/IdeTestBase.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using MonoDevelop.Core;
 using MonoDevelop.Ide;
 using UnitTests;
 
@@ -31,11 +32,6 @@ namespace MonoDevelop.Ide
 {
 	public class IdeTestBase: TestBase
 	{
-		static IdeTestBase()
-		{
-			Composition.CompositionManager.DisableCacheWrite = true;
-		}
-
 		protected override void InternalSetup(string rootDir)
 		{
 			base.InternalSetup(rootDir);

--- a/main/tests/Ide.Tests/IdeTestBase.cs
+++ b/main/tests/Ide.Tests/IdeTestBase.cs
@@ -31,6 +31,11 @@ namespace MonoDevelop.Ide
 {
 	public class IdeTestBase: TestBase
 	{
+		static IdeTestBase()
+		{
+			Composition.CompositionManager.DisableCacheWrite = true;
+		}
+
 		protected override void InternalSetup(string rootDir)
 		{
 			base.InternalSetup(rootDir);

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Composition/CompositionManager.CachingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Composition/CompositionManager.CachingTests.cs
@@ -1,0 +1,100 @@
+﻿//
+// CompositionManager.CachingTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Ide.Composition
+{
+	[TestFixture]
+	public class CompositionManagerCachingTests
+	{
+		static CompositionManager.Caching GetCaching (Action<string> onCacheFileRequested = null, [CallerMemberName] string testName = null)
+		{
+			var assemblies = CompositionManager.ReadAssembliesFromAddins ();
+			return new CompositionManager.Caching (assemblies, file => {
+				onCacheFileRequested?.Invoke (file);
+
+				var tmpDir = Path.Combine (Util.TmpDir, "mef", testName);
+				if (Directory.Exists (tmpDir)) {
+					Directory.Delete (tmpDir, true);
+				}
+				Directory.CreateDirectory (tmpDir);
+				return Path.Combine (tmpDir, file);
+			});
+		}
+
+		[Test]
+		public void TestCacheFileNames ()
+		{
+			bool cacheFileRequested = false;
+			bool cacheControlFileRequested = false;
+
+			var caching = GetCaching (fileName => {
+				cacheFileRequested |= fileName == "mef-cache";
+				cacheControlFileRequested |= fileName == "mef-cache-control";
+			});
+
+			Assert.AreEqual (true, cacheFileRequested, "Cache file was not requested");
+			Assert.AreEqual (true, cacheControlFileRequested, "Cache control file was not requested");
+		}
+
+		[Test]
+		public void TestNonExistentCache ()
+		{
+			var caching = GetCaching ();
+			Assert.AreEqual (false, caching.CanUse (), "Cache should not be usable when it doesnt exist");
+		}
+
+		[Test]
+		public async Task TestCacheIsSaved ()
+		{
+			var caching = GetCaching ();
+			var composition = await CompositionManager.CreateRuntimeCompositionFromDiscovery (caching);
+			var cacheManager = new CachedComposition ();
+
+			await caching.Write (composition, cacheManager);
+			Assert.AreEqual (true, File.Exists (caching.MefCacheFile), "MEF cache file was not written");
+			Assert.AreEqual (true, File.Exists (caching.MefCacheControlFile), "MEF cache control file was not written");
+		}
+
+		[Test]
+		public async Task TestSavedCacheCanBeUsed ()
+		{
+			var caching = GetCaching ();
+			var composition = await CompositionManager.CreateRuntimeCompositionFromDiscovery (caching);
+			var cacheManager = new CachedComposition ();
+
+			await caching.Write (composition, cacheManager);
+			Assert.AreEqual (true, caching.CanUse (), "MEF cache should be usable");
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -54,6 +54,10 @@
       <HintPath>..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Composition">
+      <HintPath>..\..\build\bin\Microsoft.VisualStudio.Composition.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ProjectTemplateTests.cs" />
@@ -120,6 +124,7 @@
     <Compile Include="MonoDevelop.Ide.Projects\PclToProjectJsonConversionTests.cs" />
     <Compile Include="MonoDevelop.Ide.Tasks\CommentTasksProviderTests.cs" />
     <Compile Include="MonoDevelop.Ide.Tasks\CommentTasksProviderTests.Controller.cs" />
+    <Compile Include="MonoDevelop.Ide.Composition\CompositionManager.CachingTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -187,6 +192,7 @@
     <Folder Include="MonoDevelop.SourceEditor\" />
     <Folder Include="MonoDevelop.Components\" />
     <Folder Include="MonoDevelop.Ide.Tasks\" />
+    <Folder Include="MonoDevelop.Ide.Composition\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This changeset aims to improve MEF Composition in a few ways:
a) Adding logging for when something on the UI thread queries MEF before it's loaded.
b) Fixes offenders
c) Adds timer infrastructure around MEF composition and refactors code
d) Implements a rudimentary MEF cache which decides whether to invalidate the MEF cache based on assembly timestamp changes
e) Reliability around MEF cache usage, so cache cannot become corrupt
f) Makes the cache logic unit testable