### PR TITLE
[d15-7][F#] Fix F# project template tests

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
@@ -105,7 +105,7 @@ type ``Template tests``() =
             cinfo.Parameters.["AppIdentifier"] <- tt
             cinfo.Parameters.["AndroidMinSdkVersionAttribute"] <- "android:minSdkVersion=\"10\""
             cinfo.Parameters.["AndroidThemeAttribute"] <- ""
-            cinfo.Parameters.["TargetFrameworkVersion"] <- "MonoAndroid,Version=v7.0"
+            cinfo.Parameters.["TargetFrameworkVersion"] <- "MonoAndroid,Version=v8.1"
 
             for templateParameter in TemplateParameter.CreateParameters (parameters) do
                 cinfo.Parameters.[templateParameter.Name] <- templateParameter.Value


### PR DESCRIPTION
The template tests were failing when trying to install the Android
Support NuGet packages since these have been updated and need the
Android project to target at least 8.0. The tests were setting the
target framework version to 7.0. This has been changed to 8.1 which
is used by default in the Xamarin.Forms project templates.