### PR TITLE
Fix concurrency issues in RemoteProcessConnection

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1735,7 +1735,8 @@ namespace MonoDevelop.Projects
 
 		protected override async Task<BuildResult> OnBuild (ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext operationContext)
 		{
-			return (await RunTarget (monitor, "Build", configuration, new TargetEvaluationContext (operationContext))).BuildResult;
+			var newContext = operationContext as TargetEvaluationContext ?? new TargetEvaluationContext (operationContext);
+			return (await RunTarget (monitor, "Build", configuration, newContext)).BuildResult;
 		}
 
 		async Task<TargetEvaluationResult> RunBuildTarget (ProgressMonitor monitor, ConfigurationSelector configuration, TargetEvaluationContext context)
@@ -2105,7 +2106,8 @@ namespace MonoDevelop.Projects
 
 		protected override async Task<BuildResult> OnClean (ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext operationContext)
 		{
-			return (await RunTarget (monitor, "Clean", configuration, new TargetEvaluationContext (operationContext))).BuildResult;
+			var newContext = operationContext as TargetEvaluationContext ?? new TargetEvaluationContext (operationContext);
+			return (await RunTarget (monitor, "Clean", configuration, newContext)).BuildResult;
 		}
 
 		async Task<TargetEvaluationResult> RunCleanTarget (ProgressMonitor monitor, ConfigurationSelector configuration, TargetEvaluationContext context)

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -61,7 +61,6 @@ namespace MonoDevelop.Projects.MSBuild
 				throw new ArgumentException ("runTargets is empty");
 
 			MSBuildResult result = null;
-			CheckProperties (globalProperties);
 
 			BuildEngine.RunSTA (taskId, delegate {
 				Project project = null;
@@ -239,13 +238,6 @@ namespace MonoDevelop.Projects.MSBuild
 				BuildRequestData data = new BuildRequestData (pi, targets);
 				results = BuildManager.DefaultBuildManager.BuildRequest (data);
 			}
-		}
-
-		void CheckProperties (Dictionary<string, string> globalProperties)
-		{
-			// Used for unit testing
-			if (globalProperties != null && globalProperties.Any (prop => prop.Key == "__CRASH_ME__"))
-				System.Diagnostics.Process.GetCurrentProcess ().Kill ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.Formats.MSBuild/ProjectBuilder.v4.0.cs
@@ -61,6 +61,7 @@ namespace MonoDevelop.Projects.MSBuild
 				throw new ArgumentException ("runTargets is empty");
 
 			MSBuildResult result = null;
+			CheckProperties (globalProperties);
 
 			BuildEngine.RunSTA (taskId, delegate {
 				Project project = null;
@@ -140,7 +141,7 @@ namespace MonoDevelop.Projects.MSBuild
 			});
 			return result;
 		}
-		
+
 		Project SetupProject (ProjectConfigurationInfo[] configurations)
 		{
 			Project project = null;
@@ -238,6 +239,13 @@ namespace MonoDevelop.Projects.MSBuild
 				BuildRequestData data = new BuildRequestData (pi, targets);
 				results = BuildManager.DefaultBuildManager.BuildRequest (data);
 			}
+		}
+
+		void CheckProperties (Dictionary<string, string> globalProperties)
+		{
+			// Used for unit testing
+			if (globalProperties != null && globalProperties.Any (prop => prop.Key == "__CRASH_ME__"))
+				System.Diagnostics.Process.GetCurrentProcess ().Kill ();
 		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
@@ -798,6 +798,25 @@ namespace MonoDevelop.Projects
 
 			sol.Dispose ();
 		}
+
+		[Test]
+		public async Task RecoverFromBuilderCrash ()
+		{
+			using (var sol = TestProjectsChecks.CreateConsoleSolution ("console-project-msbuild")) {
+				await sol.SaveAsync (Util.GetMonitor ());
+
+				// This property will cause the builder process to crash.
+				// The process crash should cause the build operation to
+				// fail gracefully, instead of crashing the main process (VSTS bug #580790)
+
+				var ctx = new TargetEvaluationContext ();
+				ctx.GlobalProperties.SetValue ("__CRASH_ME__", "yes");
+
+				var result = await sol.Build (Util.GetMonitor (), "Debug", ctx);
+				Assert.AreEqual (1, result.ErrorCount, "#1");
+			}
+		}
+
 	}
 
 	[TestFixture]

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
@@ -802,21 +802,12 @@ namespace MonoDevelop.Projects
 		[Test]
 		public async Task RecoverFromBuilderCrash ()
 		{
-			using (var sol = TestProjectsChecks.CreateConsoleSolution ("console-project-msbuild")) {
-				await sol.SaveAsync (Util.GetMonitor ());
-
-				// This property will cause the builder process to crash.
-				// The process crash should cause the build operation to
-				// fail gracefully, instead of crashing the main process (VSTS bug #580790)
-
-				var ctx = new TargetEvaluationContext ();
-				ctx.GlobalProperties.SetValue ("__CRASH_ME__", "yes");
-
-				var result = await sol.Build (Util.GetMonitor (), "Debug", ctx);
+			string projFile = Util.GetSampleProject ("builder-manager-tests", "crasher", "ConsoleProject.csproj");
+			using (var p = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				var result = await p.Build (Util.GetMonitor (), ConfigurationSelector.Default);
 				Assert.AreEqual (1, result.ErrorCount, "#1");
 			}
 		}
-
 	}
 
 	[TestFixture]

--- a/main/tests/test-projects/builder-manager-tests/crasher/ConsoleProject.csproj
+++ b/main/tests/test-projects/builder-manager-tests/crasher/ConsoleProject.csproj
@@ -1,0 +1,51 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="CrashMe" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[ System.Diagnostics.Process.GetCurrentProcess ().Kill (); ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+      <CrashMe />
+  </Target>
+</Project>

--- a/main/tests/test-projects/builder-manager-tests/crasher/Program.cs
+++ b/main/tests/test-projects/builder-manager-tests/crasher/Program.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConsoleProject
+{
+    class Program
+    {
+        static void Main (string[] args)
+        {
+            Console.WriteLine ("Hello world");
+        }
+    }
+}

--- a/main/tests/test-projects/builder-manager-tests/crasher/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/builder-manager-tests/crasher/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle ("ConsoleProject")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("ConsoleProject")]
+[assembly: AssemblyCopyright ("Copyright ©  2008")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible (false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid ("a1b85c5f-e506-462a-911c-cbe67c035c93")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion ("1.0.0.0")]
+[assembly: AssemblyFileVersion ("1.0.0.0")]


### PR DESCRIPTION
When aborting pending messages, do it outside the message waiters lock,
since that can cause new messages to be posted from the thread that has
the lock, modify the messageWaiters collection, and break everything.

Also make sure no new messages are queued after the connction has
been disposed.

Fixes VSTS bug #580790 - The stable monodevelop version crashes very frequently.
Fixes VSTS bug #605244 - Fatal error on opening solution created in windows on mac