### PR TITLE
Use Mono for monodoc.dll on Windows

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -173,7 +173,6 @@
     <Reference Include="Mono.Cecil.Rocks">
       <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
     <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -137,7 +137,10 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
+    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <HintPath Condition="'$(OS)' == 'Windows_NT'">$(MSBuildProgramFiles32)\Mono\lib\mono\monodoc\monodoc.dll</HintPath>
+      <Private Condition="'$(OS)' == 'Windows_NT'">True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
     <Reference Include="System.ServiceModel" />


### PR DESCRIPTION
We've told people to use "MonoLiraries.msi" for years to satisfy MonoDevelop build dependencies on Windows. This is antique - grabbed from Mono 2.6, signed with an expired Novell Authenticode cert. Much better to use monodoc.dll from a Mono installation than from MonoLibraries.msi

This patch adds a conditional HintPath to the Mono install directory

Tested as fixing builds on Windows, and not breaking on Linux.