### PR TITLE
Fix VSTS 609859 - access the correct snapshot on text change

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.SpanUpdateListener.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.SpanUpdateListener.cs
@@ -62,13 +62,13 @@ namespace Mono.TextEditor
 			{
 				this.textEditor = textEditor;
 				textEditor.Document.TextChanged += Document_TextChanged;
-				textEditor.Document.TextChanging += Document_TextChanging;
+				textEditor.Document.TextChangedHighPriority += Document_TextChanging;
 			}
 
 			public void Dispose()
 			{
 				textEditor.Document.TextChanged -= Document_TextChanged;
-				textEditor.Document.TextChanging -= Document_TextChanging;
+				textEditor.Document.TextChangedHighPriority -= Document_TextChanging;
 			}
 
 			List<HighlightedLine> lines = new List<HighlightedLine> ();

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -259,6 +259,7 @@ namespace Mono.TextEditor
 			TextChanging?.Invoke(this, textChange);           
 			// After TextChanging notification has been sent, we can update the cached snapshot
 			this.currentSnapshot = args.After;
+			TextChangedHighPriority?.Invoke (this, textChange);
 		}
 
 		void OnTextBufferChanged(object sender, Microsoft.VisualStudio.Text.TextContentChangedEventArgs args)
@@ -628,6 +629,12 @@ namespace Mono.TextEditor
 
 		public event EventHandler<TextChangeEventArgs> TextChanged;
 		public event EventHandler<TextChangeEventArgs> TextChanging;
+
+		// Temporary fix for https://github.com/mono/monodevelop/issues/4702
+		// Some listeners of TextChanging assume that the currentSnapshot is the new snapshot.
+		// Switch them to use this event, which happens immediately after the currentSnapshot 
+		// has been updated to the new snapshot.
+		internal event EventHandler<TextChangeEventArgs> TextChangedHighPriority;
 
 		#endregion
 


### PR DESCRIPTION
TextViewMargin.SpanUpdateListener was listening to Document_TextChanging, but calling Layout code that assumed that the currentSnapshot is the new snapshot.

At the time TextChanging is called the currentSnapshot has not been updated yet and still points to the old snapshot. If the new code tries to apply the new changes against the old snapshot they will get corrupt data.

Instead, as a tactical fix for 15.7 introduce a new internal event, TextChangedHighPriority, which is analogous to the same-named event of VS Editor, which is raised immediately after the currentSnapshot has been updated and it is what the layout code expects.

Long term, the right fix would be to move off TextDocument.TextChanging/TextChanged events entirely and listen to the appropriate events of ITextBuffer.