### PR TITLE
Fix VSTS 609859.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -49,11 +49,8 @@ namespace Microsoft.VisualStudio.Platform
 
         public async Task<HighlightedLine> GetHighlightedLineAsync(IDocumentLine line, CancellationToken cancellationToken)
         {
-            //TODO verify that the snapshot line from this.textBuffer is equivalent to the document line converted to a snapshotline.
-            //Possibly take in a TextDataModel as a parameter and verify the buffers are appropriate.
-            //ITextSnapshotLine snapshotLine = (line as Mono.TextEditor.TextDocument.DocumentLineFromTextSnapshotLine)?.Line;
-            ITextSnapshotLine snapshotLine = textBuffer.CurrentSnapshot.GetLineFromLineNumber (line.LineNumber - 1);
-            if ((this.classifier == null) || (snapshotLine == null))
+            ITextSnapshotLine snapshotLine = (line as Mono.TextEditor.TextDocument.DocumentLineFromTextSnapshotLine)?.Line;
+            if (this.classifier == null || snapshotLine == null || snapshotLine.Snapshot != snapshotLine.Snapshot.TextBuffer.CurrentSnapshot)
             {
                 return new HighlightedLine(line, new[] { new ColoredSegment(0, line.Length, ScopeStack.Empty) });
             }


### PR DESCRIPTION
All Web editor classifiers (HTML, CSS, Json) expect to only be called on the TextSnapshot which is the CurrentSnapshot of the buffer they're attached to.

Avoid calling into those classifiers in a moment when TextBuffer.CurrentSnapshot has been updated to V2, but the snapshot passed is still V1.