### PR TITLE
Prevent crashes and bring back C# highlighting in Razor

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.SpanUpdateListener.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.SpanUpdateListener.cs
@@ -75,10 +75,14 @@ namespace Mono.TextEditor
 
 			void Document_TextChanging (object sender, TextChangeEventArgs e)
 			{
-				HasUpdatedMultilineSpan = false;
-				foreach (var change in e.TextChanges) {
-					var layout = textEditor.TextViewMargin.GetLayout (textEditor.GetLineByOffset (change.Offset));
-					lines.Add (layout.HighlightedLine);
+				try {
+					HasUpdatedMultilineSpan = false;
+					foreach (var change in e.TextChanges) {
+						var layout = textEditor.TextViewMargin.GetLayout (textEditor.GetLineByOffset (change.Offset));
+						lines.Add (layout.HighlightedLine);
+					}
+				}
+				catch {
 				}
 			}
 
@@ -86,15 +90,20 @@ namespace Mono.TextEditor
 			{
 				int i = 0;
 
-				foreach (var change in e.TextChanges) {
-					if (i >= lines.Count)
-						break; // should never happen
-					var oldHighlightedLine = lines [i++];
-					var curLine = textEditor.GetLineByOffset (change.Offset);
-					var curLayout = textEditor.TextViewMargin.GetLayout (curLine);
-					if (!UpdateLineHighlight (curLine.LineNumber, oldHighlightedLine, curLayout.HighlightedLine))
-						break;
+				try {
+					foreach (var change in e.TextChanges) {
+						if (i >= lines.Count)
+							break; // should never happen
+						var oldHighlightedLine = lines[i++];
+						var curLine = textEditor.GetLineByOffset (change.Offset);
+						var curLayout = textEditor.TextViewMargin.GetLayout (curLine);
+						if (!UpdateLineHighlight (curLine.LineNumber, oldHighlightedLine, curLayout.HighlightedLine))
+							break;
+					}
 				}
+				catch {
+				}
+
 				lines.Clear ();
 			}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -49,8 +49,11 @@ namespace Microsoft.VisualStudio.Platform
 
         public async Task<HighlightedLine> GetHighlightedLineAsync(IDocumentLine line, CancellationToken cancellationToken)
         {
-            ITextSnapshotLine snapshotLine = (line as Mono.TextEditor.TextDocument.DocumentLineFromTextSnapshotLine)?.Line;
-            if (this.classifier == null || snapshotLine == null || snapshotLine.Snapshot != snapshotLine.Snapshot.TextBuffer.CurrentSnapshot)
+            //TODO verify that the snapshot line from this.textBuffer is equivalent to the document line converted to a snapshotline.
+            //Possibly take in a TextDataModel as a parameter and verify the buffers are appropriate.
+            //ITextSnapshotLine snapshotLine = (line as Mono.TextEditor.TextDocument.DocumentLineFromTextSnapshotLine)?.Line;
+            ITextSnapshotLine snapshotLine = textBuffer.CurrentSnapshot.GetLineFromLineNumber (line.LineNumber - 1);
+            if ((this.classifier == null) || (snapshotLine == null))
             {
                 return new HighlightedLine(line, new[] { new ColoredSegment(0, line.Length, ScopeStack.Empty) });
             }


### PR DESCRIPTION
Reverting the fix that killed C# highlighting in Razor and just use try/catch to suppress crashes.