### PR TITLE
[Git] Show stash message in Stash Manager dialog

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
@@ -77,6 +77,8 @@ namespace MonoDevelop.VersionControl.Git
 					else
 						name = GettextCatalog.GetString ("Local changes of branch '{0}'", branch);
 				}
+				if (!string.IsNullOrEmpty (s.Message))
+					name += ": " + s.Message.Trim ();
 				store.AppendValues (s, s.Index.Author.When.LocalDateTime.ToString (), name);
 			}
 			tvs.Load ();


### PR DESCRIPTION
The Stash Manager dialog now shows the same information that the
`git stash list` command line shows. Previously just the stash
number "stash@{0}" was shown for each stash making it difficult to
know what the stash was for. Now the stash message is shown which
includes the branch name.

    stash@{0}: On master:
    stash@{1}: On master: Added new file
    stash@{2}: On master: Change MyClass name

Before:

<img width="571" alt="stashmanager" src="https://user-images.githubusercontent.com/372361/39663087-9054e424-5064-11e8-8a65-7c40fb8baa84.png">

After:

<img width="571" alt="stashmanager2" src="https://user-images.githubusercontent.com/372361/39663091-96467398-5064-11e8-9748-ce2c85d88bf8.png">

Fixes issue #4723 - Git stash comment not displayed in Stash Manager
dialog