### PR TITLE
Fixes issue #4709 Right-click -> FindReferences when used in an

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpFindReferencesProvider.cs
@@ -212,7 +212,8 @@ namespace MonoDevelop.CSharp.Refactoring
 				var workspace = TypeSystemService.AllWorkspaces.FirstOrDefault (w => w.CurrentSolution == lookup.Solution) as MonoDevelopWorkspace;
 				if (workspace == null)
 					return;
-				await FindReferencesHandler.FindRefs (await GatherSymbols (lookup.SymbolAndProjectId, lookup.Solution, monitor.CancellationToken), lookup.Solution, monitor);
+
+				await FindReferencesHandler.FindRefs (new[] { lookup.SymbolAndProjectId }, lookup.Solution, monitor);
 			});
 		}
 
@@ -247,7 +248,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					}
 					await FindReferencesHandler.FindRefs (symbolsToLookup.ToArray (), lookup.Solution, monitor);
 				} else {
-					await FindReferencesHandler.FindRefs (new [] { lookup.SymbolAndProjectId }, lookup.Solution, monitor);
+					await FindReferencesHandler.FindRefs (await GatherSymbols (lookup.SymbolAndProjectId, lookup.Solution, monitor.CancellationToken), lookup.Solution, monitor);
 				}
 			});
 		}


### PR DESCRIPTION
interface, returns too many useless results For some reason the find &
find all refs calls were swapped. Find all should find the whole
familiy where find just should find the specific symbol and it's
usages.