### PR TITLE
Fixes VSTS 610190: Collapsed Regions Auto Expand

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -1356,7 +1356,6 @@ namespace Mono.TextEditor
 					RemoveFolding (oldSegments [oldIndex]);
 					oldIndex++;
 				}
-
 				if (oldIndex < oldSegments.Count && offset == oldSegments [oldIndex].Offset) {
 					FoldSegment curSegment = oldSegments [oldIndex];
 					if (curSegment.IsCollapsed && newFoldSegment.Length != curSegment.Length)
@@ -1366,16 +1365,16 @@ namespace Mono.TextEditor
 
 					if (newFoldSegment.IsCollapsed) {
 						foldedSegmentAdded |= !curSegment.IsCollapsed;
-						curSegment.isFolded = true;
+						curSegment.IsCollapsed = true;
 					}
-					if (curSegment.isFolded)
+					if (curSegment.IsCollapsed)
 						newFoldedSegments.Add (curSegment);
 					oldIndex++;
 				} else {
 					newFoldSegment.isAttached = true;
 					foldedSegmentAdded |= newFoldSegment.IsCollapsed;
 					if (oldIndex < oldSegments.Count && newFoldSegment.Length == oldSegments [oldIndex].Length) {
-						newFoldSegment.isFolded = oldSegments [oldIndex].IsCollapsed;
+						newFoldSegment.IsCollapsed = oldSegments [oldIndex].IsCollapsed;
 					}
 					if (newFoldSegment.IsCollapsed)
 						newFoldedSegments.Add (newFoldSegment);
@@ -1505,7 +1504,9 @@ namespace Mono.TextEditor
 
 		public void EnsureSegmentIsUnfolded (int offset, int length)
 		{
-			foreach (var fold in GetFoldingContaining (offset, length).Where (f => f.IsCollapsed)) {
+			foreach (var fold in GetFoldingContaining (offset, length)) {
+				if (!fold.IsCollapsed || fold.EndOffset <= offset)
+					continue;
 				fold.IsCollapsed = false;
 				InformFoldChanged(new FoldSegmentEventArgs(fold));
 			}

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/FoldingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/FoldingTests.cs
@@ -602,6 +602,22 @@ AAAAAAAA$
 			data.Document.UpdateFoldSegments (segments);
 			Assert.AreEqual (3, data.Document.FoldSegments.Count ());
 
-		}	
+		}
+
+		/// <summary>
+		/// FeedbackTicket 610190: Collapsed Regions Auto Expand
+		/// </summary>
+		[Test]
+		public void TestVSTS610190 ()
+		{
+			var data = Create (@"01+[234]5");
+			var segments = GetFoldSegments (data.Document);
+			data.Document.UpdateFoldSegments (segments);
+
+			Assert.AreEqual (true, data.Document.FoldSegments.First ().IsCollapsed);
+			data.Document.InsertText (segments.First().EndOffset, "test");
+			Assert.AreEqual (true, data.Document.FoldSegments.First ().IsCollapsed);
+		}
+
 	}
 }


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/610190

GetFoldingContaining is end inclusive which doesn't work here. the
auto formatter may make a text change right after the collapsed fold
which unfolds the region.