### PR TITLE
Fixes VSTS 609809: Closing curly brace removed on deleting curly

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/AbstractTokenBraceCompletionSession.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/AbstractTokenBraceCompletionSession.cs
@@ -31,6 +31,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using MonoDevelop.Ide;
 using MonoDevelop.Core.Text;
+using System;
 
 namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 {
@@ -97,6 +98,8 @@ namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 		{
 			base.BeforeBackspace (out handledCommand);
 			if (Editor.CaretOffset <= StartOffset + 1 || Editor.CaretOffset > EndOffset) {
+				if (HasNoForwardTyping ())
+					Editor.RemoveText (StartOffset + 1, EndOffset - StartOffset);
 				Editor.EndSession ();
 			}
 		}
@@ -107,6 +110,17 @@ namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 			if (Editor.CaretOffset <= StartOffset || Editor.CaretOffset >= EndOffset) {
 				Editor.EndSession ();
 			}
+		}
+
+		bool HasNoForwardTyping ()
+		{
+			for (int i = StartOffset + 1; i < EndOffset - 1; i++) {
+				char ch = Editor.GetCharAt (i);
+				if (ch != ' ' && ch != '\t') {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		protected bool IsValidToken (SyntaxToken token)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/EditActions.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/EditActions.cs
@@ -55,9 +55,6 @@ namespace MonoDevelop.SourceEditor
 			//DeleteActions.Backspace (data, RemoveCharBeforCaret);
 		}
 		
-		const string open    = "'\"([{<";
-		const string closing = "'\")]}>";
-		
 		static int GetNextNonWsCharOffset (TextEditorData data, int offset)
 		{
 			int result = offset;
@@ -81,14 +78,6 @@ namespace MonoDevelop.SourceEditor
 						var stack = await data.Document.SyntaxMode.GetScopeStackAsync (data.Caret.Offset - 1, CancellationToken.None);
 						if (stack.Any (s => s.Contains ("string") || s.Contains ("comment"))) {
 							return;
-						}
-					}
-
-					int idx = open.IndexOf (ch);
-					if (idx >= 0) {
-						int nextCharOffset = GetNextNonWsCharOffset (data, data.Caret.Offset);
-						if (nextCharOffset >= 0 && closing[idx] == data.Document.GetCharAt (nextCharOffset)) {
-							data.Remove (data.Caret.Offset, nextCharOffset - data.Caret.Offset + 1);
 						}
 					}
 					return;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditSession.cs
@@ -167,8 +167,21 @@ namespace MonoDevelop.Ide.Editor
 		{
 			base.BeforeBackspace (out handledCommand);
 			if (Editor.CaretOffset <= StartOffset + 1 || Editor.CaretOffset > EndOffset) {
+				if (HasNoForwardTyping ())
+					Editor.RemoveText (StartOffset + 1, EndOffset - StartOffset);
 				Editor.EndSession ();
 			}	
+		}
+
+		bool HasNoForwardTyping ()
+		{
+			for (int i = StartOffset + 1; i < EndOffset - 1; i++) {
+				char ch = Editor.GetCharAt (i);
+				if (ch != ' ' && ch != '\t') {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		public override void BeforeDelete (out bool handledCommand)

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests.DefaultEditActions/DeleteActionTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests.DefaultEditActions/DeleteActionTests.cs
@@ -218,32 +218,6 @@ namespace Mono.TextEditor.Tests.Actions
 		}
 
 		[Test]
-		public void AdvancedBackspaceTests ()
-		{
-			var data = Create (@"($)", mimeType: "text/x-csharp");
-			DefaultSourceEditorOptions.Instance.AutoInsertMatchingBracket = true;
-			MonoDevelop.SourceEditor.EditActions.AdvancedBackspace (data);
-			Check (data, @"$");
-			data = Create (@"[$]", mimeType:"text/x-csharp");
-			MonoDevelop.SourceEditor.EditActions.AdvancedBackspace (data);
-			Check (data, @"$");
-			data = Create ("\"$\"", mimeType:"text/x-csharp");
-			MonoDevelop.SourceEditor.EditActions.AdvancedBackspace (data);
-			Check (data, @"$");
-			data = Create ("'$'", mimeType: "text/x-csharp");
-			MonoDevelop.SourceEditor.EditActions.AdvancedBackspace (data);
-			Check (data, @"$");
-
-			data = Create (@"// ($)", mimeType: "text/x-csharp");
-			MonoDevelop.SourceEditor.EditActions.AdvancedBackspace (data);
-			Check (data, @"// $)");
-
-			data = Create (@""" ($)", mimeType: "text/x-csharp");
-			MonoDevelop.SourceEditor.EditActions.AdvancedBackspace (data);
-			Check (data, @""" $)");
-		}
-
-		[Test]
 		public void TestBackspaceUTF32 ()
 		{
 			var data = Create (@"12🚀$34");


### PR DESCRIPTION
braces above it in .cs file

The skip char session backspace behavior is already covered inside
SkipCharSessionTests.