### PR TITLE
Fixes unexpected issues breaking current treeview click tunneling behaviour

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -633,8 +633,12 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 
 			//HACK: to avoid automatic scroll behaviour in Gtk (we handle the behaviour)
-			args.Handled = true;
-			((TreeView)ParentWidget).SelectRow (node);
+			//we only want break the normal click behaviour of treeview, in cases when label size is bigger than tree height
+			var treeView = ((TreeView)ParentWidget);
+			if (status.Expanded && status.LastRenderBounds.Height > treeView.Size.Height) {
+				args.Handled = true;
+				treeView.SelectRow (node);
+			}
 			base.OnButtonPressed (args);
 		}
 


### PR DESCRIPTION
Fixes unexpected issues breaking current treeview click tunneling behaviour.

We only want break this behaviour in cases where our label exceeded the size of the current treeview. 

Fixes
https://devdiv.visualstudio.com/DevDiv/Xamarin%20VS%20for%20Mac/_workitems/edit/602813
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/602872
