### PR TITLE
Fixes VSTS 611923: Unable to add declarations to an empty C# file

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionData.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.CSharp.Completion
 			return false;
 		}
 
-		protected override void Format (TextEditor editor, Ide.Gui.Document document, int start, int end)
+		protected override void Format (TextEditor editor, DocumentContext document, int start, int end)
 		{
 			OnTheFlyFormatter.Format (editor, document, start, end);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/KeyDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/KeyDescriptor.cs
@@ -38,6 +38,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 		public static KeyDescriptor Down = new KeyDescriptor (SpecialKey.Down, '\t', ModifierKeys.None, null);
 		public static KeyDescriptor PageUp = new KeyDescriptor (SpecialKey.PageUp, '\t', ModifierKeys.None, null);
 		public static KeyDescriptor PageDown = new KeyDescriptor (SpecialKey.PageDown, '\t', ModifierKeys.None, null);
+		public static KeyDescriptor Return = new KeyDescriptor (SpecialKey.Return, '\t', ModifierKeys.None, null);
 
 		public readonly SpecialKey SpecialKey;
 		public readonly char KeyChar;


### PR DESCRIPTION
which is added to existing .net console project.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/611923