### PR TITLE
[C#] Fix type filter not working

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/ProjectSearchCategory.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/ProjectSearchCategory.cs
@@ -132,9 +132,13 @@ namespace MonoDevelop.CSharp
 
 		public override Task GetResults (ISearchResultCallback searchResultCallback, SearchPopupSearchPattern searchPattern, CancellationToken token)
 		{
+			if (string.IsNullOrEmpty (searchPattern.Pattern))
+				return Task.CompletedTask;
+
+			if (searchPattern.Tag != null && !tags.Contains (searchPattern.Tag) || searchPattern.HasLineNumber)
+				return Task.CompletedTask;
+
 			return Task.Run (async delegate {
-				if (searchPattern.Tag != null && !tags.Contains (searchPattern.Tag) || searchPattern.HasLineNumber)
-					return;
 				try {
 					// Maybe use language services instead of AbstractNavigateToSearchService
 					var aggregatedResults = await Task.WhenAll (TypeSystemService.AllWorkspaces


### PR DESCRIPTION
Fixes VSTS #612896 - NavigateTo type filter isn't working

master counterpart is here: https://github.com/mono/monodevelop/pull/4585/commits/1e6339a5951927adf54fe492029c9c337a63a209