### PR TITLE
[Ide] Fix duplicate references added to project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MetadataReferenceCache.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MetadataReferenceCache.cs
@@ -133,13 +133,8 @@ namespace MonoDevelop.Ide.TypeSystem
 						foreach (var solution in IdeApp.Workspace.GetAllSolutions ()) {
 							var workspace = TypeSystemService.GetWorkspace (solution);
 							foreach (var projId in InUseBy) {
-								while (true) {
-									var project = workspace.CurrentSolution.GetProject (projId);
-									if (project == null)
-										break;
-									if (workspace.TryApplyChanges (project.RemoveMetadataReference (Reference).Solution))
-										break;
-								}
+								if (workspace.CurrentSolution.ContainsProject (projId))
+									workspace.OnMetadataReferenceRemoved (projId, Reference);
 							}
 						}
 					}
@@ -148,13 +143,8 @@ namespace MonoDevelop.Ide.TypeSystem
 						foreach (var solution in IdeApp.Workspace.GetAllSolutions ()) {
 							var workspace = TypeSystemService.GetWorkspace (solution);
 							foreach (var projId in InUseBy) {
-								while (true) {
-									var project = workspace.CurrentSolution.GetProject (projId);
-									if (project == null)
-										break;
-									if (workspace.TryApplyChanges (project.AddMetadataReference (Reference).Solution))
-										break;
-								}
+								if (workspace.CurrentSolution.ContainsProject (projId))
+									workspace.OnMetadataReferenceAdded (projId, Reference);
 							}
 						}
 					}


### PR DESCRIPTION
When a project referenced another project and the referenced assembly
changed a Reference MSBuild item would be added to the project. This
would result in unwanted Reference MSBuild items being added since
the ProjectReference was all that was needed.

Changed the MetadataReferenceCache so it no longer calls TryApplyChanges
on the MonoDevelopWorkspace which would result in the project being
modified. Now OnMetadataReferenceRemoved and OnMetadataReferenceAdded
are called which just updates the metadata so code completion is
up to date based on the latest assemblies.

Fixes VSTS #613601 - Duplicate references added on rebuilding project