### PR TITLE
Fix 614155: Text editor rendering breaks in master

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -47,7 +47,7 @@ namespace Mono.TextEditor
 	{
 		#region Private Members
 
-		public Gtk.Container VisualElement { get => this; }
+		public Gtk.Container VisualElement { get => textArea; }
 
 		ITextBuffer textBuffer;
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Mono.TextEditor\Gui\FoldMarkerMargin.FoldMarkerMarginDrawer.cs" />
     <Compile Include="Mono.TextEditor\Gui\FoldMarkerMargin.VSNetFoldMarkerMarginDrawer.cs" />
     <Compile Include="Mono.TextEditor\Gui\FoldMarkerMargin.VSCodeFoldMarkerMarginDrawer.cs" />
+    <Compile Include="VSEditor\Text\Impl\WpfToolTipAdornment\ViewElementFactories\WpfObjectViewElementFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.SourceEditor.addin.xml">

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/BaseWpfToolTipPresenter.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/BaseWpfToolTipPresenter.cs
@@ -112,7 +112,6 @@
             this.Update(content);
 
             this.popup.Closed += this.OnPopupClosed;
-            this.popup.Padding = 4.0;
             this.popup.Visible = true;
            //todo this.popup.BringIntoView();
             this.obscuringTipManager.PushTip(this.textView, this);
@@ -127,16 +126,10 @@
                     .Where(item => item != null);
 
             var vbox = new Xwt.VBox ();
-			// This dummy delegate and registration/unregistration is just so it forces
-			//xwt to create EventBox for VBox.
-			EventHandler<MouseMovedEventArgs> dummyDelegate = (o, e) => { };
-			vbox.MouseMoved += dummyDelegate;
-			vbox.MouseMoved -= dummyDelegate;
             foreach (var view in contentViewElements)
             {
-                vbox.PackStart (view);
+				vbox.PackStart (view, margin: 4);
             }
-            vbox.Margin = 4.0;
             this.popup.Content = vbox;
         }
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/BaseWpfToolTipPresenter.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/BaseWpfToolTipPresenter.cs
@@ -127,6 +127,11 @@
                     .Where(item => item != null);
 
             var vbox = new Xwt.VBox ();
+			// This dummy delegate and registration/unregistration is just so it forces
+			//xwt to create EventBox for VBox.
+			EventHandler<MouseMovedEventArgs> dummyDelegate = (o, e) => { };
+			vbox.MouseMoved += dummyDelegate;
+			vbox.MouseMoved -= dummyDelegate;
             foreach (var view in contentViewElements)
             {
                 vbox.PackStart (view);

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/MouseTrackingWpfToolTipPresenter.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/MouseTrackingWpfToolTipPresenter.cs
@@ -7,8 +7,6 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
     using Microsoft.VisualStudio.Text.Adornments;
     using Microsoft.VisualStudio.Text.Editor;
     using Microsoft.VisualStudio.Text.Formatting;
-	using UIElement = Gtk.Widget;
-	using MouseEventArgs = Xwt.MouseMovedEventArgs;
 	using Xwt;
 	using Rect = Xwt.Rectangle;
 	using System.Windows.Input;
@@ -19,7 +17,7 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
         // The tooltip can cause flickering issues if shown on the pixel row immediately below text. This
         // offset is used to move all tooltips down in order to eliminate the flicker.
         private const int ToolTipVerticalOffset = 1;
-        private UIElement mouseContainer;
+		private object mouseContainer;
 
         public MouseTrackingWpfToolTipPresenter(
             IViewElementFactoryService viewElementFactoryService,
@@ -35,8 +33,13 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
         {
             if (this.mouseContainer != null)
             {
-				this.mouseContainer.LeaveNotifyEvent -= this.OnMouseLeaveContainer;
-				this.mouseContainer.MotionNotifyEvent -= this.OnMouseMoveContainer;
+				if (this.mouseContainer is Xwt.Widget xwtWidget) {
+					xwtWidget.MouseExited -= this.OnMouseLeaveContainer;
+					xwtWidget.MouseMoved -= this.OnMouseMoveContainer;
+				} else if (this.mouseContainer is Gtk.Widget gtkWidget) {
+					gtkWidget.LeaveNotifyEvent -= this.OnMouseLeaveContainer;
+					gtkWidget.MotionNotifyEvent -= this.OnMouseMoveContainer;
+				}
                 this.mouseContainer = null;
             }
 
@@ -79,12 +82,17 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
 				&& (this.mouseContainer == null)
 				&& (((IMdTextView)textView).VisualElement.IsMouseOver () || (popup.IsMouseOver () && popup.Content != null))) {
 				if (popup.IsMouseOver ()) {
-					mouseContainer = popup.Content.ToGtkWidget ();
+					mouseContainer = popup.Content;
 				} else {
 					mouseContainer = ((IMdTextView)textView).VisualElement;
 				}
-				mouseContainer.LeaveNotifyEvent += this.OnMouseLeaveContainer;
-				mouseContainer.MotionNotifyEvent += this.OnMouseMoveContainer;
+				if (this.mouseContainer is Xwt.Widget xwtWidget) {
+					xwtWidget.MouseExited += this.OnMouseLeaveContainer;
+					xwtWidget.MouseMoved += this.OnMouseMoveContainer;
+				} else if (this.mouseContainer is Gtk.Widget gtkWidget) {
+					gtkWidget.LeaveNotifyEvent += this.OnMouseLeaveContainer;
+					gtkWidget.MotionNotifyEvent += this.OnMouseMoveContainer;
+				}
 			}
         }
 
@@ -92,8 +100,13 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
         {
             if (this.mouseContainer != null)
             {
-				this.mouseContainer.LeaveNotifyEvent -= this.OnMouseLeaveContainer;
-				this.mouseContainer.MotionNotifyEvent -= this.OnMouseMoveContainer;
+				if (this.mouseContainer is Xwt.Widget xwtWidget) {
+					xwtWidget.MouseExited -= this.OnMouseLeaveContainer;
+					xwtWidget.MouseMoved -= this.OnMouseMoveContainer;
+				} else if (this.mouseContainer is Gtk.Widget gtkWidget) {
+					gtkWidget.LeaveNotifyEvent -= this.OnMouseLeaveContainer;
+					gtkWidget.MotionNotifyEvent -= this.OnMouseMoveContainer;
+				}
                 this.mouseContainer = null;
             }
         }

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/MouseTrackingWpfToolTipPresenter.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/MouseTrackingWpfToolTipPresenter.cs
@@ -1,3 +1,4 @@
+using Xwt.Backends;
 namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
 {
     using System;
@@ -6,11 +7,12 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
     using Microsoft.VisualStudio.Text.Adornments;
     using Microsoft.VisualStudio.Text.Editor;
     using Microsoft.VisualStudio.Text.Formatting;
-	using UIElement = Xwt.Widget;
+	using UIElement = Gtk.Widget;
 	using MouseEventArgs = Xwt.MouseMovedEventArgs;
 	using Xwt;
 	using Rect = Xwt.Rectangle;
 	using System.Windows.Input;
+	using MonoDevelop.Components;
 
 	internal sealed class MouseTrackingWpfToolTipPresenter : BaseWpfToolTipPresenter
     {
@@ -33,8 +35,8 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
         {
             if (this.mouseContainer != null)
             {
-                this.mouseContainer.MouseExited -= this.OnMouseLeaveContainer;
-                this.mouseContainer.MouseMoved -= this.OnMouseMoveContainer;
+				this.mouseContainer.LeaveNotifyEvent -= this.OnMouseLeaveContainer;
+				this.mouseContainer.MotionNotifyEvent -= this.OnMouseMoveContainer;
                 this.mouseContainer = null;
             }
 
@@ -76,9 +78,13 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
 			if (!this.isDismissed
 				&& (this.mouseContainer == null)
 				&& (((IMdTextView)textView).VisualElement.IsMouseOver () || (popup.IsMouseOver () && popup.Content != null))) {
-				mouseContainer = popup.IsMouseOver () ? popup.Content : Xwt.Toolkit.CurrentEngine.WrapWidget (((IMdTextView)textView).VisualElement);
-				mouseContainer.MouseExited += this.OnMouseLeaveContainer;
-				mouseContainer.MouseMoved += this.OnMouseMoveContainer;
+				if (popup.IsMouseOver ()) {
+					mouseContainer = popup.Content.ToGtkWidget ();
+				} else {
+					mouseContainer = ((IMdTextView)textView).VisualElement;
+				}
+				mouseContainer.LeaveNotifyEvent += this.OnMouseLeaveContainer;
+				mouseContainer.MotionNotifyEvent += this.OnMouseMoveContainer;
 			}
         }
 
@@ -86,8 +92,8 @@ namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
         {
             if (this.mouseContainer != null)
             {
-                this.mouseContainer.MouseExited -= this.OnMouseLeaveContainer;
-                this.mouseContainer.MouseMoved -= this.OnMouseMoveContainer;
+				this.mouseContainer.LeaveNotifyEvent -= this.OnMouseLeaveContainer;
+				this.mouseContainer.MotionNotifyEvent -= this.OnMouseMoveContainer;
                 this.mouseContainer = null;
             }
         }

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/ViewElementFactories/WpfObjectViewElementFactory.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Text/Impl/WpfToolTipAdornment/ViewElementFactories/WpfObjectViewElementFactory.cs
@@ -1,0 +1,40 @@
+﻿namespace Microsoft.VisualStudio.Text.AdornmentLibrary.ToolTip.Implementation
+{
+	using System;
+	using System.ComponentModel.Composition;
+	using System.Diagnostics;
+	using Microsoft.VisualStudio.Text.Adornments;
+	using Microsoft.VisualStudio.Text.Classification;
+	using Microsoft.VisualStudio.Text.Editor;
+	using Microsoft.VisualStudio.Text.Utilities;
+	using Microsoft.VisualStudio.Utilities;
+	using UIElement = Xwt.Widget;
+
+	[Export (typeof (IViewElementFactory))]
+	[Name ("default object to Xwt.Widget")]
+	[TypeConversion (from: typeof (object), to: typeof (UIElement))]
+	[Order]
+	internal sealed class WpfObjectViewElementFactory : IViewElementFactory
+	{
+		public TView CreateViewElement<TView> (ITextView textView, object model) where TView : class
+		{
+			// Should never happen if the service's code is correct, but it's good to be paranoid.
+			if (typeof (UIElement) != typeof (TView)) {
+				throw new ArgumentException ($"Invalid type conversion. Unsupported {nameof (model)} or {nameof (TView)} type");
+			}
+
+			string text;
+
+			if (model is ITextBuffer modelBuffer) {
+				//TODO: This is very simplified compared to VSWindows
+				//which supports classification of ITextBuffer
+				//but our editor is not ready yet to be used like VSWindows editor.
+				text = modelBuffer.CurrentSnapshot.GetText ();
+			} else {
+				text = model.ToString ();
+			}
+
+			return new Xwt.Label (text) as TView;
+		}
+	}
+}


### PR DESCRIPTION
Main problem was in file MouseTrackingWpfToolTipPresenter.cs where Xwt.Toolkit.CurrentEngine.WrapWidget was called on editor, I assumed in past any native object can be wrapped as needed, but it seems like only new(widgets without parents can be wrapped) so we can't act like Editor is Xwt object, instead handle everything is Gtk...
I also noticed that we were missing new ViewElementFactory(one for object) which I added now, very primitive for now, just so it's not empty popup.
Rest of changes are related to making sure MouseLeave and MouseMove events work for both, popup.Content and IMdTextView.VisualElement correctly.