### PR TITLE
[NuGet] Support no-op restores on opening a solution

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
@@ -80,12 +80,53 @@ namespace MonoDevelop.PackageManagement
 			IEnumerable<BuildIntegratedNuGetProject> projects,
 			CancellationToken cancellationToken)
 		{
+			var spec = await DependencyGraphRestoreUtility.GetSolutionRestoreSpec (solutionManager, context);
+
+			var now = DateTime.UtcNow;
+			Action<SourceCacheContext> cacheContextModifier = c => c.MaxAge = now;
+			bool forceRestore = false;
+
+			var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync (
+				solutionManager,
+				context,
+				new RestoreCommandProvidersCache (),
+				cacheContextModifier,
+				sourceRepositories,
+				forceRestore,
+				spec,
+				context.Logger,
+				cancellationToken);
+
+			bool restoreFailed = false;
+			int noOpRestoreCount = 0;
+			foreach (RestoreSummary restoreSummary in restoreSummaries) {
+				if (restoreSummary.Success && restoreSummary.NoOpRestore) {
+					noOpRestoreCount++;
+				} else if (!restoreSummary.Success) {
+					restoreFailed = true;
+				}
+			}
+
+			if (noOpRestoreCount == projects.Count ()) {
+				// Nothing to do.
+				return;
+			}
+
+			if (restoreFailed) {
+				throw new ApplicationException (GettextCatalog.GetString ("Restore failed."));
+			}
+
+			await OnProjectsRestored (projects);
+		}
+
+		async Task OnProjectsRestored (IEnumerable<BuildIntegratedNuGetProject> projects)
+		{
 			var changedLocks = new List<FilePath> ();
 			var affectedProjects = new List<BuildIntegratedNuGetProject> ();
 
 			foreach (BuildIntegratedNuGetProject project in projects) {
 				DotNetProject projectToReload = GetProjectToReloadAfterRestore (project);
-				var changedLock = await RestorePackagesInternal (project, cancellationToken);
+				string changedLock = await project.GetAssetsFilePathAsync ();
 				if (projectToReload != null) {
 					await ReloadProject (projectToReload, changedLock);
 				} else if (changedLock != null) {


### PR DESCRIPTION
On opening a solution containing projects that use PackageReferences
the restore that runs was forcing a restore for each project. This
resulted in the project.assets.json file being re-generated and
the projects being re-evaluated. Now if the package references have
not changed a no-op restore will occur. This makes the restore much
faster on opening a solution. It also prevents NuGet going online to
fetch NuGet package information if a wildcard is used for a
PackageReference or if the version cannot be found. In the Package
Console when a no-op restore occurs you will see the following
messages:

    Assets file has not changed. Skipping assets file writing.
    No-Op restore. The cache will not be updated.

Fixes VSTS #614192 - NuGet Restore is never a no-op