### PR TITLE
Fix initial output message in F# interactive

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/FileService.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/FileService.fs
@@ -1,5 +1,4 @@
-﻿
-namespace MonoDevelop.FSharp
+﻿namespace MonoDevelop.FSharp
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open System.IO
 open MonoDevelop.Ide

--- a/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/Program.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpi.Service/Program.fs
@@ -126,7 +126,9 @@ module CompletionServer =
                                 do! writeOutput "SERVER-PROMPT>"
                             return ""
                         else
-                           return currentInput + "\n" + input
+                            match currentInput with
+                            | "" -> return input
+                            | _ -> return currentInput + "\n" + input
                     | Tooltip filter ->
                         let! tooltip = Completion.getCompletionTooltip filter
                         do! writeData "tooltip" tooltip


### PR DESCRIPTION
Fixes VSTS #615186

We now send the filename of the active document along with the user
input on each invocation.

This also means that __SOURCE_FILE__ works now too.