### PR TITLE
[WebReferences] Fix background thread used when adding file to project

### DIFF
--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.WS/WebServiceDiscoveryResultWS.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.WS/WebServiceDiscoveryResultWS.cs
@@ -86,14 +86,14 @@ namespace MonoDevelop.WebReferences.WS
 				dotNetProject.Items.Add (met);
 			}
 
-			DiscoveryClientResultCollection files = await Task.Run (() => {
-				WebReferenceUrl wru = dotNetProject.Items.GetAll<WebReferenceUrl> ().FirstOrDefault (m => m.RelPath.CanonicalPath == basePath);
-				if (wru == null) {
-					wru = new WebReferenceUrl (protocol.Url);
-					wru.RelPath = basePath;
-					dotNetProject.Items.Add (wru);
-				}
+			WebReferenceUrl wru = dotNetProject.Items.GetAll<WebReferenceUrl> ().FirstOrDefault (m => m.RelPath.CanonicalPath == basePath);
+			if (wru == null) {
+				wru = new WebReferenceUrl (protocol.Url);
+				wru.RelPath = basePath;
+				dotNetProject.Items.Add (wru);
+			}
 
+			DiscoveryClientResultCollection files = await Task.Run (() => {
 				protocol.ResolveAll ();
 				return protocol.WriteAll (basePath, "Reference.map");
 			});


### PR DESCRIPTION
Adding a .NET 2.0 Web Services web reference would add a file to
the project using a background thread. For ASP.NET Core MVC projects
that use a .cshtml file this would result in an error message:

   The web reference could not be added
   'DotNetProject_Modified' must be called on the foreground thread.

Fixes VSTS #615584 - Cannot add web reference to ASP.NET Core MVC
project