### PR TITLE
[Loc] Possible fix at many localizations issues with have

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -274,11 +274,11 @@
 		<string>ja</string>
 		<string>ko</string>
 		<string>pl</string>
-		<string>pt_BR</string>
+		<string>pt-BR</string>
 		<string>ru</string>
 		<string>tr</string>
-		<string>zh_TW</string>
-		<string>zh_CN</string>
+		<string>zh-Hans</string>
+		<string>zh-Hant</string>
 	</array>
 </dict>
 </plist>

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -255,17 +255,16 @@ run_md_bundle (NSString *appDir, NSArray *arguments)
 static void
 correct_locale(void)
 {
-	NSString *preferredLanguage;
+	NSString *preferredLanguage = [[[NSBundle mainBundle] preferredLocalizations] firstObject];
 
-	preferredLanguage = [[NSLocale preferredLanguages] objectAtIndex: 0];
 	// Apply fixups such as zh_HANS/HANT -> zh_CN/TW
 	// Strip other languages of remainder so we choose a generic culture.
-	if ([preferredLanguage caseInsensitiveCompare:@"zh-hans"] == NSOrderedSame)
+	if ([preferredLanguage hasPrefix:@"zh-Hans"])
 		preferredLanguage = @"zh_CN";
-	else if ([preferredLanguage caseInsensitiveCompare:@"zh-hant"] == NSOrderedSame)
+	else if ([preferredLanguage hasPrefix:@"zh-Hant"])
 		preferredLanguage = @"zh_TW";
-	else
-		preferredLanguage = [[preferredLanguage componentsSeparatedByString:@"-"] objectAtIndex:0];
+
+	preferredLanguage = [preferredLanguage stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
 
 	setenv("MONODEVELOP_STUB_LANGUAGE", [preferredLanguage UTF8String], 1);
 	setenv("LANGUAGE", [preferredLanguage UTF8String], 1);


### PR DESCRIPTION
See: https://openradar.appspot.com/radar?id=4960317826138112

This means that anything loc related should be using localizations from bundle,
and leave NSLocale to do its own job

Fixes VSTS #587766 - Chinese langauge not reflected in VSfM when selected from the system language.
Fixes VSTS #591373 - [Feedback] After adding Japanese keyboard input, some context menu items are in Japanese, even though the preferred system language is Portuguese and Visual Studio for Mac UI Language is set to default
Fixes VSTS #591378 - [Feedback] Default UI Language preference does not reflect system settings