### PR TITLE
Fix #3513: TestSessionTimeout is not configurable

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 				ResultsDirectory = project.BaseIntermediateOutputPath.Combine (Constants.ResultsDirectoryName),
 				ShouldCollectSourceInformation = false,
 				TestAdaptersPaths = GetTestAdapters (project),
-				TestSessionTimeout = 60000,
+				TestSessionTimeout = int.MaxValue
 			}.ToXml ().OuterXml + "</RunSettings>";
 		}
 


### PR DESCRIPTION
Instead of adding new option to preferences and make it even more bloated, I decided to set timeout to maximum possible value. User can always cancel execution of unit test from IDE so there is no upside to having timeout from IDE. It would only confuse new users who would need to find setting and update to bigger value...