### PR TITLE
Fix mimeTypes attribute on CSharpAutoInsertBracketHandler.

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -340,7 +340,7 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/AutoInsertBracketHandler">
-		<Handler class="MonoDevelop.CSharp.Features.AutoInsertBracket.CSharpAutoInsertBracketHandler" mimeType = "text/x-csharp" />
+		<Handler class="MonoDevelop.CSharp.Features.AutoInsertBracket.CSharpAutoInsertBracketHandler" mimeTypes = "text/x-csharp" />
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/TypeService/MefHostServices">


### PR DESCRIPTION
It was being loaded for all mime types. Now the mimeTypes will be respected.

Bug https://github.com/mono/mono-addins/issues/116 is a suggestion to add a warning to prevent such errors in the future.