### PR TITLE
Fixes VSTS Bug 615849: Automatic matching brace completion deletes `{`

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/AbstractTokenBraceCompletionSession.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/AutoInsertBracket/AbstractTokenBraceCompletionSession.cs
@@ -97,7 +97,11 @@ namespace MonoDevelop.CSharp.Features.AutoInsertBracket
 		public override void BeforeBackspace (out bool handledCommand)
 		{
 			base.BeforeBackspace (out handledCommand);
-			if (Editor.CaretOffset <= StartOffset + 1 || Editor.CaretOffset > EndOffset) {
+			if (Editor.CaretOffset > EndOffset) {
+				Editor.EndSession ();
+				return;
+			}
+			if (Editor.CaretOffset <= StartOffset + 1) {
 				if (HasNoForwardTyping ())
 					Editor.RemoveText (StartOffset + 1, EndOffset - StartOffset);
 				Editor.EndSession ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditSession.cs
@@ -166,7 +166,11 @@ namespace MonoDevelop.Ide.Editor
 		public override void BeforeBackspace (out bool handledCommand)
 		{
 			base.BeforeBackspace (out handledCommand);
-			if (Editor.CaretOffset <= StartOffset + 1 || Editor.CaretOffset > EndOffset) {
+			if (Editor.CaretOffset > EndOffset) {
+				Editor.EndSession ();
+				return;
+			}
+			if (Editor.CaretOffset <= StartOffset + 1) {
 				if (HasNoForwardTyping ())
 					Editor.RemoveText (StartOffset + 1, EndOffset - StartOffset);
 				Editor.EndSession ();

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SkipCharSessionTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SkipCharSessionTests.cs
@@ -73,5 +73,30 @@ namespace MonoDevelop.Ide.Editor
 				}
 			return default (T);
 		}
+		/// <summary>
+		/// Bug 615849: Automatic matching brace completion deletes `{` when `}` is deleted
+		/// </summary>
+		[TestCase]
+		public void TestVSTS615849 ()
+		{
+			DefaultSourceEditorOptions.Instance.AutoInsertMatchingBracket = true;
+			var tww = new TestWorkbenchWindow ();
+			var content = new TestViewContent ();
+			tww.ViewContent = content;
+
+			var document = new Document (tww);
+
+			var editor = TextEditorFactory.CreateNewEditor (document);
+			editor.MimeType = "text/xml";
+			const string originalText = @"";
+			editor.Text = originalText;
+
+			var extensibleEditor = FindChild<ExtensibleTextEditor> (editor.GetNativeWidget<Container> ());
+			extensibleEditor.OnIMProcessedKeyPressEvent ((Gdk.Key)'"', '"', Gdk.ModifierType.None);
+			extensibleEditor.OnIMProcessedKeyPressEvent (Gdk.Key.Right, '\0', Gdk.ModifierType.None);
+			extensibleEditor.OnIMProcessedKeyPressEvent (Gdk.Key.BackSpace, '\0', Gdk.ModifierType.None);
+			Assert.AreEqual ("\"", editor.Text);
+		}
+
 	}
 }


### PR DESCRIPTION
when `}` is deleted

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/615849