### PR TITLE
Fix https://github.com/mono/monodevelop/issues/4816 (disable Roslyn Quick Info)

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Language/Impl/QuickInfo/QuickInfoTextViewCreationListener.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/Language/Impl/QuickInfo/QuickInfoTextViewCreationListener.cs
@@ -29,9 +29,15 @@
 
         public void TextViewCreated(ITextView textView)
         {
-            // No need to do anything further, this type hooks up events to the
-            // text view and tracks its own life cycle.
-            new QuickInfoController(
+			// TODO: remove this as described in
+			// https://devdiv.visualstudio.com/DevDiv/Xamarin%20VS%20for%20Mac/_workitems/edit/617427
+			if (textView.TextBuffer.ContentType.IsOfType ("CSharp")) {
+				return;
+			}
+
+			// No need to do anything further, this type hooks up events to the
+			// text view and tracks its own life cycle.
+			new QuickInfoController(
                 this.quickInfoBroker,
                 this.joinableTaskContext,
                 textView);


### PR DESCRIPTION
Disable the Roslyn-based Quick Info for now for C#, because it conflicts with the MonoDevelop one.

We will reenable it later as part of moving to VS Editor.

Also fixes https://github.com/mono/monodevelop/issues/4818