### PR TITLE
Fixes VSTS 616981: [Feedback] VSMac Freezes When Saving A file

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Utils/CompressingTreeList.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Utils/CompressingTreeList.cs
@@ -115,7 +115,7 @@ namespace Mono.TextEditor.Utils
 
 		}
 
-		internal RedBlackTree<CompressingNode> tree = new RedBlackTree<CompressingNode> ();
+		internal readonly RedBlackTree<CompressingNode> tree = new RedBlackTree<CompressingNode> ();
 
 		/// <summary>
 		/// Creates a new CompressingTreeList instance.


### PR DESCRIPTION
Can't repro the issue but the diff tracker relied on text
changing/text changed pairs which is kind of broken in the current
editor. Reworked it so that only the text changed event is used &
handled the exception from the log.