### PR TITLE
Fixes VSTS 616981: [Feedback] VSMac Freezes When Saving A file

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Utils/CompressingTreeList.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Utils/CompressingTreeList.cs
@@ -115,7 +115,7 @@ namespace Mono.TextEditor.Utils
 
 		}
 
-		internal RedBlackTree<CompressingNode> tree = new RedBlackTree<CompressingNode> ();
+		internal readonly RedBlackTree<CompressingNode> tree = new RedBlackTree<CompressingNode> ();
 
 		/// <summary>
 		/// Creates a new CompressingTreeList instance.

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DiffTracker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/DiffTracker.cs
@@ -25,6 +25,8 @@
 // THE SOFTWARE.
 using System;
 using Mono.TextEditor.Utils;
+using MonoDevelop.Core;
+using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Editor;
 
 namespace Mono.TextEditor
@@ -47,7 +49,9 @@ namespace Mono.TextEditor
 
 		CompressingTreeList<LineChangeInfo> lineStates;
 		TextDocument trackDocument;
-//		TextDocument baseDocument;
+		IReadonlyTextDocument trackDocumentSnapshot;
+
+		//		TextDocument baseDocument;
 
 		public Mono.TextEditor.TextDocument.LineState GetLineState (DocumentLine line)
 		{
@@ -67,31 +71,30 @@ namespace Mono.TextEditor
 		public void SetTrackDocument (TextDocument document)
 		{
 			trackDocument = document;
+			trackDocumentSnapshot = document.CreateDocumentSnapshot ();
 		}
 
-		void TrackDocument_TextChanging (object sender, MonoDevelop.Core.Text.TextChangeEventArgs e)
+		void TrackDocument_TextChanged (object sender, MonoDevelop.Core.Text.TextChangeEventArgs e)
 		{
-			if (lineStates == null)
+			if (lineStates == null || e.TextChanges.Count == 0)
 				return;
-			for(int i = e.TextChanges.Count - 1; i >= 0; i--) {
-				var change = e.TextChanges[i];
+			for (int i = e.TextChanges.Count - 1; i >= 0; i--) {
+				var change = e.TextChanges [i];
 				if (change.RemovalLength == 0)
 					continue;
-				var startLine = trackDocument.GetLineByOffset (change.Offset);
-				var endRemoveLine = trackDocument.GetLineByOffset (change.Offset + change.RemovalLength);
+
+				var startLine = trackDocumentSnapshot.GetLineByOffset (change.Offset);
+				var endRemoveLine = trackDocumentSnapshot.GetLineByOffset (change.Offset + change.RemovalLength);
 				if (startLine == null || endRemoveLine == null)
 					continue;
 				try {
 					var lineNumber = startLine.LineNumber;
 					lineStates.RemoveRange (lineNumber, endRemoveLine.LineNumber - lineNumber);
 				} catch (Exception ex) {
-					Console.WriteLine ("error while DiffTracker.TrackDocument_TextChanging:" + ex);
+					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanged changing update", ex);
 				}
 			}
-		}
 
-		void TrackDocument_TextChanged (object sender, MonoDevelop.Core.Text.TextChangeEventArgs e)
-		{
 			for (int i = 0; i < e.TextChanges.Count; ++i) {
 				var change = e.TextChanges[i];
 				var startLine = trackDocument.GetLineByOffset (change.NewOffset);
@@ -100,7 +103,7 @@ namespace Mono.TextEditor
 				var insertedLines = endLine.LineNumber - lineNumber;
 				if (insertedLines == 0) {
 					var oldState = lineNumber < lineStates.Count ? lineStates [lineNumber] : null;
-					if (oldState != null && oldState.state == TextDocument.LineState.Dirty) 
+					if (oldState != null && oldState.state == TextDocument.LineState.Dirty)
 						continue;
 					lineStates[lineNumber] = LineChangeInfo.Dirty;
 					if (trackDocument != null)
@@ -112,22 +115,28 @@ namespace Mono.TextEditor
 					if (trackDocument != null)
 						trackDocument.CommitMultipleLineUpdate (lineNumber, lineNumber + insertedLines);
 				} catch (Exception ex) {
-					Console.WriteLine ("error while DiffTracker.TrackDocument_TextChanged:" + ex);
+					LoggingService.LogError ("error while DiffTracker.TrackDocument_TextChanged changed update", ex);
 				}
 			}
+			trackDocumentSnapshot = trackDocument.CreateDocumentSnapshot ();
 		}
 
 		public void SetBaseDocument (IReadonlyTextDocument document)
 		{
-			if (lineStates != null) {
-				foreach (var node in lineStates.tree) {
-					if (node.value.state == Mono.TextEditor.TextDocument.LineState.Dirty)
-						node.value = LineChangeInfo.Changed;
+			var curLineStates = lineStates;
+			if (curLineStates != null) {
+				try {
+					foreach (var node in curLineStates.tree) {
+						if (node.value.state == TextDocument.LineState.Dirty)
+							node.value = LineChangeInfo.Changed;
+					}
+				} catch (Exception e) {
+					LoggingService.LogError ("error while DiffTracker.SetBaseDocument", e);
+					Reset ();
 				}
 			} else {
 				lineStates = new CompressingTreeList<LineChangeInfo>((x, y) => x.Equals(y));
 				lineStates.InsertRange (0, document.LineCount + 1, LineChangeInfo.Unchanged);
-				trackDocument.TextChanging += TrackDocument_TextChanging;
 				trackDocument.TextChanged += TrackDocument_TextChanged;
 			}
 		}
@@ -139,4 +148,3 @@ namespace Mono.TextEditor
 		}
 	}
 }
-


### PR DESCRIPTION
Can't repro the issue but the diff tracker relied on text
changing/text changed pairs which is kind of broken in the current
editor. Reworked it so that only the text changed event is used &
handled the exception from the log.