### PR TITLE
[NuGet] Fix build error after updating Xamarin.Forms NuGet package 

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProjectContext.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProjectContext.cs
@@ -47,10 +47,14 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			get { return null; }
 		}
 
+		public bool LogToConsole { get; set; }
+
 		public void Log (MessageLevel level, string message, params object [] args)
 		{
 			LastLogLevel = level;
 			LastMessageLogged = String.Format (message, args);
+			if (LogToConsole)
+				Console.WriteLine (LastMessageLogged);
 		}
 
 		public MessageLevel? LastLogLevel { get; set; }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -208,6 +208,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectSystemReferencesReaderTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectJsonBuildIntegratedNuGetProjectTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\ItemTemplateNuGetPackageInstallerTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\UpdateXamarinFormsBuildTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateXamarinFormsBuildTest.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateXamarinFormsBuildTest.cs
@@ -102,6 +102,38 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsFalse (result.HasErrors, "Build failed: {0}", buildError);
 		}
 
+		/// <summary>
+		/// Tests that a build error due to a mismatched Xamarin.Forms NuGet package used
+		/// in two projects can be fixed by updating the NuGet package to match without
+		/// having to close and re-open the solution
+		/// </summary>
+		[Test]
+		public async Task UpdateXamarinFormsNuGetPackageReference_ThenBuild ()
+		{
+			string solutionFileName = Util.GetSampleProject ("FormsUpdatePackageRef", "FormsUpdatePackageRef.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			CreateNuGetConfigFile (solution.BaseDirectory);
+			var netStandardProject = (DotNetProject)solution.FindProjectByName ("NetStandardProject");
+
+			var process = Process.Start ("msbuild", $"/t:Restore /p:RestoreDisableParallel=true \"{solutionFileName}\"");
+			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+			Assert.AreEqual (0, process.ExitCode);
+
+			// Build should fail due to mismatched Xamarin.Forms versions being used.
+			var result = await solution.Build (Util.GetMonitor (), ConfigurationSelector.Default);
+			Assert.IsTrue (result.HasErrors);
+			var buildError = result.Errors [0];
+			Assert.AreEqual ("XF002", buildError.ErrorNumber);
+
+			// Update NuGet package in PCL project.
+			await UpdateNuGetPackage (netStandardProject, "Xamarin.Forms", "3.0.0.482510");
+
+			// Build should not fail.
+			result = await solution.Build (Util.GetMonitor (), ConfigurationSelector.Default);
+			buildError = result.Errors.FirstOrDefault ();
+			Assert.IsFalse (result.HasErrors, "Build failed: {0}", buildError);
+		}
+
 		static Task<PackageRestoreResult> RestoreNuGetPackages (Solution solution)
 		{
 			var solutionManager = new MonoDevelopSolutionManager (solution);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateXamarinFormsBuildTest.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateXamarinFormsBuildTest.cs
@@ -1,0 +1,143 @@
+﻿//
+// UpdateXamarinFormsBuildTest.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using NuGet.Versioning;
+using NuGet.PackageManagement;
+using System.Threading;
+using System.Linq;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class UpdateXamarinFormsBuildTest : TestBase
+	{
+		Solution solution;
+
+		[TearDown]
+		public void TearDownTest ()
+		{
+			solution?.Dispose ();
+		}
+
+		/// <summary>
+		/// Clear all other package sources and just use the main NuGet package source when
+		/// restoring the packages for the project temlate tests.
+		/// </summary>
+		protected static void CreateNuGetConfigFile (FilePath directory)
+		{
+			var fileName = directory.Combine ("NuGet.Config");
+
+			string xml =
+				"<configuration>\r\n" +
+				"  <packageSources>\r\n" +
+				"    <clear />\r\n" +
+				"    <add key=\"NuGet v3 Official\" value=\"https://api.nuget.org/v3/index.json\" />\r\n" +
+				"  </packageSources>\r\n" +
+				"</configuration>";
+
+			File.WriteAllText (fileName, xml);
+		}
+
+		/// <summary>
+		/// Tests that a build error due to a mismatched Xamarin.Forms NuGet package used
+		/// in two projects can be fixed by updating the NuGet package to match without
+		/// having to close and re-open the solution
+		/// </summary>
+		[Test]
+		public async Task UpdateXamarinFormsNuGetPackage_ThenBuild ()
+		{
+			string solutionFileName = Util.GetSampleProject ("FormsUpdateTest", "FormsUpdateTest.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			CreateNuGetConfigFile (solution.BaseDirectory);
+			var pclProject = (DotNetProject)solution.FindProjectByName ("PclProject");
+
+			var restoreResult = await RestoreNuGetPackages (solution);
+			Assert.IsTrue (restoreResult.Restored);
+			Assert.AreEqual (2, restoreResult.RestoredPackages.Count ());
+
+			// Build should fail due to mismatched Xamarin.Forms versions being used.
+			var result = await solution.Build (Util.GetMonitor (), ConfigurationSelector.Default);
+			Assert.IsTrue (result.HasErrors);
+			var buildError = result.Errors [0];
+			Assert.AreEqual ("XF002", buildError.ErrorNumber);
+
+			// Update NuGet package in PCL project.
+			await UpdateNuGetPackage (pclProject, "Xamarin.Forms", "3.0.0.482510");
+
+			// Build should not fail.
+			result = await solution.Build (Util.GetMonitor (), ConfigurationSelector.Default);
+			buildError = result.Errors.FirstOrDefault ();
+			Assert.IsFalse (result.HasErrors, "Build failed: {0}", buildError);
+		}
+
+		static Task<PackageRestoreResult> RestoreNuGetPackages (Solution solution)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (solution);
+			var context = new FakeNuGetProjectContext {
+				LogToConsole = true
+			};
+
+			var restoreManager = new PackageRestoreManager (
+				solutionManager.CreateSourceRepositoryProvider (),
+				solutionManager.Settings,
+				solutionManager
+			);
+
+			return restoreManager.RestoreMissingPackagesInSolutionAsync (
+				solutionManager.SolutionDirectory,
+				new FakeNuGetProjectContext (),
+				CancellationToken.None);
+		}
+
+		Task UpdateNuGetPackage (DotNetProject project, string packageId, string packageVersion)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (project.ParentSolution);
+			var context = new FakeNuGetProjectContext {
+				LogToConsole = true
+			};
+			var sources = solutionManager.CreateSourceRepositoryProvider ().GetRepositories ();
+
+			var action = new InstallNuGetPackageAction (sources, solutionManager, new DotNetProjectProxy (project), context);
+			action.LicensesMustBeAccepted = false;
+			action.OpenReadmeFile = false;
+			action.PackageId = packageId;
+			action.Version = NuGetVersion.Parse (packageVersion);
+
+			return Task.Run (() => {
+				action.Execute ();
+			});
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -307,6 +307,9 @@ namespace MonoDevelop.PackageManagement
 				await restoreTask;
 			}
 
+			// Ensure MSBuild tasks are up to date when the next build is run.
+			project.ShutdownProjectBuilder ();
+
 			if (!packageRestorer.LockFileChanged) {
 				// Need to refresh the references since the restore did not.
 				await Runtime.RunInMainThread (() => {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -566,6 +566,14 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		void OnMSBuildProjectImportChanged (object sender, EventArgs args)
 		{
+			// Unload the remote build engine so new MSBuild task assemblies can be used.
+			// This prevents the old MSBuild task assemblies from being used at build time
+			// after a NuGet package has been updated.
+			RemoteBuildEngineManager.UnloadProject (FileName).Ignore ();
+			string solutionFileName = ParentSolution?.FileName;
+			if (solutionFileName != null)
+				RemoteBuildEngineManager.UnloadSolution (solutionFileName).Ignore ();
+
 			lock (evaluatedCompileItemsLock) {
 				// Do not re-evaluate if the compile items have never been evaluated.
 				if (evaluatedCompileItemsTask != null)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -566,13 +566,8 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		void OnMSBuildProjectImportChanged (object sender, EventArgs args)
 		{
-			// Unload the remote build engine so new MSBuild task assemblies can be used.
-			// This prevents the old MSBuild task assemblies from being used at build time
-			// after a NuGet package has been updated.
-			RemoteBuildEngineManager.UnloadProject (FileName).Ignore ();
-			string solutionFileName = ParentSolution?.FileName;
-			if (solutionFileName != null)
-				RemoteBuildEngineManager.UnloadSolution (solutionFileName).Ignore ();
+			// Ensure MSBuild tasks used when building are up to date after imports changed.
+			ShutdownProjectBuilder ();
 
 			lock (evaluatedCompileItemsLock) {
 				// Do not re-evaluate if the compile items have never been evaluated.
@@ -1581,6 +1576,17 @@ namespace MonoDevelop.Projects
 		public void ReloadProjectBuilder ()
 		{
 			RemoteBuildEngineManager.RefreshProject (FileName).Ignore ();
+		}
+
+		public void ShutdownProjectBuilder ()
+		{
+			// Unload the remote build engine so new MSBuild task assemblies can be used.
+			// This prevents the old MSBuild task assemblies from being used at build time
+			// after a NuGet package has been updated.
+			RemoteBuildEngineManager.UnloadProject (FileName).Ignore ();
+			string solutionFileName = ParentSolution?.FileName;
+			if (solutionFileName != null)
+				RemoteBuildEngineManager.UnloadSolution (solutionFileName).Ignore ();
 		}
 
 		#endregion

--- a/main/tests/test-projects/FormsUpdatePackageRef/FormsUpdatePackageRef.sln
+++ b/main/tests/test-projects/FormsUpdatePackageRef/FormsUpdatePackageRef.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandardProject", "NetStandardProject\NetStandardProject.csproj", "{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryProject", "LibraryProject\LibraryProject.csproj", "{4E1821DD-EE60-48C1-8552-05B2793263DC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/FormsUpdatePackageRef/LibraryProject/LibraryProject.csproj
+++ b/main/tests/test-projects/FormsUpdatePackageRef/LibraryProject/LibraryProject.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4E1821DD-EE60-48C1-8552-05B2793263DC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>LibraryProject</RootNamespace>
+    <AssemblyName>LibraryProject</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NetStandardProject\NetStandardProject.csproj">
+      <Project>{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}</Project>
+      <Name>NetStandardProject</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/FormsUpdatePackageRef/LibraryProject/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/FormsUpdatePackageRef/LibraryProject/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("LibraryProject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Microsoft")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/FormsUpdatePackageRef/NetStandardProject/Class1.cs
+++ b/main/tests/test-projects/FormsUpdatePackageRef/NetStandardProject/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace NetStandardProject
+{
+	public class Class1
+	{
+	}
+}

--- a/main/tests/test-projects/FormsUpdatePackageRef/NetStandardProject/NetStandardProject.csproj
+++ b/main/tests/test-projects/FormsUpdatePackageRef/NetStandardProject/NetStandardProject.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.121934" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/FormsUpdateTest/FormsUpdateTest.sln
+++ b/main/tests/test-projects/FormsUpdateTest/FormsUpdateTest.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PclProject", "PclProject\PclProject.csproj", "{66D551D6-3229-4962-A01B-287808894542}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryProject", "LibraryProject\LibraryProject.csproj", "{045544D3-9A09-4903-9A6D-0FB3064D4FF7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{66D551D6-3229-4962-A01B-287808894542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66D551D6-3229-4962-A01B-287808894542}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66D551D6-3229-4962-A01B-287808894542}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66D551D6-3229-4962-A01B-287808894542}.Release|Any CPU.Build.0 = Release|Any CPU
+		{045544D3-9A09-4903-9A6D-0FB3064D4FF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{045544D3-9A09-4903-9A6D-0FB3064D4FF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{045544D3-9A09-4903-9A6D-0FB3064D4FF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{045544D3-9A09-4903-9A6D-0FB3064D4FF7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/FormsUpdateTest/LibraryProject/LibraryProject.csproj
+++ b/main/tests/test-projects/FormsUpdateTest/LibraryProject/LibraryProject.csproj
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.Forms.3.0.0.482510\build\netstandard2.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.3.0.0.482510\build\netstandard2.0\Xamarin.Forms.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{045544D3-9A09-4903-9A6D-0FB3064D4FF7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>LibraryProject</RootNamespace>
+    <AssemblyName>LibraryProject</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.3.0.0.482510\lib\netstandard2.0\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.3.0.0.482510\lib\netstandard2.0\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.3.0.0.482510\lib\netstandard2.0\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PclProject\PclProject.csproj">
+      <Project>{66D551D6-3229-4962-A01B-287808894542}</Project>
+      <Name>PclProject</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.3.0.0.482510\build\netstandard2.0\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.3.0.0.482510\build\netstandard2.0\Xamarin.Forms.targets')" />
+</Project>

--- a/main/tests/test-projects/FormsUpdateTest/LibraryProject/MyClass.cs
+++ b/main/tests/test-projects/FormsUpdateTest/LibraryProject/MyClass.cs
@@ -1,0 +1,11 @@
+
+using System;
+namespace LibraryProject
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/FormsUpdateTest/LibraryProject/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/FormsUpdateTest/LibraryProject/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("LibraryProject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Microsoft")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/FormsUpdateTest/LibraryProject/packages.config
+++ b/main/tests/test-projects/FormsUpdateTest/LibraryProject/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Forms" version="3.0.0.482510" targetFramework="net47" />
+</packages>

--- a/main/tests/test-projects/FormsUpdateTest/PclProject/MyPage.xaml
+++ b/main/tests/test-projects/FormsUpdateTest/PclProject/MyPage.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="PclProject.MyPage">
+	<ContentPage.Content>
+	</ContentPage.Content>
+</ContentPage>

--- a/main/tests/test-projects/FormsUpdateTest/PclProject/MyPage.xaml.cs
+++ b/main/tests/test-projects/FormsUpdateTest/PclProject/MyPage.xaml.cs
@@ -1,0 +1,16 @@
+
+using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace PclProject
+{
+	public partial class MyPage : ContentPage
+	{
+		public MyPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/main/tests/test-projects/FormsUpdateTest/PclProject/PclProject.csproj
+++ b/main/tests/test-projects/FormsUpdateTest/PclProject/PclProject.csproj
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{66D551D6-3229-4962-A01B-287808894542}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>PclProject</RootNamespace>
+    <AssemblyName>PclProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MyPage.xaml.cs">
+      <DependentUpon>MyPage.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="MyPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.0.121934\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.121934\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
+</Project>

--- a/main/tests/test-projects/FormsUpdateTest/PclProject/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/FormsUpdateTest/PclProject/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("PclProject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Microsoft")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/FormsUpdateTest/PclProject/packages.config
+++ b/main/tests/test-projects/FormsUpdateTest/PclProject/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Forms" version="2.5.0.121934" targetFramework="portable45-net45+win8+wpa81" />
+</packages>


### PR DESCRIPTION
This problem was fixed in Xamarin Studio 5.8 ac84628
and seems to have re-surfaced. On updating Xamarin.Forms in a solution
that contains multiple projects that use it the build would sometimes
fail with errors like:

    Could not load file or assembly 'Xamarin.Forms.Xaml,
    Version=2.0.0.0, Culture=neutral, PublicKeyToken=null' or one of
    its dependencies.

    Error XF002: Xamarin.Forms tasks do not match targets. Please
    ensure that all projects reference the same version of
    Xamarin.Forms, and if the error persists, please restart the IDE.

The old MSBuild tasks and targets were being used after they have
been updated. Now when an MSBuild import has changed in a project
the remote MSBuild host is shutdown to ensure the correct tasks are
used.

Fixes VSTS #576301 - Getting "Could not load file or assembly
'Xamarin.Forms.Xaml" when update forms version to prerelease and build
project
Fixes VSTS #571579 - Reopen solution needed after updating Xamarin.Forms
package