### PR TITLE
[Loc] Choose pt_BR in case of any Portuguese langauge being chosen

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -274,7 +274,7 @@
 		<string>ja</string>
 		<string>ko</string>
 		<string>pl</string>
-		<string>pt-BR</string>
+		<string>pt</string>
 		<string>ru</string>
 		<string>tr</string>
 		<string>zh-Hans</string>


### PR DESCRIPTION
This fixes the IDE to choose pt_BR in case of any of the Portuguese
languages being chosen for Mac. So if any portuguese language is set
as Preferred Language first in the IDE options, it will map to
pt_BR due to the mapping in Gettext.cs

Fixes VSTS #591378 - [Feedback] Default UI Language preference does not reflect system settings