### PR TITLE
[Core] Cache evaluated source files

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -542,12 +542,8 @@ namespace MonoDevelop.Projects
 			// pre-load the results with the current list of files in the project
 			var results = new List<ProjectFile> ();
 
-			var buildActions = GetBuildActions ().Where (a => a != "Folder" && a != "--").ToArray ();
-
-			var config = configuration != null ? GetConfiguration (configuration) : null;
-			var pri = await CreateProjectInstaceForConfigurationAsync (config?.Name, config?.Platform, false);
-			foreach (var it in pri.EvaluatedItems.Where (i => buildActions.Contains (i.Name)))
-				results.Add (CreateProjectFile (it));
+			var evaluatedItems = await GetEvaluatedSourceFiles (configuration);
+			results.AddRange (evaluatedItems);
 
 			// add in any compile items that we discover from running the CoreCompile dependencies
 			var evaluatedCompileItems = await GetCompileItemsFromCoreCompileDependenciesAsync (monitor, configuration);
@@ -555,6 +551,49 @@ namespace MonoDevelop.Projects
 			results.AddRange (addedItems);
 
 			return results.ToArray ();
+		}
+
+		object evaluatedSourceFilesLock = new object ();
+		string evaluatedSourceFilesConfiguration;
+		TaskCompletionSource<ImmutableList<ProjectFile>.Builder> evaluatedSourceFilesTask;
+
+		async Task<ImmutableList<ProjectFile>.Builder> GetEvaluatedSourceFiles (ConfigurationSelector configuration)
+		{
+			bool startTask = false;
+			TaskCompletionSource<ImmutableList<ProjectFile>.Builder> currentTask = null;
+			var config = configuration != null ? GetConfiguration (configuration) : null;
+
+			lock (evaluatedSourceFilesLock) {
+				if (evaluatedSourceFilesTask == null || evaluatedSourceFilesConfiguration != config?.Id) {
+					// The configuration changed or query not yet done
+					evaluatedSourceFilesConfiguration = config?.Id;
+					evaluatedSourceFilesTask = new TaskCompletionSource<ImmutableList<ProjectFile>.Builder> ();
+					startTask = true;
+				}
+				currentTask = evaluatedSourceFilesTask;
+			}
+
+			if (startTask) {
+				var buildActions = GetBuildActions ().Where (a => a != "Folder" && a != "--").ToArray ();
+				var results = ImmutableList.CreateBuilder<ProjectFile> ();
+
+				var pri = await CreateProjectInstaceForConfigurationAsync (config?.Name, config?.Platform, false);
+				foreach (var it in pri.EvaluatedItems.Where (i => buildActions.Contains (i.Name)))
+					results.Add (CreateProjectFile (it));
+
+				currentTask.SetResult (results);
+			}
+
+			return await currentTask.Task;
+		}
+
+		protected override Task OnClearCachedData ()
+		{
+			lock (evaluatedSourceFilesLock) {
+				evaluatedSourceFilesConfiguration = null;
+				evaluatedSourceFilesTask = null;
+			}
+			return base.OnClearCachedData ();
 		}
 
 		/// <summary>


### PR DESCRIPTION
If the configuration has not changed and the project has not been
modified then the files returned from Project.GetSourceFilesAsync
will be returned from a cached result. This prevents the project
being re-evaluated each time this method is called.

Currently repeated calls to GetSourceFilesAsync only occur when
the project has files that need to be generated. The project's
PerformGeneratorAsync method calls GetProjectFileTimestamps which
then calls GetSourceFilesAsync. Note that the GetProjectFileTimestamps
will most likely be removed with the file watcher integration since
it is only used to programmatically generate FileService.FileChanged
events which would be automatically generated by the file watcher.

Fixes VSTS #620341 - Cache evaluated source files.