### PR TITLE
[TextEditor] Set editor container's text direction as LTR

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.cs
@@ -82,6 +82,7 @@ namespace Mono.TextEditor
 
 		internal MonoTextEditor (TextDocument doc, ITextEditorOptions options, EditMode initialMode) 
 		{
+			this.Direction = TextDirection.Ltr;
 			uiThread = Thread.CurrentThread;
 			GtkWorkarounds.FixContainerLeak (this);
 			WidgetFlags |= WidgetFlags.NoWindow;


### PR DESCRIPTION
This fixes broken-looking indentation for RTL languages like
Hebrew. It also fixes another issue I observed where inserting
text after a // comment in Hebrew would actually insert it
before the comment.

Fixes VSTS #577636