### PR TITLE
[NuGet] Fix test failing on Wrench

### DIFF
--- a/main/tests/test-projects/FormsUpdatePackageRef/NetStandardProject/NetStandardProject.csproj
+++ b/main/tests/test-projects/FormsUpdatePackageRef/NetStandardProject/NetStandardProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Change the .NET Standard project to use .NET Standard 1.6 instead of
2.0. The test now works when .NET Core 2.0 SDK is not installed. This
fixes the UpdateXamarinFormsNuGetPackageReference_ThenBuild test which
was failing Wrench.