### PR TITLE
[d15-7][Ide] Add code completion stats counter

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
@@ -34,6 +34,7 @@ namespace MonoDevelop.Core.Instrumentation
 	{
 		void Trace (string message);
 		void End ();
+		TimeSpan Duration { get; }
 	}
 	
 	class DummyTimerCounter: ITimeTracker
@@ -49,6 +50,8 @@ namespace MonoDevelop.Core.Instrumentation
 		public void Dispose ()
 		{
 		}
+
+		public TimeSpan Duration { get; }
 	}
 	
 	class TimeCounter: ITimeTracker
@@ -117,6 +120,7 @@ namespace MonoDevelop.Core.Instrumentation
 			}
 
 			stopWatch.Stop ();
+			Duration = stopWatch.Elapsed;
 
 			if (counter.LogMessages) {
 				var time = stopWatch.ElapsedMilliseconds;
@@ -145,6 +149,8 @@ namespace MonoDevelop.Core.Instrumentation
 		{
 			End ();
 		}
+
+		public TimeSpan Duration { get; private set; }
 	}
 	
 	[Serializable]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionStatistics.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionStatistics.cs
@@ -1,0 +1,100 @@
+﻿//
+// CompletionStatistics.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+
+namespace MonoDevelop.Ide.Editor.Extension
+{
+	class CompletionStatistics
+	{
+		TimeSpan maxTime;
+		TimeSpan minTime = TimeSpan.MaxValue;
+		TimeSpan totalTime;
+		TimeSpan? firstTime;
+		int timingsCount;
+		int failureCount;
+		int cancelCount;
+		int successCount;
+
+		public void OnSuccess (TimeSpan duration)
+		{
+			successCount++;
+			AddTime (duration);
+		}
+
+		public void OnFailure (TimeSpan duration)
+		{
+			failureCount++;
+			AddTime (duration);
+		}
+
+		public void OnUserCanceled (TimeSpan duration)
+		{
+			cancelCount++;
+			AddTime (duration);
+		}
+
+		void AddTime (TimeSpan duration)
+		{
+			if (duration > maxTime) {
+				maxTime = duration;
+			}
+
+			if (duration < minTime) {
+				minTime = duration;
+			}
+
+			if (!firstTime.HasValue) {
+				firstTime = duration;
+			}
+
+			totalTime += duration;
+			timingsCount++;
+		}
+
+		public void Report ()
+		{
+			if (timingsCount == 0) {
+				// No timings recorded.
+				return;
+			}
+
+			var metadata = new Dictionary<string, string> ();
+
+			var average = totalTime.TotalMilliseconds / timingsCount;
+			metadata ["AverageDuration"] = average.ToString ();
+			metadata ["FirstDuration"] = firstTime.Value.TotalMilliseconds.ToString ();
+			metadata ["MaximumDuration"] = maxTime.TotalMilliseconds.ToString ();
+			metadata ["MinimumDuration"] = minTime.TotalMilliseconds.ToString ();
+			metadata ["FailureCount"] = failureCount.ToString ();
+			metadata ["SuccessCount"] = successCount.ToString ();
+			metadata ["CancelCount"] = cancelCount.ToString ();
+
+			Counters.CodeCompletionStats.Inc (metadata);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -9654,6 +9654,7 @@
     <Compile Include="MonoDevelop.Ide.Templates\ItemTemplatePackageInstaller.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\TemplatePackageReference.cs" />
     <Compile Include="MonoDevelop.Ide.Templates\MicrosoftTemplateEngineImageLoader.cs" />
+    <Compile Include="MonoDevelop.Ide.Editor.Extension\CompletionStatistics.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.am" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -60,6 +60,7 @@ namespace MonoDevelop.Ide
 		internal static Counter Startup = InstrumentationService.CreateTimerCounter ("IDE Startup", "IDE", id:"Ide.Startup");
 
 		internal static TimerCounter ProcessCodeCompletion = InstrumentationService.CreateTimerCounter ("Process Code Completion", "IDE", id: "Ide.ProcessCodeCompletion", logMessages:false);
+		internal static Counter CodeCompletionStats = InstrumentationService.CreateCounter ("Code Completion Statistics", "IDE", id:"Ide.CodeCompletionStatistics");
 
 		internal static class ParserService {
 			public static TimerCounter FileParsed = InstrumentationService.CreateTimerCounter ("File parsed", "Parser Service");


### PR DESCRIPTION
Code completion timing statis are captured and sent when the document
is closed. The timings include:

1. How long the first code completion took in milliseconds.
2. Minimum code completion time.
3. Maximum code completion time.
4. Average code completion time.
5. Counts of the number of failures, cancellations or successful
code completion events.

Fixes VSTS #620251 - Convert completion telemetry to use statistics
to avoid sending many messages

Needs md-addins change.