### PR TITLE
Fixes missing semantic highlighting after switch to TagBasedSyntaxHightligthing after scrolling

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -97,6 +97,7 @@ namespace Mono.TextEditor
 		{
 			this.roles = roles;
 			this.textArea.TextViewLines = new MdTextViewLineCollection (this);
+			textArea.LayoutChanged += TextAreaLayoutChanged;
 			this.factoryService = factoryService;
             GuardedOperations = this.factoryService.GuardedOperations;
             _spaceReservationStack = new SpaceReservationStack(this.factoryService.OrderedSpaceReservationManagerDefinitions, this);
@@ -115,6 +116,13 @@ namespace Mono.TextEditor
 
 			if (initialize)
 				this.Initialize ();
+		}
+
+		static List<ITextViewLine> emptyTextViewLineList = new List<ITextViewLine> (0);
+		void TextAreaLayoutChanged(object sender, EventArgs args)
+		{
+			//TODO: Properly implement LayoutChanged with all data
+			LayoutChanged?.Invoke (this, new TextViewLayoutChangedEventArgs (new ViewState (this), new ViewState (this), emptyTextViewLineList, emptyTextViewLineList));
 		}
 
 		internal bool IsTextViewInitialized { get { return hasInitializeBeenCalled; } }
@@ -299,8 +307,8 @@ namespace Mono.TextEditor
 		public event EventHandler Closed;
 		public event EventHandler GotAggregateFocus;
 		public event EventHandler LostAggregateFocus;
-#pragma warning disable CS0067
 		public event EventHandler<TextViewLayoutChangedEventArgs> LayoutChanged;
+#pragma warning disable CS0067
 		public event EventHandler ViewportLeftChanged;
 		public event EventHandler ViewportHeightChanged;
 		public event EventHandler ViewportWidthChanged;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -2232,7 +2232,7 @@ namespace Mono.TextEditor
 				foreach (var drawer in margin.MarginDrawer)
 					drawer.Draw (cr, cairoRectangle);
 			}
-			
+			LayoutChanged?.Invoke (this, EventArgs.Empty);
 			if (setLongestLine) 
 				SetHAdjustment ();
 		}
@@ -3578,6 +3578,7 @@ namespace Mono.TextEditor
 		}
 		
 		internal List<MonoTextEditor.EditorContainerChild> containerChildren = new List<MonoTextEditor.EditorContainerChild> ();
+		internal event EventHandler LayoutChanged;
 
 		public void AddTopLevelWidget (Gtk.Widget widget, int x, int y)
 		{


### PR DESCRIPTION
Problem was that Semantic highligthing was generated only for text visible on screen + few lines before and after
But since MonoTextEditor didn't report `LayoutChanged` events SemanticTagger didn't know it needs to update classifications for new area of file hence it didn't work
With this change we notify hence it works...