### PR TITLE
[Ide] Make option deserialization a bit more permissive

### DIFF
--- a/main/tests/Ide.Tests/MonoDevelop.Ide.RoslynServices.Options/MonoDevelopOptionPersisterTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.RoslynServices.Options/MonoDevelopOptionPersisterTests.cs
@@ -88,10 +88,16 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			}
 		}
 
+		class MyCustomClass { public int X; }
+
 		static CodeStyleOption<bool> boolOption =
 			new CodeStyleOption<bool> (true, NotificationOption.Suggestion);
 		static CodeStyleOption<ExpressionBodyPreference> enumOption =
 			new CodeStyleOption<ExpressionBodyPreference> (ExpressionBodyPreference.WhenOnSingleLine, NotificationOption.Suggestion);
+		static CodeStyleOption<string> stringOption =
+			new CodeStyleOption<string> ("testString", NotificationOption.Error);
+		static CodeStyleOption<MyCustomClass> classOption =
+			new CodeStyleOption<MyCustomClass> (new MyCustomClass { X = 1 }, NotificationOption.Error);
 		static NamingStylePreferences namingOption = NamingStylePreferences.Default;
 
 		SerializationTestCase [] SerializationTestCases = {
@@ -100,8 +106,10 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			SerializationTestCase.Ok (PlatformID.Unix),
 			SerializationTestCase.Ok (boolOption, boolOption.ToXElement ().ToString ()),
 			SerializationTestCase.Ok (enumOption, enumOption.ToXElement ().ToString ()),
+			SerializationTestCase.Ok (stringOption, stringOption.ToXElement ().ToString ()),
 			SerializationTestCase.Ok (namingOption, namingOption.CreateXElement ().ToString ()),
 			SerializationTestCase.Ok ("string"),
+			SerializationTestCase.Fail<CodeStyleOption<MyCustomClass>> (classOption, stringOption.ToXElement ().ToString ()),
 		};
 
 		[TestCaseSource (nameof (SerializationTestCases))]
@@ -113,6 +121,7 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 				var optionKey = testCase.Wrap (preferences);
 
 				var property = optionKey.GetPropertyName ();
+				PropertyService.Set (property, null);
 
 				// Try persisting it.
 				Assert.AreEqual (testCase.Success, persister.TryPersist (optionKey, testCase.Value));
@@ -136,11 +145,12 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			SerializationTestCase.Ok<bool?>(true, true),
 			SerializationTestCase.Ok<bool?>(false, false),
 			SerializationTestCase.Ok<bool?>(null, null),
-			SerializationTestCase.Fail<PlatformID>(-1, 1.0),
+			SerializationTestCase.Fail<PlatformID> (-1, 1.0),
 			SerializationTestCase.Fail<PlatformID> (-1, ulong.MaxValue),
 			SerializationTestCase.Ok(namingOption, namingOption.CreateXElement ().ToString()),
 			SerializationTestCase.Ok(boolOption, boolOption.ToXElement ().ToString()),
 			SerializationTestCase.Ok(enumOption, enumOption.ToXElement ().ToString()),
+			SerializationTestCase.Fail<CodeStyleOption<MyCustomClass>>(classOption, stringOption.ToXElement ().ToString()),
 		};
 
 		[TestCaseSource (nameof (DeserializationTestCases))]


### PR DESCRIPTION
Any enum, string or bool value is allowed. Resort to querying FromXElement via reflection on all types and let roslyn bail if anything's wrong

Also, handle a few more test cases

Fixes log spew like
```
ERROR [2018-05-26 02:24:02Z]: Failed to deserialize type: Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption`1[System.String] value: <CodeStyleOption SerializationVersion="1" Type="String" Value="public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async" DiagnosticSeverity="Hidden" />
System.Runtime.Serialization.SerializationException: Serialization error.
  at MonoDevelop.Ide.RoslynServices.Options.MonoDevelopGlobalOptionPersister.Deserialize (System.Object value, System.Type optionType) [0x001b0] in /Users/therzok/Work/md/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/MonoDevelopGlobalOptionPersister.cs:241
  at MonoDevelop.Ide.RoslynServices.Options.MonoDevelopGlobalOptionPersister.TryFetch (Microsoft.CodeAnalysis.Options.OptionKey optionKey, System.Object& value) [0x0004e] in /Users/therzok/Work/md/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/MonoDevelopGlobalOptionPersister.cs:104
ERROR [2018-05-26 02:24:02Z]: Failed to deserialize type: Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption`1[Microsoft.CodeAnalysis.CodeStyle.AccessibilityModifiersRequired] value: <CodeStyleOption SerializationVersion="1" Type="Int32" Value="2" DiagnosticSeverity="Hidden" />
System.Runtime.Serialization.SerializationException: Serialization error.
  at MonoDevelop.Ide.RoslynServices.Options.MonoDevelopGlobalOptionPersister.Deserialize (System.Object value, System.Type optionType) [0x001b0] in /Users/therzok/Work/md/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/MonoDevelopGlobalOptionPersister.cs:241
  at MonoDevelop.Ide.RoslynServices.Options.MonoDevelopGlobalOptionPersister.TryFetch (Microsoft.CodeAnalysis.Options.OptionKey optionKey, System.Object& value) [0x0004e] in /Users/therzok/Work/md/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/MonoDevelopGlobalOptionPersister.cs:104
```