### PR TITLE
Fixes issue #4906 Gutter on the left corrupts when you hover over the

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -2284,9 +2284,7 @@ namespace Mono.TextEditor
 				
 				cr.LineWidth = Options.Zoom;
 				textViewCr.LineWidth = Options.Zoom;
-				textViewCr.Rectangle (textViewMargin.XOffset, 0, Allocation.Width - textViewMargin.XOffset, Allocation.Height);
-				textViewCr.Clip ();
-				
+
 				RenderMargins (cr, textViewCr, cairoArea);
 			
 #if DEBUG_EXPOSE

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -3050,6 +3050,9 @@ namespace Mono.TextEditor
 		{
 //			double xStart = System.Math.Max (area.X, XOffset);
 //			xStart = System.Math.Max (0, xStart);
+			cr.Rectangle (XOffset, 0, textEditor.Allocation.Width - XOffset, textEditor.Allocation.Height);
+			cr.Clip ();
+
 			var correctedXOffset = System.Math.Floor (XOffset) - 1;
 			var extendingMarker = line != null ? (IExtendingTextLineMarker)textEditor.Document.GetMarkers (line).FirstOrDefault (l => l is IExtendingTextLineMarker) : null;
 			isSpaceAbove = extendingMarker != null ? extendingMarker.IsSpaceAbove : false;
@@ -3281,6 +3284,7 @@ namespace Mono.TextEditor
 			DrawScrollShadow (cr, x, y, _lineHeight);
 			if (wrapper != null && wrapper.IsUncached)
 				wrapper.Dispose ();
+			cr.ResetClip ();
 		}
 
 		void DrawScrollShadow (Cairo.Context cr, double x, double y, double _lineHeight)


### PR DESCRIPTION
'...' associated with a compile error

Seems that the clip rectangle is forgotten for the textViewCr when
drawing on other Contexts occur in some - but not all - cases. Moving
the clipping to the text view margin (where it belongs to btw.)
corrects the behavior.