### PR TITLE
Fix VSTS 605711: Incorrect XAML completion for </ContentPage.Re

### DIFF
--- a/main/src/addins/Xml/Completion/XmlMultipleClosingTagCompletionData.cs
+++ b/main/src/addins/Xml/Completion/XmlMultipleClosingTagCompletionData.cs
@@ -44,7 +44,7 @@ namespace MonoDevelop.Xml.Completion
 		{
 			name = finalEl.Name.FullName;
 			description = GettextCatalog.GetString ("Closing tag for '{0}', also closing all intermediate tags", name);
-			name = string.Format ("/{0}>...", name);
+			name = string.Format ("...</{0}>", name);
 			this.intEls = intermediateElements;
 			this.finalEl = finalEl;
 		}
@@ -91,5 +91,11 @@ namespace MonoDevelop.Xml.Completion
 		*/
 		#endregion
 		
+		public override bool IsCommitCharacter (char keyChar, string partialWord)
+		{
+			if (keyChar == '.')
+				return false;
+			return base.IsCommitCharacter (keyChar, partialWord);
+		}
 	}
 }

--- a/main/src/addins/Xml/Completion/XmlTagCompletionData.cs
+++ b/main/src/addins/Xml/Completion/XmlTagCompletionData.cs
@@ -54,7 +54,14 @@ namespace MonoDevelop.Xml.Completion
 			this.element = element;
 			this.closing = closing;
 		}
-		
+
+		public override bool IsCommitCharacter (char keyChar, string partialWord)
+		{
+			if (closing && keyChar == '.')
+				return false;
+			return base.IsCommitCharacter (keyChar, partialWord);
+		}
+
 		public override IconId Icon {
 			get { return closing? Gtk.Stock.GoBack : Gtk.Stock.GoForward; }
 		}
@@ -65,20 +72,6 @@ namespace MonoDevelop.Xml.Completion
 		
 		public override string CompletionText {
 			get { return element; }
-		}
-		
-		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
-		{
-			var buf = window.CompletionWidget;
-			if (buf != null) {
-				//completion context gets nulled from window as soon as we alter the buffer
-				var codeCompletionContext = window.CodeCompletionContext;
-
-				buf.Replace (buf.CaretOffset, 0, element);
-					
-				// Move caret into the middle of the tags
-				buf.CaretOffset = codeCompletionContext.TriggerOffset + cursorOffset;
-			}
 		}
 	}
 }

--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -685,8 +685,9 @@ namespace MonoDevelop.Xml.Editor
 				
 				if (elements.Count == 0) {
 					string name = el.Name.FullName;
-					completionList.Add (new BaseXmlCompletionData("/" + name + ">", Gtk.Stock.GoBack,
-					                                              GettextCatalog.GetString ("Closing tag for '{0}'", name)));
+					completionList.Add (new XmlTagCompletionData ("/" + name + ">", 0, true) {
+						Description = GettextCatalog.GetString ("Closing tag for '{0}'", name)
+					});
 				} else {
 					foreach (XElement listEl in elements) {
 						if (listEl.Name == el.Name)


### PR DESCRIPTION
Added `.` to ignored commit characters for closing element completion. Reason for this is that `.` can be part of element name...
Also moved `...` in front of element name because:
  a) it's more correct since other elements are inserted before
  b) because general code completion logic has weird rule to "ignore" `IsCommitCharacter` if `DisplayText` ends with `.`
Also found bug with `InsertCompletionText` that was attempting to fix caret position but failed, but also failed at inserting text by not removing existing text.