### PR TITLE
Fixes unwanted states using a Expander in CellRenderer

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -318,6 +318,12 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		public BuildOutputCellSelection GetCurrentSelection () => new BuildOutputCellSelection (selectionRow, selectionStart, selectionEnd);
 
+		internal bool IsViewClickable (BuildOutputNode node, Point position)
+		{
+			var view = GetViewStatus (node);
+			return !view.LastRenderExpanderBounds.Contains (position) && view.LastRenderBounds.Contains (position);
+		}
+
 		static Font defaultFont;
 		static Font defaultBoldFont;
 		static Font monospaceFont;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -287,6 +287,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 		const int FontSize = 11;
 		const int MinLayoutWidth = 30;
 
+		const int DefaultExpandClickDelay = 250;
+		DateTime lastExpanderClick = DateTime.Now;
+
 		public Color StrongSelectionColor { get; set; }
 		public Color SelectionColor { get; set; }
 
@@ -713,7 +716,11 @@ namespace MonoDevelop.Ide.BuildOutputView
 			status.CalculateLayout (status.LastRenderBounds, out var layout, out var layoutBounds, out var expanderRect);
 
 			if (expanderRect != Rectangle.Zero && expanderRect.Contains (args.Position)) {
+				if (DateTime.Now.Subtract (lastExpanderClick).TotalMilliseconds < DefaultExpandClickDelay) {
+					return;
+				}
 				status.Expanded = !status.Expanded;
+				lastExpanderClick = DateTime.Now;
 				QueueResize ();
 				return;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -624,7 +624,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 				ParentWidget.Cursor = CursorType.Arrow;
 			}
 
-			CalcLayout (status, Bounds, out var layout, out var layoutBounds, out var expanderRect);
+			CalcLayout (status, status.LastRenderBounds, out var layout, out var layoutBounds, out var expanderRect);
 
 			var insideText = layoutBounds.Contains (args.Position);
 			if (clicking && insideText && selectionRow == node) {
@@ -664,7 +664,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			}
 
-			CalcLayout (status, Bounds, out var layout, out var layoutBounds, out var expanderRect);
+			CalcLayout (status, status.LastRenderBounds, out var layout, out var layoutBounds, out var expanderRect);
 
 			if (expanderRect != Rectangle.Zero && expanderRect.Contains (args.Position)) {
 				status.Expanded = !status.Expanded;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -328,6 +328,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 
 			if (e.Button == PointerButton.Left && e.MultiplePress == 2) {
+				if (!cellView.IsViewClickable (selectedNode, e.Position)) {
+					return;
+				}
 				if (selectedNode.NodeType == BuildOutputNodeType.Warning || selectedNode.NodeType == BuildOutputNodeType.Error) {
 					GoToTask (selectedNode);
 					return;


### PR DESCRIPTION
Our renderer has some issues in managing click events:

* we are handling clicks in renderer and from calling controls, we added additional check to ensure the click is not a managed area only from renderer.
* added a small delay in user click to ensure our renderer is in the correct state
* fixes pipeline order calculating bounds while clicking the expander

Fixes Bugs:

* Output Disclosure Toggles Twice
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/607739

* Flickering observed while expanding code at build output file
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/618855

* After eye marking, sometimes marker jumps at first position inspite of expanding at same location even as space is available
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/619625

* Output Text Snippet Sticks to the Top
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/619857