### PR TITLE
Switch addins.monodevelop.com to HTTPS

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Setup/AddinSetupService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Setup/AddinSetupService.cs
@@ -65,7 +65,7 @@ namespace MonoDevelop.Core.Setup
 			else
 				platform = "Linux";
 			
-			return "http://addins.monodevelop.com/" + level + "/" + platform + "/" + AddinManager.CurrentAddin.Version + "/main.mrep";
+			return "https://addins.monodevelop.com/" + level + "/" + platform + "/" + AddinManager.CurrentAddin.Version + "/main.mrep";
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -163,7 +163,7 @@ namespace MonoDevelop.Core
 			foreach (AddinRepository rep in reps.GetRepositories ()) {
 				if (rep.Url.StartsWith ("http://go-mono.com/md/") || 
 					(rep.Url.StartsWith ("http://monodevelop.com/files/addins/")) ||
-					(rep.Url.StartsWith ("http://addins.monodevelop.com/") && !validUrls.Contains (rep.Url)))
+					(rep.Url.StartsWith ("https://addins.monodevelop.com/") && !validUrls.Contains (rep.Url)))
 					reps.RemoveRepository (rep.Url);
 			}
 			
@@ -188,7 +188,7 @@ namespace MonoDevelop.Core
 			else
 				platform = "Linux";
 			
-			return "http://addins.monodevelop.com/" + quality + "/" + platform + "/" + AddinManager.CurrentAddin.Version + "/main.mrep";
+			return "https://addins.monodevelop.com/" + quality + "/" + platform + "/" + AddinManager.CurrentAddin.Version + "/main.mrep";
 		}
 		
 		static void SetupInstrumentation ()


### PR DESCRIPTION
I've added an SSL certificate for [addins.monodevelop.com](https://addins.monodevelop.com), so we can switch the default generated repo URL from `http` to `https`.