### PR TITLE
Filter facades from NUnit support libs

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AssemblyReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AssemblyReference.cs
@@ -80,6 +80,16 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		public bool IsFrameworkFile => MetadataIsTrue ("FrameworkFile");
 
+		/// <summary>
+		/// Whether the assembly is a facade assembly.
+		/// </summary>
+		public bool IsFacade => ResolvedFrom == "ImplicitlyExpandDesignTimeFacades";
+
+		/// <summary>
+		/// The value of the ResolvedFrom metadata, for example '{GAC}' or 'ImplicitlyExpandDesignTimeFacades'.
+		/// </summary>
+		public string ResolvedFrom => GetMetadata ("ResolvedFrom");
+
 		public IReadOnlyPropertySet Metadata {
 			get { return metadata; }
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -943,7 +943,12 @@ namespace MonoDevelop.Projects
 			if (!noStdLib) {
 				var sa = AssemblyContext.GetAssemblies (TargetFramework).FirstOrDefault (a => a.Name == "System.Core" && a.Package.IsFrameworkPackage);
 				if (sa != null) {
-					var ar = new AssemblyReference (sa.Location);
+					var props = new MSBuildPropertyGroupEvaluated (null);
+					var trueString = "true";
+					var property = new MSBuildPropertyEvaluated (null, "Implicit", trueString, trueString);
+					props.SetProperty (property.Name, property);
+
+					var ar = new AssemblyReference (sa.Location, props);
 					if (!result.Contains (ar))
 						result.Add (ar);
 				}
@@ -985,6 +990,11 @@ namespace MonoDevelop.Projects
 
 		internal protected virtual Task<List<AssemblyReference>> OnGetFacadeAssemblies ()
 		{
+			var sharedProperties = new MSBuildPropertyGroupEvaluated (null);
+			var resolvedFrom = "ImplicitlyExpandDesignTimeFacades";
+			var property = new MSBuildPropertyEvaluated (null, "ResolvedFrom", resolvedFrom, resolvedFrom);
+			sharedProperties.SetProperty (property.Name, property);
+
 			List<AssemblyReference> result = null;
 			var runtime = TargetRuntime ?? Runtime.SystemAssemblyService.DefaultRuntime;
 			var facades = runtime.FindFacadeAssembliesForPCL (TargetFramework);
@@ -993,7 +1003,8 @@ namespace MonoDevelop.Projects
 					continue;
 				if (result == null)
 					result = new List<AssemblyReference> ();
-				var ar = new AssemblyReference (facade);
+
+				var ar = new AssemblyReference (facade, sharedProperties);
 				result.Add (ar);
 			}
 			return Task.FromResult (result);


### PR DESCRIPTION
Updates metadata on the implicit assembly references to match MSBuild, and use this to correctly filter out facades and implicit framework assemblies from the NUnit support libraries.