### PR TITLE
Fix VSTS 623772: IntelliSense in CSS, Json, etc.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -848,7 +848,10 @@ namespace MonoDevelop.Ide.Gui
 			if (analysisDocument != null) {
 				Microsoft.CodeAnalysis.Document doc;
 				try {
-					 doc = RoslynWorkspace.CurrentSolution.GetDocument (analysisDocument);
+					doc = RoslynWorkspace.CurrentSolution.GetDocument (analysisDocument);
+					if (doc == null && RoslynWorkspace.CurrentSolution.ContainsAdditionalDocument (analysisDocument)) {
+						return Task.CompletedTask;
+					}
 				} catch (Exception) {
 					doc = null;
 				}
@@ -867,7 +870,7 @@ namespace MonoDevelop.Ide.Gui
 						return Task.CompletedTask;
 					SubscribeRoslynWorkspace ();
 					analysisDocument = FileName != null ? TypeSystemService.GetDocumentId (this.Project, this.FileName) : null;
-					if (analysisDocument != null && !RoslynWorkspace.IsDocumentOpen(analysisDocument)) {
+					if (analysisDocument != null && !RoslynWorkspace.CurrentSolution.ContainsAdditionalDocument (analysisDocument) && !RoslynWorkspace.IsDocumentOpen(analysisDocument)) {
 						TypeSystemService.InformDocumentOpen (analysisDocument, Editor, this);
 						OnAnalysisDocumentChanged (EventArgs.Empty);
 					}


### PR DESCRIPTION
After a recent change to use Roslyn's SourceTextContainer instead of MonoDevelopSourceTextContainer the text container for an additional document such as .css started being reused across both MonoDevelopWorkspace and WebEditorsRoslynWorkspace. As a result the MonoDevelopWorkspace was overwriting the workspace registration on the document and WebEditorsRoslynWorkspace wasn't finding the document in its workspace.

The problem effectively was because the document belonged to two workspaces at the same time but the registration only allows a single document. This explains why after reopening the document intellisense came back - this is because the association with WebEditorsRoslynWorkspace was restored as the document got readded.

This should fix quite a few issues such as 623772 and 623774.

The solution here is to avoid adding additional documents to the MonoDevelop workspace.

Fixes VSTS #623772.
Fixes VSTS #623774.