### PR TITLE
Fix VSTS 623602: SnapshotSpan is on a different ITextSnapshot than th…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
@@ -62,6 +62,15 @@ namespace Mono.TextEditor
 
 			public ITextSnapshot Snapshot => lineSpan.Snapshot;
 
+			public void TranslateToSnapshot(ITextSnapshot newSnapshot)
+			{
+				if (Snapshot == newSnapshot) {
+					return;
+				}
+
+				lineSpan = lineSpan.TranslateTo (newSnapshot, SpanTrackingMode.EdgeExclusive);
+			}
+
 			public bool IsFirstTextViewLineForSnapshotLine => collection[0] == this;
 
 			public bool IsLastTextViewLineForSnapshotLine => collection[collection.Count - 1] == this;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.cs
@@ -46,6 +46,7 @@ namespace Mono.TextEditor
 		{
 			this.textEditor = textEditor;
 			this.version = this.textEditor.Document.Version;
+			textEditor.TextViewModel.VisualBuffer.ChangedLowPriority += OnVisualBufferChanged;
 		}
 
 		internal void Add (int logicalLineNumber, DocumentLine line)
@@ -102,6 +103,14 @@ namespace Mono.TextEditor
 				} else {
 					return new SnapshotSpan (start.TranslateTo (end.Snapshot, PointTrackingMode.Negative), end);
 				}
+			}
+		}
+
+		internal void OnVisualBufferChanged (object sender, TextContentChangedEventArgs e)
+		{
+			// make sure all lines are on the same snapshot after text changes
+			foreach (MdTextViewLine line in this) {
+				line.TranslateToSnapshot (e.After);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -96,14 +96,15 @@ namespace Mono.TextEditor
 		internal void Initialize (ITextViewModel textViewModel, ITextViewRoleSet roles, IEditorOptions parentOptions, TextEditorFactoryService factoryService, bool initialize = true)
 		{
 			this.roles = roles;
-			this.textArea.TextViewLines = new MdTextViewLineCollection (this);
-			textArea.LayoutChanged += TextAreaLayoutChanged;
 			this.factoryService = factoryService;
             GuardedOperations = this.factoryService.GuardedOperations;
             _spaceReservationStack = new SpaceReservationStack(this.factoryService.OrderedSpaceReservationManagerDefinitions, this);
 
 			this.TextDataModel = textViewModel.DataModel;
 			this.TextViewModel = textViewModel;
+
+			this.textArea.TextViewLines = new MdTextViewLineCollection (this);
+			textArea.LayoutChanged += TextAreaLayoutChanged;
 
 			textBuffer = textViewModel.EditBuffer;
             //			_visualBuffer = textViewModel.VisualBuffer;


### PR DESCRIPTION
…is SnapshotSpan.

After a text change only the lines that were re-rendered were moved to the latest snapshot. This resulted in some lines being on an older snapshot than others.

Now we forcibly advance all lines to the latest snapshot after every change.