### PR TITLE
[TextEditor] Remove leftover change from structured-build-output

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -373,7 +373,6 @@ namespace Mono.TextEditor
 			set {
 				var tmp = IsReadOnly;
 				IsReadOnly = false;
-				ClearFoldSegments();
 				this.ReplaceText(0, this.currentSnapshot.Length, value);
 				ClearUndoBuffer ();
 				IsReadOnly = tmp;


### PR DESCRIPTION
This change was added for some reason I don't remember when we
were using a TextEditor to display the .binlog file, and was left in the
structured-build-output PR.