### PR TITLE
Fix slow code completion caused by AdditionalDocuments

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
@@ -210,21 +210,18 @@ namespace MonoDevelop.Core.Instrumentation
 
 		string DebuggingText {
 			get {
-				if (FirstTrace == null)
-					return string.Empty;
 				var stringBuilder = new StringBuilder ();
-				ToString (stringBuilder, FirstTrace, null);
+				var current = FirstTrace;
+				TimerTrace previous = null;
+				while (current != null) {
+					stringBuilder.Append (previous == null ? "N/A" : (current.Timestamp - previous.Timestamp).ToString (@"ss\.fff"));
+					stringBuilder.Append (" : ");
+					stringBuilder.AppendLine (current.Message);
+					previous = current;
+					current = current.Next;
+				}
 				return stringBuilder.ToString ();
 			}
-		}
-
-		void ToString (StringBuilder stringBuilder, TimerTrace current, TimerTrace previous)
-		{
-			stringBuilder.Append (previous == null ? "N/A" : (current.Timestamp - previous.Timestamp).ToString (@"ss\.fff"));
-			stringBuilder.Append (" : ");
-			stringBuilder.AppendLine (current.Message);
-			if (current.Next != null)
-				ToString (stringBuilder, current.Next, current);
 		}
 	}
 	

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using System.Text;
 
 namespace MonoDevelop.Core.Instrumentation
 {
@@ -196,6 +197,7 @@ namespace MonoDevelop.Core.Instrumentation
 	}
 	
 	[Serializable]
+	[DebuggerDisplay ("{DebuggingText}")]
 	class TimerTraceList
 	{
 		public TimerTrace FirstTrace;
@@ -205,6 +207,25 @@ namespace MonoDevelop.Core.Instrumentation
 		// Timer metadata is stored here, since it may change while the timer is alive.
 		// CounterValue will take the metadata from here.
 		public IDictionary<string, string> Metadata;
+
+		string DebuggingText {
+			get {
+				if (FirstTrace == null)
+					return string.Empty;
+				var stringBuilder = new StringBuilder ();
+				ToString (stringBuilder, FirstTrace, null);
+				return stringBuilder.ToString ();
+			}
+		}
+
+		void ToString (StringBuilder stringBuilder, TimerTrace current, TimerTrace previous)
+		{
+			stringBuilder.Append (previous == null ? "N/A" : (current.Timestamp - previous.Timestamp).ToString (@"ss\.fff"));
+			stringBuilder.Append (" : ");
+			stringBuilder.AppendLine (current.Message);
+			if (current.Next != null)
+				ToString (stringBuilder, current.Next, current);
+		}
 	}
 	
 	[Serializable]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -633,6 +633,8 @@ namespace MonoDevelop.Ide.TypeSystem
 		Tuple<List<DocumentInfo>, List<DocumentInfo>> CreateDocuments (ProjectData projectData, MonoDevelop.Projects.Project p, CancellationToken token, MonoDevelop.Projects.ProjectFile [] sourceFiles, ProjectData oldProjectData)
 		{
 			var documents = new List<DocumentInfo> ();
+			// We don' add additionalDocuments anymore because they were causing slowdown of compilation generation
+			// and no upside to setting additionalDocuments, keeping this around in case this changes in future.
 			var additionalDocuments = new List<DocumentInfo> ();
 			var duplicates = new HashSet<DocumentId> ();
 			// use given source files instead of project.Files because there may be additional files added by msbuild targets
@@ -649,11 +651,6 @@ namespace MonoDevelop.Ide.TypeSystem
 						continue;
 					documents.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));
 				} else {
-					var id = projectData.GetOrCreateDocumentId (f.Name, oldProjectData);
-					if (!duplicates.Add (id))
-						continue;
-					additionalDocuments.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));
-
 					foreach (var projectedDocument in GenerateProjections (f, projectData, p, oldProjectData)) {
 						var projectedId = projectData.GetOrCreateDocumentId (projectedDocument.FilePath, oldProjectData);
 						if (!duplicates.Add (projectedId))


### PR DESCRIPTION
It's not really clear what is purpose of `AdditionalDocuments`. I can't find any use case in Roslyn source code(or MonoDevelop). I also debugged VS Windows and checked on MonoDevelop.Ide.csproj and Wpf application from template, neither had any `AdditionalDocuments`. Problem was at https://github.com/dotnet/roslyn/blob/5b113ae/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs#L202 which iterates over all documents and additionalDocuments and checks for latest version to see if compilation needs to be recalculated. In case of MonoDevelop.Ide.csproj documents were ~1k and additionalDocuments were ~2.8k(.png and other files).
"C#: Got completions" went from  ~1second to ~40ms.
I suspect also other cases where Semantic Model is requested will be faster.

I also added `DebuggerDisplay` for `TmerTraceList` this is result:
![image](https://user-images.githubusercontent.com/774791/40845765-f15d33b2-65b7-11e8-90c6-d3d304f9125f.png)
