### PR TITLE
Remove some editorconfig var suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,9 +73,9 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_indent_switch_labels = false
 
 # Prefer "var" everywhere it's apparent
-csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_for_built_in_types = true:none
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_elsewhere = true:none
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none


### PR DESCRIPTION
Stop suggesting use of var in nonapparent cases. Still allow it. Gets rid of huge amounts of annoying suggestions in the editor.