### PR TITLE
[release-7.6] [Mac] Add binlog to the list of file types handled by the IDE

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -61,6 +61,20 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>monodevelop.sln.icns</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>binlog</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>@APP_NAME@ MSBuild Binary Log</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSIsAppleDefaultForType</key>
+			<true/>
+		</dict>
+		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>cs</string>


### PR DESCRIPTION
Backport of #5004.

/cc @Therzok