### PR TITLE
Fixes issue #5014 Search window is overdrawn The reset clip call got

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -3284,7 +3284,6 @@ namespace Mono.TextEditor
 			DrawScrollShadow (cr, x, y, _lineHeight);
 			if (wrapper != null && wrapper.IsUncached)
 				wrapper.Dispose ();
-			cr.ResetClip ();
 		}
 
 		void DrawScrollShadow (Cairo.Context cr, double x, double y, double _lineHeight)


### PR DESCRIPTION
introduced with the fix of #4906 it's not needed AFAICT - it just
produced the side effect with the overlay controls.