### PR TITLE
[csharp] Fix invalid string format in SignatureMarkupCreator.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/SignatureMarkupCreator.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/SignatureMarkupCreator.cs
@@ -1080,13 +1080,13 @@ namespace MonoDevelop.CSharp
 						break;
 					} else if (node.Parent is SwitchStatementSyntax) {
 						result.AddCategory (GettextCatalog.GetString ("Form"),
-						                    GettextCatalog.GetString ("{0} (expression) { \n  {1} constant-expression:\n    statement\n    jump-statement\n  [{2}:\n    statement\n    jump-statement]\n}",
+						                    GettextCatalog.GetString ("{0} (expression) {{ \n  {1} constant-expression:\n    statement\n    jump-statement\n  [{2}:\n    statement\n    jump-statement]\n}}",
 						                    Highlight ("switch", GetThemeColor (keywordOther)), Highlight ("case", GetThemeColor (keywordOther)), Highlight ("default", GetThemeColor (keywordOther))));
 						break;
 					}
 				}
 				result.AddCategory (GettextCatalog.GetString ("Form"),
-						            GettextCatalog.GetString ("{0} (Type)\n\nor\n\n{1} (expression) { \n  {2} constant-expression:\n    statement\n    jump-statement\n  [{3}:\n    statement\n    jump-statement]\n}", 
+						            GettextCatalog.GetString ("{0} (Type)\n\nor\n\n{1} (expression) {{ \n  {2} constant-expression:\n    statement\n    jump-statement\n  [{3}:\n    statement\n    jump-statement]\n}}", 
 						                                      Highlight ("default", GetThemeColor (keywordOther)), Highlight ("switch", GetThemeColor (keywordOther)), Highlight ("case", GetThemeColor (keywordOther)), Highlight ("default", GetThemeColor (keywordOther)))
 						           );
 				break;


### PR DESCRIPTION
I cannot reproduce the exact issue but this invalid format string resulted in errors logged on the console output.