### PR TITLE
Fixes issue #5025 Text loses indentation when typing

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -66,7 +66,7 @@ using System.Collections.Immutable;
 namespace MonoDevelop.SourceEditor
 {	
 	partial class SourceEditorView : ViewContent, IBookmarkBuffer, IClipboardHandler, ITextFile,
-		ICompletionWidget,  ISplittable, IFoldable, IToolboxDynamicProvider,
+		ICompletionWidget2,  ISplittable, IFoldable, IToolboxDynamicProvider,
 		ICustomFilteringToolboxConsumer, IZoomable, ITextEditorResolver, ITextEditorDataProvider,
 		ICodeTemplateHandler, ICodeTemplateContextProvider, IPrintable,
 	ITextEditorImpl, ITextMarkerFactory, IUndoHandler
@@ -2010,6 +2010,12 @@ namespace MonoDevelop.SourceEditor
 		}
 		
 		public event EventHandler CompletionContextChanged;
+
+		void ICompletionWidget2.NotifyCompletionWindowClosed ()
+		{
+			GetTextEditorData ().FixVirtualIndentation ();
+		}
+
 		#endregion
 		
 		#region commenting and indentation

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -3446,5 +3446,8 @@ namespace MonoDevelop.SourceEditor
 				return this.TextEditor.HasFocus;
 			}
 		}
+
+		bool ITextEditorImpl.LockFixIndentation { get => TextEditor.GetTextEditorData ().LockFixIndentation; set => TextEditor.GetTextEditorData ().LockFixIndentation = value; }
+
 	}
 } 

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextEditorData.cs
@@ -653,13 +653,21 @@ namespace Mono.TextEditor
 			FixVirtualIndentation (Caret.Line);
 		}
 
+		public bool LockFixIndentation { get; set; }
+
 		public void FixVirtualIndentation (int lineNumber)
 		{
-			if (!HasIndentationTracker || Options.IndentStyle != IndentStyle.Virtual)
+			if (!HasIndentationTracker || Options.IndentStyle != IndentStyle.Virtual || LockFixIndentation)
 				return;
 			var line = Document.GetLine (lineNumber);
-			if (line != null && line.Length > 0 && GetIndentationString (lineNumber, line.Length + 1) == Document.GetTextAt (line.Offset, line.Length))
+			if (line == null || line.Length == 0)
+				return;
+			var indentString = GetIndentationString (lineNumber, line.Length + 1);
+			if (indentString.Length != line.Length)
+				return;
+			if (indentString == Document.GetTextAt (line.Offset, line.Length)) {
 				Remove (line.Offset, line.Length);
+			}
 		}
 
 		void CaretPositionChanged (object sender, DocumentLocationEventArgs args)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/TextChangeEventArgs.cs
@@ -129,6 +129,11 @@ namespace MonoDevelop.Core.Text
 				return InsertionLength - RemovalLength;
 			}
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("[TextChange: Offset={0}, NewOffset={1}, RemovedText={2}, InsertedText={3}]", Offset, NewOffset, RemovedText?.Text, InsertedText?.Text);
+		}
 	}
 
 	/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
@@ -224,6 +224,8 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		public void HideWindow ()
 		{
+			if (CompletionWidget is ITextEditorImpl impl)
+				impl.FixVirtualIndentation ();
 			HideDeclarationView ();
 			view.Hide ();
 			ReleaseObjects ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
@@ -224,8 +224,8 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		public void HideWindow ()
 		{
-			if (CompletionWidget is ITextEditorImpl impl)
-				impl.FixVirtualIndentation ();
+			if (CompletionWidget is ICompletionWidget2 widget2)
+				widget2.NotifyCompletionWindowClosed ();
 			HideDeclarationView ();
 			view.Hide ();
 			ReleaseObjects ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ICompletionWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ICompletionWidget.cs
@@ -59,4 +59,10 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		event EventHandler CompletionContextChanged;
 	}
+
+	// TODO: Join with ICompletionWidget on next public API break.
+	interface ICompletionWidget2 : ICompletionWidget
+	{
+		void NotifyCompletionWindowClosed ();
+	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
@@ -134,7 +134,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 			if (!IsActiveExtension ())
 				return base.KeyPress (descriptor);
 			bool res;
-			if (CurrentCompletionContext != null) {
+			if (CurrentCompletionContext != null && CompletionWindowManager.Wnd != null) {
 				if (CompletionWindowManager.PreProcessKeyEvent (descriptor)) {
 					CompletionWindowManager.PostProcessKeyEvent (descriptor);
 					autoHideCompletionWindow = true;
@@ -163,8 +163,14 @@ namespace MonoDevelop.Ide.Editor.Extension
 				deleteOrBackspaceTriggerChar = Editor.GetCharAt (Editor.CaretOffset);
 			if (descriptor.SpecialKey == SpecialKey.BackSpace && Editor.CaretOffset > 0)
 				deleteOrBackspaceTriggerChar = Editor.GetCharAt (Editor.CaretOffset - 1);
-			
-			res = base.KeyPress (descriptor);
+			var impl = Editor.GetContent<ITextEditorImpl> ();
+			if (CompletionWindowManager.IsVisible)
+				impl.LockFixIndentation = true;
+			try {
+				res = base.KeyPress (descriptor);
+			} finally {
+				impl.LockFixIndentation = false;
+			}
 			if (Editor.EditMode == EditMode.TextLink && Editor.TextLinkPurpose == TextLinkPurpose.Rename) {
 				return res;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/KeyDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/KeyDescriptor.cs
@@ -39,6 +39,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 		public static KeyDescriptor PageUp = new KeyDescriptor (SpecialKey.PageUp, '\t', ModifierKeys.None, null);
 		public static KeyDescriptor PageDown = new KeyDescriptor (SpecialKey.PageDown, '\t', ModifierKeys.None, null);
 		public static KeyDescriptor Return = new KeyDescriptor (SpecialKey.Return, '\t', ModifierKeys.None, null);
+		public static KeyDescriptor Backspace = new KeyDescriptor (SpecialKey.BackSpace, '\t', ModifierKeys.None, null);
 
 		public readonly SpecialKey SpecialKey;
 		public readonly char KeyChar;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/InternalExtensionAPI/ITextEditorImpl.cs
@@ -224,6 +224,7 @@ namespace MonoDevelop.Ide.Editor
 
 		void GrabFocus ();
 		bool HasFocus { get; }
+		bool LockFixIndentation { get; set; }
 
 		event EventHandler<LineEventArgs> LineShowing;
 		event EventHandler FocusLost;

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompletionTextEditorTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompletionTextEditorTests.cs
@@ -40,6 +40,9 @@ using NUnit.Framework;
 using MonoDevelop.Debugger;
 using Mono.Debugging.Client;
 using System.Threading;
+using MonoDevelop.Ide.Editor;
+using MonoDevelop.SourceEditor;
+using Gtk;
 
 namespace MonoDevelop.CSharpBinding
 {
@@ -152,12 +155,12 @@ namespace console61
 
 		}
 
-		Task TestCompletion (string text, Action<Document, ICompletionDataList> action)
+		Task TestCompletion (string text, Action<Document, ICompletionDataList> action, Action<Document> preCompletionAction = null)
 		{
-			return TestCompletion (text, action, CompletionTriggerInfo.CodeCompletionCommand);
+			return TestCompletion (text, action, CompletionTriggerInfo.CodeCompletionCommand, preCompletionAction);
 		}
 
-		async Task TestCompletion (string text, Action<Document, ICompletionDataList> action, CompletionTriggerInfo triggerInfo)
+		async Task TestCompletion (string text, Action<Document, ICompletionDataList> action, CompletionTriggerInfo triggerInfo, Action<Document> preCompletionAction = null)
 		{
 			int endPos = text.IndexOf ('$');
 			if (endPos >= 0)
@@ -165,6 +168,8 @@ namespace console61
 
 			using (var testCase = await SetupTestCase (text, cursorPosition: Math.Max (0, endPos))) {
 				var doc = testCase.Document;
+				if (preCompletionAction != null)
+					preCompletionAction (doc);
 
 				var compExt = doc.GetContent<CSharpCompletionTextEditorExtension> ();
 				compExt.CurrentCompletionContext = new CodeCompletionContext {
@@ -313,5 +318,76 @@ namespace console61
 				Assert.AreEqual (1, completionResult.ExpressionLength);
 			}
 		}
+
+
+		/// <summary>
+		/// Text loses indentation when typing #5025
+		/// </summary>
+		[Test]
+		public async Task TestIssue5025 ()
+		{
+			IdeApp.Preferences.AddImportedItemsToCompletionList.Value = true;
+			await TestCompletion (@"
+namespace console61
+{
+    class MainClass
+    {
+        public static void Main (string[] args)
+        {
+            t$
+        }
+    }
+}
+",
+								  (doc, list) => {
+									  var extEditor = GetExtensibleEditor (doc.Editor);
+									  var compExt = doc.GetContent<CSharpCompletionTextEditorExtension> ();
+									  CompletionWindowManager.StartPrepareShowWindowSession ();
+									  extEditor.EditorExtension = compExt;
+									  extEditor.OnIMProcessedKeyPressEvent (Gdk.Key.BackSpace, '\0', Gdk.ModifierType.None);
+									  var listWindow = new CompletionListWindow ();
+									  var widget = new NamedArgumentCompletionTests.TestCompletionWidget (doc.Editor, doc);
+									  listWindow.CompletionWidget = widget;
+									  listWindow.CodeCompletionContext = widget.CurrentCodeCompletionContext;
+									  var item = (RoslynCompletionData)list.FirstOrDefault (d => d.CompletionText == "MainClass");
+									  KeyActions ka = KeyActions.Process;
+									  Gdk.Key key = Gdk.Key.Tab;
+									  item.InsertCompletionText (doc.Editor, doc, ref ka, KeyDescriptor.FromGtk (key, (char)key, Gdk.ModifierType.None));
+									  Assert.AreEqual (@"
+namespace console61
+{
+    class MainClass
+    {
+        public static void Main (string[] args)
+        {
+            MainClass
+        }
+    }
+}
+", doc.Editor.Text);
+								  });
+		}
+
+		internal static ExtensibleTextEditor GetExtensibleEditor (TextEditor editor)
+	{
+		//Reason why we use GetNativeWidget, and navigate to ExtensibleTextEditor child
+		//and execute KeyPress on it instead something more abstract is...
+		//EditSession key processing is done inside ExtensibleTextEditor.
+		return FindChild<ExtensibleTextEditor> (editor.GetNativeWidget<Container> ());
+	}
+
+	static T FindChild<T> (Container container) where T : Widget
+	{
+		foreach (var child in container.Children)
+			if (child is T) {
+				return (T)child;
+			} else if (child is Container) {
+				var foundChild = FindChild<T> ((Container)child);
+				if (foundChild != null)
+					return foundChild;
+			}
+		return default (T);
+	}
+
 	}
 }

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/NamedArgumentCompletionTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/NamedArgumentCompletionTests.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.CSharpBinding
 			yield return new CSharpCompletionTextEditorExtension ();
 		}
 
-		class TestCompletionWidget : ICompletionWidget
+		internal class TestCompletionWidget : ICompletionWidget
 		{
 			DocumentContext documentContext;
 


### PR DESCRIPTION
The virtual indent behavior was quite broken in the completion window
case. This should stop virtual indent to interfere with completion and
indent should be corrected after the completion session ends.