### PR TITLE
[Core] Fix null reference when opening SDK style project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -234,7 +234,11 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public IEnumerable<MSBuildItem> FindGlobItemsIncludingFile (string include)
 		{
-			return engine?.FindGlobItemsIncludingFile (projectInstance, include);
+			var currentEngine = engine;
+			var currentProjectInstance = projectInstance;
+			if (currentEngine == null || currentProjectInstance == null)
+				return null;
+			return currentEngine.FindGlobItemsIncludingFile (currentProjectInstance, include);
 		}
 
 		internal IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (string include, MSBuildItem globItem)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -243,7 +243,11 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (string include, MSBuildItem globItem)
 		{
-			return engine?.FindUpdateGlobItemsIncludingFile (projectInstance, include, globItem);
+			var currentEngine = engine;
+			var currentProjectInstance = projectInstance;
+			if (currentEngine == null || currentProjectInstance == null)
+				return null;
+			return currentEngine.FindUpdateGlobItemsIncludingFile (currentProjectInstance, include, globItem);
 		}
 
 		/// <summary>


### PR DESCRIPTION
On opening a SDK style project sometimes a null reference exception
was logged.

```
System.NullReferenceException: Object reference not set to an instance
of an object
  at MonoDevelop.Projects.MSBuild.DefaultMSBuildEngine+<FindGlobItemsIncludingFile>d__85.MoveNext ()
  in MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs:1441
  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].MoveNext ()
  in System/Linq/Where.cs:140
  at MonoDevelop.Projects.Project.OnFileCreatedExternally (System.String fileName)
  in MonoDevelop.Projects/Project.cs:4293
  at MonoDevelop.Projects.Project+<>c__DisplayClass338_0.<OnFileCreated>b__0 ()
  in MonoDevelop.Projects/Project.cs:4258
```

This was difficult to reproduce. In the end adding a Thread.Sleep in
MSBuildProjectInstance's Dispose and Evaluate methods between where
the engine is set and the projectInstance is set was a way to make it
happen more consistently. So the problem seems to be that if a file
is generated externally when the engine is not null but the
projectInstance is null then a null reference exception would occur.
Now the projectInstance being null is handled. The file being
generated on project load was a .tmp file that would not be added
to the project.

Fixes VSTS #611795 - NRE when file externally added