### PR TITLE
[MSBuild] Use the global collection when evaluating projets

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
@@ -39,7 +39,7 @@ namespace MonoDevelop.Projects.MSBuild
 	{
 		static CultureInfo uiCulture;
 		readonly Dictionary<string, string> unsavedProjects = new Dictionary<string, string> ();
-		readonly ProjectCollection engine = new ProjectCollection { DefaultToolsVersion = MSBuildConsts.Version };
+		readonly ProjectCollection engine = ProjectCollection.GlobalProjectCollection;
 		MSBuildLoggerAdapter loggerAdapter;
 
 		IEngineLogWriter sessionLogWriter;

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -85,7 +85,6 @@ namespace MonoDevelop.Projects.MSBuild
 							foreach (var p in globalProperties)
 								project.SetGlobalProperty (p.Key, p.Value);
 						}
-						project.ReevaluateIfNecessary ();
 					}
 
 					// Building the project will create items and alter properties, so we use a new instance
@@ -134,7 +133,6 @@ namespace MonoDevelop.Projects.MSBuild
 							project.RemoveGlobalProperty (p.Key);
 						foreach (var p in originalGlobalProperties)
 							project.SetGlobalProperty (p.Key, p.Value);
-						project.ReevaluateIfNecessary ();
 					}
 				}
 			});
@@ -197,15 +195,12 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 
-			bool reevaluate = false;
-
 			if (p.GetPropertyValue ("Configuration") != configuration || (p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
 				p.SetGlobalProperty ("Configuration", configuration);
 				if (!string.IsNullOrEmpty (platform))
 					p.SetGlobalProperty ("Platform", platform);
 				else
 					p.RemoveGlobalProperty ("Platform");
-				reevaluate = true;
 			}
 
 			// The CurrentSolutionConfigurationContents property only needs to be set once
@@ -214,11 +209,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			if (!buildEngine.BuildOperationStarted && this.file == file && p.GetPropertyValue ("CurrentSolutionConfigurationContents") != slnConfigContents) {
 				p.SetGlobalProperty ("CurrentSolutionConfigurationContents", slnConfigContents);
-				reevaluate = true;
 			}
-
-			if (reevaluate)
-				p.ReevaluateIfNecessary ();
 
 			return p;
 		}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -188,8 +188,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 					// Use the engine's default tools version to load the project. We want to build with the latest
 					// tools version.
-					string toolsVersion = engine.DefaultToolsVersion;
-					p = new Project (projectRootElement, engine.GlobalProperties, toolsVersion, engine);
+					p = new Project (projectRootElement, engine.GlobalProperties, MSBuildConsts.Version, engine);
 				}
 			}
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -183,7 +183,12 @@ namespace MonoDevelop.Projects.MSBuild
 				else {
 					if (!string.IsNullOrEmpty (projectDir) && Directory.Exists (projectDir))
 						Environment.CurrentDirectory = projectDir;
-					var projectRootElement = ProjectRootElement.Create (new XmlTextReader (new StringReader (content)));
+
+					var settings = new XmlReaderSettings {
+						DtdProcessing = DtdProcessing.Ignore,
+						IgnoreWhitespace = true,
+					};
+					var projectRootElement = ProjectRootElement.Create (XmlReader.Create (new StringReader (content), settings), engine);
 					projectRootElement.FullPath = file;
 
 					// Use the engine's default tools version to load the project. We want to build with the latest


### PR DESCRIPTION
Optimizes MSBuild evaluation by reducing the total number of evaluations and reusing the same project collection when evaluating.