### PR TITLE
[Core] Fix editor errors when .NET Standard assembly referenced

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -460,6 +460,35 @@ namespace MonoDevelop.Core.Assemblies
 			return false;
 		}
 
+		static Dictionary<string, bool> facadeReferenceDict = new Dictionary<string, bool> ();
+
+		static bool RequiresFacadeAssembliesInternal (string fileName)
+		{
+			bool result;
+			if (facadeReferenceDict.TryGetValue (fileName, out result))
+				return result;
+
+			AssemblyDefinition assembly = null;
+			try {
+				try {
+					assembly = Mono.Cecil.AssemblyDefinition.ReadAssembly (fileName);
+				} catch {
+					return false;
+				}
+				foreach (var r in assembly.MainModule.AssemblyReferences) {
+					// Don't compare the version number since it may change depending on the version of .net standard
+					if (r.Name.Equals ("System.Runtime") || r.Name.Equals ("netstandard")) {
+						facadeReferenceDict [fileName] = true; ;
+						return true;
+					}
+				}
+			} finally {
+				assembly?.Dispose ();
+			}
+			facadeReferenceDict [fileName] = false;
+			return false;
+		}
+
 		static object referenceLock = new object ();
 		public static bool ContainsReferenceToSystemRuntime (string fileName)
 		{
@@ -474,6 +503,23 @@ namespace MonoDevelop.Core.Assemblies
 			try {
 				await referenceLockAsync.WaitAsync ().ConfigureAwait (false);
 				return ContainsReferenceToSystemRuntimeInternal (filename);
+			} finally {
+				referenceLockAsync.Release ();
+			}
+		}
+
+		internal static bool RequiresFacadeAssemblies (string fileName)
+		{
+			lock (referenceLock) {
+				return RequiresFacadeAssembliesInternal (fileName);
+			}
+		}
+
+		internal static async System.Threading.Tasks.Task<bool> RequiresFacadeAssembliesAsync (string filename)
+		{
+			try {
+				await referenceLockAsync.WaitAsync ().ConfigureAwait (false);
+				return RequiresFacadeAssembliesInternal (filename);
 			} finally {
 				referenceLockAsync.Release ();
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -490,6 +490,8 @@ namespace MonoDevelop.Core.Assemblies
 		}
 
 		static object referenceLock = new object ();
+
+		[Obsolete ("Use RequiresFacadeAssemblies (string fileName)")]
 		public static bool ContainsReferenceToSystemRuntime (string fileName)
 		{
 			lock (referenceLock) {
@@ -498,6 +500,8 @@ namespace MonoDevelop.Core.Assemblies
 		}
 
 		static SemaphoreSlim referenceLockAsync = new SemaphoreSlim (1, 1);
+
+		[Obsolete ("Use RequiresFacadeAssembliesAsync (string fileName)")]
 		public static async System.Threading.Tasks.Task<bool> ContainsReferenceToSystemRuntimeAsync (string filename)
 		{
 			try {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -964,7 +964,7 @@ namespace MonoDevelop.Projects
 					} else {
 						fullPath = Path.GetFullPath (refFilename.FilePath);
 					}
-					if (await SystemAssemblyService.ContainsReferenceToSystemRuntimeAsync (fullPath)) {
+					if (await SystemAssemblyService.RequiresFacadeAssembliesAsync (fullPath)) {
 						addFacadeAssemblies = true;
 						break;
 					}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -51,6 +51,22 @@ namespace MonoDevelop.Core.Assemblies
 			Assert.That(result, Is.EqualTo(withSystemRuntime));
 		}
 
+		[TestCase (true, "System.Collections.Immutable.dll")]
+		[TestCase (false, "MonoDevelop.Core.dll")]
+		public void RequiresFacadeAssemblies (bool addFacades, string relativeDllPath)
+		{
+			var result = SystemAssemblyService.RequiresFacadeAssemblies (relativeDllPath);
+			Assert.That (result, Is.EqualTo (addFacades));
+		}
+
+		[TestCase (true, "System.Collections.Immutable.dll")]
+		[TestCase (false, "MonoDevelop.Core.dll")]
+		public async Task RequiresFacadeAssembliesAsync (bool addFacades, string relativeDllPath)
+		{
+			var result = await SystemAssemblyService.RequiresFacadeAssembliesAsync (relativeDllPath);
+			Assert.That (result, Is.EqualTo (addFacades));
+		}
+
 		[Test]
 		public void CheckReferencesAreOk()
 		{

--- a/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections.sln
+++ b/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "iOSImmutableCollections", "iOSImmutableCollections\iOSImmutableCollections.csproj", "{548A1099-6C66-410D-9D72-CD5105E51D9D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{548A1099-6C66-410D-9D72-CD5105E51D9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{548A1099-6C66-410D-9D72-CD5105E51D9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{548A1099-6C66-410D-9D72-CD5105E51D9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{548A1099-6C66-410D-9D72-CD5105E51D9D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections/MyClass.cs
+++ b/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections/MyClass.cs
@@ -1,0 +1,15 @@
+﻿
+using System;
+using System.Collections.Immutable;
+
+namespace iOSImmutableCollections
+{
+	public class MyClass
+	{
+		ImmutableArray<int> array = ImmutableArray<int>.Empty;
+
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("iOSImmutableCollections")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Microsoft")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections/iOSImmutableCollections.csproj
+++ b/main/tests/test-projects/iOSImmutableCollections/iOSImmutableCollections/iOSImmutableCollections.csproj
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{548A1099-6C66-410D-9D72-CD5105E51D9D}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>iOSImmutableCollections</RootNamespace>
+    <AssemblyName>iOSImmutableCollections</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <IOSDebuggerPort>50484</IOSDebuggerPort>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>


### PR DESCRIPTION
With a Xamarin.iOS project that uses an assembly that is compiled
for .NET Standard, such as the assembly used in the
System.Collections.Immutable NuGet package, the facade assemblies
were not being included in the list of referenced assemblies given
to the type system. This then resulted in the text editor showing
errors even though the project could be compiled without succesfully.
The error displayed was similar to:

    The type 'ValueType' is defined in an assembly that is not
    referenced. You must add a reference to assembly 'netstandard,
    Version=2.0.0.0, Culture=neutral, PublicKeytoken=cc7b1dffcd2ddd51'.

A short term fix has been added here. A check is made to determine if
the assembly referencing netstandard and if so the facade assemblies
are included. Previously only a check was made for the assembly
referencing System.Runtime. Ideally the information would be found by
using MSBuild.

Fixes VSTS #632353 - Editor doesn't work with .NET Standard 2 NuGets