### PR TITLE
[DotNetCore] Fix default build action for new file

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
@@ -250,6 +251,92 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.IsTrue (project.UseDefaultMetadataForExcludedExpandedItems);
 			Assert.IsTrue (project.UseAdvancedGlobSupport);
 			Assert.IsTrue (project.UseFileWatcher);
+		}
+
+		/// <summary>
+		/// ASP.NET Core projects have different build actions for files in the wwwroot folder. This
+		/// tests that the correct build actions are used for different folders.
+		/// </summary>
+		[Test]
+		public async Task AspNetCoreProject_DefaultBuildActions ()
+		{
+			string projectFileName = Util.GetSampleProject ("aspnetcore", "aspnetcore.csproj");
+			using (var project = (DotNetProject) await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFileName)) {
+
+				var fileName = project.BaseDirectory.Combine ("test.txt");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("MyClass.cs");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("Compile", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("MyPage.html");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("MyPage.cshtml");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("Content", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("settings.json");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("Content", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("test.config");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("Content", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("MyPage.resx");
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("EmbeddedResource", project.GetDefaultBuildAction (fileName));
+
+				fileName = project.BaseDirectory.Combine ("wwwroot", "MyPage.html");
+				Directory.CreateDirectory (fileName.ParentDirectory);
+				File.WriteAllText (fileName, string.Empty);
+				Assert.AreEqual ("Content", project.GetDefaultBuildAction (fileName));
+			}
+		}
+
+		[Test]
+		public async Task DotNetCoreProject_DefaultBuildActions ()
+		{
+			string solutionFileName = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-sdk-console.sln");
+			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllProjects ().Single ();
+
+			var fileName = project.BaseDirectory.Combine ("test.txt");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("MyClass.cs");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("Compile", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("MyPage.html");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("MyPage.cshtml");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("settings.json");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("test.config");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("MyPage.resx");
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("EmbeddedResource", project.GetDefaultBuildAction (fileName));
+
+			fileName = project.BaseDirectory.Combine ("wwwroot", "MyPage.html");
+			Directory.CreateDirectory (fileName.ParentDirectory);
+			File.WriteAllText (fileName, string.Empty);
+			Assert.AreEqual ("None", project.GetDefaultBuildAction (fileName));
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -692,5 +692,20 @@ namespace MonoDevelop.DotNetCore
 					await extension.GetTransitiveAssemblyReferences (traversedProjects, references, configuration, false, token);
 			}
 		}
+
+		/// <summary>
+		/// ASP.NET Core projects have different build actions if the file is in the wwwroot folder.
+		/// It also uses Content build actions for *.json, *.config and *.cshtml files. To support
+		/// this the default file globs for the file are found and the MSBuild item name is returned.
+		/// </summary>
+		protected override string OnGetDefaultBuildAction (string fileName)
+		{
+			string include = MSBuildProjectService.ToMSBuildPath (Project.ItemDirectory, fileName);
+			var globItems = Project.MSBuildProject.FindGlobItemsIncludingFile (include).ToList ();
+			if (globItems.Count == 1)
+				return globItems [0].Name;
+
+			return base.OnGetDefaultBuildAction (fileName);
+		}
 	}
 }

--- a/main/tests/test-projects/aspnetcore/aspnetcore.csproj
+++ b/main/tests/test-projects/aspnetcore/aspnetcore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adding a new .html file to the wwwroot folder of an ASP.NET Core
project would add the file as a None item instead of a Content
item. This would result in the .html file not being used when
publishing the project. If you use use 'dotnet publish' the
publish directory would not contain the .html file. ASP.NET Core
projects have different build actions for files based on where they
are added. An .html file in the root directory would be a None item
whilst a .html file in the wwwroot directory would be a Content item
by default. To fix this the default build action for a file is
determined from the file glob information available from the .NET
Core SDK.

Fixes VSTS #627227 - Publish the project, content is not the same
as the localhost page.