### PR TITLE
[Core] Fix .xaml.cs intellisense in new Forms .NET Standard project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ItemCollection.cs
@@ -91,10 +91,12 @@ namespace MonoDevelop.Projects
 			AssertCanWrite ();
 
 			list = ImmutableList<T>.Empty.AddRange (items);
-			if (newItems.Any ())
-				OnItemsAdded (newItems);
+			// Remove items first before adding in case there are common filenames to prevent
+			// items being removed from the ProjectFileCollection's files lookup list.
 			if (removedItems.Any ())
 				OnItemsRemoved (removedItems);
+			if (newItems.Any ())
+				OnItemsAdded (newItems);
 		}
 
 		IEnumerable<T> ReuseExistingItems (IEnumerable<T> items)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -431,5 +431,52 @@ namespace MonoDevelop.Projects
 
 			sol.Dispose ();
 		}
+
+		/// <summary>
+		/// Verifies that the .xaml files can be found by ProjectFileCollection's GetFile method
+		/// after the project is re-evaluated after the package references are restored the first time
+		/// for the project. There is a separate lookup cache of files in the ProjectFileCollection.
+		/// </summary>
+		[Test]
+		public async Task ReevaluateXamarinFormsVersion24PackageReference ()
+		{
+			FilePath solFile = Util.GetSampleProject ("NetStandardXamarinForms", "NetStandardXamarinForms.sln");
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (Project)sol.Items [0];
+				var xamlCSharpFile = p.Files.Single (fi => fi.FilePath.FileName == "MyPage.xaml.cs");
+				var xamlFile = p.Files.Single (fi => fi.FilePath.FileName == "MyPage.xaml");
+
+				// No generator set before NuGet restore and re-evaluation.
+				Assert.AreEqual (string.Empty, xamlFile.Generator);
+				// No DependsOn set until NuGet restore and re-evaluation.
+				Assert.AreEqual (string.Empty, xamlCSharpFile.DependsOn);
+
+				var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
+				Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+				Assert.AreEqual (0, process.ExitCode);
+
+				await p.ReevaluateProject (Util.GetMonitor ());
+
+				xamlCSharpFile = p.Files.GetFile (xamlCSharpFile.FilePath);
+				xamlFile = p.Files.GetFile (xamlFile.FilePath);
+
+				Assert.IsNotNull (xamlCSharpFile);
+				Assert.IsNotNull (xamlFile);
+				Assert.AreEqual ("MSBuild:UpdateDesignTimeXaml", xamlFile.Generator);
+				Assert.AreEqual (xamlFile, xamlCSharpFile.DependsOnFile);
+
+				Assert.IsNotNull (p.GetProjectFile (xamlCSharpFile.FilePath));
+				Assert.IsNotNull (p.GetProjectFile (xamlFile.FilePath));
+
+				xamlCSharpFile = p.GetProjectFile (xamlCSharpFile.FilePath);
+				xamlFile = p.GetProjectFile(xamlFile.FilePath);
+
+				Assert.IsNotNull (xamlCSharpFile);
+				Assert.IsNotNull (xamlFile);
+				Assert.AreEqual ("MSBuild:UpdateDesignTimeXaml", xamlFile.Generator);
+				Assert.AreEqual (xamlFile, xamlCSharpFile.DependsOnFile);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Creating a new Xamarin.Forms .NET Standard project and then
modifing the .xaml to add new named UI items would result in no
intellisense in the .xaml.cs file until the solution was closed
and re-opened. The problem was that the .xaml and .xaml.cs files
were being removed from the ProjectFileCollection's files lookup
list when the project was re-evaluated. On re-evaluation after
the NuGet restore is first done the old MSBuild items for the
.xaml and .xaml.cs file have the wrong metadata, so they need
to be removed, whilst new MSBuild items with the updated metadata
need to be added. To fix this when re-evaluating the items are now
removed first and then added to prevent the newly added items being
removed incorrectly since they have the same filenames.

Fixes VSTS #615578 - Intellisense does not work for auto-generated
field via Xamarin.Forms XAML