### PR TITLE
[15.7] [TextEditor] Ensure preedit is committed before selecting left/right

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -649,7 +649,7 @@ namespace Mono.TextEditor
 
 		void CommitString (string str)
 		{
-			if (!IsRealized || !IsFocus)
+			if (!IsRealized || !IsFocus || String.IsNullOrEmpty(str))
 				return;
 
 			for (int i = 0; i < str.Length; i++) {

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1334,6 +1334,10 @@ namespace Mono.TextEditor
 			pressPositionX = e.X;
 			pressPositionY = e.Y;
 			base.IsFocus = true;
+
+			// If there is anything in the preedit buffer, commit it otherwise text
+			// selection may have the wrong offsets.
+			CommitPreedit ();
 			
 
 			if (lastTime != e.Time) {// filter double clicks

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -746,6 +746,11 @@ namespace MonoDevelop.SourceEditor
 			info.Bypass = HasFocus == false;
 		}
 
+		void EnsurePreeditCommitted()
+		{
+			TextArea.CommitPreedit ();
+		}
+
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineEnd)]
 		internal void OnLineEnd ()
 		{
@@ -875,12 +880,16 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveLeft)]
 		internal void OnSelectionMoveLeft ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveLeft);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveRight)]
 		internal void OnSelectionMoveRight ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveRight);
 		}
 


### PR DESCRIPTION
This is https://github.com/mono/monodevelop/pull/4913 but for 15.7

Before we shift-left or shift-right to select, ensure that the preedit
buffer is committed or the selection can be in the wrong place and
mess things up.

Fixes VSTS #617555

Also commit the preedit string on mouse click. This fixes issues with
text selection when you try to select the last visible character when
there is a preedit string (described in VSTS #617559) and also another
bug I observed that isn't in VSTS where if you click elsewhere in the
text editor while there is a preedit string then text gets moved in a way
that looks very jarring and unpredictable to the user.

Fixes VSTS #617559