### PR TITLE
[NuGet] Fix updating PackageReference removes metadata

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
@@ -65,11 +65,11 @@ namespace MonoDevelop.PackageManagement.Tests
 			return project;
 		}
 
-		void AddDotNetProjectPackageReference (string packageId, string version)
+		ProjectPackageReference AddDotNetProjectPackageReference (string packageId, string version)
 		{
 			var packageReference = ProjectPackageReference.Create (packageId, version);
-
 			dotNetProject.Items.Add (packageReference);
+			return packageReference;
 		}
 
 		Task<bool> UninstallPackageAsync (string packageId, string version)
@@ -193,17 +193,22 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual (MessageLevel.Warning, context.LastLogLevel);
 		}
 
+		/// <summary>
+		/// Original PackageReference in project should be updated with new version and not removed since this
+		/// will keep any custom metadata added to the PackageReference.
+		/// </summary>
 		[Test]
-		public async Task InstallPackageAsync_PackageAlreadyInstalledWithDifferentVersion_OldPackageReferenceIsRemoved ()
+		public async Task InstallPackageAsync_PackageAlreadyInstalledWithDifferentVersion_OldPackageReferenceIsUpdated ()
 		{
 			CreateNuGetProject ("MyProject");
-			AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+			var nunitPackageReference = AddDotNetProjectPackageReference ("NUnit", "2.6.1");
+			nunitPackageReference.Metadata.SetValue ("PrivateAssets", "All");
 
 			bool result = await InstallPackageAsync ("NUnit", "3.6.0");
 
-			var packageReference = dotNetProject.Items.OfType<ProjectPackageReference> ()
-				.Single ()
-				.CreatePackageReference ();
+			var projectPackageReference = dotNetProject.Items.OfType<ProjectPackageReference> ()
+				.Single ();
+			var packageReference = projectPackageReference.CreatePackageReference ();
 
 			Assert.AreEqual ("NUnit", packageReference.PackageIdentity.Id);
 			Assert.AreEqual ("3.6.0", packageReference.PackageIdentity.Version.ToNormalizedString ());
@@ -211,6 +216,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsTrue (project.IsSaved);
 			Assert.IsFalse (packageReference.HasAllowedVersions);
 			Assert.IsNull (packageReference.AllowedVersions);
+			Assert.AreEqual ("All", projectPackageReference.Metadata.GetValue ("PrivateAssets"));
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -152,26 +152,20 @@ namespace MonoDevelop.PackageManagement
 
 		bool AddPackageReference (PackageIdentity packageIdentity, INuGetProjectContext context)
 		{
-			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity);
-			if (packageReference != null) {
+			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity, matchVersion: false);
+			if (packageReference?.Equals (packageIdentity, matchVersion: true) == true) {
 				context.Log (MessageLevel.Warning, GettextCatalog.GetString ("Package '{0}' already exists in project '{1}'", packageIdentity, project.Name));
 				return false;
 			}
 
-			RemoveExistingPackageReference (packageIdentity);
-
-			packageReference = ProjectPackageReference.Create (packageIdentity);
-			project.Items.Add (packageReference);
+			if (packageReference != null) {
+				packageReference.Version = packageIdentity.Version.ToNormalizedString ();
+			} else {
+				packageReference = ProjectPackageReference.Create (packageIdentity);
+				project.Items.Add (packageReference);
+			}
 
 			return true;
-		}
-
-		void RemoveExistingPackageReference (PackageIdentity packageIdentity)
-		{
-			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity, matchVersion: false);
-			if (packageReference != null) {
-				project.Items.Remove (packageReference);
-			}
 		}
 
 		public override async Task<bool> UninstallPackageAsync (

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageReferenceNuGetProject.cs
@@ -143,26 +143,20 @@ namespace MonoDevelop.PackageManagement
 
 		bool AddPackageReference (PackageIdentity packageIdentity, INuGetProjectContext context)
 		{
-			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity);
-			if (packageReference != null) {
+			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity, matchVersion: false);
+			if (packageReference?.Equals (packageIdentity, matchVersion: true) == true) {
 				context.Log (MessageLevel.Warning, GettextCatalog.GetString ("Package '{0}' already exists in project '{1}'", packageIdentity, project.Name));
 				return false;
 			}
 
-			RemoveExistingPackageReference (packageIdentity);
-
-			packageReference = ProjectPackageReference.Create (packageIdentity);
-			project.Items.Add (packageReference);
+			if (packageReference != null) {
+				packageReference.Version = packageIdentity.Version.ToNormalizedString ();
+			} else {
+				packageReference = ProjectPackageReference.Create (packageIdentity);
+				project.Items.Add (packageReference);
+			}
 
 			return true;
-		}
-
-		void RemoveExistingPackageReference (PackageIdentity packageIdentity)
-		{
-			ProjectPackageReference packageReference = project.GetPackageReference (packageIdentity, matchVersion: false);
-			if (packageReference != null) {
-				project.Items.Remove (packageReference);
-			}
 		}
 
 		public override async Task<bool> UninstallPackageAsync (

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
@@ -144,5 +144,10 @@ namespace MonoDevelop.PackageManagement
 		}
 
 		public bool IsImplicit { get; internal set; }
+
+		public string Version {
+			get { return Metadata.GetValue ("Version"); }
+			set { Metadata.SetValue ("Version", value); }
+		}
 	}
 }


### PR DESCRIPTION
On updating a NuGet PackageReference the old PackageReference was
removed from the project and then a new PackageReference was added.
This resulted in any custom MSBuild properties associated with the
PackageReference being removed. Now on updating a NuGet package the
version of the existing PackageReference is updated.

Fixes VSTS #568994 - Updating PackageReference removes metadata