### PR TITLE
[Telemetry] Use CounterMetadata subclasses

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/GotoDefinition/GotoDefinitionService.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Features/GotoDefinition/GotoDefinitionService.cs
@@ -82,15 +82,10 @@ namespace ICSharpCode.NRefactory6.CSharp.Features.GotoDefinition
 		public static bool TryGoToDefinition (Document document, int position, CancellationToken cancellationToken)
 		{
 			var metadata = Counters.CreateNavigateToMetadata ("Declaration");
-
-			using (var timer = Counters.NavigateTo.BeginTiming (metadata)) {
-				try {
-					bool result = TryGoToDefinitionInternal (document, position, cancellationToken);
-					Counters.UpdateNavigateResult (metadata, result);
-					return result;
-				} finally {
-					Counters.UpdateUserCancellation (metadata, cancellationToken);
-				}
+			using (var timer = Counters.NavigateTo.BeginTiming (metadata, cancellationToken)) {
+				bool result = TryGoToDefinitionInternal (document, position, cancellationToken);
+				metadata.SetResult (result);
+				return result;
 			}
 		}
 

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindDerivedSymbolsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindDerivedSymbolsHandler.cs
@@ -126,16 +126,16 @@ namespace MonoDevelop.CSharp.Refactoring
 			using (var timer = Navigation.Counters.NavigateTo.BeginTiming (metadata)) {
 				var sym = await FindBaseSymbolsHandler.GetSymbolAtCaret (IdeApp.Workbench.ActiveDocument);
 				if (sym == null) {
-					Navigation.Counters.UpdateUserFault (metadata);
+					metadata.SetUserFault ();
 					return;
 				}
 
 				using (var source = new CancellationTokenSource ()) {
 					try {
 						await FindDerivedSymbols (sym, source);
-						Navigation.Counters.UpdateNavigateResult (metadata, true);
+						metadata.SetResult (true);
 					} finally {
-						Navigation.Counters.UpdateUserCancellation (metadata, source.Token);
+						metadata.UpdateUserCancellation (source.Token);
 					}
 				}
 			}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindExtensionMethodsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindExtensionMethodsHandler.cs
@@ -53,16 +53,16 @@ namespace MonoDevelop.CSharp.Navigation
 				var doc = IdeApp.Workbench.ActiveDocument;
 				var sym = await GetNamedTypeAtCaret (doc);
 				if (sym == null) {
-					Counters.UpdateUserFault (metadata);
+					metadata.SetUserFault ();
 					return;
 				}
 
 				using (var source = new CancellationTokenSource ()) {
 					try {
 						FindExtensionMethods (await doc.GetCompilationAsync (), sym, source);
-						Counters.UpdateNavigateResult (metadata, true);
+						metadata.SetResult (true);
 					} finally {
-						Counters.UpdateUserCancellation (metadata, source.Token);
+						metadata.UpdateUserCancellation (source.Token);
 					}
 				}
 			}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindImplementingMembersHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindImplementingMembersHandler.cs
@@ -53,16 +53,16 @@ namespace MonoDevelop.CSharp.Navigation
 				var doc = IdeApp.Workbench.ActiveDocument;
 				var sym = await GetNamedTypeAtCaret (doc);
 				if (sym == null) {
-					Counters.UpdateUserFault (metadata);
+					metadata.SetUserFault ();
 					return;
 				}
 
 				using (var source = new CancellationTokenSource ()) {
 					try {
 						await FindImplementingSymbols (await doc.GetCompilationAsync (), sym, source);
-						Counters.UpdateNavigateResult (metadata, true);
+						metadata.SetResult (true);
 					} finally {
-						Counters.UpdateUserCancellation (metadata, source.Token);
+						metadata.UpdateUserCancellation (source.Token);
 					}
 				}
 			}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindMemberOverloadsHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Navigation/FindMemberOverloadsHandler.cs
@@ -109,16 +109,16 @@ namespace MonoDevelop.CSharp.Navigation
 				var info = await RefactoringSymbolInfo.GetSymbolInfoAsync (doc, doc.Editor);
 				var sym = info.Symbol ?? info.DeclaredSymbol;
 				if (sym == null) {
-					Counters.UpdateUserFault (metadata);
+					metadata.SetUserFault ();
 					return;
 				}
 
 				using (var source = new CancellationTokenSource ()) {
 					try {
 						FindOverloads (sym, source);
-						Counters.UpdateNavigateResult (metadata, true);
+						metadata.SetResult (true);
 					} finally {
-						Counters.UpdateUserCancellation (metadata, source.Token);
+						metadata.UpdateUserCancellation (source.Token);
 					}
 				}
 			}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/FindReferencesHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/FindReferencesHandler.cs
@@ -178,7 +178,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					await Task.WhenAll (tasks);
 				} catch (OperationCanceledException) {
 				} catch (Exception ex) {
-					MonoDevelop.Refactoring.Counters.SetFailure (metadata);
+					metadata.SetFailure ();
 					if (monitor != null)
 						monitor.ReportError ("Error finding references", ex);
 					else
@@ -187,7 +187,7 @@ namespace MonoDevelop.CSharp.Refactoring
 					if (owningMonitor)
 						monitor.Dispose ();
 					if (monitor.CancellationToken.IsCancellationRequested)
-						MonoDevelop.Refactoring.Counters.SetUserCancel (metadata);
+						metadata.SetUserCancel ();
 					if (timer != null)
 						timer.Dispose ();
 				}

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/GotoBaseDeclarationHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/GotoBaseDeclarationHandler.cs
@@ -85,7 +85,7 @@ namespace MonoDevelop.CSharp.Refactoring
 			var metadata = Navigation.Counters.CreateNavigateToMetadata ("Base");
 			using (var timer = Navigation.Counters.NavigateTo.BeginTiming (metadata)) {
 				await GotoBaseInternal (doc, symbol);
-				Navigation.Counters.UpdateNavigateResult (metadata, true);
+				metadata.SetResult (true);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/BackgroundPackageActionRunnerTests.cs
@@ -145,13 +145,13 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		static void AssertCounterIncrementedForPackage (
-			IDictionary<string, string> metadata,
+			PackageMetadata metadata,
 			string packageId,
 			string packageVersion)
 		{
 			string fullInfo = packageId + " v" + packageVersion;
-			Assert.AreEqual (packageId, metadata["PackageId"]);
-			Assert.AreEqual (fullInfo, metadata["Package"]);
+			Assert.AreEqual (packageId, metadata.PackageId);
+			Assert.AreEqual (fullInfo, metadata.Package);
 		}
 
 		void AssertUninstallCounterIncrementedForPackage (string packageId, string packageVersion)
@@ -161,9 +161,9 @@ namespace MonoDevelop.PackageManagement.Tests
 
 		void AssertUninstallCounterIncrementedForPackage (string packageId)
 		{
-			Assert.AreEqual (packageId, instrumentationService.UninstallPackageMetadata["PackageId"]);
-			Assert.IsFalse (instrumentationService.UninstallPackageMetadata.ContainsKey ("PackageVersion"));
-			Assert.IsFalse (instrumentationService.UninstallPackageMetadata.ContainsKey ("Package"));
+			Assert.AreEqual (packageId, instrumentationService.UninstallPackageMetadata.PackageId);
+			Assert.IsFalse (instrumentationService.UninstallPackageMetadata.HasPackageVersion);
+			Assert.IsFalse (instrumentationService.UninstallPackageMetadata.HasPackage);
 		}
 
 		void AddInstallPackageIntoProjectAction (FakeNuGetPackageManager packageManager, string packageId, string version)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/TestableInstrumentationService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/TestableInstrumentationService.cs
@@ -30,16 +30,16 @@ namespace MonoDevelop.PackageManagement.Tests
 {
 	class TestableInstrumentationService : PackageManagementInstrumentationService
 	{
-		public IDictionary<string, string> InstallPackageMetadata;
+		public PackageMetadata InstallPackageMetadata;
 
-		public override void IncrementInstallPackageCounter (IDictionary<string, string> metadata)
+		public override void IncrementInstallPackageCounter (PackageMetadata metadata)
 		{
 			InstallPackageMetadata = metadata;
 		}
 
-		public IDictionary<string, string> UninstallPackageMetadata;
+		public PackageMetadata UninstallPackageMetadata;
 
-		public override void IncrementUninstallPackageCounter (IDictionary<string, string> metadata)
+		public override void IncrementUninstallPackageCounter (PackageMetadata metadata)
 		{
 			UninstallPackageMetadata = metadata;
 		}

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -46,6 +46,7 @@ using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
+using MonoDevelop.Ide.CodeCompletion;
 
 namespace MonoDevelop.Refactoring
 { 
@@ -251,10 +252,10 @@ namespace MonoDevelop.Refactoring
 					try {
 						tasks.Add ((provider.FindReferences (documentIdString, hintProject, monitor), provider));
 					} catch (OperationCanceledException) {
-						Counters.SetUserCancel (metadata);
+						metadata.SetUserCancel ();
 						return;
 					} catch (Exception ex) {
-						Counters.SetFailure (metadata);
+						metadata.SetFailure ();
 						if (monitor != null)
 							monitor.ReportError ("Error finding references", ex);
 						LoggingService.LogError ("Error finding references", ex);
@@ -265,10 +266,10 @@ namespace MonoDevelop.Refactoring
 					try {
 						await task.task;
 					} catch (OperationCanceledException) {
-						Counters.SetUserCancel (metadata);
+						metadata.SetUserCancel ();
 						return;
 					} catch (Exception ex) {
-						Counters.SetFailure (metadata);
+						metadata.SetFailure ();
 						if (monitor != null)
 							monitor.ReportError ("Error finding references", ex);
 						LoggingService.LogError ("Error finding references", ex);
@@ -310,10 +311,10 @@ namespace MonoDevelop.Refactoring
 					try {
 						tasks.Add ((provider.FindAllReferences (documentIdString, hintProject, monitor), provider));
 					} catch (OperationCanceledException) {
-						Counters.SetUserCancel (metadata);
+						metadata.SetUserCancel ();
 						return;
 					} catch (Exception ex) {
-						Counters.SetFailure (metadata);
+						metadata.SetFailure ();
 						if (monitor != null)
 							monitor.ReportError ("Error finding references", ex);
 						LoggingService.LogError ("Error finding references", ex);
@@ -324,10 +325,10 @@ namespace MonoDevelop.Refactoring
 					try {
 						await task.task;
 					} catch (OperationCanceledException) {
-						Counters.SetUserCancel (metadata);
+						metadata.SetUserCancel ();
 						return;
 					} catch (Exception ex) {
-						Counters.SetFailure (metadata);
+						metadata.SetFailure ();
 						if (monitor != null)
 							monitor.ReportError ("Error finding references", ex);
 						LoggingService.LogError ("Error finding references", ex);
@@ -363,24 +364,23 @@ namespace MonoDevelop.Refactoring
 
 	internal static class Counters
 	{
-		public static TimerCounter FindReferences = InstrumentationService.CreateTimerCounter ("Find references", "Code Navigation", id: "CodeNavigation.FindReferences");
+		public static TimerCounter<FindReferencesMetadata> FindReferences = InstrumentationService.CreateTimerCounter<FindReferencesMetadata> ("Find references", "Code Navigation", id: "CodeNavigation.FindReferences");
 		public static TimerCounter<FixesMenuMetadata> FixesMenu = InstrumentationService.CreateTimerCounter<FixesMenuMetadata> ("Show fixes", "Code Actions", id: "CodeActions.ShowFixes");
 
-		public static IDictionary<string, string> CreateFindReferencesMetadata ()
+		public static FindReferencesMetadata CreateFindReferencesMetadata ()
 		{
-			var metadata = new Dictionary<string, string> ();
-			metadata ["Result"] = "Success";
+			var metadata = new FindReferencesMetadata {
+				ResultString = "Success"
+			};
 			return metadata;
 		}
 
-		public static void SetFailure (IDictionary<string, string> metadata)
+		public class FindReferencesMetadata : CounterMetadata
 		{
-			metadata ["Result"] = "Failure";
-		}
-
-		public static void SetUserCancel (IDictionary<string, string> metadata)
-		{
-			metadata ["Result"] = "UserCancel";
+			public string ResultString {
+				get => (string)Properties["Result"];
+				set => Properties["Result"] = value;
+			}
 		}
 
 		public class FixesMenuMetadata : CounterMetadata

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/Counters.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/Counters.cs
@@ -26,6 +26,7 @@
 
 using System;
 using MonoDevelop.Core.Instrumentation;
+using Mono.TextEditor;
 
 namespace MonoDevelop.SourceEditor
 {
@@ -34,6 +35,6 @@ namespace MonoDevelop.SourceEditor
 		public static Counter EditorsInMemory = InstrumentationService.CreateCounter ("Editors in Memory", "Text Editor");
 		public static Counter SourceViewsInMemory = InstrumentationService.CreateCounter ("Source Views in Memory", "Text Editor");
 		public static Counter LoadedEditors = InstrumentationService.CreateCounter ("Loaded Editors", "Text Editor");
-		public static Counter Typing = InstrumentationService.CreateCounter ("Typing", "Text Editor", id: "TextEditor.Typing");
+		public static Counter<TypingTimingMetadata> Typing = InstrumentationService.CreateCounter<TypingTimingMetadata> ("Typing", "Text Editor", id: "TextEditor.Typing");
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -16,7 +16,7 @@ namespace MonoDevelop.VersionControl
 	[DataItem (FallbackType=typeof(UnknownRepository))]
 	public abstract class Repository: IDisposable
 	{
-		static Counter Repositories = InstrumentationService.CreateCounter ("VersionControl.RepositoryOpened", "Version Control", id:"VersionControl.RepositoryOpened");
+		static Counter<RepositoryMetadata> Repositories = InstrumentationService.CreateCounter<RepositoryMetadata> ("VersionControl.RepositoryOpened", "Version Control", id:"VersionControl.RepositoryOpened");
 
 		string name;
 		VersionControlSystem vcs;
@@ -42,10 +42,11 @@ namespace MonoDevelop.VersionControl
 		protected Repository (VersionControlSystem vcs): this ()
 		{
 			VersionControlSystem = vcs;
-			Repositories.SetValue (Repositories.Count + 1, string.Format ("Repository #{0}", Repositories.Count + 1), new Dictionary<string, string> {
-				{ "Type", vcs.Name },
-				{ "Type+Version", string.Format ("{0} {1}", vcs.Name, vcs.Version) },
-			});
+			var metadata = new RepositoryMetadata {
+				Type = vcs.Name,
+				TypeAndVersion = $"{vcs.Name} {vcs.Version}"
+			};
+			Repositories.SetValue (Repositories.Count + 1, string.Format ("Repository #{0}", Repositories.Count + 1), metadata);
 		}
 
 		public override bool Equals (object obj)
@@ -999,5 +1000,22 @@ namespace MonoDevelop.VersionControl
 		None = 0,
 		IgnoreCache = 1,
 		IncludeRemoteStatus = 2
+	}
+
+	public class RepositoryMetadata : CounterMetadata
+	{
+		public RepositoryMetadata ()
+		{
+		}
+
+		public string Type {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string TypeAndVersion {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimeCounter.cs
@@ -164,7 +164,7 @@ namespace MonoDevelop.Core.Instrumentation
 			Duration = stopWatch.Elapsed;
 
 			if (metadata != null && cancellationToken != CancellationToken.None && cancellationToken.IsCancellationRequested)
-				metadata.Result = CounterResult.UserCancel;
+				metadata.SetUserCancel ();
 
 			if (counter.LogMessages) {
 				var time = stopWatch.ElapsedMilliseconds;
@@ -207,7 +207,7 @@ namespace MonoDevelop.Core.Instrumentation
 
 		// Timer metadata is stored here, since it may change while the timer is alive.
 		// CounterValue will take the metadata from here.
-		public IDictionary<string, string> Metadata;
+		public IDictionary<string, object> Metadata;
 
 		string DebuggingText {
 			get {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -238,6 +238,11 @@ namespace MonoDevelop.Core.Instrumentation
 			this.properties = properties;
 		}
 
+		public CounterMetadata (CounterMetadata original)
+		{
+			this.properties = new Dictionary<string, object> (original.properties);
+		}
+
 		public CounterResult Result {
 			get {
 				var rs = GetProperty<string> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -261,7 +261,7 @@ namespace MonoDevelop.Core.Instrumentation
 		public void SetUserCancel () => Result = CounterResult.UserCancel;
 
 		protected void SetProperty (object value, [CallerMemberName]string name = null)
-			=> properties[name] = value;
+			=> properties[name] = value.ToString ();
 
 		protected T GetProperty<T> ([CallerMemberName]string name = null)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -29,6 +29,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace MonoDevelop.Core.Instrumentation
 {
@@ -109,20 +111,29 @@ namespace MonoDevelop.Core.Instrumentation
 
 		public ITimeTracker BeginTiming ()
 		{
-			return BeginTiming (null, null);
+			return BeginTiming (null, (IDictionary<string, object>)null);
 		}
 
 		public ITimeTracker BeginTiming (string message)
 		{
-			return BeginTiming (message, null);
+			return BeginTiming (message, (IDictionary<string, object>)null);
 		}
 
+		[Obsolete ("Use BeginTiming (string, IDictionary<string,object>) instead")]
 		public ITimeTracker BeginTiming (IDictionary<string, string> metadata)
 		{
-			return BeginTiming (null, metadata);
+			var converted = metadata.ToDictionary (k => k.Key, k => (object)(k.Value));
+			return BeginTiming (null, converted);
 		}
 
+		[Obsolete ("Use BeginTiming (string, IDictionary<string, object>) instead")]
 		public ITimeTracker BeginTiming (string message, IDictionary<string, string> metadata)
+		{
+			var converted = metadata.ToDictionary (k => k.Key, k => (object)(k.Value));
+			return BeginTiming (message, converted);
+		}
+
+		public ITimeTracker BeginTiming (string message, IDictionary<string, object> metadata)
 		{
 			return BeginTiming (message, metadata != null ? new CounterMetadata (metadata) : null, CancellationToken.None);
 		}
@@ -213,32 +224,30 @@ namespace MonoDevelop.Core.Instrumentation
 
 	public class CounterMetadata
 	{
-		readonly IDictionary<string, string> properties;
+		readonly IDictionary<string, object> properties;
 
-		internal protected IDictionary<string, string> Properties => properties;
+		internal protected IDictionary<string, object> Properties => properties;
 
 		public CounterMetadata ()
 		{
-			properties = new Dictionary<string, string> ();
+			properties = new Dictionary<string, object> ();
 		}
 
-		public CounterMetadata (IDictionary<string, string> properties)
+		public CounterMetadata (IDictionary<string, object> properties)
 		{
 			this.properties = properties;
 		}
 
 		public CounterResult Result {
 			get {
-				if (!properties.TryGetValue (nameof(Result), out var result) || !Enum.TryParse (result, out CounterResult res))
-					return CounterResult.Unspecified;
-				return res;
+				var rs = GetProperty<string> ();
+				if (Enum.TryParse<CounterResult> (rs, out var result)) {
+					return result;
+				}
+
+				return CounterResult.Unspecified;
 			}
-			set {
-				if (value == CounterResult.Unspecified)
-					properties.Remove (nameof (Result));
-				else
-					SetProperty (value.ToString ());
-			}
+			set => SetProperty (value.ToString ());
 		}
 
 		public void SetUserFault () => Result = CounterResult.UserFault;
@@ -246,17 +255,8 @@ namespace MonoDevelop.Core.Instrumentation
 		public void SetSuccess () => Result = CounterResult.Success;
 		public void SetUserCancel () => Result = CounterResult.UserCancel;
 
-		protected void SetProperty (string value, [CallerMemberName]string name = null)
-			=> properties[name] = value;
-
 		protected void SetProperty (object value, [CallerMemberName]string name = null)
-			=> properties[name] = Convert.ToString (value, CultureInfo.InvariantCulture);
-
-		protected string GetProperty ([CallerMemberName]string name = null)
-		{
-			properties.TryGetValue (name, out var result);
-			return result;
-		}
+			=> properties[name] = value;
 
 		protected T GetProperty<T> ([CallerMemberName]string name = null)
 		{
@@ -265,6 +265,11 @@ namespace MonoDevelop.Core.Instrumentation
 			}
 
 			return default (T);
+		}
+
+		protected bool ContainsProperty ([CallerMemberName]string propName = null)
+		{
+			return properties.ContainsKey (propName);
 		}
 	}
 
@@ -277,5 +282,11 @@ namespace MonoDevelop.Core.Instrumentation
 		UserFault
 	}
 
+	public class IncorrectPropertyTypeException : Exception
+	{
+		public IncorrectPropertyTypeException (string message) : base (message)
+		{
+		}
+	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -261,7 +261,7 @@ namespace MonoDevelop.Core.Instrumentation
 		public void SetUserCancel () => Result = CounterResult.UserCancel;
 
 		protected void SetProperty (object value, [CallerMemberName]string name = null)
-			=> properties[name] = value.ToString ();
+			=> properties[name] = value;
 
 		protected T GetProperty<T> ([CallerMemberName]string name = null)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -46,6 +46,8 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using MonoDevelop.Core.Collections;
+using ICSharpCode.Decompiler.TypeSystem.Implementation;
+using System.Runtime.CompilerServices;
 
 namespace MonoDevelop.Projects
 {
@@ -59,7 +61,7 @@ namespace MonoDevelop.Projects
 	public class Project : SolutionItem
 	{
 		string[] flavorGuids = new string[0];
-		static Counter ProjectOpenedCounter = InstrumentationService.CreateCounter ("Project Opened", "Project Model", id:"Ide.Project.Open");
+		static Counter<ProjectEventMetadata> ProjectOpenedCounter = InstrumentationService.CreateCounter<ProjectEventMetadata> ("Project Opened", "Project Model", id:"Ide.Project.Open");
 
 		string[] buildActions;
 		MSBuildProject sourceProject;
@@ -712,7 +714,23 @@ namespace MonoDevelop.Projects
 				sb.Append (p);
 				first = false;
 			}
-			metadata ["ProjectTypes"] = sb.ToString ();
+			metadata["ProjectTypes"] = sb.ToString ();
+		}
+
+		protected override void OnGetProjectEventMetadata (ProjectEventMetadata metadata)
+		{
+			base.OnGetProjectEventMetadata (metadata);
+			var sb = new System.Text.StringBuilder ();
+			var first = true;
+
+			var projectTypes = this.GetTypeTags ().ToList ();
+			foreach (var p in projectTypes.Where (x => (x != "DotNet") || projectTypes.Count == 1)) {
+				if (!first)
+					sb.Append (", ");
+				sb.Append (p);
+				first = false;
+			}
+			metadata.ProjectTypes = sb.ToString ();
 		}
 
 		protected override void OnEndLoad ()
@@ -1233,6 +1251,7 @@ namespace MonoDevelop.Projects
 			var includeReferencedProjects = context?.LoadReferencedProjects ?? false;
 			var configs = GetConfigurations (configuration, includeReferencedProjects);	
 
+
 			string [] evaluateItems = context != null ? context.ItemsToEvaluate.ToArray () : new string [0];
 			string [] evaluateProperties = context != null ? context.PropertiesToEvaluate.ToArray () : new string [0];
 
@@ -1248,13 +1267,13 @@ namespace MonoDevelop.Projects
 			await Task.Run (async delegate {
 
 				bool operationRequiresExclusiveLock = context.BuilderQueue == BuilderQueue.LongOperations;
-				TimerCounter buildTimer = null;
+				TimerCounter<ProjectEventMetadata> buildTimer = null;
 				switch (target) {
 				case "Build": buildTimer = Counters.BuildMSBuildProjectTimer; break;
 				case "Clean": buildTimer = Counters.CleanMSBuildProjectTimer; break;
 				}
 
-				var metadata = GetProjectEventMetadata (configuration);
+				var metadata = CreateProjectEventMetadata (configuration);
 				var t1 = Counters.RunMSBuildTargetTimer.BeginTiming (metadata);
 				var t2 = buildTimer?.BeginTiming (metadata);
 
@@ -1354,27 +1373,27 @@ namespace MonoDevelop.Projects
 		}
 
 		void AddRunMSBuildTargetTimerMetadata (
-			IDictionary<string, string> metadata,
+			ProjectEventMetadata metadata,
 			MSBuildResult result,
 			string target,
 			ConfigurationSelector configuration)
 		{
 			if (target == "Build") {
-				metadata ["BuildType"] = "4";
+				metadata.BuildType = 4;
 			} else if (target == "Clean") {
-				metadata ["BuildType"] = "1";
+				metadata.BuildType = 1;
 			}
-			metadata ["BuildTypeString"] = target;
+			metadata.BuildTypeString = target;
 
-			metadata ["FirstBuild"] = IsFirstBuild.ToString ();
-			metadata ["ProjectID"] = ItemId;
-			metadata ["ProjectType"] = TypeGuid;
-			metadata ["ProjectFlavor"] = FlavorGuids.FirstOrDefault () ?? TypeGuid;
+			metadata.FirstBuild = IsFirstBuild;
+			metadata.ProjectID = ItemId;
+			metadata.ProjectType = TypeGuid;
+			metadata.ProjectFlavor = FlavorGuids.FirstOrDefault () ?? TypeGuid;
 
 			var c = GetConfiguration (configuration);
 			if (c != null) {
-				metadata ["Configuration"] = c.Id;
-				metadata ["Platform"] = GetExplicitPlatform (c);
+				metadata.Configuration = c.Id;
+				metadata.Platform = GetExplicitPlatform (c);
 			}
 
 			bool success = false;
@@ -1388,8 +1407,8 @@ namespace MonoDevelop.Projects
 				}
 			}
 
-			metadata ["Success"] = success.ToString ();
-			metadata ["Cancelled"] = cancelled.ToString ();
+			metadata.Success = success;
+			metadata.Cancelled = cancelled;
 		}
 
 		string activeTargetFramework;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -133,46 +133,38 @@ namespace MonoDevelop.Projects
 			});
 		}
 
-		static IDictionary<string, string> GetReadSolutionItemMetadata (string file, string typeGuid, string itemGuid)
+		static ReadSolutionItemMetadata GetReadSolutionItemMetadata (string file, string typeGuid, string itemGuid)
 		{
-			var metadata = new Dictionary<string, string> ();
-
 			string extension = Path.GetExtension (file);
 			if (!string.IsNullOrEmpty (extension) && extension [0] == '.') {
 				extension = extension.Substring (1);
 			}
 
-			metadata ["FileNameExtension"] = extension;
-
-			// Will be set to true later after a successful load
-			metadata ["LoadSucceed"] = bool.FalseString;
-
-			if (typeGuid != null)
-				metadata ["ProjectType"] = typeGuid;
-
-			if (itemGuid != null)
-				metadata ["ProjectID"] = itemGuid;
-
-			return metadata;
+			return new ReadSolutionItemMetadata {
+				LoadSucceed = false,
+				FileNameExtension = extension,
+				ProjectType = typeGuid,
+				ProjectID = itemGuid
+			};
 		}
 
-		static void UpdateReadSolutionItemMetadata (IDictionary<string, string> metadata, SolutionItem item)
+		static void UpdateReadSolutionItemMetadata (ReadSolutionItemMetadata metadata, SolutionItem item)
 		{
-			metadata ["ProjectType"] = item.TypeGuid;
-			metadata ["ProjectID"] = item.ItemId;
-			metadata ["LoadSucceed"] = bool.TrueString;
+			metadata.ProjectType = item.TypeGuid;
+			metadata.ProjectID = item.ItemId;
+			metadata.LoadSucceed = true;
 
 			var project = item as Project;
 			if (project == null)
 				return;
 
 			// Use TypeGuid by default for ProjectFlavor.
-			metadata ["ProjectFlavor"] = project.FlavorGuids.FirstOrDefault () ?? item.TypeGuid;
-			metadata ["Flavors"] =  string.Join (";", project.GetItemTypeGuids ());
+			metadata.ProjectFlavor = project.FlavorGuids.FirstOrDefault () ?? item.TypeGuid;
+			metadata.Flavors =  string.Join (";", project.GetItemTypeGuids ());
 
 			var capabilities = project.GetProjectCapabilities ();
 			if (capabilities.Any ()) {
-				metadata ["Capabilities"] = string.Join (" ", capabilities);
+				metadata.Capabilities = string.Join (" ", capabilities);
 			}
 		}
 
@@ -477,23 +469,65 @@ namespace MonoDevelop.Projects
 		public static Counter SolutionsLoaded = InstrumentationService.CreateCounter ("Solutions loaded", "Project Model");
 
 		public static TimerCounter ReadWorkspaceItem = InstrumentationService.CreateTimerCounter ("Workspace item read", "Project Model", id:"Projects.WorkspaceItemRead");
-		public static TimerCounter ReadSolutionItem = InstrumentationService.CreateTimerCounter ("Solution item read", "Project Model", id:"Projects.SolutionItemRead");
+		public static TimerCounter<ReadSolutionItemMetadata> ReadSolutionItem = InstrumentationService.CreateTimerCounter<ReadSolutionItemMetadata> ("Solution item read", "Project Model", id:"Projects.SolutionItemRead");
 		public static TimerCounter ReadMSBuildProject = InstrumentationService.CreateTimerCounter ("MSBuild project read", "Project Model", id:"Projects.MSBuildProjectRead");
 		public static TimerCounter WriteMSBuildProject = InstrumentationService.CreateTimerCounter ("MSBuild project written", "Project Model", id:"Projects.MSBuildProjectWritten");
 
 		public static TimerCounter BuildSolutionTimer = InstrumentationService.CreateTimerCounter ("Build solution", "Project Model", id:"Projects.BuildSolution");
-		public static TimerCounter BuildProjectAndReferencesTimer = InstrumentationService.CreateTimerCounter ("Build project and references", "Project Model", id:"Projects.BuildProjectAndReferences");
-		public static TimerCounter BuildProjectTimer = InstrumentationService.CreateTimerCounter ("Build project", "Project Model", id:"Projects.BuildProject");
+		public static TimerCounter<ProjectEventMetadata> BuildProjectAndReferencesTimer = InstrumentationService.CreateTimerCounter<ProjectEventMetadata> ("Build project and references", "Project Model", id:"Projects.BuildProjectAndReferences");
+		public static TimerCounter<ProjectEventMetadata> BuildProjectTimer = InstrumentationService.CreateTimerCounter<ProjectEventMetadata> ("Build project", "Project Model", id:"Projects.BuildProject");
 		public static TimerCounter CleanProjectTimer = InstrumentationService.CreateTimerCounter ("Clean project", "Project Model", id:"Projects.CleanProject");
 		public static TimerCounter BuildWorkspaceItemTimer = InstrumentationService.CreateTimerCounter ("Build workspace item", "Project Model");
 		public static TimerCounter NeedsBuildingTimer = InstrumentationService.CreateTimerCounter ("Check needs building", "Project Model");
 		
-		public static TimerCounter BuildMSBuildProjectTimer = InstrumentationService.CreateTimerCounter ("Build MSBuild project", "Project Model", id:"Projects.BuildMSBuildProject");
-		public static TimerCounter CleanMSBuildProjectTimer = InstrumentationService.CreateTimerCounter ("Clean MSBuild project", "Project Model", id:"Projects.CleanMSBuildProject");
-		public static TimerCounter RunMSBuildTargetTimer = InstrumentationService.CreateTimerCounter ("Run MSBuild target", "Project Model", id:"Projects.RunMSBuildTarget");
-		public static TimerCounter ResolveMSBuildReferencesTimer = InstrumentationService.CreateTimerCounter ("Resolve MSBuild references", "Project Model", id:"Projects.ResolveMSBuildReferences");
+		public static TimerCounter<ProjectEventMetadata> BuildMSBuildProjectTimer = InstrumentationService.CreateTimerCounter<ProjectEventMetadata> ("Build MSBuild project", "Project Model", id:"Projects.BuildMSBuildProject");
+		public static TimerCounter<ProjectEventMetadata> CleanMSBuildProjectTimer = InstrumentationService.CreateTimerCounter<ProjectEventMetadata> ("Clean MSBuild project", "Project Model", id:"Projects.CleanMSBuildProject");
+		public static TimerCounter<ProjectEventMetadata> RunMSBuildTargetTimer = InstrumentationService.CreateTimerCounter<ProjectEventMetadata> ("Run MSBuild target", "Project Model", id:"Projects.RunMSBuildTarget");
+		public static TimerCounter<ProjectEventMetadata> ResolveMSBuildReferencesTimer = InstrumentationService.CreateTimerCounter<ProjectEventMetadata> ("Resolve MSBuild references", "Project Model", id:"Projects.ResolveMSBuildReferences");
 
 		public static TimerCounter HelpServiceInitialization = InstrumentationService.CreateTimerCounter ("Help Service initialization", "IDE");
 		public static TimerCounter ParserServiceInitialization = InstrumentationService.CreateTimerCounter ("Parser Service initialization", "IDE");
+	}
+
+	internal class ReadSolutionItemMetadata : CounterMetadata
+	{
+		public ReadSolutionItemMetadata ()
+		{
+		}
+
+		public string ProjectType {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string ProjectID {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public bool LoadSucceed {
+			get => GetProperty<bool> ();
+			set => SetProperty (value);
+		}
+
+		public string FileNameExtension {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string ProjectFlavor {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string Flavors {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string Capabilities {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -900,11 +900,6 @@ namespace MonoDevelop.Projects
 			return metadata;
 		}
 
-		public void UpdateProjectEventMetadata (ProjectEventMetadata metadata)
-		{
-			OnGetProjectEventMetadata (metadata);
-		}
-
 		[Obsolete ("Use OnGetProjectEventMetadata (ProjectEventMetadata) instead")]
 		protected virtual void OnGetProjectEventMetadata (IDictionary<string, string> metadata)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionStatistics.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionStatistics.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using MonoDevelop.Core.Instrumentation;
 
 namespace MonoDevelop.Ide.Editor.Extension
 {
@@ -83,18 +84,61 @@ namespace MonoDevelop.Ide.Editor.Extension
 				return;
 			}
 
-			var metadata = new Dictionary<string, string> ();
-
 			var average = totalTime.TotalMilliseconds / timingsCount;
-			metadata ["AverageDuration"] = average.ToString ();
-			metadata ["FirstDuration"] = firstTime.Value.TotalMilliseconds.ToString ();
-			metadata ["MaximumDuration"] = maxTime.TotalMilliseconds.ToString ();
-			metadata ["MinimumDuration"] = minTime.TotalMilliseconds.ToString ();
-			metadata ["FailureCount"] = failureCount.ToString ();
-			metadata ["SuccessCount"] = successCount.ToString ();
-			metadata ["CancelCount"] = cancelCount.ToString ();
+
+			var metadata = new CompletionStatisticsMetadata {
+				AverageDuration = average,
+				FirstDuration = firstTime.Value.TotalMilliseconds,
+				MaximumDuration = maxTime.TotalMilliseconds,
+				MinimumDuration = minTime.TotalMilliseconds,
+				FailureCount = failureCount,
+				SuccessCount = successCount,
+				CancelCount = cancelCount
+			};
 
 			Counters.CodeCompletionStats.Inc (metadata);
+		}
+	}
+
+	class CompletionStatisticsMetadata : CounterMetadata
+	{
+		public CompletionStatisticsMetadata ()
+		{
+		}
+
+		public double AverageDuration {
+			get => GetProperty<double> ();
+			set => SetProperty (value);
+		}
+
+		public double FirstDuration {
+			get => GetProperty<double> ();
+			set => SetProperty (value);
+		}
+
+		public double MaximumDuration {
+			get => GetProperty<double> ();
+			set => SetProperty (value);
+		}
+
+		public double MinimumDuration {
+			get => GetProperty<double> ();
+			set => SetProperty (value);
+		}
+
+		public int FailureCount {
+			get => GetProperty<int> ();
+			set => SetProperty (value);
+		}
+
+		public int SuccessCount {
+			get => GetProperty<int> ();
+			set => SetProperty (value);
+		}
+
+		public int CancelCount {
+			get => GetProperty<int> ();
+			set => SetProperty (value);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -648,22 +648,24 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
-		Dictionary<string, string> CreateOpenDocumentTimerMetadata ()
+		OpenDocumentMetadata CreateOpenDocumentTimerMetadata ()
 		{
-			var metadata = new Dictionary<string, string> ();
-			metadata ["Result"] = "None";
+			var metadata = new OpenDocumentMetadata {
+				ResultString = "None"
+			};
+
 			return metadata;
 		}
 
-		void AddOpenDocumentTimerMetadata (IDictionary<string, string> metadata, FileOpenInformation info, bool result)
+		void AddOpenDocumentTimerMetadata (OpenDocumentMetadata metadata, FileOpenInformation info, bool result)
 		{
 			if (info.NewContent != null)
-				metadata ["EditorType"] = info.NewContent.GetType ().FullName;
+				metadata.EditorType = info.NewContent.GetType ().FullName;
 			if (info.Project != null)
-				metadata ["OwnerProjectGuid"] = info.Project?.ItemId;
+				metadata.OwnerProjectGuid = info.Project?.ItemId;
 			
-			metadata ["Extension"] = info.FileName.Extension;
-			metadata ["Result"] = result ? "Success" : "Failure";
+			metadata.Extension = info.FileName.Extension;
+			metadata.ResultString = result ? "Success" : "Failure";
 		}
 
 		async Task<ViewContent> BatchOpenDocument (ProgressMonitor monitor, FilePath fileName, Project project, int line, int column, DockNotebook dockNotebook)
@@ -1650,5 +1652,34 @@ namespace MonoDevelop.Ide.Gui
 		Default = BringToFront | CenterCaretLine | HighlightCaretLine | TryToReuseViewer,
 		Debugger = BringToFront | CenterCaretLine | TryToReuseViewer,
 		DefaultInternal = Default | OnlyInternalViewer,
+	}
+
+	class OpenDocumentMetadata : CounterMetadata
+	{
+		public OpenDocumentMetadata ()
+		{
+		}
+
+		// CounterMetadata already has a Result property which isn't a string
+		// but we can overwrite the property directly in the dictionary
+		public string ResultString {
+			get => (string)Properties["Result"];
+			set => Properties["Result"] = value;
+		}
+
+		public string EditorType {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string OwnerProjectGuid {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string Extension {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineProjectTemplatingProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineProjectTemplatingProvider.cs
@@ -45,6 +45,7 @@ using MonoDevelop.Ide.CodeFormatting;
 using MonoDevelop.Core.StringParsing;
 using MonoDevelop.Core.Text;
 using MonoDevelop.Projects.Policies;
+using MonoDevelop.Core.Instrumentation;
 
 namespace MonoDevelop.Ide.Templates
 {
@@ -68,7 +69,7 @@ namespace MonoDevelop.Ide.Templates
 			return MicrosoftTemplateEngine.CreateProjectTemplate (templateId, scanPath);
 		}
 
-		static MonoDevelop.Core.Instrumentation.Counter TemplateCounter = MonoDevelop.Core.Instrumentation.InstrumentationService.CreateCounter ("Template Instantiated", "Project Model", id: "Core.Template.Instantiated");
+		static Counter<TemplateMetadata> TemplateCounter = InstrumentationService.CreateCounter<TemplateMetadata> ("Template Instantiated", "Project Model", id: "Core.Template.Instantiated");
 
 		public async Task<ProcessedTemplateResult> ProcessTemplate (SolutionTemplate template, NewProjectConfiguration config, SolutionFolder parentFolder)
 		{
@@ -108,11 +109,12 @@ namespace MonoDevelop.Ide.Templates
 					workspaceItems.Add (await MonoDevelop.Projects.Services.ProjectService.ReadSolutionItem (new Core.ProgressMonitor (), fullPath));
 			}
 
-			var metadata = new Dictionary<string, string> ();
-			metadata ["Id"] = templateInfo.Identity;
-			metadata ["Name"] = templateInfo.Name;
-			metadata ["Language"] = template.Language;
-			metadata ["Platform"] = string.Join(";", templateInfo.Classifications);
+			var metadata = new TemplateMetadata {
+				Id = templateInfo.Identity,
+				Name = templateInfo.Name,
+				Language = template.Language,
+				Platform = string.Join(";", templateInfo.Classifications)
+			};
 			TemplateCounter.Inc (1, null, metadata);
 
 			MicrosoftTemplateEngineProcessedTemplateResult processResult;
@@ -185,6 +187,33 @@ namespace MonoDevelop.Ide.Templates
 		{
 			return TemplateParameter.CreateParameters (parameters)
 				.Where (parameter => parameter.IsValid);
+		}
+	}
+
+	class TemplateMetadata : CounterMetadata
+	{
+		public TemplateMetadata ()
+		{
+		}
+
+		public string Id {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string Name {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string Language {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string Platform {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplate.cs
@@ -41,12 +41,14 @@ using System.CodeDom;
 using System.CodeDom.Compiler;
 
 using MonoDevelop.Core;
+using MonoDevelop.Core.Instrumentation;
 using Mono.Addins;
 using MonoDevelop.Ide.Codons;
 using MonoDevelop.Projects;
 using MonoDevelop.Ide.Gui;
 using System.Linq;
 using System.Threading.Tasks;
+using YamlDotNet.Core.Tokens;
 
 namespace MonoDevelop.Ide.Templates
 {
@@ -54,7 +56,7 @@ namespace MonoDevelop.Ide.Templates
 	{
 		public static List<ProjectTemplate> ProjectTemplates = new List<ProjectTemplate> ();
 
-		static MonoDevelop.Core.Instrumentation.Counter TemplateCounter = MonoDevelop.Core.Instrumentation.InstrumentationService.CreateCounter ("Template Instantiated", "Project Model", id:"Core.Template.Instantiated");
+		static Counter<TemplateMetadata> TemplateCounter = InstrumentationService.CreateCounter<TemplateMetadata> ("Template Instantiated", "Project Model", id:"Core.Template.Instantiated");
 
 		private List<string> actions = new List<string> ();
 
@@ -315,11 +317,12 @@ namespace MonoDevelop.Ide.Templates
 
 			var pDesc = this.solutionDescriptor.EntryDescriptors.OfType<ProjectDescriptor> ().ToList ();
 
-			var metadata = new Dictionary<string, string> ();
-			metadata ["Id"] = this.Id;
-			metadata ["Name"] = this.nonLocalizedName;
-			metadata ["Language"] = this.LanguageName;
-			metadata ["Platform"] = pDesc.Count == 1 ? pDesc[0].ProjectType : "Multiple";
+			var metadata = new TemplateMetadata {
+				Id = Id,
+				Name = nonLocalizedName,
+				Language = LanguageName,
+				Platform = pDesc.Count == 1 ? pDesc[0].ProjectType : "Multiple"
+			};
 			TemplateCounter.Inc (1, null, metadata);
 
 			return workspaceItemInfo.WorkspaceItem;
@@ -346,11 +349,12 @@ namespace MonoDevelop.Ide.Templates
 			}
 
 			var pDesc = this.solutionDescriptor.EntryDescriptors.OfType<ProjectDescriptor> ().FirstOrDefault ();
-			var metadata = new Dictionary<string, string> ();
-			metadata ["Id"] = this.Id;
-			metadata ["Name"] = this.nonLocalizedName;
-			metadata ["Language"] = this.LanguageName;
-			metadata ["Platform"] = pDesc != null ? pDesc.ProjectType : "Unknown";
+			var metadata = new TemplateMetadata {
+				Id = Id,
+				Name = nonLocalizedName,
+				Language = LanguageName,
+				Platform = pDesc != null ? pDesc.ProjectType : "Unknown"
+			};
 			TemplateCounter.Inc (1, null, metadata);
 
 			return solutionEntryItems;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -371,7 +371,7 @@ namespace MonoDevelop.Ide
 		}
 
 		//this method is MIT/X11, 2009, Michael Hutchinson / (c) Novell
-		internal static async void OpenFiles (IEnumerable<FileOpenInformation> files, IDictionary<string, string> metadata)
+		internal static async void OpenFiles (IEnumerable<FileOpenInformation> files, OpenWorkspaceItemMetadata metadata)
 		{
 			if (!files.Any ())
 				return;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -779,7 +779,7 @@ namespace MonoDevelop.Ide
 			return new StartupMetadata {
 				CorrectedStartupTime = startupTimer.ElapsedMilliseconds,
 				StartupType = 0,
-				AssetTypeId = assetType.Id.ToString (),
+				AssetTypeId = assetType.Id,
 				AssetTypeName = assetType.Name,
 				IsInitialRun = IdeApp.IsInitialRun,
 				IsInitialRunAfterUpgrade = IdeApp.IsInitialRunAfterUpgrade,
@@ -788,10 +788,11 @@ namespace MonoDevelop.Ide
 			};
 		}
 
-		internal static IDictionary<string, string> GetOpenWorkspaceOnStartupMetadata ()
+		internal static OpenWorkspaceItemMetadata GetOpenWorkspaceOnStartupMetadata ()
 		{
-			var metadata = new Dictionary<string, string> ();
-			metadata ["OnStartup"] = bool.TrueString;
+			var metadata = new OpenWorkspaceItemMetadata {
+				OnStartup = true
+			};
 			return metadata;
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -476,7 +476,7 @@ namespace MonoDevelop.Ide
 			return OpenWorkspaceItem (file, closeCurrent, loadPreferences, null);
 		}
 
-		internal async Task<bool> OpenWorkspaceItem (FilePath file, bool closeCurrent, bool loadPreferences, IDictionary<string, string> metadata)
+		internal async Task<bool> OpenWorkspaceItem (FilePath file, bool closeCurrent, bool loadPreferences, OpenWorkspaceItemMetadata metadata)
 		{
 			lock (loadLock) {
 				if (++loadOperationsCount == 1)
@@ -510,7 +510,7 @@ namespace MonoDevelop.Ide
 			return OpenWorkspaceItemInternal (file, closeCurrent, loadPreferences, null, null);
 		}
 
-		internal async Task<bool> OpenWorkspaceItemInternal (FilePath file, bool closeCurrent, bool loadPreferences, IDictionary<string, string> metadata, ProgressMonitor loadMonitor)
+		internal async Task<bool> OpenWorkspaceItemInternal (FilePath file, bool closeCurrent, bool loadPreferences, OpenWorkspaceItemMetadata metadata, ProgressMonitor loadMonitor)
 		{
 			var item = GetAllItems<WorkspaceItem> ().FirstOrDefault (w => w.FileName == file.FullPath);
 			if (item != null) {
@@ -560,7 +560,7 @@ namespace MonoDevelop.Ide
 			}
 		}
 		
-		async Task<bool> BackgroundLoadWorkspace (ProgressMonitor monitor, FilePath file, bool loadPreferences, bool reloading, IDictionary<string, string> metadata, ITimeTracker timer)
+		async Task<bool> BackgroundLoadWorkspace (ProgressMonitor monitor, FilePath file, bool loadPreferences, bool reloading, OpenWorkspaceItemMetadata metadata, ITimeTracker timer)
 		{
 			WorkspaceItem item = null;
 
@@ -582,9 +582,9 @@ namespace MonoDevelop.Ide
 					// It is a project, not a solution. Try to create a dummy solution and add the project to it
 
 					if (File.Exists (Path.ChangeExtension (file, ".sln"))) {
-						metadata ["Reason"] = "OpenProject";
+						metadata.Reason = OpenWorkspaceItemMetadata.OpenReason.OpenProject;
 					} else {
-						metadata ["Reason"] = "CreateSolution";
+						metadata.Reason = OpenWorkspaceItemMetadata.OpenReason.CreateSolution;
 					}
 
 					timer.Trace ("Getting wrapper solution");
@@ -655,26 +655,26 @@ namespace MonoDevelop.Ide
 			return true;
 		}
 
-		static IDictionary<string, string> GetOpenWorkspaceItemMetadata (IDictionary<string, string> metadata)
+		static OpenWorkspaceItemMetadata GetOpenWorkspaceItemMetadata (OpenWorkspaceItemMetadata metadata)
 		{
 			if (metadata == null) {
-				metadata = new Dictionary<string, string> ();
-				metadata ["OnStartup"] = bool.FalseString;
+				metadata = new OpenWorkspaceItemMetadata ();
+				metadata.OnStartup = false;
 			}
 
 			// Will be set to true after a successful load.
-			metadata ["LoadSucceed"] = bool.FalseString;
-			metadata ["Reason"] = "OpenSolution";
+			metadata.LoadSucceed = false;
+			metadata.Reason = OpenWorkspaceItemMetadata.OpenReason.OpenSolution;
 
 			return metadata;
 		}
 
-		static void UpdateOpenWorkspaceItemMetadata (IDictionary<string, string> metadata, WorkspaceItem item)
+		static void UpdateOpenWorkspaceItemMetadata (OpenWorkspaceItemMetadata metadata, WorkspaceItem item)
 		{
 			// Is this a workspace or a solution?
-			metadata ["IsSolution"] = (item is Solution).ToString ();
-			metadata ["LoadSucceed"] = bool.TrueString;
-			metadata ["TotalProjectCount"] = item.GetAllItems<Project> ().Count ().ToString ();
+			metadata.IsSolution = (item is Solution);
+			metadata.LoadSucceed = true;
+			metadata.TotalProjectCount = item.GetAllItems<Project> ().Count ();
 		}
 
 		string GetStoredActiveConfiguration (WorkspaceItem item, bool loadPreferences)
@@ -1545,6 +1545,55 @@ namespace MonoDevelop.Ide
 		public void Dispose ()
 		{
 			NotifyChanges ();
+		}
+	}
+
+
+	class OpenWorkspaceItemMetadata : CounterMetadata
+	{
+		public enum OpenReason
+		{
+			Unknown,
+			OpenProject,
+			OpenSolution,
+			CreateSolution
+		};
+
+		public OpenWorkspaceItemMetadata ()
+		{
+		}
+
+		public bool OnStartup {
+			get => GetProperty<bool> ();
+			set => SetProperty (value);
+		}
+
+		public bool LoadSucceed {
+			get => GetProperty<bool> ();
+			set => SetProperty (value);
+		}
+
+		public OpenReason Reason {
+			get {
+				var rs = GetProperty<string> ();
+				if (Enum.TryParse<OpenReason> (rs, out var result)) {
+					return result;
+				}
+
+				return OpenReason.Unknown;
+			}
+
+			set => SetProperty (value.ToString ());
+		}
+
+		public bool IsSolution {
+			get => GetProperty<bool> ();
+			set => SetProperty (value);
+		}
+
+		public int TotalProjectCount {
+			get => GetProperty<int> ();
+			set => SetProperty (value);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Tasks;
 using MonoDevelop.Projects;
 using MonoDevelop.Core.Instrumentation;
+using MonoDevelop.Ide.Editor.Extension;
 
 namespace MonoDevelop.Ide
 {
@@ -49,8 +50,8 @@ namespace MonoDevelop.Ide
 		internal static Counter DocumentsInMemory = InstrumentationService.CreateCounter ("Documents in memory", "IDE");
 		internal static Counter PadsLoaded = InstrumentationService.CreateCounter ("Pads loaded", "IDE");
 		internal static TimerCounter CommandTargetScanTime = InstrumentationService.CreateTimerCounter ("Command target scan", "Timing", 0.3, false);
-		internal static TimerCounter OpenWorkspaceItemTimer = InstrumentationService.CreateTimerCounter ("Solution opened in the IDE", "IDE", id:"Ide.Shell.SolutionOpened");
-		internal static TimerCounter OpenDocumentTimer = InstrumentationService.CreateTimerCounter ("Open document", "IDE", id:"Ide.Shell.OpenDocument");
+		internal static TimerCounter<OpenWorkspaceItemMetadata> OpenWorkspaceItemTimer = InstrumentationService.CreateTimerCounter<OpenWorkspaceItemMetadata> ("Solution opened in the IDE", "IDE", id:"Ide.Shell.SolutionOpened");
+		internal static TimerCounter<OpenDocumentMetadata> OpenDocumentTimer = InstrumentationService.CreateTimerCounter<OpenDocumentMetadata> ("Open document", "IDE", id:"Ide.Shell.OpenDocument");
 		internal static TimerCounter DocumentOpened = InstrumentationService.CreateTimerCounter ("Document opened", "IDE", id:"Ide.Shell.DocumentOpened");
 		internal static Counter AutoSavedFiles = InstrumentationService.CreateCounter ("Autosaved Files", "Text Editor");
 		internal static TimerCounter BuildItemTimer = InstrumentationService.CreateTimerCounter ("Project/Solution built in the IDE", "IDE", id:"Ide.Shell.ProjectBuilt");
@@ -64,7 +65,7 @@ namespace MonoDevelop.Ide
 		internal static TimerCounter CompositionCache = InstrumentationService.CreateTimerCounter ("MEF Composition From Cache", "IDE", id: "Ide.Startup.Composition.Cache");
 		internal static TimerCounter CompositionSave = InstrumentationService.CreateTimerCounter ("MEF Composition Save", "IDE", id: "Ide.CompositionSave");
 		internal static TimerCounter ProcessCodeCompletion = InstrumentationService.CreateTimerCounter ("Process Code Completion", "IDE", id: "Ide.ProcessCodeCompletion", logMessages:false);
-		internal static Counter CodeCompletionStats = InstrumentationService.CreateCounter ("Code Completion Statistics", "IDE", id:"Ide.CodeCompletionStatistics");
+		internal static Counter<CompletionStatisticsMetadata> CodeCompletionStats = InstrumentationService.CreateCounter<CompletionStatisticsMetadata> ("Code Completion Statistics", "IDE", id:"Ide.CodeCompletionStatistics");
 		internal static Counter<TimeToCodeMetadata> TimeToCode = InstrumentationService.CreateCounter<TimeToCodeMetadata> ("Time To Code", "IDE", id: "Ide.TimeToCode");
 
 		internal static bool TrackingBuildAndDeploy;
@@ -104,12 +105,12 @@ namespace MonoDevelop.Ide
 
 	class AssetMetadata : CounterMetadata
 	{
-		public string AssetTypeId {
-			get => GetProperty ();
+		public int AssetTypeId {
+			get => GetProperty<int> ();
 			set => SetProperty (value);
 		}
 		public string AssetTypeName {
-			get => GetProperty ();
+			get => GetProperty<string> ();
 			set => SetProperty (value);
 		}
 	}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
@@ -126,8 +126,8 @@ namespace MonoDevelop.Core
 			var timer = InstrumentationService.CreateTimerCounter<CustomCounterMetadata> ("TestCounter");
 			var md = new CustomCounterMetadata {
 				SomeMeasure = 5,
-				Result = CounterResult.Success
 			};
+			md.SetSuccess ();
 			var t = timer.BeginTiming (md);
 			t.Dispose ();
 			Assert.AreEqual (1, counterValues.Count);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
@@ -104,7 +104,7 @@ namespace MonoDevelop.Core
 
 			Assert.IsNotNull (value.Metadata);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CustomCounterMetadata.SomeMeasure), out var measure));
-			Assert.AreEqual ("4", measure);
+			Assert.AreEqual (4, measure);
 			Assert.IsFalse (value.Metadata.TryGetValue (nameof (CounterMetadata.Result), out var result));
 		}
 
@@ -135,7 +135,7 @@ namespace MonoDevelop.Core
 
 			Assert.IsNotNull (value.Metadata);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CustomCounterMetadata.SomeMeasure), out var measure));
-			Assert.AreEqual ("5", measure);
+			Assert.AreEqual (5, measure);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CounterMetadata.Result), out var result));
 			Assert.AreEqual ("Success", result);
 		}
@@ -174,7 +174,7 @@ namespace MonoDevelop.Core
 
 			Assert.IsNotNull (value.Metadata);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CustomCounterMetadata.SomeMeasure), out var measure));
-			Assert.AreEqual ("4", measure);
+			Assert.AreEqual (4, measure);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CounterMetadata.Result), out var result));
 			Assert.AreEqual ("UserCancel", result);
 		}
@@ -194,7 +194,7 @@ namespace MonoDevelop.Core
 
 			Assert.IsNotNull (value.Metadata);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CustomCounterMetadata.SomeMeasure), out var measure));
-			Assert.AreEqual ("5", measure);
+			Assert.AreEqual (5, measure);
 			Assert.IsTrue (value.Metadata.TryGetValue (nameof (CounterMetadata.Result), out var result));
 			Assert.AreEqual ("Success", result);
 		}


### PR DESCRIPTION
Use CounterMetadata subclasses so that metadata properties aren't reduced to
strings and will be placed into the correct property or measures bag

Fixes VSTS #633544