### PR TITLE
[Core] Fix UI hang when building ASP.NET Core 2.1 Angular project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4244,16 +4244,22 @@ namespace MonoDevelop.Projects
 
 		void OnFileCreated (object sender, FileSystemEventArgs e)
 		{
-			if (Directory.Exists (e.FullPath))
-				return;
+			try {
+				if (Directory.Exists (e.FullPath))
+					return;
 
-			FilePath filePath = e.FullPath;
-			if (filePath.FileName == ".DS_Store")
-				return;
+				FilePath filePath = e.FullPath;
+				if (filePath.FileName == ".DS_Store")
+					return;
 
-			Runtime.RunInMainThread (() => {
+				// Ignore temporary files created when saving a file in the editor.
+				if (filePath.FileName.StartsWith (".#", StringComparison.OrdinalIgnoreCase))
+					return;
+
 				OnFileCreatedExternally (e.FullPath);
-			});
+			} catch (Exception ex) {
+				LoggingService.LogError ("OnFileCreated error.", ex);
+			}
 		}
 
 		void OnFileDeleted (object sender, FileSystemEventArgs e)
@@ -4291,7 +4297,16 @@ namespace MonoDevelop.Projects
 				var eit = CreateFakeEvaluatedItem (sourceProject, it, include, null);
 				var pi = CreateProjectItem (eit);
 				pi.Read (this, eit);
-				Items.Add (pi);
+				if (Runtime.IsMainThread) {
+					Items.Add (pi);
+				} else {
+					Runtime.RunInMainThread (() => {
+						// Double check the file has not been added on the UI thread by the IDE.
+						if (!Files.Any (file => file.FilePath == fileName)) {
+							Items.Add (pi);
+						}
+					}).Ignore ();
+				}
 			}
 		}
 


### PR DESCRIPTION
Creating a new ASP.NET Core 2.1 Angular project from the command line,
then opening it into the IDE, and building it would result in the
IDE hanging.

On building an ASP.NET Core 2.1 Angular project (also React.js and
Redux) will attempt to run an npm install. This results in thousands
of files being created in the node_modules directory. These files
being created resulted in the UI thread being used to check to
see if the file needed to be automatically added to the project
and resulted in a hang of the IDE. This check has been moved off
the UI thread when files are created which prevents the UI hang.

Also adding some code to ignore temporary files which are
generated by the text editor on saving (e.g. '.#MyClass.cs) which
broke TextFileUtility_WriteText_FileNotRemovedAndAddedBackToProject
in the tests. These temporary files were being added to the project
and breaking the test.

Fixes VSTS #632347 - UI hang when building ASP.NET Core 2.1 Angular
project