### PR TITLE
[TODO] Fix off by 1 indices in todo comments

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TagCommentsTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TagCommentsTextEditorExtension.cs
@@ -94,7 +94,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 					if (token.IsCancellationRequested)
 						return;
 
-					var offset = Editor.LocationToOffset (todoItem.MappedLine, todoItem.MappedColumn);
+					var offset = Editor.LocationToOffset (todoItem.MappedLine + 1, todoItem.MappedColumn + 1);
 					var newTask = new QuickTask (todoItem.Message, offset, DiagnosticSeverity.Info);
 					newTasks.Add (newTask);
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/Tag.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/Tag.cs
@@ -88,8 +88,10 @@ namespace MonoDevelop.Ide.TypeSystem
 			var message = item.Message;
 			var index = message.IndexOf (':');
 			var tag = message.Substring (0, index);
+			int line = item.MappedLine + 1;
+			int column = item.MappedColumn + 1;
 
-			return new Tag (tag, message, new Editor.DocumentRegion (item.MappedLine, item.MappedColumn, item.MappedLine, item.MappedColumn));
+			return new Tag (tag, message, new Editor.DocumentRegion (line, column, line, column));
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tasks/CommentTasksProviderTests.Controller.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tasks/CommentTasksProviderTests.Controller.cs
@@ -86,10 +86,10 @@ namespace MonoDevelop.Ide.Tasks
 					if (!withToDos)
 						yield break;
 
-					yield return ("TODO: Fill this file", "TODO", 0, 3);
-					yield return ("FIXME: This is broken", "FIXME", 1, 3);
-					yield return ("HACK: Just for the test", "HACK", 2, 3);
-					yield return ("UNDONE: Not done yet", "UNDONE", 3, 3);
+					yield return ("TODO: Fill this file", "TODO", 1, 4);
+					yield return ("FIXME: This is broken", "FIXME", 2, 4);
+					yield return ("HACK: Just for the test", "HACK", 3, 4);
+					yield return ("UNDONE: Not done yet", "UNDONE", 4, 4);
 				}
 			}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tasks/CommentTasksProviderTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tasks/CommentTasksProviderTests.cs
@@ -111,10 +111,10 @@ namespace MonoDevelop.Ide.Tasks
 
 				await helper.LoadProject (new Controller.Options (withToDos: true) {
 					ExpectedComments = new[] {
-						("FIXME: This is broken", "FIXME", 1, 3),
-						("HACK: Just for the test", "HACK", 2, 3),
-						("UNDONE: Not done yet", "UNDONE", 3, 3),
-						("CUSTOMTAG: Shouldn't be in first", "CUSTOMTAG", 4, 3),
+						("FIXME: This is broken", "FIXME", 2, 4),
+						("HACK: Just for the test", "HACK", 3, 4),
+						("UNDONE: Not done yet", "UNDONE", 4, 4),
+						("CUSTOMTAG: Shouldn't be in first", "CUSTOMTAG", 5, 4),
 					},
 				});
 
@@ -154,7 +154,7 @@ namespace MonoDevelop.Ide.Tasks
 				};
 
 				var list = options.ExpectedComments.ToList ();
-				list.Add (("TODO: Added", "TODO", 5, 3));
+				list.Add (("TODO: Added", "TODO", 6, 4));
 				options.ExpectedComments = list.ToArray ();
 
 				await helper.ModifyToDoFile ("// TODO: Added", options);


### PR DESCRIPTION
Fixes VSTS #626731 - Line/col for TODO issues is off by 1