### PR TITLE
Fix #4822: Fixing code comment command for all cases

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -50,6 +50,9 @@ namespace Microsoft.VisualStudio.Platform
 		private ITextView textView { get; }
 		private IAccurateClassifier classifier { get; set; }
 		readonly Dictionary<string, ScopeStack> classificationMap;
+		Dictionary<IClassificationType, ScopeStack> classificationTypeToScopeCache = new Dictionary<IClassificationType, ScopeStack> ();
+		ScopeStack defaultScopeStack = new ScopeStack (EditorThemeColors.Foreground);
+		ScopeStack userScope;
 		private MonoDevelop.Ide.Editor.ITextDocument textDocument { get; }
 
 		internal TagBasedSyntaxHighlighting (ITextView textView, string defaultScope)
@@ -58,6 +61,7 @@ namespace Microsoft.VisualStudio.Platform
 			this.textDocument = textView.GetTextEditor ();
 			if (defaultScope != null)
 				classificationMap = GetClassificationMap (defaultScope);
+			this.userScope = this.defaultScopeStack.Push (EditorThemeColors.UserTypes);
 		}
 
 		public Task<HighlightedLine> GetHighlightedLineAsync (IDocumentLine line, CancellationToken cancellationToken)
@@ -78,7 +82,7 @@ namespace Microsoft.VisualStudio.Platform
 			ScopeStack scopeStack;
 			foreach (ClassificationSpan curSpan in classifications) {
 				if (curSpan.Span.Start > lastClassifiedOffsetEnd) {
-					scopeStack = new ScopeStack (EditorThemeColors.Foreground);
+					scopeStack = userScope;
 					ColoredSegment whitespaceSegment = new ColoredSegment (lastClassifiedOffsetEnd - start, curSpan.Span.Start - lastClassifiedOffsetEnd, scopeStack);
 					coloredSegments.Add (whitespaceSegment);
 				}
@@ -95,7 +99,7 @@ namespace Microsoft.VisualStudio.Platform
 			}
 
 			if (end > lastClassifiedOffsetEnd) {
-				scopeStack = new ScopeStack (EditorThemeColors.Foreground);
+				scopeStack = userScope;
 				ColoredSegment whitespaceSegment = new ColoredSegment (lastClassifiedOffsetEnd - start, end - lastClassifiedOffsetEnd, scopeStack);
 				coloredSegments.Add (whitespaceSegment);
 			}
@@ -162,7 +166,7 @@ namespace Microsoft.VisualStudio.Platform
 				if (segment.Offset <= offset && segment.EndOffset >= offset)
 					return segment.ScopeStack;
 			}
-			return ScopeStack.Empty;
+			return defaultScopeStack;
 		}
 
 		private EventHandler<LineEventArgs> _highlightingStateChanged;
@@ -215,9 +219,6 @@ namespace Microsoft.VisualStudio.Platform
 				}
 			}
 		}
-
-		Dictionary<IClassificationType, ScopeStack> classificationTypeToScopeCache = new Dictionary<IClassificationType, ScopeStack> ();
-		static ScopeStack defaultScopeStack = new ScopeStack (EditorThemeColors.Foreground);
 
 		private ScopeStack GetScopeStackFromClassificationType (IClassificationType classificationType)
 		{
@@ -387,12 +388,12 @@ namespace Microsoft.VisualStudio.Platform
 		}
 
 		static ImmutableDictionary<string, Dictionary<string, ScopeStack>> classificationMapCache = ImmutableDictionary<string, Dictionary<string, ScopeStack>>.Empty;
-		static Dictionary<string, ScopeStack> GetClassificationMap (string scope)
+		Dictionary<string, ScopeStack> GetClassificationMap (string scope)
 		{
 			Dictionary<string, ScopeStack> result;
+			defaultScopeStack = new ScopeStack (scope);
 			if (classificationMapCache.TryGetValue (scope, out result))
 				return result;
-			var defaultScopeStack = new ScopeStack (scope);
 			result = new Dictionary<string, ScopeStack> {
 				[ClassificationTypeNames.Comment] = MakeScope (defaultScopeStack, "comment." + scope),
 				[ClassificationTypeNames.ExcludedCode] = MakeScope (defaultScopeStack, "comment.excluded." + scope),

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/Commands/CodeCommentTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/Commands/CodeCommentTests.cs
@@ -211,6 +211,36 @@ namespace MonoDevelop.Ide.Editor
 			}
 		}
 
+
+
+		[Test]
+		public async Task TestToggle_Visible_StartOfLine ()
+		{
+			//We need to create full document and not just editor
+			//so extensions are initialized which set custom C#
+			//tagger based syntax highligthing
+			const string input = @"class Foo
+{
+	void Bar ()
+$	{
+		//test
+	}
+}";
+			using (var testCase = await SetupTestCase ("", wrap: true)) {
+				var editor = testCase.Document.Editor;
+				SetupInput (editor, input);
+
+				//Call UpdateParseDocument so AdHock Roslyn Workspace is created for file
+				await testCase.Document.UpdateParseDocument ();
+
+				//Finnaly call command Update so it sets values which we assert
+				var info = new Components.Commands.CommandInfo ();
+				testCase.GetContent<DefaultCommandTextEditorExtension> ().OnUpdateToggleComment (info);
+				Assert.AreEqual (true, info.Visible);
+				Assert.AreEqual (true, info.Enabled);
+			}
+		}
+
 		[Test]
 		public async Task TestToggle_AddAsync ()
 		{


### PR DESCRIPTION
Problem was that in case of start/end of line where Roslyn didn’t report any specific highlighting we used defaultScope, problem with that was that after switch from RoslynClassifier to TagBased one I used Foreground which didn’t stack on top of “sources.cs”. So now `defaultScopeStack` is set correctly, and to better match with RoslynClassifier I also re-introduced userScope.
Also includes unit tests