### PR TITLE
[release-7.6] Omitting TargetFramework causes latest Android SDK to be used

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
@@ -105,7 +105,6 @@ type ``Template tests``() =
             cinfo.Parameters.["AppIdentifier"] <- tt
             cinfo.Parameters.["AndroidMinSdkVersionAttribute"] <- "android:minSdkVersion=\"10\""
             cinfo.Parameters.["AndroidThemeAttribute"] <- ""
-            cinfo.Parameters.["TargetFrameworkVersion"] <- "MonoAndroid,Version=v8.1"
 
             for templateParameter in TemplateParameter.CreateParameters (parameters) do
                 cinfo.Parameters.[templateParameter.Name] <- templateParameter.Value

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
@@ -136,6 +136,12 @@ type ``Template tests``() =
             // This is because the Import is grouped with the Xamarin.Build.Download .props Import which is inserted
             // at the top of the project file.
             do! sln.SaveAsync(monitor)
+
+            projects
+            |> List.map(fun p -> p.FileName.FullPath |> string)
+            |> List.map File.ReadAllText
+            |> List.iter (printfn "%s")
+
             do! NuGetPackageInstaller.InstallPackages (sln, projectTemplate.PackageReferencesForCreatedProjects)
 
             let errors = getErrorsForProject sln |> AsyncSeq.toSeq |> List.ofSeq

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/TemplateTests.fs
@@ -103,7 +103,7 @@ type ``Template tests``() =
             cinfo.Parameters.["CreateAndroidUITest"] <- "False"
             cinfo.Parameters.["MinimumOSVersion"] <- "10.7"
             cinfo.Parameters.["AppIdentifier"] <- tt
-            cinfo.Parameters.["AndroidMinSdkVersionAttribute"] <- "android:minSdkVersion=\"10\""
+            cinfo.Parameters.["AndroidMinSdkVersionAttribute"] <- "android:minSdkVersion=\"27\""
             cinfo.Parameters.["AndroidThemeAttribute"] <- ""
 
             for templateParameter in TemplateParameter.CreateParameters (parameters) do
@@ -136,12 +136,6 @@ type ``Template tests``() =
             // This is because the Import is grouped with the Xamarin.Build.Download .props Import which is inserted
             // at the top of the project file.
             do! sln.SaveAsync(monitor)
-
-            projects
-            |> List.map(fun p -> p.FileName.FullPath |> string)
-            |> List.map File.ReadAllText
-            |> List.iter (printfn "%s")
-
             do! NuGetPackageInstaller.InstallPackages (sln, projectTemplate.PackageReferencesForCreatedProjects)
 
             let errors = getErrorsForProject sln |> AsyncSeq.toSeq |> List.ofSeq


### PR DESCRIPTION
Backport of #5099.

/cc @nosami