### PR TITLE
[Core] Allow loading of SDK style projects without TargetFramework  

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreMSBuildProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreMSBuildProjectTests.cs
@@ -369,6 +369,28 @@ namespace MonoDevelop.DotNetCore.Tests
 		}
 
 		[Test]
+		public void WriteProject_TargetFrameworkVersionChangedThenChangedBackAgain_OriginalTargetFrameworkUsedInProject ()
+		{
+			CreateMSBuildProject (
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"      <OutputType>Exe</OutputType>\r\n" +
+				"      <TargetFramework>netcoreapp1.0</TargetFramework>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"</Project>");
+			msbuildProject.Evaluate ();
+			ReadProject ();
+			project.Sdk = "Microsoft.NET.Sdk";
+
+			WriteProject (".NETCoreApp,Version=v1.1");
+			WriteProject (".NETCoreApp,Version=v1.0");
+
+			string savedFramework = msbuildProject.GetGlobalPropertyGroup ()
+				.GetValue ("TargetFramework");
+			Assert.AreEqual ("netcoreapp1.0", savedFramework);
+		}
+
+		[Test]
 		public void WriteProject_NetStandardTargetFrameworkVersionChanged_TargetFrameworkUpdated ()
 		{
 			CreateMSBuildProject (

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreMSBuildProject.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreMSBuildProject.cs
@@ -96,7 +96,7 @@ namespace MonoDevelop.DotNetCore
 			globalPropertyGroup.RemoveProperty ("TargetFrameworkVersion");
 
 			if (!IsOutputTypeDefined)
-				globalPropertyGroup.RemoveProperty ("OutputType");
+				RemoveOutputTypeIfHasDefaultValue (project, globalPropertyGroup);
 
 			RemoveMSBuildProjectNameDerivedProperties (globalPropertyGroup);
 
@@ -114,6 +114,16 @@ namespace MonoDevelop.DotNetCore
 
 			if (HasSdk) {
 				project.ToolsVersion = ToolsVersion;
+			}
+		}
+
+		static void RemoveOutputTypeIfHasDefaultValue (MSBuildProject project, MSBuildPropertyGroup globalPropertyGroup)
+		{
+			string outputType = project.EvaluatedProperties.GetValue ("OutputType");
+			if (string.IsNullOrEmpty (outputType)) {
+				globalPropertyGroup.RemoveProperty ("OutputType");
+			} else {
+				globalPropertyGroup.RemovePropertyIfHasDefaultValue ("OutputType", outputType);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreMSBuildProject.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreMSBuildProject.cs
@@ -154,6 +154,7 @@ namespace MonoDevelop.DotNetCore
 			else
 				targetFrameworks[0] = shortFrameworkName;
 
+			targetFrameworkMoniker = framework;
 			project.UpdateTargetFrameworks (targetFrameworks);
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -480,7 +480,7 @@ namespace MonoDevelop.Projects.MSBuild
 		internal MSBuildProjectInstanceInfo LoadNativeInstance (bool evaluateItems)
 		{
 			lock (readLock) {
-				var supportsMSBuild = UseMSBuildEngine && GetGlobalPropertyGroup ().GetValue ("UseMSBuildEngine", true);
+				var supportsMSBuild = UseMSBuildEngine && (GetGlobalPropertyGroup ()?.GetValue ("UseMSBuildEngine", true) ?? true);
 
 				if (engineManager == null) {
 					engineManager = new MSBuildEngineManager ();
@@ -573,7 +573,12 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public string [] ProjectTypeGuids
 		{
-			get { return GetGlobalPropertyGroup ().GetValue ("ProjectTypeGuids", "").Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select (t => t.Trim ()).ToArray (); }
+			get {
+				var propertyGroup = GetGlobalPropertyGroup ();
+				if (propertyGroup == null)
+					return Array.Empty<string> ();
+				return propertyGroup.GetValue ("ProjectTypeGuids", "").Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select (t => t.Trim ()).ToArray ();
+			}
 			set { GetGlobalPropertyGroup ().SetValue ("ProjectTypeGuids", string.Join (";", value), preserveExistingCase: true); }
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroup.cs
@@ -463,6 +463,17 @@ namespace MonoDevelop.Projects.MSBuild
 				i++;
 			}
 		}
+
+		internal bool SkipSerializationOnNoChildren { get; set; } = false;
+
+		internal override bool SkipSerialization {
+			get {
+				if (SkipSerializationOnNoChildren)
+					return !GetChildren ().Any (c => !c.SkipSerialization);
+
+				return base.SkipSerialization;
+			}
+		}
 	}
 
 	public interface IMSBuildPropertyGroupEvaluated: IReadOnlyPropertySet

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -199,13 +199,7 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		void InitBeforeProjectExtensionLoad ()
 		{
-			var ggroup = sourceProject.GetGlobalPropertyGroup ();
-			// Avoid crash if there is not global group
-			if (ggroup == null) {
-				ggroup = sourceProject.AddNewPropertyGroup (false);
-				// Ensure empty property group is not added on saving if it has no child properties.
-				ggroup.SkipSerializationOnNoChildren = true;
-			}
+			var ggroup = sourceProject.GetOrCreateGlobalPropertyGroup ();
 
 			// Load the evaluated properties
 			InitMainGroupProperties (ggroup);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -201,8 +201,11 @@ namespace MonoDevelop.Projects
 		{
 			var ggroup = sourceProject.GetGlobalPropertyGroup ();
 			// Avoid crash if there is not global group
-			if (ggroup == null)
+			if (ggroup == null) {
 				ggroup = sourceProject.AddNewPropertyGroup (false);
+				// Ensure empty property group is not added on saving if it has no child properties.
+				ggroup.SkipSerializationOnNoChildren = true;
+			}
 
 			// Load the evaluated properties
 			InitMainGroupProperties (ggroup);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1425,7 +1425,7 @@ namespace MonoDevelop.Projects
 				return null;
 
 			var propertyGroup = project.GetGlobalPropertyGroup ();
-			string propertyValue = propertyGroup.GetValue ("TargetFramework", null);
+			string propertyValue = propertyGroup?.GetValue ("TargetFramework", null);
 			if (propertyValue != null)
 				return null;
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -478,5 +478,22 @@ namespace MonoDevelop.Projects
 				Assert.AreEqual (xamlFile, xamlCSharpFile.DependsOnFile);
 			}
 		}
+
+		[Test]
+		public async Task DotNetCoreNoMainPropertyGroup ()
+		{
+			FilePath solFile = Util.GetSampleProject ("DotNetCoreNoMainPropertyGroup", "DotNetCoreNoMainPropertyGroup.sln");
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (Project)sol.Items [0];
+				Assert.AreEqual ("DotNetCoreNoMainPropertyGroup", p.Name);
+
+				var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
+				Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+				Assert.AreEqual (0, process.ExitCode);
+
+				await p.ReevaluateProject (Util.GetMonitor ());
+			}
+		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -493,6 +493,13 @@ namespace MonoDevelop.Projects
 				Assert.AreEqual (0, process.ExitCode);
 
 				await p.ReevaluateProject (Util.GetMonitor ());
+
+				string projectXml = File.ReadAllText (p.FileName);
+				await p.SaveAsync (Util.GetMonitor ());
+
+				// Project xml should not be changed.
+				string savedProjectXml = File.ReadAllText (p.FileName);
+				Assert.AreEqual (projectXml, savedProjectXml);
 			}
 		}
 	}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -1570,6 +1570,34 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void ProjectHasNoMainPropertyGroup_AddRemoveProjectTypeGuid ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+
+			var projectTypeGuids = new string[] { "{test}" };
+			p.ProjectTypeGuids = projectTypeGuids;
+			Assert.AreEqual (projectTypeGuids, p.ProjectTypeGuids);
+
+			// Reload to ensure GlobalPropertyGroups is not available.
+			p.LoadXml (projectXml);
+
+			p.AddProjectTypeGuid ("{test}");
+			Assert.AreEqual (projectTypeGuids, p.ProjectTypeGuids);
+
+			// Reload to ensure GlobalPropertyGroups is not available.
+			p.LoadXml (projectXml);
+
+			p.AddProjectTypeGuid ("{test}");
+
+			p.Dispose ();
+		}
+
+		[Test]
 		public void GlobalPropertyProvider ()
 		{
 			var prov = new CustomGlobalPropertyProvider ("Works!");

--- a/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/Directory.Build.props
+++ b/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup.sln
+++ b/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCoreNoMainPropertyGroup", "DotNetCoreNoMainPropertyGroup\DotNetCoreNoMainPropertyGroup.csproj", "{32587BAB-C960-47D9-B952-FEFA8E55D76B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{32587BAB-C960-47D9-B952-FEFA8E55D76B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32587BAB-C960-47D9-B952-FEFA8E55D76B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32587BAB-C960-47D9-B952-FEFA8E55D76B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32587BAB-C960-47D9-B952-FEFA8E55D76B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup.csproj
+++ b/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup/Program.cs
+++ b/main/tests/test-projects/DotNetCoreNoMainPropertyGroup/DotNetCoreNoMainPropertyGroup/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DotNetCoreNoMainPropertyGroup
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			Console.WriteLine("Hello World!");
+		}
+	}
+}


### PR DESCRIPTION
Handle the missing main property group when loading and saving a
project. Previously a null reference would occur in several places
on loading.

Fixes VSTS #567738 - NullReferenceException loading sdk-style project
with no TargetFramework