### PR TITLE
[AspNetCore] Fix dev certs console app being run with mono32

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/DotNetCoreDevCertsTool.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/DotNetCoreDevCertsTool.cs
@@ -111,8 +111,9 @@ namespace MonoDevelop.AspNetCore
 				try {
 					string installerPath = GetInstallerPath ();
 
+					// Needs to be run with mono64.
 					var monoRuntime = Runtime.SystemAssemblyService.DefaultRuntime as MonoTargetRuntime;
-					string monoPath = monoRuntime.GetMonoExecutableForAssembly (installerPath);
+					string monoPath = Path.Combine (monoRuntime.MonoRuntimeInfo.Prefix, "bin", "mono64");
 					string message = GettextCatalog.GetString ("dotnet-dev-certs wants to make changes.");
 
 					var process = Runtime.ProcessService.StartConsoleProcess (


### PR DESCRIPTION
The dev certs console app needs to be run with mono64 otherwise it
crashes since it uses 64 bit Xamarin.Mac.

```
at <unknown> <0xffffffff>
  at (wrapper managed-to-native) Security.Authorization.AuthorizationCreate (Security.AuthorizationItemSet*,Security.AuthorizationItemSet*,Security.AuthorizationFlags,intptr&) <0x00012>
  at Security.Authorization.Create (Security.AuthorizationParameters,Security.AuthorizationEnvironment,Security.AuthorizationFlags) [0x001f8] in <1d35452d95a94ac5bbd68a29ad6a434d>:0
  at MonoDevelop.AspNetCore.DevCertInstaller.MainClass.Run (string,string,string) [0x00031] in <bde88a041aeb46609477112e419aea87>:0
  at MonoDevelop.AspNetCore.DevCertInstaller.MainClass.Main (string[]) [0x00031] in <bde88a041aeb46609477112e419aea87>:0
  at (wrapper runtime-invoke) <Module>.runtime_invoke_int_object (object,intptr,intptr,intptr)
```

A recent change was made to build the console app as AnyCPU instead
of x64 - 985271cbdd61ad3a5a2328e1bd6856823d063269