### PR TITLE
Fix Get Implementing Symbols

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -198,6 +198,7 @@ module SymbolUse =
         not symbol.IsConstructor && 
         not symbol.IsPropertyGetterMethod && 
         not symbol.IsPropertySetterMethod &&
+        not symbol.IsProperty &&
         not (symbol.LogicalName = ".ctor")
 
     let (|Method|_|) (symbolUse:FSharpSymbolUse) =


### PR DESCRIPTION
notCtorOrProp was returning true for a property. This was causing the
`Val` active pattern to return true for properties.

Fixes VSTS #585696 (#4226)