### PR TITLE
[Core] Detect circular dependencies between MSBuild imports

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -1220,6 +1220,8 @@ namespace MonoDevelop.Projects.MSBuild
 			if (!File.Exists (file))
 				return;
 
+			context.AddImport (file);
+
 			var pref = LoadProject (context, file);
 			project.ReferencedProjects.Add (pref);
 
@@ -1244,6 +1246,8 @@ namespace MonoDevelop.Projects.MSBuild
 				
 				project.Properties [p.Key] = p.Value;
 			}
+
+			context.RemoveImport (file);
 		}
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildChoose choose, bool evalItems)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectLoadSaveTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectLoadSaveTests.cs
@@ -1382,6 +1382,17 @@ namespace MonoDevelop.Projects
 
 			p.Dispose ();
 		}
+
+		[Test]
+		public async Task LoadProject_ImportHasCircularDependency ()
+		{
+			string solFile = Util.GetSampleProject ("ImportCircularDependency", "ImportCircularDependency.sln");
+
+			using (var item = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = item.Items [0] as UnknownSolutionItem;
+				Assert.That (p.LoadError, Contains.Substring ("circular dependency"));
+			}
+		}
 	}
 
 	class CustomItem : ProjectItem

--- a/main/tests/test-projects/ImportCircularDependency/FirstImport.targets
+++ b/main/tests/test-projects/ImportCircularDependency/FirstImport.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="SecondImport.targets" />
+</Project>

--- a/main/tests/test-projects/ImportCircularDependency/ImportCircularDependency.csproj
+++ b/main/tests/test-projects/ImportCircularDependency/ImportCircularDependency.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E94E47AF-A61B-4FB0-A22C-1C14FD129FF7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ImportCircularDependency</RootNamespace>
+    <AssemblyName>ImportCircularDependency</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="FirstImport.targets" />
+</Project>

--- a/main/tests/test-projects/ImportCircularDependency/ImportCircularDependency.sln
+++ b/main/tests/test-projects/ImportCircularDependency/ImportCircularDependency.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportCircularDependency", "ImportCircularDependency.csproj", "{E94E47AF-A61B-4FB0-A22C-1C14FD129FF7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E94E47AF-A61B-4FB0-A22C-1C14FD129FF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E94E47AF-A61B-4FB0-A22C-1C14FD129FF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E94E47AF-A61B-4FB0-A22C-1C14FD129FF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E94E47AF-A61B-4FB0-A22C-1C14FD129FF7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ImportCircularDependency/SecondImport.targets
+++ b/main/tests/test-projects/ImportCircularDependency/SecondImport.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="FirstImport.targets" />
+</Project>


### PR DESCRIPTION
If project has an import which caused a circular dependency a
stackoverflow exception would be thrown. Circular dependencies are
now detected and an error is reported to the user indicating the
problem.

Fixes VSTS #569959 - attempt to load a project with conflicting
custom SDKs results in StackOverflowException