### PR TITLE
[Ide] Fix build not being done when file is unsaved

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -431,6 +431,9 @@ namespace MonoDevelop.Ide.Gui
 						}
 						DocumentRegistry.SkipNextChange (fileName);
 						await Window.ViewContent.Save (fileName);
+						// Force a change notification. This is needed for FastCheckNeedsBuild to be updated
+						// when saving before a build, for example.
+						FileService.NotifyFileChanged (fileName);
                         OnSaved(EventArgs.Empty);
 					}
 				}


### PR DESCRIPTION
With an unsaved file open in the text editor, running the project
would not trigger a build after the file was saved. The problem
was that the file watcher file change event happened after the
FastCheckNeedsBuild was checked so no build occurred. To fix this
the Document now uses the FileService.NotifyFileChanged to force
a file notification to occur on saving the file so the
FastCheckNeedsBuild is updated before checking if a build is needed.