### PR TITLE
[NuGet] Fix wrong FSharp.Core NuGet package restored

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
@@ -1,0 +1,103 @@
+﻿//
+// RestoreTestBase.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using NuGet.PackageManagement;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests.Helpers
+{
+	public abstract class RestoreTestBase : TestBase
+	{
+		protected Solution solution;
+
+		[TearDown]
+		public void TearDownTest ()
+		{
+			solution?.Dispose ();
+		}
+
+		/// <summary>
+		/// Clear all other package sources and just use the main NuGet package source when
+		/// restoring the packages for the project temlate tests.
+		/// </summary>
+		protected static void CreateNuGetConfigFile (FilePath directory)
+		{
+			var fileName = directory.Combine ("NuGet.Config");
+
+			string xml =
+				"<configuration>\r\n" +
+				"  <packageSources>\r\n" +
+				"    <clear />\r\n" +
+				"    <add key=\"NuGet v3 Official\" value=\"https://api.nuget.org/v3/index.json\" />\r\n" +
+				"  </packageSources>\r\n" +
+				"</configuration>";
+
+			File.WriteAllText (fileName, xml);
+		}
+
+		protected static Task<PackageRestoreResult> RestoreNuGetPackages (Solution solution)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (solution);
+			var context = new FakeNuGetProjectContext {
+				LogToConsole = true
+			};
+
+			var restoreManager = new PackageRestoreManager (
+				solutionManager.CreateSourceRepositoryProvider (),
+				solutionManager.Settings,
+				solutionManager
+			);
+
+			return restoreManager.RestoreMissingPackagesInSolutionAsync (
+				solutionManager.SolutionDirectory,
+				context,
+				CancellationToken.None);
+		}
+
+		protected static Task RestoreDotNetCoreNuGetPackages (Solution solution)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (solution);
+			var context = new FakeNuGetProjectContext {
+				LogToConsole = true
+			};
+
+			var restoreManager = new MonoDevelopBuildIntegratedRestorer (solutionManager);
+
+			var projects = solution.GetAllDotNetProjects ().Select (p => new DotNetCoreNuGetProject (p));
+
+			return restoreManager.RestorePackages (
+				projects,
+				CancellationToken.None);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -176,6 +176,8 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectJsonBuildIntegratedNuGetProjectTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\ItemTemplateNuGetPackageInstallerTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\UpdateXamarinFormsBuildTest.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\DotNetCoreRestoreTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\RestoreTestBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
@@ -1,0 +1,62 @@
+﻿//
+// DotNetCoreRestoreTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class DotNetCoreRestoreTests : RestoreTestBase
+	{
+		/// <summary>
+		/// PackageReference defined in project should override implicit package references from SDK.
+		/// </summary>
+		[Test]
+		public async Task GetDependencies_FSharpCore45InProjectFSharpCore43Implicit_FSharpCore45Used ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("DotNetCoreFSharpCore45", "DotNetCoreFSharpCore45.sln");
+
+			CreateNuGetConfigFile (solutionFileName.ParentDirectory);
+
+			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			await RestoreDotNetCoreNuGetPackages (solution);
+
+			var dependencies = (await project.GetPackageDependencies (ConfigurationSelector.Default, default (CancellationToken))).ToList ();
+			var fsharpCore = dependencies.SingleOrDefault (d => d.Name == "FSharp.Core");
+
+			Assert.AreEqual ("4.5.0", fsharpCore.Version);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectProxy.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectProxy.cs
@@ -158,14 +158,17 @@ namespace MonoDevelop.PackageManagement
 		/// avoid duplicate package references and also to avoid old versions being
 		/// returned since the evaluated items may still have old values if the
 		/// package references have just been updated. This avoids the wrong value being
-		/// added to the project.assets.json file.
+		/// added to the project.assets.json file. Returns the project's PackageReferences
+		/// first since these should override any implicit PackageReferences. The first
+		/// PackageReference returned will be used and any duplicate ones that are returned
+		/// afterwards are ignored.
 		/// </summary>
 		public IEnumerable<ProjectPackageReference> GetPackageReferences ()
 		{
-			foreach (var item in DotNetProject.MSBuildProject.GetImportedPackageReferences (DotNetProject)) {
+			foreach (var item in DotNetProject.Items.OfType<ProjectPackageReference> ()) {
 				yield return item;
 			}
-			foreach (var item in DotNetProject.Items.OfType<ProjectPackageReference> ()) {
+			foreach (var item in DotNetProject.MSBuildProject.GetImportedPackageReferences (DotNetProject)) {
 				yield return item;
 			}
 		}

--- a/main/tests/test-projects/DotNetCoreFSharpCore45/DotNetCoreFSharpCore45.fsproj
+++ b/main/tests/test-projects/DotNetCoreFSharpCore45/DotNetCoreFSharpCore45.fsproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreFSharpCore45/DotNetCoreFSharpCore45.sln
+++ b/main/tests/test-projects/DotNetCoreFSharpCore45/DotNetCoreFSharpCore45.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "DotNetCoreFSharpCore45", "DotNetCoreFSharpCore45.fsproj", "{66FA1301-92BB-4721-AB4D-FA6BB685C3F1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{66FA1301-92BB-4721-AB4D-FA6BB685C3F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66FA1301-92BB-4721-AB4D-FA6BB685C3F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66FA1301-92BB-4721-AB4D-FA6BB685C3F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66FA1301-92BB-4721-AB4D-FA6BB685C3F1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Creating a F# .NET Core console project, then installing FSharp.Core
4.5.0, would result in FSharp.Core 4.3.4 being used and displayed
in the Dependencies folder. FSharp.Core 4.3.4 is the NuGet package
implicitly added by the F# .NET Core SDK and was being used by
the project instead of the PackageReference in the project.
PackageReferences in the project will now override any implicitly
added NuGet packages which is the behaviour of dotnet restore on
the command line.

Fixes VSTS #636604 - Adding FSharp.Core 4.5.0 NuGet package restores
4.3.4 in .NET Core project