### PR TITLE
[Telemetry] Protect the GetLoginTime

### DIFF
--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -66,10 +66,10 @@ namespace MacPlatform
 
 			try {
 				var login = GetLoginTime ();
-				if (login != DateTime.MinValue) {
-					var epoch = new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+				if (login != DateTimeOffset.MinValue) {
+					var epoch = new DateTimeOffset (1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 
-					var timeSinceEpoch = DateTime.UtcNow - epoch;
+					var timeSinceEpoch = DateTimeOffset.UtcNow - epoch;
 					var loginSinceEpoch = login - epoch;
 					result.sinceLogin = timeSinceEpoch - loginSinceEpoch;
 				}
@@ -225,7 +225,7 @@ namespace MacPlatform
 			LastLogX ll = new LastLogX ();
 			if (IntPtr.Zero == getlastlogxbyname (Environment.UserName, ref ll)) {
 				// getlastlogxbyname doesn't work if SIP is disabled
-				return DateTime.MinValue;
+				return DateTimeOffset.MinValue;
 			}
 
 			var dt = DateTimeOffset.FromUnixTimeSeconds (ll.ll_tv_tv_sec);

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -31,6 +31,7 @@ using System.Runtime.InteropServices;
 using CoreFoundation;
 using System.Linq;
 using System.Threading.Tasks;
+using MonoDevelop.Core;
 
 namespace MacPlatform
 {
@@ -63,15 +64,19 @@ namespace MacPlatform
 
 			result.osType = GetMediaType ("/");
 
-			var login = GetLoginTime ();
-			if (login != DateTime.MinValue) {
-				var epoch = new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+			try {
+				var login = GetLoginTime ();
+				if (login != DateTime.MinValue) {
+					var epoch = new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
-				var timeSinceEpoch = DateTime.UtcNow - epoch;
-				var loginSinceEpoch = login - epoch;
-				result.sinceLogin = timeSinceEpoch - loginSinceEpoch;
+					var timeSinceEpoch = DateTime.UtcNow - epoch;
+					var loginSinceEpoch = login - epoch;
+					result.sinceLogin = timeSinceEpoch - loginSinceEpoch;
+				}
+			} catch (Exception e) {
+				LoggingService.LogError ("Error getting logintime", e);
+				result.sinceLogin = TimeSpan.Zero;
 			}
-
 			return result;
 		}
 


### PR DESCRIPTION
Wrap GetLoginTime and related code in a try catch so that if there's an issue
the details still get set up correctly

Fixes VSTS #637410
FIxes VSTS #637958