### PR TITLE
[PerformanceDiagnostics] Add UI hang detection for telemetry

### DIFF
--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -10,15 +10,15 @@ namespace PerformanceDiagnosticsAddIn
 	{
 		protected override void Run ()
 		{
-			if (UIThreadMonitor.Instance.IsListening)
-				UIThreadMonitor.Instance.Stop ();
+			if (UIThreadMonitor.Instance.IsSampling)
+				UIThreadMonitor.Instance.Start (sample: false);
 			else
-				UIThreadMonitor.Instance.Start ();
+				UIThreadMonitor.Instance.Start (sample: true);
 		}
 
 		protected override void Update (CommandInfo info)
 		{
-			info.Text = UIThreadMonitor.Instance.IsListening ? GettextCatalog.GetString ("Stop monitoring UIThread hangs") : GettextCatalog.GetString ("Start monitoring UIThread hangs");
+			info.Text = UIThreadMonitor.Instance.IsSampling ? GettextCatalog.GetString ("Stop monitoring UIThread hangs") : GettextCatalog.GetString ("Start monitoring UIThread hangs");
 			base.Update (info);
 		}
 	}
@@ -34,7 +34,8 @@ namespace PerformanceDiagnosticsAddIn
 			if (UIThreadMonitor.Instance.IsListening)
 				UIThreadMonitor.Instance.Stop ();
 
-			UIThreadMonitor.Instance.Start (hangFileName, profile: false);
+			UIThreadMonitor.Instance.HangFileName = hangFileName;
+			UIThreadMonitor.Instance.Start (sample: false);
 		}
 	}
 

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -23,22 +23,6 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	class StartUIThreadMonitorHandler : CommandHandler
-	{
-		protected override void Run (object dataItem)
-		{
-			var hangFileName = dataItem as string;
-			if (string.IsNullOrEmpty (hangFileName))
-				return;
-
-			if (UIThreadMonitor.Instance.IsListening)
-				UIThreadMonitor.Instance.Stop ();
-
-			UIThreadMonitor.Instance.HangFileName = hangFileName;
-			UIThreadMonitor.Instance.Start (sample: false);
-		}
-	}
-
 	public class ProfileFor5SecondsHandler : CommandHandler
 	{
 		protected override void Run ()

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -23,6 +23,21 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
+	class StartUIThreadMonitorHandler : CommandHandler
+	{
+		protected override void Run (object dataItem)
+		{
+			var hangFileName = dataItem as string;
+			if (string.IsNullOrEmpty (hangFileName))
+				return;
+
+			if (UIThreadMonitor.Instance.IsListening)
+				UIThreadMonitor.Instance.Stop ();
+
+			UIThreadMonitor.Instance.Start (hangFileName, profile: false);
+		}
+	}
+
 	public class ProfileFor5SecondsHandler : CommandHandler
 	{
 		protected override void Run ()

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
@@ -20,6 +20,9 @@
 			defaultHandler="PerformanceDiagnosticsAddIn.EnhanceSampleFile"
 			_label="Enhance Sample output file"
 			_description="Use this command to covert JITed method addresses to full method names of Sample tool output file." />
+		<Command id="PerformanceDiagnosticsAddIn.StartUIThreadMonitorHandler"
+			_label="Start monitoring UIThread hangs"
+			defaultHandler="PerformanceDiagnosticsAddIn.StartUIThreadMonitorHandler" />
 	</Extension>
 	<Extension path="/MonoDevelop/Ide/MainMenu/Help">
 		<ItemSet id="Diagnostics" _label="_Diagnostics">

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
@@ -20,9 +20,6 @@
 			defaultHandler="PerformanceDiagnosticsAddIn.EnhanceSampleFile"
 			_label="Enhance Sample output file"
 			_description="Use this command to covert JITed method addresses to full method names of Sample tool output file." />
-		<Command id="PerformanceDiagnosticsAddIn.StartUIThreadMonitorHandler"
-			_label="Start monitoring UIThread hangs"
-			defaultHandler="PerformanceDiagnosticsAddIn.StartUIThreadMonitorHandler" />
 	</Extension>
 	<Extension path="/MonoDevelop/Ide/MainMenu/Help">
 		<ItemSet id="Diagnostics" _label="_Diagnostics">

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -20,7 +20,19 @@ namespace PerformanceDiagnosticsAddIn
 	{
 		public static UIThreadMonitor Instance { get; } = new UIThreadMonitor ();
 
-		UIThreadMonitor () { }
+		UIThreadMonitor ()
+		{
+			IdeApp.Exited += IdeAppExited;
+		}
+
+		void IdeAppExited (object sender, EventArgs e)
+		{
+			try {
+				Instance.Stop ();
+			} catch (Exception ex) {
+				LoggingService.LogError ("UIThreadMonitor stop error.", ex);
+			}
+		}
 
 		Thread tcpLoopThread;
 		Thread dumpsReaderThread;

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -144,7 +144,7 @@ namespace PerformanceDiagnosticsAddIn
 				dumpsReaderThread = new Thread (new ParameterizedThreadStart (DumpsReader));
 				dumpsReaderThread.IsBackground = true;
 				dumpsReaderThread.Start (process);
-				PumpErrorStream (process).Ignore ();
+				Task.Run (() => PumpErrorStream (process)).Ignore ();
 			}
 		}
 

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -124,9 +124,12 @@ namespace PerformanceDiagnosticsAddIn
 			process.StartInfo.RedirectStandardError = true;//Ignore it, otherwise it goes to IDE logging
 			process.Start ();
 			process.StandardError.ReadLine ();
-			dumpsReaderThread = new Thread (new ParameterizedThreadStart (DumpsReader));
-			dumpsReaderThread.IsBackground = true;
-			dumpsReaderThread.Start (process);
+
+			if (IsSampling) {
+				dumpsReaderThread = new Thread (new ParameterizedThreadStart (DumpsReader));
+				dumpsReaderThread.IsBackground = true;
+				dumpsReaderThread.Start (process);
+			}
 
 			pumpErrorThread = new Thread (new ParameterizedThreadStart (PumpErrorStream));//We need to read this...
 			pumpErrorThread.IsBackground = true;

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace PerformanceDiagnosticsAddIn
 {
-	class UIThreadMonitor
+	public class UIThreadMonitor
 	{
 		public static UIThreadMonitor Instance { get; } = new UIThreadMonitor ();
 

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -140,7 +140,6 @@ namespace PerformanceDiagnosticsAddIn
 			process.StartInfo.RedirectStandardOutput = true;
 			process.StartInfo.RedirectStandardError = true;//Ignore it, otherwise it goes to IDE logging
 			process.Start ();
-			process.StandardError.ReadLine ();
 
 			if (IsSampling) {
 				dumpsReaderThread = new Thread (new ParameterizedThreadStart (DumpsReader));

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -33,9 +33,7 @@ namespace PerformanceDiagnosticsAddIn
 			var socket = (Socket)param;
 			byte [] buffer = new byte [1];
 			ManualResetEvent waitUIThread = new ManualResetEvent (false);
-			var sw = Stopwatch.StartNew ();
 			while (true) {
-				sw.Restart ();
 				var readBytes = socket.Receive (buffer, 1, SocketFlags.None);
 				if (readBytes != 1)
 					return;

--- a/main/src/addins/PerformanceDiagnostics/UIThreadMonitorDaemon/Program.cs
+++ b/main/src/addins/PerformanceDiagnostics/UIThreadMonitorDaemon/Program.cs
@@ -46,6 +46,7 @@ namespace UIThreadMonitorDaemon
 		static string hangFile;
 		static bool hangFileCreated;
 		static int sendInterval;
+		static Process parentProcess;
 
 		public static int Main (string [] args)
 		{
@@ -53,23 +54,31 @@ namespace UIThreadMonitorDaemon
 			if (result != 0)
 				return result;
 
-			var events = new [] { responseEvent, disconnectEvent };
+			parentProcess = Process.GetProcessById (processId);
+
+			var sendEvents = new WaitHandle[] { sentEvent, parentProcessExitedEvent };
+			var events = new WaitHandle[] { responseEvent, disconnectEvent, parentProcessExitedEvent };
 			var thread = new Thread (new ParameterizedThreadStart (Loop));
 			thread.Start (tcpPort);
 			var sw = Stopwatch.StartNew ();
-			while (!disconnected) {
-				sentEvent.WaitOne ();
+			while (!parentProcess.HasExited) {
+				int waitResult = WaitHandle.WaitAny (sendEvents);
+				if (waitResult == 1)
+					return 0; // Parent process exited.
+
 				sw.Restart ();
 				if (!responseEvent.WaitOne (100)) {
 					Console.Error.WriteLine ($"Timeout({seq}):" + sw.Elapsed);
 					if (sample)
 						StartCollectingStacks ();
 
-					int waitResult = WaitHandle.WaitAny (events, 10000);
+					waitResult = WaitHandle.WaitAny (events, 10000);
 					if (waitResult == 0) // Got a response.
 						Console.Error.WriteLine ($"Response({seq}) in {sw.Elapsed}");
-					else if (waitResult == 1) { // Disconnect
-						// Do nothing. The while loop checks for a disconnect.
+					else if (waitResult == 1) { // Disconnected
+						// Do nothing. The while loop will wait for the next send event.
+					} else if (waitResult == 2) { // Parent process exited
+						// Do nothing. The while loop checks for an exit.
 					} else { // Timeout
 						Console.Error.WriteLine ($"No response({seq}) in 10sec");
 						CreateHangFile ();
@@ -158,29 +167,62 @@ namespace UIThreadMonitorDaemon
 		static AutoResetEvent sentEvent = new AutoResetEvent (false);
 		static ManualResetEvent responseEvent = new ManualResetEvent (false);
 		static ManualResetEvent disconnectEvent = new ManualResetEvent (false);
-		static bool disconnected;
+		static ManualResetEvent parentProcessExitedEvent = new ManualResetEvent (false);
 		static byte seq;
 		static void Loop (object portObj)
 		{
-			var ipe = new IPEndPoint (IPAddress.Loopback, (int)portObj);
-			var socket = new Socket (ipe.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-			socket.Connect (ipe);
+			int port = (int)portObj;
+			Socket socket = Connect (port);
 			var response = new byte [1];
-			while (true) {
-				Thread.Sleep (sendInterval);
-				socket.Send (new byte [1] { ++seq });
-				responseEvent.Reset ();
-				sentEvent.Set ();
-				var readBytes = socket.Receive (response, 1, SocketFlags.None);
-				if (readBytes != 1) {
-					disconnected = true;
-					disconnectEvent.Set ();
-					return;
+			while (!parentProcess.HasExited) {
+				try {
+					Thread.Sleep (sendInterval);
+					socket.Send (new byte [1] { ++seq });
+					responseEvent.Reset ();
+					sentEvent.Set ();
+					var readBytes = socket.Receive (response, 1, SocketFlags.None);
+					if (readBytes != 1) {
+						disconnectEvent.Set ();
+						throw new ApplicationException ("Disconnected from parent.");
+					}
+					if (response [0] != seq)
+						throw new InvalidOperationException ($"Expected {seq}, got {response [0]}.");
+					responseEvent.Set ();
+				} catch (Exception ex) {
+					Console.Error.WriteLine ($"Error communicating with parent. {ex.Message}");
+					try {
+						socket.Close ();
+					} catch (Exception) {
+						// Ignore.
+					}
+					socket = Connect (port);
 				}
-				if (response [0] != seq)
-					throw new InvalidOperationException ($"Expected {seq}, got {response [0]}.");
-				responseEvent.Set ();
 			}
+			// Ensure main loop exits if it is waiting for a send event.
+			parentProcessExitedEvent.Set ();
+		}
+
+		static int connectRetryInterval = 500; // ms
+
+		static Socket Connect (int port)
+		{
+			while (!parentProcess.HasExited) {
+				try {
+					var ipe = new IPEndPoint (IPAddress.Loopback, port);
+					var socket = new Socket (ipe.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+					socket.Connect (ipe);
+
+					disconnectEvent.Reset ();
+
+					return socket;
+				} catch (Exception ex) {
+					Console.Error.WriteLine ($"Could not connect. {ex.Message}");
+					if (!parentProcess.HasExited) {
+						Thread.Sleep (connectRetryInterval);
+					}
+				}
+			}
+			return null;
 		}
 	}
 }

--- a/main/src/addins/PerformanceDiagnostics/UIThreadMonitorDaemon/Program.cs
+++ b/main/src/addins/PerformanceDiagnostics/UIThreadMonitorDaemon/Program.cs
@@ -42,7 +42,7 @@ namespace UIThreadMonitorDaemon
 	{
 		static int tcpPort;
 		static int processId;
-		static bool profile = true;
+		static bool sample = true;
 		static string hangFile;
 		static bool hangFileCreated;
 
@@ -60,14 +60,14 @@ namespace UIThreadMonitorDaemon
 				sw.Restart ();
 				if (!responseEvent.WaitOne (100)) {
 					Console.Error.WriteLine ($"Timeout({seq}):" + sw.Elapsed);
-					if (profile)
+					if (sample)
 						StartCollectingStacks ();
 					if (!responseEvent.WaitOne (10000)) {
 						Console.Error.WriteLine ($"No response({seq}) in 10sec");
 						CreateHangFile ();
 					} else
 						Console.Error.WriteLine ($"Response({seq}) in {sw.Elapsed}");
-					if (profile)
+					if (sample)
 						StopCollectingStacks ();
 				} else {
 					if (sw.ElapsedMilliseconds > 20)
@@ -90,8 +90,8 @@ namespace UIThreadMonitorDaemon
 			if (args.Length > 2) {
 				const string hangFileOption = "--hangFile:";
 				foreach (string arg in args.Skip (2)) {
-					if (arg == "--noProfile")
-						profile = false;
+					if (arg == "--noSample")
+						sample = false;
 					else if (arg.StartsWith (hangFileOption, StringComparison.OrdinalIgnoreCase))
 						hangFile = arg.Substring (hangFileOption.Length);
 				}


### PR DESCRIPTION
The UI thread monitor console application now has a way to check for
the IDE's UI thread hanging without profiling the process. It will
create a file to indicate a hang is occurring. This file will be
used by the IDE when reporting the previous shutdown reason.

Needs md-addins changes.

Fixes VSTS #619945

Not implemented:

 - [x] UI Thread console app connection retry. If the connection back to the IDE is lost the console app currently exits. I think it should retry the connection until the IDE process exits. The IDE will terminate the console app itself.