### PR TITLE
Solution context filetype condition

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -227,7 +227,7 @@
   </Extension>
 
   <Extension path = "/MonoDevelop/Ide/ContextMenu/ProjectPad">
-    <Condition id="ItemType" value="IFileItem">
+    <Condition id="FileType" fileExtensions=".fs,.fsi,.fsx,.fsscript">
       <CommandItem id = "MonoDevelop.FSharp.SolutionPad.DebugScriptInternal"/>
       <CommandItem id = "MonoDevelop.FSharp.SolutionPad.DebugScriptExternal"/>
     </Condition>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -32,20 +32,16 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
-
 using Mono.Addins;
-using MonoDevelop.Core;
 using MonoDevelop.Components;
-using MonoDevelop.Components.AtkCocoaHelper;
-using MonoDevelop.Ide.Commands;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Commands;
+using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Ide.Gui.Pads;
 using MonoDevelop.Projects.Extensions;
-using System.Linq;
-using MonoDevelop.Ide.Tasks;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace MonoDevelop.Ide.Gui.Components
 {
@@ -1981,6 +1977,12 @@ namespace MonoDevelop.Ide.Gui.Components
 			} else {
 				ExtensionContext ctx = AddinManager.CreateExtensionContext ();
 				ctx.RegisterCondition ("ItemType", new ItemTypeCondition (tnav.DataItem.GetType (), contextMenuTypeNameAliases));
+				if (tnav.DataItem is MonoDevelop.Projects.IFileItem fileItem) {
+					var fileTypeCondition = new FileTypeCondition ();
+					fileTypeCondition.SetFileName (fileItem.FileName);
+					ctx.RegisterCondition ("FileType", fileTypeCondition);
+				}
+
 				CommandEntrySet eset = IdeApp.CommandService.CreateCommandEntrySet (ctx, menuPath);
 
 				eset.AddItem (Command.Separator);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -6,6 +6,9 @@
 	<ConditionType id="ItemType" type="MonoDevelop.Projects.Extensions.ItemTypeCondition">
 		<Description>Type of the item. If no namespace is provided, MonoDevelop.Projects is assumed.</Description>
 	</ConditionType>
+	<ConditionType id="FileType" type="MonoDevelop.Ide.Extensions.FileTypeCondition">
+		<Description>Type of the file.</Description>
+	</ConditionType>
 </ExtensionPoint>
 
 <Extension path = "/MonoDevelop/Ide/ContextMenu/ProjectPad">


### PR DESCRIPTION
Allow FileType conditions on the solution tree context menu, and use this to limit F# commands to F# files.