### PR TITLE
[StructuredOutput] Fixes rounding rendering duration time

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
@@ -372,24 +372,27 @@ namespace MonoDevelop.Ide.BuildOutputView
 			return null;
 		}
 
+		const int NormalRoundPrecision = 1;
+		const int DiagnosticRoundPrecision = 3;
 		public static string GetDurationAsString (this BuildOutputNode node, bool includeDiagnostics)
 		{
 			var duration = node.EndTime.Subtract (node.StartTime);
-			if (includeDiagnostics) {
-				if (duration.TotalHours >= 1) {
-					return string.Format ("{0,12}", duration.ToString (@"hh\:mm\:ss\.fff"));
-				} 
-				return string.Format ("{0,12}", duration.ToString (@"mm\:ss\.fff"));
-			} 
-
 			if (duration.TotalHours >= 1) {
 				return string.Format ("{0,7}", GettextCatalog.GetString ("{0}h {1}m", duration.Hours.ToString(), duration.Minutes.ToString ("00")));
-			} 
+			}
 
 			if (duration.TotalMinutes >= 1) {
 				return string.Format ("{0,7}", GettextCatalog.GetString ("{0}m {1}s", duration.Minutes.ToString(), duration.Seconds.ToString ("00")));
-			} 
-			return string.Format ("{0,7}", GettextCatalog.GetString ("{0}s", duration.Seconds.ToString ()));
+			}
+
+			var precision = includeDiagnostics ? DiagnosticRoundPrecision : NormalRoundPrecision;
+			var value = Math.Round ((duration.Seconds + duration.Milliseconds / 1000d), precision);
+
+			//We don't want print 0 values
+			if (value == 0) {
+				return null;
+			}
+			return value.ToString ("F" + precision) + "s";
 		}
 
 		static void ToString (this BuildOutputNode node, bool includeChildren, StringBuilder result, string margin)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
@@ -374,6 +374,9 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		const int NormalRoundPrecision = 1;
 		const int DiagnosticRoundPrecision = 3;
+		const string NormalRoundPrecisioFormat = "{0:F1}s";
+		const string DiagnosticRoundPrecisionFormat = "{0:F3}s";
+
 		public static string GetDurationAsString (this BuildOutputNode node, bool includeDiagnostics)
 		{
 			var duration = node.EndTime.Subtract (node.StartTime);
@@ -382,17 +385,26 @@ namespace MonoDevelop.Ide.BuildOutputView
 			}
 
 			if (duration.TotalMinutes >= 1) {
-				return string.Format ("{0,7}", GettextCatalog.GetString ("{0}m {1}s", duration.Minutes.ToString(), duration.Seconds.ToString ("00")));
+				return GettextCatalog.GetString ("{0}m {1}s", duration.Minutes.ToString(), duration.Seconds.ToString ("00"));
 			}
 
-			var precision = includeDiagnostics ? DiagnosticRoundPrecision : NormalRoundPrecision;
+			string precisionFormat;
+			int precision;
+			if (includeDiagnostics) {
+				precisionFormat = DiagnosticRoundPrecisionFormat;
+				precision = DiagnosticRoundPrecision;
+			} else {
+				precisionFormat = NormalRoundPrecisioFormat;
+				precision = NormalRoundPrecision;
+			}
+
 			var value = Math.Round ((duration.Seconds + duration.Milliseconds / 1000d), precision);
 
 			//We don't want print 0 values
 			if (value == 0) {
 				return null;
 			}
-			return value.ToString ("F" + precision) + "s";
+			return string.Format (precisionFormat, value);
 		}
 
 		static void ToString (this BuildOutputNode node, bool includeChildren, StringBuilder result, string margin)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -266,11 +266,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 				return layout;
 			}
 
-			internal void Initialize ()
+			internal string Duration { get; private set; }
+
+			internal void Initialize (bool isShowingDiagnostics)
 			{
 				DrawsBottomLine = Node.Next == null || !(Node.Next.NodeType == BuildOutputNodeType.Error || Node.Next.NodeType == BuildOutputNodeType.Warning);
 				DrawsTopLine = Node.Previous == null || !(Node.Previous.NodeType == BuildOutputNodeType.Error || Node.Previous.NodeType == BuildOutputNodeType.Warning);
-
+				Duration = Node.GetDurationAsString (isShowingDiagnostics);
 				Reload ();
 			}
 		}
@@ -541,7 +543,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			Size size = Size.Zero;
 
 			//Duration text
-			var duration = buildOutputNode.GetDurationAsString (contextProvider.IsShowingDiagnostics);
+			var duration = status.Duration;
 			if (duration != "") {
 				size = DrawText (ctx, cellArea, textStartX, duration, padding, defaultFont, DefaultInformationContainerWidth).GetSize ();
 				textStartX += size.Width + 10;
@@ -676,7 +678,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			var node = GetValue (BuildOutputNodeField);
 			if (node != null) {
 				var status = GetViewStatus (node);
-				status.Initialize ();
+				status.Initialize (contextProvider.IsShowingDiagnostics);
 			}
 		}
 


### PR DESCRIPTION

This PR fixes rendendering in diagnostic and normal mode

Removed the old format in diagnostic 00:02.748 to use

2.341s rounding 1 decimal in case de normal and 3 decimal
in case of diagnostic.

Example: 0.94 displays as 0.9, 0.95 displays as 1.0

Before | After
------------ | -------------
00:00.001 | .001s
00:02.341 | 2.341s
1:50.211 | 1m 50.001s

Fixes Bug #636828
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/636828

Fixes Bug #636830
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/636830

<img width="618" alt="screen shot 2018-07-16 at 20 36 46" src="https://user-images.githubusercontent.com/1587480/42776667-fe3efd4c-8937-11e8-8021-c89531862568.png">




