### PR TITLE
[release-7.6] [Roslyn] Fix show stacktrace not showing the exception

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/LoggingService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/LoggingService.cs
@@ -139,11 +139,7 @@ namespace MonoDevelop.Core
 		/// Creates a session log file with the given identifier.
 		/// </summary>
 		/// <returns>A TextWriter, null if the file cannot be created.</returns>
-		public static TextWriter CreateLogFile (string identifier)
-		{
-			string filename;
-			return CreateLogFile (identifier, out filename);
-		}
+		public static TextWriter CreateLogFile (string identifier) => CreateLogFile (identifier, out _);
 
 		public static TextWriter CreateLogFile (string identifier, out string filename)
 		{
@@ -289,9 +285,11 @@ namespace MonoDevelop.Core
 		static MonoDevelop.Core.ProgressMonitoring.LogTextWriter stderr;
 		static MonoDevelop.Core.ProgressMonitoring.LogTextWriter stdout;
 		static TextWriter writer;
+		static string logFile;
+
 		static void RedirectOutputToFileWindows ()
 		{
-			writer = CreateLogFile ("Ide");
+			writer = CreateLogFile ("Ide", out logFile);
 			if (writer == Console.Out)
 				return;
 
@@ -323,7 +321,6 @@ namespace MonoDevelop.Core
 			Directory.CreateDirectory (logDir);
 
 			int fd;
-			string logFile;
 			int oldIdx = logFileSuffix;
 
 			while (true) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopErrorReportingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopErrorReportingService.cs
@@ -34,7 +34,7 @@ using MonoDevelop.Core;
 namespace MonoDevelop.Ide.RoslynServices
 {
 	[ExportWorkspaceServiceFactory (typeof (IErrorReportingService), ServiceLayer.Host), Shared]
-	sealed class VisualStudioErrorReportingServiceFactory : IWorkspaceServiceFactory
+	sealed class MonoDevelopErrorReportingServiceFactory : IWorkspaceServiceFactory
 	{
 		public IWorkspaceService CreateService (HostWorkspaceServices workspaceServices)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopErrorReportingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopErrorReportingService.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.Composition;
+using System.Reflection;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -56,8 +57,16 @@ namespace MonoDevelop.Ide.RoslynServices
 				_infoBarService.ShowInfoBarInGlobalView (message, items);
 
 			// These are usually analyzers which would crash the process.
-			public void ShowDetailedErrorInfo (Exception exception) =>
-				LoggingService.LogError ("Roslyn wanted to display an exception to user", exception);
+			public void ShowDetailedErrorInfo (Exception exception)
+			{
+				LoggingService.LogError("Roslyn reported an exception to the user", exception);
+				
+				var logFile = (string)typeof (LoggingService).InvokeMember ("logFile", BindingFlags.GetField | BindingFlags.Static | BindingFlags.NonPublic, null, null, null);
+
+				// If the output is redirected, open the log file, otherwise do not do anything.
+				if (logFile != null)
+					DesktopService.OpenFile (logFile);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Backport of #5199.

Fixes #5170 - Show stack trace in exception bar does not show display any information

/cc @slluis