### PR TITLE
[StructuredBuildOutput] Fixes Summary Links Cursor Display

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -673,7 +673,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 			var node = GetValue (BuildOutputNodeField);
 			var status = GetViewStatus (node);
 
-			if (status.TaskLinkRenderRectangle.Contains (args.Position) || status.ErrorsRectangle.Contains (args.Position) || status.WarningsRectangle.Contains (args.Position)) {
+			var containsClickableElement = status.TaskLinkRenderRectangle.Contains (args.Position) || status.ErrorsRectangle.Contains (args.Position) || status.WarningsRectangle.Contains (args.Position);
+			if (containsClickableElement) {
 				ParentWidget.Cursor = CursorType.Hand;
 			} else {
 				ParentWidget.Cursor = CursorType.Arrow;
@@ -688,10 +689,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 					selectionEnd = pos;
 					QueueDraw ();
 				}
-			} else {
-				if (insideText) {
-					ParentWidget.Cursor = CursorType.IBeam;
-				}
+			} else if (insideText && !containsClickableElement)  {
+				ParentWidget.Cursor = CursorType.IBeam;
 			}
 		}
 


### PR DESCRIPTION
Steps to reproduce:

1. Build a solution and open Build Output tab;
2. Navigate to a tree summary and hover Errors or Warnings indicator. You will see an inconsistent cursor on hover. Indicators are links so interaction needs to be the same as with path links.

![errorwarningcursos](https://user-images.githubusercontent.com/1587480/41972195-6394b8a2-7a11-11e8-9156-dc3d09f51154.gif)

Fixes Bug #619943

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/619943