### PR TITLE
Fixes Bug 627039: Editor occasionally becomes unresponsive to user

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/Projection.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Projection/Projection.cs
@@ -30,6 +30,7 @@ using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.TypeSystem;
 using System.Collections.Generic;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Editor.Projection
 {
@@ -122,7 +123,11 @@ namespace MonoDevelop.Ide.Editor.Projection
 				foreach (var segment in originalProjections) {
 					if (segment.Contains (change.Offset)) {
 						var projectedOffset = change.Offset - segment.Offset + segment.LinkedTo.Offset;
-						projectedEditor.ReplaceText (projectedOffset, change.RemovalLength, change.InsertedText);
+						try {
+							projectedEditor.ReplaceText (projectedOffset, change.RemovalLength, change.InsertedText);
+						} catch (Exception ex) {
+							LoggingService.LogError ($"Error while replacing in projected editor at {projectedOffset} with length {projectedEditor.Length} change: {change}", ex);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
input

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/627039

Can't reproduce the issue however that patch ensures that the edit
operation in the main buffer works - a projection buffer could not be
updated but will be corrected on the next parse event.