### PR TITLE
[Ide] Addin startup logging and lazy loading

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -108,6 +108,7 @@ namespace MonoDevelop.Core
 			AddinManager.AddinLoadError += OnLoadError;
 			AddinManager.AddinLoaded += OnLoad;
 			AddinManager.AddinUnloaded += OnUnload;
+			AddinManager.AddinAssembliesLoaded += OnAssembliesLoaded;
 
 			try {
 				Counters.RuntimeInitialization.Trace ("Initializing Addin Manager");
@@ -219,13 +220,20 @@ namespace MonoDevelop.Core
 				{ "LoadTrace", Environment.StackTrace },
 			});
 #if DEBUG
-			LoggingService.LogDebug (Environment.StackTrace);
+			LoggingService.LogDebug ("Add-in loaded: {0}: {1}", args.AddinId, Environment.StackTrace);
 #endif
 		}
 		
 		static void OnUnload (object s, AddinEventArgs args)
 		{
 			Counters.AddinsLoaded.Dec ("Add-in unloaded: " + args.AddinId);
+		}
+
+		static void OnAssembliesLoaded (object s, AddinEventArgs args)
+		{
+#if DEBUG
+			LoggingService.LogDebug ("Add-in assemblies loaded: {0}: {1}", args.AddinId, Environment.StackTrace);
+#endif
 		}
 		
 		public static bool Initialized {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -211,10 +211,16 @@ namespace MonoDevelop.Core
 			string msg = "Add-in error (" + args.AddinId + "): " + args.Message;
 			LoggingService.LogError (msg, args.Exception);
 		}
-		
+
 		static void OnLoad (object s, AddinEventArgs args)
 		{
-			Counters.AddinsLoaded.Inc ("Add-in loaded: " + args.AddinId, new Dictionary<string,string> { { "AddinId", args.AddinId } });
+			Counters.AddinsLoaded.Inc ("Add-in loaded: " + args.AddinId, new Dictionary<string, string> {
+				{ "AddinId", args.AddinId },
+				{ "LoadTrace", Environment.StackTrace },
+			});
+#if DEBUG
+			LoggingService.LogDebug (Environment.StackTrace);
+#endif
 		}
 		
 		static void OnUnload (object s, AddinEventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -175,7 +175,7 @@ namespace MonoDevelop.Ide.Desktop
 
 		public string GetMimeTypeForRoslynLanguage (string language)
 		{
-			foreach (MimeTypeNode mt in mimeTypeNodes) {
+			foreach (MimeTypeNode mt in MimeTypeNodes.All) {
 				if (mt.RoslynName == language)
 					return mt.Id;
 			}
@@ -276,25 +276,31 @@ namespace MonoDevelop.Ide.Desktop
 				return null;
 		}
 
-		static List<MimeTypeNode> mimeTypeNodes = new List<MimeTypeNode> ();
-		static PlatformService ()
+		static class MimeTypeNodes
 		{
-			if (AddinManager.IsInitialized) {
-				AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Core/MimeTypes", delegate (object sender, ExtensionNodeEventArgs args) {
-					var newList = new List<MimeTypeNode> (mimeTypeNodes);
-					var mimeTypeNode = (MimeTypeNode)args.ExtensionNode;
-					switch (args.Change) {
-					case ExtensionChange.Add:
-						// initialize child nodes.
-						mimeTypeNode.ChildNodes.GetEnumerator ();
-						newList.Add (mimeTypeNode);
-						break;
-					case ExtensionChange.Remove:
-						newList.Remove (mimeTypeNode);
-						break;
-					}
-					mimeTypeNodes = newList;
-				});
+			public static List<MimeTypeNode> All => mimeTypeNodes;
+
+			static List<MimeTypeNode> mimeTypeNodes = new List<MimeTypeNode> ();
+
+			static MimeTypeNodes ()
+			{
+				if (AddinManager.IsInitialized) {
+					AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Core/MimeTypes", delegate (object sender, ExtensionNodeEventArgs args) {
+						var newList = new List<MimeTypeNode> (mimeTypeNodes);
+						var mimeTypeNode = (MimeTypeNode)args.ExtensionNode;
+						switch (args.Change) {
+						case ExtensionChange.Add:
+							// initialize child nodes.
+							mimeTypeNode.ChildNodes.GetEnumerator ();
+							newList.Add (mimeTypeNode);
+							break;
+						case ExtensionChange.Remove:
+							newList.Remove (mimeTypeNode);
+							break;
+						}
+						mimeTypeNodes = newList;
+					});
+				}
 			}
 		}
 
@@ -316,7 +322,7 @@ namespace MonoDevelop.Ide.Desktop
 				LoggingService.LogError ("IFilePathRegistryService query failed", ex);
 			}
 
-			foreach (MimeTypeNode mt in mimeTypeNodes) {
+			foreach (MimeTypeNode mt in MimeTypeNodes.All) {
 				if (mt.SupportsFile (fileName))
 					return mt;
 			}
@@ -325,7 +331,7 @@ namespace MonoDevelop.Ide.Desktop
 
 		MimeTypeNode FindMimeType (string type)
 		{
-			foreach (MimeTypeNode mt in mimeTypeNodes) {
+			foreach (MimeTypeNode mt in MimeTypeNodes.All) {
 				if (mt.Id == type)
 					return mt;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -233,7 +233,6 @@ namespace MonoDevelop.Ide
 				Counters.Initialization.Trace ("Loading Icons");
 				//force initialisation before the workbench so that it can register stock icons for GTK before they get requested
 				ImageService.Initialize ();
-				LocalizationService.Initialize ();
 
 				// If we display an error dialog before the main workbench window on OS X then a second application menu is created
 				// which is then replaced with a second empty Apple menu.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/LocalizationService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/LocalizationService.cs
@@ -37,7 +37,7 @@ namespace MonoDevelop.Ide
 		const string path = "/MonoDevelop/Ide/LocaleSet";
 		static readonly List<LocaleSet[]> locales = new List<LocaleSet[]> ();
 
-		internal static void Initialize ()
+		static LocalizationService ()
 		{
 			AddinManager.AddExtensionNodeHandler (path, OnExtensionChanged);
 			Array.Sort (defaultLocaleSet, (x, y) => x.DisplayName.CompareTo (y.DisplayName));


### PR DESCRIPTION
Needs mono-addins change.

- AddinManager has a new AddinAssembliesLoaded event which is logged in debug mode.
- Fixes VSTS #640897 - Mime Types loaded on startup
- Fixes VSTS #640899 - FileService loads file system extensions on startup
- Fixes VSTS #641263 - LocationService loads addins on startup
- Fixes VSTS #591639 - Log addin load stacktraces to have a baseline of where an addin is loaded

With the above changes addins are still being loaded by the CommandManager (due to string translations), pad NodeBuilders and startup handlers. So startup is doing less but the addin assemblies are still being loaded.