### PR TITLE
[Ide] Fix renaming a class asks to reload the file

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -169,9 +169,15 @@ namespace MonoDevelop.Ide.Gui
 			if (window.ViewContent.Project != null)
 				window.ViewContent.Project.Modified += HandleProjectModified;
 			window.ViewsChanged += HandleViewsChanged;
-			window.ViewContent.ContentNameChanged += ReloadAnalysisDocumentHandler;
+			window.ViewContent.ContentNameChanged += OnContentNameChanged;
 			MonoDevelopWorkspace.LoadingFinished += ReloadAnalysisDocumentHandler;
 			DocumentRegistry.Add (this);
+		}
+
+		void OnContentNameChanged (object sender, EventArgs e)
+		{
+			OnFileNameChanged ();
+			ReloadAnalysisDocumentHandler (sender, e);
 		}
 
 		void ReloadAnalysisDocumentHandler (object sender, EventArgs e)
@@ -199,6 +205,13 @@ namespace MonoDevelop.Ide.Gui
 					return null;
 				return Window.ViewContent.IsUntitled ? Window.ViewContent.UntitledName : Window.ViewContent.ContentName;
 			}
+		}
+
+		internal event EventHandler FileNameChanged;
+
+		void OnFileNameChanged ()
+		{
+			FileNameChanged?.Invoke (this, EventArgs.Empty);
 		}
 
 		public bool IsFile {
@@ -603,6 +616,7 @@ namespace MonoDevelop.Ide.Gui
 			if (window.ViewContent.Project != null)
 				window.ViewContent.Project.Modified -= HandleProjectModified;
 			window.ViewsChanged += HandleViewsChanged;
+			window.ViewContent.ContentNameChanged -= OnContentNameChanged;
 			MonoDevelopWorkspace.LoadingFinished -= ReloadAnalysisDocumentHandler;
 
 			window = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -615,7 +615,7 @@ namespace MonoDevelop.Ide.Gui
 			// Unsubscribe project events
 			if (window.ViewContent.Project != null)
 				window.ViewContent.Project.Modified -= HandleProjectModified;
-			window.ViewsChanged += HandleViewsChanged;
+			window.ViewsChanged -= HandleViewsChanged;
 			window.ViewContent.ContentNameChanged -= OnContentNameChanged;
 			MonoDevelopWorkspace.LoadingFinished -= ReloadAnalysisDocumentHandler;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentRegistry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentRegistry.cs
@@ -216,6 +216,7 @@ namespace MonoDevelop.Ide.Gui
 				LastSaveTimeUtc = DateTime.UtcNow;
 				doc.Saved += Doc_Saved;
 				doc.Reloaded += Doc_Saved;
+				doc.FileNameChanged += Doc_Saved;
 			}
 
 
@@ -233,6 +234,7 @@ namespace MonoDevelop.Ide.Gui
 			{
 				Document.Saved -= Doc_Saved;
 				Document.Reloaded -= Doc_Saved;
+				Document.FileNameChanged -= Doc_Saved;
 			}
 		}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/DocumentReloadTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/DocumentReloadTests.cs
@@ -1,0 +1,96 @@
+//
+// DocumentReloadTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Core.Text;
+using MonoDevelop.Ide.Gui;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.Editor
+{
+	[TestFixture]
+	public class DocumentReloadTests : IdeTestBase
+	{
+		[Test]
+		public async Task Refactor_RenameClassNameAndFileName_ShouldNotPromptToReload ()
+		{
+			FilePath directory = UnitTests.Util.CreateTmpDir ("FileRenameShouldNotPromptToReload");
+			FilePath fileName = directory.Combine ("test.cs");
+			File.WriteAllText (fileName, "class Test {}");
+
+			var window = new TestWorkbenchWindow ();
+			var content = new TestViewContentWithDocumentReloadPresenter ();
+			window.ViewContent = content;
+			var doc = new Document (window);
+			content.Document = doc;
+			await content.Load (fileName);
+
+			bool reloadWarningDisplayed = false;
+			content.OnShowFileChangeWarning = multiple => {
+				reloadWarningDisplayed = true;
+			};
+			doc.Editor.Text = "class rename {}";
+			doc.IsDirty = true; // Refactor leaves file unsaved in text editor.
+			FilePath newFileName = fileName.ChangeName ("renamed");
+			FileService.RenameFile (fileName, newFileName);
+			// Simulate DefaultWorkbench which updates the view content name when the FileService
+			// fires the rename event.
+			content.ContentName = newFileName;
+			FileService.NotifyFileChanged (newFileName);
+
+			Assert.IsFalse (reloadWarningDisplayed);
+		}
+
+		class TestViewContentWithDocumentReloadPresenter : TestViewContent, IDocumentReloadPresenter
+		{
+			public Document Document { get; set; }
+
+			public void RemoveMessageBar ()
+			{
+			}
+
+			public Action<bool> OnShowFileChangeWarning = multiple => { };
+
+			public void ShowFileChangedWarning (bool multiple)
+			{
+				OnShowFileChangeWarning (multiple);
+			}
+
+			public override Task Load (FileOpenInformation fileOpenInformation)
+			{
+				var fileName = fileOpenInformation.FileName;
+				string text = text = TextFileUtility.ReadAllText (fileName, out Encoding encoding);
+				Document.Editor.Text = text;
+				ContentName = fileName;
+				return Task.FromResult (true);
+			}
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="MonoDevelop.Ide.RoslynServices.Options\MonoDevelopOptionPersisterTests.cs" />
     <Compile Include="TypeForwarders.cs" />
     <Compile Include="MonoDevelop.Ide.RoslynServices\ExportedServicesAndWorkspaceServicesTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Editor\DocumentReloadTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">


### PR DESCRIPTION
Right clicking a MyClass definition, selecting Refactoring - Rename,
specifying a new name for the class and opting in to rename the file
at the same time would result in the text editor showing a message
indicating the file has changed outside the IDE and allows the file
to be reloaded.

The problem was that the refactoring renames the file and changes
the last saved date of the file. When the rename occurs the file
watcher generates a change event for the new file and the last saved
time of the document was not updated in the DocumentRegistry so the
text editor believed the file had been changed outside the IDE. To
handle this when the document's filename has been changed the last
saved date is updated in the DocumentRegistry since a rename could
affect this date.

Fixes VSTS #637706 - Renaming a class asks to reload file
Fixes VSTS #642585 - Document.DisposeDocument subscribes to an event