### PR TITLE
Remove --caption from KdeTerminalRunner

### DIFF
--- a/main/src/addins/GnomePlatform/GnomePlatform.cs
+++ b/main/src/addins/GnomePlatform/GnomePlatform.cs
@@ -267,12 +267,11 @@ namespace MonoDevelop.Platform
 				? BashPause.Replace ("'", "\"")
 					: String.Empty;
 
-			return String.Format (@" --nofork --caption ""{4}"" --workdir=""{3}"" -e ""bash"" -c '{0} {1} ; {2}'",
+			return String.Format (@" --nofork --workdir=""{3}"" -e ""bash"" -c '{0} {1} ; {2}'",
 			                      command,
 			                      args,
 			                      extra_commands,
-			                      EscapeDir (dir),
-			                      title);
+			                      EscapeDir (dir));
 		}
 
 		private static string GnomeTerminalOpenFolderRunner (string dir) {


### PR DESCRIPTION
Konsole no longer supports the --caption argument, remove it entirely as there is no replacement.
Stops "Cannot connect to the debugger" errors under KDE.

Fixes #4627 