### PR TITLE
[Core] Improve error information on project load failure

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormatException.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormatException.cs
@@ -31,6 +31,10 @@ namespace MonoDevelop.Projects.MSBuild
 		public MSBuildFileFormatException (string message): base (message)
 		{
 		}
+
+		public MSBuildFileFormatException (string message, Exception innerException): base (message, innerException)
+		{
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -232,7 +232,8 @@ namespace MonoDevelop.Projects.MSBuild
 				string xml = File.ReadAllText (file);
 
 				LoadXml (xml, reader);
-
+			} catch (Exception ex) {
+				throw new MSBuildFileFormatException (ex.Message + " " + file, ex);
 			} finally {
 				EnableChangeTracking ();
 			}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -1633,6 +1633,25 @@ namespace MonoDevelop.Projects
 				MSBuildProjectService.UnregisterGlobalPropertyProvider (prov2);
 			}
 		}
+
+		/// <summary>
+		/// Tests that the MSBuildProject.Load method includes information about the file
+		/// being loaded when there was an error. This makes it easier to fix problems when
+		/// the project file or imported file fails to load in the IDE.
+		/// </summary>
+		[Test]
+		public void LoadInvalidXml_ExceptionContainsFileBeingLoaded ()
+		{
+			string directory = Util.CreateTmpDir ("MSBuildProjectLoadInvalidXml");
+			string fileName = Path.Combine (directory, "MSBuildProjectLoadInvalidXml.csproj");
+			File.WriteAllText (fileName, "<Project></Project>\n</Project>");
+			var p = new MSBuildProject ();
+			try {
+				p.Load (fileName);
+			} catch (Exception ex) {
+				Assert.That (ex.Message, Contains.Substring (fileName));
+			}
+		}
 	}
 
 	class CustomGlobalPropertyProvider : IMSBuildGlobalPropertyProvider

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -1652,6 +1652,23 @@ namespace MonoDevelop.Projects
 				Assert.That (ex.Message, Contains.Substring (fileName));
 			}
 		}
+
+		[Test]
+		public void EvaluateInvalidMSBuildImportXml_ExceptionContainsFileBeingLoaded ()
+		{
+			string directory = Util.CreateTmpDir ("MSBuildImportLoadInvalidXml");
+			string fileName = Path.Combine (directory, "MSBuildImportLoadInvalidXml.csproj");
+			File.WriteAllText (fileName, "<Project><Import Project='InvalidXmlImport.targets' /></Project>");
+			string importFileName = Path.Combine (directory, "InvalidXmlImport.targets");
+			File.WriteAllText (importFileName, "<Project></Project>\n</Project>");
+			var p = new MSBuildProject ();
+			p.Load (fileName);
+			try {
+				p.Evaluate ();
+			} catch (Exception ex) {
+				Assert.That (ex.Message, Contains.Substring (importFileName));
+			}
+		}
 	}
 
 	class CustomGlobalPropertyProvider : IMSBuildGlobalPropertyProvider


### PR DESCRIPTION
Include the filename in the error message when a project or an
imported MSBuild project cannot be loaded. This will help locate the
problem. If there is invalid xml, for example, previously you would
see an error about the xml being invalid but there would be no
information about what file has the invalid xml.

Fixes VSTS #640783 - Failure while evaluating MSBuild project

Before:

<img width="583" alt="before" src="https://user-images.githubusercontent.com/372361/42277011-ceaf0594-7f8d-11e8-9ec6-432066300fe7.png">

After:

<img width="503" alt="after" src="https://user-images.githubusercontent.com/372361/42277015-d20df060-7f8d-11e8-805d-2afe6abef132.png">

In the above screenshots the project filename is displayed. Here you could say that the information is not required in this case since the project file has the error. However if the project is in an imported MSBuild project file somewhere else, say Xamarin.iOS.targets, the error message would indicate which file needs to be looked at.