### PR TITLE
[Instrumentation] Fix possible crash when converting null to value type

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -260,8 +260,11 @@ namespace MonoDevelop.Core.Instrumentation
 
 		protected T GetProperty<T> ([CallerMemberName]string name = null)
 		{
-			properties.TryGetValue (name, out var result);
-			return (T) Convert.ChangeType (result, typeof (T), CultureInfo.InvariantCulture);
+			if (properties.TryGetValue (name, out var result)) {
+				return (T)Convert.ChangeType (result, typeof (T), CultureInfo.InvariantCulture);
+			}
+
+			return default (T);
 		}
 	}
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
@@ -211,5 +211,13 @@ namespace MonoDevelop.Core
 
 			Assert.IsNull (value.Metadata);
 		}
+
+		[Test]
+		public void CounterMetadataQueryingDoesNotCrash ()
+		{
+			var metadata = new CustomCounterMetadata ();
+
+			Assert.AreEqual (default (int), metadata.SomeMeasure);
+		}
 	}
 }


### PR DESCRIPTION
If a new CounterMetadata is created and it is a value type, by querying
the property without setting it first, we would crash because
Convert.ToType does not handle that scenario