### PR TITLE
[IDE] Search results aren't shown with fullscreen and multiple monitors

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -36,6 +36,7 @@ using MonoDevelop.Projects;
 using MonoDevelop.Core.Execution;
 using System.Text;
 using MonoDevelop.Ide.TypeSystem;
+using MonoDevelop.Components.Mac;
 
 namespace MonoDevelop.Components.MainToolbar
 {
@@ -643,11 +644,20 @@ namespace MonoDevelop.Components.MainToolbar
 			if (popup == null)
 				return;
 
-			if (IdeApp.Workbench.RootWindow.Visible)
-				popup.ShowPopup (ToolbarView.PopupAnchor, PopupPosition.TopRight);
+			popup.IgnoreRepositionWindow = false;
 
-			if (ToolbarView.PopupAnchor.GdkWindow == null)
-				popup.Location = new Xwt.Point (ToolbarView.PopupAnchor.Allocation.Width - popup.Size.Width, ToolbarView.PopupAnchor.Allocation.Y);
+			var anchor = ToolbarView.PopupAnchor;
+			if (IdeApp.Workbench.RootWindow.Visible)
+				popup.ShowPopup (anchor, PopupPosition.TopRight);
+
+			if (anchor.GdkWindow == null) {
+				var location = new Xwt.Point (anchor.Allocation.Width - popup.Size.Width, anchor.Allocation.Y);
+
+				// Need to hard lock the location because Xwt doesn't know that the allocation might be coming from a
+				// Cocoa control and thus has been changed to take macOS monitor layout into consideration
+				popup.IgnoreRepositionWindow = true;
+				popup.Location = location;
+			}
 		}
 
 		void DestroyPopup ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Xwt/XwtThemedPopup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Xwt/XwtThemedPopup.cs
@@ -129,8 +129,13 @@ namespace MonoDevelop.Components
 			return false;
 		}
 
+		internal bool IgnoreRepositionWindow { get; set; }
 		public override void RepositionWindow (Rectangle? newTargetRect = default (Rectangle?))
 		{
+			if (IgnoreRepositionWindow) {
+				return;
+			}
+
 			if (!HasParent)
 				return;
 


### PR DESCRIPTION
XwtThemedPopup can't know that the location set came from a Cocoa and that it
has been converted to take multiple monitors and desktop configuration into
account. Then when RepositionWindow is called after setting the location, it
overrides the location and places it at an incorrect part of the screen where it
is hidden offscreen.

Instead, if the location is set explicitly, then we ignore any calls to
RepositionWindow

Fixes VSTS #552502