### PR TITLE
[Core] Optimize ExtensionChain logic

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ChainedExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ChainedExtension.cs
@@ -63,6 +63,7 @@ namespace MonoDevelop.Projects
 			if (!type.IsInstanceOfType (next))
 				return FindNextImplementation_Internal (type, next.nextInChain, ref position);
 
+			// Maybe it would make sense to cache these, but not sure if we should.
 			foreach (var method in type.GetMethods (BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
 				if (method != null && method.IsVirtual && method.Name != "InitializeChain") {
 					var paramArray = method.GetParameters ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExtensionChain.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExtensionChain.cs
@@ -72,7 +72,7 @@ namespace MonoDevelop.Projects
 
 		internal void AddExtension (ChainedExtension ext, ChainedExtension insertAfter = null, ChainedExtension insertBefore = null)
 		{
-			int index;
+			int index = -1;
 			if (insertBefore != null) {
 				index = Array.IndexOf (extensions, insertBefore);
 			} else if (insertAfter != null) {
@@ -81,9 +81,12 @@ namespace MonoDevelop.Projects
 					index++;
 			} else if (defaultInsertBefore != null) {
 				index = Array.IndexOf (extensions, defaultInsertBefore);
-			} else
+			}
+
+			if (index == -1) {
 				index = extensions.Length;
-			
+			}
+
 			Array.Resize (ref extensions, extensions.Length + 1);
 			for (int n = extensions.Length - 1; n > index; n--)
 				extensions [n] = extensions [n - 1];

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExtensionChain.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExtensionChain.cs
@@ -32,6 +32,7 @@ namespace MonoDevelop.Projects
 	public class ExtensionChain
 	{
 		Dictionary<Type,ChainedExtensionSentinel> chains = new Dictionary<Type, ChainedExtensionSentinel> ();
+		// Maybe an array is not the best solution here, given chains grow and decrease, a list might be better.
 		ChainedExtension [] extensions;
 		ChainedExtension defaultInsertBefore;
 		BatchModifier batchModifier;
@@ -160,7 +161,8 @@ namespace MonoDevelop.Projects
 				if (extensionIndex < firstChainChangeIndex)
 					return;
 
-				// Maybe it would be useful to skip extensions until the first chain change, as they've already been scanned.
+				// Maybe it would be useful to skip extensions until min(indices), as they've already been scanned
+				// in a previous check
 				var impl = ChainedExtension.FindNextImplementation (type, chain.extensions[0], out extensionIndex);
 				Extension.InitChain (chain, impl);
 			}
@@ -181,6 +183,10 @@ namespace MonoDevelop.Projects
 
 			public void UpdateFirstIndex (int firstChainChangeIndex)
 			{
+				// If we added a node at firstChainChangeIndex then removed that one
+				// it might help not to rechain in that case and reset the index.
+				// Maybe we can keep track of that and handle it.
+				// Regardless, the code is simpler this way and it should not be a bottleneck
 				minChangedIndex = Math.Min (firstChainChangeIndex, minChangedIndex);
 			}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExtensionChain.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ExtensionChain.cs
@@ -123,6 +123,13 @@ namespace MonoDevelop.Projects
 			var first = extensions [0];
 			extensions = null;
 			first.DisposeChain ();
+
+			foreach (var kvp in chains) {
+				// Dispose the placeholder extension just in case the extension itself registers something
+				// in InitializeChain that it cleans up in Dispose.
+				var extension = kvp.Value;
+				extension.Dispose ();
+			}
 		}
 
 		class BatchModifier : IDisposable

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceObject.cs
@@ -385,8 +385,7 @@ namespace MonoDevelop.Projects
 				}
 			}
 
-			foreach (var e in tempExtensions)
-				e.Dispose ();
+			extensionChain.Dispose ();
 
 			// Now create the final extension chain
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -111,6 +111,7 @@
     <Compile Include="MonoDevelop.Core\InstrumentationTests.cs" />
     <Compile Include="MonoDevelop.FSW\PathTreeNodeTests.cs" />
     <Compile Include="MonoDevelop.FSW\PathTreeTests.cs" />
+    <Compile Include="MonoDevelop.Projects\ExtensionChainTests.cs" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
@@ -279,6 +279,12 @@ namespace MonoDevelop.Projects
 			chain.Dispose ();
 
 			// Check that the extensions we queried get disposed
+			Assert.IsTrue (square.IsDisposed);
+			Assert.IsTrue (rectangle.IsDisposed);
+			Assert.IsTrue (shape.IsDisposed);
+			Assert.IsTrue (green.IsDisposed);
+			Assert.IsTrue (color.IsDisposed);
+			Assert.IsTrue (chainedExtension.IsDisposed);
 		}
 
 		class BaseTestChainedExtension : ChainedExtension

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
@@ -1,0 +1,170 @@
+﻿//
+// ExtensionChainTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace MonoDevelop.Projects
+{
+	[TestFixture]
+	public class ExtensionChainTests
+	{
+		static (BaseTestChainedExtension[], ExtensionChain) CreateTestExtensionChainAndArray (int count)
+		{
+			var arr = new BaseTestChainedExtension [count];
+			for (int i = 0; i < count; ++i)
+				arr [i] = new BaseTestChainedExtension ();
+			return (arr, ExtensionChain.Create (arr));
+		}
+
+		static ExtensionChain CreateTestExtensionChain (int count)
+		{
+			var (_, chain) = CreateTestExtensionChainAndArray (count);
+			return chain;
+		}
+
+		[Test]
+		public void ExtensionChainConstruction ()
+		{
+			var (exts, chain) = CreateTestExtensionChainAndArray (2);
+
+			var allExtensions = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (2, allExtensions.Length);
+			Assert.AreSame (exts[0], allExtensions [0]);
+			Assert.AreSame (exts[1], allExtensions [1]);
+		}
+
+		[Test]
+		public void ExtensionChainInitializedOnCreation ()
+		{
+			var (array, chain) = CreateTestExtensionChainAndArray (2);
+
+			Assert.AreEqual (1, array [0].InitializedCount);
+
+			// The equivalent of the default extension.
+			Assert.AreEqual (0, array [1].InitializedCount);
+		}
+
+		[Test]
+		public void ExtensionChainModification ()
+		{
+			var (initial, chain) = CreateTestExtensionChainAndArray (2);
+
+			// Assert default insertion position is at the end.
+			var ext = new BaseTestChainedExtension ();
+			chain.AddExtension (ext);
+			var currentExts = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (3, currentExts.Length);
+			Assert.AreSame (ext, currentExts[currentExts.Length - 1]);
+
+			// Make it insert by default the beginning
+			chain.SetDefaultInsertionPosition (currentExts [0]);
+
+			// Assert insert in default position
+			var defaultInserted = new BaseTestChainedExtension ();
+			chain.AddExtension (defaultInserted);
+			currentExts = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (4, currentExts.Length);
+			Assert.AreSame (defaultInserted, currentExts [0]);
+
+			// Assert insert before a given extension
+			var beforeExt = new BaseTestChainedExtension ();
+			chain.AddExtension (beforeExt, insertBefore: ext);
+			currentExts = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (5, currentExts.Length);
+			Assert.AreSame (beforeExt, currentExts[currentExts.Length - 2]);
+			Assert.AreSame (ext, currentExts [currentExts.Length - 1]);
+
+			// Assert insert after a given extension
+			var afterExt = new BaseTestChainedExtension ();
+			chain.AddExtension (afterExt, insertAfter: ext);
+			currentExts = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (6, currentExts.Length);
+			Assert.AreSame (beforeExt, currentExts [currentExts.Length - 3]);
+			Assert.AreSame (ext, currentExts [currentExts.Length - 2]);
+			Assert.AreSame (afterExt, currentExts [currentExts.Length - 1]);
+
+			// Remove the default one and probe it doesn't exist
+			chain.RemoveExtension (defaultInserted);
+			currentExts = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (5, currentExts.Length);
+			Assert.That (currentExts, Is.Not.Contains (defaultInserted));
+
+			// Validate that we insert at the end now
+			var lastExt = new BaseTestChainedExtension ();
+			chain.AddExtension (lastExt);
+			currentExts = chain.GetAllExtensions ().ToArray ();
+
+			Assert.AreEqual (6, currentExts.Length);
+			Assert.AreSame (lastExt, currentExts [currentExts.Length - 1]);
+		}
+
+		[Test]
+		public void AssertDisposedExtensionChain ()
+		{
+			var chain = CreateTestExtensionChain (2);
+
+			chain.Dispose ();
+
+			Assert.IsNull (chain.GetAllExtensions ());
+			Assert.Throws<NullReferenceException> (() => {
+				chain.AddExtension (new BaseTestChainedExtension ());
+			});
+			Assert.Throws<NullReferenceException> (() => {
+				chain.RemoveExtension (new BaseTestChainedExtension ());
+			});
+		}
+
+		[Test]
+		public void ExtensionChainRechainedOnModification ()
+		{
+		}
+
+		class BaseTestChainedExtension : ChainedExtension
+		{
+			public int InitializedCount { get; private set; }
+			public bool Disposed { get; private set; }
+
+			protected internal override void InitializeChain (ChainedExtension next)
+			{
+				InitializedCount++;
+				base.InitializeChain (next);
+			}
+
+			public override void Dispose ()
+			{
+				Disposed = true;
+				base.Dispose ();
+			}
+		}
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
@@ -287,6 +287,115 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (chainedExtension.IsDisposed);
 		}
 
+		[Test]
+		public void ExtensionChainQueryingCaching ()
+		{
+			var exts = new BaseTestChainedExtension [] {
+				new SquareChainedExtension (),
+				new RectangleChainedExtension (),
+				new ShapeChainedExtension (),
+				new GreenChainedExtension (),
+				new ColorChainedExtension (),
+				new BaseTestChainedExtension (),
+			};
+
+			var arrSquare = exts.Single (x => x.GetType () == typeof (SquareChainedExtension));
+			var arrRect = exts.Single (x => x.GetType () == typeof (RectangleChainedExtension));
+			var arrShape = exts.Single (x => x.GetType () == typeof (ShapeChainedExtension));
+			var arrGreen = exts.Single (x => x.GetType () == typeof (GreenChainedExtension));
+			var arrColor = exts.Single (x => x.GetType () == typeof (ColorChainedExtension));
+			var arrBase = exts.Single (x => x.GetType () == typeof (BaseTestChainedExtension));
+
+			var chain = ExtensionChain.Create (exts);
+
+			// Look for shape extensions
+			var square = chain.GetExtension<SquareChainedExtension> ();
+			var rectangle = chain.GetExtension<RectangleChainedExtension> ();
+			var shape = chain.GetExtension<ShapeChainedExtension> ();
+			var green = chain.GetExtension<GreenChainedExtension> ();
+			var color = chain.GetExtension<ColorChainedExtension> ();
+			var chainedExtension = chain.GetExtension<BaseTestChainedExtension> ();
+
+			int shapeInitializedCount = 1;
+			int colorInitializedCount = 1;
+			int baseInitializedCount = 1;
+			int noNextInitializedCount = 1;
+
+			AssertInitializedCount ();
+
+			// Add a BaseTestChainedExtension before the last item
+			// This should not trigger any init, as it's not a candidate for anything.
+			var toAdd = new BaseTestChainedExtension ();
+			chain.AddExtension (toAdd, insertBefore: arrBase);
+			noNextInitializedCount++;
+			AssertInitializedCount ();
+
+			// Remove the same one we added.
+			chain.RemoveExtension (toAdd);
+			noNextInitializedCount++;
+			AssertInitializedCount ();
+
+			// This won't have any effect, all of the colors go to green which is to the left of the node we insert after
+			toAdd = new ColorChainedExtension ();
+			chain.AddExtension (toAdd, insertAfter: arrColor);
+			noNextInitializedCount++;
+			AssertInitializedCount ();
+
+			// This won't have any effect, all of the colors go to green, before color
+			toAdd = new ColorChainedExtension ();
+			chain.AddExtension (toAdd, insertBefore: arrColor);
+			noNextInitializedCount++;
+			AssertInitializedCount ();
+
+			// Removing green would cause colors and the base extensions to be rechained.
+			chain.RemoveExtension (arrGreen);
+			noNextInitializedCount++;
+			baseInitializedCount++;
+			colorInitializedCount++;
+			AssertInitializedCount ();
+
+			// Adding a new square after the first one should rechain everything but shapes
+			toAdd = new SquareChainedExtension ();
+			chain.AddExtension (toAdd, insertAfter: arrSquare);
+			noNextInitializedCount++;
+			baseInitializedCount++;
+			colorInitializedCount++;
+			AssertInitializedCount ();
+
+			// Removing the square rechain everything but shapes
+			chain.RemoveExtension (toAdd);
+			noNextInitializedCount++;
+			baseInitializedCount++;
+			colorInitializedCount++;
+			AssertInitializedCount ();
+
+			// Adding a square at the beginning should rechain everything
+			chain.AddExtension (toAdd, insertBefore: arrSquare);
+			noNextInitializedCount++;
+			baseInitializedCount++;
+			colorInitializedCount++;
+			shapeInitializedCount++;
+			AssertInitializedCount ();
+
+			// Then removing it should rechain everything.
+			chain.RemoveExtension (toAdd);
+			noNextInitializedCount++;
+			baseInitializedCount++;
+			colorInitializedCount++;
+			shapeInitializedCount++;
+			AssertInitializedCount ();
+
+			void AssertInitializedCount ()
+			{
+				Assert.AreEqual (noNextInitializedCount, square.InitializedCount);
+				Assert.AreEqual (shapeInitializedCount, rectangle.InitializedCount);
+				Assert.AreEqual (shapeInitializedCount, shape.InitializedCount);
+				Assert.AreEqual (noNextInitializedCount, green.InitializedCount);
+				Assert.AreEqual (colorInitializedCount, color.InitializedCount);
+				Assert.AreEqual (noNextInitializedCount, chainedExtension.InitializedCount);
+			}
+		}
+
 		class BaseTestChainedExtension : ChainedExtension
 		{
 			public int InitializedCount { get; private set; }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ExtensionChainTests.cs
@@ -239,6 +239,48 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (0, currentExts [2].InitializedCount);
 		}
 
+		[Test]
+		public void ExtensionChainQuerying ()
+		{
+			var exts = new BaseTestChainedExtension [] {
+				new SquareChainedExtension (),
+				new RectangleChainedExtension (),
+				new ShapeChainedExtension (),
+				new GreenChainedExtension (),
+				new ColorChainedExtension (),
+				new BaseTestChainedExtension (),
+			};
+
+			var initialSquare = exts [0];
+			var initialGreen = exts [3];
+			var initialBase = exts [5];
+
+			var chain = ExtensionChain.Create (exts);
+
+			// Look for shape extensions
+			var square = chain.GetExtension<SquareChainedExtension> ();
+			var rectangle = chain.GetExtension<RectangleChainedExtension> ();
+			var shape = chain.GetExtension<ShapeChainedExtension> ();
+
+			Assert.IsNull (square.Next);
+			Assert.AreSame (initialSquare, rectangle.Next);
+			Assert.AreSame (initialSquare, shape.Next);
+
+			// Look for color extensions
+			var green = chain.GetExtension<GreenChainedExtension> ();
+			var color = chain.GetExtension<ColorChainedExtension> ();
+
+			Assert.IsNull (green.Next);
+			Assert.AreSame (initialGreen, color.Next);
+
+			var chainedExtension = chain.GetExtension<BaseTestChainedExtension> ();
+			Assert.IsNull (chainedExtension.Next);
+
+			chain.Dispose ();
+
+			// Check that the extensions we queried get disposed
+		}
+
 		class BaseTestChainedExtension : ChainedExtension
 		{
 			public int InitializedCount { get; private set; }
@@ -255,6 +297,31 @@ namespace MonoDevelop.Projects
 				IsDisposed = true;
 				base.Dispose ();
 			}
+		}
+
+		class ShapeChainedExtension : BaseTestChainedExtension
+		{
+			public virtual string GetShapeName () => "None";
+		}
+
+		class RectangleChainedExtension : ShapeChainedExtension
+		{
+			public override string GetShapeName () => "Rectangle";
+		}
+
+		class SquareChainedExtension : RectangleChainedExtension
+		{
+			public override string GetShapeName () => "Square";
+		}
+
+		class ColorChainedExtension : BaseTestChainedExtension
+		{
+			public virtual string GetColorName () => "None";
+		}
+
+		class GreenChainedExtension : ColorChainedExtension
+		{
+			public override string GetColorName () => "Green";
 		}
 	}
 }


### PR DESCRIPTION
This PR is a consolidated effort to prevent rechaining of extension chains where not needed and making the logic it follows reliable.

This PR touches users of ExtensionChain and ExtensionChain itself.

ExtensionChain is modified to do the following things:
* Dispose of the placeholder extensions at the beginning of the chain, as we cannot guarantee that a ChainedExtension's implementation will not hold onto resources indefinitely if not (one case where Dispose is overriden is in the MSBuild Extension).
* Provide new API that allows for batch modification of an extension, which only rechains on the disposal of the batch modification context.
* Fixed a bug where if insertAfter/insertBefore were not found, we would insert at the -1 position (thus, throw an exception). We now insert before the default position.
* Modify the placeholder extensions to not rechain unless needed.

The logic of `unless needed` is as follows. Given an Extension Chain and the type we want to look for an extension for, we check if the new chain was had a node inserted before or in place of the node we picked as the next implementation. Otherwise, it's just doing reflection checks to get to the same result.

Combined with the batch modifier, this reduces the amount of times an extension chain is init and also the number of times we do reflection on the types.

Users of ExtensionChain are modified to use operations which cause the least amount of rechains possible. That is, instead of manually disposing extensions in a chain, it disposes the chain completely, removing the rechaining on every disposal and they make use of the new API which allows batch modification of the ExtensionChain.

This PR also adds tests around how many times an extension is initialized and how the whole logic works, some docs around how the code works and some comments on what could be possible future improvements.

Fixes VSTS #643291 - ExtensionChain does a lot of unnecessary operations

Supersedes https://github.com/mono/monodevelop/pull/2491