### PR TITLE
[VCS] Fix Review and Commit selection persisting through context menu

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -821,7 +821,7 @@ namespace MonoDevelop.VersionControl.Views
 			VersionControlItemList items = new VersionControlItemList ();
 			foreach (string file in files) {
 				Project prj = IdeApp.Workspace.GetProjectsContainingFile (file).FirstOrDefault ();
-				items.Add (new VersionControlItem (vc, prj, file, Directory.Exists (file), null));
+				items.Add (new VersionControlItem (vc, prj, file, Directory.Exists (file), GetVersionInfo (file)));
 			}
 			return items;
 		}
@@ -1225,10 +1225,9 @@ namespace MonoDevelop.VersionControl.Views
 				}
 			}
 
-			handled = handled || (
-				IsClickedNodeSelected ((int)evnt.X, (int)evnt.Y)
+			handled |= (IsClickedNodeSelected ((int)evnt.X, (int)evnt.Y) && ctxMenu)
 				&& this.Selection.GetSelectedRows ().Length > 1
-				&& (evnt.State & selectionModifiers) == 0);
+				&& (evnt.State & selectionModifiers) == 0;
 
 			if (!handled)
 				handled = base.OnButtonPressEvent (evnt);


### PR DESCRIPTION
The fix is two fold, once the current info needed to be passed
to the command update handlers used by the context menu.

Then, there was a bug surrounding select all and clicking in the tree,
which would make nodes in the tree unselectable.

Fixes VSTS #621178 - [Feedback] Source Control selection in "Tools -> Options -> Source Control" is lost when opening context menu.