### PR TITLE
[MSBuild] Fix fatal exception on cancelling an MSBuild target being run

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
@@ -143,16 +143,19 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			// End the MSBuild build session started in BeginBuildOperation
 
-			RunSTA (this, delegate {
-				engine.RemoveGlobalProperty ("CurrentSolutionConfigurationContents");
-				BuildOperationStarted = false;
-				BuildManager.DefaultBuildManager.EndBuild ();
+			RunSTA (this, EndBuildOperationNonSTA);
+		}
 
-				// Dispose the loggers. This will flush pending output.
-				loggerAdapter.Dispose ();
-				loggerAdapter = null;
-				sessionLogWriter = null;
-			});
+		void EndBuildOperationNonSTA ()
+		{
+			engine.RemoveGlobalProperty ("CurrentSolutionConfigurationContents");
+			BuildOperationStarted = false;
+			BuildManager.DefaultBuildManager.EndBuild ();
+
+			// Dispose the loggers. This will flush pending output.
+			loggerAdapter.Dispose ();
+			loggerAdapter = null;
+			sessionLogWriter = null;
 		}
 
 		public MSBuildLoggerAdapter StartProjectSessionBuild (IEngineLogWriter logWriter)
@@ -179,7 +182,7 @@ namespace MonoDevelop.Projects.MSBuild
 			if (buildEngine.BuildOperationStarted) {
 				// Try to end the build here, to workaround a finalizer crash in zstream in mono
 				// https://github.com/mono/mono/issues/9142
-				BuildManager.DefaultBuildManager.EndBuild ();
+				buildEngine.EndBuildOperationNonSTA ();
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
@@ -25,13 +25,14 @@
 // THE SOFTWARE.
 
 using System.Collections.Generic;
-using Microsoft.Build.Evaluation;
+using System.Diagnostics;
 using System.Globalization;
-using Microsoft.Build.Execution;
 using System.Linq;
-using Microsoft.Build.Logging;
+using System.Threading;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
-using System;
+using Microsoft.Build.Logging;
 
 namespace MonoDevelop.Projects.MSBuild
 {
@@ -148,6 +149,8 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void EndBuildOperationNonSTA ()
 		{
+			Debug.Assert (Monitor.IsEntered (threadLock));
+
 			engine.RemoveGlobalProperty ("CurrentSolutionConfigurationContents");
 			BuildOperationStarted = false;
 			BuildManager.DefaultBuildManager.EndBuild ();

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -62,7 +62,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			MSBuildResult result = null;
 
-			BuildEngine.RunSTA (taskId, delegate {
+			BuildEngine.RunSTA (taskId, buildEngine, delegate {
 				Project project = null;
 				Dictionary<string, string> originalGlobalProperties = null;
 


### PR DESCRIPTION
Cancelling an MSBuild target that was being run, which was not a build,
would cause a fatal unhandled exception in the MSBuild build host.

```
The operation cannot be completed because BeginBuild has not yet been
called.
  at Microsoft.Build.Shared.ErrorUtilities.ThrowInvalidOperation (System.String resourceName, System.Object[] args)
 in /_/src/Shared/ErrorUtilities.cs:304
  at Microsoft.Build.Execution.BuildManager.ErrorIfState (Microsoft.Build.Execution.BuildManager+BuildManagerState disallowedState, System.String exceptionResouorce)
 in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:1195
  at Microsoft.Build.Execution.BuildManager.EndBuild ()
 in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:571
at MonoDevelop.Projects.MSBuild.BuildEngine.STARunner ()
 in MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.Shared.cs:333
```

So Project.RunTarget is called with a cancellation token and that token
is cancelled.

The problem was that the cancel request caused the worker thread to be
aborted. Code in the ThreadAbortException catch block would then try
to call EndBuild on the DefaultBuildManager. When not running a build
the DefaultBuildManager's BeginBuild is not called. The EndBuild
method has some state checks which throw an exception if a build is not
being run.

Now a check is made to see if a build operation was started before
trying to call EndBuild when the thread is aborted.

Fixes VSTS #643113 - MSBuild broken due to commit 1c63942