### PR TITLE
[release-7.6] [Roslyn] Disable ClosedFileDiagnostic for C# by default

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
@@ -81,7 +81,6 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 
 				SolutionCrawlerClosedFileDiagnostic = preferences.Wrap<bool?> (
 					new OptionKey (ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language),
-					true
 				);
 			}
 		}


### PR DESCRIPTION
Backport of #5324.

/cc @Therzok