### PR TITLE
Surface lazy methods for CompositionManager

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -89,18 +89,22 @@ namespace MonoDevelop.Ide.Composition
 		/// <summary>
 		/// Returns an instance of type T that is exported by some composition part. The instance is shared (singleton).
 		/// </summary>
-		public static T GetExportedValue<T> ()
-		{
-			return Instance.ExportProvider.GetExportedValue<T> ();
-		}
+		public static T GetExportedValue<T> () => Instance.ExportProvider.GetExportedValue<T> ();
 
 		/// <summary>
-		/// Returns all instance of type T that are exported by some composition part. The instances are shared (singletons).
+		/// Returns all instances of type T that are exported by some composition part. The instances are shared (singletons).
 		/// </summary>
-		public static IEnumerable<T> GetExportedValues<T> ()
-		{
-			return Instance.ExportProvider.GetExportedValues<T> ();
-		}
+		public static IEnumerable<T> GetExportedValues<T> () => Instance.ExportProvider.GetExportedValues<T> ();
+
+		/// <summary>
+		/// Returns a lazy holding the instance of type T that is exported by some composition part. The instance is shared (singleton).
+		/// </summary>
+		public static Lazy<T> GetExport<T> () => Instance.ExportProvider.GetExport<T> ();
+
+		/// <summary>
+		/// Returns lazies holding all instances of type T that are exported by some composition part. The instances are shared (singletons).
+		/// </summary>
+		public static IEnumerable<Lazy<T>> GetExports<T> () => Instance.ExportProvider.GetExports<T> ();
 
 		public RuntimeComposition RuntimeComposition { get; private set; }
 		public IExportProviderFactory ExportProviderFactory { get; private set; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -304,7 +304,7 @@ namespace MonoDevelop.Ide.Desktop
 			}
 		}
 
-		static Lazy<IFilePathRegistryService> filePathRegistryService = new Lazy<IFilePathRegistryService> (() => CompositionManager.GetExportedValue<IFilePathRegistryService> ());
+		static Lazy<IFilePathRegistryService> filePathRegistryService = CompositionManager.GetExport<IFilePathRegistryService> ();
 		MimeTypeNode FindMimeTypeForFile (string fileName)
 		{
 			try {


### PR DESCRIPTION
This API is useful for cases where you want to lazily query a service which you use later on.