### PR TITLE
[release-7.6] Fix syntax highlighting not showing for some languages (TypeScript).

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
@@ -399,18 +399,9 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 					if (readFileTypes && fileTypesEndRegex.Match (line).Success)
 						break;
 					if (readFileTypes) {
-						line = line.Trim ();
-						if (line.Length > 3 && line[0] == '"' && line[line.Length - 1] == '"') {
-							int start = 1;
-
-							// the . is optional, some extensions mention it and some don't
-							if (line[1] == '.') {
-								start = 2;
-							}
-
-							string fileType = line.Substring (start, line.Length - start - 1);
+						string fileType = ParseFileType (line);
+						if (!string.IsNullOrEmpty(fileType))
 							fileTypes.Add (fileType);
-						}
 					}
 				}
 				if (fileTypes == null)
@@ -426,6 +417,19 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			return false;
 		}
 
+		internal static string ParseFileType (string line)
+		{
+			var idx1 = line.IndexOf ('"');
+			var idx2 = line.LastIndexOf ('"');
+			if (idx1 < 0 || idx1 + 1 >= idx2)
+				return null;
+			// the . is optional, some extensions mention it and some don't
+			if (line [idx1 + 1] == '.')
+				idx1++;
+			idx1++; // skip "
+			return line.Substring (idx1, idx2 - idx1);
+
+		}
 		static bool TryScanTextMateSyntax (Stream stream, out List<string> fileTypes, out string name, out string scopeName)
 		{
 			fileTypes = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
@@ -400,8 +400,15 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 						break;
 					if (readFileTypes) {
 						line = line.Trim ();
-						if (line.Length > 3) {
-							var fileType = line.Substring (1, line.Length - 3);
+						if (line.Length > 3 && line[0] == '"' && line[line.Length - 1] == '"') {
+							int start = 1;
+
+							// the . is optional, some extensions mention it and some don't
+							if (line[1] == '.') {
+								start = 2;
+							}
+
+							string fileType = line.Substring (start, line.Length - start - 1);
 							fileTypes.Add (fileType);
 						}
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
@@ -351,9 +351,9 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 		static System.Text.RegularExpressions.Regex fileTypesRegex = new System.Text.RegularExpressions.Regex ("\\s*\"fileTypes\"");
 		static System.Text.RegularExpressions.Regex fileTypesEndRegex = new System.Text.RegularExpressions.Regex ("\\],");
 
-		enum JSonFormat { Unknown, OldSyntaxTheme, TextMateJsonSyntax }
+		internal enum JSonFormat { Unknown, OldSyntaxTheme, TextMateJsonSyntax }
 
-		static bool TryScanJSonStyle (Stream stream, out string name, out JSonFormat format, out List<string> fileTypes, out string scopeName)
+		internal static bool TryScanJSonStyle (Stream stream, out string name, out JSonFormat format, out List<string> fileTypes, out string scopeName)
 		{
 			name = null;
 			scopeName = null;

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -120,7 +120,6 @@ namespace Mono.TextEditor.Tests
 		}
 		
 		[Test]
-		[Ignore("FIXME")] // https://github.com/mono/monodevelop/issues/5322
 		public void TestCDATASection ()
 		{
 			TestOutput ("<![CDATA[ test]]>",
@@ -213,6 +212,16 @@ namespace Mono.TextEditor.Tests
 			TestOutput ("$\"{foo}\"",
 			  			"<span foreground=\"#e5da73\">$\"{</span><span foreground=\"#eeeeec\">foo</span><span foreground=\"#e5da73\">}\"</span>");
 		}
-
+		[Test]
+		public void ParseFileTypeTest ()
+		{
+			Assert.AreEqual ("xml", SyntaxHighlightingService.ParseFileType ("\"xml\""));
+			Assert.AreEqual ("xml", SyntaxHighlightingService.ParseFileType ("\".xml\""));
+			Assert.AreEqual ("xml", SyntaxHighlightingService.ParseFileType ("\"xml\","));
+			Assert.AreEqual ("xml", SyntaxHighlightingService.ParseFileType ("\".xml\","));
+			Assert.IsTrue (string.IsNullOrEmpty (SyntaxHighlightingService.ParseFileType ("\"\",")));
+			Assert.IsTrue (string.IsNullOrEmpty (SyntaxHighlightingService.ParseFileType ("\".\",")));
+			Assert.IsTrue (string.IsNullOrEmpty (SyntaxHighlightingService.ParseFileType ("}")));
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -120,7 +120,7 @@ namespace Mono.TextEditor.Tests
 		}
 		
 		[Test]
-		[Ignore("FIXME")]
+		[Ignore("FIXME")] // https://github.com/mono/monodevelop/issues/5322
 		public void TestCDATASection ()
 		{
 			TestOutput ("<![CDATA[ test]]>",

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -120,6 +120,7 @@ namespace Mono.TextEditor.Tests
 		}
 		
 		[Test]
+		[Ignore("FIXME")]
 		public void TestCDATASection ()
 		{
 			TestOutput ("<![CDATA[ test]]>",

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SyntaxHighlightingTest_TextMate.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SyntaxHighlightingTest_TextMate.cs
@@ -147,9 +147,9 @@ test ""f\t"" this bar
 		[Test]
 		public void TestTryScanJSonStyle ()
 		{
-			var stream = new MemoryStream ();
-			var writer = new StreamWriter (stream);
-			writer.Write (@"{
+			using (var stream = new MemoryStream ())
+			using (var writer = new StreamWriter (stream)) {
+				writer.Write (@"{
 	""information_for_contributors"": [
 		""This file has been converted from https://github.com/Microsoft/TypeScript-TmLanguage/blob/master/TypeScript.tmLanguage"",
 		""If you want to provide a fix or improvement, please create a pull request against the original repository."",
@@ -161,13 +161,14 @@ test ""f\t"" this bar
 	""fileTypes"": [
 		""ts""
 	],");
-			writer.Flush ();
-			stream.Position = 0;
-			bool result = SyntaxHighlightingService.TryScanJSonStyle (stream, out var name, out var format, out var fileTypes, out var scopeName);
-			Assert.AreEqual (true, result);
-			Assert.AreEqual ("TypeScript", name);
-			Assert.AreEqual ("source.ts", scopeName);
-			Assert.True (fileTypes.Contains ("ts"));
+				writer.Flush ();
+				stream.Position = 0;
+				bool result = SyntaxHighlightingService.TryScanJSonStyle (stream, out var name, out var format, out var fileTypes, out var scopeName);
+				Assert.AreEqual (true, result);
+				Assert.AreEqual ("TypeScript", name);
+				Assert.AreEqual ("source.ts", scopeName);
+				Assert.True (fileTypes.Contains ("ts"));
+			}
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SyntaxHighlightingTest_TextMate.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/SyntaxHighlightingTest_TextMate.cs
@@ -143,5 +143,31 @@ test ""f\t"" this bar
 			var h = TextMateFormat.ReadHighlighting (new MemoryStream (Encoding.UTF8.GetBytes (highlighting)));
 			SyntaxHighlightingTest.RunHighlightingTest (h, test);
 		}
+
+		[Test]
+		public void TestTryScanJSonStyle ()
+		{
+			var stream = new MemoryStream ();
+			var writer = new StreamWriter (stream);
+			writer.Write (@"{
+	""information_for_contributors"": [
+		""This file has been converted from https://github.com/Microsoft/TypeScript-TmLanguage/blob/master/TypeScript.tmLanguage"",
+		""If you want to provide a fix or improvement, please create a pull request against the original repository."",
+		""Once accepted there, we are happy to receive an update request.""
+	],
+	""version"": ""https://github.com/Microsoft/TypeScript-TmLanguage/commit/7bf8960f7042474b10b519f39339fc527907ce16"",
+	""name"": ""TypeScript"",
+	""scopeName"": ""source.ts"",
+	""fileTypes"": [
+		""ts""
+	],");
+			writer.Flush ();
+			stream.Position = 0;
+			bool result = SyntaxHighlightingService.TryScanJSonStyle (stream, out var name, out var format, out var fileTypes, out var scopeName);
+			Assert.AreEqual (true, result);
+			Assert.AreEqual ("TypeScript", name);
+			Assert.AreEqual ("source.ts", scopeName);
+			Assert.True (fileTypes.Contains ("ts"));
+		}
 	}
 }


### PR DESCRIPTION
Backport of #5291.

Fixes VSTS 642869

/cc @slluis