### PR TITLE
Use the proper new line setting from the editor.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
@@ -603,6 +603,7 @@ namespace MonoDevelop.Ide.Completion.Presentation
 			var editorOptionsFactory = CompositionManager.GetExportedValue<IEditorOptionsFactoryService> ();
 			var editorOptions = editorOptionsFactory.GetOptions (DataBuffer);
 			var options = _workspace.Options
+										.WithChangedOption (FormattingOptions.NewLine, root.Language, editorOptions.GetNewLineCharacter ())
 										.WithChangedOption (FormattingOptions.UseTabs, root.Language, !editorOptions.IsConvertTabsToSpacesEnabled ())
 										.WithChangedOption (FormattingOptions.TabSize, root.Language, editorOptions.GetTabSize ())
 										.WithChangedOption (FormattingOptions.IndentationSize, root.Language, editorOptions.GetIndentSize ());


### PR DESCRIPTION
This doesn't fix any bug, just something to be consistent with the Windows original of this source code.

See https://github.com/dotnet/roslyn/pull/28268.

We don't need this in release-7.6.