### PR TITLE
[release-7.6] Fix VSTS 585147: Code in indented @{} block jumps up a line when committed

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
@@ -315,7 +315,8 @@ namespace MonoDevelop.Ide.Completion.Presentation
 				var ch = text[i];
 				switch (ch) {
 				case ' ':
-					if (!TextAt (text, i - 1, ' ')) {
+				case '\t':
+					if (!TextAt (text, i - 1, ' ') && !TextAt (text, i - 1, '\t')) {
 						start = i;
 					}
 
@@ -326,7 +327,7 @@ namespace MonoDevelop.Ide.Completion.Presentation
 					if (i == 0) {
 						groups.Add (TextSpan.FromBounds (0, 0));
 					}
-					else if (TextAt (text, i - 1, ' ')) {
+					else if (TextAt (text, i - 1, ' ') || TextAt (text, i - 1, '\t')) {
 						groups.Add (TextSpan.FromBounds (start, i));
 					}
 					else if (TextAt (text, i - 1, '\n')) {


### PR DESCRIPTION
Backport of #5335.

/cc @KirillOsenkov