### PR TITLE
Fixes VSTS: 632539 - Allow native mac dialogs to render formatted strings

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -85,7 +85,7 @@ namespace MonoDevelop.MacIntegration
 				} else
 					alert.InformativeText = secondaryText;
 
-				var accessoryViews = new NSView [accessoryViewItemsCount];
+				var accessoryViews = accessoryViewItemsCount > 0 ? new NSView [accessoryViewItemsCount] : null;
 				int accessoryViewsIndex = 0;
 
 				if (messageView != null)
@@ -141,7 +141,9 @@ namespace MonoDevelop.MacIntegration
 					}
 				}
 
-				alert.AccessoryView = ArrangeAccessoryViews (accessoryViews);
+				var accessoryView = ArrangeAccessoryViews (accessoryViews);
+				if (accessoryView != null)
+					alert.AccessoryView = accessoryView;
 
 				NSButton applyToAllCheck = null;
 				if (data.Message.AllowApplyToAll) {
@@ -222,10 +224,7 @@ namespace MonoDevelop.MacIntegration
 
 		static NSStackView ArrangeAccessoryViews (NSView[] views, int viewWidth = 450, int spacing = 5)
 		{
-			if (views == null)
-				throw new ArgumentNullException (nameof (views));
-
-			if (views.Length == 0)
+			if (views == null || views.Length == 0)
 				return null;
 
 			var stackView = NSStackView.FromViews (views);


### PR DESCRIPTION
VSTS issue:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/632539?src=alerts&src-action=cta

Related PR in md-addins:
https://github.com/xamarin/md-addins/pull/3330

Related PR in maciostools:
https://github.com/xamarin/maciostools/pull/133

For example, here we show a clickable link and instead of plain markdown (<a href='...'>...</a>):

<img width="602" alt="screen shot 2018-07-09 at 10 27 10 am" src="https://user-images.githubusercontent.com/1524073/42459789-6962fbb0-836a-11e8-92b3-beb68e96246d.png">