### PR TITLE
[Telemetry] Add solution extension for fetching platform-specific metadata

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1273,8 +1273,7 @@ namespace MonoDevelop.Projects
 				case "Clean": buildTimer = Counters.CleanMSBuildProjectTimer; break;
 				}
 
-				var eventMetadata = CreateProjectEventMetadata (configuration);
-				var metadata = ProjectExtension.UpdateProjectEventMetadata (configuration, eventMetadata);
+				var metadata = CreateProjectEventMetadata (configuration);
 				var t1 = Counters.RunMSBuildTargetTimer.BeginTiming (metadata);
 				var t2 = buildTimer?.BeginTiming (metadata);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -717,9 +717,9 @@ namespace MonoDevelop.Projects
 			metadata["ProjectTypes"] = sb.ToString ();
 		}
 
-		protected override void OnGetProjectEventMetadata (ProjectEventMetadata metadata)
+		protected override ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
 		{
-			base.OnGetProjectEventMetadata (metadata);
+			var metadata = base.OnGetProjectEventMetadata (configurationSelector);
 			var sb = new System.Text.StringBuilder ();
 			var first = true;
 
@@ -731,6 +731,8 @@ namespace MonoDevelop.Projects
 				first = false;
 			}
 			metadata.ProjectTypes = sb.ToString ();
+
+			return metadata;
 		}
 
 		protected override void OnEndLoad ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1273,7 +1273,8 @@ namespace MonoDevelop.Projects
 				case "Clean": buildTimer = Counters.CleanMSBuildProjectTimer; break;
 				}
 
-				var metadata = CreateProjectEventMetadata (configuration);
+				var eventMetadata = CreateProjectEventMetadata (configuration);
+				var metadata = ProjectExtension.UpdateProjectEventMetadata (configuration, eventMetadata);
 				var t1 = Counters.RunMSBuildTargetTimer.BeginTiming (metadata);
 				var t2 = buildTimer?.BeginTiming (metadata);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -302,10 +302,6 @@ namespace MonoDevelop.Projects
 
 		#endregion
 
-		internal protected virtual ProjectEventMetadata UpdateProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata metadata)
-		{
-			return next.UpdateProjectEventMetadata (configurationSelector, metadata);
-		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -301,6 +301,11 @@ namespace MonoDevelop.Projects
 		}
 
 		#endregion
+
+		internal protected virtual ProjectEventMetadata UpdateProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata metadata)
+		{
+			return next.UpdateProjectEventMetadata (configurationSelector, metadata);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -301,7 +301,6 @@ namespace MonoDevelop.Projects
 		}
 
 		#endregion
-
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -887,7 +887,7 @@ namespace MonoDevelop.Projects
 
 		public ProjectEventMetadata CreateProjectEventMetadata (ConfigurationSelector configurationSelector)
 		{
-			return ItemExtension.OnGetProjectEventMetadata (configurationSelector, new ProjectEventMetadata ());
+			return ItemExtension.OnGetProjectEventMetadata (configurationSelector);
 		}
 
 		[Obsolete ("Use OnGetProjectEventMetadata (ProjectEventMetadata) instead")]
@@ -895,11 +895,7 @@ namespace MonoDevelop.Projects
 		{
 		}
 
-		protected virtual void OnGetProjectEventMetadata (ProjectEventMetadata metadata)
-		{
-		}
-
-		protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata origMetadata)
+		protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
 		{
 			string id = null;
 			if (configurationSelector != null) {
@@ -909,9 +905,7 @@ namespace MonoDevelop.Projects
 				}
 			}
 
-			var metadata = new ProjectEventMetadata (id);
-			OnGetProjectEventMetadata (metadata);
-			return metadata;
+			return new ProjectEventMetadata (id);
 		}
 
 		/// <summary>
@@ -1607,9 +1601,10 @@ namespace MonoDevelop.Projects
 				return Item.OnGetReferencedItems (configuration);
 			}
 
-			protected internal override ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata metadata)
+			protected internal override ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
 			{
-				return Item.OnGetProjectEventMetadata (configurationSelector, metadata);
+				var metadata = Item.OnGetProjectEventMetadata (configurationSelector);
+				return new ProjectEventMetadata (metadata);
 			}
 
 			internal protected override void OnSetFormat (MSBuildFileFormat format)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -1834,14 +1834,6 @@ namespace MonoDevelop.Projects
 		{
 		}
 
-		public ProjectEventMetadata (CounterMetadata metadata, string configurationId)
-			: base (metadata)
-		{
-			if (configurationId != null) {
-				Properties ["Config.Id"] = configurationId;
-			}
-		}
-
 		public ProjectEventMetadata (string configurationId)
 		{
 			if (configurationId != null) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -887,16 +887,7 @@ namespace MonoDevelop.Projects
 
 		public ProjectEventMetadata CreateProjectEventMetadata (ConfigurationSelector configurationSelector)
 		{
-			string id = null;
-			if (configurationSelector != null) {
-				var slnConfig = configurationSelector as SolutionConfigurationSelector;
-				if (slnConfig != null) {
-					id = slnConfig.Id;
-				}
-			}
-
-			var metadata = new ProjectEventMetadata (id);
-			return itemExtension.OnGetProjectEventMetadata (metadata, configurationSelector);
+			return ItemExtension.OnGetProjectEventMetadata (configurationSelector, new ProjectEventMetadata ());
 		}
 
 		[Obsolete ("Use OnGetProjectEventMetadata (ProjectEventMetadata) instead")]
@@ -906,6 +897,21 @@ namespace MonoDevelop.Projects
 
 		protected virtual void OnGetProjectEventMetadata (ProjectEventMetadata metadata)
 		{
+		}
+
+		protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata origMetadata)
+		{
+			string id = null;
+			if (configurationSelector != null) {
+				var slnConfig = configurationSelector as SolutionConfigurationSelector;
+				if (slnConfig != null) {
+					id = slnConfig.Id;
+				}
+			}
+
+			var metadata = new ProjectEventMetadata (id);
+			OnGetProjectEventMetadata (metadata);
+			return metadata;
 		}
 
 		/// <summary>
@@ -1601,6 +1607,11 @@ namespace MonoDevelop.Projects
 				return Item.OnGetReferencedItems (configuration);
 			}
 
+			protected internal override ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata metadata)
+			{
+				return Item.OnGetProjectEventMetadata (configurationSelector, metadata);
+			}
+
 			internal protected override void OnSetFormat (MSBuildFileFormat format)
 			{
 				Item.OnSetFormat (format);
@@ -1827,6 +1838,14 @@ namespace MonoDevelop.Projects
 		public ProjectEventMetadata (CounterMetadata metadata)
 			: base (metadata)
 		{
+		}
+
+		public ProjectEventMetadata (CounterMetadata metadata, string configurationId)
+			: base (metadata)
+		{
+			if (configurationId != null) {
+				Properties ["Config.Id"] = configurationId;
+			}
 		}
 
 		public ProjectEventMetadata (string configurationId)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -1603,8 +1603,7 @@ namespace MonoDevelop.Projects
 
 			protected internal override ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
 			{
-				var metadata = Item.OnGetProjectEventMetadata (configurationSelector);
-				return new ProjectEventMetadata (metadata);
+				return Item.OnGetProjectEventMetadata (configurationSelector);
 			}
 
 			internal protected override void OnSetFormat (MSBuildFileFormat format)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -896,8 +896,7 @@ namespace MonoDevelop.Projects
 			}
 
 			var metadata = new ProjectEventMetadata (id);
-			OnGetProjectEventMetadata (metadata);
-			return metadata;
+			return itemExtension.OnGetProjectEventMetadata (metadata, configurationSelector);
 		}
 
 		[Obsolete ("Use OnGetProjectEventMetadata (ProjectEventMetadata) instead")]
@@ -908,6 +907,7 @@ namespace MonoDevelop.Projects
 		protected virtual void OnGetProjectEventMetadata (ProjectEventMetadata metadata)
 		{
 		}
+
 		/// <summary>
 		/// Executes this solution item
 		/// </summary>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -1824,6 +1824,11 @@ namespace MonoDevelop.Projects
 		{
 		}
 
+		public ProjectEventMetadata (CounterMetadata metadata)
+			: base (metadata)
+		{
+		}
+
 		public ProjectEventMetadata (string configurationId)
 		{
 			if (configurationId != null) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
@@ -88,9 +88,10 @@ namespace MonoDevelop.Projects
 			next.OnInitializeFromTemplate (projectCreateInfo, template);
 		}
 
-		internal protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata metadata)
+		internal protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
 		{
-			return next.OnGetProjectEventMetadata (configurationSelector, metadata);
+			var metadata = next.OnGetProjectEventMetadata (configurationSelector);
+			return new ProjectEventMetadata (metadata);
 		}
 
 		internal void ItemReady ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
@@ -88,9 +88,9 @@ namespace MonoDevelop.Projects
 			next.OnInitializeFromTemplate (projectCreateInfo, template);
 		}
 
-		internal protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ProjectEventMetadata metadata, ConfigurationSelector configurationSelector)
+		internal protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector, ProjectEventMetadata metadata)
 		{
-			return next.OnGetProjectEventMetadata (metadata, configurationSelector);
+			return next.OnGetProjectEventMetadata (configurationSelector, metadata);
 		}
 
 		internal void ItemReady ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
@@ -90,8 +90,7 @@ namespace MonoDevelop.Projects
 
 		internal protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
 		{
-			var metadata = next.OnGetProjectEventMetadata (configurationSelector);
-			return new ProjectEventMetadata (metadata);
+			return next.OnGetProjectEventMetadata (configurationSelector);
 		}
 
 		internal void ItemReady ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemExtension.cs
@@ -88,6 +88,11 @@ namespace MonoDevelop.Projects
 			next.OnInitializeFromTemplate (projectCreateInfo, template);
 		}
 
+		internal protected virtual ProjectEventMetadata OnGetProjectEventMetadata (ProjectEventMetadata metadata, ConfigurationSelector configurationSelector)
+		{
+			return next.OnGetProjectEventMetadata (metadata, configurationSelector);
+		}
+
 		internal void ItemReady ()
 		{
 			OnItemReady ();


### PR DESCRIPTION
This adds a way to fetch platform-specific metadata for extra `XS.Solution.Perf.ProjectBuild.*` properties.

This is part of VSTS #598635