### PR TITLE
[CommentTasks] Prevent possible error when removing a document

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
@@ -159,13 +159,12 @@ namespace MonoDevelop.Ide.Tasks
 		{
 			if (args.Item is MonoDevelop.Projects.Solution sol) {
 				var ws = await TypeSystemService.GetWorkspaceAsync (sol);
-				var solId = ws.GetSolutionId (sol);
 
 				lock (lockObject) {
 					if (cachedUntilViewCreated == null)
 						return;
 
-					cachedUntilViewCreated = cachedUntilViewCreated.Where (x => x.Value.Solution.Id != solId).ToDictionary (x => x.Key, x => x.Value);
+					cachedUntilViewCreated = cachedUntilViewCreated.Where (x => x.Value.Workspace != ws).ToDictionary (x => x.Key, x => x.Value);
 				}
 			}
 		}


### PR DESCRIPTION
There is a possibility that TodoListUpdated is called with a null solution
value.

So just clear out any items matching the workspace

Fixes VSTS #636279 - Text in editor is invisible

```
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Ide.Tasks.CommentTasksProvider+<>c__DisplayClass13_0.<OnWorkspaceItemClosed>b__0 (System.Collections.Generic.KeyValuePair`2[TKey,TValue] x) [0x00000] in /Users/vsts/agent/2.134.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs:168
  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].MoveNext () [0x00037] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/Where.cs:143
  at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.Collections.Generic.IEqualityComparer`1[T] comparer) [0x000a2] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/ToCollection.cs:140
  at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/ToCollection.cs:100
  at MonoDevelop.Ide.Tasks.CommentTasksProvider+<OnWorkspaceItemClosed>d__13.MoveNext () [0x000d9] in /Users/vsts/agent/2.134.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs:168
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:152
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__6_0 (System.Object state) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:1018
  at MonoDevelop.Ide.DispatchService+GtkSynchronizationContext+TimeoutProxy.HandlerInternal (System.IntPtr data) [0x00014] in /Users/vsts/agent/2.134.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:77
```