### PR TITLE
[Ide][Mac] Fix closed window handling in IdeTheme

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/IdeTheme.cs
@@ -376,8 +376,13 @@ namespace MonoDevelop.Components
 		static void OnClose (NSNotification note)
 		{
 			var w = (NSWindow)note.Object;
-			NSNotificationCenter.DefaultCenter.RemoveObserver(nsWindows[w]);
+			if (MacSystemInformation.OsVersion < MacSystemInformation.HighSierra)
+				// Since HighSierra observers don't need to be removed manually, doing so
+				// after a window has been released might even lead to a native crash
+				// see: https://developer.apple.com/library/archive/releasenotes/Foundation/RN-Foundation/index.html#10_11NotificationCenter
+				NSNotificationCenter.DefaultCenter.RemoveObserver(nsWindows[w]);
 			nsWindows.Remove (w);
+
 		}
 
 		static void UpdateMacWindows ()


### PR DESCRIPTION
With HighSierra [NSNotificationCenter observer handling has been
redeisgned](https://developer.apple.com/library/archive/releasenotes/Foundation/RN-Foundation/index.html#10_11NotificationCenter) and now observers are removed automatically during finalization.
However the actual NSWindow.WillCloseNotification might be raised
after the window has been finalized and removing the observer manually
would result in a hard native crash, hence we need to treat
window closed winows differently depending on the macOS version.