### PR TITLE
[NUnit] Fix NUnit3 test runner name

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnit3Runner.csproj
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/NUnit3Runner/NUnit3Runner.csproj
@@ -5,6 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D2A4E99E-FC2D-45A9-8BE7-1AB7DF95BA2A}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <AssemblyName>NUnitRunner</AssemblyName>
     <TargetFrameworkVersion>$(MDFrameworkVersion)</TargetFrameworkVersion>
     <OutputPath>..\..\..\..\build\AddIns\MonoDevelop.UnitTesting\NUnit3</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
The NUnit3 test runner was being created with the filename:
NUnit3Runner.exe instead of NUnitRunner.exe so the IDE test runner
would fail to start this process. Changed the assembly name to
NUnitRunner.

Fixes VSTS #645844 - NUnit 3 integration broken because of misnamed
runner