### PR TITLE
[DotNetCore] Fix project not restored on target framework being changed

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreRuntimeOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreRuntimeOptionsPanelWidget.cs
@@ -92,7 +92,6 @@ namespace MonoDevelop.DotNetCore.Gui
 
 			if (framework != project.TargetFramework) {
 				project.TargetFramework = frameworks [runtimeVersionCombo.Active];
-				dotNetCoreProject.RestoreAfterSave = true;
 			}
 		}
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesInProjectHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesInProjectHandler.cs
@@ -48,18 +48,18 @@ namespace MonoDevelop.PackageManagement.Commands
 			Run (project, false);
 		}
 
-		public static void Run (DotNetProject project, bool restoreTransitiveProjectReferences)
+		public static void Run (DotNetProject project, bool restoreTransitiveProjectReferences, bool reevaluateBeforeRestore = false)
 		{
 			try {
 				ProgressMonitorStatusMessage message = ProgressMonitorStatusMessageFactory.CreateRestoringPackagesInProjectMessage ();
-				IPackageAction action = CreateRestorePackagesAction (project, restoreTransitiveProjectReferences);
+				IPackageAction action = CreateRestorePackagesAction (project, restoreTransitiveProjectReferences, reevaluateBeforeRestore);
 				PackageManagementServices.BackgroundPackageActionRunner.Run (message, action);
 			} catch (Exception ex) {
 				ShowStatusBarError (ex);
 			}
 		}
 
-		static IPackageAction CreateRestorePackagesAction (DotNetProject project, bool restoreTransitiveProjectReferences)
+		static IPackageAction CreateRestorePackagesAction (DotNetProject project, bool restoreTransitiveProjectReferences, bool reevaluateBeforeRestore)
 		{
 			var solutionManager = PackageManagementServices.Workspace.GetSolutionManager (project.ParentSolution);
 			var nugetProject = solutionManager.GetNuGetProject (new DotNetProjectProxy (project));
@@ -70,7 +70,9 @@ namespace MonoDevelop.PackageManagement.Commands
 					project,
 					buildIntegratedProject,
 					solutionManager,
-					restoreTransitiveProjectReferences);
+					restoreTransitiveProjectReferences) {
+					ReevaluateBeforeRestore = reevaluateBeforeRestore
+				};
 			}
 
 			var nugetAwareProject = project as INuGetAwareProject;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectTargetFrameworkMonitorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectTargetFrameworkMonitorTests.cs
@@ -114,6 +114,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (project, eventArgs [0].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
 			Assert.AreEqual (0, eventArgsCountBeforeSave);
 		}
 
@@ -153,6 +154,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (project, eventArgs [0].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
 		}
 
 		[Test]
@@ -182,6 +184,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (project, eventArgs [0].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
 		}
 
 		[Test]
@@ -226,6 +229,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (reloadedProject, eventArgs [0].Project);
+			Assert.IsTrue (eventArgs [0].IsReload);
 		}
 
 		[Test]
@@ -285,6 +289,8 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual (2, eventArgs.Count);
 			Assert.AreEqual (firstProject, eventArgs [0].Project);
 			Assert.AreEqual (secondProject, eventArgs [1].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
+			Assert.IsFalse (eventArgs [1].IsReload);
 		}
 
 		[Test]
@@ -304,6 +310,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (firstProject, eventArgs [0].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
 		}
 
 		[Test]
@@ -324,6 +331,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (secondProject, eventArgs [0].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
 		}
 
 		[Test]
@@ -370,6 +378,7 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (1, eventArgs.Count);
 			Assert.AreEqual (project, eventArgs [0].Project);
+			Assert.IsFalse (eventArgs [0].IsReload);
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementServices.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementServices.cs
@@ -125,5 +125,9 @@ namespace MonoDevelop.PackageManagement
 		internal static PackageManagementWorkspace Workspace {
 			get { return workspace; }
 		}
+
+		internal static ProjectTargetFrameworkMonitor ProjectTargetFrameworkMonitor {
+			get { return projectTargetFrameworkMonitor;  }
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectTargetFrameworkChangedEventArgs.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectTargetFrameworkChangedEventArgs.cs
@@ -30,12 +30,14 @@ namespace MonoDevelop.PackageManagement
 {
 	internal class ProjectTargetFrameworkChangedEventArgs : EventArgs
 	{
-		public ProjectTargetFrameworkChangedEventArgs (IDotNetProject project)
+		public ProjectTargetFrameworkChangedEventArgs (IDotNetProject project, bool isReload)
 		{
 			Project = project;
+			IsReload = isReload;
 		}
 
 		public IDotNetProject Project { get; private set; }
+		public bool IsReload { get; private set; }
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectTargetFrameworkMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectTargetFrameworkMonitor.cs
@@ -43,11 +43,11 @@ namespace MonoDevelop.PackageManagement
 
 		public event EventHandler<ProjectTargetFrameworkChangedEventArgs> ProjectTargetFrameworkChanged;
 
-		protected virtual void OnProjectTargetFrameworkChanged (IDotNetProject project)
+		protected virtual void OnProjectTargetFrameworkChanged (IDotNetProject project, bool isReload = false)
 		{
 			var handler = ProjectTargetFrameworkChanged;
 			if (handler != null) {
-				handler (this, new ProjectTargetFrameworkChangedEventArgs (project));
+				handler (this, new ProjectTargetFrameworkChangedEventArgs (project, isReload));
 			}
 		}
 
@@ -124,7 +124,7 @@ namespace MonoDevelop.PackageManagement
 		void ProjectReloaded (object sender, ProjectReloadedEventArgs e)
 		{
 			if (HasTargetFrameworkChanged (e.NewProject, e.OldProject)) {
-				OnProjectTargetFrameworkChanged (e.NewProject);
+				OnProjectTargetFrameworkChanged (e.NewProject, isReload: true);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesInNuGetIntegratedProject.cs
@@ -74,6 +74,8 @@ namespace MonoDevelop.PackageManagement
 				IncludeTransitiveProjectReferences ();
 		}
 
+		internal bool ReevaluateBeforeRestore { get; set; }
+
 		public PackageActionType ActionType {
 			get { return PackageActionType.Restore; }
 		}
@@ -98,6 +100,9 @@ namespace MonoDevelop.PackageManagement
 
 		async Task ExecuteAsync (CancellationToken cancellationToken)
 		{
+			if (ReevaluateBeforeRestore)
+				await project.DotNetProject.ReevaluateProject (new ProgressMonitor ());
+
 			if (referencingProjects == null)
 				await packageRestorer.RestorePackages (nugetProject, cancellationToken);
 			else


### PR DESCRIPTION
Changing the target framework of a .NET Core project in project
options would not trigger a NuGet package restore. After doing this
if the project file was edited in the text editor and saved the
packages would not be restored. This was because the file watcher
integration changed the logic around file reloads. The .NET Core addin
was setting the Project.NeedsReload flag to true and then calling
FileService.NotifyFileChanged to force a file reload of the project.
This no longer works since the file watcher is not responsible for
triggering the reload based on file events that happen outside the
IDE. To force a reload in the IDE there are Reload methods available
on the Project itself. To solve this problem this old logic has been
removed and now when the target framework of the project is changed,
after the project is saved, a NuGet package restore is run. Before the
restore is run the project needs to be re-evaluated to ensure the
target framework and any implicit PackageReferences are correct when
the restore is run. Without this re-evaluation the old  target
framework and old PackageReferences were being used.

Fixes VSTS #635592 - .NET Core project not restored after changing
project properties