### PR TITLE
[Core] Make Disconnected event handler actually waited for 

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngine.cs
@@ -89,7 +89,7 @@ namespace MonoDevelop.Projects.MSBuild
 		/// <summary>
 		/// Occurs when the remote process shuts down
 		/// </summary>
-		public event EventHandler Disconnected;
+		public event AsyncEventHandler Disconnected;
 
 		/// <summary>
 		/// Handle of the currently active build session, or null if there is no build session.
@@ -289,8 +289,8 @@ namespace MonoDevelop.Projects.MSBuild
 		internal async Task<bool> CheckDisconnected ()
 		{
 			if (!await CheckAlive ()) {
-				if (Disconnected != null)
-					Disconnected (this, EventArgs.Empty);
+				foreach (AsyncEventHandler d in Disconnected.GetInvocationList ())
+					await d (this, EventArgs.Empty);
 				return true;
 			}
 			return false;

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.Shared.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.Shared.cs
@@ -327,10 +327,6 @@ namespace MonoDevelop.Projects.MSBuild
 						} catch (ThreadAbortException) {
 							// Gracefully stop the thread
 							Thread.ResetAbort ();
-
-							// Try to end the build here, to workaround a finalizer crash in zstream in mono
-							// https://github.com/mono/mono/issues/9142
-							Microsoft.Build.Execution.BuildManager.DefaultBuildManager.EndBuild ();
 							return;
 						} catch (Exception ex) {
 							workError = ex;


### PR DESCRIPTION
This fixes reliability issues around the MSBuild builder.

What happens here is that the event handler was ported from
sync to async, while the event itself did not handle async code.

So, as soon as hitting the semaphore lock with concurrent builders,
we'd end up exiting the disconnected event way too early.

That meant that we'd end up killing the process is something was
underway.

Therefore, we never got to actually call EndBuildOperation, which
caused the zlib stream to get finalized which caused a mono crash.

Make the event handler wait for disconnection to finish.

Fixes VSTS #644694 - Intermittent crashing when building Xamarin Forms Control Gallery
Fixes VSTS #643113 - MSBuild broken due to commit 1c63942

```
Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.Runtime.InteropServices.GCHandle.CheckCurrentDomain (int) [0x00007] in <30f82f22c5df4a87974ae23bf2702f8f>:0
  at System.Runtime.InteropServices.GCHandle.op_Explicit (intptr) [0x00018] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs:134
  at System.Runtime.InteropServices.GCHandle.FromIntPtr (intptr) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs:176
  at System.IO.Compression.DeflateStreamNative.UnmanagedWrite (intptr,int,intptr) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/System/System.IO.Compression/DeflateStream.cs:437
  at (wrapper native-to-managed) System.IO.Compression.DeflateStreamNative.UnmanagedWrite (intptr,int,intptr) [0x00023] in <81ba78c8dc794b7f9f7b530c53db0f84>:0
  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.IO.Compression.DeflateStreamNative.CloseZStream (intptr) [0x00009] in <81ba78c8dc794b7f9f7b530c53db0f84>:0
  at System.IO.Compression.DeflateStreamNative/SafeDeflateStreamHandle.ReleaseHandle () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/System/System.IO.Compression/DeflateStream.cs:563
  at System.Runtime.InteropServices.SafeHandle.DangerousReleaseInternal (bool) [0x000a3] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Runtime.InteropServices/SafeHandle.cs:227
  at System.Runtime.InteropServices.SafeHandle.InternalFinalize () [0x00008] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Runtime.InteropServices/SafeHandle.cs:163
  at System.Runtime.InteropServices.SafeHandle.Dispose (bool) [0x0000a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/interopservices/safehandle.cs:262
  at System.Runtime.InteropServices.SafeHandle.Finalize () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/interopservices/safehandle.cs:199
  at (wrapper runtime-invoke) object.runtime_invoke_virtual_void__this__ (object,intptr,intptr,intptr) [0x0001f] in <30f82f22c5df4a87974ae23bf2702f8f>:0
```