### PR TITLE
Fix crash in MEF cache deserialization

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -196,13 +196,17 @@ namespace MonoDevelop.Ide.Composition
 		[Serializable]
 		class MefControlCache
 		{
+			[JsonRequired]
 			public MefControlCacheAssemblyInfo [] AssemblyInfos;
 		}
 
 		[Serializable]
 		internal class MefControlCacheAssemblyInfo
 		{
+			[JsonRequired]
 			public string Location;
+
+			[JsonRequired]
 			public DateTime LastWriteTimeUtc;
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // CompositionManager.Caching.cs
 //
 // Author:
@@ -29,11 +29,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
 using Microsoft.VisualStudio.Composition;
 using Mono.Addins;
 using MonoDevelop.Core;
-using MonoDevelop.Core.AddIns;
 using MonoDevelop.Core.Instrumentation;
 using Newtonsoft.Json;
 
@@ -55,7 +53,7 @@ namespace MonoDevelop.Ide.Composition
 		internal class Caching
 		{
 			internal static bool writeCache;
-			ICachingFaultInjector cachingFaultInjector;
+			readonly ICachingFaultInjector cachingFaultInjector;
 			Task saveTask;
 			public HashSet<Assembly> Assemblies { get; }
 			internal string MefCacheFile { get; }
@@ -113,6 +111,13 @@ namespace MonoDevelop.Ide.Composition
 						}
 					} catch (Exception ex) {
 						LoggingService.LogError ("Could not deserialize MEF cache control", ex);
+						DeleteFiles ();
+						return false;
+					}
+
+					//this can return null (if the cache format changed?). clean up and start over.
+					if (controlCache == null) {
+						LoggingService.LogError ("MEF cache control deserialized as null");
 						DeleteFiles ();
 						return false;
 					}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Composition/CompositionManager.CachingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Composition/CompositionManager.CachingTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // CompositionManager.CachingTests.cs
 //
 // Author:
@@ -157,6 +157,50 @@ namespace MonoDevelop.Ide.Composition
 			await CreateAndWrite (caching);
 
 			File.WriteAllText (caching.MefCacheControlFile, "corrupted");
+
+			Assert.IsFalse (caching.CanUse ());
+			Assert.IsFalse (File.Exists (caching.MefCacheFile), "Cache was not deleted on corruption");
+			Assert.IsFalse (File.Exists (caching.MefCacheControlFile), "Cache control was not deleted on corruption");
+		}
+
+		[Test]
+		public async Task TestControlCacheFilePartial ()
+		{
+			var caching = GetCaching ();
+			await CreateAndWrite (caching);
+
+			File.WriteAllText (caching.MefCacheControlFile, @"{
+   ""AssemblyInfos"":[
+      {
+         ""Location"":""/Applications/Visual Studio.app/Contents/Resources/lib/monodevelop/bin/Microsoft.VisualStudio.Text.Logic.dll"",
+         ""LastWriteTimeUtc"":""2018-03-10T01:13:54Z""
+      },");
+
+			Assert.IsFalse (caching.CanUse ());
+			Assert.IsFalse (File.Exists (caching.MefCacheFile), "Cache was not deleted on corruption");
+			Assert.IsFalse (File.Exists (caching.MefCacheControlFile), "Cache control was not deleted on corruption");
+		}
+
+		[Test]
+		public async Task TestControlCacheFileEmpty ()
+		{
+			var caching = GetCaching ();
+			await CreateAndWrite (caching);
+
+			File.WriteAllText (caching.MefCacheControlFile, "");
+
+			Assert.IsFalse (caching.CanUse ());
+			Assert.IsFalse (File.Exists (caching.MefCacheFile), "Cache was not deleted on corruption");
+			Assert.IsFalse (File.Exists (caching.MefCacheControlFile), "Cache control was not deleted on corruption");
+		}
+
+		[Test]
+		public async Task TestControlCacheFileEmptyObject ()
+		{
+			var caching = GetCaching ();
+			await CreateAndWrite (caching);
+
+			File.WriteAllText (caching.MefCacheControlFile, "{}");
 
 			Assert.IsFalse (caching.CanUse ());
 			Assert.IsFalse (File.Exists (caching.MefCacheFile), "Cache was not deleted on corruption");


### PR DESCRIPTION
Fixes a crash that happened on my machine because for some reason the MEF cache control deserialized as null. Guessing it was because of a format change?