### PR TITLE
Unify on MonoDevelop/Ide/Composition extension point.

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -347,14 +347,10 @@
 		<Handler class="MonoDevelop.CSharp.Features.AutoInsertBracket.CSharpAutoInsertBracketHandler" mimeTypes = "text/x-csharp" />
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/MefHostServices">
+	<Extension path="/MonoDevelop/Ide/Composition">
 		<Assembly file="MonoDevelop.CSharpBinding.dll"/>
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
-		<Assembly file="MonoDevelop.CSharpBinding.dll"/>
-	</Extension>
-	
 	<Extension path="/MonoDevelop/Ide/TypeService/OptionProviders">
 		<Class class="MonoDevelop.CSharp.OptionProvider.EditorConfigDocumentOptionsProviderFactory"/>
 	</Extension>

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.addin.xml
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.addin.xml
@@ -150,7 +150,7 @@
 		</Condition>
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/MefHostServices">
+	<Extension path="/MonoDevelop/Ide/Composition">
 		<Assembly file="MonoDevelop.Refactoring.dll"/>
 		<Assembly file="RefactoringEssentials.dll"/>
 	</Extension>

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.addin.xml
@@ -190,7 +190,7 @@
 		<StockIcon stockid="md-prefs-completion" resource="prefs-completion-16.png" size="Menu" />
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
+	<Extension path="/MonoDevelop/Ide/Composition">
 		<Assembly file="MonoDevelop.SourceEditor.dll"/>
 	</Extension>
 </ExtensionModel>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -402,10 +402,6 @@
 		<Class class = "MonoDevelop.Ide.GettingStarted.GettingStartedProjectExtension"/>
 	</Extension>
 
-	<Extension path="/MonoDevelop/Ide/TypeService/PlatformMefHostServices">
-		<Assembly file="Microsoft.VisualStudio.Text.Logic.dll"/>
-	</Extension>
-
 	<Extension path="/MonoDevelop/Ide/Composition">
 		<Assembly file="Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll"/>
 		<Assembly file="Microsoft.CodeAnalysis.EditorFeatures.dll"/>


### PR DESCRIPTION
There were two legacy extension points: MefHostServices and PlatformMefHostServices. There is no need to differentiate.

I will remove the two legacy extension points in 16.0 after we make sure nobody external uses them.