### PR TITLE
Fixes VSTS Bug 515119: Accessibility:MAS36:KB: Unable to see mouse ov…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -549,6 +549,7 @@ namespace Mono.TextEditor
 		void CaretPositionChanged (object sender, DocumentLocationEventArgs args) 
 		{
 			HideTooltip ();
+			textViewMargin.HideCodeSegmentPreviewWindow ();
 			ResetIMContext ();
 			
 			if (Caret.AutoScrollToCaret && HasFocus)
@@ -1278,8 +1279,7 @@ namespace Mono.TextEditor
 			uint keyVal = (uint)key;
 			CurrentMode.SelectValidShortcut (accels, out key, out mod);
 			if (key == Gdk.Key.F1 && (mod & (ModifierType.ControlMask | ModifierType.ShiftMask)) == ModifierType.ControlMask) {
-				var p = LocationToPoint (Caret.Location);
-				ShowTooltip (Gdk.ModifierType.None, Caret.Offset, p.X, p.Y);
+				ShowQuickInfo ();
 				keyPressTimings.EndTimer ();
 				return true;
 			}
@@ -3163,6 +3163,14 @@ namespace Mono.TextEditor
 
 		public void ShowQuickInfo ()
 		{
+			int caretOffset = Caret.Offset;
+			foreach (var shownFolding in textViewMargin.GetFoldRectangles (Caret.Line)) {
+				if (shownFolding.Value.Offset == caretOffset || shownFolding.Value.EndOffset == caretOffset) {
+					textViewMargin.ShowCodeSegmentPreviewTooltip (shownFolding.Value.Segment, shownFolding.Key, 0);
+					return;
+				}
+			}
+
 			var p = LocationToPoint (Caret.Location);
 			ShowTooltip (Gdk.ModifierType.None, Caret.Offset, p.X, p.Y, 0);
 		}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -670,7 +670,7 @@ namespace Mono.TextEditor
 
 		void DisposeGCs ()
 		{
-			ShowTooltip (TextSegment.Invalid, Gdk.Rectangle.Zero);
+			ShowCodeSegmentPreviewTooltip (TextSegment.Invalid, Gdk.Rectangle.Zero);
 		}
 
 		int underlinePosition, underLineThickness;
@@ -2523,7 +2523,7 @@ namespace Mono.TextEditor
 
 		uint codeSegmentTooltipTimeoutId = 0;
 
-		void ShowTooltip (ISegment segment, Rectangle hintRectangle)
+		internal void ShowCodeSegmentPreviewTooltip (ISegment segment, Rectangle hintRectangle, uint timeout = 650)
 		{
 			if (previewWindow != null && previewWindow.Segment.Equals (segment))
 				return;
@@ -2531,7 +2531,7 @@ namespace Mono.TextEditor
 			HideCodeSegmentPreviewWindow ();
 			if (segment.IsInvalid () || segment.Length == 0)
 				return;
-			codeSegmentTooltipTimeoutId = GLib.Timeout.Add (650, delegate {
+			codeSegmentTooltipTimeoutId = GLib.Timeout.Add (timeout, delegate {
 				codeSegmentTooltipTimeoutId = 0;
 				previewWindow = new CodeSegmentPreviewWindow (textEditor, false, segment);
 				if (previewWindow.IsEmptyText) {
@@ -2698,12 +2698,12 @@ namespace Mono.TextEditor
 				int lineNr = args.LineNumber;
 				foreach (var shownFolding in GetFoldRectangles (lineNr)) {
 					if (shownFolding.Key.Contains ((int)(args.X + this.XOffset), (int)args.Y)) {
-						ShowTooltip (shownFolding.Value.Segment, shownFolding.Key);
+						ShowCodeSegmentPreviewTooltip (shownFolding.Value.Segment, shownFolding.Key);
 						return;
 					}
 				}
 
-				ShowTooltip (TextSegment.Invalid, Gdk.Rectangle.Zero);
+				ShowCodeSegmentPreviewTooltip (TextSegment.Invalid, Gdk.Rectangle.Zero);
 				string link = GetLink != null ? GetLink (args) : null;
 
 				if (!String.IsNullOrEmpty (link)) {
@@ -2870,7 +2870,7 @@ namespace Mono.TextEditor
 			cr.Fill ();
 		}
 
-		IEnumerable<KeyValuePair<Gdk.Rectangle, FoldSegment>> GetFoldRectangles (int lineNr)
+		internal IEnumerable<KeyValuePair<Gdk.Rectangle, FoldSegment>> GetFoldRectangles (int lineNr)
 		{
 			if (lineNr < 0)
 				yield break;
@@ -3306,7 +3306,7 @@ namespace Mono.TextEditor
 		protected internal override void MouseLeft ()
 		{
 			base.MouseLeft ();
-			ShowTooltip (TextSegment.Invalid, Gdk.Rectangle.Zero);
+			ShowCodeSegmentPreviewTooltip (TextSegment.Invalid, Gdk.Rectangle.Zero);
 		}
 
 		#region Coordinate transformation


### PR DESCRIPTION
…er content when using the keyboard

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/515119

We now have a keyboad command for showing tooltips however the code segment tooltips were not showable by that. I changed the command so that the code segment tooltips can be queried when placing the caret before the folding.