### PR TITLE
[Editor] Ensure preedit committed before all selections actions

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -730,11 +730,6 @@ namespace MonoDevelop.SourceEditor
 			info.Bypass = HasFocus == false;
 		}
 
-		void EnsurePreeditCommitted()
-		{
-			TextArea.CommitPreedit ();
-		}
-
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.LineEnd)]
 		internal void OnLineEnd ()
 		{
@@ -864,16 +859,12 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveLeft)]
 		internal void OnSelectionMoveLeft ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveLeft);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveRight)]
 		internal void OnSelectionMoveRight ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveRight);
 		}
 
@@ -892,16 +883,12 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMovePrevWord)]
 		internal void OnSelectionMovePrevWord ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MovePreviousWord);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextWord)]
 		internal void OnSelectionMoveNextWord ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveNextWord);
 		}
 		
@@ -920,72 +907,54 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMovePrevSubword)]
 		internal void OnSelectionMovePrevSubword ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MovePreviousSubword);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextSubword)]
 		internal void OnSelectionMoveNextSubword ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveNextSubword);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveUp)]
 		internal void OnSelectionMoveUp ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveUp);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveDown)]
 		internal void OnSelectionMoveDown ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveDown);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveHome)]
 		internal void OnSelectionMoveHome ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveLineHome);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveEnd)]
 		internal void OnSelectionMoveEnd ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveLineEnd);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveToDocumentStart)]
 		internal void OnSelectionMoveToDocumentStart ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveToDocumentStart);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.ExpandSelectionToLine)]
 		internal void OnExpandSelectionToLine ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.ExpandSelectionToLine);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveToDocumentEnd)]
 		internal void OnSelectionMoveToDocumentEnd ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MoveToDocumentEnd);
 		}
 
@@ -1062,16 +1031,12 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionPageDownAction)]
 		internal void OnSelectionPageDownAction ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MovePageDown);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionPageUpAction)]
 		internal void OnSelectionPageUpAction ()
 		{
-			EnsurePreeditCommitted ();
-
 			RunAction (SelectionActions.MovePageUp);
 		}
 		

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -892,12 +892,16 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMovePrevWord)]
 		internal void OnSelectionMovePrevWord ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MovePreviousWord);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextWord)]
 		internal void OnSelectionMoveNextWord ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveNextWord);
 		}
 		
@@ -916,54 +920,72 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMovePrevSubword)]
 		internal void OnSelectionMovePrevSubword ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MovePreviousSubword);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextSubword)]
 		internal void OnSelectionMoveNextSubword ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveNextSubword);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveUp)]
 		internal void OnSelectionMoveUp ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveUp);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveDown)]
 		internal void OnSelectionMoveDown ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveDown);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveHome)]
 		internal void OnSelectionMoveHome ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveLineHome);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveEnd)]
 		internal void OnSelectionMoveEnd ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveLineEnd);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveToDocumentStart)]
 		internal void OnSelectionMoveToDocumentStart ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveToDocumentStart);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.ExpandSelectionToLine)]
 		internal void OnExpandSelectionToLine ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.ExpandSelectionToLine);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveToDocumentEnd)]
 		internal void OnSelectionMoveToDocumentEnd ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MoveToDocumentEnd);
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -1062,12 +1062,16 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionPageDownAction)]
 		internal void OnSelectionPageDownAction ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MovePageDown);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionPageUpAction)]
 		internal void OnSelectionPageUpAction ()
 		{
+			EnsurePreeditCommitted ();
+
 			RunAction (SelectionActions.MovePageUp);
 		}
 		

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/SelectionActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/SelectionActions.cs
@@ -77,6 +77,8 @@ namespace Mono.TextEditor
 		
 		public static void Select (TextEditorData data, Action<TextEditorData> caretMoveAction)
 		{
+			data.Parent.CommitPreedit ();
+
 			using (var undoGroup = data.OpenUndoGroup ()) {
 				PositionChangedHandler handler = new PositionChangedHandler (data);
 				data.Caret.PositionChanged += handler.DataCaretPositionChanged;

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/SelectionActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/SelectionActions.cs
@@ -77,7 +77,7 @@ namespace Mono.TextEditor
 		
 		public static void Select (TextEditorData data, Action<TextEditorData> caretMoveAction)
 		{
-			data.Parent.CommitPreedit ();
+			data?.Parent?.CommitPreedit ();
 
 			using (var undoGroup = data.OpenUndoGroup ()) {
 				PositionChangedHandler handler = new PositionChangedHandler (data);


### PR DESCRIPTION
This is a follow-up to https://github.com/mono/monodevelop/pull/5083

That PR fixed the issue when holding shift and pressing an arrow key
to change the selection when a multi-key language such as Korean is
being used, but the issue persists when changing the selection in
other ways. For example, Cmd-Shift-Left arrow key will cause the
selection to move back as expected, but it will drop the last character
of the selection (and then when you unselect the buffer will be
broken in totally unexpected ways).

This PR committs the preedit for the necessary action, plus all other
selection actions to be on the safe side.

Fixes VSTS #635558