### PR TITLE
Append zero byte to URL path to find username and password in Keychain

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -542,6 +542,8 @@ namespace MonoDevelop.MacInterop
 		{
 			var pathStr = string.Join (string.Empty, uri.Segments);
 			byte[] path = pathStr.Length > 0 ? Encoding.UTF8.GetBytes (pathStr.Substring (1)) : new byte[0]; // don't include the leading '/'
+			byte[] path0 = new byte[path.Length + 1];
+			Array.Copy (path, path0, path.Length);
 			byte[] host = Encoding.UTF8.GetBytes (uri.Host);
 			var auth = GetSecAuthenticationType (uri.Query);
 			IntPtr passwordData;
@@ -550,7 +552,7 @@ namespace MonoDevelop.MacInterop
 
 			var result = SecKeychainFindInternetPassword (
 				CurrentKeychain, (uint) host.Length, host, 0, null,
-				0, null, (uint) path.Length, path, (ushort) uri.Port,
+				0, null, (uint) path0.Length, path0, (ushort) uri.Port,
 				protocol, auth, out passwordLength, out passwordData, ref item);
 
 			try {


### PR DESCRIPTION
On macOS High Sierra, the current Visual Studio for Mac 7.5.3 (build 7) is unable to find my VSTS Git credentials which it has saved in the keychain, and it prompts for my username and password every time I do anything that requires credentials. I hope that a fix for this issue, by this means or otherwise, gets into VS for Mac.

MonoDevelop has the same issue. With this change to MonoDevelop, it finds the saved keychain item and uses the saved username and password. The change is to add a zero byte to the end of the path string used in the call to SecKeychainFindInternetPassword. I guessed it might require the URL path criteria to be a C-style string with zero byte terminator and this actually worked.