### PR TITLE
Fixes issue #3869 "[TestCaseSource ("xzy")]" isn't seen as a test in

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.UnitTests/UnitTestTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.UnitTests/UnitTestTextEditorExtension.cs
@@ -181,7 +181,7 @@ namespace MonoDevelop.CSharp
 				IUnitTestMarkers markers = null;
 				foreach (var attr in method.GetAttributes ()) {
 					var cname = attr.AttributeClass.GetFullName ();
-					markers = unitTestMarkers.FirstOrDefault (m => (m.TestMethodAttributeMarker == cname || m.TestCaseMethodAttributeMarker == cname));
+					markers = unitTestMarkers.FirstOrDefault (m => (m.TestMethodAttributeMarker == cname || m.TestCaseMethodAttributeMarker == cname || (m as IUnitTestMarkers2)?.TestCaseSourceAttributeMarker == cname));
 					if (markers != null) {
 						if (test == null) {
 							TagClass (parentClass, markers);

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelopNUnit.addin.xml
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelopNUnit.addin.xml
@@ -27,6 +27,7 @@
 		<TestMarkers
 				testMethodAttributeMarker="NUnit.Framework.TestAttribute"
 				testCaseMethodAttributeMarker="NUnit.Framework.TestCaseAttribute"
+				testCaseSourceMethodAttributeMarker="NUnit.Framework.TestCaseSourceAttribute"
 				ignoreTestMethodAttributeMarker="NUnit.Framework.IgnoreAttribute"
 				ignoreTestClassAttributeMarker="NUnit.Framework.IgnoreAttribute"
 			/>

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
@@ -386,5 +386,17 @@ namespace MonoDevelop.UnitTesting
 		/// <value>The ignore test method attribute marker.</value>
 		string IgnoreTestClassAttributeMarker { get; }
 	}
+
+	/// <summary>
+	/// TODO: Merge with IUnitTestMarkers - possible replace it with an abstract class in next API break.
+	/// </summary>
+	public interface IUnitTestMarkers2 : IUnitTestMarkers
+	{
+		/// <summary>
+		/// TestCaseSourceAttribute is used on a parameterized test method to identify the property, method or field that will provide the required arguments.  It has to be applied to a test method.
+		/// </summary>
+		/// <value>The test method attribute marker.</value>
+		string TestCaseSourceAttributeMarker { get; }
+	}
 }
 

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestMarkersExtension.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestMarkersExtension.cs
@@ -28,13 +28,16 @@ using Mono.Addins;
 
 namespace MonoDevelop.UnitTesting
 {
-	class UnitTestMarkersExtension: ExtensionNode, IUnitTestMarkers
+	class UnitTestMarkersExtension: ExtensionNode, IUnitTestMarkers2
 	{
 		[NodeAttribute ("testMethodAttributeMarker")]
 		public string TestMethodAttributeMarker { get; set; }
 
 		[NodeAttribute ("testCaseMethodAttributeMarker")]
 		public string TestCaseMethodAttributeMarker { get; set; }
+
+		[NodeAttribute ("testCaseSourceMethodAttributeMarker")]
+		public string TestCaseSourceAttributeMarker { get; set; }
 
 		[NodeAttribute ("ignoreTestMethodAttributeMarker")]
 		public string IgnoreTestMethodAttributeMarker { get; set; }

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/UnitTesteditorIntegrationTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/UnitTesteditorIntegrationTests.cs
@@ -75,6 +75,7 @@ namespace MonoDevelop.CSharpBinding.Tests
 			var text = @"namespace NUnit.Framework {
 	public class TestFixtureAttribute : System.Attribute {} 
 	public class TestAttribute : System.Attribute {} 
+	public class TestCaseSourceAttribute : System.Attribute {} 
 } namespace TestNs { " + input + "}";
 			int endPos = text.IndexOf ('$');
 			if (endPos >= 0)
@@ -164,6 +165,35 @@ class TestClass
 {
 	[Test]
 	public void MyTest () {}
+}
+", async ext => {
+				var tests = await ext.GatherUnitTests (unitTestMarkers, default (CancellationToken));
+				Assert.IsNotNull (tests);
+				Assert.AreEqual (2, tests.Count);
+			});
+		}
+
+		/// <summary>
+		/// Issue #3869 "[TestCaseSource ("xzy")]" isn't seen as a test in the text editor. No dot next to it. 
+		/// </summary>
+		[Test]
+		public async Task TestIssue3869 ()
+		{
+			await Setup (@"using NUnit.Framework;
+class TestClass
+{
+	[TestCaseSource(""DivideCases"")]
+    public void DivideTest(int n, int d, int q)
+    {
+        Assert.AreEqual(q, n / d);
+    }
+
+    static object[] DivideCases =
+    {
+        new object[] { 12, 3, 4 },
+        new object[] { 12, 2, 6 },
+        new object[] { 12, 4, 3 }
+    };
 }
 ", async ext => {
 				var tests = await ext.GatherUnitTests (unitTestMarkers, default (CancellationToken));

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/UnitTesteditorIntegrationTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/UnitTesteditorIntegrationTests.cs
@@ -51,10 +51,11 @@ namespace MonoDevelop.CSharpBinding.Tests
 			yield return new UnitTestTextEditorExtension ();
 		}
 
-		class UnitTestMarkers: IUnitTestMarkers
+		class UnitTestMarkers: IUnitTestMarkers2
 		{
 			public string TestMethodAttributeMarker { get; set; }
 			public string TestCaseMethodAttributeMarker { get; set; }
+			public string TestCaseSourceAttributeMarker { get; set; }
 			public string IgnoreTestMethodAttributeMarker { get; set; }
 			public string IgnoreTestClassAttributeMarker { get; set; }
 		}
@@ -63,6 +64,7 @@ namespace MonoDevelop.CSharpBinding.Tests
 			new UnitTestMarkers {
 				TestMethodAttributeMarker = "NUnit.Framework.TestAttribute",
 				TestCaseMethodAttributeMarker = "NUnit.Framework.TestCaseAttribute",
+				TestCaseSourceAttributeMarker = "NUnit.Framework.TestCaseSourceAttribute",
 				IgnoreTestMethodAttributeMarker = "NUnit.Framework.IgnoreAttribute",
 				IgnoreTestClassAttributeMarker = "NUnit.Framework.IgnoreAttribute"
 			}


### PR DESCRIPTION
the text editor. No dot next to it.

TODO: Merge interfaces in the next AP break.