### PR TITLE
Add an .editorconfig to the VSEditor folder

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/.editorconfig
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/.editorconfig
@@ -1,0 +1,18 @@
+[*.cs]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+
+# spaces before parens
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+


### PR DESCRIPTION
It's important to preserve the original formatting of the VS codebase, so it's easier to sync sources back and forth.