### PR TITLE
Fixes issue #4110 Inconvenient behavior of Ctrl+Right and Ctrl+Left

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.cs
@@ -153,7 +153,11 @@ namespace Mono.TextEditor
 
 		public SnapshotSpan GetTextElementSpan (SnapshotPoint bufferPosition)
 		{
-			return new SnapshotSpan (bufferPosition, 1);
+			var line = GetTextViewLineContainingBufferPosition (bufferPosition);
+			if (line == null)
+				throw new ArgumentOutOfRangeException (nameof (bufferPosition));
+
+			return line.GetTextElementSpan (bufferPosition);
 		}
 
 		public ITextViewLine GetTextViewLineContainingBufferPosition (SnapshotPoint bufferPosition)

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -40,6 +40,8 @@ using System.Diagnostics;
 using MonoDevelop.Ide;
 using Microsoft.VisualStudio.Text.Classification;
 using System.Threading;
+using Microsoft.VisualStudio.Text.Operations.Implementation;
+using Microsoft.VisualStudio.Text.Operations;
 
 namespace Mono.TextEditor
 {
@@ -64,6 +66,8 @@ namespace Mono.TextEditor
 		bool hasInitializeBeenCalled = false;
 
 		ITextSelection selection;
+
+		internal IEditorOperations EditorOperations { get; private set; }
 
 		bool hasAggregateFocus;
 
@@ -144,7 +148,7 @@ namespace Mono.TextEditor
 			//			this.Loaded += OnLoaded;
 
 			// TODO: *Someone* needs to call this to execute UndoHistoryRegistry.RegisterHistory -- VS does this via the ShimCompletionControllerFactory.
-			factoryService.EditorOperationsProvider.GetEditorOperations (this);
+			EditorOperations =  factoryService.EditorOperationsProvider.GetEditorOperations (this);
 
 			connectionManager = new ConnectionManager (this, factoryService.TextViewConnectionListeners, factoryService.GuardedOperations);
 
@@ -350,7 +354,8 @@ namespace Mono.TextEditor
 
 		public SnapshotSpan GetTextElementSpan (SnapshotPoint point)
 		{
-			throw new NotImplementedException ();
+			var line = this.GetTextViewLineContainingBufferPosition (point);
+			return line.GetTextElementSpan (point);
 		}
 
 		public ITextViewLine GetTextViewLineContainingBufferPosition (SnapshotPoint bufferPosition)

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -880,27 +880,27 @@ namespace MonoDevelop.SourceEditor
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.MovePrevWord)]
 		internal void OnMovePrevWord ()
 		{
-			RunAction (CaretMoveActions.PreviousWord);
+			EditorOperations.MoveToPreviousWord (false);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.MoveNextWord)]
 		internal void OnMoveNextWord ()
 		{
-			RunAction (CaretMoveActions.NextWord);
+			EditorOperations.MoveToNextWord (false);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMovePrevWord)]
 		internal void OnSelectionMovePrevWord ()
 		{
-			RunAction (SelectionActions.MovePreviousWord);
+			EditorOperations.MoveToPreviousWord (true);
 		}
 
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.SelectionMoveNextWord)]
 		internal void OnSelectionMoveNextWord ()
 		{
-			RunAction (SelectionActions.MoveNextWord);
+			EditorOperations.MoveToNextWord (true);
 		}
-		
+
 		[CommandHandler (MonoDevelop.Ide.Commands.TextEditorCommands.MovePrevSubword)]
 		internal void OnMovePrevSubword ()
 		{


### PR DESCRIPTION
In theory we could switch to all vs.net editor operations however
we've many mac behavior commands built in so we would break some mac
specific behavior. But it's ok for ctrl+left/right there are no mac
specifics here.