### PR TITLE
[Core] Refresh type system when configuration mapping changes

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
@@ -187,9 +187,12 @@ namespace MonoDevelop.Projects
 			
 			assembly = conf.assembly;
 			sourcePath = conf.sourcePath;
+			bool notifyParentItem = ParentItem != null;
 			if (ParentItem == null)
 				SetParentItem (conf.ParentItem);
 			CompilationParameters = conf.compilationParameters != null ? conf.compilationParameters.Clone () : null;
+			if (notifyParentItem)
+				ParentItem?.NotifyModified ("CompilerParameters");
 			signAssembly = conf.signAssembly;
 			delaySign = conf.delaySign;
 			assemblyKeyFile = conf.assemblyKeyFile;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -817,6 +817,28 @@ namespace MonoDevelop.Projects
 			Assert.AreEqual (expectedDefaultNamespace, result);
 		}
 
+		/// <summary>
+		/// Ensures the type system is notified when the project configuration is copied.
+		/// </summary>
+		[Test]
+		public async Task CloneAndUpdateProjectConfigurations ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (DotNetProject)sol.Items [0];
+				var debugConfig = p.Configurations ["Debug"];
+				string modifiedHint = null;
+				p.Modified += (sender, e) => {
+					modifiedHint = e.First ().Hint;
+				};
+				var cloneDebugConfig = ConfigurationTargetExtensions.CloneConfiguration (p, debugConfig, debugConfig.Id);
+				Assert.IsNull (modifiedHint);
+
+				debugConfig.CopyFrom (cloneDebugConfig);
+				Assert.AreEqual ("CompilerParameters", modifiedHint);
+			}
+		}
+
 		[Test]
 		public async Task XamarinIOSProjectReferencesCollectionsImmutableNetStandardAssembly_GetReferencedAssembliesShouldIncludeNetStandard ()
 		{


### PR DESCRIPTION
Changing a solution configuration mapping for a project in the
Solution Options, such as changing a project so its Debug|x86
configuration is mapped to Debug|AnyCPU, would not refresh the type
system. If the project had conditional code based on the configuration
then this would not be highlighted correctly in the text editor until
the solution was closed and re-opened.

When the solution configurations are updated by the Solution Options
dialog the project configurations are updated. When these project
configurations updated they now raise the Project's Modified event
and pass the CompilerParameters hint text. This then causes the
type system to be refreshed for the project.

Problems with this change:

Project.Modified event is fired once for every configuration when
it is updated - this will trigger the type system to start and then
cancel a project reload.

Fixes VSTS #589733 - Configuration mapping change for a project does
not notify modifications