### PR TITLE
[StructuredOutput] Fixes select last character in node title

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -117,8 +117,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 	{
 		const int SelectionDistancePixel = 1;
 
-		Point selectionStartingPoint { get; set; }
-
+		Point selectionStartingPoint;
 		int selectionStart;
 		int selectionEnd;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -384,7 +384,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 			SelectionColor = Styles.CellSelectionColor;
 			UseStrongSelectionColor = true;
 			contextProvider = context;
-			TextSelection = new TextSelection<BuildOutputNode> ();
 		}
 
 		internal void OnBoundsChanged (object sender, EventArgs args) 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -742,7 +742,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			status.CalculateLayout (status.LastRenderBounds, out var layout, out var layoutBounds, out var expanderRect);
 
 			var insideText = layoutBounds.Contains (args.Position);
-			if ((TextSelection?.IsStarting (node) ?? false) && insideText) {
+			if ((TextSelection?.IsStarting (node) ?? false)) {
 				var pos = layout.GetIndexFromCoordinates (args.Position.X - layoutBounds.X, args.Position.Y - layoutBounds.Y);
 				if (pos != -1) {
 					TextSelection.Set (pos, args.Position);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -332,6 +332,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 		const int MinLayoutWidth = 30;
 
 		const int DefaultExpandClickDelay = 250;
+
 		DateTime lastExpanderClick = DateTime.Now;
 
 		public Color StrongSelectionColor { get; set; }
@@ -818,11 +819,16 @@ namespace MonoDevelop.Ide.BuildOutputView
 					TextSelection.Stop ();
 					QueueDraw ();
 				} else if (TextSelection.State == TextSelectionState.Clicked) {
-					TextSelection = null;
-					QueueDraw ();
+					ClearSelection ();
 				}
 			}
 			base.OnButtonReleased (args);
+		}
+
+		public void ClearSelection ()
+		{
+			TextSelection = null;
+			QueueDraw ();
 		}
 
 		protected override void OnMouseExited ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs
@@ -388,7 +388,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		double lastErrorPanelStartX;
 
-		public TextSelectionManager<BuildOutputNode> CellSelection { get; private set; }
+		readonly public TextSelectionManager<BuildOutputNode> CellSelection;
 
 		static BuildOutputTreeCellView ()
 		{
@@ -828,7 +828,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		protected override void OnButtonReleased (ButtonEventArgs args)
 		{
-			//var node = GetValue (BuildOutputNodeField);
 			if (CellSelection.State == TextSelectionState.Selecting) {
 				CellSelection.Stop ();
 				QueueDraw ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -495,8 +495,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 		{
 			var currentRow = treeView.SelectedRow as BuildOutputNode;
 
-			var cellSelection = cellView.CellSelection;
-			if (cellSelection.IsShown (currentRow)) {
+			var cellSelection = cellView.TextSelection;
+			if (cellSelection?.IsShown (currentRow) ?? false) {
 				Clipboard.SetText (cellSelection.Content.Message.Substring (cellSelection.Index, cellSelection.Length));
 			} else {
 				ClipboardCopy (currentRow);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -493,16 +493,13 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 		public void ClipboardCopy ()
 		{
-			var selection = cellView.GetCurrentSelection ();
-			if (selection.Node != null && selection.SelectionStart != selection.SelectionEnd) {
-				var init = Math.Min (selection.SelectionStart, selection.SelectionEnd);
-				var end = Math.Max (selection.SelectionStart, selection.SelectionEnd);
-				Clipboard.SetText (selection.Node.Message.Substring (init, end - init));
+			var currentRow = treeView.SelectedRow as BuildOutputNode;
+
+			var cellSelection = cellView.CellSelection;
+			if (cellSelection.IsShown (currentRow)) {
+				Clipboard.SetText (cellSelection.Content.Message.Substring (cellSelection.Index, cellSelection.Length));
 			} else {
-				var selectedNode = treeView.SelectedRow as BuildOutputNode;
-				if (selectedNode != null) {
-					ClipboardCopy (selectedNode);
-				}
+				ClipboardCopy (currentRow);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -377,20 +377,26 @@ namespace MonoDevelop.Ide.BuildOutputView
 				return;
 			}
 
-			if (e.Button == PointerButton.Left && e.MultiplePress == 2) {
+			if (e.Button == PointerButton.Left) {
 				if (!cellView.IsViewClickable (selectedNode, e.Position)) {
 					return;
 				}
-				if (selectedNode.NodeType == BuildOutputNodeType.Warning || selectedNode.NodeType == BuildOutputNodeType.Error) {
-					GoToTask (selectedNode);
+
+				if (e.MultiplePress == 1) {
+					cellView.ClearSelection ();
+				} else if (e.MultiplePress == 2) {
+
+					if (selectedNode.NodeType == BuildOutputNodeType.Warning || selectedNode.NodeType == BuildOutputNodeType.Error) {
+						GoToTask (selectedNode);
+						return;
+					}
+					if (treeView.IsRowExpanded (selectedNode)) {
+						treeView.CollapseRow (selectedNode);
+					} else {
+						treeView.ExpandRow (selectedNode, false);
+					}
 					return;
 				}
-				if (treeView.IsRowExpanded (selectedNode)) {
-					treeView.CollapseRow (selectedNode);
-				} else {
-					treeView.ExpandRow (selectedNode, false);
-				}
-				return;
 			}
 
 			if (e.IsContextMenuTrigger) {


### PR DESCRIPTION
This improves the current code selecting characters in structured build output, fixing the issue selecting last character and encapsulating some code related to selection in a reusable agnostic class [TextSelectionManager](https://github.com/mono/monodevelop/blob/e22993eb6eee3deca8cf3de5215532d414b3e37c/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputTreeCellView.cs#L117-L187).

![selection](https://user-images.githubusercontent.com/1587480/42839650-a5795d74-8a04-11e8-912f-bacc1d837a53.gif)

Fixes Bug #603558

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/603558