### PR TITLE
Fixes issue #4390 Cmd does not light up navigation for symbol under

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpNavigationTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpNavigationTextEditorExtension.cs
@@ -115,21 +115,6 @@ namespace MonoDevelop.CSharp
 			{
 				return info.Symbol != null && info.Symbol.Kind != SymbolKind.Namespace;
 			}
-
-			public override void VisitMemberAccessExpression (MemberAccessExpressionSyntax node)
-			{
-				var info = model.GetSymbolInfo (node); 
-				if (IsNavigatable(info)) {
-					result.Add (new NavigationSegment (node.Name.Span.Start, node.Name.Span.Length, delegate {
-						GLib.Timeout.Add (50, delegate {
-							RefactoringService.RoslynJumpToDeclaration (info.Symbol, documentContext.Project);
-							return false;
-						});
-					})); 
-				}
-
-				base.VisitMemberAccessExpression (node);
-			}
 			 
 			public override void VisitBlock (BlockSyntax node)
 			{


### PR DESCRIPTION
mouse Fixes issue #4389 Cmd-click navigation sometimes gets stuck

Improved the reliablility of teh cmd navigation. There were duplicate
hover segments and some possible issues with the event system that may
have caused #4389.