### PR TITLE
[TODO] Fix todo comments not showing up in some cases

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/Tag.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/Tag.cs
@@ -87,7 +87,21 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			var message = item.Message;
 			var index = message.IndexOf (':');
-			var tag = message.Substring (0, index);
+
+			string tag = string.Empty;
+
+			// Slow path if we don't have a colon
+			if (index == -1) {
+				foreach (var tagComment in Tasks.CommentTag.SpecialCommentTags) {
+					if (message.StartsWith (tagComment.Tag, StringComparison.OrdinalIgnoreCase)) {
+						tag = message;
+						break;
+					}
+				}
+			} else {
+				tag = message.Substring (0, index);
+			}
+
 			int line = item.MappedLine + 1;
 			int column = item.MappedColumn + 1;
 


### PR DESCRIPTION
In cases where todo comments didn't have a colon,
we'd log an exception

Fixes VSTS #645581 [Feedback] TODO comments stopped working in latest beta