### PR TITLE
[NuGet] Ensure generated files are available for code completion

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\UpdateXamarinFormsBuildTest.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\DotNetCoreRestoreTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\RestoreTestBase.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\NuGetPackageAssetSourceFilesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/NuGetPackageAssetSourceFilesTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/NuGetPackageAssetSourceFilesTests.cs
@@ -1,0 +1,69 @@
+﻿//
+// NuGetPackageAssetSourceFilesTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+using System.Linq;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class NuGetPackageAssetSourceFilesTests : RestoreTestBase
+	{
+		/// <summary>
+		/// The LibLog NuGet package has .cs.pp content files that are pre-processed and the
+		/// generated .cs files are implicitly included in the project. This test ensures that
+		/// these generated files are available to the type system when Project.GetSourceFilesAsync
+		/// is called. 
+		/// </summary>
+		[Test]
+		public async Task NetCoreAndPackageReferenceProjectWithLibLogPackage ()
+		{
+			string solutionFileName = Util.GetSampleProject ("NuGetPackageAssetFiles", "NuGetPackageAssetFiles.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			CreateNuGetConfigFile (solution.BaseDirectory);
+			var netStandardProject = (DotNetProject)solution.FindProjectByName ("NetStandardProject");
+			var packageReferenceProject = (DotNetProject)solution.FindProjectByName ("NetFrameworkProject");
+
+			var process = Process.Start ("msbuild", $"/t:Restore /p:RestoreDisableParallel=true \"{solutionFileName}\"");
+			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+			Assert.AreEqual (0, process.ExitCode);
+
+			var netStandardProjectSourceFiles = await netStandardProject.GetSourceFilesAsync (ConfigurationSelector.Default);
+			var packageReferenceProjectSourceFiles = await packageReferenceProject.GetSourceFilesAsync (ConfigurationSelector.Default);
+
+			var libLogExceptionFileFromNetCoreProject = netStandardProjectSourceFiles.FirstOrDefault (f => f.FilePath.FileName == "LibLogException.cs");
+			var libLogExceptionFileFromPackageReferenceProject = packageReferenceProjectSourceFiles.FirstOrDefault (f => f.FilePath.FileName == "LibLogException.cs");
+
+			Assert.IsNotNull (libLogExceptionFileFromNetCoreProject);
+			Assert.IsNotNull (libLogExceptionFileFromPackageReferenceProject);
+		}
+	}
+}

--- a/main/tests/test-projects/NuGetPackageAssetFiles/NetFrameworkProject/MyClass.cs
+++ b/main/tests/test-projects/NuGetPackageAssetFiles/NetFrameworkProject/MyClass.cs
@@ -1,0 +1,15 @@
+﻿
+using System;
+using NetFrameworkProject.Logging.LogProviders;
+
+namespace NetFrameworkProject
+{
+	public class MyClass
+	{
+		LibLogException exception;
+
+		public MyClass ()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/NuGetPackageAssetFiles/NetFrameworkProject/NetFrameworkProject.csproj
+++ b/main/tests/test-projects/NuGetPackageAssetFiles/NetFrameworkProject/NetFrameworkProject.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3DD86499-45B8-4538-AB43-3333129D0363}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>NetFrameworkProject</RootNamespace>
+    <AssemblyName>NetFrameworkProject</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MyClass.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="LibLog" Version="5.0.0" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/NuGetPackageAssetFiles/NetFrameworkProject/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/NuGetPackageAssetFiles/NetFrameworkProject/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("NetFrameworkProject")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/NuGetPackageAssetFiles/NetStandardProject/Class1.cs
+++ b/main/tests/test-projects/NuGetPackageAssetFiles/NetStandardProject/Class1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NetStandardProject.Logging.LogProviders;
+
+namespace NetStandardProject
+{
+	public class Class1
+	{
+		LibLogException exception;
+	}
+}

--- a/main/tests/test-projects/NuGetPackageAssetFiles/NetStandardProject/NetStandardProject.csproj
+++ b/main/tests/test-projects/NuGetPackageAssetFiles/NetStandardProject/NetStandardProject.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibLog" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/NuGetPackageAssetFiles/NuGetPackageAssetFiles.sln
+++ b/main/tests/test-projects/NuGetPackageAssetFiles/NuGetPackageAssetFiles.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetFrameworkProject", "NetFrameworkProject\NetFrameworkProject.csproj", "{3DD86499-45B8-4538-AB43-3333129D0363}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandardProject", "NetStandardProject\NetStandardProject.csproj", "{97EBB5B4-6356-4899-9229-DF67AA6F088E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3DD86499-45B8-4538-AB43-3333129D0363}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DD86499-45B8-4538-AB43-3333129D0363}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DD86499-45B8-4538-AB43-3333129D0363}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DD86499-45B8-4538-AB43-3333129D0363}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97EBB5B4-6356-4899-9229-DF67AA6F088E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97EBB5B4-6356-4899-9229-DF67AA6F088E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97EBB5B4-6356-4899-9229-DF67AA6F088E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97EBB5B4-6356-4899-9229-DF67AA6F088E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The LibLog NuGet package has contentFiles that are processed by
MSBuild and converted into .cs files that are implicitly included
in the project. These files are generated into the obj folder,
for example:

    obj/Debug/netstandard2.0/NuGet/SomeID/LibLog/5.0.0/ILog.cs

These types defined inside these generated files can be referenced by
code in the project and the project will compile but the text editor
would show an error.

These generated files are not created or returned by running the
CoreCompileDependsOn target. So to fix this the NuGet addin has
a project extension that overrides the OnGetSourceFiles method and
modifies the targets being called, when the CoreCompileDependsOn
target is evaluated, so that NuGet specific targets are also run to
generate the files and returns them to the type system.

Fixes VSTS #636061 - NuGet source transformations not recognized by
intellisense