### PR TITLE
[VCS] Fixup more UI thread semantics and make Wakeup use the UI context

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CheckoutCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CheckoutCommand.cs
@@ -53,15 +53,22 @@ namespace MonoDevelop.VersionControl
 				);
 			}
 
+			AlertButton AskForCheckoutPath ()
+			{
+				return MessageService.AskQuestion (
+					GettextCatalog.GetString ("Checkout path is not empty. Do you want to delete its contents?"),
+					path,
+					AlertButton.Cancel,
+					AlertButton.Ok);
+			}
+
 			protected override void Run ()
 			{
 				if (System.IO.Directory.Exists (path) && System.IO.Directory.EnumerateFileSystemEntries (path).Any ()) {
-					if (MessageService.AskQuestion (GettextCatalog.GetString (
-							"Checkout path is not empty. Do you want to delete its contents?"),
-							path,
-							AlertButton.Cancel,
-							AlertButton.Ok) == AlertButton.Cancel)
+					var result = Runtime.RunInMainThread (() => AskForCheckoutPath ()).Result;
+					if (result == AlertButton.Cancel)
 						return;
+
 					FileService.DeleteDirectory (path);
 					FileService.CreateDirectory (path);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -633,7 +633,7 @@ namespace MonoDevelop.VersionControl
 			Pad outPad = IdeApp.Workbench.ProgressMonitors.GetPadForMonitor (monitor);
 			
 			AggregatedProgressMonitor mon = new AggregatedProgressMonitor (monitor);
-			mon.AddFollowerMonitor (IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (operation, statusIcon, true, true, false, outPad, cancellable));
+			mon.AddFollowerMonitor (IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (operation, statusIcon, false, true, false, outPad, cancellable));
 			return mon;
 		}
 		

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -70,7 +70,8 @@ namespace MonoDevelop.VersionControl
 		public void Wakeup() {
 			try {
 				tracker.EndTask();
-				tracker.Dispose();
+				// Remove this when https://github.com/mono/monodevelop/issue/4751 is fixed.
+				Runtime.MainSynchronizationContext.Post (o => ((ProgressMonitor)o).Dispose (), tracker);
 			} finally {
 				Finished();
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -54,6 +54,7 @@ namespace MonoDevelop.VersionControl
 					if (exception is DllNotFoundException) {
 						var msg = GettextCatalog.GetString ("The operation could not be completed because a shared library is missing: ");
 						tracker.ReportError (msg + exception.Message, null);
+						LoggingService.LogError ("Version Control command failed: ", exception);
 					} else if (exception is VersionControlException) {
 						var msg = GettextCatalog.GetString ("Version control operation failed: ");
 						tracker.ReportError (msg + exception.Message, exception);
@@ -61,7 +62,6 @@ namespace MonoDevelop.VersionControl
 						var msg = GettextCatalog.GetString ("Version control operation failed: ");
 						tracker.ReportError (msg, exception);
 					}
-					LoggingService.LogError ("Version Control command failed: ", exception);
 				}
 				Wakeup ();
 			}, Runtime.MainTaskScheduler);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -46,27 +46,27 @@ namespace MonoDevelop.VersionControl
 			BackgroundWorker ();
 		}
 		
-		async void BackgroundWorker ()
+		void BackgroundWorker ()
 		{
-			try {
-				await Task.Run (() => Run ());
-			} catch (DllNotFoundException e) {
-				string msg = GettextCatalog.GetString ("The operation could not be completed because a shared library is missing: ");
-				tracker.ReportError (msg + e.Message, null);
-				LoggingService.LogError ("Version Control command failed: ", e);
-			} catch (VersionControlException e) {
-				string msg = GettextCatalog.GetString ("Version control operation failed: ");
-				tracker.ReportError (msg + e.Message, e);
-				LoggingService.LogError ("Version Control command failed: ", e);
-			} catch (Exception e) {
-				string msg = GettextCatalog.GetString ("Version control operation failed: ");
-				tracker.ReportError (msg, e);
-				LoggingService.LogError ("Version Control command failed: ", e);
-			} finally {
+			Task.Run (() => Run ()).ContinueWith (t => {
+				if (t.IsFaulted) {
+					var exception = t.Exception.FlattenAggregate ().InnerException;
+					if (exception is DllNotFoundException) {
+						var msg = GettextCatalog.GetString ("The operation could not be completed because a shared library is missing: ");
+						tracker.ReportError (msg + exception.Message, null);
+					} else if (exception is VersionControlException) {
+						var msg = GettextCatalog.GetString ("Version control operation failed: ");
+						tracker.ReportError (msg + exception.Message, exception);
+					} else {
+						var msg = GettextCatalog.GetString ("Version control operation failed: ");
+						tracker.ReportError (msg, exception);
+					}
+					LoggingService.LogError ("Version Control command failed: ", exception);
+				}
 				Wakeup ();
-			}
+			}, Runtime.MainTaskScheduler);
 		}
-	
+
 		public void Wakeup() {
 			try {
 				tracker.EndTask();


### PR DESCRIPTION
This was a race condition. the UI lock-up would happen when dispose
would finish before the EndTask did.

The reason here is that the Dispose() method on ProgressMonitor
does not take into account the monitor's synchronization context.

See https://github.com/mono/monodevelop/issues/4751

Second attempt at:
Fixes VSTS #641132 - [Feedback] Visual Studio Mac checkout functionality freezes entire program
Fixes VSTS #619788 - Error when cloning new Git repository locks IDE main menu