### PR TITLE
Fixes VSTS Bug 643536: XAML & .EditorConfig issues

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Ide.Editor
 
 		public static Task<ICodingConventionContext> GetEditorConfigContext (string fileName, CancellationToken token = default (CancellationToken))
 		{
-			if (!string.IsNullOrEmpty (fileName))
+			if (string.IsNullOrEmpty (fileName))
 				return TaskUtil.Default<ICodingConventionContext> ();
 			lock (contextCacheLock) {
 				if (contextCache.TryGetValue (fileName, out Task<ICodingConventionContext> result))

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -52,6 +52,10 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.VisualStudio.CodingConventions">
+      <HintPath>..\..\build\bin\Microsoft.VisualStudio.CodingConventions.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ProjectTemplateTests.cs" />


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/643536

The real issue here was that the editor config tests got broken and a
break was unrecognized.