### PR TITLE
Fixes VSTS Bug 643536: XAML & .EditorConfig issues

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1055,9 +1055,13 @@ namespace MonoDevelop.Ide.Editor
 			this.TextView = Microsoft.VisualStudio.Platform.PlatformCatalog.Instance.TextEditorFactoryService.CreateTextView(this);
 		}
 
-		void TextEditor_FileNameChanged (object sender, EventArgs e)
+		async void TextEditor_FileNameChanged (object sender, EventArgs e)
 		{
 			fileTypeCondition.SetFileName (FileName);
+			EditorConfigService.RemoveEditConfigContext (FileName).Ignore ();
+			var context = await EditorConfigService.GetEditorConfigContext (FileName, default (CancellationToken));
+			if (context != null && Options is DefaultSourceEditorOptions options)
+				options.SetContext (context);
 		}
 
 		void TextEditor_MimeTypeChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -78,18 +78,12 @@ namespace MonoDevelop.Ide.Editor
 			textEditor.Options = DefaultSourceEditorOptions.Instance.Create ();
 		}
 
-		protected override async void OnContentNameChanged ()
+		protected override void OnContentNameChanged ()
 		{
 			base.OnContentNameChanged ();
 			if (ContentName != textEditorImpl.ContentName && !string.IsNullOrEmpty (textEditorImpl.ContentName))
 				AutoSave.RemoveAutoSaveFile (textEditorImpl.ContentName);
-			if (textEditorImpl.ContentName != null && textEditorImpl.ContentName != this.ContentName) {
-				EditorConfigService.RemoveEditConfigContext (textEditorImpl.ContentName).Ignore ();
-				var context = await EditorConfigService.GetEditorConfigContext (textEditor.FileName, default (CancellationToken));
-				if (context != null) 
-					((DefaultSourceEditorOptions)textEditor.Options).SetContext (context);
-			}
-			textEditorImpl.ContentName = this.ContentName;
+			textEditor.FileName = ContentName;
 			if (this.WorkbenchWindow?.Document != null)
 				textEditor.InitializeExtensionChain (this.WorkbenchWindow.Document);
 			UpdateTextEditorOptions (null, null);


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/643536

Work around for a bug in the xaml editor extension. However it's not
needed that the extensions can handle the edit config support - moved
that to the TextEditor layer. This should solve the issue for the xaml
previewer.