### PR TITLE
[Core] Fix NuGet packaging project not creating .nupkg

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Templating/PackagingProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Templating/PackagingProjectTemplateWizard.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Packaging.Templating
 			var readmeFile = project.Files.FirstOrDefault (f => f.FilePath.FileName == "readme.txt");
 			readmeFile.Metadata.SetValue ("IncludeInPackage", true, false);
 
-			IdeApp.ProjectOperations.SaveAsync (project);
+			SaveAsync (project);
 		}
 
 		PackagingProject GetPackagingProject (IEnumerable<IWorkspaceFileObject> items)
@@ -60,6 +60,11 @@ namespace MonoDevelop.Packaging.Templating
 			}
 
 			return items.OfType<PackagingProject> ().FirstOrDefault ();
+		}
+
+		protected virtual void SaveAsync (PackagingProject project)
+		{
+			IdeApp.ProjectOperations.SaveAsync (project);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
@@ -60,10 +60,6 @@
       <Project>{2645C9F3-9ED5-4806-AB09-DAD9BE90C67B}</Project>
       <Name>MonoDevelop.PackageManagement.Tests</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\MonoDevelop.DotNetCore\MonoDevelop.DotNetCore.csproj">
-      <Project>{6868153E-41EA-43A4-A81A-C1E7256373F7}</Project>
-      <Name>MonoDevelop.DotNetCore</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\external\xwt\Xwt\Xwt.csproj">
       <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>
       <Name>Xwt</Name>

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="MonoDevelop.Packaging.Tests\AddPlatformImplementationTests.cs" />
     <Compile Include="MonoDevelop.Packaging.Tests\TestableAddPlatformImplementationViewModel.cs" />
     <Compile Include="MonoDevelop.Packaging.Tests\TestableCrossPlatformLibraryTemplateWizard.cs" />
+    <Compile Include="MonoDevelop.Packaging.Tests\TestablePackagingProjectTemplateWizard.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
@@ -62,6 +62,10 @@
     <ProjectReference Include="..\..\MonoDevelop.DotNetCore\MonoDevelop.DotNetCore.csproj">
       <Project>{6868153E-41EA-43A4-A81A-C1E7256373F7}</Project>
       <Name>MonoDevelop.DotNetCore</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\external\xwt\Xwt\Xwt.csproj">
+      <Project>{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}</Project>
+      <Name>Xwt</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests.csproj
@@ -69,6 +69,11 @@
       <Name>Xwt</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\tests\IdeUnitTests\IdeUnitTests.csproj">
+      <Project>{F7B2B155-7CF4-42C4-B5AF-63C0667D2E4F}</Project>
+      <Name>IdeUnitTests</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
@@ -27,6 +27,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Templates;
 using MonoDevelop.Projects;
 using NUnit.Framework;
@@ -38,9 +39,18 @@ namespace MonoDevelop.Packaging.Tests
 	[TestFixture]
 	public class AddPlatformImplementationTests : TestBase
 	{
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			if (!Platform.IsMac)
+				Assert.Ignore ("Platform not Mac - Ignoring AddPlatformImplementationTests");
+		}
+
 		protected override void InternalSetup (string rootDir)
 		{
 			base.InternalSetup (rootDir);
+			Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
+			Ide.DesktopService.Initialize ();
 
 			#pragma warning disable 219
 			// Ensure MSBuildSdksPath is registered otherwise the project builders are recycled
@@ -50,7 +60,6 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
-		[Platform (Exclude = "Linux")]
 		public async Task AddAndroidProjectForPCLProject ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";
@@ -134,8 +143,6 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
-		[Platform (Exclude = "Win")]
-		[Platform (Exclude = "Linux")]
 		public async Task AddIOSProjectForPCLProject ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";
@@ -216,8 +223,6 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
-		[Platform (Exclude = "Win")]
-		[Platform (Exclude = "Linux")]
 		public async Task AddSharedProjectForPCLProject ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";
@@ -347,8 +352,6 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
-		[Platform (Exclude = "Win")]
-		[Platform (Exclude = "Linux")]
 		public async Task PCLProjectInSameDirectoryAsSolution ()
 		{
 			string templateId = "MonoDevelop.CSharp.PortableLibrary";

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
@@ -47,17 +47,6 @@ namespace MonoDevelop.Packaging.Tests
 				Assert.Ignore ("Platform not Mac - Ignoring AddPlatformImplementationTests");
 		}
 
-		protected override void InternalSetup (string rootDir)
-		{
-			base.InternalSetup (rootDir);
-
-			#pragma warning disable 219
-			// Ensure MSBuildSdksPath is registered otherwise the project builders are recycled
-			// when we try to build the packaging project which breaks the tests.
-			string directory = DotNetCore.DotNetCoreSdk.MSBuildSDKsPath;
-			#pragma warning restore 219
-		}
-
 		[Test]
 		public async Task AddAndroidProjectForPCLProject ()
 		{

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 using MonoDevelop.Ide.Templates;
 using MonoDevelop.Projects;
 using NUnit.Framework;
@@ -37,7 +38,7 @@ using MonoDevelop.Projects.SharedAssetsProjects;
 namespace MonoDevelop.Packaging.Tests
 {
 	[TestFixture]
-	public class AddPlatformImplementationTests : TestBase
+	public class AddPlatformImplementationTests : IdeTestBase
 	{
 		[TestFixtureSetUp]
 		public void SetUp ()
@@ -49,8 +50,6 @@ namespace MonoDevelop.Packaging.Tests
 		protected override void InternalSetup (string rootDir)
 		{
 			base.InternalSetup (rootDir);
-			Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
-			Ide.DesktopService.Initialize ();
 
 			#pragma warning disable 219
 			// Ensure MSBuildSdksPath is registered otherwise the project builders are recycled
@@ -97,7 +96,7 @@ namespace MonoDevelop.Packaging.Tests
 			await viewModel.CreateProjects (Util.GetMonitor ());
 
 			// Verify projects created as expected.
-			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			solution = (Solution) await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 
 			pclProject = solution.GetAllProjects ().OfType<DotNetProject> ().FirstOrDefault (p => p.Name == "MyProject");
 
@@ -180,7 +179,7 @@ namespace MonoDevelop.Packaging.Tests
 			await viewModel.CreateProjects (Util.GetMonitor ());
 
 			// Verify projects created as expected.
-			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			solution = (Solution) await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 
 			pclProject = solution.GetAllProjects ().OfType<DotNetProject> ().FirstOrDefault (p => p.Name == "MyProject");
 
@@ -266,7 +265,7 @@ namespace MonoDevelop.Packaging.Tests
 			await viewModel.CreateProjects (Util.GetMonitor ());
 
 			// Verify projects created as expected.
-			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			solution = (Solution) await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 
 			pclProject = solution.GetAllProjects ().OfType<DotNetProject> ().FirstOrDefault (p => p.Name == "MyProject");
 
@@ -389,7 +388,7 @@ namespace MonoDevelop.Packaging.Tests
 			await viewModel.CreateProjects (Util.GetMonitor ());
 
 			// Verify projects created as expected.
-			solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			solution = (Solution) await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 
 			var androidProject = solution.GetAllProjects ().FirstOrDefault (p => p.Name == "MyProject.Android");
 			var nugetProject = solution.GetAllProjects ().FirstOrDefault (p => p.Name == "MyProject.NuGet");

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -44,6 +44,8 @@ namespace MonoDevelop.Packaging.Tests
 		protected override void InternalSetup (string rootDir)
 		{
 			base.InternalSetup (rootDir);
+			Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
+			Ide.DesktopService.Initialize ();
 
 			#pragma warning disable 219
 			// Ensure MSBuildSdksPath is registered otherwise the project builders are recycled
@@ -109,6 +111,10 @@ namespace MonoDevelop.Packaging.Tests
 			await NuGetPackageInstaller.InstallPackages ((Solution)workspaceItem, template.PackageReferencesForCreatedProjects);
 
 			var solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+
+			// Ensure readme.txt has metadata to include it in the NuGet package.
+			var wizard = new TestablePackagingProjectTemplateWizard ();
+			wizard.ItemsCreated (new [] { solution });
 
 			BuildResult cr = await solution.Build (Util.GetMonitor (), "Debug");
 			Assert.IsNotNull (cr);

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -27,6 +27,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Templates;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
@@ -85,7 +86,6 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
-		[Ignore ("Build does not work with project.json on Mono")]
 		public async Task BuildPackagingProjectFromTemplate ()
 		{
 			string templateId = "MonoDevelop.Packaging.Project";
@@ -121,9 +121,11 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
-		[Platform (Exclude = "Linux")]
 		public async Task CreateMultiPlatformProjectFromTemplateWithAndroidOnly ()
 		{
+			if (!Platform.IsMac)
+				Assert.Ignore ("Platform not Mac - Ignoring CreateMultiPlatformProjectFromTemplateWithAndroidOnly");
+
 			string templateId = "MonoDevelop.Packaging.CrossPlatformLibrary";
 			var template = ProjectTemplate.ProjectTemplates.FirstOrDefault (t => t.Id == templateId);
 			var dir = Util.CreateTmpDir (template.Id);

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -42,17 +42,6 @@ namespace MonoDevelop.Packaging.Tests
 	[TestFixture]
 	public class ProjectTemplateTests : IdeTestBase
 	{
-		protected override void InternalSetup (string rootDir)
-		{
-			base.InternalSetup (rootDir);
-
-			#pragma warning disable 219
-			// Ensure MSBuildSdksPath is registered otherwise the project builders are recycled
-			// when we try to build the packaging project which breaks the tests.
-			string directory = DotNetCore.DotNetCoreSdk.MSBuildSDKsPath;
-			#pragma warning restore 219
-		}
-
 		[Test]
 		public async Task CreatePackagingProjectFromTemplate ()
 		{

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 using MonoDevelop.Ide.Templates;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
@@ -39,13 +40,11 @@ using UnitTests;
 namespace MonoDevelop.Packaging.Tests
 {
 	[TestFixture]
-	public class ProjectTemplateTests : TestBase
+	public class ProjectTemplateTests : IdeTestBase
 	{
 		protected override void InternalSetup (string rootDir)
 		{
 			base.InternalSetup (rootDir);
-			Xwt.Application.Initialize (Xwt.ToolkitType.Gtk);
-			Ide.DesktopService.Initialize ();
 
 			#pragma warning disable 219
 			// Ensure MSBuildSdksPath is registered otherwise the project builders are recycled
@@ -110,7 +109,7 @@ namespace MonoDevelop.Packaging.Tests
 
 			await NuGetPackageInstaller.InstallPackages ((Solution)workspaceItem, template.PackageReferencesForCreatedProjects);
 
-			var solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var solution = (Solution)await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 
 			// Ensure readme.txt has metadata to include it in the NuGet package.
 			var wizard = new TestablePackagingProjectTemplateWizard ();
@@ -149,7 +148,7 @@ namespace MonoDevelop.Packaging.Tests
 			string solutionFileName = Path.Combine (dir, "SolutionName.sln");
 			await workspaceItem.SaveAsync (solutionFileName, Util.GetMonitor ());
 
-			var solution = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var solution = (Solution) await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 
 			var project = solution.GetAllProjects ().OfType<DotNetProject> ().FirstOrDefault (p => p.FileName.FileName == "ProjectName.NuGet.nuproj");
 			Assert.IsNotNull (project);
@@ -199,7 +198,7 @@ namespace MonoDevelop.Packaging.Tests
 
 			await NuGetPackageInstaller.InstallPackages ((Solution)workspaceItem, template.PackageReferencesForCreatedProjects);
 
-			var solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var solution = (Solution)await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			project = solution.GetAllProjects ().First ();
 			BuildResult cr = await solution.Build (Util.GetMonitor (), "Debug");
 			Assert.IsNotNull (cr);

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/TestablePackagingProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/TestablePackagingProjectTemplateWizard.cs
@@ -1,0 +1,39 @@
+﻿//
+// TestablePackagingProjectTemplateWizard.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Core;
+using MonoDevelop.Packaging.Templating;
+
+namespace MonoDevelop.Packaging.Tests
+{
+	class TestablePackagingProjectTemplateWizard : PackagingProjectTemplateWizard
+	{
+		protected override void SaveAsync (PackagingProject project)
+		{
+			project.SaveAsync (new ProgressMonitor ());
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -760,7 +760,7 @@ namespace MonoDevelop.Projects.MSBuild
 			
 			foreach (var node in GetItemTypeNodes ().OfType<ProjectTypeNode> ()) {
 				if (node.Guid.Equals (project.TypeGuid, StringComparison.OrdinalIgnoreCase)) {
-					if (node.MSBuildSupport != MSBuildSupport.Supported)
+					if (node.MSBuildSupport == MSBuildSupport.NotSupported)
 						return false;
 					return GetMSBuildSupportForFlavors (project.FlavorGuids);
 				}


### PR DESCRIPTION
The packaging project type indicated that it only worked with
MSBuild through the project model MSBuild item types:

<Extension path="/MonoDevelop/ProjectModel/MSBuildItemTypes">
	<DotNetProjectType
		language="NuGet.Packaging"
		extension="nuproj"
		guid="{5DD5E4FA-CB73-4610-85AB-557B54E96AA9}"
		type="MonoDevelop.Packaging.PackagingProject"
		alias="NuGetPackaging"
		msbuildSupport="Required" />
</Extension>

Whilst the msbuildSupport property is obsolete the logic seems
to have changed and broken this so the NuGet packaging project
was not using MSBuild so nothing was being compiled. The check
to see if MSBuild should be used now handles the MSBuild support
being set to Required.

Fixes VSTS #650951 - Building NuGet packaging project does not
generate .nupkg

Also enabled some more packaging tests that should detect this problem happening again. Needs a new VSTS test run step - there is a clone of the VS Mac VSTS build with a new NuGetizer step which I am trying out.