### PR TITLE
[Ide] Don't show welcome page when opening a specific item

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -205,7 +205,9 @@ namespace MonoDevelop.Ide
 			}
 		}
 
-		public static void Initialize (ProgressMonitor monitor)
+		public static void Initialize (ProgressMonitor monitor) => Initialize (monitor, showWelcomePage: true);
+
+		internal static void Initialize (ProgressMonitor monitor, bool showWelcomePage)
 		{
 			// Already done in IdeSetup, but called again since unit tests don't use IdeSetup.
 			DispatchService.Initialize ();
@@ -250,7 +252,8 @@ namespace MonoDevelop.Ide
 			monitor.Step (1);
 			
 			MonoDevelop.Ide.WelcomePage.WelcomePageService.Initialize ();
-			MonoDevelop.Ide.WelcomePage.WelcomePageService.ShowWelcomePage ();
+			if (showWelcomePage)
+				MonoDevelop.Ide.WelcomePage.WelcomePageService.ShowWelcomePage ();
 
 			monitor.Step (1);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -241,7 +241,8 @@ namespace MonoDevelop.Ide
 				// which is then replaced with a second empty Apple menu.
 				// XBC #33699
 				Counters.Initialization.Trace ("Initializing IdeApp");
-				IdeApp.Initialize (monitor);
+				bool showWelcomePage = !startupInfo.HasFiles;
+				IdeApp.Initialize (monitor, showWelcomePage);
 
 				if (errorsList.Count > 0) {
 					using (AddinLoadErrorDialog dlg = new AddinLoadErrorDialog (errorsList.ToArray (), false)) {


### PR DESCRIPTION
Showing the welcome page delays loading the IDE (querying the welcome page
service and so on).

Fixes VSTS #652347 - Welcome page should not show when loading a solution from finder

Still working on the UX, trying to get the welcome page to show while the workspace is loading, but also trying to prevent a race.

<img width="1770" alt="screen shot 2018-07-20 at 23 33 44" src="https://user-images.githubusercontent.com/109974/43025075-fb63fef8-8c78-11e8-931b-9a4b60885dc3.png">

