### PR TITLE
[Core] Define MSBuildRuntimeVersion when evaluating project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -137,6 +137,7 @@ namespace MonoDevelop.Projects.MSBuild
 			properties.Add ("MSBuildBinPath", msBuildBinPathEscaped);
 			properties.Add ("MSBuildToolsPath", msBuildBinPathEscaped);
 			properties.Add ("MSBuildBinPath32", msBuildBinPathEscaped);
+			properties.Add ("MSBuildRuntimeVersion", "4.0.30319");
 
 			properties.Add ("MSBuildToolsRoot", MSBuildProjectService.ToMSBuildPath (null, Path.GetDirectoryName (toolsPath)));
 			properties.Add ("MSBuildToolsVersion", toolsVersion);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -839,6 +839,21 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Tests that the MSBuildRuntimeVersion property is defined when evaluating the project.
+		/// Xamarin.Android targets use this to determine whether xbuild is being used.
+		/// </summary>
+		[Test]
+		public async Task MSBuildRuntimeVersionProperty ()
+		{
+			string projFile = Util.GetSampleProject ("msbuild-tests", "msbuildruntimeversion.csproj");
+			using (var p = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				bool isXBuild = p.MSBuildProject.EvaluatedProperties.GetValue<bool> ("IsXBuild");
+				string msbuildRuntimeVersion = p.MSBuildProject.EvaluatedProperties.GetValue ("MSBuildRuntimeVersion");
+				Assert.IsFalse (isXBuild);
+			}
+		}
+
 		[Test]
 		public async Task XamarinIOSProjectReferencesCollectionsImmutableNetStandardAssembly_GetReferencedAssembliesShouldIncludeNetStandard ()
 		{

--- a/main/tests/test-projects/msbuild-tests/msbuildruntimeversion.csproj
+++ b/main/tests/test-projects/msbuild-tests/msbuildruntimeversion.csproj
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
When building a project with MSBuild the MSBuildRuntimeVersion
property is defined however when evaluating the project this
property was not defined. For Xamarin.Android 8.3.99.15 this was
causing an MSBuild targets file to not be imported since IsXBuild
was evaluating to true.

    <IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>

    <Import Project="Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(IsXBuild)' != 'true' and '$(EnableDefaultOutputPaths)' == 'true'" />

Note that the MSBuildRuntimeVersion is set to '4.0.30319' and this
value does not seem to have changed with MSBuild 15 for the last
two years - https://github.com/Microsoft/msbuild/blob/fc13d08cac0717707002a04b49970e3f6243ba54/src/MSBuild/app.config#L88

Fixes VSTS #620311 - "No Launch-able Activity found" error popup
while deploying Cross-platform debugging sample on Android device/AVD