### PR TITLE
Fix issue in razor where typing "@if " yielded "@if" (the space for t…

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpSnippetInfoService.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/CSharpSnippetInfoService.cs
@@ -40,6 +40,10 @@ namespace MonoDevelop.CSharp.Refactoring
 	[ExportLanguageService (typeof (ISnippetInfoService), LanguageNames.CSharp), Shared]
 	class CSharpSnippetInfoService : ISnippetInfoService
 	{
+		// #region and #endregion when appears in the completion list as snippets
+		// we should format the snippet on commit. 
+		private ISet<string> _formatTriggeringSnippets = new HashSet<string>(new string[] { "#region", "#endregion" });
+
 		IEnumerable<SnippetInfo> ISnippetInfoService.GetSnippetsIfAvailable ()
 		{
 			foreach (var template in CodeTemplateService.GetCodeTemplates (CSharp.Formatting.CSharpFormatter.MimeType)) {
@@ -49,7 +53,7 @@ namespace MonoDevelop.CSharp.Refactoring
 
 		bool ISnippetInfoService.ShouldFormatSnippet (SnippetInfo snippetInfo)
 		{
-			return true;
+			return _formatTriggeringSnippets.Contains(snippetInfo.Shortcut);
 		}
 
 		bool ISnippetInfoService.SnippetShortcutExists_NonBlocking (string shortcut)


### PR DESCRIPTION
…he commit was lost). This was due to the MonoDevelop implementation of CSharpSnippetInfoService always returning that the snippet completion item needed to be formatted. (This differs from the Roslyn implementation at https://github.com/dotnet/roslyn/blob/master/src/VisualStudio/CSharp/Impl/Snippets/CSharpSnippetInfoService.cs). The formatting of the commit ends up causing an edit at a projection seam on the language buffer, which is a nasty scenario where characters can get lost.

Long term, we should evaluate whether monodevelop could just consume the roslyn implementation of this service.