### PR TITLE
Fixes issue #5489 C# completion improperly escapes \ within @ strings

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CompletionProvider/RegexCompletionProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CompletionProvider/RegexCompletionProvider.cs
@@ -167,7 +167,7 @@ namespace MonoDevelop.CSharp.Completion.Provider
 			}
 		}
 
-		static readonly CompletionItem [] formatItems =  {
+		static readonly CompletionItem [] verbatimFormatItems =  {
 			FormatItemCompletionProvider.CreateCompletionItem("d", "Digit character", null),
 			FormatItemCompletionProvider.CreateCompletionItem("D", "Non-digit character", null),
 			FormatItemCompletionProvider.CreateCompletionItem("b", "Word boundary", null),
@@ -183,7 +183,7 @@ namespace MonoDevelop.CSharp.Completion.Provider
 			FormatItemCompletionProvider.CreateCompletionItem("p{name}", "Unicode category or unicode block", null)
 		};
 
-		static readonly CompletionItem [] verbatimFormatItems =  {
+		static readonly CompletionItem [] formatItems =  {
 			FormatItemCompletionProvider.CreateCompletionItem("\\d", "Digit character", null),
 			FormatItemCompletionProvider.CreateCompletionItem("\\D", "Non-digit character", null),
 			FormatItemCompletionProvider.CreateCompletionItem("\\b", "Word boundary", null),

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/Features/Completion/RegexCompletionProviderTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/Features/Completion/RegexCompletionProviderTests.cs
@@ -58,7 +58,7 @@ namespace ConsoleApplication1
     }
 }
 ";
-			VerifyItemExists (text, "W", usePreviousCharAsTrigger: true);
+			VerifyItemExists (text, "\\W", usePreviousCharAsTrigger: true);
 		}
 
 		[Test]
@@ -79,7 +79,7 @@ namespace ConsoleApplication1
     }
 }
 ";
-			VerifyItemExists (text, "\\W", usePreviousCharAsTrigger: true);
+			VerifyItemExists (text, "W", usePreviousCharAsTrigger: true);
 		}
 
 		[Test]
@@ -100,7 +100,7 @@ namespace ConsoleApplication1
     }
 }
 ";
-			VerifyItemExists (text, "W", usePreviousCharAsTrigger: true);
+			VerifyItemExists (text, "\\W", usePreviousCharAsTrigger: true);
 		}
 
 		[Test]


### PR DESCRIPTION
The tests tested the wrong thing verbatim <--> non verbatim cases were
swapped.