### PR TITLE
[Core] Fix project run configurations not used when running solution

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4103,6 +4103,8 @@ namespace MonoDevelop.Projects
 					var oldCapabilities = new HashSet<string> (projectCapabilities);
 					bool oldSupportsExecute = SupportsExecute ();
 
+					var solutionStartupProjectRunConfig = GetSolutionStartupProjectRunConfigurationForThisProject ();
+
 					try {
 						IsReevaluating = true;
 
@@ -4137,8 +4139,31 @@ namespace MonoDevelop.Projects
 					if (oldSupportsExecute != SupportsExecute ()) {
 						OnSupportsExecuteChanged (!oldSupportsExecute);
 					}
+
+					if (solutionStartupProjectRunConfig != null && !runConfigurations.Contains (solutionStartupProjectRunConfig)) {
+						// Need to refresh solution startup run configuration since the re-evaluation
+						// removed it from the project's run configurations but the solution still refers
+						// to the old project run configuration.
+						ParentSolution.RefreshStartupConfiguration ();
+					}
 				}
 			}));
+		}
+
+		/// <summary>
+		/// If the solution's startup run configuration is a run configuration for this
+		/// project then the project run configuration will be returned.
+		/// </summary>
+		SolutionItemRunConfiguration GetSolutionStartupProjectRunConfigurationForThisProject ()
+		{
+			var config = ParentSolution?.StartupConfiguration as SingleItemSolutionRunConfiguration;
+			if (config == null)
+				return null;
+
+			if (runConfigurations.Contains (config.RunConfiguration))
+				return config.RunConfiguration;
+
+			return null;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Creating a new .NET Core console project, editing the project run
configuration to use extra command line arguments or to not use the
external console, then building and running the solution would result
in the project run configuration not being used. So no extra
arguments would be passed to the console project, and the external
console would still be used. This could be fixed by closing and
re-opening the solution.

The problem was that when the project is re-evaluated when it is
initially created its run configurations are cleared. The solution's
StartupConfiguration has a run configuration that was still using
the original project run configuration that was no longer used. So
changes to the project run configuration had no affect when running
the solution since the two project run configurations were not the
same object. Closing and re-opening the solution fixed this since
the run configuration in the .csproj.user file is re-used when the
project is re-evaluated so both the solution run configuration and
the project run configuration refer to the same object. To fix this,
on re-evaluating the project, if the solution's run configuration
referred to a project run configuration which has been removed then
the solution's startup configuration is refreshed.

Note that there is a similar problem with multiple solution run
configurations that can occur which is not addressed by this fix.

Fixes VSTS #602834 - Unchecking Use External Console/passing command
line args has no affect for .NET Core project