### PR TITLE
[Ide] Fix no files added to new project 

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/AddPlatformImplementationTests.cs
@@ -60,7 +60,7 @@ namespace MonoDevelop.Packaging.Tests
 				SolutionPath = dir
 			};
 
-			var solution = template.CreateWorkspaceItem (cinfo) as Solution;
+			var solution = await template.CreateWorkspaceItem (cinfo) as Solution;
 			string solutionFileName = Path.Combine (dir, "Solution.sln");
 			await solution.SaveAsync (solutionFileName, Util.GetMonitor ());
 
@@ -143,7 +143,7 @@ namespace MonoDevelop.Packaging.Tests
 				SolutionPath = dir
 			};
 
-			var solution = template.CreateWorkspaceItem (cinfo) as Solution;
+			var solution = await template.CreateWorkspaceItem (cinfo) as Solution;
 			string solutionFileName = Path.Combine (dir, "Solution.sln");
 			await solution.SaveAsync (solutionFileName, Util.GetMonitor ());
 
@@ -223,7 +223,7 @@ namespace MonoDevelop.Packaging.Tests
 				SolutionPath = dir
 			};
 
-			var solution = template.CreateWorkspaceItem (cinfo) as Solution;
+			var solution = await template.CreateWorkspaceItem (cinfo) as Solution;
 			string solutionFileName = Path.Combine (dir, "Solution.sln");
 			await solution.SaveAsync (solutionFileName, Util.GetMonitor ());
 
@@ -352,7 +352,7 @@ namespace MonoDevelop.Packaging.Tests
 				SolutionPath = dir
 			};
 
-			var solution = template.CreateWorkspaceItem (cinfo) as Solution;
+			var solution = await template.CreateWorkspaceItem (cinfo) as Solution;
 			string solutionFileName = Path.Combine (dir, "Solution.sln");
 			await solution.SaveAsync (solutionFileName, Util.GetMonitor ());
 

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.Packaging.Tests
 				SolutionPath = dir
 			};
 
-			var workspaceItem = template.CreateWorkspaceItem (cinfo);
+			var workspaceItem = await template.CreateWorkspaceItem (cinfo);
 			string solutionFileName = Path.Combine (dir, "SolutionName.sln");
 			await workspaceItem.SaveAsync (solutionFileName, Util.GetMonitor ());
 
@@ -92,7 +92,7 @@ namespace MonoDevelop.Packaging.Tests
 			cinfo.Parameters["PackageDescription"] = "Description";
 			cinfo.Parameters["PackageVersion"] = "1.0.0";
 
-			var workspaceItem = template.CreateWorkspaceItem (cinfo);
+			var workspaceItem = await template.CreateWorkspaceItem (cinfo);
 			string solutionFileName = Path.Combine (dir, "SolutionName.sln");
 			await workspaceItem.SaveAsync (solutionFileName, Util.GetMonitor ());
 
@@ -133,7 +133,7 @@ namespace MonoDevelop.Packaging.Tests
 			cinfo.Parameters["CreateSharedProject"] = bool.TrueString;
 			cinfo.Parameters["CreateNuGetProject"] = bool.TrueString;
 
-			var workspaceItem = template.CreateWorkspaceItem (cinfo);
+			var workspaceItem = await template.CreateWorkspaceItem (cinfo);
 			string solutionFileName = Path.Combine (dir, "SolutionName.sln");
 			await workspaceItem.SaveAsync (solutionFileName, Util.GetMonitor ());
 
@@ -174,7 +174,7 @@ namespace MonoDevelop.Packaging.Tests
 			cinfo.Parameters["PackageDescription"] = "Description";
 			cinfo.Parameters["PackageVersion"] = "1.0.0";
 
-			var workspaceItem = template.CreateWorkspaceItem (cinfo);
+			var workspaceItem = await template.CreateWorkspaceItem (cinfo);
 
 			var wizard = new TestableCrossPlatformLibraryTemplateWizard ();
 			wizard.Parameters = cinfo.Parameters;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ISolutionItemDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ISolutionItemDescriptor.cs
@@ -27,7 +27,7 @@
 //
 
 
-using System;
+using System.Threading.Tasks;
 using MonoDevelop.Projects;
 
 namespace MonoDevelop.Ide.Templates
@@ -35,6 +35,6 @@ namespace MonoDevelop.Ide.Templates
 	internal interface ISolutionItemDescriptor
 	{
 		SolutionItem CreateItem (ProjectCreateInformation projectCreateInformation, string defaultLanguage);
-		void InitializeItem (SolutionFolderItem policyParent, ProjectCreateInformation projectCreateInformation, string defaultLanguage, SolutionItem item);
+		Task InitializeItem (SolutionFolderItem policyParent, ProjectCreateInformation projectCreateInformation, string defaultLanguage, SolutionItem item);
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectDescriptor.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Core.Assemblies;
 using MonoDevelop.Projects;
 using System.IO;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Linq;
 using MonoDevelop.Projects.MSBuild;
@@ -141,7 +142,7 @@ namespace MonoDevelop.Ide.Templates
 			return project;
 		}
 
-		public async void InitializeItem (SolutionFolderItem policyParent, ProjectCreateInformation projectCreateInformation, string defaultLanguage, SolutionItem item)
+		public async Task InitializeItem (SolutionFolderItem policyParent, ProjectCreateInformation projectCreateInformation, string defaultLanguage, SolutionItem item)
 		{
 			MonoDevelop.Projects.Project project = item as MonoDevelop.Projects.Project;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplate.cs
@@ -308,9 +308,9 @@ namespace MonoDevelop.Ide.Templates
 		{
 		}
 
-		public WorkspaceItem CreateWorkspaceItem (ProjectCreateInformation cInfo)
+		public async Task<WorkspaceItem> CreateWorkspaceItem (ProjectCreateInformation cInfo)
 		{
-			WorkspaceItemCreatedInformation workspaceItemInfo = solutionDescriptor.CreateEntry (cInfo, this.languagename);
+			WorkspaceItemCreatedInformation workspaceItemInfo = await solutionDescriptor.CreateEntry (cInfo, this.languagename);
 
 			this.createdSolutionName = workspaceItemInfo.WorkspaceItem.FileName;
 			this.packageReferencesForCreatedProjects = workspaceItemInfo.PackageReferencesForCreatedProjects;
@@ -339,7 +339,7 @@ namespace MonoDevelop.Ide.Templates
 			foreach (ISolutionItemDescriptor solutionItemDescriptor in GetItemsToCreate (solutionDescriptor, cInfo)) {
 				ProjectCreateInformation itemCreateInfo = GetItemSpecificCreateInfo (solutionItemDescriptor, cInfo);
 				itemCreateInfo = new ProjectTemplateCreateInformation (itemCreateInfo, cInfo.ProjectName);
-				itemCreateInfo.TemplateInitializationCallback = p => solutionItemDescriptor.InitializeItem (policyParent, itemCreateInfo, this.languagename, p);
+				itemCreateInfo.TemplateInitializationCallback = async p => await solutionItemDescriptor.InitializeItem (policyParent, itemCreateInfo, this.languagename, p);
 
 				SolutionItem solutionEntryItem = solutionItemDescriptor.CreateItem (itemCreateInfo, this.languagename);
 				if (solutionEntryItem != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplatingProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplatingProvider.cs
@@ -55,16 +55,16 @@ namespace MonoDevelop.Ide.Templates
 
 		public Task<ProcessedTemplateResult> ProcessTemplate (SolutionTemplate template, NewProjectConfiguration config, SolutionFolder parentFolder)
 		{
-			return Task.FromResult (ProcessTemplate ((DefaultSolutionTemplate)template, config, parentFolder));
+			return ProcessTemplate ((DefaultSolutionTemplate)template, config, parentFolder);
 		}
 
-		ProcessedTemplateResult ProcessTemplate (DefaultSolutionTemplate template, NewProjectConfiguration config, SolutionFolder parentFolder)
+		async Task<ProcessedTemplateResult> ProcessTemplate (DefaultSolutionTemplate template, NewProjectConfiguration config, SolutionFolder parentFolder)
 		{
 			IEnumerable<IWorkspaceFileObject> newItems = null;
 			ProjectCreateInformation cinfo = CreateProjectCreateInformation (config, parentFolder);
 
 			if (parentFolder == null) {
-				IWorkspaceFileObject newItem = template.Template.CreateWorkspaceItem (cinfo);
+				IWorkspaceFileObject newItem = await template.Template.CreateWorkspaceItem (cinfo);
 				if (newItem != null) {
 					newItems = new [] { newItem };
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SingleFileDescriptionTemplate.cs
@@ -470,7 +470,8 @@ namespace MonoDevelop.Ide.Templates
 
 			if (formatter != null) {
 				var document = TextEditorFactory.CreateNewReadonlyDocument (new StringTextSource (content), fileName);
-				var formatted = formatter.Format (policyParent?.Policies, document);
+				// Avoid possible UI thread deadlock in CSharpFormatter by running the formatter with Task.Run.
+				var formatted = await Task.Run (() => formatter.Format (policyParent?.Policies, document));
 				if (formatted != null)
 					content = formatted.Text;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionDescriptor.cs
@@ -29,7 +29,7 @@
 
 using System;
 using System.IO;
-using System.Threading;
+using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Linq;
 using MonoDevelop.Core;
@@ -101,7 +101,7 @@ namespace MonoDevelop.Ide.Templates
             return solutionDescriptor;
         }
 
-		public WorkspaceItemCreatedInformation CreateEntry (ProjectCreateInformation projectCreateInformation, string defaultLanguage)
+		public async Task<WorkspaceItemCreatedInformation> CreateEntry (ProjectCreateInformation projectCreateInformation, string defaultLanguage)
         {
             WorkspaceItem workspaceItem = null;
 
@@ -162,7 +162,7 @@ namespace MonoDevelop.Ide.Templates
 					if (info == null)
 						continue;
 
-					solutionItemDesc.InitializeItem (solution.RootFolder, entryProjectCI, defaultLanguage, info);
+					await solutionItemDesc.InitializeItem (solution.RootFolder, entryProjectCI, defaultLanguage, info);
 
                     IConfigurationTarget configurationTarget = info as IConfigurationTarget;
                     if (configurationTarget != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionItemDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionItemDescriptor.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Collections;
 using System.Collections.Specialized;
@@ -83,8 +84,9 @@ namespace MonoDevelop.Ide.Templates
 			return item;
 		}
 		
-		public void InitializeItem (SolutionFolderItem policyParent, ProjectCreateInformation projectCreateInformation, string defaultLanguage, SolutionItem item)
+		public Task InitializeItem (SolutionFolderItem policyParent, ProjectCreateInformation projectCreateInformation, string defaultLanguage, SolutionItem item)
 		{
+			return Task.CompletedTask;
 		}
 		
 		public static SolutionItemDescriptor CreateDescriptor (RuntimeAddin addin, XmlElement element)

--- a/main/tests/Ide.Tests/ProjectTemplateTests.cs
+++ b/main/tests/Ide.Tests/ProjectTemplateTests.cs
@@ -102,7 +102,22 @@ namespace MonoDevelop.Ide
 
 			var sharedAssetsProject = template.CreateProjects (solution.RootFolder, cinfo)
 				.OfType<SharedAssetsProject> ().Single ();
-			var myclassFile = sharedAssetsProject.Files.First (f => f.FilePath.FileName == "MyClass.cs");
+
+			// Template initialization is now asynchronous so we need to wait and unblock the UI thread
+			// to ensure the template finishes adding files to the project.
+			const int timeout = 2000; // ms
+			int waitedTime = 0;
+			int delayTime = 100;
+			ProjectFile myclassFile = null;
+			while (myclassFile == null) {
+				myclassFile = sharedAssetsProject.Files.FirstOrDefault (f => f.FilePath.FileName == "MyClass.cs");
+				if (myclassFile == null) {
+					if (waitedTime >= timeout)
+						Assert.Fail ("Timed out waiting for file to be added to shared project.");
+					await Task.Run (async () => await Task.Delay (delayTime));
+					waitedTime += delayTime;
+				}
+			};
 			Assert.AreEqual ("Compile", myclassFile.BuildAction);
 		}
 

--- a/main/tests/Ide.Tests/ProjectTemplateTests.cs
+++ b/main/tests/Ide.Tests/ProjectTemplateTests.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.Ide
 
 		[Test]
 		[TestCaseSource ("Templates")]
-		public void CreateEveryProjectTemplate (string tt)
+		public async Task CreateEveryProjectTemplate (string tt)
 		{
 			var template = ProjectTemplate.ProjectTemplates.FirstOrDefault (t => t.Id == tt);
 			if (template.Name.Contains ("Gtk#"))
@@ -82,7 +82,7 @@ namespace MonoDevelop.Ide
 			cinfo.Parameters ["CreateiOSUITest"] = "False";
 			cinfo.Parameters ["CreateAndroidUITest"] = "False";
 
-			solution = template.CreateWorkspaceItem (cinfo) as Solution;
+			solution = await template.CreateWorkspaceItem (cinfo) as Solution;
 		}
 
 		[Test]


### PR DESCRIPTION
Creating a Xamarin.Mac project inside a directory with other existing
projects could cause the project to be created without any files added
to the project but the files were created on disk.

The problem is that the ProjectDescriptor.InitializeItem method was
an async void method and when the Info.plist was created it called
into the EditorConfigService.GetEditorConfigContext when then called
codingConventionsManager.GetConventionContextAsync which presumably
was using a Task.Run in certain cases. This meant the UI thread was
unblocked and New Project dialog would then save the project before
all the files were created. Resulting in the files not being added
to the project file.

To fix this the InitializeItem method now returns a Task that is
awaited. One problem here that is not fixed is that there is a
TemplateInitializationCallback when adding a new project to an
existing solution that may run after the project is saved in a similar
way as for a new project. The TemplateInitializationCallback calls
the project descriptor's InitializeItem method. Note that this delay
does not seem to happen in practice. Changing the
TemplateInitializationCallback to be Task based is a more complicated
change since most of this API is public so has been left for now.
Note that with a Task.Run and delay added to the project descriptor's
InitializeItem and adding a new project to a solution the files are
added to the project and displayed in the Solution pad but the project
is not saved. This happens with or without the fix applied here.

Fixes VSTS #645418 - The project is empty after creation