### PR TITLE
[Ide] Fix no build on running a project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.SolutionItemBuildBatch.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.SolutionItemBuildBatch.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.Ide
 						if (sln != null && sln != s) {
 							throw new InvalidOperationException ("All items must be in the same solution");
 						}
-						return sln;
+						return s;
 					}
 				}
 				if (buildTargets.Count == 1) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1400,7 +1400,7 @@ namespace MonoDevelop.Ide
 			if (r.Failed)
 				return false;
 
-			IBuildTarget buildTarget = SolutionItemBuildBatch.Create (executionTargets.SelectMany (et => et.GetExecutionDependencies ()));
+			IBuildTarget buildTarget = SolutionItemBuildBatch.Create (executionTargets);
 
 			if (!FastCheckNeedsBuild (buildTarget, configuration)) {
 				return true;


### PR DESCRIPTION
Creating a new project and then running it does not build the
project first. There was a change made to the ProjectOperations
around building which is relying on the project model implementing
GetExecutionDependencies. This has not been implemented anywhere
in the code. So nothing was being built. The use of
GetExecutionDependencies has removed for now so projects are
compiled.

Fixes VSTS #652873 - Outdated Build dialog is no longer displayed