### PR TITLE
[Ide] Fix null ref logged by telemetry when creating NuGet project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectTemplate.cs
@@ -320,7 +320,7 @@ namespace MonoDevelop.Ide.Templates
 			var metadata = new TemplateMetadata {
 				Id = Id,
 				Name = nonLocalizedName,
-				Language = LanguageName,
+				Language = LanguageName ?? string.Empty,
 				Platform = pDesc.Count == 1 ? pDesc[0].ProjectType : "Multiple"
 			};
 			TemplateCounter.Inc (1, null, metadata);


### PR DESCRIPTION
The language name for a NuGet packaging project is not set, since
it does not have a language. This was causing a null reference
exception to be logged by the telemetry when it attempted to call
ToString() on the value.

Fixes VSTS #655218 - Null reference exception logged on creating a
NuGet packaging project