### PR TITLE
[PerformanceDiagnostics] Fix UI thread hang app not starting

### DIFF
--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/UIThreadMonitor.cs
@@ -163,7 +163,7 @@ namespace PerformanceDiagnosticsAddIn
 		string GetArguments (int port, bool sample)
 		{
 			var arguments = new StringBuilder ();
-			arguments.Append ($"{typeof (UIThreadMonitorDaemon.MainClass).Assembly.Location} {port} {Process.GetCurrentProcess ().Id}");
+			arguments.Append ($"\"{typeof (UIThreadMonitorDaemon.MainClass).Assembly.Location}\" {port} {Process.GetCurrentProcess ().Id}");
 
 			if (!sample)
 				arguments.Append (" --noSample");


### PR DESCRIPTION
The UI thread hang console app was being started without quoting
the path to the executable so it was failing to start when inside
a path with a space, such as from within the 'Visual Studio.app'
bundle.

Fixes VSTS #655338 - Exception on quit