### PR TITLE
Fix VSTS 656752 (Classification doesn't update)

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
@@ -45,6 +45,10 @@ namespace Mono.TextEditor
 			MonoTextEditor textEditor;
 			SnapshotSpan lineSpan;
 			int lineBreakLength;
+
+			/// <summary>
+			/// 1-based
+			/// </summary>
 			public int LineNumber { get; private set; }
 
 			public MdTextViewLine(MdTextViewLineCollection collection, MonoTextEditor textEditor, DocumentLine line, int lineNumber, TextViewMargin.LayoutWrapper layoutWrapper)
@@ -62,15 +66,6 @@ namespace Mono.TextEditor
 			public object IdentityTag => indentityTag;
 
 			public ITextSnapshot Snapshot => lineSpan.Snapshot;
-
-			public void TranslateToSnapshot(ITextSnapshot newSnapshot)
-			{
-				if (Snapshot == newSnapshot) {
-					return;
-				}
-
-				lineSpan = lineSpan.TranslateTo (newSnapshot, SpanTrackingMode.EdgeExclusive);
-			}
 
 			public bool IsFirstTextViewLineForSnapshotLine => collection[0] == this;
 


### PR DESCRIPTION
Fix VSTS 645599 (ArgumentOutOfRange in Razor)

Update MdTextViewLineCollection to the latest editor Snapshot when buffer changes. We've had a number of issues in TagBasedSyntaxHighlighting where some lines were partially translated to the latest snapshot, but created a discrepancy because a SnapshotSpan would be tracked to latest, but a DocumentLine wouldn't get translated.

Now we re-add the lines we want to reuse against the latest snapshot, and the changed lines would be added later by the layout engine.

Removing the incorrect fix to translate lines as it didn't properly translate the DocumentLine of an MdTextViewLine.