### PR TITLE
Fix VSTS 645707: HTML tag smart indent doesn't work with Tabs

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/CaretImpl.ITextCaret.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/CaretImpl.ITextCaret.cs
@@ -39,7 +39,13 @@ namespace Mono.TextEditor
 		VirtualSnapshotPoint insertionPoint;
 		PositionAffinity _caretAffinity;
 
-		ITextViewLine ITextCaret.ContainingTextViewLine => TextEditor.GetTextViewLineContainingBufferPosition (((ITextCaret)this).Position.VirtualBufferPosition.Position);
+		ITextViewLine ITextCaret.ContainingTextViewLine {
+			get {
+				var position = ((ITextCaret)this).Position.BufferPosition;
+				var line = TextEditor.GetTextViewLineContainingBufferPosition (position);
+				return line;
+			}
+		}
 
 		double ITextCaret.Left => TextEditor.TextArea.TextViewMargin.caretX;
 
@@ -221,9 +227,15 @@ namespace Mono.TextEditor
 			int col;
 			if (bufferPosition.IsInVirtualSpace) {
 				col = bufferPosition.VirtualSpaces;
+
+				if (!TextEditor.Options.TabsToSpaces) {
+					col = col / TextEditor.Options.TabSize;
+				}
 			} else {
-				col = requestedPosition - snapshotLine.Start + 1;
+				col = requestedPosition - snapshotLine.Start;
 			}
+
+			col += 1;
 
 			TextEditor.SetCaretTo (line, col, false, false);
 		}


### PR DESCRIPTION
Our ITextCaret.ContainingTextViewLine implementation was wrong, it was taking a virtual position, not buffer position, returning null.

Separate issue: when we were in virtual space, and the editor was set to Tabs, the col calculation was incorrect. Didn't divide by TabSize and increment by 1.