### PR TITLE
[Editor] Simplify editor config context querying a bit

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1058,9 +1058,16 @@ namespace MonoDevelop.Ide.Editor
 		async void TextEditor_FileNameChanged (object sender, EventArgs e)
 		{
 			fileTypeCondition.SetFileName (FileName);
+
+			// This is a sync call to remove from the cache, then async to dispose the context after the load is awaited.
 			EditorConfigService.RemoveEditConfigContext (FileName).Ignore ();
-			var context = await EditorConfigService.GetEditorConfigContext (FileName, default (CancellationToken));
-			if (context != null && Options is DefaultSourceEditorOptions options)
+
+			// There is no use to try and create a cached context if we won't use it.
+			if (!(Options is DefaultSourceEditorOptions options))
+				return;
+
+			var context = await EditorConfigService.GetEditorConfigContext (FileName);
+			if (context != null)
 				options.SetContext (context);
 		}
 


### PR DESCRIPTION
Fixes VSTS #657369 - EditorConfig context is queried even for files which will not use it