### PR TITLE
[Ide] Fix autosave not loading autosaved file

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -84,7 +84,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			this.tabControl = tabControl;
 			this.tab = tabLabel;
-			SetTitleEvent(null, null);
+			SetTitleEvent (false);
 			SetDockNotebookTabTitle ();
 		}
 
@@ -114,7 +114,7 @@ namespace MonoDevelop.Ide.Gui
 			box.Show ();
 			Add (box);
 			
-			SetTitleEvent(null, null);
+			SetTitleEvent (false);
 		}
 
 		internal void CreateCommandHandler ()
@@ -441,6 +441,11 @@ namespace MonoDevelop.Ide.Gui
 		
 		public void SetTitleEvent(object sender, EventArgs e)
 		{
+			SetTitleEvent ();
+		}
+
+		void SetTitleEvent(bool allowMarkFileDirty = true)
+		{
 			if (content == null)
 				return;
 				
@@ -473,7 +478,7 @@ namespace MonoDevelop.Ide.Gui
 			}
 			
 			if (content.IsDirty) {
-				if (!String.IsNullOrEmpty (content.ContentName))
+				if (allowMarkFileDirty && !String.IsNullOrEmpty (content.ContentName))
 					IdeApp.ProjectOperations.MarkFileDirty (content.ContentName);
 			} else if (content.IsReadOnly) {
 				newTitle += "+";


### PR DESCRIPTION
With unsaved changes in the text editor, and the IDE crashes, on
re-starting the IDE, and opening the solution containing the file
that was unsaved, the editor was not showing the 'An autosave file
has been found for this file' message in the text editor. Instead the
text editor was showing a message saying that the file had been
changed outside the IDE. The Keep Changes button if clicked would
result in an empty file in the text editor and the file changes
would be lost.

The problem was that on loading the file with an associated autosave
file the last write time was being updated which caused the file
watcher to raise a file changed event. This then caused the
autosave message to be replaced with the file has been changed
outside the IDE message. The SdiWorkspaceWindow's SetTitleEvent
method would change the last write time of the file if the
text editor view indicated it was dirty. To avoid this when an
SdiWorkspaceWindow is created, either on opening a file, or by
docking the text editor view side by side in the IDE, the
SetTitleEvent now does not change the file's last write time.

Fixes VSTS #656105 - Autosave does not load autosaved file