### PR TITLE
Add binding redirect for Microsoft.Diagnostics.Tracing.EventSource.dll.

### DIFF
--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -151,6 +151,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-2.9.0.0" newVersion="2.9.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Diagnostics.Tracing.EventSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.1.28.0" newVersion="1.1.28.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
 			</dependentAssembly>


### PR DESCRIPTION
Looks like we ship 1.1.28.0 in the app bundle, but some .dlls reference a smaller version.