### PR TITLE
Implement IBuildTarget.GetExecutionDependencies correctly

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Solution.cs
@@ -750,6 +750,16 @@ namespace MonoDevelop.Projects
 			return CanExecute (context, configuration, (SolutionRunConfiguration)runConfiguration);
 		}
 
+		public new IEnumerable<IBuildTarget> GetExecutionDependencies ()
+		{
+			return SolutionExtension.OnGetExecutionDependencies ();
+		}
+
+		protected virtual IEnumerable<IBuildTarget> OnGetExecutionDependencies ()
+		{
+			yield return this;
+		}
+
 		public IEnumerable<SolutionRunConfiguration> GetRunConfigurations ()
 		{
 			return SolutionExtension.OnGetRunConfigurations ();
@@ -1508,6 +1518,11 @@ namespace MonoDevelop.Projects
 			internal protected override IEnumerable<ExecutionTarget> GetExecutionTargets (Solution solution, ConfigurationSelector configuration)
 			{
 				yield break;
+			}
+
+			protected internal override IEnumerable<IBuildTarget> OnGetExecutionDependencies ()
+			{
+				return Solution.OnGetExecutionDependencies ();
 			}
 
 			internal protected override bool OnGetSupportsFormat (MSBuildFileFormat format)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionExtension.cs
@@ -113,6 +113,11 @@ namespace MonoDevelop.Projects
 			return next.GetExecutionTargets (solution, configuration, runConfiguration);
 		}
 
+		internal protected virtual IEnumerable<IBuildTarget> OnGetExecutionDependencies ()
+		{
+			return next.OnGetExecutionDependencies ();
+		}
+
 		internal protected virtual IEnumerable<SolutionRunConfiguration> OnGetRunConfigurations ()
 		{
 			return next.OnGetRunConfigurations ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -404,9 +404,22 @@ namespace MonoDevelop.Projects
 			return Task.FromResult (false);
 		}
 
+		// note: although executing folders isn't supported, this may still get called when
+		// executing unit tests
 		public IEnumerable<IBuildTarget> GetExecutionDependencies ()
 		{
-			yield break;
+			if (IsRoot) {
+				yield return ParentSolution;
+				yield break;
+			}
+
+			foreach (var item in GetAllItems ()) {
+				if (item is IBuildTarget bt) {
+					foreach (var dep in bt.GetExecutionDependencies ()) {
+						yield return dep;
+					}
+				}
+			}
 		}
 
 		/// <remarks>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -371,7 +371,7 @@ namespace MonoDevelop.Projects
 
 		protected virtual IEnumerable<IBuildTarget> OnGetExecutionDependencies ()
 		{
-			yield break;
+			yield return this;
 		}
 
 		/// <summary>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -310,9 +310,10 @@ namespace MonoDevelop.Projects
 		}
 
 		[ThreadSafe]
+		[Obsolete ("This should be implemented by subclasses that implement IBuildTarget")]
 		public IEnumerable<IBuildTarget> GetExecutionDependencies ()
 		{
-			yield break;
+			throw new InvalidOperationException ("Must be reimplemented by subclasses");
 		}
 
 		protected bool Loading { get; private set; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1433,7 +1433,8 @@ namespace MonoDevelop.Ide
 			if (r.Failed)
 				return false;
 
-			IBuildTarget buildTarget = SolutionItemBuildBatch.Create (executionTargets.SelectMany (et => et.GetExecutionDependencies ()));
+			var executionDeps = executionTargets.SelectMany (et => et.GetExecutionDependencies ());
+			IBuildTarget buildTarget = SolutionItemBuildBatch.Create (executionDeps);
 
 			if (!FastCheckNeedsBuild (buildTarget, configuration)) {
 				return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1433,7 +1433,7 @@ namespace MonoDevelop.Ide
 			if (r.Failed)
 				return false;
 
-			IBuildTarget buildTarget = SolutionItemBuildBatch.Create (executionTargets);
+			IBuildTarget buildTarget = SolutionItemBuildBatch.Create (executionTargets.SelectMany (et => et.GetExecutionDependencies ()));
 
 			if (!FastCheckNeedsBuild (buildTarget, configuration)) {
 				return true;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectOperationsTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectOperationsTests.cs
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2018 Microsoft Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.Projects
+{
+	[TestFixture]
+	public class ProjectOperationsTests : IdeTestBase
+	{
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			if (!IdeApp.IsInitialized) {
+				IdeApp.Initialize (new ProgressMonitor ());
+			}
+		}
+
+		Solution CreateSimpleSolutionWithItems (params SolutionItem[] items)
+		{
+			var sln = new Solution ();
+			foreach (var item in items) {
+				sln.RootFolder.AddItem (item);
+			}
+			var cfg = sln.AddConfiguration ("Debug", true);
+			foreach (var item in items) {
+				cfg.GetEntryForItem (item).Build = true;
+			}
+			return sln;
+		}
+
+		[Test]
+		public async Task CheckAndBuildForExecute_ProjectOnly ()
+		{
+			using (var other = new ProjectWithExecutionDeps ("Other"))
+			using (var executing = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (other, executing)) {
+
+				var success = await IdeApp.ProjectOperations.CheckAndBuildForExecute (new [] { executing }, ConfigurationSelector.Default);
+
+				Assert.IsTrue (success);
+				Assert.IsFalse (other.WasBuilt);
+				Assert.IsTrue (executing.WasBuilt);
+			}
+		}
+
+		[Test]
+		public async Task CheckAndBuildForExecute_DependencyButNotSelf ()
+		{
+			using (var executionDep = new ProjectWithExecutionDeps ("Dependency"))
+			using (var executing = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (executionDep, executing)) {
+
+				executing.OverrideExecutionDependencies = new [] { executionDep };
+
+				var success = await IdeApp.ProjectOperations.CheckAndBuildForExecute (new [] { executing }, ConfigurationSelector.Default);
+
+				Assert.IsTrue (success);
+				Assert.IsTrue (executionDep.WasBuilt);
+				Assert.False (executing.WasBuilt);
+			}
+		}
+
+		[Test]
+		public async Task CheckAndBuildForExecute_DependencyReferencesExecuting ()
+		{
+			using (var executionDep = new ProjectWithExecutionDeps ("Dependency"))
+			using (var executing = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (executionDep, executing)) {
+
+				executing.OverrideExecutionDependencies = new [] { executionDep };
+				executionDep.ItemDependencies.Add (executing);
+
+				var success = await IdeApp.ProjectOperations.CheckAndBuildForExecute (new [] { executing }, ConfigurationSelector.Default);
+				Assert.IsTrue (success);
+				Assert.IsTrue (executionDep.WasBuilt);
+				Assert.IsTrue (executing.WasBuilt);
+			}
+		}
+
+		[DebuggerDisplay ("Project {Name}")]
+		class ProjectWithExecutionDeps : Project
+		{
+			public ProjectWithExecutionDeps (string name) : base ("foo")
+			{
+				EnsureInitialized ();
+				Name = name;
+			}
+
+			public IBuildTarget[] OverrideExecutionDependencies { get; set; }
+			public bool WasBuilt { get; private set; }
+
+			protected override IEnumerable<IBuildTarget> OnGetExecutionDependencies ()
+			{
+				return OverrideExecutionDependencies ?? base.OnGetExecutionDependencies ();
+			}
+
+			protected override Task<BuildResult> OnBuild (ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext operationContext)
+			{
+				WasBuilt = true;
+				return Task.FromResult (new BuildResult { BuildCount = 1 });
+			}
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="MonoDevelop.Ide.RoslynServices.Options\FullSolutionAnalysisTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManagerTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\ProjectOperationsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">


### PR DESCRIPTION
Per the docs for `GetExecutionDependencies`, implementors should return themselves
if they want to be built.