### PR TITLE
Always set the LangVersion to latest for C#

### DIFF
--- a/main/msbuild/MonoDevelop.BeforeCommon.targets
+++ b/main/msbuild/MonoDevelop.BeforeCommon.targets
@@ -20,6 +20,7 @@
 		<NoWarn>$(NoWarn);1591;1573</NoWarn>
 	</PropertyGroup>
 
+	<!-- https://aka.ms/roslyn-packages has a list that maps Roslyn version to latest language version -->
 	<!-- Set the roslyn language version to the latest stable version our provisioned csc supports -->
 	<PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.csproj'">
 		<LangVersion>7.2</LangVersion>

--- a/main/msbuild/MonoDevelop.BeforeCommon.targets
+++ b/main/msbuild/MonoDevelop.BeforeCommon.targets
@@ -18,6 +18,8 @@
 		<DocumentationFile Condition="'$(SuppressDocs)'!='True'">$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 		<!-- don't warn about missing doc comments -->
 		<NoWarn>$(NoWarn);1591;1573</NoWarn>
+		<!-- set the language version to the latest usable C# -->
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MDConfigIsDebug)'=='true'">

--- a/main/msbuild/MonoDevelop.BeforeCommon.targets
+++ b/main/msbuild/MonoDevelop.BeforeCommon.targets
@@ -18,8 +18,15 @@
 		<DocumentationFile Condition="'$(SuppressDocs)'!='True'">$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 		<!-- don't warn about missing doc comments -->
 		<NoWarn>$(NoWarn);1591;1573</NoWarn>
-		<!-- set the language version to the latest usable C# -->
-		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
+
+	<!-- Set the roslyn language version to the latest stable version our provisioned csc supports -->
+	<PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.csproj'">
+		<LangVersion>7.2</LangVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.vbproj'">
+		<LangVersion>15.5</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MDConfigIsDebug)'=='true'">


### PR DESCRIPTION
This allows us to use newer features like default literal,
new valuetype ref semantics, private protected, stackalloc arrays