### PR TITLE
Only build executing projects

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1346,17 +1346,31 @@ namespace MonoDevelop.Ide
 			}
 		}
 
+		static IBuildTarget[] GetBuildTargetsForExecution (IBuildTarget executionTarget, RunConfiguration runConfiguration)
+		{
+			if (executionTarget is Solution sol) {
+				if (runConfiguration is SingleItemSolutionRunConfiguration src) {
+					return new [] { src.Item };
+				}
+				if (runConfiguration is MultiItemSolutionRunConfiguration mrc) {
+					var buildTargets = new IBuildTarget [mrc.Items.Count];
+					int i = 0;
+					foreach (var item in mrc.Items) {
+						buildTargets [i++] = item.SolutionItem;
+					}
+					return buildTargets;
+				}
+			}
+			return new [] { executionTarget };
+		}
+
 		Task<bool> CheckAndBuildForExecute (IBuildTarget executionTarget, ExecutionContext context, ConfigurationSelector configuration, RunConfiguration runConfiguration)
 		{
-			var buildTarget = executionTarget;
-
-			// When executing a solution we are actually going to execute the startup project. So we only need to build that project.
-			// TODO: handle multi-startup solutions.
-			if (buildTarget is Solution sol && sol.StartupItem != null)
-				buildTarget = sol.StartupItem;
+			// When executing a solution we are actually going to execute the startup project(s), so we only need to build it/them
+			IBuildTarget [] buildTargets = GetBuildTargetsForExecution (executionTarget, runConfiguration);
 
 			return CheckAndBuildForExecute (
-				new [] { buildTarget }, configuration,
+				buildTargets, configuration,
 				IdeApp.Preferences.BuildBeforeExecuting, IdeApp.Preferences.RunWithWarnings,
 				(target, monitor) => {
 					if (target is IRunTarget)


### PR DESCRIPTION
When building for a multi-project run config, only build the executing projects, not the whole solution.