### PR TITLE
Extend support for Sdk definition in .NET Core

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.DotNetCore
 		/// </summary>
 		bool IsSdkProject (DotNetProject project)
 		{
-			return project.MSBuildProject.GetProjectSdksName() != null;
+			return project.MSBuildProject.GetReferencedSDKs().Length > 0;
 		}
 
 		protected override bool OnGetCanReferenceProject (DotNetProject targetProject, out string reason)
@@ -406,7 +406,7 @@ namespace MonoDevelop.DotNetCore
 
 		protected override void OnBeginLoad ()
 		{
-			dotNetCoreMSBuildProject.Sdk = Project.MSBuildProject.GetProjectSdksName();
+			dotNetCoreMSBuildProject.Sdk = Project.MSBuildProject.Sdk;
 			base.OnBeginLoad ();
 		}
 
@@ -416,7 +416,7 @@ namespace MonoDevelop.DotNetCore
 
 		protected bool IsWebProject (DotNetProject project)
 		{
-			return (project.MSBuildProject.GetProjectSdksName()?.IndexOf ("Microsoft.NET.Sdk.Web", System.StringComparison.OrdinalIgnoreCase) ?? -1) != -1;
+			return (project.MSBuildProject.GetReferencedSDKs()?.FirstOrDefault(x => x?.IndexOf ("Microsoft.NET.Sdk.Web", System.StringComparison.OrdinalIgnoreCase) != -1) != null);
 		}
 
 		public bool IsWeb {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.DotNetCore
 		/// </summary>
 		bool IsSdkProject (DotNetProject project)
 		{
-			return project.MSBuildProject.Sdk != null;
+			return project.MSBuildProject.GetProjectSdksName() != null;
 		}
 
 		protected override bool OnGetCanReferenceProject (DotNetProject targetProject, out string reason)
@@ -406,7 +406,7 @@ namespace MonoDevelop.DotNetCore
 
 		protected override void OnBeginLoad ()
 		{
-			dotNetCoreMSBuildProject.Sdk = Project.MSBuildProject.Sdk;
+			dotNetCoreMSBuildProject.Sdk = Project.MSBuildProject.GetProjectSdksName();
 			base.OnBeginLoad ();
 		}
 
@@ -416,7 +416,7 @@ namespace MonoDevelop.DotNetCore
 
 		protected bool IsWebProject (DotNetProject project)
 		{
-			return (project.MSBuildProject.Sdk?.IndexOf ("Microsoft.NET.Sdk.Web", System.StringComparison.OrdinalIgnoreCase) ?? -1) != -1;
+			return (project.MSBuildProject.GetProjectSdksName()?.IndexOf ("Microsoft.NET.Sdk.Web", System.StringComparison.OrdinalIgnoreCase) ?? -1) != -1;
 		}
 
 		public bool IsWeb {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectReader.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectReader.cs
@@ -55,19 +55,40 @@ namespace MonoDevelop.DotNetCore
 			return GetDotNetCoreSdk (file) != null;
 		}
 
+		/// <summary>
+		/// Returns the first Sdk property defined by the project, if any exists
+		/// </summary>
 		public static string GetDotNetCoreSdk (FilePath file)
 		{
 			try {
-				using (var tr = new XmlTextReader (new StreamReader (file))) {
-					if (tr.MoveToContent () == XmlNodeType.Element) {
-						if (tr.LocalName != "Project")
-							return null;
+				// A .NET Core project can define an sdk in any of the following ways
+				// 1) An Sdk attribute on the Project node
+				// 2) An Sdk node as a child of the Project node
+				// 3) An Sdk attribute on any Import node
+				XmlDocument document = new XmlDocument ();
+				document.Load (new StreamReader (file));
+				XmlNode projectNode = document.SelectSingleNode ("/Project");
+				if (projectNode != null) {
+					XmlAttribute sdkAttr = projectNode.Attributes["Sdk"];
+					if (sdkAttr != null) {
+						// Found an Sdk definition on the root Project node
+						return sdkAttr.Value;
+					}
 
-						string sdk = tr.GetAttribute ("Sdk");
-						if (string.IsNullOrEmpty (sdk))
-							return null;
+					var childSdkNode = projectNode.SelectSingleNode ("Sdk");
+					if (childSdkNode != null) {
+						var name = childSdkNode.Attributes["Name"];
+						if (name != null) {
+							// Found an Sdk definition on an Sdk node
+							return name.Value;
+						}
+					}
 
-						return sdk;
+					foreach (XmlNode importNode in projectNode.SelectNodes ("//Import")) {
+						sdkAttr = importNode.Attributes["Sdk"];
+						if (sdkAttr != null) {
+							return sdkAttr.Value;
+						}
 					}
 				}
 			} catch {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -98,7 +98,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static bool CanCreate (DotNetProject project)
 		{
-			return project.MSBuildProject.Sdk != null;
+			return project.MSBuildProject.GetProjectSdksName() != null;
 		}
 
 		public static NuGetProject Create (DotNetProject project)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -98,7 +98,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static bool CanCreate (DotNetProject project)
 		{
-			return project.MSBuildProject.GetProjectSdksName() != null;
+			return project.MSBuildProject.GetReferencedSDKs().Length > 0;
 		}
 
 		public static NuGetProject Create (DotNetProject project)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -171,7 +171,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static bool IsDotNetCoreProject (this Project project)
 		{
-			return project.MSBuildProject.GetProjectSdksName() != null;
+			return project.MSBuildProject.GetReferencedSDKs().Length > 0;
 		}
 
 		public static bool HasPackageReferences (this DotNetProject project)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -171,7 +171,7 @@ namespace MonoDevelop.PackageManagement
 
 		public static bool IsDotNetCoreProject (this Project project)
 		{
-			return project.MSBuildProject.Sdk != null;
+			return project.MSBuildProject.GetProjectSdksName() != null;
 		}
 
 		public static bool HasPackageReferences (this DotNetProject project)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -556,6 +556,7 @@
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildEvaluationContext.cs" />
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildImport.cs" />
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildObject.cs" />
+    <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildSdk.cs" />
     <Compile Include="MonoDevelop.Projects\IPropertySet.cs" />
     <Compile Include="MonoDevelop.Projects.MSBuild\IMSBuildPropertySet.cs" />
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildPropertyGroupEvaluated.cs" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -246,7 +246,7 @@ namespace MonoDevelop.Projects.MSBuild
 			context.InitEvaluation (pi.Project);
 			var objects = pi.Project.GetAllObjects ();
 
-			if (!string.IsNullOrEmpty (pi.Project.Sdk)) {
+			if (!string.IsNullOrEmpty (pi.Project.SdkWithImplicitImports)) {
 				var rootProject = pi.GetRootMSBuildProject ();
 				var sdkPaths = pi.Project.Sdk
 				                 .Split (sdkPathSeparator, StringSplitOptions.RemoveEmptyEntries)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -246,17 +246,13 @@ namespace MonoDevelop.Projects.MSBuild
 			context.InitEvaluation (pi.Project);
 			var objects = pi.Project.GetAllObjects ();
 
-			if (!string.IsNullOrEmpty (pi.Project.SdkWithImplicitImports)) {
+			string[] implicitSdks = pi.Project.GetReferencedSDKs ().Where(x => x.Implicit).Select(x => x.QualifiedName).ToArray();
+			if(implicitSdks.Length > 0) {
 				var rootProject = pi.GetRootMSBuildProject ();
-				var sdkPaths = pi.Project.Sdk
-				                 .Split (sdkPathSeparator, StringSplitOptions.RemoveEmptyEntries)
-				                 .Select (s => s.Trim ())
-				                 .Where (s => s.Length > 0)
-				                 .ToList ();
 
-				objects = sdkPaths.Select (sdkPath => new MSBuildImport { Sdk = sdkPath, Project = "Sdk.props" })
-				                  .Concat (objects)
-				                  .Concat (sdkPaths.Select (sdkPath => new MSBuildImport { Sdk = sdkPath, Project = "Sdk.targets" }));
+				objects = implicitSdks.Select (sdkPath => new MSBuildImport { Sdk = sdkPath, Project = "Sdk.props" })
+								  .Concat (objects)
+								  .Concat (implicitSdks.Select (sdkPath => new MSBuildImport { Sdk = sdkPath, Project = "Sdk.targets" }));
 			}
 
 			// If there is a .user project file load it using a fake import item added at the end of the objects list

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -246,7 +246,7 @@ namespace MonoDevelop.Projects.MSBuild
 			context.InitEvaluation (pi.Project);
 			var objects = pi.Project.GetAllObjects ();
 
-			string[] implicitSdks = pi.Project.GetReferencedSDKs ().Where(x => x.Implicit).Select(x => x.QualifiedName).ToArray();
+			string[] implicitSdks = pi.Project.GetReferencedSDKs (true, false);
 			if(implicitSdks.Length > 0) {
 				var rootProject = pi.GetRootMSBuildProject ();
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildImport.cs
@@ -73,13 +73,19 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public string Sdk {
 			get { return sdk; }
-			set { AssertCanModify (); sdk = value; NotifyImportChanged (); }
+			set { AssertCanModify (); sdk = value; NotifyImportChanged (); NotifySdkChanged (); }
 		}
 
 		void NotifyImportChanged ()
 		{
 			if (ParentProject != null)
 				ParentProject.NotifyImportChanged ();
+		}
+
+		void NotifySdkChanged ()
+		{
+			if (ParentProject != null)
+				ParentProject.NotifySdkChanged ();
 		}
 
 		internal override void Write (XmlWriter writer, WriteContext context)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -1043,6 +1043,10 @@ namespace MonoDevelop.Projects.MSBuild
 		/// </summary>
 		public string[] GetReferencedSDKs (bool includeImplicitSdks, bool includeExplicitSdks)
 		{
+			if(sdkArray == null) {
+				GenerateSdkArray ();
+			}
+
 			if (includeImplicitSdks && includeExplicitSdks) {
 				return sdkArray;
 			} else if (includeImplicitSdks) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -601,29 +601,6 @@ namespace MonoDevelop.Projects.MSBuild
 			sdkArray = explicitSdks.Concat (implicitSdks).ToArray ();
 		}
 
-		void ClearAllSdks()
-		{
-			sdk = null;
-
-			foreach(MSBuildSdk sdkNode in GetChildren ().OfType<MSBuildSdk> ()) {
-				Remove (sdkNode);
-			}
-
-			foreach(MSBuildImport import in Imports) {
-				if(import.Sdk != null) {
-					Remove (import);
-				}
-			}
-
-			foreach(MSBuildImportGroup importGroup in ImportGroups) {
-				foreach(MSBuildImport import in importGroup.Imports) {
-					if(import.Sdk != null) {
-						importGroup.RemoveImport (import);
-					}
-				}
-			}
-		}
-
 		string sdk;
 		public string Sdk {
 			get => sdk;
@@ -1076,23 +1053,6 @@ namespace MonoDevelop.Projects.MSBuild
 				return Array.Empty<string> ();
 			}
 		}
-
-		/// <summary>
-		/// Sets the Sdk attribute for the current project. This will clear every other previous definition
-		/// and will set an explicit sdk attribute on the project node.
-		/// </summary>
-		public void SetProjectSdk(string sdk)
-		{
-			string currentSdk = string.Join (";", GetReferencedSDKs ());
-			if (sdk != currentSdk) {
-				// Setting an Sdk will reset to the default set to the project (i.e. remove any Sdk node,
-				// and all Sdk imports
-				ClearAllSdks ();
-				Sdk = sdk;
-				NotifySdkChanged ();
-			}
-		}
-
 
 		XmlNamespaceManager GetNamespaceManagerForProject ()
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildSdk.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildSdk.cs
@@ -1,0 +1,86 @@
+//
+// MSBuildSdk.cs
+//
+// Author:
+//       Mathieu Bourgeois <mathieubourgeois1338@gmail.com>
+//
+// Copyright (c) 2015 Xamarin, Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Xml;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoDevelop.Projects.MSBuild
+{
+	public class MSBuildSdk : MSBuildElement
+	{
+		static readonly string[] knownAttributes = { "Name", "Version" };
+
+		internal override string[] GetKnownAttributes ()
+		{
+			return knownAttributes;
+		}
+
+		private string name;
+		public string Name {
+			get { return name; }
+			set { AssertCanModify (); name = value; NotifySdkChanged (); }
+		}
+
+		private string version;
+		public string Version {
+			get { return version; }
+			set { AssertCanModify (); version = value; NotifySdkChanged (); }
+		}
+
+		void NotifySdkChanged ()
+		{
+			if (ParentProject != null)
+				ParentProject.NotifySdkChanged ();
+		}
+
+		internal override string GetElementName ()
+		{
+			return "Sdk";
+		}
+
+		internal override void ReadAttribute (string name, string value)
+		{
+			if (name == "Name")
+				Name = value;
+			else if (name == "Version")
+				Version = value;
+			else
+				base.ReadAttribute (name, value);
+		}
+
+		internal override string WriteAttribute (string name)
+		{
+			if (name == "Name")
+				return Name;
+			else if (name == "Version")
+				return Version;
+			else
+				return base.WriteAttribute (name);
+		}
+	}
+}
+

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1450,7 +1450,7 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		static string[] GetTargetFrameworks (MSBuildProject project)
 		{
-			if (string.IsNullOrEmpty (project.GetProjectSdksName()))
+			if (project.GetReferencedSDKs().Length == 0)
 				return null;
 
 			var propertyGroup = project.GetGlobalPropertyGroup ();
@@ -1561,7 +1561,7 @@ namespace MonoDevelop.Projects
 			if (projectSdks.Length > 0) {
 				if (sdks == null)
 					sdks = new HashSet<string> ();
-				sdks.UnionWith (projectSdks.Select(x => x.QualifiedName));
+				sdks.UnionWith (projectSdks);
 			}
 
 			var dotNetProject = project as DotNetProject;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1450,7 +1450,7 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		static string[] GetTargetFrameworks (MSBuildProject project)
 		{
-			if (string.IsNullOrEmpty (project.Sdk))
+			if (string.IsNullOrEmpty (project.GetProjectSdksName()))
 				return null;
 
 			var propertyGroup = project.GetGlobalPropertyGroup ();
@@ -1561,7 +1561,7 @@ namespace MonoDevelop.Projects
 			if (projectSdks.Length > 0) {
 				if (sdks == null)
 					sdks = new HashSet<string> ();
-				sdks.UnionWith (projectSdks);
+				sdks.UnionWith (projectSdks.Select(x => x.QualifiedName));
 			}
 
 			var dotNetProject = project as DotNetProject;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DotNetCoreProjectTests.cs
@@ -60,5 +60,38 @@ namespace MonoDevelop.Ide.Projects
 				Assert.AreEqual (expectedProjectXml, projectXml);
 			}
 		}
+
+		[Test]
+		public async Task LoadDotNetCoreProjectWithProjectSdkAttribute()
+		{
+			FilePath projFile = Util.GetSampleProject ("DotNetCoreSdkFormat", "DotNetCoreProjectSdk", "DotNetCoreProjectSdk.csproj");
+
+			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				Assert.AreEqual (p.MSBuildProject.GetProjectSdksName (), "Microsoft.NET.Sdk");
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs ().Where (x => x.Implicit).Count (), 1);
+			}
+		}
+
+		[Test]
+		public async Task LoadDotNetCoreProjectWithSdkNode ()
+		{
+			FilePath projFile = Util.GetSampleProject ("DotNetCoreSdkFormat", "DotNetCoreSdkNode", "DotNetCoreSdkNode.csproj");
+
+			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				Assert.AreEqual (p.MSBuildProject.GetProjectSdksName (), "Microsoft.NET.Sdk");
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs ().Where (x => x.Implicit).Count (), 1);
+			}
+		}
+
+		[Test]
+		public async Task LoadDotNetCoreProjectWithSdkImports ()
+		{
+			FilePath projFile = Util.GetSampleProject ("DotNetCoreSdkFormat", "DotNetCoreImportSdk", "DotNetCoreImportSdk.csproj");
+
+			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				Assert.AreEqual (p.MSBuildProject.GetProjectSdksName (), "Microsoft.NET.Sdk");
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs ().Where (x => x.Implicit).Count (), 0);
+			}
+		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/DotNetCoreProjectTests.cs
@@ -67,8 +67,8 @@ namespace MonoDevelop.Ide.Projects
 			FilePath projFile = Util.GetSampleProject ("DotNetCoreSdkFormat", "DotNetCoreProjectSdk", "DotNetCoreProjectSdk.csproj");
 
 			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
-				Assert.AreEqual (p.MSBuildProject.GetProjectSdksName (), "Microsoft.NET.Sdk");
-				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs ().Where (x => x.Implicit).Count (), 1);
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs (), new string[] { "Microsoft.NET.Sdk" });
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs (true, false).Length, 1);
 			}
 		}
 
@@ -78,8 +78,8 @@ namespace MonoDevelop.Ide.Projects
 			FilePath projFile = Util.GetSampleProject ("DotNetCoreSdkFormat", "DotNetCoreSdkNode", "DotNetCoreSdkNode.csproj");
 
 			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
-				Assert.AreEqual (p.MSBuildProject.GetProjectSdksName (), "Microsoft.NET.Sdk");
-				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs ().Where (x => x.Implicit).Count (), 1);
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs (), new string[] { "Microsoft.NET.Sdk" });
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs (true, false).Length, 1);
 			}
 		}
 
@@ -89,8 +89,8 @@ namespace MonoDevelop.Ide.Projects
 			FilePath projFile = Util.GetSampleProject ("DotNetCoreSdkFormat", "DotNetCoreImportSdk", "DotNetCoreImportSdk.csproj");
 
 			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
-				Assert.AreEqual (p.MSBuildProject.GetProjectSdksName (), "Microsoft.NET.Sdk");
-				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs ().Where (x => x.Implicit).Count (), 0);
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs (), new string[] { "Microsoft.NET.Sdk" });
+				Assert.AreEqual (p.MSBuildProject.GetReferencedSDKs (true, false).Length, 0);
 			}
 		}
 	}

--- a/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreImportSdk/DotNetCoreImportSdk.csproj
+++ b/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreImportSdk/DotNetCoreImportSdk.csproj
@@ -1,0 +1,10 @@
+<Project>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>DotNetCoreImportSdk</AssemblyName>
+    <RootNamespace>DotNetCoreImportSdk</RootNamespace>
+  </PropertyGroup>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+</Project>

--- a/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreImportSdk/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreImportSdk/MyClass.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace DotNetCoreImportSdk
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreProjectSdk/Class1.cs
+++ b/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreProjectSdk/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace DotNetCoreProjectSdk
+{
+    public class Class1
+    {
+    }
+}

--- a/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreProjectSdk/DotNetCoreProjectSdk.csproj
+++ b/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreProjectSdk/DotNetCoreProjectSdk.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>DotNetCoreProjectSdk</AssemblyName>
+    <RootNamespace>DotNetCoreProjectSdk</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreSdkNode/DotNetCoreSdkNode.csproj
+++ b/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreSdkNode/DotNetCoreSdkNode.csproj
@@ -1,0 +1,9 @@
+<Project>
+  <Sdk Name="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>DotNetCoreSdkNode</AssemblyName>
+    <RootNamespace>DotNetCoreSdkNode</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreSdkNode/MyClass.cs
+++ b/main/tests/test-projects/DotNetCoreSdkFormat/DotNetCoreSdkNode/MyClass.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace DotNetCoreSdkNode
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58564 (I couldn't find an equivalent on the Github issues)

MsBuild has 3 methods of defining an SDK:
- Sdk attribute on the Project node
- Sdk node as a child of the Project node
- Sdk attribute on any Import. This permits explicit imports

Currently, MonoDevelop only supports the first one. Adding support for the other two cases, including not doing any implicit importing if the project already does so.