### PR TITLE
Disable failing test: CreateMultiPlatformProjectFromTemplateWithPCLOnly

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Tests/MonoDevelop.Packaging.Tests/ProjectTemplateTests.cs
@@ -156,6 +156,7 @@ namespace MonoDevelop.Packaging.Tests
 		}
 
 		[Test]
+		[Ignore] // https://github.com/mono/monodevelop/issues/5602
 		public async Task CreateMultiPlatformProjectFromTemplateWithPCLOnly ()
 		{
 			string templateId = "MonoDevelop.Packaging.CrossPlatformLibrary";


### PR DESCRIPTION
https://github.com/mono/monodevelop/issues/5602 tracks fixing and reenabling.