### PR TITLE
Fixes VSTS Bug 659996: [Feedback] VS Mac 2017 - Pick members to

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.PickMembersService/PickMembersDialog.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.PickMembersService/PickMembersDialog.cs
@@ -166,13 +166,15 @@ namespace MonoDevelop.Refactoring.PickMembersService
 				treeStore.SetValue (row, symbolTextField, member.ToDisplayString (memberDisplayFormat));
 				treeStore.SetValue (row, symbolIconField, ImageService.GetIcon (MonoDevelop.Ide.TypeSystem.Stock.GetStockIcon (member)));
 			}
-			foreach (var option in options) {
-				var checkBox = new CheckBox (option.Title);
-				checkBox.State = option.Value ? CheckBoxState.On : CheckBoxState.Off;
-				checkBox.Toggled += delegate {
-					option.Value = !option.Value;
-				};
-				contentVBox.PackStart (checkBox);
+			if (!options.IsDefaultOrEmpty) {
+				foreach (var option in options) {
+					var checkBox = new CheckBox (option.Title);
+					checkBox.State = option.Value ? CheckBoxState.On : CheckBoxState.Off;
+					checkBox.Toggled += delegate {
+						option.Value = !option.Value;
+					};
+					contentVBox.PackStart (checkBox);
+				}
 			}
 		}
 


### PR DESCRIPTION
override for a class window doesn't render options correctly

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/659996

Can't reproduce what's seen in the screenshot howover this test case
fails for me which is fixed by that patch.