### PR TITLE
[Telemetry] Fix editor keypress telemetry to not report overflowed va…

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1250,7 +1250,7 @@ namespace Mono.TextEditor
 			if (currentFocus == FocusMargin.TextView) {
 				long time;
 #if MAC
-				time = (long)AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp;
+				time = (long)TimeSpan.FromSeconds (AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp).TotalMilliseconds;
 #else
 				// Warning, Gdk returns uint32 as time value, so this might overflow.
 				time = evt.Time;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1248,7 +1248,14 @@ namespace Mono.TextEditor
 		protected override bool OnKeyPressEvent (Gdk.EventKey evt)
 		{
 			if (currentFocus == FocusMargin.TextView) {
-				keyPressTimings.StartTimer (evt);
+				long time;
+#if MAC
+				time = (long)AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp;
+#else
+				// Warning, Gdk returns uint32 as time value, so this might overflow.
+				time = evt.Time;
+#endif
+				keyPressTimings.StartTimer (time);
 				return HandleTextKey (evt);
 			} else if (currentFocus != FocusMargin.None) {
 				return HandleMarginKeyCommand (evt);

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -100,6 +100,9 @@
       <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Xamarin.Mac" Condition=" '$(Configuration)' == 'DebugMac' Or '$(Configuration)' == 'ReleaseMac' ">
+      <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="MonoDevelop.SourceEditor.dll.config">

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -102,6 +102,7 @@
     </Reference>
     <Reference Include="Xamarin.Mac" Condition=" '$(Configuration)' == 'DebugMac' Or '$(Configuration)' == 'ReleaseMac' ">
       <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorKeyPressTimingsTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorKeyPressTimingsTests.cs
@@ -1,0 +1,55 @@
+//
+// TextEditorKeyPressTimingsTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Threading;
+using MonoDevelop.Ide;
+using NUnit.Framework;
+
+namespace Mono.TextEditor.Tests
+{
+	[TestFixture]
+	class TextEditorKeyPressTimingsTests : TextEditorTestBase
+	{
+		[Test]
+		public void TestSimpleTimer ()
+		{
+			var timings = new TextEditorKeyPressTimings ();
+
+			var telemetry = DesktopService.PlatformTelemetry;
+			if (telemetry == null)
+				Assert.Ignore ("Platform does not implement telemetry details");
+
+			var time = (long)telemetry.TimeSinceMachineStart.TotalMilliseconds;
+			timings.StartTimer (time);
+			Thread.Sleep (800);
+			timings.EndTimer ();
+
+			var metadata = timings.GetTypingTimingMetadata (null);
+			Assert.That (metadata.First, Is.GreaterThan (800.0));
+			Assert.That (metadata.First, Is.LessThanOrEqualTo (1600));
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/MonoDevelop.TextEditor.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Mono.TextEditor.Tests\DiffTrackerTests.cs" />
     <Compile Include="Mono.TextEditor.Tests\TextViewTests.cs" />
     <Compile Include="Mono.TextEditor.Tests\TextLinkModeTests.cs" />
+    <Compile Include="Mono.TextEditor.Tests\TextEditorKeyPressTimingsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">


### PR DESCRIPTION
…lues

TimeSinceMachineStart was a long value, while gdk event time is
an uint32 value which would overflow and reset from 0.

To prevent this issue, we're now requesting a long value by default
which we can pass from native APIs.

Current gdk event is translated from an NSEvent, so we can assume
GdkEvent.Current is translated from the actual current NSEvent.

Fixes VSTS #659150 - xs/editor/textcommandtiming/typechar has very large values in GeoCountryRegionIso == 'US'