### PR TITLE
[Ide] Add "log verbosity" setting back

### DIFF
--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.OptionPanels.BuildPanelWidget.cs
@@ -15,6 +15,8 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 
 		private global::Gtk.CheckButton skipBuildingUnmodifiedProjectsCheckbox;
 
+		private global::Gtk.ComboBox verbosityCombo;
+
 		private global::Gtk.Label buildAndRunOptionsLabel;
 
 		private global::Gtk.HBox hbox44;
@@ -87,6 +89,28 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			w4.Position = 3;
 			w4.Expand = false;
 			w4.Fill = false;
+			// Log verbosity settings
+			var logContainer = new global::Gtk.HBox ();
+			logContainer.Spacing = 6;
+			var label = new global::Gtk.Label();		
+ 			label.Name = "label1";		
+ 			label.LabelProp = global::Mono.Unix.Catalog.GetString("Log _verbosity:");		
+ 			label.UseUnderline = true;
+			logContainer.PackStart (label, false, false, 6);
+			this.verbosityCombo = global::Gtk.ComboBox.NewText ();
+			this.verbosityCombo.AppendText (global::Mono.Unix.Catalog.GetString ("Quiet"));
+			this.verbosityCombo.AppendText (global::Mono.Unix.Catalog.GetString ("Minimal"));
+			this.verbosityCombo.AppendText (global::Mono.Unix.Catalog.GetString ("Normal"));
+			this.verbosityCombo.AppendText (global::Mono.Unix.Catalog.GetString ("Detailed"));
+			this.verbosityCombo.AppendText (global::Mono.Unix.Catalog.GetString ("Diagnostic"));
+			this.verbosityCombo.Name = "verbosityCombo";
+			this.verbosityCombo.Active = 2;
+			logContainer.PackStart (this.verbosityCombo, false, false, 6);
+			this.vbox66.Add (logContainer);
+			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox66 [logContainer]));
+			w5.Position = 4;
+			w5.Expand = false;
+			w5.Fill = false;
 			// Container child vbox66.Gtk.Box+BoxChild
 			this.skipBuildingUnmodifiedProjectsCheckbox = new global::Gtk.CheckButton();
 			this.skipBuildingUnmodifiedProjectsCheckbox.CanFocus = true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/BuildPanel.cs
@@ -61,6 +61,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			noSaveRadioButton.Active = action == BeforeCompileAction.Nothing;
 			runWithWarningsCheckBox.Active = IdeApp.Preferences.RunWithWarnings;
 			buildBeforeRunCheckBox.Active = IdeApp.Preferences.BuildBeforeExecuting;
+			verbosityCombo.Active = (int)IdeApp.Preferences.MSBuildVerbosity.Value;
 			buildBeforeTestCheckBox.Active = IdeApp.Preferences.BuildBeforeRunningTests;
 			skipBuildingUnmodifiedProjectsCheckbox.Active = Runtime.Preferences.SkipBuildingUnmodifiedProjects;
 			parallelBuildCheckbox.Active = MonoDevelop.Core.Runtime.Preferences.ParallelBuild.Value;
@@ -87,12 +88,16 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			                                                    GettextCatalog.GetString ("Check to not save changes before building"));
 			promptChangesRadioButton.SetCommonAccessibilityAttributes ("BuildPanel.promptSave", "",
 			                                                           GettextCatalog.GetString ("Check to be prompted to save changes before building"));
+
+			verbosityCombo.SetCommonAccessibilityAttributes ("BuildPanel.verbosity", "",
+			                                                 GettextCatalog.GetString ("Select the verbosity level of the build"));
 		}
 		
 		public void Store ()
 		{
 			IdeApp.Preferences.RunWithWarnings.Value = runWithWarningsCheckBox.Active;
 			IdeApp.Preferences.BuildBeforeExecuting.Value = buildBeforeRunCheckBox.Active;
+			IdeApp.Preferences.MSBuildVerbosity.Value = (MSBuildVerbosity)verbosityCombo.Active;
 			IdeApp.Preferences.BuildBeforeRunningTests.Value = buildBeforeTestCheckBox.Active;
 			Runtime.Preferences.SkipBuildingUnmodifiedProjects.Value = skipBuildingUnmodifiedProjectsCheckbox.Active;
 			MonoDevelop.Core.Runtime.Preferences.ParallelBuild.Value = parallelBuildCheckbox.Active;


### PR DESCRIPTION
This was removed because structured build output was going to be the
only way to view the output, and it needed diagnostics build always, but
that adds some problems with the old build output on large projects,
which make the output be truncated, so quite useless.

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/645913