### PR TITLE
Refactor MonoDevelopWorkspace into logical components

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.DocumentMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.DocumentMap.cs
@@ -1,0 +1,88 @@
+//
+// MonoDevelopWorkspace.DocumentMap.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class DocumentMap
+		{
+			readonly Dictionary<string, DocumentId> documentIdMap = new Dictionary<string, DocumentId> (FilePath.PathComparer);
+			readonly ProjectId projectId;
+
+			public DocumentMap (ProjectId projectId)
+			{
+				this.projectId = projectId;
+			}
+
+			internal DocumentId GetOrCreate (string name, ProjectData previous)
+			{
+				var oldId = previous?.DocumentData.Get (name);
+				if (oldId != null) {
+					Add (oldId, name);
+					return oldId;
+				}
+				return GetOrCreate (name);
+			}
+
+			internal DocumentId GetOrCreate (string name)
+			{
+				lock (documentIdMap) {
+					if (!documentIdMap.TryGetValue (name, out DocumentId result)) {
+						documentIdMap[name] = result = DocumentId.CreateNewId (projectId, name);
+					}
+					return result;
+				}
+			}
+
+			internal void Add (DocumentId id, string name)
+			{
+				lock (documentIdMap) {
+					documentIdMap [name] = id;
+				}
+			}
+
+			public DocumentId Get (string name)
+			{
+				lock (documentIdMap) {
+					documentIdMap.TryGetValue (name, out DocumentId result);
+					return result;
+				}
+			}
+
+			internal void Remove (string name)
+			{
+				lock (documentIdMap) {
+					documentIdMap.Remove (name);
+				}
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.DocumentMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.DocumentMap.cs
@@ -42,9 +42,9 @@ namespace MonoDevelop.Ide.TypeSystem
 				this.projectId = projectId;
 			}
 
-			internal DocumentId GetOrCreate (string name, ProjectData previous)
+			internal DocumentId GetOrCreate (string name, DocumentMap previous)
 			{
-				var oldId = previous?.DocumentData.Get (name);
+				var oldId = previous?.Get (name);
 				if (oldId != null) {
 					Add (oldId, name);
 					return oldId;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.MetadataReferenceHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.MetadataReferenceHandler.cs
@@ -1,0 +1,203 @@
+//
+// MonoDevelopWorkspace.MetadataReferenceHandler.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class MetadataReferenceHandler
+		{
+			static readonly string [] DefaultAssemblies = {
+				typeof(string).Assembly.Location,                                // mscorlib
+				typeof(System.Text.RegularExpressions.Regex).Assembly.Location,  // System
+				typeof(System.Linq.Enumerable).Assembly.Location,                // System.Core
+				typeof(System.Data.VersionNotFoundException).Assembly.Location,  // System.Data
+				typeof(System.Xml.XmlDocument).Assembly.Location,                // System.Xml
+			};
+
+			readonly MonoDevelopMetadataReferenceManager manager;
+			readonly ProjectDataMap projectMap;
+			public MetadataReferenceHandler (MonoDevelopMetadataReferenceManager manager, ProjectDataMap projectMap)
+			{
+				this.manager = manager;
+				this.projectMap = projectMap;
+			}
+
+			ImmutableArray<MonoDevelopMetadataReference> CreateDefaultMetadataReferences ()
+			{
+				var builder = ImmutableArray.CreateBuilder<MonoDevelopMetadataReference> (DefaultAssemblies.Length);
+
+				foreach (var asm in DefaultAssemblies) {
+					var metadataReference = manager.GetOrCreateMetadataReference (asm, MetadataReferenceProperties.Assembly);
+					builder.Add (metadataReference);
+				}
+				return builder.MoveToImmutable ();
+			}
+
+			public async Task<(ImmutableArray<MonoDevelopMetadataReference>, ImmutableArray<ProjectReference>)> CreateReferences (MonoDevelop.Projects.Project proj, CancellationToken token)
+			{
+				var metadataReferences = await CreateMetadataReferences (proj, token).ConfigureAwait (false);
+				if (token.IsCancellationRequested)
+					return (ImmutableArray<MonoDevelopMetadataReference>.Empty, ImmutableArray<ProjectReference>.Empty);
+
+				var projectReferences = await CreateProjectReferences (proj, token).ConfigureAwait (false);
+				return (metadataReferences, projectReferences);
+			}
+
+			async Task<ImmutableArray<MonoDevelopMetadataReference>> CreateMetadataReferences (MonoDevelop.Projects.Project proj, CancellationToken token)
+			{
+				// create some default references for unsupported project types.
+				if (!(proj is MonoDevelop.Projects.DotNetProject netProject)) {
+					return CreateDefaultMetadataReferences ();
+				}
+
+				var data = new AddMetadataReferencesData {
+					Result = new List<MonoDevelopMetadataReference> (),
+					Project = netProject,
+					Visited = new HashSet<string> (FilePath.PathComparer),
+					ConfigurationSelector = IdeApp.Workspace?.ActiveConfiguration ?? MonoDevelop.Projects.ConfigurationSelector.Default,
+					Token = token,
+				};
+
+				if (!await AddMetadataAssemblyReferences (data))
+					return ImmutableArray<MonoDevelopMetadataReference>.Empty;
+
+				if (!AddMetadataProjectReferences (data))
+					return ImmutableArray<MonoDevelopMetadataReference>.Empty;
+				return data.Result.ToImmutableArray ();
+			}
+
+			class AddMetadataReferencesData
+			{
+				public List<MonoDevelopMetadataReference> Result;
+				public MonoDevelop.Projects.DotNetProject Project;
+				public MonoDevelop.Projects.ConfigurationSelector ConfigurationSelector;
+				public HashSet<string> Visited;
+				public CancellationToken Token;
+			}
+
+			async Task<bool> AddMetadataAssemblyReferences (AddMetadataReferencesData data)
+			{
+				try {
+					var referencedAssemblies = await data.Project.GetReferencedAssemblies (data.ConfigurationSelector, false).ConfigureAwait (false);
+					foreach (var file in referencedAssemblies) {
+						if (data.Token.IsCancellationRequested)
+							return false;
+
+						if (!data.Visited.Add (file.FilePath))
+							continue;
+
+						var aliases = file.EnumerateAliases ().ToImmutableArray ();
+						var metadataReference = manager.GetOrCreateMetadataReference (file.FilePath, new MetadataReferenceProperties (aliases: aliases));
+						if (metadataReference != null)
+							data.Result.Add (metadataReference);
+					}
+
+					return true;
+				} catch (Exception e) {
+					LoggingService.LogError ("Error while getting referenced assemblies", e);
+					// TODO: Check whether this should return false, I retained compat for now.
+					return true;
+				}
+			}
+
+			bool AddMetadataProjectReferences (AddMetadataReferencesData data)
+			{
+				try {
+					var referencedProjects = data.Project.GetReferencedItems (data.ConfigurationSelector);
+					foreach (var pr in referencedProjects) {
+						if (data.Token.IsCancellationRequested)
+							return false;
+
+						if (!(pr is MonoDevelop.Projects.DotNetProject referencedProject) || !TypeSystemService.IsOutputTrackedProject (referencedProject))
+							continue;
+
+						var fileName = referencedProject.GetOutputFileName (data.ConfigurationSelector);
+						if (!data.Visited.Add (fileName))
+							continue;
+
+						var metadataReference = manager.GetOrCreateMetadataReference (fileName, MetadataReferenceProperties.Assembly);
+						if (metadataReference != null)
+							data.Result.Add (metadataReference);
+					}
+				} catch (Exception e) {
+					LoggingService.LogError ("Error while getting referenced assemblies", e);
+					// TODO: Check whether this should return false, I retained compat for now.
+					return true;
+				}
+
+				return true;
+			}
+
+			async Task<ImmutableArray<ProjectReference>> CreateProjectReferences (MonoDevelop.Projects.Project p, CancellationToken token)
+			{
+				if (!(p is MonoDevelop.Projects.DotNetProject netProj))
+					return ImmutableArray<ProjectReference>.Empty;
+
+				List<MonoDevelop.Projects.AssemblyReference> references;
+				try {
+					var config = IdeApp.Workspace?.ActiveConfiguration ?? MonoDevelop.Projects.ConfigurationSelector.Default;
+					references = await netProj.GetReferences (config, token).ConfigureAwait (false);
+				} catch (Exception e) {
+					LoggingService.LogError ("Error while getting referenced projects.", e);
+					return ImmutableArray<ProjectReference>.Empty;
+				};
+				return CreateProjectReferencesFromAssemblyReferences (netProj, references).ToImmutableArray ();
+			}
+
+			IEnumerable<ProjectReference> CreateProjectReferencesFromAssemblyReferences (MonoDevelop.Projects.DotNetProject p, List<MonoDevelop.Projects.AssemblyReference> references)
+			{
+				var addedProjects = new HashSet<MonoDevelop.Projects.DotNetProject> ();
+
+				foreach (var pr in references) {
+					if (!pr.IsProjectReference || !pr.ReferenceOutputAssembly)
+						continue;
+
+					var referencedItem = pr.GetReferencedItem (p.ParentSolution);
+					if (!(referencedItem is MonoDevelop.Projects.DotNetProject referencedProject))
+						continue;
+
+					if (!addedProjects.Add (referencedProject))
+						continue;
+
+					if (TypeSystemService.IsOutputTrackedProject (referencedProject))
+						continue;
+
+					var aliases = pr.EnumerateAliases ();
+					yield return new ProjectReference (projectMap.GetOrCreateId (referencedProject, null), aliases.ToImmutableArray ());
+				}
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.OpenDocumentsData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.OpenDocumentsData.cs
@@ -1,0 +1,85 @@
+//
+// MonoDevelopWorkspace.OpenDocumentsData.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using MonoDevelop.Ide.Editor;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class OpenDocumentsData
+		{
+			readonly Dictionary<DocumentId, (SourceTextContainer Container, TextEditor Editor, DocumentContext Context)> openDocuments =
+				new Dictionary<DocumentId, (SourceTextContainer, TextEditor, DocumentContext)> ();
+
+			internal void Add (DocumentId documentId, SourceTextContainer container, TextEditor editor, DocumentContext context)
+			{
+				lock (openDocuments) {
+					openDocuments.Add (documentId, (container, editor, context));
+				}
+			}
+
+			internal bool Contains (DocumentId documentId)
+			{
+				lock (openDocuments) {
+					return openDocuments.ContainsKey (documentId);
+				}
+			}
+
+			internal bool Remove (DocumentId documentId)
+			{
+				lock (openDocuments) {
+					return openDocuments.Remove (documentId);
+				}
+			}
+
+			internal void CorrectDocumentIds (DotNetProject project, ProjectInfo projectInfo)
+			{
+				lock (openDocuments) {
+					foreach (var openDoc in openDocuments) {
+						if (openDoc.Value.Context.Project != project)
+							continue;
+
+						var doc = openDoc.Value.Context.AnalysisDocument;
+						if (doc == null)
+							continue;
+
+						var newDocument = projectInfo.Documents.FirstOrDefault (d => d.FilePath == doc.FilePath);
+						if (newDocument == null || newDocument.Id == doc.Id)
+							continue;
+
+						openDoc.Value.Context.UpdateDocumentId (newDocument.Id);
+					}
+				}
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
@@ -41,13 +41,12 @@ namespace MonoDevelop.Ide.TypeSystem
 			readonly List<MonoDevelopMetadataReference> metadataReferences;
 			internal DocumentMap DocumentData { get; }
 
-			// FIXME: This should be an ImmutableArray
-			public ProjectData (ProjectId projectId, List<MonoDevelopMetadataReference> metadataReferences, MonoDevelopWorkspace ws)
+			public ProjectData (ProjectId projectId, ImmutableArray<MonoDevelopMetadataReference> metadataReferences, MonoDevelopWorkspace ws)
 			{
 				this.projectId = projectId;
 				workspaceRef = new WeakReference<MonoDevelopWorkspace> (ws);
 				DocumentData = new DocumentMap (projectId);
-				this.metadataReferences = new List<MonoDevelopMetadataReference> (metadataReferences.Count);
+				this.metadataReferences = new List<MonoDevelopMetadataReference> (metadataReferences.Length);
 
 				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
 				foreach (var metadataReference in metadataReferences) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
@@ -1,0 +1,103 @@
+//
+// MonoDevelopWorkspace.ProjectData.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class ProjectData : IDisposable
+		{
+			readonly WeakReference<MonoDevelopWorkspace> workspaceRef;
+			readonly ProjectId projectId;
+			readonly List<MonoDevelopMetadataReference> metadataReferences;
+			internal DocumentMap DocumentData { get; }
+
+			// FIXME: This should be an ImmutableArray
+			public ProjectData (ProjectId projectId, List<MonoDevelopMetadataReference> metadataReferences, MonoDevelopWorkspace ws)
+			{
+				this.projectId = projectId;
+				workspaceRef = new WeakReference<MonoDevelopWorkspace> (ws);
+				DocumentData = new DocumentMap (projectId);
+				this.metadataReferences = new List<MonoDevelopMetadataReference> (metadataReferences.Count);
+
+				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
+				foreach (var metadataReference in metadataReferences) {
+					AddMetadataReference_NoLock (metadataReference, ws);
+				}
+			}
+
+			void OnMetadataReferenceUpdated (object sender, EventArgs args)
+			{
+				var reference = (MonoDevelopMetadataReference)sender;
+				// If we didn't contain the reference, bail
+				if (!workspaceRef.TryGetTarget (out var workspace))
+					return;
+
+				lock (workspace.updatingProjectDataLock) {
+					if (!RemoveMetadataReference_NoLock (reference, workspace))
+						return;
+					workspace.OnMetadataReferenceRemoved (projectId, reference.CurrentSnapshot);
+
+					reference.UpdateSnapshot ();
+					AddMetadataReference_NoLock (reference, workspace);
+					workspace.OnMetadataReferenceAdded (projectId, reference.CurrentSnapshot);
+				}
+			}
+
+			internal void AddMetadataReference_NoLock (MonoDevelopMetadataReference metadataReference, MonoDevelopWorkspace ws)
+			{
+				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
+
+				metadataReferences.Add (metadataReference);
+				metadataReference.UpdatedOnDisk += OnMetadataReferenceUpdated;
+			}
+
+			internal bool RemoveMetadataReference_NoLock (MonoDevelopMetadataReference metadataReference, MonoDevelopWorkspace ws)
+			{
+				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
+
+				metadataReference.UpdatedOnDisk -= OnMetadataReferenceUpdated;
+				return metadataReferences.Remove (metadataReference);
+			}
+
+			public void Dispose ()
+			{
+				if (!workspaceRef.TryGetTarget (out var ws))
+					return;
+
+				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
+				foreach (var reference in metadataReferences)
+					reference.UpdatedOnDisk -= OnMetadataReferenceUpdated;
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
@@ -72,7 +72,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				}
 			}
 
-			internal void AddMetadataReference_NoLock (MonoDevelopMetadataReference metadataReference, MonoDevelopWorkspace ws)
+			void AddMetadataReference_NoLock (MonoDevelopMetadataReference metadataReference, MonoDevelopWorkspace ws)
 			{
 				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
 
@@ -80,7 +80,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				metadataReference.UpdatedOnDisk += OnMetadataReferenceUpdated;
 			}
 
-			internal bool RemoveMetadataReference_NoLock (MonoDevelopMetadataReference metadataReference, MonoDevelopWorkspace ws)
+			bool RemoveMetadataReference_NoLock (MonoDevelopMetadataReference metadataReference, MonoDevelopWorkspace ws)
 			{
 				System.Diagnostics.Debug.Assert (Monitor.IsEntered (ws.updatingProjectDataLock));
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
@@ -1,0 +1,142 @@
+//
+// MonoDevelopWorkspace.ProjectDataMap.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class ProjectDataMap
+		{
+			public MonoDevelopWorkspace Workspace { get; }
+			readonly object gate = new object ();
+
+			ImmutableDictionary<ProjectId, MonoDevelop.Projects.Project> projectIdToMdProjectMap = ImmutableDictionary<ProjectId, MonoDevelop.Projects.Project>.Empty;
+			readonly Dictionary<MonoDevelop.Projects.Project, ProjectId> projectIdMap = new Dictionary<MonoDevelop.Projects.Project, ProjectId> ();
+			// FIXME: Make this private
+			internal readonly Dictionary<ProjectId, ProjectData> projectDataMap = new Dictionary<ProjectId, ProjectData> ();
+
+			public ProjectDataMap (MonoDevelopWorkspace workspace)
+			{
+				Workspace = workspace;
+			}
+
+			internal ProjectId GetId (MonoDevelop.Projects.Project p)
+			{
+				lock (gate) {
+					return projectIdMap.TryGetValue (p, out ProjectId result) ? result : null;
+				}
+			}
+
+			internal ProjectId GetOrCreateId (MonoDevelop.Projects.Project p, MonoDevelop.Projects.Project oldProject)
+			{
+				lock (gate) {
+					var result = MigrateOldProjectInfo ();
+					if (result == null) {
+						projectIdMap [p] = result = ProjectId.CreateNewId (p.Name);
+						projectIdToMdProjectMap = projectIdToMdProjectMap.Add (result, p);
+					}
+					return result;
+				}
+
+				ProjectId MigrateOldProjectInfo ()
+				{
+					if (projectIdMap.TryGetValue (p, out var id))
+						return id;
+
+					p.Modified += Workspace.OnProjectModified;
+					if (oldProject == null)
+						return null;
+
+					oldProject.Modified -= Workspace.OnProjectModified;
+					if (projectIdMap.TryGetValue (oldProject, out id)) {
+						projectIdMap.Remove (oldProject);
+						projectIdMap [p] = id;
+						projectIdToMdProjectMap = projectIdToMdProjectMap.SetItem (id, p);
+					}
+					return id;
+				}
+			}
+
+			internal void RemoveProject (MonoDevelop.Projects.Project project, ProjectId id)
+			{
+				lock (gate) {
+					if (projectIdMap.TryGetValue (project, out ProjectId val))
+						projectIdMap.Remove (project);
+					projectIdToMdProjectMap = projectIdToMdProjectMap.Remove (val);
+				}
+
+				lock (Workspace.updatingProjectDataLock) {
+					projectDataMap.Remove (id);
+				}
+			}
+
+			internal MonoDevelop.Projects.Project GetMonoProject (ProjectId projectId)
+			{
+				lock (gate) {
+					return projectIdToMdProjectMap.TryGetValue (projectId, out var result) ? result : null;
+				}
+			}
+
+			internal bool Contains (ProjectId projectId)
+			{
+				lock (Workspace.updatingProjectDataLock) {
+					return projectDataMap.ContainsKey (projectId);
+				}
+			}
+
+			internal ProjectData GetData (ProjectId id)
+			{
+				lock (Workspace.updatingProjectDataLock) {
+					projectDataMap.TryGetValue (id, out ProjectData result);
+					return result;
+				}
+			}
+
+			internal ProjectData RemoveData (ProjectId id)
+			{
+				lock (Workspace.updatingProjectDataLock) {
+					if (projectDataMap.TryGetValue (id, out ProjectData result))
+						projectDataMap.Remove (id);
+					return result;
+				}
+			}
+
+			// FIXME: Should be ImmutableArray.
+			internal ProjectData CreateData (ProjectId id, List<MonoDevelopMetadataReference> metadataReferences)
+			{
+				lock (Workspace.updatingProjectDataLock) {
+					var result = new ProjectData (id, metadataReferences, Workspace);
+					projectDataMap [id] = result;
+					return result;
+				}
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
@@ -128,8 +128,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				}
 			}
 
-			// FIXME: Should be ImmutableArray.
-			internal ProjectData CreateData (ProjectId id, List<MonoDevelopMetadataReference> metadataReferences)
+			internal ProjectData CreateData (ProjectId id, ImmutableArray<MonoDevelopMetadataReference> metadataReferences)
 			{
 				lock (Workspace.updatingProjectDataLock) {
 					var result = new ProjectData (id, metadataReferences, Workspace);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -263,7 +263,7 @@ namespace MonoDevelop.Ide.TypeSystem
 							continue;
 						documents.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));
 					} else {
-						foreach (var projectedDocument in GenerateProjections (f, projectData.DocumentData, p, oldProjectData, duplicates)) {
+						foreach (var projectedDocument in GenerateProjections (f, projectData.DocumentData, p, oldProjectData, null)) {
 							var projectedId = projectData.DocumentData.GetOrCreate (projectedDocument.FilePath, oldProjectData);
 							if (!duplicates.Add (projectedId))
 								continue;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -1,0 +1,345 @@
+//
+// MonoDevelopWorkspace.ProjectSystemHandler.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Editor.Projection;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class ProjectSystemHandler
+		{
+			readonly MonoDevelopWorkspace workspace;
+			readonly ProjectDataMap projectMap;
+			readonly ProjectionData projections;
+			readonly Lazy<MetadataReferenceHandler> metadataHandler;
+
+			bool added;
+			readonly object addLock = new object ();
+
+			internal List<MonoDevelop.Projects.DotNetProject> modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
+			SolutionData solutionData;
+
+			public ProjectSystemHandler (MonoDevelopWorkspace workspace, ProjectDataMap projectMap, ProjectionData projections)
+			{
+				this.workspace = workspace;
+				this.projectMap = projectMap;
+				this.projections = projections;
+
+				metadataHandler = new Lazy<MetadataReferenceHandler> (() => new MetadataReferenceHandler (workspace.MetadataReferenceManager, projectMap));
+			}
+
+			#region Solution mapping
+			// No need to remove mappings, it's handled on workspace dispose.
+			readonly Dictionary<MonoDevelop.Projects.Solution, SolutionId> solutionIdMap = new Dictionary<MonoDevelop.Projects.Solution, SolutionId> ();
+
+			internal SolutionId GetSolutionId (MonoDevelop.Projects.Solution solution)
+			{
+				if (solution == null)
+					throw new ArgumentNullException (nameof (solution));
+
+				lock (solutionIdMap) {
+					if (!solutionIdMap.TryGetValue (solution, out SolutionId result)) {
+						solutionIdMap [solution] = result = SolutionId.CreateNewId (solution.Name);
+					}
+					return result;
+				}
+			}
+
+			static async void OnSolutionModified (object sender, MonoDevelop.Projects.WorkspaceItemEventArgs args)
+			{
+				var sol = (MonoDevelop.Projects.Solution)args.Item;
+				var workspace = await TypeSystemService.GetWorkspaceAsync (sol, CancellationToken.None);
+				var solId = workspace.ProjectHandler.GetSolutionId (sol);
+				if (solId == null)
+					return;
+
+				NotifySolutionModified (sol, solId, workspace);
+			}
+
+			static void NotifySolutionModified (MonoDevelop.Projects.Solution sol, SolutionId solId, MonoDevelopWorkspace workspace)
+			{
+				if (string.IsNullOrWhiteSpace (sol.BaseDirectory))
+					return;
+
+				var locService = (MonoDevelopPersistentStorageLocationService)workspace.Services.GetService<IPersistentStorageLocationService> ();
+				locService.NotifyStorageLocationChanging (solId, sol.GetPreferencesDirectory ());
+			}
+			#endregion
+
+			class SolutionData
+			{
+				public ConcurrentDictionary<string, TextLoader> Files = new ConcurrentDictionary<string, TextLoader> ();
+			}
+
+			internal async Task<ProjectInfo> LoadProject (MonoDevelop.Projects.Project p, CancellationToken token, MonoDevelop.Projects.Project oldProject)
+			{
+				var projectId = projectMap.GetOrCreateId (p, oldProject);
+
+				var config = IdeApp.Workspace != null ? p.GetConfiguration (IdeApp.Workspace.ActiveConfiguration) as MonoDevelop.Projects.DotNetProjectConfiguration : null;
+				MonoDevelop.Projects.DotNetCompilerParameters cp = config?.CompilationParameters;
+				FilePath fileName = IdeApp.Workspace != null ? p.GetOutputFileName (IdeApp.Workspace.ActiveConfiguration) : (FilePath)"";
+				if (fileName.IsNullOrEmpty)
+					fileName = new FilePath (p.Name + ".dll");
+
+				var (references, projectReferences) = await metadataHandler.Value.CreateReferences (p, token);
+				if (token.IsCancellationRequested)
+					return null;
+
+				var sourceFiles = await p.GetSourceFilesAsync (config?.Selector).ConfigureAwait (false);
+				if (token.IsCancellationRequested)
+					return null;
+
+				lock (workspace.updatingProjectDataLock) {
+					//when reloading e.g. after a save, preserve document IDs
+					using (var oldProjectData = projectMap.RemoveData (projectId)) {
+						var projectData = projectMap.CreateData (projectId, references);
+
+						var documents = CreateDocuments (projectData, p, token, sourceFiles, oldProjectData);
+						if (documents == null)
+							return null;
+
+						// TODO: Pass in the WorkspaceMetadataFileReferenceResolver
+						var info = ProjectInfo.Create (
+							projectId,
+							VersionStamp.Create (),
+							p.Name,
+							fileName.FileNameWithoutExtension,
+							LanguageNames.CSharp,
+							p.FileName,
+							fileName,
+							cp?.CreateCompilationOptions (),
+							cp?.CreateParseOptions (config),
+							documents.Item1,
+							projectReferences,
+							references.Select (x => x.CurrentSnapshot),
+							additionalDocuments: documents.Item2
+						);
+						return info;
+					}
+				}
+			}
+
+			async Task<ConcurrentBag<ProjectInfo>> CreateProjectInfos (IEnumerable<MonoDevelop.Projects.Project> mdProjects, CancellationToken token)
+			{
+				var projects = new ConcurrentBag<ProjectInfo> ();
+				var allTasks = new List<Task> ();
+
+				foreach (var proj in mdProjects) {
+					if (token.IsCancellationRequested)
+						return null;
+					if (proj is MonoDevelop.Projects.DotNetProject netProj && !netProj.SupportsRoslyn)
+						continue;
+					var tp = LoadProject (proj, token, null).ContinueWith (t => {
+						if (!t.IsCanceled)
+							projects.Add (t.Result);
+					});
+					allTasks.Add (tp);
+
+				}
+				await Task.WhenAll (allTasks.ToArray ()).ConfigureAwait (false);
+				if (token.IsCancellationRequested)
+					return null;
+
+				return projects;
+			}
+
+			bool IsModifiedWhileLoading (MonoDevelop.Projects.Solution solution)
+			{
+				List<MonoDevelop.Projects.DotNetProject> modifiedWhileLoading;
+				lock (workspace.projectModifyLock) {
+					modifiedWhileLoading = modifiedProjects;
+					modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
+				}
+
+				foreach (var project in modifiedWhileLoading) {
+					// TODO: Maybe optimize this so we don't do O(n^2)
+					if (solution.ContainsItem (project)) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			internal Task<SolutionInfo> CreateSolutionInfo (MonoDevelop.Projects.Solution sol, CancellationToken ct)
+			{
+				return Task.Run (delegate {
+					return CreateSolutionInfoInternal (sol, ct);
+				});
+
+				async Task<SolutionInfo> CreateSolutionInfoInternal (MonoDevelop.Projects.Solution solution, CancellationToken token)
+				{
+					using (var timer = Counters.AnalysisTimer.BeginTiming ()) {
+						projections.ClearOldProjectionList ();
+
+						solutionData = new SolutionData ();
+
+						var projectInfos = await CreateProjectInfos (solution.GetAllProjects (), token).ConfigureAwait (false);
+						if (IsModifiedWhileLoading (solution)) {
+							return await CreateSolutionInfoInternal (solution, token).ConfigureAwait (false);
+						}
+
+						var solutionId = GetSolutionId (solution);
+						var solutionInfo = SolutionInfo.Create (solutionId, VersionStamp.Create (), solution.FileName, projectInfos);
+
+						lock (addLock) {
+							if (!added) {
+								added = true;
+								solution.Modified += OnSolutionModified;
+								NotifySolutionModified (solution, solutionId, workspace);
+								workspace.OnSolutionAdded (solutionInfo);
+								lock (workspace.generatedFiles) {
+									foreach (var generatedFile in workspace.generatedFiles) {
+										if (!workspace.IsDocumentOpen (generatedFile.Key.Id))
+											workspace.OnDocumentOpened (generatedFile.Key.Id, generatedFile.Value);
+									}
+								}
+							}
+						}
+						return solutionInfo;
+					}
+				}
+			}
+
+			static bool CanGenerateAnalysisContextForNonCompileable (MonoDevelop.Projects.Project p, MonoDevelop.Projects.ProjectFile f)
+			{
+				var mimeType = DesktopService.GetMimeTypeForUri (f.FilePath);
+				var node = TypeSystemService.GetTypeSystemParserNode (mimeType, f.BuildAction);
+				if (node?.Parser == null)
+					return false;
+				return node.Parser.CanGenerateAnalysisDocument (mimeType, f.BuildAction, p.SupportedLanguages);
+			}
+
+			Tuple<List<DocumentInfo>, List<DocumentInfo>> CreateDocuments (ProjectData projectData, MonoDevelop.Projects.Project p, CancellationToken token, MonoDevelop.Projects.ProjectFile [] sourceFiles, ProjectData oldProjectData)
+			{
+				var documents = new List<DocumentInfo> ();
+				// We don' add additionalDocuments anymore because they were causing slowdown of compilation generation
+				// and no upside to setting additionalDocuments, keeping this around in case this changes in future.
+				var additionalDocuments = new List<DocumentInfo> ();
+				var duplicates = new HashSet<DocumentId> ();
+				// use given source files instead of project.Files because there may be additional files added by msbuild targets
+				foreach (var f in sourceFiles) {
+					if (token.IsCancellationRequested)
+						return null;
+					if (f.Subtype == MonoDevelop.Projects.Subtype.Directory)
+						continue;
+
+					if (TypeSystemParserNode.IsCompileableFile (f, out SourceCodeKind sck) || CanGenerateAnalysisContextForNonCompileable (p, f)) {
+						var id = projectData.DocumentData.GetOrCreate (f.Name, oldProjectData);
+						if (!duplicates.Add (id))
+							continue;
+						documents.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));
+					} else {
+						foreach (var projectedDocument in GenerateProjections (f, projectData.DocumentData, p, oldProjectData, duplicates)) {
+							var projectedId = projectData.DocumentData.GetOrCreate (projectedDocument.FilePath, oldProjectData);
+							if (!duplicates.Add (projectedId))
+								continue;
+							documents.Add (projectedDocument);
+						}
+					}
+				}
+				var projectId = projectMap.GetId (p);
+				lock (workspace.generatedFiles) {
+					foreach (var generatedFile in workspace.generatedFiles) {
+						if (generatedFile.Key.Id.ProjectId == projectId)
+							documents.Add (generatedFile.Key);
+					}
+				}
+				return Tuple.Create (documents, additionalDocuments);
+			}
+
+			IEnumerable<DocumentInfo> GenerateProjections (MonoDevelop.Projects.ProjectFile f, DocumentMap documentMap, MonoDevelop.Projects.Project p, ProjectData oldProjectData, HashSet<DocumentId> duplicates)
+			{
+				var mimeType = DesktopService.GetMimeTypeForUri (f.FilePath);
+				var node = TypeSystemService.GetTypeSystemParserNode (mimeType, f.BuildAction);
+				if (node == null || !node.Parser.CanGenerateProjection (mimeType, f.BuildAction, p.SupportedLanguages))
+					yield break;
+				var options = new ParseOptions {
+					FileName = f.FilePath,
+					Project = p,
+					Content = TextFileProvider.Instance.GetReadOnlyTextEditorData (f.FilePath),
+				};
+				var generatedProjections = node.Parser.GenerateProjections (options);
+				var list = new List<Projection> ();
+				var entry = new ProjectionEntry {
+					File = f,
+					Projections = list,
+				};
+
+				foreach (var projection in generatedProjections.Result) {
+					list.Add (projection);
+					if (duplicates != null && !duplicates.Add (documentMap.GetOrCreate (projection.Document.FileName, oldProjectData)))
+						continue;
+					var plainName = projection.Document.FileName.FileName;
+					var folders = GetFolders (p.Name, f);
+					yield return DocumentInfo.Create (
+						documentMap.GetOrCreate (projection.Document.FileName, oldProjectData),
+						plainName,
+						folders,
+						SourceCodeKind.Regular,
+						TextLoader.From (TextAndVersion.Create (new MonoDevelopSourceText (projection.Document), VersionStamp.Create (), projection.Document.FileName)),
+						projection.Document.FileName,
+						false
+					);
+				}
+				projections.AddProjectionEntry (entry);
+			}
+
+			static DocumentInfo CreateDocumentInfo (SolutionData data, string projectName, ProjectData id, MonoDevelop.Projects.ProjectFile f, SourceCodeKind sourceCodeKind)
+			{
+				var filePath = f.FilePath;
+				var folders = GetFolders (projectName, f);
+
+				return DocumentInfo.Create (
+					id.DocumentData.GetOrCreate (filePath),
+					filePath,
+					folders,
+					sourceCodeKind,
+					CreateTextLoader (f.Name),
+					f.Name,
+					isGenerated: false
+				);
+
+				TextLoader CreateTextLoader (string fileName) => data.Files.GetOrAdd (fileName, a => new MonoDevelopTextLoader (a));
+			}
+
+			static IEnumerable<string> GetFolders (string projectName, MonoDevelop.Projects.ProjectFile f)
+			{
+				return new [] { projectName }.Concat (f.ProjectVirtualPath.ParentDirectory.ToString ().Split (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -258,13 +258,13 @@ namespace MonoDevelop.Ide.TypeSystem
 						continue;
 
 					if (TypeSystemParserNode.IsCompileableFile (f, out SourceCodeKind sck) || CanGenerateAnalysisContextForNonCompileable (p, f)) {
-						var id = projectData.DocumentData.GetOrCreate (f.Name, oldProjectData);
+						var id = projectData.DocumentData.GetOrCreate (f.Name, oldProjectData?.DocumentData);
 						if (!duplicates.Add (id))
 							continue;
 						documents.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f, sck));
 					} else {
 						foreach (var projectedDocument in GenerateProjections (f, projectData.DocumentData, p, oldProjectData, null)) {
-							var projectedId = projectData.DocumentData.GetOrCreate (projectedDocument.FilePath, oldProjectData);
+							var projectedId = projectData.DocumentData.GetOrCreate (projectedDocument.FilePath, oldProjectData?.DocumentData);
 							if (!duplicates.Add (projectedId))
 								continue;
 							documents.Add (projectedDocument);
@@ -301,12 +301,12 @@ namespace MonoDevelop.Ide.TypeSystem
 
 				foreach (var projection in generatedProjections.Result) {
 					list.Add (projection);
-					if (duplicates != null && !duplicates.Add (documentMap.GetOrCreate (projection.Document.FileName, oldProjectData)))
+					if (duplicates != null && !duplicates.Add (documentMap.GetOrCreate (projection.Document.FileName, oldProjectData?.DocumentData)))
 						continue;
 					var plainName = projection.Document.FileName.FileName;
 					var folders = GetFolders (p.Name, f);
 					yield return DocumentInfo.Create (
-						documentMap.GetOrCreate (projection.Document.FileName, oldProjectData),
+						documentMap.GetOrCreate (projection.Document.FileName, oldProjectData?.DocumentData),
 						plainName,
 						folders,
 						SourceCodeKind.Regular,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectionData.cs
@@ -1,0 +1,133 @@
+//
+// MonoDevelopWorkspace.ProjectionData.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Editor.Projection;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal class ProjectionData
+		{
+			readonly object projectionListUpdateLock = new object ();
+
+			ImmutableList<ProjectionEntry> projectionList = ImmutableList<ProjectionEntry>.Empty;
+			internal IReadOnlyList<ProjectionEntry> ProjectionList => projectionList;
+
+			internal void AddProjectionEntry (ProjectionEntry entry)
+			{
+				lock (projectionListUpdateLock)
+					projectionList = projectionList.Add (entry);
+			}
+
+			internal void UpdateProjectionEntry (MonoDevelop.Projects.ProjectFile projectFile, IReadOnlyList<Projection> projections)
+			{
+				if (projectFile == null)
+					throw new ArgumentNullException (nameof (projectFile));
+				if (projections == null)
+					throw new ArgumentNullException (nameof (projections));
+
+				lock (projectionListUpdateLock) {
+					foreach (var entry in projectionList) {
+						if (entry?.File?.FilePath == projectFile.FilePath) {
+							projectionList = projectionList.Remove (entry);
+							// Since it's disposing projected editor, it needs to dispose in MainThread.
+							Runtime.RunInMainThread (() => entry.Dispose ()).Ignore ();
+							break;
+						}
+					}
+					projectionList = projectionList.Add (new ProjectionEntry { File = projectFile, Projections = projections });
+				}
+			}
+
+			/// <summary>
+			/// Tries the get original file from projection. If the fileName / offset is inside a projection this method tries to convert it 
+			/// back to the original physical file.
+			/// </summary>
+			internal bool TryGetOriginalFileFromProjection (string fileName, int offset, out string originalName, out int originalOffset)
+			{
+				foreach (var projectionEntry in ProjectionList) {
+					var projection = projectionEntry.Projections.FirstOrDefault (p => FilePath.PathComparer.Equals (p.Document.FileName, fileName));
+					if (projection == null)
+						continue;
+
+					if (projection.TryConvertFromProjectionToOriginal (offset, out originalOffset)) {
+						originalName = projectionEntry.File.FilePath;
+						return true;
+					}
+				}
+
+				originalName = fileName;
+				originalOffset = offset;
+				return false;
+			}
+
+			internal void ClearOldProjectionList ()
+			{
+				ImmutableList<ProjectionEntry> toDispose;
+				lock (projectionListUpdateLock) {
+					toDispose = projectionList;
+					projectionList = projectionList.Clear ();
+				}
+				foreach (var p in toDispose)
+					p.Dispose ();
+			}
+
+			internal (Projection, string) Get (string filePath)
+			{
+				Projection projection = null;
+				foreach (var entry in projectionList) {
+					var p = entry.Projections.FirstOrDefault (proj => proj?.Document?.FileName != null && FilePath.PathComparer.Equals (proj.Document.FileName, filePath));
+					if (p != null) {
+						filePath = entry.File.FilePath;
+						projection = p;
+						break;
+					}
+				}
+
+				return (projection, filePath);
+			}
+		}
+
+		internal class ProjectionEntry : IDisposable
+		{
+			public MonoDevelop.Projects.ProjectFile File;
+			public IReadOnlyList<Projection> Projections;
+
+			public void Dispose ()
+			{
+				Runtime.RunInMainThread (delegate {
+					foreach (var p in Projections)
+						p.Dispose ();
+				});
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.Shims.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.Shims.cs
@@ -1,0 +1,66 @@
+//
+// MonoDevelopWorkspace.Shims.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using MonoDevelop.Ide.Editor.Projection;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class MonoDevelopWorkspace
+	{
+		internal bool Contains (ProjectId projectId)
+			=> ProjectMap.Contains (projectId);
+
+		internal ProjectId GetProjectId (MonoDevelop.Projects.Project project)
+			=> ProjectMap.GetId (project);
+
+		internal MonoDevelop.Projects.Project GetMonoProject (Project project)
+			=> GetMonoProject (project.Id);
+
+		internal MonoDevelop.Projects.Project GetMonoProject (ProjectId projectId)
+			=> ProjectMap.GetMonoProject (projectId);
+
+		internal DocumentId GetDocumentId (ProjectId projectId, string name)
+		{
+			var projectData = ProjectMap.GetData (projectId);
+			return projectData?.DocumentData.Get (name);
+		}
+
+		internal IReadOnlyList<ProjectionEntry> ProjectionList => Projections.ProjectionList;
+		/// <summary>
+		/// Tries the get original file from projection. If the fileName / offset is inside a projection this method tries to convert it 
+		/// back to the original physical file.
+		/// </summary>
+		internal bool TryGetOriginalFileFromProjection (string fileName, int offset, out string originalName, out int originalOffset)
+			=> Projections.TryGetOriginalFileFromProjection (fileName, offset, out originalName, out originalOffset);
+
+		internal void UpdateProjectionEntry (MonoDevelop.Projects.ProjectFile projectFile, IReadOnlyList<Projection> projections)
+			=> Projections.UpdateProjectionEntry (projectFile, projections);
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.Shims.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.Shims.cs
@@ -46,6 +46,9 @@ namespace MonoDevelop.Ide.TypeSystem
 		internal MonoDevelop.Projects.Project GetMonoProject (ProjectId projectId)
 			=> ProjectMap.GetMonoProject (projectId);
 
+		internal Task<ProjectInfo> LoadProject (MonoDevelop.Projects.Project p, CancellationToken token, MonoDevelop.Projects.Project oldProject)
+			=> ProjectHandler.LoadProject (p, token, oldProject);
+
 		internal DocumentId GetDocumentId (ProjectId projectId, string name)
 		{
 			var projectData = ProjectMap.GetData (projectId);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -440,39 +440,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		internal MonoDevelop.Projects.Project GetMonoProject (Project project)
-		{
-			return GetMonoProject (project.Id);
-		}
-
-		internal MonoDevelop.Projects.Project GetMonoProject (ProjectId projectId)
-		{
-			return ProjectMap.GetMonoProject (projectId);
-		}
-
-		internal bool Contains (ProjectId projectId) 
-		{
-			return ProjectMap.Contains (projectId);
-		}
-
-		internal ProjectId GetProjectId (MonoDevelop.Projects.Project p)
-		{
-			return ProjectMap.GetId (p);
-		}
-
-		internal ProjectId GetOrCreateProjectId (MonoDevelop.Projects.Project p)
-		{
-			return ProjectMap.GetOrCreateId (p, null);
-		}
-
-		internal DocumentId GetDocumentId (ProjectId projectId, string name)
-		{
-			var data = ProjectMap.GetData (projectId);
-			if (data == null)
-				return null;
-			return data.DocumentData.Get (name);
-		}
-
 		void UnloadMonoProject (MonoDevelop.Projects.Project project)
 		{
 			if (project == null)
@@ -533,11 +500,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		internal void UpdateProjectionEntry (MonoDevelop.Projects.ProjectFile projectFile, IReadOnlyList<Projection> projections)
-		{
-			Projections.UpdateProjectionEntry (projectFile, projections);
-		}
-
 		internal class SolutionData
 		{
 			public ConcurrentDictionary<string, TextLoader> Files = new ConcurrentDictionary<string, TextLoader> (); 
@@ -558,8 +520,6 @@ namespace MonoDevelop.Ide.TypeSystem
 				false
 			);
 		}
-
-		internal IReadOnlyList<ProjectionEntry> ProjectionList => Projections.ProjectionList;
 
 		static bool CanGenerateAnalysisContextForNonCompileable (MonoDevelop.Projects.Project p, MonoDevelop.Projects.ProjectFile f)
 		{
@@ -1494,15 +1454,6 @@ namespace MonoDevelop.Ide.TypeSystem
 		}
 
 		#endregion
-
-		/// <summary>
-		/// Tries the get original file from projection. If the fileName / offset is inside a projection this method tries to convert it 
-		/// back to the original physical file.
-		/// </summary>
-		internal bool TryGetOriginalFileFromProjection (string fileName, int offset, out string originalName, out int originalOffset)
-		{
-			return Projections.TryGetOriginalFileFromProjection (fileName, offset, out originalName, out originalOffset);
-		}
 	}
 
 	//	static class MonoDevelopWorkspaceFeatures

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -71,7 +71,7 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		CancellationTokenSource src = new CancellationTokenSource ();
 		bool disposed;
-		object updatingProjectDataLock = new object ();
+		readonly object updatingProjectDataLock = new object ();
 		Lazy<MonoDevelopMetadataReferenceManager> manager;
 		Lazy<MetadataReferenceHandler> metadataHandler;
 		ProjectionData Projections { get; }
@@ -1031,7 +1031,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		#region Project modification handlers
 
 		List<MonoDevelop.Projects.DotNetProject> modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
-		object projectModifyLock = new object ();
+		readonly object projectModifyLock = new object ();
 		bool freezeProjectModify;
 		Dictionary<MonoDevelop.Projects.DotNetProject, CancellationTokenSource> projectModifiedCts = new Dictionary<MonoDevelop.Projects.DotNetProject, CancellationTokenSource> ();
 		void OnProjectModified (object sender, MonoDevelop.Projects.SolutionItemModifiedEventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -57,7 +57,7 @@ using MonoDevelop.Ide.RoslynServices;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
-	public class MonoDevelopWorkspace : Workspace
+	public partial class MonoDevelopWorkspace : Workspace
 	{
 		public const string ServiceLayer = nameof(MonoDevelopWorkspace);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -116,12 +116,12 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (filesToUpdate.Count == 0)
 					return;
 
-				Task.Run (delegate {
+				Task.Run (async delegate {
 					try {
 						foreach (var file in filesToUpdate) {
 							var text = MonoDevelop.Core.Text.StringTextSource.ReadFrom (file).Text;
 							foreach (var w in workspaces)
-								w.UpdateFileContent (file, text);
+								await w.UpdateFileContent (file, text);
 						}
 
 						Gtk.Application.Invoke ((o, args) => {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4194,6 +4194,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectionData.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.Shims.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.MetadataReferenceHandler.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectSystemHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4187,6 +4187,8 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManager.RecoverableMetadataValueSource.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManager.MetadataReferenceCache.cs" />
     <Compile Include="MonoDevelop.Components.MainToolbar\RoslynSearchCategory.ShimNavigateToSearchService.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.DocumentMap.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectData.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4192,6 +4192,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectDataMap.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.OpenDocumentsData.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectionData.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.Shims.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4190,6 +4190,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.DocumentMap.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectData.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectDataMap.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.OpenDocumentsData.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4193,6 +4193,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.OpenDocumentsData.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectionData.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.Shims.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.MetadataReferenceHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4191,6 +4191,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectData.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectDataMap.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.OpenDocumentsData.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectionData.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4189,6 +4189,7 @@
     <Compile Include="MonoDevelop.Components.MainToolbar\RoslynSearchCategory.ShimNavigateToSearchService.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.DocumentMap.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectData.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectDataMap.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="MonoDevelop.Ide.Projects\ProjectOperationsTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceDocumentMapTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceProjectionDataTests.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceProjectDataMapTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -138,6 +138,8 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceDocumentMapTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceProjectionDataTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceProjectDataMapTests.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceProjectDataTests.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceOpenDocumentDataTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -135,6 +135,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManagerTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\ProjectOperationsTests.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceDocumentMapTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\ProjectOperationsTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceDocumentMapTests.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceProjectionDataTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceDocumentMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceDocumentMapTests.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			Assert.IsNull (doc0);
 
 			var doc1 = map.GetOrCreate ("TestName");
-			var doc2 = map.GetOrCreate ("TestName");
+			var doc2 = map.GetOrCreate ("TestName", map);
 			var doc3 = map.Get ("TestName");
 
 			Assert.AreSame (doc1, doc2);
@@ -58,6 +58,9 @@ namespace MonoDevelop.Ide.TypeSystem
 			map.Remove ("TestName");
 
 			Assert.IsNull (map.Get ("TestName"));
+
+			var doc6 = map.GetOrCreate ("TestName", map);
+			Assert.AreSame (doc4, doc6);
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceDocumentMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceDocumentMapTests.cs
@@ -1,0 +1,60 @@
+//
+// MonoDevelopWorkspace.DocumentMapTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	[TestFixture]
+	public class MonoDevelopWorkspaceDocumentMapTests
+	{
+		[Test]
+		public void TestSimpleCreation ()
+		{
+			var pid = ProjectId.CreateNewId ();
+			var map = new MonoDevelopWorkspace.DocumentMap (pid);
+
+			var doc1 = map.GetOrCreate ("TestName");
+			var doc2 = map.GetOrCreate ("TestName");
+			var doc3 = map.Get ("TestName");
+
+			Assert.AreSame (doc1, doc2);
+			Assert.AreSame (doc1, doc3);
+
+			map.Add (DocumentId.CreateNewId (pid), "TestName");
+			var doc4 = map.Get ("TestName");
+			var doc5 = map.GetOrCreate ("TestName");
+
+			Assert.AreNotSame (doc1, doc4);
+			Assert.AreSame (doc4, doc5);
+
+			map.Remove ("TestName");
+
+			Assert.IsNull (map.Get ("TestName"));
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceDocumentMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceDocumentMapTests.cs
@@ -48,19 +48,37 @@ namespace MonoDevelop.Ide.TypeSystem
 			Assert.AreSame (doc1, doc2);
 			Assert.AreSame (doc1, doc3);
 
-			map.Add (DocumentId.CreateNewId (pid), "TestName");
+			var docIdAdd = DocumentId.CreateNewId (pid);
+			map.Add (docIdAdd, "TestName");
+
 			var doc4 = map.Get ("TestName");
 			var doc5 = map.GetOrCreate ("TestName");
 
 			Assert.AreNotSame (doc1, doc4);
-			Assert.AreSame (doc4, doc5);
+			Assert.AreSame (docIdAdd, doc4);
+			Assert.AreSame (docIdAdd, doc5);
 
 			map.Remove ("TestName");
-
+		
 			Assert.IsNull (map.Get ("TestName"));
+		}
 
-			var doc6 = map.GetOrCreate ("TestName", map);
-			Assert.AreSame (doc4, doc6);
+		[Test]
+		public void TestMigration ()
+		{
+			var pid = ProjectId.CreateNewId ();
+			var map1 = new MonoDevelopWorkspace.DocumentMap (pid);
+			var map2 = new MonoDevelopWorkspace.DocumentMap (pid);
+
+			var doc1 = map1.GetOrCreate ("TestName");
+			var doc2 = map2.GetOrCreate ("TestName");
+
+			Assert.AreNotSame (doc1, doc2);
+
+			map2.Remove ("TestName");
+			var doc3 = map2.GetOrCreate ("TestName", map1);
+
+			Assert.AreSame (doc1, doc3);
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceOpenDocumentDataTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceOpenDocumentDataTests.cs
@@ -1,0 +1,52 @@
+//
+// MonoDevelopWorkspaceOpenDocumentDataTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	[TestFixture]
+	public class MonoDevelopWorkspaceOpenDocumentDataTests
+	{
+		[Test]
+		public void TestFunctionality ()
+		{
+			var map = new MonoDevelopWorkspace.OpenDocumentsData ();
+
+			var pid = ProjectId.CreateNewId ();
+			var docId = DocumentId.CreateNewId (pid);
+
+			Assert.IsFalse (map.Contains (docId));
+
+			map.Add (docId, null, null, null);
+			Assert.IsTrue (map.Contains (docId));
+
+			map.Remove (docId);
+			Assert.IsFalse (map.Contains (docId));
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
@@ -1,5 +1,5 @@
 //
-// MonoDevelopWorkspace.DocumentMapTests.cs
+// MonoDevelopWorkspaceProjectDataMapTests.cs
 //
 // Author:
 //       Marius Ungureanu <maungu@microsoft.com>
@@ -24,40 +24,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using Microsoft.CodeAnalysis;
-using NUnit.Framework;
-
 namespace MonoDevelop.Ide.TypeSystem
 {
-	[TestFixture]
-	public class MonoDevelopWorkspaceDocumentMapTests
+	public class MonoDevelopWorkspaceProjectDataMapTests
 	{
-		[Test]
-		public void TestSimpleCreation ()
+		public MonoDevelopWorkspaceProjectDataMapTests ()
 		{
-			var pid = ProjectId.CreateNewId ();
-			var map = new MonoDevelopWorkspace.DocumentMap (pid);
-
-			var doc0 = map.Get ("TestName");
-			Assert.IsNull (doc0);
-
-			var doc1 = map.GetOrCreate ("TestName");
-			var doc2 = map.GetOrCreate ("TestName");
-			var doc3 = map.Get ("TestName");
-
-			Assert.AreSame (doc1, doc2);
-			Assert.AreSame (doc1, doc3);
-
-			map.Add (DocumentId.CreateNewId (pid), "TestName");
-			var doc4 = map.Get ("TestName");
-			var doc5 = map.GetOrCreate ("TestName");
-
-			Assert.AreNotSame (doc1, doc4);
-			Assert.AreSame (doc4, doc5);
-
-			map.Remove ("TestName");
-
-			Assert.IsNull (map.Get ("TestName"));
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataTests.cs
@@ -1,0 +1,47 @@
+//
+// MonoDevelopWorkspaceProjectDataTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	[TestFixture]
+	public class MonoDevelopWorkspaceProjectDataTests : IdeTestBase
+	{
+		[Test]
+		public void TestEmptyMetadataCreation ()
+		{
+			var pid = ProjectId.CreateNewId ();
+
+			using (var workspace = new MonoDevelopWorkspace (null))
+			using (var data = new MonoDevelopWorkspace.ProjectData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty, workspace)) {
+				// Do nothing, we just want to see it construct and dispose properly.
+			}
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectionDataTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectionDataTests.cs
@@ -1,0 +1,105 @@
+//
+// MonoDevelopWorkspaceProjectionDataTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using MonoDevelop.Ide.Editor;
+using MonoDevelop.Ide.Editor.Projection;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	[TestFixture]
+	public class MonoDevelopWorkspaceProjectionDataTests
+	{
+		[Test]
+		public void TestSimpleCreation ()
+		{
+			var data = new MonoDevelopWorkspace.ProjectionData ();
+
+			var projections = new List<Projection> ();
+			var initial = new MonoDevelopWorkspace.ProjectionEntry {
+				File = new MonoDevelop.Projects.ProjectFile ("name"),
+				Projections = projections,
+			};
+			data.AddProjectionEntry (initial);
+
+			var (projectionFromMap, filePathFromMap) = data.Get ("fileName");
+			Assert.IsNull (projectionFromMap);
+
+			// Using a real document from the tests dir
+			var document = TextEditorFactory.CreateNewDocument ("GitIgnore.txt");
+			projections.Add (new Projection (document, Array.Empty<ProjectedSegment> ()));
+
+			(projectionFromMap, filePathFromMap) = data.Get ("GitIgnore.txt");
+			Assert.IsNotNull (projectionFromMap);
+			Assert.AreEqual ((string)initial.File.FilePath, filePathFromMap);
+		}
+
+		[Test]
+		public void TestClearingOldProjections ()
+		{
+			var data = new MonoDevelopWorkspace.ProjectionData ();
+
+			var projections = new List<Projection> ();
+			// Using a real document from the tests dir
+			var document = TextEditorFactory.CreateNewDocument ("GitIgnore.txt");
+			projections.Add (new Projection (document, Array.Empty<ProjectedSegment> ()));
+
+			var initial = new MonoDevelopWorkspace.ProjectionEntry {
+				File = new MonoDevelop.Projects.ProjectFile ("name"),
+				Projections = projections,
+			};
+			data.AddProjectionEntry (initial);
+
+			data.ClearOldProjectionList ();
+
+			var (projectionFromMap, filePathFromMap) = data.Get ("GitIgnore.txt");
+			Assert.IsNull (projectionFromMap);
+		}
+
+		[Test]
+		public void TestUpdatingProjections ()
+		{
+			var data = new MonoDevelopWorkspace.ProjectionData ();
+
+			var projections = new List<Projection> ();
+			// Using a real document from the tests dir
+			var document = TextEditorFactory.CreateNewDocument ("GitIgnore.txt");
+			projections.Add (new Projection (document, Array.Empty<ProjectedSegment> ()));
+
+			var initial = new MonoDevelopWorkspace.ProjectionEntry {
+				File = new MonoDevelop.Projects.ProjectFile ("name"),
+				Projections = projections,
+			};
+			data.AddProjectionEntry (initial);
+
+			data.UpdateProjectionEntry (initial.File, new List<Projection> ());
+
+			var (projectionFromMap, filePathFromMap) = data.Get ("GitIgnore.txt");
+			Assert.IsNull (projectionFromMap);
+		}
+	}
+}


### PR DESCRIPTION
This splits functionality in MDWorkspace into logical components and makes them testable.

TODO:
* [x] Decouple the workspace into maintanable and testable layers
* [x] Add tests
* [x] Rework commits to make them atomic