### PR TITLE
Temp workaround for VSTS 662639.

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.csproj
+++ b/main/src/addins/CSharpBinding/CSharpBinding.csproj
@@ -346,6 +346,7 @@
     <Compile Include="MonoDevelop.Ide.Completion.Presentation\RoslynCompletionPresenter.cs" />
     <Compile Include="MonoDevelop.Ide.Completion.Presentation\RoslynCompletionPresenterSession.ICompletionPresenterSession.cs" />
     <Compile Include="MonoDevelop.Ide.Completion.Presentation\ContainedDocumentPreserveFormattingRule.cs" />
+    <Compile Include="MonoDevelop.Ide.Completion.Presentation\ExtensionMethods.cs" />
     <Compile Include="MonoDevelop.Ide.Completion.Presentation\IMonoDevelopContainedLanguageHost.cs" />
     <Compile Include="MonoDevelop.Ide.Completion.Presentation\IMyRoslynCompletionDataProvider.cs" />
     <Compile Include="MonoDevelop.Ide.Completion.Presentation\MonoDevelopContainedDocument.cs" />

--- a/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/ExtensionMethods.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/ExtensionMethods.cs
@@ -1,0 +1,31 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+
+namespace MonoDevelop.Ide.Completion.Presentation
+{
+	public static class ExtensionMethods
+	{
+		/// <summary>
+		/// Temporary workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/662639.
+		/// The first call may fail with the ArgumentException coming from Mono due to ConditionalWeakTable
+		/// reentrancy, however by that time the table will have already been populated. 
+		/// Subsequent call should not hit this problem and should succeed.
+		/// TODO: remove when https://github.com/dotnet/roslyn/issues/28256 is fixed.
+		/// </summary>
+		public static Document GetOpenDocumentInCurrentContextWithChangesSafe (this ITextSnapshot textSnapshot)
+		{
+			Document document = null;
+			try {
+				document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges ();
+			} catch {
+				try {
+					document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges ();
+				} catch {
+				}
+			}
+
+			return document;
+		}
+	}
+}

--- a/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
@@ -104,7 +104,7 @@ namespace MonoDevelop.Ide.Completion.Presentation
 
 		private void FinishInitialization ()
 		{
-			var document = LanguageBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges ();
+			var document = LanguageBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChangesSafe ();
 			var project = document.Project;
 
 			_workspace = project.Solution.Workspace;
@@ -451,7 +451,7 @@ namespace MonoDevelop.Ide.Completion.Presentation
 
 		private IHierarchicalDifferenceCollection DiffStrings (string leftTextWithReplacement, string rightTextWithReplacement)
 		{
-			var document = LanguageBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges (); ;
+			var document = LanguageBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChangesSafe ();
 
 			var diffService = _differenceSelectorService.GetTextDifferencingService (
 				_workspace.Services.GetLanguageServices (document.Project.Language).GetService<IContentTypeLanguageService> ().GetDefaultContentType ());

--- a/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/RoslynCompletionPresenterSession.View.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/RoslynCompletionPresenterSession.View.cs
@@ -632,7 +632,7 @@ namespace MonoDevelop.Ide.Completion.Presentation
 
 			TooltipInformation description = null;
 			try {
-				var document = _subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges ();
+				var document = _subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChangesSafe ();
 				description = await RoslynCompletionData.CreateTooltipInformation (document, completionItem, false, token);
 			} catch {
 			}


### PR DESCRIPTION
The first call may fail with the ArgumentException coming from Mono due to ConditionalWeakTable
reentrancy, however by that time the table will have already been populated.
Subsequent call should not hit this problem and should succeed.

TODO: remove when https://github.com/dotnet/roslyn/issues/28256 is fixed.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/662639.