### PR TITLE
[Ide] Prevent out of date projections being used

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -232,6 +232,9 @@ namespace MonoDevelop.Ide.TypeSystem
 			var t = Counters.ParserService.FileParsed.BeginTiming (options.FileName);
 			try {
 				var result = await parser.GenerateParsedDocumentProjection (options, cancellationToken);
+				if (cancellationToken.IsCancellationRequested)
+					return null;
+
 				if (options.Project != null) {
 					var ws = workspaces.First () ;
 					var projectId = ws.GetProjectId (options.Project);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -52,9 +52,12 @@ namespace MonoDevelop.Ide.TypeSystem
 		static string[] filesSkippedInParseThread = new string[0];
 		public static Microsoft.CodeAnalysis.SyntaxAnnotation InsertionModeAnnotation = new Microsoft.CodeAnalysis.SyntaxAnnotation();
 
-		static IEnumerable<TypeSystemParserNode> Parsers {
+		internal static IEnumerable<TypeSystemParserNode> Parsers {
 			get {
 				return parsers;
+			}
+			set {
+				parsers = value;
 			}
 		}
 


### PR DESCRIPTION
 If a parser takes a long time to parse a project this can result in
out of date information being used by the type system. Now a check
is made to see if the token was cancelled and the parsed projection
is ignored in this case.

Also added a TypeSystemService test for the projection being cancelled.

Partial fix for VSTS #663898 - Failing Xamarin.Forms tests