### PR TITLE
Fix GitHub https://github.com/mono/monodevelop/issues/5501

### DIFF
--- a/main/src/addins/WindowsPlatform/WindowsAPICodePack/Core/Core.csproj
+++ b/main/src/addins/WindowsPlatform/WindowsAPICodePack/Core/Core.csproj
@@ -8,6 +8,8 @@
     <AssemblyName>Microsoft.WindowsAPICodePack</AssemblyName>
     <OutputPath>..\..\..\..\..\build\AddIns\WindowsPlatform</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <!-- see https://github.com/mono/monodevelop/issues/5501 -->
+    <ShortEmbeddedResourceIDs>False</ShortEmbeddedResourceIDs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -60,8 +62,7 @@
     <Compile Include="PowerManagement\BatteryState.cs" />
     <Compile Include="PowerManagement\EventManager.cs" />
     <Compile Include="PowerManagement\ExecutionState.cs" />
-    <Compile Include="PowerManagement\MessageManager.cs">
-    </Compile>
+    <Compile Include="PowerManagement\MessageManager.cs" />
     <Compile Include="PowerManagement\PersonalityGuids.cs" />
     <Compile Include="PowerManagement\Power.cs" />
     <Compile Include="PowerManagement\PowerManager.cs" />

--- a/main/src/addins/WindowsPlatform/WindowsAPICodePack/Shell/Shell.csproj
+++ b/main/src/addins/WindowsPlatform/WindowsAPICodePack/Shell/Shell.csproj
@@ -8,6 +8,8 @@
     <AssemblyName>Microsoft.WindowsAPICodePack.Shell</AssemblyName>
     <OutputPath>..\..\..\..\..\build\AddIns\WindowsPlatform</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <!-- see https://github.com/mono/monodevelop/issues/5501 -->
+    <ShortEmbeddedResourceIDs>False</ShortEmbeddedResourceIDs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -87,8 +89,7 @@
     <Compile Include="Interop\Common\WindowUtilities.cs" />
     <Compile Include="KnownFolders\IKnownFolder.cs" />
     <Compile Include="Interop\Common\ShellCOMClasses.cs" />
-    <Compile Include="Interop\ExplorerBrowser\ExplorerBrowserCOMGuids.cs">
-    </Compile>
+    <Compile Include="Interop\ExplorerBrowser\ExplorerBrowserCOMGuids.cs" />
     <Compile Include="Interop\ExplorerBrowser\ExplorerBrowserCOMInterfaces.cs" />
     <Compile Include="Interop\ExplorerBrowser\ExplorerBrowserNativeMethods.cs" />
     <Compile Include="KnownFolders\DefinitionOptions.cs" />
@@ -97,9 +98,7 @@
     <Compile Include="KnownFolders\FoldersIdentifiers.cs" />
     <Compile Include="KnownFolders\FolderTypes.cs" />
     <Compile Include="KnownFolders\KnownFolderHelper.cs" />
-    <Compile Include="KnownFolders\KnownFolders.cs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="KnownFolders\KnownFolders.cs" />
     <Compile Include="KnownFolders\KnownFolderSettings.cs" />
     <Compile Include="KnownFolders\RedirectionCapabilities.cs" />
     <Compile Include="KnownFolders\RetrievalOptions.cs" />
@@ -197,8 +196,7 @@
     <Compile Include="Taskbar\JumpList.cs" />
     <Compile Include="Taskbar\JumpListItem.cs" />
     <Compile Include="Taskbar\TaskbarList.cs" />
-    <Compile Include="Taskbar\TaskbarManager.cs">
-    </Compile>
+    <Compile Include="Taskbar\TaskbarManager.cs" />
     <Compile Include="Taskbar\TaskbarInterfaces.cs" />
     <Compile Include="Taskbar\TaskbarWindow.cs" />
     <Compile Include="Taskbar\TaskbarWindowManager.cs" />


### PR DESCRIPTION
Menu items (such as File Open) didn't work on Windows.

The ItemDefinitionGroup in MonoDevelop.AfterCommon.props sets the LogicalName default metadata on EmbeddedResource. The way GenerateResource works is it passes the LogicalName on .resx files to the C# compiler after a comma, if it is set:

/resource:obj\Debug\Microsoft.WindowsAPICodePack.Resources.LocalizedMessages.resources,LocalizedMessages.resx

The C# compiler then names the resource "LocalizedMessages.resx" instead of the .resources file name. Then at runtime the ResourceManager can't find the resource by the name it expects and fails.

The fix is to turn off the default item metadata in the two Windows projects.

Amazingly, these are the only two instances in the entire MonoDevelop codebase that embed .resx as EmbeddedResource.