### PR TITLE
[Project] Skip building unmodified projects by default

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -586,7 +586,7 @@ namespace MonoDevelop.Core
 		[Obsolete]
 		public readonly ConfigurationProperty<bool> BuildWithMSBuild = ConfigurationProperty.CreateObsolete (true);
 
-		public readonly ConfigurationProperty<bool> SkipBuildingUnmodifiedProjects = ConfigurationProperty.Create ("MonoDevelop.Ide.SkipBuildingUnmodifiedProjects", false);
+		public readonly ConfigurationProperty<bool> SkipBuildingUnmodifiedProjects = ConfigurationProperty.Create ("MonoDevelop.Ide.SkipBuildingUnmodifiedProjects", true);
 		public readonly ConfigurationProperty<bool> ParallelBuild = ConfigurationProperty.Create ("MonoDevelop.ParallelBuild", true);
 
 		public readonly ConfigurationProperty<string> AuthorName = ConfigurationProperty.Create ("Author.Name", Environment.UserName, oldName:"ChangeLogAddIn.Name");

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/SolutionTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/SolutionTests.cs
@@ -924,9 +924,11 @@ namespace MonoDevelop.Projects
 					msbuildEndCount++;
 			};
 
-			var oldStatus = Runtime.Preferences.ParallelBuild.Value;
+			var oldPrefParallelBuild = Runtime.Preferences.ParallelBuild.Value;
+			var oldPrefSkipUnmodified = Runtime.Preferences.SkipBuildingUnmodifiedProjects.Value;
 			try {
 				Runtime.Preferences.ParallelBuild.Set (false);
+				Runtime.Preferences.SkipBuildingUnmodifiedProjects.Set (false);
 				FilePath solFile = Util.GetSampleProject ("build-session", "build-session.sln");
 				var sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 
@@ -1003,7 +1005,8 @@ namespace MonoDevelop.Projects
 				WorkspaceObject.UnregisterCustomExtension (en);
 				WorkspaceObject.UnregisterCustomExtension (en2);
 
-				Runtime.Preferences.ParallelBuild.Set (oldStatus);
+				Runtime.Preferences.ParallelBuild.Set (oldPrefParallelBuild);
+				Runtime.Preferences.SkipBuildingUnmodifiedProjects.Set (oldPrefSkipUnmodified);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #5429. Should improve build perf in many cases, and appears to match what VS on Windows does (see https://github.com/mono/monodevelop/issues/5431)