### PR TITLE
[Core] Fix incorrect build location with imported config based property

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectDescriptor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/ProjectDescriptor.cs
@@ -257,6 +257,11 @@ namespace MonoDevelop.Ide.Templates
 			string dir = ReplaceParameters (directory, substitution, projectCreateInformation);
 			projectCreateInformation.ProjectBasePath = Path.Combine (projectCreateInformation.SolutionPath, dir);
 
+			// Ensure that any relative path (e.g. "./Droid") used by 'directory' for the project template is removed since this
+			// can cause a problem with the remote msbuild host trying to load the project multiple times into the build engine
+			// due to a mismatch in the filename being used.
+			projectCreateInformation.ProjectBasePath = projectCreateInformation.ProjectBasePath.FullPath;
+
 			if (ShouldCreateProject (projectCreateInformation) && !Directory.Exists (projectCreateInformation.ProjectBasePath))
 				Directory.CreateDirectory (projectCreateInformation.ProjectBasePath);
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -196,8 +196,11 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 
-			if (p.GetPropertyValue ("Configuration") != configuration || (p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
-				p.SetGlobalProperty ("Configuration", configuration);
+			// Always set the configuration. This ensures that imported projects that use the
+			// Configuration have properties evaluated correctly.
+			p.SetGlobalProperty ("Configuration", configuration);
+
+			if ((p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
 				if (!string.IsNullOrEmpty (platform))
 					p.SetGlobalProperty ("Platform", platform);
 				else

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -166,8 +166,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 		Project ConfigureProject (string file, string configuration, string platform, string slnConfigContents)
 		{			
+			bool firstConfigure = false;
 			var p = engine.GetLoadedProjects (file).FirstOrDefault ();
 			if (p == null) {
+				firstConfigure = true;
 				var projectDir = Path.GetDirectoryName (file);
 
 				// HACK: workaround to MSBuild bug #53019. We need to ensure that $(BaseIntermediateOutputPath) exists before
@@ -196,14 +198,13 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 
-			// Always set the configuration and platform. This ensures that imported projects that use the
-			// Configuration or Platform have properties evaluated correctly.
-			p.SetGlobalProperty ("Configuration", configuration);
-
-			if (!string.IsNullOrEmpty (platform))
-				p.SetGlobalProperty ("Platform", platform);
-			else
-				p.RemoveGlobalProperty ("Platform");
+			if (firstConfigure || p.GetPropertyValue ("Configuration") != configuration || (p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
+				p.SetGlobalProperty ("Configuration", configuration);
+				if (!string.IsNullOrEmpty (platform))
+					p.SetGlobalProperty ("Platform", platform);
+				else
+					p.RemoveGlobalProperty ("Platform");
+			}
 
 			// The CurrentSolutionConfigurationContents property only needs to be set once
 			// for the project actually being built

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -196,16 +196,14 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 			}
 
-			// Always set the configuration. This ensures that imported projects that use the
-			// Configuration have properties evaluated correctly.
+			// Always set the configuration and platform. This ensures that imported projects that use the
+			// Configuration or Platform have properties evaluated correctly.
 			p.SetGlobalProperty ("Configuration", configuration);
 
-			if ((p.GetPropertyValue ("Platform") ?? "") != (platform ?? "")) {
-				if (!string.IsNullOrEmpty (platform))
-					p.SetGlobalProperty ("Platform", platform);
-				else
-					p.RemoveGlobalProperty ("Platform");
-			}
+			if (!string.IsNullOrEmpty (platform))
+				p.SetGlobalProperty ("Platform", platform);
+			else
+				p.RemoveGlobalProperty ("Platform");
 
 			// The CurrentSolutionConfigurationContents property only needs to be set once
 			// for the project actually being built

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
@@ -826,7 +826,7 @@ namespace MonoDevelop.Projects
 		}
 
 		/// <summary>
-		/// The project's OutputPath is based on an MSBuild property imported from another MSBuild file.
+		/// The project's OutputPath is based on an MSBuild property that uses the Configuration and is imported from another MSBuild file.
 		/// This test ensures that when building the debug build the assembly is created in the correct directory.
 		/// </summary>
 		[Test]
@@ -837,6 +837,25 @@ namespace MonoDevelop.Projects
 				var project = sol.GetAllProjects ().Single ();
 				var outputDirectory = project.BaseDirectory.Combine ("target", "Debug", "Common");
 				var outputAssembly = outputDirectory.Combine ("ImportedOutputPathProperty.dll");
+
+				var result = await sol.Build (Util.GetMonitor (), "Debug");
+
+				Assert.AreEqual (0, result.ErrorCount);
+				Assert.IsTrue (File.Exists (outputAssembly), "Output assembly not built in correct location.");
+			}
+		}
+
+		/// <summary>
+		/// Similar to the above test but uses the Platform property inste
+		/// </summary>
+		[Test]
+		public async Task BuildProjectWithImportedPlatformOutputPathProperty ()
+		{
+			FilePath solFile = Util.GetSampleProject ("ImportedOutputPathProperty", "ImportedPlatformOutputPathProperty.sln");
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var project = sol.GetAllProjects ().Single ();
+				var outputDirectory = project.BaseDirectory.Combine ("target", "AnyCPU", "Common");
+				var outputAssembly = outputDirectory.Combine ("ImportedPlatformOutputPathProperty.dll");
 
 				var result = await sol.Build (Util.GetMonitor (), "Debug");
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectBuildTests.cs
@@ -824,6 +824,26 @@ namespace MonoDevelop.Projects
 				Assert.AreEqual (1, result.ErrorCount, "#1");
 			}
 		}
+
+		/// <summary>
+		/// The project's OutputPath is based on an MSBuild property imported from another MSBuild file.
+		/// This test ensures that when building the debug build the assembly is created in the correct directory.
+		/// </summary>
+		[Test]
+		public async Task BuildProjectWithImportedOutputPathProperty ()
+		{
+			FilePath solFile = Util.GetSampleProject ("ImportedOutputPathProperty", "ImportedOutputPathProperty.sln");
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var project = sol.GetAllProjects ().Single ();
+				var outputDirectory = project.BaseDirectory.Combine ("target", "Debug", "Common");
+				var outputAssembly = outputDirectory.Combine ("ImportedOutputPathProperty.dll");
+
+				var result = await sol.Build (Util.GetMonitor (), "Debug");
+
+				Assert.AreEqual (0, result.ErrorCount);
+				Assert.IsTrue (File.Exists (outputAssembly), "Output assembly not built in correct location.");
+			}
+		}
 	}
 
 	class EvalContextCreationTestExtension : ProjectExtension

--- a/main/tests/test-projects/ImportedOutputPathProperty/ImportedOutputPathProperty.csproj
+++ b/main/tests/test-projects/ImportedOutputPathProperty/ImportedOutputPathProperty.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ImportedOutputPathProperty.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{53B157AE-5781-4C9D-A615-6F6149368750}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ImportedOutputPathProperty</RootNamespace>
+    <AssemblyName>ImportedOutputPathProperty</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <OutputPath>$(OutputBase)\Common</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ImportedOutputPathProperty/ImportedOutputPathProperty.props
+++ b/main/tests/test-projects/ImportedOutputPathProperty/ImportedOutputPathProperty.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetDir>target</TargetDir>
+    <OutputBase>$([System.IO.Path]::Combine($(TargetDir), $(Configuration)))</OutputBase>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/ImportedOutputPathProperty/ImportedOutputPathProperty.sln
+++ b/main/tests/test-projects/ImportedOutputPathProperty/ImportedOutputPathProperty.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportedOutputPathProperty", "ImportedOutputPathProperty.csproj", "{53B157AE-5781-4C9D-A615-6F6149368750}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ImportedOutputPathProperty/ImportedPlatformOutputPathProperty.csproj
+++ b/main/tests/test-projects/ImportedOutputPathProperty/ImportedPlatformOutputPathProperty.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="ImportedPlatformOutputPathProperty.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{53B157AE-5781-4C9D-A615-6F6149368750}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ImportedPlatformOutputPathProperty</RootNamespace>
+    <AssemblyName>ImportedPlatformOutputPathProperty</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <OutputPath>$(OutputBase)\Common</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ImportedOutputPathProperty/ImportedPlatformOutputPathProperty.props
+++ b/main/tests/test-projects/ImportedOutputPathProperty/ImportedPlatformOutputPathProperty.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetDir>target</TargetDir>
+    <OutputBase>$([System.IO.Path]::Combine($(TargetDir), $(Platform)))</OutputBase>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/ImportedOutputPathProperty/ImportedPlatformOutputPathProperty.sln
+++ b/main/tests/test-projects/ImportedOutputPathProperty/ImportedPlatformOutputPathProperty.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportedPlatformOutputPathProperty", "ImportedPlatformOutputPathProperty.csproj", "{53B157AE-5781-4C9D-A615-6F6149368750}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53B157AE-5781-4C9D-A615-6F6149368750}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ImportedOutputPathProperty/MyClass.cs
+++ b/main/tests/test-projects/ImportedOutputPathProperty/MyClass.cs
@@ -1,0 +1,11 @@
+
+using System;
+namespace ImportedOutputPathProperty
+{
+	public class MyClass
+	{
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/ImportedOutputPathProperty/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/ImportedOutputPathProperty/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("ImportedOutputPathProperty")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Xamarin Inc. (http://xamarin.com)")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]


### PR DESCRIPTION
With a project that has an import that defines a property based on
the configuration the build location of the assembly would be
incorrect.

Project file:

    <Project ...>
      <Import Project="Imported.props" />
      <PropertyGroup>
        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
        <OutputPath>$(OutputBase)\Common</OutputPath>
      </PropertyGroup>

Imported.props:

     <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
      <PropertyGroup>
        <TargetDir>target</TargetDir>
        <OutputBase>$([System.IO.Path]::Combine($(TargetDir), $(Configuration)))</OutputBase>
      </PropertyGroup>
    </Project>

When building the above project, with the debug configuration
selected, the assembly would be built into the directory
'target/Common' instead of 'target/Debug/Common'. To fix this the
configuration is now always set for the project in the remote project
builder.

Fixes VSTS #540728 - OutputBase No Longer Includes Build Configuration