### PR TITLE
[Ide] Disable some more code for new build output

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -340,7 +340,9 @@ namespace MonoDevelop.Ide.Gui.Pads
 			warnBtn.Toggled -= FilterChanged;
 			msgBtn.Toggled -= FilterChanged;
 			logBtn.Toggled -= HandleTextLogToggled;
+#if ENABLE_BUILD_OUTPUT
 			buildLogBtn.Clicked -= HandleBinLogClicked;
+#endif
 			searchEntry.Entry.Changed -= searchPatternChanged;
 
 			IdeApp.Workspace.FirstWorkspaceItemOpened -= OnCombineOpen;
@@ -1056,7 +1058,9 @@ namespace MonoDevelop.Ide.Gui.Pads
 		Document buildOutputDoc;
 		void HandleBinLogClicked (object sender, EventArgs e)
 		{
+#if ENABLE_BUILD_OUTPUT
 			OpenBuildOutputViewDocument ();
+#endif
 		}
 
 		void OpenBuildOutputViewDocument () 


### PR DESCRIPTION
Since we're not creating the button now, unsubscribing an event from
it just makes the app crash, so disable this code also.