### PR TITLE
[a11y] Fix keyboard focus for statusbar action icons

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/AwesomeBar.cs
@@ -62,6 +62,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			SearchBar = new SearchBar ();
 			AddSubview (SearchBar);
 
+			StatusBar.SearchBar = SearchBar;
+
 			Ide.Gui.Styles.Changed +=  (o, e) => UpdateLayout ();
 		}
 

--- a/main/src/addins/MacPlatform/MainToolbar/NSFocusButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/NSFocusButton.cs
@@ -30,6 +30,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 {
 	public class NSFocusButton: NSButton
 	{
+		/*
 		public override void KeyDown (NSEvent theEvent)
 		{
 			var key = theEvent.Characters.FirstOrDefault ();
@@ -48,5 +49,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			
 			return GetNextFocusable (view.NextKeyView);
 		}
+		*/
 	}
 }

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -545,7 +545,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 				if (theEvent.Characters == "\t") {
 					focusedCellIndex++;
-					if(focusedCellIndex > VisibleCellIds.Length){
+					if(focusedCellIndex >= VisibleCellIds.Length){
 						if (NextKeyView != null) {
 							Window.MakeFirstResponder (NextKeyView);
 							SetSelection ();

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -547,16 +547,16 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					focusedCellIndex++;
 					if(focusedCellIndex >= VisibleCellIds.Length){
 						if (NextKeyView != null) {
-							Window.MakeFirstResponder (NextKeyView);
 							SetSelection ();
 							focusedCellIndex = 0;
 							focusedItem = null;
-							return;
 						}
+					} else {
+						SetSelection ();
+						return;
 					}
 				}
 
-				SetSelection ();
 				base.KeyDown (theEvent);
 			}
 

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -1177,11 +1177,12 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 		}
 
+		bool isFirstResponder;
 		public override void KeyDown (NSEvent theEvent)
 		{
 			// 36 is <Enter>
 			// 49 is <Space>
-			if (theEvent.KeyCode == 36 || theEvent.KeyCode == 49) {
+			if (isFirstResponder && (theEvent.KeyCode == 36 || theEvent.KeyCode == 49)) {
 				sourcePad?.BringToFront (true);
 				return;
 			}
@@ -1195,7 +1196,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public override bool BecomeFirstResponder ()
 		{
+			isFirstResponder = true;
 			return true;
+		}
+
+		public override bool ResignFirstResponder ()
+		{
+			isFirstResponder = false;
+			return base.ResignFirstResponder ();
 		}
 
 		public override CGRect Frame {

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -40,6 +40,7 @@ using MonoDevelop.Ide.Gui.Components;
 using MonoDevelop.Ide.Tasks;
 using MonoDevelop.Components.Mac;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
@@ -1111,6 +1112,21 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			if (textField.IsMouseInRect (location, textField.Frame) && sourcePad != null) {
 				sourcePad.BringToFront (true);
 			}
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			// 49 is <space>
+			if (theEvent.KeyCode == 49) {
+				sourcePad?.BringToFront (true);
+				return;
+			}
+			base.KeyDown (theEvent);
+		}
+
+		public override bool AcceptsFirstResponder ()
+		{
+			return true;
 		}
 
 		public override CGRect Frame {

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -48,6 +48,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 	class StatusIcon : NSButton, StatusBarIcon
 	{
 		StatusBar bar;
+		readonly ObjCRuntime.Selector OnButtonClickedSelector = new ObjCRuntime.Selector ("OnButtonActivated:");
 
 		public StatusIcon (StatusBar bar) : base (CGRect.Empty)
 		{
@@ -55,7 +56,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			var trackingArea = new NSTrackingArea (CGRect.Empty, NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.InVisibleRect | NSTrackingAreaOptions.MouseEnteredAndExited, this, null);
 			AddTrackingArea (trackingArea);
 
-			Activated += ButtonClicked;
+			Target = this;
+			Action = OnButtonClickedSelector;
+
 			this.bar = bar;
 		}
 
@@ -132,7 +135,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			Exited?.Invoke (this, EventArgs.Empty);
 		}
 
-		void ButtonClicked (object sender, EventArgs args)
+		[Export ("OnButtonActivated:")]
+		void ButtonClicked (NSObject sender)
 		{
 			NotifyClicked (Xwt.PointerButton.Left);
 		}

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -1180,7 +1180,8 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public override void KeyDown (NSEvent theEvent)
 		{
 			// 36 is <Enter>
-			if (theEvent.KeyCode == 36) {
+			// 49 is <Space>
+			if (theEvent.KeyCode == 36 || theEvent.KeyCode == 49) {
 				sourcePad?.BringToFront (true);
 				return;
 			}


### PR DESCRIPTION
Allow focussing action icons in the status bar with the keyboard.
> Fixes VSTS [#648188](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/648188)