### PR TITLE
Fixes VSTS Bug 665407: TypeScript/JavaScript TextMate syntax

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MimeTypes.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MimeTypes.addin.xml
@@ -96,6 +96,10 @@
 	<MimeType id="application/x-msbuild" _description="MSBuild targets file" baseType="application/xml">
 		<File pattern="*.targets" />
 	</MimeType>
+
+	<MimeType id="text/x-typescript" _description="typescript files" isText="true">
+		<File pattern="*.ts" />
+	</MimeType>
 </Extension>
 
 </ExtensionModel>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlighting.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlighting.cs
@@ -184,7 +184,6 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 				if (ContextStack.IsEmpty)
 					return Task.FromResult (new HighlightedLine (new TextSegment (startOffset, length), new [] { new ColoredSegment (0, length, ScopeStack.Empty) }));
 				SyntaxContext currentContext = null;
-				List<SyntaxContext> lastContexts = new List<SyntaxContext> ();
 				Match match = null;
 				SyntaxMatch curMatch = null;
 				var segments = new List<ColoredSegment> ();
@@ -200,17 +199,6 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 					timeoutOccursAt = Environment.TickCount + (int)matchTimeout.TotalMilliseconds;
 				}
 			restart:
-				if (lastMatch == offset) {
-					if (lastContexts.Contains (currentContext)) {
-						offset++;
-						length--;
-					} else {
-						lastContexts.Add (currentContext);
-					}
-				} else {
-					lastContexts.Clear ();
-					lastContexts.Add (currentContext);
-				}
 				if (offset >= lineText.Length)
 					goto end;
 				lastMatch = offset;

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -223,5 +223,18 @@ namespace Mono.TextEditor.Tests
 			Assert.IsTrue (string.IsNullOrEmpty (SyntaxHighlightingService.ParseFileType ("\".\",")));
 			Assert.IsTrue (string.IsNullOrEmpty (SyntaxHighlightingService.ParseFileType ("}")));
 		}
+
+		/// <summary>
+		/// VSTS Bug 665407: TypeScript/JavaScript TextMate syntax highlighting errors
+		/// </summary>
+		[Test]
+		public void TestVSTS665407 ()
+		{
+			TestOutput (@"function foo(i: string) {}
+function foo() {}",
+						@"<span foreground=""#719dcf"">function</span><span foreground=""#eeeeec""> foo(i</span><span foreground=""#719dcf"">:</span><span foreground=""#eeeeec""> </span><span foreground=""#4ec9b0"">string</span><span foreground=""#eeeeec"">) {}</span>
+<span foreground=""#719dcf"">function</span><span foreground=""#eeeeec""> foo() {}</span>",
+						"application/typescript");
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -234,7 +234,7 @@ namespace Mono.TextEditor.Tests
 function foo() {}",
 						@"<span foreground=""#719dcf"">function</span><span foreground=""#eeeeec""> foo(i</span><span foreground=""#719dcf"">:</span><span foreground=""#eeeeec""> </span><span foreground=""#4ec9b0"">string</span><span foreground=""#eeeeec"">) {}</span>
 <span foreground=""#719dcf"">function</span><span foreground=""#eeeeec""> foo() {}</span>",
-						"application/typescript");
+						"text/x-typescript");
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/SyntaxHighlightingTests.cs
@@ -230,10 +230,8 @@ namespace Mono.TextEditor.Tests
 		[Test]
 		public void TestVSTS665407 ()
 		{
-			TestOutput (@"function foo(i: string) {}
-function foo() {}",
-						@"<span foreground=""#719dcf"">function</span><span foreground=""#eeeeec""> foo(i</span><span foreground=""#719dcf"">:</span><span foreground=""#eeeeec""> </span><span foreground=""#4ec9b0"">string</span><span foreground=""#eeeeec"">) {}</span>
-<span foreground=""#719dcf"">function</span><span foreground=""#eeeeec""> foo() {}</span>",
+			TestOutput ("function foo(i: string) {}\nfunction foo() {}",
+						"<span foreground=\"#719dcf\">function</span><span foreground=\"#eeeeec\"> foo(i</span><span foreground=\"#719dcf\">:</span><span foreground=\"#eeeeec\"> </span><span foreground=\"#4ec9b0\">string</span><span foreground=\"#eeeeec\">) {}</span>\n<span foreground=\"#719dcf\">function</span><span foreground=\"#eeeeec\"> foo() {}</span>",
 						"text/x-typescript");
 		}
 	}


### PR DESCRIPTION
highlighting errors

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/665407

Was caused by an isanity check to prevent infinite loops.
Unfortunately it's not so easy to determine state changes that way in
complex grammars. However there is another one implemented : timeouts.

That's enough to prevent infinite loops so this is not really needed
anymore.