### PR TITLE
[Ide] Fix project not being run when it has warnings

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1388,7 +1388,7 @@ namespace MonoDevelop.Ide
 
 			return CheckAndBuildForExecute (
 				buildTargets, configuration,
-				IdeApp.Preferences.BuildBeforeExecuting, IdeApp.Preferences.RunWithWarnings,
+				IdeApp.Preferences.BuildBeforeExecuting, !IdeApp.Preferences.RunWithWarnings,
 				(target, monitor) => {
 					if (target is IRunTarget runTarget) {
 						var projectRunConfig = GetProjectRunConfiguration (runTarget, runConfiguration);


### PR DESCRIPTION
With "Run project if build completed with warnings" set to true in
Preferences a project would not be run if the build had warnings.
The preferences setting had the opposite effect since it was being
treated as though it indicated the run should be cancelled when it
was true.

Fixes VSTS #667156 - [VSM] Project is not built and started to run
after Toolbar -> Run hit