### PR TITLE
[Ide] Fix crash on trying to change PCL profile in project options

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SupportedFramework.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SupportedFramework.cs
@@ -172,6 +172,7 @@ namespace MonoDevelop.Core.Assemblies
 			}
 			WriteNonEmptyAttribute ("Profile", Profile);
 			WriteNonEmptyAttribute ("Identifier", Identifier);
+			WriteNonEmptyAttribute ("DisplayName", DisplayName);
 			WriteNonEmptyAttribute ("MinimumVersionDisplayName", MinimumVersionDisplayName);
 			WriteNonEmptyAttribute ("MonoSpecificVersion", MonoSpecificVersion);
 			WriteNonEmptyAttribute ("MonoSpecificVersionDisplayName", MonoSpecificVersionDisplayName);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFramework.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFramework.cs
@@ -238,6 +238,15 @@ namespace MonoDevelop.Core.Assemblies
 				//if Mono was upgraded since caching, the cached location may no longer be valid
 				if (!Directory.Exists (fxInfo.TargetFrameworkDirectory)) {
 					fxInfo = null;
+				} else if (fxInfo.SupportedFrameworks.Count > 0) {
+					// Ensure DisplayName was saved for the SupportedFrameworks. If missing invalidate the
+					// cache to ensure DisplayName is saved. Only check the first framework since the
+					// DisplayName was not being saved previously. The DisplayName will not be empty when
+					// saved even if the framework .xml file does not define it since the filename will be
+					// used as the DisplayName in that case.
+					if (string.IsNullOrEmpty (fxInfo.SupportedFrameworks [0].DisplayName)) {
+						fxInfo = null;
+					}
 				}
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/PortableRuntimeSelectorDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/PortableRuntimeSelectorDialog.cs
@@ -280,7 +280,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			for (int i = 0; i < targetFrameworks.Count; i++) {
 				var fx = targetFrameworks[i];
 
-				model.AppendValues (GetPclShortDisplayName (fx, fx == missingFramework), fx);
+				model.AppendValues (GetPclShortDisplayName (fx, fx == missingFramework));
 				if (fx.Id.Equals (TargetFramework.Id))
 					combo.Active = i;
 			}


### PR DESCRIPTION
On opening the project options for a PCL project and clicking
Change to re-target the profile the IDE would terminate.

Needs to be backported to release-7.6 but needs another pull request to be merged first - https://github.com/mono/monodevelop/pull/5737

```
Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) Gtk.ListStore.gtk_list_store_set_valuesv (intptr,Gtk.TreeIter&,int*,GLib.Value*,int) [0x0000e] in <13dfc6c534074eb08a8f382a81e605d5>:0
  at Gtk.ListStore.SetValues (Gtk.TreeIter,object[]) [0x00068] in 2018-02/external/bockbuild/builds/gtk-sharp-None/gtk/generated/ListStore.custom:171
  at Gtk.ListStore.AppendValues (object[]) [0x0000b] in 2018-02/external/bockbuild/builds/gtk-sharp-None/gtk/generated/ListStore.custom:120
  at MonoDevelop.Ide.Projects.OptionPanels.PortableRuntimeSelectorDialog.AddTopSelectorCombo () [0x0005f] in monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/PortableRuntimeSelectorDialog.cs:283
```

The problem was the list store model used was defined as having one
column whilst some code was trying to append two columns to the model.

Fixes VSTS #668484 - Crash when you try to change the PCL profile

Also fixed the PCL dialog only showing the one target framework '.NET 4.5 or later'. This was because the supported framework DisplayName was not being saved in the framework cache.

<img width="302" alt="pcldialog" src="https://user-images.githubusercontent.com/372361/44461004-27f2b700-a607-11e8-96be-aa179db466d1.png">

Also added logic to invalidate the cache if the DisplayName is not saved.