### PR TITLE
[MSBuild] Enable usage of analyzers from `<Analyzer>` itemgroup

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -468,12 +468,12 @@ namespace MonoDevelop.Projects
 		/// <summary>
 		/// Gets the analyzer files that are included in the project, including any that are added by `CoreCompileDependsOn`
 		/// </summary>
-		public Task<FilePath []> GetAnalyzerFilesAsync (ConfigurationSelector configuration)
+		public Task<ImmutableArray<FilePath>> GetAnalyzerFilesAsync (ConfigurationSelector configuration)
 		{
 			if (sourceProject == null)
-				return Task.FromResult (Array.Empty<FilePath> ());
+				return Task.FromResult (ImmutableArray<FilePath>.Empty);
 
-			return BindTask<FilePath []> (cancelToken => {
+			return BindTask<ImmutableArray<FilePath>> (cancelToken => {
 				var cancelSource = new CancellationTokenSource ();
 				cancelToken.Register (() => cancelSource.Cancel ());
 
@@ -486,7 +486,7 @@ namespace MonoDevelop.Projects
 		/// <summary>
 		/// Gets the analyzer files that are included in the project, including any that are added by `CoreCompileDependsOn`
 		/// </summary>
-		public Task<FilePath []> GetAnalyzerFilesAsync (ProgressMonitor monitor, ConfigurationSelector configuration)
+		public Task<ImmutableArray<FilePath>> GetAnalyzerFilesAsync (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			return ProjectExtension.OnGetAnalyzerFiles (monitor, configuration);
 		}
@@ -520,10 +520,10 @@ namespace MonoDevelop.Projects
 		/// <summary>
 		/// Gets the analyzer files that are included in the project, including any that are added by `CoreCompileDependsOn`
 		/// </summary>
-		protected virtual async Task<FilePath[]> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
+		protected virtual async Task<ImmutableArray<FilePath>> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			var coreCompileResult = await compileEvaluator.GetItemsFromCoreCompileDependenciesAsync (this, monitor, configuration);
-			return coreCompileResult.AnalyzerFiles.ToArray ();
+			return coreCompileResult.AnalyzerFiles;
 		}
 
 		/// <summary>
@@ -615,16 +615,16 @@ namespace MonoDevelop.Projects
 
 		readonly struct CoreCompileEvaluationResult
 		{
-			public static CoreCompileEvaluationResult Empty = new CoreCompileEvaluationResult (Array.Empty<ProjectFile> (), Array.Empty<FilePath> ());
+			public static CoreCompileEvaluationResult Empty = new CoreCompileEvaluationResult (Array.Empty<ProjectFile> (), ImmutableArray<FilePath>.Empty);
 
-			public CoreCompileEvaluationResult (ProjectFile[] sourceFiles, FilePath[] analyzerFiles)
+			public CoreCompileEvaluationResult (ProjectFile[] sourceFiles, ImmutableArray<FilePath> analyzerFiles)
 			{
 				SourceFiles = sourceFiles;
 				AnalyzerFiles = analyzerFiles;
 			}
 
 			public readonly ProjectFile[] SourceFiles;
-			public readonly FilePath[] AnalyzerFiles;
+			public readonly ImmutableArray<FilePath> AnalyzerFiles;
 		}
 
 		class CachingCoreCompileEvaluator
@@ -730,7 +730,7 @@ namespace MonoDevelop.Projects
 						analyzerList.Add (msbuildPath);
 				}
 
-				return new CoreCompileEvaluationResult (sourceFilesList.ToArray (), analyzerList.ToArray ());
+				return new CoreCompileEvaluationResult (sourceFilesList.ToArray (), analyzerList.ToImmutableArray ());
 			}
 		}
 
@@ -4763,7 +4763,7 @@ namespace MonoDevelop.Projects
 			}
 
 
-			internal protected override Task<FilePath []> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
+			internal protected override Task<ImmutableArray<FilePath>> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 			{
 				return Project.OnGetAnalyzerFiles (monitor, configuration);
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -170,6 +170,11 @@ namespace MonoDevelop.Projects
 			return next.OnReevaluateProject (monitor);
 		}
 
+		internal protected virtual Task<FilePath []> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
+		{
+			return next.OnGetAnalyzerFiles (monitor, configuration);
+		}
+
 		internal protected virtual Task<ProjectFile []> OnGetSourceFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			return next.OnGetSourceFiles (monitor, configuration);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -170,7 +170,7 @@ namespace MonoDevelop.Projects
 			return next.OnReevaluateProject (monitor);
 		}
 
-		internal protected virtual Task<FilePath []> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
+		internal protected virtual Task<ImmutableArray<FilePath>> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			return next.OnGetAnalyzerFiles (monitor, configuration);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/HostDiagnosticUpdateSource.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/HostDiagnosticUpdateSource.cs
@@ -1,0 +1,138 @@
+//
+// HostDiagnosticUpdateSource.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Utilities;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	// exporting both Abstract and HostDiagnosticUpdateSource is just to make testing easier.
+	// use HostDiagnosticUpdateSource when abstract one is not needed for testing purpose
+
+	// FIXME: Not sure we can use this until roslyn supports multi-workspace or we go single workspace
+	//[Export (typeof (AbstractHostDiagnosticUpdateSource))]
+	//[Export (typeof (HostDiagnosticUpdateSource))]
+	internal sealed class HostDiagnosticUpdateSource : AbstractHostDiagnosticUpdateSource
+	{
+		private readonly MonoDevelopWorkspace _workspace;
+		private readonly object _gate = new object ();
+		private readonly Dictionary<ProjectId, HashSet<object>> _diagnosticMap = new Dictionary<ProjectId, HashSet<object>> ();
+
+		public HostDiagnosticUpdateSource (MonoDevelopWorkspace workspace, IDiagnosticUpdateSourceRegistrationService registrationService)
+		{
+			_workspace = workspace;
+
+			registrationService.Register (this);
+		}
+
+		public override Microsoft.CodeAnalysis.Workspace Workspace {
+			get {
+				return _workspace;
+			}
+		}
+
+		private void RaiseDiagnosticsCreatedForProject (ProjectId projectId, object key, IEnumerable<DiagnosticData> items)
+		{
+			var args = DiagnosticsUpdatedArgs.DiagnosticsCreated (
+				CreateId (projectId, key),
+				_workspace,
+				solution: null,
+				projectId: projectId,
+				documentId: null,
+				diagnostics: items.AsImmutableOrEmpty ());
+
+			RaiseDiagnosticsUpdated (args);
+		}
+
+		private void RaiseDiagnosticsRemovedForProject (ProjectId projectId, object key)
+		{
+			var args = DiagnosticsUpdatedArgs.DiagnosticsRemoved (
+				CreateId (projectId, key),
+				_workspace,
+				solution: null,
+				projectId: projectId,
+				documentId: null);
+
+			RaiseDiagnosticsUpdated (args);
+		}
+
+		private object CreateId (ProjectId projectId, object key) => Tuple.Create (this, projectId, key);
+
+		public void UpdateDiagnosticsForProject (ProjectId projectId, object key, IEnumerable<DiagnosticData> items)
+		{
+			Contract.ThrowIfNull (projectId);
+			Contract.ThrowIfNull (key);
+			Contract.ThrowIfNull (items);
+
+			lock (_gate) {
+				_diagnosticMap.GetOrAdd (projectId, id => new HashSet<object> ()).Add (key);
+			}
+
+			RaiseDiagnosticsCreatedForProject (projectId, key, items);
+		}
+
+		public void ClearAllDiagnosticsForProject (ProjectId projectId)
+		{
+			Contract.ThrowIfNull (projectId);
+
+			HashSet<object> projectDiagnosticKeys;
+			lock (_gate) {
+				if (_diagnosticMap.TryGetValue (projectId, out projectDiagnosticKeys)) {
+					_diagnosticMap.Remove (projectId);
+				}
+			}
+
+			if (projectDiagnosticKeys != null) {
+				foreach (var key in projectDiagnosticKeys) {
+					RaiseDiagnosticsRemovedForProject (projectId, key);
+				}
+			}
+
+			ClearAnalyzerDiagnostics (projectId);
+		}
+
+		public void ClearDiagnosticsForProject (ProjectId projectId, object key)
+		{
+			Contract.ThrowIfNull (projectId);
+			Contract.ThrowIfNull (key);
+
+			var raiseEvent = false;
+			lock (_gate) {
+				if (_diagnosticMap.TryGetValue (projectId, out var projectDiagnosticKeys)) {
+					raiseEvent = projectDiagnosticKeys.Remove (key);
+				}
+			}
+
+			if (raiseEvent) {
+				RaiseDiagnosticsRemovedForProject (projectId, key);
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopAnalyzer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopAnalyzer.cs
@@ -1,0 +1,195 @@
+//
+// MonoDevelopAnalyzer.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	internal sealed class MonoDevelopAnalyzer : IDisposable
+	{
+		private readonly HostDiagnosticUpdateSource _hostDiagnosticUpdateSource;
+		private readonly ProjectId _projectId;
+		private readonly Microsoft.CodeAnalysis.Workspace _workspace;
+		private readonly IAnalyzerAssemblyLoader _loader;
+		private readonly string _language;
+
+		// these 2 are mutable states that must be guarded under the _gate.
+		private readonly object _gate = new object ();
+		private AnalyzerReference _analyzerReference = null;
+		private ImmutableArray<DiagnosticData> _analyzerLoadErrors = ImmutableArray<DiagnosticData>.Empty;
+
+		public MonoDevelopAnalyzer (FilePath fullPath, HostDiagnosticUpdateSource hostDiagnosticUpdateSource, ProjectId projectId, Microsoft.CodeAnalysis.Workspace workspace, IAnalyzerAssemblyLoader loader, string language)
+		{
+			FullPath = fullPath;
+			_hostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
+			_projectId = projectId;
+			_workspace = workspace;
+			_loader = loader;
+			_language = language;
+
+			FileService.FileChanged += OnUpdatedOnDisk;
+		}
+
+		public event EventHandler UpdatedOnDisk;
+
+		public FilePath FullPath { get; }
+
+		public bool HasLoadErrors {
+			get { return !_analyzerLoadErrors.IsEmpty; }
+		}
+
+		public AnalyzerReference GetReference ()
+		{
+			lock (_gate) {
+				if (_analyzerReference == null) {
+					if (File.Exists (FullPath)) {
+						// Pass down a custom loader that will ensure we are watching for file changes once we actually load the assembly.
+						var assemblyLoaderForFileTracker = new AnalyzerAssemblyLoaderThatEnsuresFileBeingWatched (this);
+						_analyzerReference = new AnalyzerFileReference (FullPath, assemblyLoaderForFileTracker);
+						((AnalyzerFileReference)_analyzerReference).AnalyzerLoadFailed += OnAnalyzerLoadError;
+					} else {
+						_analyzerReference = new VisualStudioUnresolvedAnalyzerReference (FullPath, this);
+					}
+				}
+
+				return _analyzerReference;
+			}
+		}
+
+		private void OnAnalyzerLoadError (object sender, AnalyzerLoadFailureEventArgs e)
+		{
+			var data = AnalyzerHelper.CreateAnalyzerLoadFailureDiagnostic (_workspace, _projectId, _language, FullPath, e);
+
+			lock (_gate) {
+				_analyzerLoadErrors = _analyzerLoadErrors.Add (data);
+			}
+
+			_hostDiagnosticUpdateSource.UpdateDiagnosticsForProject (_projectId, this, _analyzerLoadErrors);
+		}
+
+		public void Dispose ()
+		{
+			Reset ();
+
+			FileWatcherService.WatchDirectories (this, null);
+			FileService.FileChanged -= OnUpdatedOnDisk;
+		}
+
+		public void Reset ()
+		{
+			ResetReferenceAndErrors (out var reference, out var loadErrors);
+
+			if (reference is AnalyzerFileReference fileReference) {
+				fileReference.AnalyzerLoadFailed -= OnAnalyzerLoadError;
+
+				if (!loadErrors.IsEmpty) {
+					_hostDiagnosticUpdateSource.ClearDiagnosticsForProject (_projectId, this);
+				}
+
+				_hostDiagnosticUpdateSource.ClearAnalyzerReferenceDiagnostics (fileReference, _language, _projectId);
+			}
+		}
+
+		private void ResetReferenceAndErrors (out AnalyzerReference reference, out ImmutableArray<DiagnosticData> loadErrors)
+		{
+			lock (_gate) {
+				loadErrors = _analyzerLoadErrors;
+				reference = _analyzerReference;
+
+				_analyzerLoadErrors = ImmutableArray<DiagnosticData>.Empty;
+				_analyzerReference = null;
+			}
+		}
+
+		private void OnUpdatedOnDisk (object sender, EventArgs e)
+		{
+			UpdatedOnDisk?.Invoke (this, EventArgs.Empty);
+		}
+
+		/// <summary>
+		/// This custom loader just wraps an existing loader, but ensures that we start listening to the file
+		/// for changes once we've actually looked at the file.
+		/// </summary>
+		private class AnalyzerAssemblyLoaderThatEnsuresFileBeingWatched : IAnalyzerAssemblyLoader
+		{
+			private readonly MonoDevelopAnalyzer _analyzer;
+
+			public AnalyzerAssemblyLoaderThatEnsuresFileBeingWatched (MonoDevelopAnalyzer analyzer)
+			{
+				_analyzer = analyzer;
+			}
+
+			public void AddDependencyLocation (string fullPath)
+			{
+				_analyzer._loader.AddDependencyLocation (fullPath);
+			}
+
+			public Assembly LoadFromPath (string fullPath)
+			{
+				FileWatcherService.WatchDirectories (_analyzer, new [] { _analyzer.FullPath.ParentDirectory });
+				return _analyzer._loader.LoadFromPath (fullPath);
+			}
+		}
+
+		/// <summary>
+		/// This custom <see cref="AnalyzerReference"/>, just wraps an existing <see cref="UnresolvedAnalyzerReference"/>,
+		/// but ensure that we start listening to the file for changes once we've actually observed it, so that if the
+		/// file then gets created on disk, we are notified.
+		/// </summary>
+		private class VisualStudioUnresolvedAnalyzerReference : AnalyzerReference
+		{
+			private readonly UnresolvedAnalyzerReference _underlying;
+			private readonly MonoDevelopAnalyzer _visualStudioAnalyzer;
+
+			public VisualStudioUnresolvedAnalyzerReference (string fullPath, MonoDevelopAnalyzer visualStudioAnalyzer)
+			{
+				_underlying = new UnresolvedAnalyzerReference (fullPath);
+				_visualStudioAnalyzer = visualStudioAnalyzer;
+			}
+
+			public override string FullPath
+				=> _underlying.FullPath;
+
+			public override object Id
+				=> _underlying.Id;
+
+			public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers (string language)
+			{
+				FileWatcherService.WatchDirectories (_visualStudioAnalyzer, new [] { _visualStudioAnalyzer.FullPath.ParentDirectory });
+				return _underlying.GetAnalyzers (language);
+			}
+
+			public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages ()
+				=> _underlying.GetAnalyzersForAllLanguages ();
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -130,7 +130,6 @@ namespace MonoDevelop.Ide.TypeSystem
 					return null;
 
 				var loader = workspace.Services.GetService<IAnalyzerService> ().GetLoader ();
-				var analyzerReferences = analyzerFiles.Select (x => new MonoDevelopAnalyzer (x, hostDiagnosticUpdateSource.Value, projectId, workspace, loader, LanguageNames.CSharp));
 
 				lock (workspace.updatingProjectDataLock) {
 					//when reloading e.g. after a save, preserve document IDs
@@ -155,7 +154,10 @@ namespace MonoDevelop.Ide.TypeSystem
 						documents.Item1,
 						projectReferences,
 						references.Select (x => x.CurrentSnapshot),
-						analyzerReferences: analyzerReferences.Select (x => x.GetReference()).ToImmutableArray (),
+						analyzerReferences: analyzerFiles.SelectAsArray (x => {
+							var analyzer = new MonoDevelopAnalyzer (x, hostDiagnosticUpdateSource.Value, projectId, workspace, loader, LanguageNames.CSharp);
+							return analyzer.GetReference ();
+						}),
 						additionalDocuments: documents.Item2
 					);
 					return info;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -32,6 +32,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor.Projection;
@@ -46,6 +47,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			readonly ProjectDataMap projectMap;
 			readonly ProjectionData projections;
 			readonly Lazy<MetadataReferenceHandler> metadataHandler;
+			readonly Lazy<HostDiagnosticUpdateSource> hostDiagnosticUpdateSource;
 
 			bool added;
 			readonly object addLock = new object ();
@@ -59,6 +61,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				this.projections = projections;
 
 				metadataHandler = new Lazy<MetadataReferenceHandler> (() => new MetadataReferenceHandler (workspace.MetadataReferenceManager, projectMap));
+				hostDiagnosticUpdateSource = new Lazy<HostDiagnosticUpdateSource> (() => new HostDiagnosticUpdateSource (workspace, Composition.CompositionManager.GetExportedValue<IDiagnosticUpdateSourceRegistrationService> ()));
 			}
 
 			#region Solution mapping
@@ -122,6 +125,13 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (token.IsCancellationRequested)
 					return null;
 
+				var analyzerFiles = await p.GetAnalyzerFilesAsync (config?.Selector).ConfigureAwait (false);
+				if (token.IsCancellationRequested)
+					return null;
+
+				var loader = workspace.Services.GetService<IAnalyzerService> ().GetLoader ();
+				var analyzerReferences = analyzerFiles.Select (x => new MonoDevelopAnalyzer (x, hostDiagnosticUpdateSource.Value, projectId, workspace, loader, LanguageNames.CSharp));
+
 				lock (workspace.updatingProjectDataLock) {
 					//when reloading e.g. after a save, preserve document IDs
 					var oldProjectData = projectMap.RemoveData (projectId);
@@ -145,10 +155,10 @@ namespace MonoDevelop.Ide.TypeSystem
 						documents.Item1,
 						projectReferences,
 						references.Select (x => x.CurrentSnapshot),
+						analyzerReferences: analyzerReferences.Select (x => x.GetReference()).ToImmutableArray (),
 						additionalDocuments: documents.Item2
 					);
 					return info;
-
 				}
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4196,6 +4196,8 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.MetadataReferenceHandler.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspace.ProjectSystemHandler.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.Components\IInfoBarHost.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopAnalyzer.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\HostDiagnosticUpdateSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="MonoDevelop.FSW\PathTreeTests.cs" />
     <Compile Include="MonoDevelop.Projects\ExtensionChainTests.cs" />
     <Compile Include="MonoDevelop.Core\PropertyTests.cs" />
+    <Compile Include="MonoDevelop.Projects\GetAnalyzerFilesAsyncTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetAnalyzerFilesAsyncTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetAnalyzerFilesAsyncTests.cs
@@ -1,0 +1,136 @@
+//
+// GetAnalyzerFilesAsyncTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects.MSBuild;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Projects
+{
+	[TestFixture]
+	public class GetAnalyzerFilesAsyncTests : TestBase
+	{
+		[Test ()]
+		public async Task GetAnalyzerFilesFromProjectWithImportedCompileItems ()
+		{
+			string projectFile = Util.GetSampleProject ("project-with-corecompiledepends", "project-with-imported-files.csproj");
+			using (var project = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
+
+				var msg = "GetAnalyzerFilesAsync should include imported items";
+				Assert.AreEqual (1, analyzerFiles.Length, msg);
+
+				Assert.IsTrue (analyzerFiles.Any (f => f.FileName == "Foo.dll"));
+			}
+		}
+
+		[Test ()]
+		public async Task GetAnalyzerFilesFromProjectWithAddedCompileItems ()
+		{
+			string projectFile = Util.GetSampleProject ("project-with-corecompiledepends", "project.csproj");
+			using (var project = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
+
+				var msg = "When a project does specify CoreCompileDependsOn that adds Analyzer items, then GetAnalyzerFiles should include the added item(s)";
+				Assert.AreEqual (2, analyzerFiles.Length, msg);
+
+				msg = "When a project does specify CoreCompileDependsOn that adds Analyzer items, then GetAnalyzerFiles should also include the non-generated items";
+				Assert.IsTrue (analyzerFiles.Any (f => f.FileName == "Foo.dll"));
+				Assert.IsTrue (analyzerFiles.Any (f => f.FileName == "GeneratedFile.dll"));
+			}
+		}
+
+		[Test ()]
+		public async Task GetAnalyzerFilesFromProjectWithoutCoreCompileDependsOn ()
+		{
+			string projectFile = Util.GetSampleProject ("project-without-corecompiledepends", "project.csproj");
+			using (var project = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
+
+				const string msg = "When a project does not specify CoreCompileDependsOn, then GetAnalyzerFilesAsync should be identical to Files";
+
+				Assert.AreEqual (1, analyzerFiles.Length, msg);
+				Assert.IsTrue (analyzerFiles.Any (f => f.FileName == "Foo.dll"));
+			}
+		}
+
+		[Test ()]
+		public async Task FilesWithConfigurationCondition ()
+		{
+			string projectFile = Util.GetSampleProject ("project-with-corecompiledepends", "project-with-conditioned-file.csproj");
+			using (var project = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations ["Debug|x86"].Selector);
+
+				Assert.IsTrue (analyzerFiles.Any (f => f.FileName == "Conditioned.dll"));
+
+				analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations ["Release|x86"].Selector);
+
+				Assert.IsFalse (analyzerFiles.Any (f => f.FileName == "Conditioned.dll"));
+			}
+		}
+
+		[Test]
+		public async Task ImportWithCoreCompileDependsOnAddedAfterAnalyzerFilesCached ()
+		{
+			string projectFile = Util.GetSampleProject ("project-with-corecompiledepends", "consoleproject.csproj");
+			using (var project = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
+
+				Assert.AreEqual (0, analyzerFiles.Length);
+
+				string modifiedHint = null;
+				project.Modified += (sender, args) => modifiedHint = args.First ().Hint;
+
+				var before = new MSBuildItem (); // Ensures import added at end of project.
+				project.MSBuildProject.AddNewImport ("consoleproject-import.targets", null, before);
+				Assert.AreEqual ("Files", modifiedHint);
+
+				analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
+
+				Assert.IsTrue (analyzerFiles.Any (f => f.FileName == "GeneratedAnalyzer.g.dll"));
+
+				modifiedHint = null;
+				project.MSBuildProject.RemoveImport ("consoleproject-import.targets");
+				Assert.AreEqual ("Files", modifiedHint);
+
+				analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
+
+				Assert.IsFalse (analyzerFiles.Any (f => f.FileName == "GeneratedAnalyzer.g.dll"));
+				Assert.AreEqual (0, analyzerFiles.Count ());
+			}
+		}
+	}
+}

--- a/main/tests/test-projects/project-with-corecompiledepends/consoleproject-import.targets
+++ b/main/tests/test-projects/project-with-corecompiledepends/consoleproject-import.targets
@@ -9,6 +9,7 @@
     <WriteLinesToFile File="GeneratedFile.g.cs" Lines="hello" Overwrite="true" />
     <ItemGroup Condition="Exists('GeneratedFile.g.cs')">
         <Compile Include="GeneratedFile.g.cs" />
-    </ItemGroup>    
+		<Analyzer Include="GeneratedAnalyzer.g.dll" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/main/tests/test-projects/project-with-corecompiledepends/project-with-conditioned-file.csproj
+++ b/main/tests/test-projects/project-with-corecompiledepends/project-with-conditioned-file.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,13 +40,14 @@
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Conditioned.cs" Condition=" '$(Configuration)' == 'Debug' " />
+    <Analyzer Include="Conditioned.dll" Condition=" '$(Configuration)' == 'Debug' " />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
   </ItemGroup>
-  <ItemGroup> 
+  <ItemGroup>
     <EmbeddedResource Include="Resources\layout\Main.axml" />
     <EmbeddedResource Include="Resources\values\Strings.xml">
 			<Generator>MSBuild:UpdateGeneratedFiles</Generator>
@@ -62,15 +63,15 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="shared.props" />
-   
-   
+
+
 <Target Name="UpdateGeneratedFiles" DependsOnTargets="_UpdateGeneratedFiles">
   <ItemGroup>
     <Compile Include="GeneratedFile.g.cs" />
     <FileWrites Include="GeneratedFile.g.cs" />
   </ItemGroup>
-</Target> 
-	   
+</Target>
+
 <Target Name="_UpdateGeneratedFiles" Inputs="$(MSBuildProjectFile);@(ResourceFile)" Outputs="GeneratedFile.g.cs">
 		<WriteLinesToFile File="GeneratedFile.g.cs" Lines="hello" Overwrite="true" />
 </Target>

--- a/main/tests/test-projects/project-with-corecompiledepends/project.csproj
+++ b/main/tests/test-projects/project-with-corecompiledepends/project.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,7 +45,7 @@
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
   </ItemGroup>
-  <ItemGroup> 
+  <ItemGroup>
     <EmbeddedResource Include="Resources\layout\Main.axml" />
     <EmbeddedResource Include="Resources\values\Strings.xml">
 			<Generator>MSBuild:UpdateGeneratedFiles</Generator>
@@ -61,15 +61,16 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="shared.props" />
-   
-   
+
+
 <Target Name="UpdateGeneratedFiles" DependsOnTargets="_UpdateGeneratedFiles">
   <ItemGroup>
     <Compile Include="GeneratedFile.g.cs" />
     <FileWrites Include="GeneratedFile.g.cs" />
+    <Analyzer Include="GeneratedFile.dll" />
   </ItemGroup>
-</Target> 
-	   
+</Target>
+
 <Target Name="_UpdateGeneratedFiles" Inputs="$(MSBuildProjectFile);@(ResourceFile)" Outputs="GeneratedFile.g.cs">
 		<WriteLinesToFile File="GeneratedFile.g.cs" Lines="hello" Overwrite="true" />
 </Target>

--- a/main/tests/test-projects/project-with-corecompiledepends/shared.props
+++ b/main/tests/test-projects/project-with-corecompiledepends/shared.props
@@ -4,5 +4,6 @@
     <Compile Include="Foo.cs">
       <Link>Foo.cs</Link>
     </Compile>
+    <Analyzer Include="Foo.dll"/>
   </ItemGroup>
 </Project>

--- a/main/tests/test-projects/project-without-corecompiledepends/project.csproj
+++ b/main/tests/test-projects/project-without-corecompiledepends/project.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,13 +39,14 @@
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Analyzer Include="Foo.dll" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
   </ItemGroup>
-  <ItemGroup> 
+  <ItemGroup>
     <EmbeddedResource Include="Resources\layout\Main.axml" />
     <EmbeddedResource Include="Resources\values\Strings.xml">
 			<Generator>MSBuild:UpdateGeneratedFiles</Generator>


### PR DESCRIPTION
This patch aims to implement one part of analyzers from msbuild, and that is including items from the `<Analyzer>` itemgroup into the build.

We just pass those values to Roslyn, and it handles the rest!