### PR TITLE
Improve clipboard ring display in toolbox

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ICustomTooltipToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ICustomTooltipToolboxNode.cs
@@ -1,0 +1,31 @@
+﻿// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using MonoDevelop.Components;
+
+namespace MonoDevelop.DesignerSupport.Toolbox
+{
+	public interface ICustomTooltipToolboxNode
+	{
+		bool HasTooltip { get; }
+		Window CreateTooltipWindow (Control parent);
+	}
+}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TextToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TextToolboxNode.cs
@@ -50,13 +50,12 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public override bool Filter (string keyword)
 		{
 			return base.Filter (keyword)
-				   || ((Text==null)? false :  (Text.IndexOf (keyword, StringComparison.InvariantCultureIgnoreCase) >= 0));
+				   || ((Text != null) && (Text.IndexOf(keyword, StringComparison.InvariantCultureIgnoreCase) >= 0));
 		}
 		
 		public override bool Equals (object o)
 		{
-			TextToolboxNode n = o as TextToolboxNode;
-			return n != null && text == n.text && base.Equals (o);
+			return o is TextToolboxNode n && text == n.text && base.Equals (o);
 		}
 		
 		public override int GetHashCode ()

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/Toolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/Toolbox.cs
@@ -192,9 +192,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		void refilter ()
 		{
-			foreach (Category cat in toolboxWidget.Categories) {
+			foreach (ToolboxWidgetCategory cat in toolboxWidget.Categories) {
 				bool hasVisibleChild = false;
-				foreach (Item child in cat.Items) {
+				foreach (ToolboxWidgetItem child in cat.Items) {
 					child.IsVisible = ((ItemToolboxNode)child.Tag).Filter (filterEntry.Entry.Text);
 					hasVisibleChild |= child.IsVisible;
 				}
@@ -244,13 +244,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		
 		#region GUI population
 		
-		Dictionary<string, Category> categories = new Dictionary<string, Category> ();
+		Dictionary<string, ToolboxWidgetCategory> categories = new Dictionary<string, ToolboxWidgetCategory> ();
 		void AddItems (IEnumerable<ItemToolboxNode> nodes)
 		{
 			foreach (ItemToolboxNode itbn in nodes) {
-				Item newItem = new Item (itbn);
+				var newItem = new ToolboxWidgetItem (itbn);
 				if (!categories.ContainsKey (itbn.Category)) {
-					var cat = new Category (itbn.Category);
+					var cat = new ToolboxWidgetCategory (itbn.Category);
 					int prio;
 					if (!categoryPriorities.TryGetValue (itbn.Category, out prio))
 						prio = -1;
@@ -285,7 +285,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			var cats = categories.Values.ToList ();
 			cats.Sort ((a,b) => a.Priority != b.Priority ? a.Priority.CompareTo (b.Priority) : a.Text.CompareTo (b.Text));
 			cats.Reverse ();
-			foreach (Category category in cats) {
+			foreach (ToolboxWidgetCategory category in cats) {
 				category.IsExpanded = true;
 				toolboxWidget.AddCategory (category);
 			}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -171,10 +171,14 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			
 			layout = new Pango.Layout (this.PangoContext);
 			headerLayout = new Pango.Layout (this.PangoContext);
+
 			if (desc != null) {
 				layout.FontDescription = desc;
 				headerLayout.FontDescription = desc;
 			}
+
+			layout.Ellipsize = EllipsizeMode.End;
+
 			headerLayout.Attributes = new AttrList ();
 //			headerLayout.Attributes.Insert (new Pango.AttrWeight (Pango.Weight.Bold));
 		}
@@ -294,10 +298,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				if (listMode || !curCategory.CanIconizeItems)  {
 					cr.DrawImage (this, icon, xpos + ItemLeftPadding, ypos + Math.Round ((itemDimension.Height - icon.Height) / 2));
 					layout.SetMarkup (item.Text);
-					int width, height;
-					layout.GetPixelSize (out width, out height);
-					cr.SetSourceColor (Style.Text (item != this.SelectedItem ? StateType.Normal : StateType.Selected).ToCairoColor ());
-					cr.MoveTo (xpos + ItemLeftPadding + IconSize.Width + ItemIconTextItemSpacing, ypos + (double)(Math.Round ((double)(itemDimension.Height - height) / 2)));
+					layout.Width = (int) ((itemDimension.Width - ItemIconTextItemSpacing - IconSize.Width - ItemLeftPadding * 2) * Pango.Scale.PangoScale);
+					layout.GetPixelSize (out var width, out var height);
+					cr.SetSourceColor (Style.Text (item != SelectedItem ? StateType.Normal : StateType.Selected).ToCairoColor ());
+					cr.MoveTo (xpos + ItemLeftPadding + IconSize.Width + ItemIconTextItemSpacing, ypos + Math.Round ((double)(itemDimension.Height - height) / 2));
 					Pango.CairoHelper.ShowLayout (cr, layout);
 				} else {
 					cr.DrawImage (this, icon, xpos + Math.Round ((itemDimension.Width  - icon.Width) / 2), ypos + Math.Round ((itemDimension.Height - icon.Height) / 2));

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -946,9 +946,32 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				};
 			}
 
-			this.GdkWindow.GetOrigin (out var ox, out var oy);
-			tooltipWindow.Move (Math.Max (0, ox + tipX), oy + tipY);
+			//translate mouse position into screen coords
+			GdkWindow.GetOrigin (out var ox, out var oy);
+			int x = tipX + ox + Allocation.X;
+			int y = tipY + oy + Allocation.Y;
+
+			//get window size. might not work for all tooltips.
+			var req = tooltipWindow.SizeRequest ();
+			int w = req.Width;
+			int h = req.Height;
+
+			var geometry = Screen.GetUsableMonitorGeometry (Screen.GetMonitorAtPoint (ox + x, oy + y));
+
+			//if hits right edge, shift in
+			if (x + w > geometry.Right)
+				x = geometry.Right - w;
+
+			//if hits bottom, flip above mouse
+			if (y + h > geometry.Bottom)
+				y = y - h - 20;
+
+			int destX = Math.Max (0, x);
+			int destY = Math.Max (0, y);
+
+			tooltipWindow.Move (destX, destY);
 			tooltipWindow.ShowAll ();
+
 			return false;
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -40,16 +40,16 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 {
 	class ToolboxWidget : Gtk.DrawingArea
 	{
-		List<Category> categories = new List<Category> ();
-		
+		List<ToolboxWidgetCategory> categories = new List<ToolboxWidgetCategory> ();
+
 		bool showCategories = true;
-		bool listMode       = false;
+		bool listMode = false;
 		int mouseX, mouseY;
 		Pango.FontDescription desc;
 		Xwt.Drawing.Image discloseDown;
 		Xwt.Drawing.Image discloseUp;
 		Gdk.Cursor handCursor;
-		
+
 		const uint animationTimeSpan = 10;
 		const int animationStepSize = 35;
 
@@ -63,17 +63,17 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				this.ScrollToSelectedItem ();
 			}
 		}
-		
+
 		public bool CanIconizeToolboxCategories {
 			get {
-				foreach (Category category in categories) {
+				foreach (ToolboxWidgetCategory category in categories) {
 					if (category.CanIconizeItems)
 						return true;
 				}
 				return false;
 			}
 		}
-		
+
 		public bool ShowCategories {
 			get {
 				return showCategories;
@@ -84,9 +84,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				this.ScrollToSelectedItem ();
 			}
 		}
-		
+
 		public string CustomMessage { get; set; }
-		
+
 		internal void SetCustomFont (Pango.FontDescription desc)
 		{
 			this.desc = desc;
@@ -95,58 +95,52 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (headerLayout != null)
 				headerLayout.FontDescription = desc;
 		}
-		
+
 		Pango.Layout layout;
 		Pango.Layout headerLayout;
-		
-		Gdk.Size iconSize = new Gdk.Size (24, 24);
-		Gdk.Size IconSize {
-			get {
-				return iconSize;
-			}
-		}
-		
-		public IEnumerable<Category> Categories {
+		Size iconSize = new Size (24, 24);
+
+		public IEnumerable<ToolboxWidgetCategory> Categories {
 			get { return categories; }
 		}
-		
-		public IEnumerable<Item> AllItems {
+
+		public IEnumerable<ToolboxWidgetItem> AllItems {
 			get {
-				foreach (Category category in this.categories) {
-					foreach (Item item in category.Items) {
+				foreach (ToolboxWidgetCategory category in this.categories) {
+					foreach (ToolboxWidgetItem item in category.Items) {
 						yield return item;
 					}
 				}
 			}
 		}
-		
+
 		public void ClearCategories ()
 		{
 			categories.Clear ();
 			iconSize = new Gdk.Size (24, 24);
 		}
-		
-		public void AddCategory (Category category)
+
+		public void AddCategory (ToolboxWidgetCategory category)
 		{
 			categories.Add (category);
-			foreach (Item item in category.Items) {
+			foreach (ToolboxWidgetItem item in category.Items) {
 				if (item.Icon == null)
 					continue;
 
-				this.iconSize.Width  = Math.Max (this.iconSize.Width,  (int)item.Icon.Width);
-				this.iconSize.Height  = Math.Max (this.iconSize.Height,  (int)item.Icon.Height);
+				this.iconSize.Width = Math.Max (this.iconSize.Width, (int)item.Icon.Width);
+				this.iconSize.Height = Math.Max (this.iconSize.Height, (int)item.Icon.Height);
 			}
 		}
-		
+
 		public ToolboxWidget ()
 		{
-			this.Events =  EventMask.ExposureMask | 
-				           EventMask.EnterNotifyMask |
-				           EventMask.LeaveNotifyMask |
-				           EventMask.ButtonPressMask | 
-				           EventMask.ButtonReleaseMask | 
-				           EventMask.KeyPressMask | 
-					       EventMask.PointerMotionMask;
+			this.Events = EventMask.ExposureMask |
+						   EventMask.EnterNotifyMask |
+						   EventMask.LeaveNotifyMask |
+						   EventMask.ButtonPressMask |
+						   EventMask.ButtonReleaseMask |
+						   EventMask.KeyPressMask |
+						   EventMask.PointerMotionMask;
 			this.CanFocus = true;
 			discloseDown = ImageService.GetIcon ("md-disclose-arrow-down", Gtk.IconSize.Menu);
 			discloseUp = ImageService.GetIcon ("md-disclose-arrow-up", Gtk.IconSize.Menu);
@@ -166,9 +160,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				this.headerLayout.Dispose ();
 				this.headerLayout = null;
 			}
-			
+
 			base.OnStyleSet (previous_style);
-			
+
 			layout = new Pango.Layout (this.PangoContext);
 			headerLayout = new Pango.Layout (this.PangoContext);
 
@@ -180,10 +174,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			layout.Ellipsize = EllipsizeMode.End;
 
 			headerLayout.Attributes = new AttrList ();
-//			headerLayout.Attributes.Insert (new Pango.AttrWeight (Pango.Weight.Bold));
+			//			headerLayout.Attributes.Insert (new Pango.AttrWeight (Pango.Weight.Bold));
 		}
 
-		
+
 		protected override void OnDestroyed ()
 		{
 			HideTooltipWindow ();
@@ -198,10 +192,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			base.OnDestroyed ();
 			handCursor.Dispose ();
 		}
-		
+
 		static Cairo.Color Convert (Gdk.Color color)
 		{
-			return new Cairo.Color (color.Red / (double)ushort.MaxValue, color.Green / (double)ushort.MaxValue,  color.Blue / (double)ushort.MaxValue);
+			return new Cairo.Color (color.Red / (double)ushort.MaxValue, color.Green / (double)ushort.MaxValue, color.Blue / (double)ushort.MaxValue);
 		}
 
 		const int CategoryLeftPadding = 6;
@@ -242,12 +236,12 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			int xpos = (this.hAdjustement != null ? (int)this.hAdjustement.Value : 0);
 			int vadjustment = (this.vAdjustement != null ? (int)this.vAdjustement.Value : 0);
 			int ypos = -vadjustment;
-			Category lastCategory = null;
+			ToolboxWidgetCategory lastCategory = null;
 			int lastCategoryYpos = 0;
 
 			cr.LineWidth = 1;
 
-			Iterate (ref xpos, ref ypos, delegate (Category category, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, (category, itemDimension) => {
 				ProcessExpandAnimation (cr, lastCategory, lastCategoryYpos, backColor, area, ref ypos);
 
 				if (!area.IntersectsWith (new Gdk.Rectangle (new Gdk.Point (xpos, ypos), itemDimension)))
@@ -279,7 +273,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				lastCategoryYpos = ypos + itemDimension.Height;
 
 				return true;
-			}, delegate (Category curCategory, Item item, Gdk.Size itemDimension) {
+			}, (curCategory, item, itemDimension) => {
 				if (!area.IntersectsWith (new Gdk.Rectangle (new Gdk.Point (xpos, ypos), itemDimension)))
 					return true;
 
@@ -295,18 +289,18 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					cr.Rectangle (xpos, ypos, itemDimension.Width, itemDimension.Height);
 					cr.Fill ();
 				}
-				if (listMode || !curCategory.CanIconizeItems)  {
+				if (listMode || !curCategory.CanIconizeItems) {
 					cr.DrawImage (this, icon, xpos + ItemLeftPadding, ypos + Math.Round ((itemDimension.Height - icon.Height) / 2));
 					layout.SetMarkup (item.Text);
-					layout.Width = (int) ((itemDimension.Width - ItemIconTextItemSpacing - IconSize.Width - ItemLeftPadding * 2) * Pango.Scale.PangoScale);
+					layout.Width = (int)((itemDimension.Width - ItemIconTextItemSpacing - iconSize.Width - ItemLeftPadding * 2) * Pango.Scale.PangoScale);
 					layout.GetPixelSize (out var width, out var height);
 					cr.SetSourceColor (Style.Text (item != SelectedItem ? StateType.Normal : StateType.Selected).ToCairoColor ());
-					cr.MoveTo (xpos + ItemLeftPadding + IconSize.Width + ItemIconTextItemSpacing, ypos + Math.Round ((double)(itemDimension.Height - height) / 2));
+					cr.MoveTo (xpos + ItemLeftPadding + iconSize.Width + ItemIconTextItemSpacing, ypos + Math.Round ((double)(itemDimension.Height - height) / 2));
 					Pango.CairoHelper.ShowLayout (cr, layout);
 				} else {
-					cr.DrawImage (this, icon, xpos + Math.Round ((itemDimension.Width  - icon.Width) / 2), ypos + Math.Round ((itemDimension.Height - icon.Height) / 2));
+					cr.DrawImage (this, icon, xpos + Math.Round ((itemDimension.Width - icon.Width) / 2), ypos + Math.Round ((itemDimension.Height - icon.Height) / 2));
 				}
-					
+
 				if (item == mouseOverItem) {
 					cr.SetSourceColor (Style.Dark (StateType.Prelight).ToCairoColor ());
 					cr.Rectangle (xpos + 0.5, ypos + 0.5, itemDimension.Width - 1, itemDimension.Height - 1);
@@ -330,7 +324,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			return true;
 		}
 
-		void ProcessExpandAnimation (Cairo.Context cr, Category lastCategory, int lastCategoryYpos, Cairo.Color backColor, Gdk.Rectangle area, ref int ypos)
+		void ProcessExpandAnimation (Cairo.Context cr, ToolboxWidgetCategory lastCategory, int lastCategoryYpos, Cairo.Color backColor, Gdk.Rectangle area, ref int ypos)
 		{
 			if (lastCategory != null && lastCategory.AnimatingExpand) {
 				int newypos = lastCategory.IsExpanded ? lastCategoryYpos + lastCategory.AnimationHeight : ypos + lastCategory.AnimationHeight;
@@ -350,31 +344,31 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				cr.Fill ();
 				ypos = newypos;
 			}
-		}		
-		
+		}
+
 		protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
 		{
-			Item nextItem;
-			
+			ToolboxWidgetItem nextItem;
+
 			// Handle keyboard toolip popup
 			if ((evnt.Key == Gdk.Key.F1 && (evnt.State & Gdk.ModifierType.ControlMask) == Gdk.ModifierType.ControlMask)) {
 				if (this.SelectedItem != null) {
 					int vadjustment = (this.vAdjustement != null ? (int)this.vAdjustement.Value : 0);
 					Gdk.Rectangle rect = GetItemExtends (SelectedItem);
-					ShowTooltip (SelectedItem, 0,rect.X, rect.Bottom - vadjustment );
+					ShowTooltip (SelectedItem, 0, rect.X, rect.Bottom - vadjustment);
 				}
 				return true;
 			}
-			
+
 			switch (evnt.Key) {
 			case Gdk.Key.KP_Enter:
 			case Gdk.Key.Return:
-				if (this.SelectedItem != null) 
+				if (this.SelectedItem != null)
 					this.OnActivateSelectedItem (EventArgs.Empty);
 				return true;
 			case Gdk.Key.KP_Up:
 			case Gdk.Key.Up:
-				if (this.listMode || this.SelectedItem is Category) {
+				if (this.listMode || this.SelectedItem is ToolboxWidgetCategory) {
 					this.SelectedItem = GetPrevItem (this.SelectedItem);
 				} else {
 					nextItem = GetItemAbove (this.SelectedItem);
@@ -384,12 +378,12 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				return true;
 			case Gdk.Key.KP_Down:
 			case Gdk.Key.Down:
-				if (this.listMode || this.SelectedItem is Category) {
+				if (this.listMode || this.SelectedItem is ToolboxWidgetCategory) {
 					this.SelectedItem = GetNextItem (this.SelectedItem);
 				} else {
 					nextItem = GetItemBelow (this.SelectedItem);
 					if (nextItem == this.SelectedItem) {
-						Category category = GetCategory (this.SelectedItem);
+						ToolboxWidgetCategory category = GetCategory (this.SelectedItem);
 						nextItem = GetNextCategory (category);
 						if (nextItem == category)
 							nextItem = this.SelectedItem;
@@ -398,11 +392,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 				this.QueueDraw ();
 				return true;
-				
+
 			case Gdk.Key.KP_Left:
 			case Gdk.Key.Left:
-				if (this.SelectedItem is Category) {
-					SetCategoryExpanded ((Category)this.SelectedItem, false);
+				if (this.SelectedItem is ToolboxWidgetCategory) {
+					SetCategoryExpanded ((ToolboxWidgetCategory)this.SelectedItem, false);
 				} else {
 					if (this.listMode) {
 						this.SelectedItem = GetCategory (this.SelectedItem);
@@ -412,14 +406,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 				this.QueueDraw ();
 				return true;
-				
+
 			case Gdk.Key.KP_Right:
 			case Gdk.Key.Right:
-				if (this.SelectedItem is Category) {
-					Category selectedCategory = ((Category)this.SelectedItem);
+				if (this.SelectedItem is ToolboxWidgetCategory selectedCategory) {
 					if (selectedCategory.IsExpanded) {
 						if (selectedCategory.ItemCount > 0)
-							this.SelectedItem = selectedCategory.Items[0];
+							this.SelectedItem = selectedCategory.Items [0];
 					} else {
 						SetCategoryExpanded (selectedCategory, true);
 					}
@@ -432,7 +425,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 				this.QueueDraw ();
 				return true;
-				
+
 			}
 			return false;
 		}
@@ -442,8 +435,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			HideTooltipWindow ();
 			base.OnUnrealized ();
 		}
-		
-		protected override bool OnLeaveNotifyEvent (Gdk.EventCrossing evnt)		
+
+		protected override bool OnLeaveNotifyEvent (Gdk.EventCrossing evnt)
 		{
 			if (evnt.Mode == CrossingMode.Normal) {
 				HideTooltipWindow ();
@@ -452,23 +445,23 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			GdkWindow.Cursor = null;
 			return base.OnLeaveNotifyEvent (evnt);
 		}
-		
+
 		protected override bool OnScrollEvent (Gdk.EventScroll evnt)
 		{
 			HideTooltipWindow ();
 			ClearMouseOverItem ();
 			return base.OnScrollEvent (evnt);
 		}
-		
+
 		public Action<Gdk.EventButton> DoPopupMenu { get; set; }
-		
+
 		protected override bool OnButtonPressEvent (Gdk.EventButton e)
 		{
 			this.GrabFocus ();
 			HideTooltipWindow ();
-			if (this.mouseOverItem is Category) {
+			if (this.mouseOverItem is ToolboxWidgetCategory) {
 				if (!e.TriggersContextMenu () && e.Button == 1 && e.Type == EventType.ButtonPress) {
-					Category mouseOverCateogry = (Category)this.mouseOverItem;
+					ToolboxWidgetCategory mouseOverCateogry = (ToolboxWidgetCategory)this.mouseOverItem;
 					SetCategoryExpanded (mouseOverCateogry, !mouseOverCateogry.IsExpanded);
 					return true;
 				}
@@ -483,7 +476,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					DoPopupMenu (e);
 					return true;
 				}
-			} else if (e.Type == EventType.TwoButtonPress && this.SelectedItem != null) { 
+			} else if (e.Type == EventType.TwoButtonPress && this.SelectedItem != null) {
 				this.OnActivateSelectedItem (EventArgs.Empty);
 				return true;
 			}
@@ -495,7 +488,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			DoPopupMenu?.Invoke (null);
 		}
 
-		void SetCategoryExpanded (Category cat, bool expanded)
+		void SetCategoryExpanded (ToolboxWidgetCategory cat, bool expanded)
 		{
 			if (cat.IsExpanded == expanded)
 				return;
@@ -506,35 +499,35 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				StartCollapseAnimation (cat);
 		}
 
-		void StartExpandAnimation (Category cat)
+		void StartExpandAnimation (ToolboxWidgetCategory cat)
 		{
 			if (cat.AnimatingExpand)
 				GLib.Source.Remove (cat.AnimationHandle);
 
 			cat.AnimationHeight = 0;
 			cat.AnimatingExpand = true;
-			cat.AnimationHandle = GLib.Timeout.Add (animationTimeSpan, delegate {
+			cat.AnimationHandle = GLib.Timeout.Add (animationTimeSpan, () => {
 				cat.AnimationHeight += animationStepSize;
 				QueueResize ();
 				return true;
 			});
 		}
 
-		void StartCollapseAnimation (Category cat)
+		void StartCollapseAnimation (ToolboxWidgetCategory cat)
 		{
 			if (cat.AnimatingExpand)
 				GLib.Source.Remove (cat.AnimationHandle);
 
 			cat.AnimationHeight = 0;
 			cat.AnimatingExpand = true;
-			cat.AnimationHandle = GLib.Timeout.Add (animationTimeSpan, delegate {
+			cat.AnimationHandle = GLib.Timeout.Add (animationTimeSpan, () => {
 				cat.AnimationHeight -= animationStepSize;
 				QueueResize ();
 				return true;
 			});
 		}
 
-		void StopExpandAnimation (Category cat)
+		void StopExpandAnimation (ToolboxWidgetCategory cat)
 		{
 			if (cat.AnimatingExpand) {
 				cat.AnimatingExpand = false;
@@ -550,7 +543,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}
 			return base.OnPopupMenu ();
 		}
-		
+
 		protected override bool OnMotionNotifyEvent (Gdk.EventMotion e)
 		{
 			int xpos = 0;
@@ -561,9 +554,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			Gdk.Rectangle newItemExtents = Gdk.Rectangle.Zero;
 			this.mouseX = (int)e.X + (int)(this.hAdjustement != null ? this.hAdjustement.Value : 0);
 			this.mouseY = (int)e.Y + (int)(this.vAdjustement != null ? this.vAdjustement.Value : 0);
-			Iterate (ref xpos, ref ypos, delegate (Category category, Gdk.Size itemDimension) {
-				if (xpos <= mouseX && mouseX <= xpos + itemDimension.Width  &&
-				    ypos <= mouseY && mouseY <= ypos + itemDimension.Height) {
+			Iterate (ref xpos, ref ypos, (category, itemDimension) => {
+				if (xpos <= mouseX && mouseX <= xpos + itemDimension.Width &&
+					ypos <= mouseY && mouseY <= ypos + itemDimension.Height) {
 					mouseOverItem = category;
 					GdkWindow.Cursor = handCursor;
 					if (!e.State.HasFlag (ModifierType.Button1Mask))
@@ -572,9 +565,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					return false;
 				}
 				return true;
-			}, delegate (Category curCategory, Item item, Gdk.Size itemDimension) {
-				if (xpos <= mouseX && mouseX <= xpos + itemDimension.Width  &&
-				    ypos <= mouseY && mouseY <= ypos + itemDimension.Height) {
+			}, (curCategory, item, itemDimension) => {
+				if (xpos <= mouseX && mouseX <= xpos + itemDimension.Width &&
+					ypos <= mouseY && mouseY <= ypos + itemDimension.Height) {
 					mouseOverItem = item;
 					GdkWindow.Cursor = null;
 					if (!e.State.HasFlag (ModifierType.Button1Mask))
@@ -587,22 +580,22 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 			if (mouseOverItem == null)
 				GdkWindow.Cursor = null;
-			
+
 			if (oldItem != mouseOverItem) {
 				this.QueueDraw ();
 				var oldItemExtents = GetItemExtends (oldItem);
 				QueueDrawArea (oldItemExtents.X, oldItemExtents.Y, oldItemExtents.Width, oldItemExtents.Height);
 				QueueDrawArea (newItemExtents.X, newItemExtents.Y, newItemExtents.Width, newItemExtents.Height);
 			}
-			
+
 			return base.OnMotionNotifyEvent (e);
 		}
-		
+
 		#region Item selection logic
-		Item selectedItem  = null;
-		Item mouseOverItem = null;
-		
-		public Item SelectedItem {
+		ToolboxWidgetItem selectedItem = null;
+		ToolboxWidgetItem mouseOverItem = null;
+
+		public ToolboxWidgetItem SelectedItem {
 			get {
 				return selectedItem;
 			}
@@ -614,7 +607,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 			}
 		}
-		
+
 		public event EventHandler SelectedItemChanged;
 		protected virtual void OnSelectedItemChanged (EventArgs args)
 		{
@@ -622,14 +615,14 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (SelectedItemChanged != null)
 				SelectedItemChanged (this, args);
 		}
-		
+
 		public event EventHandler ActivateSelectedItem;
 		protected virtual void OnActivateSelectedItem (EventArgs args)
 		{
 			if (ActivateSelectedItem != null)
 				ActivateSelectedItem (this, args);
 		}
-		
+
 		void ClearMouseOverItem ()
 		{
 			if (mouseOverItem != null) {
@@ -638,12 +631,12 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			HideTooltipWindow ();
 			this.QueueDraw ();
 		}
-		
-		Category GetCategory (Item item)
+
+		ToolboxWidgetCategory GetCategory (ToolboxWidgetItem item)
 		{
-			Category result = null;
+			ToolboxWidgetCategory result = null;
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, null, delegate (Category curCategory, Item innerItem, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, null, (curCategory, innerItem, itemDimension) => {
 				if (innerItem == item) {
 					result = curCategory;
 					return false;
@@ -652,13 +645,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			});
 			return result;
 		}
-		
-		Category GetNextCategory (Category category)
+
+		ToolboxWidgetCategory GetNextCategory (ToolboxWidgetCategory category)
 		{
-			Category result = category;
-			Category last = null;
+			ToolboxWidgetCategory result = category;
+			ToolboxWidgetCategory last = null;
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, delegate (Category curCategory, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, (curCategory, itemDimension) => {
 				if (last == category) {
 					result = curCategory;
 					return false;
@@ -668,13 +661,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}, null);
 			return result;
 		}
-		
-		Item GetItemRight (Item item)
+
+		ToolboxWidgetItem GetItemRight (ToolboxWidgetItem item)
 		{
-			Item result = item;
+			ToolboxWidgetItem result = item;
 			Gdk.Rectangle rect = GetItemExtends (item);
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, null, delegate (Category curCategory, Item curItem, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, null, (curCategory, curItem, itemDimension) => {
 				if (xpos > rect.X && ypos == rect.Y && result == item) {
 					result = curItem;
 					return false;
@@ -683,13 +676,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			});
 			return result;
 		}
-		
-		Item GetItemLeft (Item item)
+
+		ToolboxWidgetItem GetItemLeft (ToolboxWidgetItem item)
 		{
-			Item result = item;
+			ToolboxWidgetItem result = item;
 			Gdk.Rectangle rect = GetItemExtends (item);
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, null, delegate (Category curCategory, Item curItem, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, null, (curCategory, curItem, itemDimension) => {
 				if (xpos < rect.X && ypos == rect.Y) {
 					result = curItem;
 					return false;
@@ -698,15 +691,15 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			});
 			return result;
 		}
-		
-		Item GetItemBelow (Item item)
+
+		ToolboxWidgetItem GetItemBelow (ToolboxWidgetItem item)
 		{
-			Category itemCategory = GetCategory (item);
-						
-			Item result = item;
+			ToolboxWidgetCategory itemCategory = GetCategory (item);
+
+			ToolboxWidgetItem result = item;
 			Gdk.Rectangle rect = GetItemExtends (item);
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, null, delegate (Category curCategory, Item curItem, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, null, (curCategory, curItem, itemDimension) => {
 				if (ypos > rect.Y && xpos == rect.X && result == item && curCategory == itemCategory) {
 					result = curItem;
 					return false;
@@ -715,14 +708,14 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			});
 			return result;
 		}
-		
-		Item GetItemAbove (Item item)
+
+		ToolboxWidgetItem GetItemAbove (ToolboxWidgetItem item)
 		{
-			Category itemCategory = GetCategory (item);
-			Item result = item;
+			ToolboxWidgetCategory itemCategory = GetCategory (item);
+			ToolboxWidgetItem result = item;
 			Gdk.Rectangle rect = GetItemExtends (item);
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, null, delegate (Category curCategory, Item curItem, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, null, (curCategory, curItem, itemDimension) => {
 				if (ypos < rect.Y && xpos == rect.X && curCategory == itemCategory) {
 					result = curItem;
 					return false;
@@ -731,18 +724,18 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			});
 			return result;
 		}
-		
-		Gdk.Rectangle GetItemExtends (Item item)
+
+		Gdk.Rectangle GetItemExtends (ToolboxWidgetItem item)
 		{
-			Gdk.Rectangle result = new Gdk.Rectangle (0, 0, 0, 0);
+			var result = new Gdk.Rectangle (0, 0, 0, 0);
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, delegate (Category category, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, (category, itemDimension) => {
 				if (item == category) {
 					result = new Gdk.Rectangle (xpos, ypos, itemDimension.Width, itemDimension.Height);
 					return false;
 				}
 				return true;
-			}, delegate (Category curCategory, Item curItem, Gdk.Size itemDimension) {
+			}, (curCategory, curItem, itemDimension) => {
 				if (item == curItem) {
 					result = new Gdk.Rectangle (xpos, ypos, itemDimension.Width, itemDimension.Height);
 					return false;
@@ -751,20 +744,20 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			});
 			return result;
 		}
-		
-		Item GetPrevItem (Item currentItem)
+
+		ToolboxWidgetItem GetPrevItem (ToolboxWidgetItem currentItem)
 		{
-			Item result = currentItem;
-			Item lastItem = null;
+			ToolboxWidgetItem result = currentItem;
+			ToolboxWidgetItem lastItem = null;
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, delegate (Category category, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, (category, itemDimension) => {
 				if (currentItem == category && lastItem != null) {
 					result = lastItem;
 					return false;
 				}
 				lastItem = category;
 				return true;
-			}, delegate (Category curCategory, Item item, Gdk.Size itemDimension) {
+			}, (curCategory, item, itemDimension) => {
 				if (currentItem == item && lastItem != null) {
 					result = lastItem;
 					return false;
@@ -772,23 +765,23 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				lastItem = item;
 				return true;
 			});
-			
+
 			return result;
 		}
-		
-		Item GetNextItem (Item currentItem)
+
+		ToolboxWidgetItem GetNextItem (ToolboxWidgetItem currentItem)
 		{
-			Item result = currentItem;
-			Item lastItem = null;
+			ToolboxWidgetItem result = currentItem;
+			ToolboxWidgetItem lastItem = null;
 			int xpos = 0, ypos = 0;
-			Iterate (ref xpos, ref ypos, delegate (Category category, Gdk.Size itemDimension) {
+			Iterate (ref xpos, ref ypos, (category, itemDimension) => {
 				if (lastItem == currentItem) {
 					result = category;
 					return false;
 				}
 				lastItem = category;
 				return true;
-			}, delegate (Category curCategory, Item item, Gdk.Size itemDimension) {
+			}, (curCategory, item, itemDimension) => {
 				if (lastItem == currentItem) {
 					result = item;
 					return false;
@@ -799,11 +792,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			return result;
 		}
 		#endregion
-		
+
 		#region Scrolling
 		Adjustment hAdjustement = null;
 		Adjustment vAdjustement = null;
-				
+
 		public void ScrollToSelectedItem ()
 		{
 			if (this.SelectedItem == null || this.vAdjustement == null)
@@ -814,31 +807,25 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (this.vAdjustement.Value + this.Allocation.Height < rect.Bottom)
 				this.vAdjustement.Value = rect.Bottom - this.Allocation.Height;
 		}
-		
+
 		protected override void OnSetScrollAdjustments (Adjustment hAdjustement, Adjustment vAdjustement)
 		{
 			this.hAdjustement = hAdjustement;
 			if (this.hAdjustement != null) {
-				this.hAdjustement.ValueChanged += delegate {
-					this.QueueDraw ();
-				};
+				this.hAdjustement.ValueChanged += (sender, e) => this.QueueDraw ();
 			}
 			this.vAdjustement = vAdjustement;
 			if (this.vAdjustement != null) {
-				this.vAdjustement.ValueChanged += delegate {
-					this.QueueDraw ();
-				};
+				this.vAdjustement.ValueChanged += (sender, e) => this.QueueDraw ();
 			}
 		}
 		#endregion
-		
+
 		#region Item & Category iteration
-		delegate bool CategoryAction (Category category, Gdk.Size categoryDimension);
-		delegate bool ItemAction (Category curCategory, Item item, Gdk.Size itemDimension);
-		bool IterateItems (Category category, ref int xpos, ref int ypos, ItemAction action)
+		bool IterateItems (ToolboxWidgetCategory category, ref int xpos, ref int ypos, Func<ToolboxWidgetCategory, ToolboxWidgetItem, Size, bool> action)
 		{
 			if (listMode || !category.CanIconizeItems) {
-				foreach (Item item in category.Items) {
+				foreach (ToolboxWidgetItem item in category.Items) {
 					if (!item.IsVisible)
 						continue;
 
@@ -847,37 +834,37 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					if (y == 0) {
 						layout.SetMarkup (item.Text);
 						layout.GetPixelSize (out x, out y);
-						y = Math.Max (IconSize.Height, y);
+						y = Math.Max (iconSize.Height, y);
 						y += ItemTopBottomPadding * 2;
 						item.ItemHeight = y;
 					}
-					
+
 					xpos = 0;
 					if (action != null && !action (category, item, new Gdk.Size (Allocation.Width, y)))
 						return false;
-					
+
 					ypos += y;
 				}
 				return true;
 			}
-			foreach (Item item in category.Items) {
+			foreach (ToolboxWidgetItem item in category.Items) {
 				if (!item.IsVisible)
 					continue;
-				if (xpos + IconSize.Width >= this.Allocation.Width) {
+				if (xpos + iconSize.Width >= this.Allocation.Width) {
 					xpos = 0;
-					ypos += IconSize.Height;
+					ypos += iconSize.Height;
 				}
-				if (action != null && !action (category, item, IconSize))
+				if (action != null && !action (category, item, iconSize))
 					return false;
-				xpos += IconSize.Width;
+				xpos += iconSize.Width;
 			}
-			ypos += IconSize.Height;
+			ypos += iconSize.Height;
 			return true;
 		}
-		
-		void Iterate (ref int xpos, ref int ypos, CategoryAction catAction, ItemAction action)
+
+		void Iterate (ref int xpos, ref int ypos, Func<ToolboxWidgetCategory, Size, bool> catAction, Func<ToolboxWidgetCategory, ToolboxWidgetItem, Size, bool> action)
 		{
-			foreach (Category category in this.categories) {
+			foreach (ToolboxWidgetCategory category in this.categories) {
 				if (!category.IsVisible)
 					continue;
 				xpos = 0;
@@ -894,37 +881,37 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					if (catAction != null && !catAction (category, new Size (this.Allocation.Width, y)))
 						return;
 					ypos += y;
-				} 
+				}
 				if (category.IsExpanded || category.AnimatingExpand || !this.showCategories) {
-					if (!IterateItems (category, ref xpos, ref  ypos, action))
+					if (!IterateItems (category, ref xpos, ref ypos, action))
 						return;
 				}
 			}
 		}
 		#endregion
-		
+
 		#region Control size management
 		bool realSizeRequest;
-		protected override void OnSizeRequested (ref Requisition req)
+		protected override void OnSizeRequested (ref Requisition requisition)
 		{
 			if (!realSizeRequest) {
 				// Request a minimal width, to size recalculation infinite loops with
 				// small widths, due to the vscrollbar being shown and hidden.
-				req.Width = 50;
-				req.Height = 0;
+				requisition.Width = 50;
+				requisition.Height = 0;
 				return;
 			}
 			int xpos = 0;
 			int ypos = 0;
 			Iterate (ref xpos, ref ypos, null, null);
-			req.Width  = 50; 
-			req.Height = ypos;
+			requisition.Width = 50;
+			requisition.Height = ypos;
 			if (this.vAdjustement != null) {
-				this.vAdjustement.SetBounds (0, 
-				                             ypos, 
-				                             20,
-				                             Allocation.Height,
-				                             Allocation.Height);
+				this.vAdjustement.SetBounds (0,
+											 ypos,
+											 20,
+											 Allocation.Height,
+											 Allocation.Height);
 				if (ypos < Allocation.Height)
 					this.vAdjustement.Value = 0;
 				if (vAdjustement.Value + vAdjustement.PageSize > vAdjustement.Upper)
@@ -933,27 +920,26 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					vAdjustement.Value = 0;
 			}
 		}
-		
+
 		protected override void OnSizeAllocated (Gdk.Rectangle allocation)
 		{
 			base.OnSizeAllocated (allocation);
 			if (!realSizeRequest) {
 				realSizeRequest = true;
 				QueueResize ();
-			}
-			else
+			} else
 				realSizeRequest = false;
 		}
-		
+
 		#endregion
-		
+
 		#region Tooltips
 		const int TipTimer = 800;
 		CustomTooltipWindow tooltipWindow = null;
-		Item tipItem;
+		ToolboxWidgetItem tipItem;
 		int tipX, tipY;
 		uint tipTimeoutId;
-		
+
 		public void HideTooltipWindow ()
 		{
 			if (tipTimeoutId != 0) {
@@ -965,10 +951,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				tooltipWindow = null;
 			}
 		}
-		
+
 		bool ShowTooltip ()
 		{
-			HideTooltipWindow (); 
+			HideTooltipWindow ();
 			tooltipWindow = new CustomTooltipWindow ();
 			tooltipWindow.Tooltip = tipItem.Tooltip;
 			tooltipWindow.ParentWindow = this.GdkWindow;
@@ -978,18 +964,19 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			tooltipWindow.ShowAll ();
 			return false;
 		}
-		
-		public void ShowTooltip (Item item, uint timer, int x, int y)
+
+		public void ShowTooltip (ToolboxWidgetItem item, uint timer, int x, int y)
 		{
 			HideTooltipWindow ();
-			if (!String.IsNullOrEmpty (item.Tooltip)) {
+
+			if (!string.IsNullOrEmpty (item.Tooltip)) {
 				tipItem = item;
 				tipX = x;
 				tipY = y;
 				tipTimeoutId = GLib.Timeout.Add (timer, ShowTooltip);
 			}
 		}
-		
+
 		class CustomTooltipWindow : MonoDevelop.Components.TooltipWindow
 		{
 			string tooltip;
@@ -1002,7 +989,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					label.Text = tooltip;
 				}
 			}
-			
+
 			Label label = new Label ();
 			public CustomTooltipWindow ()
 			{
@@ -1014,121 +1001,77 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		}
 		#endregion
 	}
-	
-	class Category : Item
+
+	class ToolboxWidgetCategory : ToolboxWidgetItem
 	{
-		bool isExpanded;
-		
-		public bool IsExpanded {
-			get {
-				return isExpanded;
-			}
-			set {
-				isExpanded = value;
-			}
-		}
+		public bool IsExpanded { get; set; }
 
 		public bool AnimatingExpand { get; set; }
 		public uint AnimationHandle;
 		public int AnimationHeight;
 
-		List<Item> items = new List<Item> ();
-		
-		public int ItemCount {
-			get {
-				return items.Count;
-			}
-		}
-		
-		public ReadOnlyCollection<Item> Items {
+		List<ToolboxWidgetItem> items = new List<ToolboxWidgetItem> ();
+
+		public int ItemCount => items.Count;
+
+		public ReadOnlyCollection<ToolboxWidgetItem> Items {
 			get {
 				return items.AsReadOnly ();
 			}
 		}
-		
-		bool canIconizeItems = true;
-		public bool CanIconizeItems {
-			get {
-				return canIconizeItems;
-			}
-			set {
-				canIconizeItems = value;
-			}
-		}
-		
-		bool isDropTarget    = false;
-		public bool IsDropTarget {
-			get {
-				return isDropTarget;
-			}
-			set {
-				isDropTarget = value;
-			}
-		}
-		
-		bool isSorted    = true;
-		public bool IsSorted {
-			get {
-				return isSorted;
-			}
-			set {
-				isSorted = value;
-			}
-		}
-		
-		public int Priority {
-			get; set;
-		}
-		
-		public Category (string text) : base (text)
+		public bool CanIconizeItems { get; set; } = true;
+		public bool IsDropTarget { get; set; } = false;
+		public bool IsSorted { get; set; } = true;
+		public int Priority { get; set; }
+
+		public ToolboxWidgetCategory (string text) : base (text)
 		{
 		}
-		
+
 		public void Clear ()
 		{
 			this.items.Clear ();
 		}
-		
-		public void Add (Item item)
+
+		public void Add (ToolboxWidgetItem item)
 		{
 			this.items.Add (item);
-			if (isSorted)
+			if (IsSorted)
 				items.Sort ();
 		}
-		
-		public void Remove (Item item)
+
+		public void Remove (ToolboxWidgetItem item)
 		{
 			this.items.Remove (item);
-			if (isSorted)
+			if (IsSorted)
 				items.Sort ();
 		}
-		
+
 		public override string ToString ()
 		{
 			return String.Format ("[Category: Text={0}]", Text);
 		}
 	}
-	
-	public class Item : IComparable<Item>
+
+	class ToolboxWidgetItem : IComparable<ToolboxWidgetItem>
 	{
 		static Xwt.Drawing.Image defaultIcon;
-		Xwt.Drawing.Image icon;
-		string     text;
-		string     tooltip;
-		object     tag;
-		bool       isVisible = true;
-		
+		readonly Xwt.Drawing.Image icon;
+		readonly string text;
+		readonly string tooltip;
+		readonly object tag;
+
 		public string Tooltip {
 			get {
-				if (node != null)
-					return string.IsNullOrEmpty (node.Description) ? node.Name : node.Description;
+				if (Node != null)
+					return string.IsNullOrEmpty (Node.Description) ? Node.Name : Node.Description;
 				return tooltip;
 			}
 		}
-		
+
 		public Xwt.Drawing.Image Icon {
 			get {
-				return node?.Icon ?? icon ?? DefaultIcon;
+				return Node?.Icon ?? icon ?? DefaultIcon;
 			}
 		}
 
@@ -1139,14 +1082,14 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				return defaultIcon;
 			}
 		}
-		
+
 		public string Text {
 			get {
-				if (node != null) {
-					var t = MonoDevelop.Ide.TypeSystem.Ambience.EscapeText (node.Name);
-					if (!string.IsNullOrEmpty (node.Source)) {
+				if (Node != null) {
+					var t = MonoDevelop.Ide.TypeSystem.Ambience.EscapeText (Node.Name);
+					if (!string.IsNullOrEmpty (Node.Source)) {
 						var c = MonoDevelop.Ide.Gui.Styles.SecondaryTextColorHexString;
-						t = string.Format ("{2} <span size=\"smaller\" color=\"{1}\">{0}</span>", node.Source, c, t);
+						t = string.Format ("{2} <span size=\"smaller\" color=\"{1}\">{0}</span>", Node.Source, c, t);
 					}
 					return t;
 				}
@@ -1158,56 +1101,74 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			get;
 			set;
 		}
-		
-		public bool IsVisible {
-			get {
-				return this.isVisible;
-			}
-			set {
-				this.isVisible = value;
-			}
-		}
-		
-		public object Tag {
-			get {
-				return node ?? tag;
-			}
+
+		public bool IsVisible { get; set; } = true;
+
+		public object Tag => Node ?? tag;
+
+		public ItemToolboxNode Node { get; private set; }
+
+		public ToolboxWidgetItem (ItemToolboxNode node)
+		{
+			Node = node;
 		}
 
-		ItemToolboxNode node;
-		public Item (ItemToolboxNode node)
+		public ToolboxWidgetItem (string text) : this (null, text, null)
 		{
-			this.node = node;
 		}
-		
 
-		public Item (string text) : this (null, text, null)
+		public ToolboxWidgetItem (Xwt.Drawing.Image icon, string text) : this (icon, text, null)
 		{
 		}
-		
-		public Item (Xwt.Drawing.Image icon, string text) : this (icon, text, null)
+
+		public ToolboxWidgetItem (Xwt.Drawing.Image icon, string text, string tooltip) : this (icon, text, tooltip, null)
 		{
 		}
-		
-		public Item (Xwt.Drawing.Image icon, string text, string tooltip) : this (icon, text, tooltip, null)
+
+		public ToolboxWidgetItem (Xwt.Drawing.Image icon, string text, string tooltip, object tag)
 		{
-		}
-		
-		public Item (Xwt.Drawing.Image icon, string text, string tooltip, object tag)
-		{
-			this.icon    = icon;
-			this.text    = MonoDevelop.Ide.TypeSystem.Ambience.EscapeText (text);
+			this.icon = icon;
+			this.text = Ide.TypeSystem.Ambience.EscapeText (text);
 			this.tooltip = tooltip;
-			this.tag     = tag;
+			this.tag = tag;
 		}
-		
-		public virtual int CompareTo (Item other)
+
+		public int CompareTo (ToolboxWidgetItem other)
 		{
-			if (other == null) 
+			if (other == null)
 				return -1;
 			return Text.CompareTo (other.Text);
 		}
-		
 	}
 
+	[Obsolete("This class should never have been public")]
+	public class Item : IComparable<Item>
+	{
+		ToolboxWidgetItem inner;
+
+		public string Tooltip => inner.Tooltip;
+		public Xwt.Drawing.Image Icon => inner.Icon;
+
+		public string Text => inner.Text;
+
+		public int ItemHeight {
+			get => inner.ItemHeight;
+			set => inner.ItemHeight = value;
+		}
+
+		public bool IsVisible {
+			get => inner.IsVisible;
+			set => inner.IsVisible = value;
+		}
+
+		public object Tag => inner.Tag;
+
+		public Item (ItemToolboxNode node) => inner = new ToolboxWidgetItem (node);
+		public Item (string text) : this (null, text, null) {}
+		public Item (Xwt.Drawing.Image icon, string text) : this (icon, text, null) {}
+		public Item (Xwt.Drawing.Image icon, string text, string tooltip) : this (icon, text, tooltip, null) {}
+		public Item (Xwt.Drawing.Image icon, string text, string tooltip, object tag) => inner = new ToolboxWidgetItem (icon, text, tooltip, tag);
+
+		public virtual int CompareTo (Item other) => other == null ? -1 : other.inner.CompareTo (other.inner);
+	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -935,7 +935,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		#region Tooltips
 		const int TipTimer = 800;
-		CustomTooltipWindow tooltipWindow = null;
+		Gtk.Window tooltipWindow = null;
 		ToolboxWidgetItem tipItem;
 		int tipX, tipY;
 		uint tipTimeoutId;
@@ -955,11 +955,17 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		bool ShowTooltip ()
 		{
 			HideTooltipWindow ();
-			tooltipWindow = new CustomTooltipWindow ();
-			tooltipWindow.Tooltip = tipItem.Tooltip;
-			tooltipWindow.ParentWindow = this.GdkWindow;
-			int ox, oy;
-			this.GdkWindow.GetOrigin (out ox, out oy);
+
+			if (tipItem.Node is ICustomTooltipToolboxNode custom) {
+				tooltipWindow = custom.CreateTooltipWindow (this);
+			} else {
+				tooltipWindow = new CustomTooltipWindow  {
+					Tooltip = tipItem.Tooltip,
+					ParentWindow = this.GdkWindow
+				};
+			}
+
+			this.GdkWindow.GetOrigin (out var ox, out var oy);
 			tooltipWindow.Move (Math.Max (0, ox + tipX), oy + tipY);
 			tooltipWindow.ShowAll ();
 			return false;
@@ -969,7 +975,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			HideTooltipWindow ();
 
-			if (!string.IsNullOrEmpty (item.Tooltip)) {
+			if (!string.IsNullOrEmpty (item.Tooltip) || (item.Node is ICustomTooltipToolboxNode custom && custom.HasTooltip)) {
 				tipItem = item;
 				tipX = x;
 				tipY = y;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxWidget.cs
@@ -268,7 +268,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				headerLayout.SetMarkup (category.Text);
 				int width, height;
 				cr.SetSourceColor (MonoDevelop.Ide.Gui.Styles.PadCategoryLabelColor.ToCairoColor ());
-				layout.GetPixelSize (out width, out height);
+				headerLayout.GetPixelSize (out width, out height);
 				cr.MoveTo (xpos + CategoryLeftPadding, ypos + (double)(Math.Round ((double)(itemDimension.Height - height) / 2)));
 				Pango.CairoHelper.ShowLayout (cr, headerLayout);
 
@@ -999,7 +999,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				}
 				set {
 					tooltip = value;
-					label.Markup = tooltip;
+					label.Text = tooltip;
 				}
 			}
 			

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -131,6 +131,7 @@
     <Compile Include="AddinInfo.cs" />
     <Compile Include="MonoDevelop.DesignerSupport.Projects\ImplicitFrameworkAssemblyReferenceDescriptor.cs" />
     <Compile Include="MonoDevelop.DesignerSupport.Toolbox\ToolboxExtensions.cs" />
+    <Compile Include="MonoDevelop.DesignerSupport.Toolbox\ICustomTooltipToolboxNode.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.DesignerSupport.addin.xml" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodePreviewWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodePreviewWindow.cs
@@ -44,13 +44,13 @@ namespace Mono.TextEditor
 
 		readonly HslColor colorText, colorBg, colorFold;
 
-		protected CodePreviewWindow (
+		public CodePreviewWindow (
 			Gdk.Window parentWindow,
 			string fontName = null,
 			EditorTheme theme = null)
 			: base (Gtk.WindowType.Popup)
 		{
-			ParentWindow = parentWindow;
+			ParentWindow = parentWindow ?? MonoDevelop.Ide.IdeApp.Workbench.RootWindow.GdkWindow;
 
 			AppPaintable = true;
 			SkipPagerHint = SkipTaskbarHint = true;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodePreviewWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodePreviewWindow.cs
@@ -1,0 +1,212 @@
+//
+// Copyright (C) 2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using Gdk;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Editor;
+using MonoDevelop.Ide.Editor.Highlighting;
+
+namespace Mono.TextEditor
+{
+	class CodePreviewWindow : Gtk.Window
+	{
+		string fontName;
+
+		Pango.FontDescription fontDescription;
+		Pango.Layout layout;
+
+		string footerText, text, markup;
+		Pango.FontDescription footerFontDescription;
+		Pango.Layout footerLayout;
+
+		readonly int maxWidth, maxHeight;
+
+		readonly HslColor colorText, colorBg, colorFold;
+
+		protected CodePreviewWindow (
+			Gdk.Window parentWindow,
+			string fontName = null,
+			EditorTheme theme = null)
+			: base (Gtk.WindowType.Popup)
+		{
+			ParentWindow = parentWindow;
+
+			AppPaintable = true;
+			SkipPagerHint = SkipTaskbarHint = true;
+			TypeHint = WindowTypeHint.Menu;
+
+			this.fontName = fontName = fontName ?? DefaultSourceEditorOptions.Instance.FontName;
+
+			layout = PangoUtil.CreateLayout (this);
+			fontDescription = Pango.FontDescription.FromString (fontName);
+			fontDescription.Size = (int)(fontDescription.Size * 0.8f);
+			layout.FontDescription = fontDescription;
+			layout.Ellipsize = Pango.EllipsizeMode.End;
+
+			var geometry = Screen.GetUsableMonitorGeometry (Screen.GetMonitorAtWindow (ParentWindow));
+			maxWidth = geometry.Width * 2 / 5;
+			maxHeight = geometry.Height * 2 / 5;
+
+			layout.SetText ("n");
+			layout.GetPixelSize (out int _, out int lineHeight);
+			MaximumLineCount = maxHeight / lineHeight;
+
+			theme = theme ?? DefaultSourceEditorOptions.Instance.GetEditorTheme ();
+			colorText = SyntaxHighlightingService.GetColor (theme, EditorThemeColors.Foreground);
+			colorBg = SyntaxHighlightingService.GetColor (theme, EditorThemeColors.Background);
+			colorFold = SyntaxHighlightingService.GetColor (theme, EditorThemeColors.CollapsedText);
+		}
+
+		/// <summary>
+		/// The maximum number of lines that will fit in this dialog
+		/// </summary>
+		public int MaximumLineCount { get; }
+
+		public string Text {
+			set {
+				text = value;
+				markup = null;
+				layout.SetText (value);
+				UpdateSize ();
+			}
+			get => text;
+		}
+
+		public string Markup {
+			set {
+				markup = value;
+				text = null;
+				layout.SetMarkup (value);
+				UpdateSize ();
+			}
+			get => markup;
+		}
+
+		protected string FooterText {
+			get {
+				return footerText;
+			}
+			set {
+				if (!string.IsNullOrEmpty (value)) {
+					if (footerLayout == null) {
+						footerLayout = PangoUtil.CreateLayout (this);
+						footerFontDescription = Pango.FontDescription.FromString (fontName);
+						footerFontDescription.Size = (int)(footerFontDescription.Size * 0.7f);
+						footerLayout.FontDescription = footerFontDescription;
+					}
+					footerLayout?.SetText (value);
+				}
+				footerText = value;
+
+				if (Text != null || markup != null) {
+					UpdateSize ();
+					QueueDraw ();
+				}
+			}
+		}
+
+		public int FooterTextHeight { get; private set; }
+
+		public bool HasFooterText => !string.IsNullOrEmpty (FooterText);
+
+		public void UpdateSize ()
+		{
+			layout.GetPixelSize (out var w, out var h);
+
+			if (HasFooterText) {
+				footerLayout.GetPixelSize (out var w2, out var h2);
+				w = Math.Max (w, w2);
+				h += h2;
+				FooterTextHeight = h2;
+			} else {
+				FooterTextHeight = 0;
+			}
+
+			SetSizeRequest (
+				Math.Max (1, Math.Min (w + 3, maxWidth) + 5),
+				Math.Max (1, Math.Min (h + 3, maxHeight)) + 5);
+		}
+		
+		protected override void OnDestroyed ()
+		{
+			layout = layout.Kill ();
+			footerLayout = footerLayout.Kill ();
+			fontDescription = fontDescription.Kill ();
+			footerFontDescription = footerFontDescription.Kill ();
+
+			base.OnDestroyed ();
+		}
+
+		protected override bool OnExposeEvent (EventExpose evnt)
+		{
+			using (var cr = CairoHelper.Create (GdkWindow)) {
+				CairoHelper.Region (cr, evnt.Region);
+				cr.Clip ();
+				cr.Translate (Allocation.X, Allocation.Y);
+				Draw (cr);
+			}
+			return true;
+		}
+
+		void Draw (Cairo.Context cr)
+		{
+			var allocation = Allocation;
+
+			cr.LineWidth = 1;
+
+			cr.Rectangle (0, 0, allocation.Width, allocation.Height);
+			cr.SetSourceColor (colorBg);
+			cr.Fill ();
+
+			cr.Save ();
+			cr.Translate (5, 4);
+			cr.SetSourceColor (colorText);
+			Pango.CairoHelper.ShowLayout (cr, layout);
+			cr.Restore ();
+
+			cr.SetSourceColor (colorBg);
+			cr.Rectangle (1.5, 1.5, allocation.Width - 3, allocation.Height - 3);
+			cr.Stroke ();
+
+			cr.SetSourceColor (colorFold);
+			cr.Rectangle (0.5, 0.5, allocation.Width - 1, allocation.Height - 1);
+			cr.Stroke ();
+
+			if (!HasFooterText) {
+				return;
+			}
+
+			footerLayout.GetPixelSize (out var w, out var h);
+			cr.SetSourceColor (colorBg);
+			cr.Rectangle (allocation.Width - w - 3, allocation.Height - h, w + 2, h - 1);
+			cr.Fill ();
+
+			cr.Save ();
+			cr.SetSourceColor (colorFold);
+			cr.Translate (allocation.Width - w - 4, allocation.Height - h - 3);
+			Pango.CairoHelper.ShowLayout (cr, footerLayout);
+			cr.Restore ();
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodeSegmentPreviewWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodeSegmentPreviewWindow.cs
@@ -35,153 +35,45 @@ using MonoDevelop.Ide.Editor.Highlighting;
 
 namespace Mono.TextEditor
 {
-	class CodeSegmentPreviewWindow : Gtk.Window
+	class CodeSegmentPreviewWindow : CodePreviewWindow
 	{
-		const int DefaultPreviewWindowWidth = 320;
-		const int DefaultPreviewWindowHeight = 200;
 		MonoTextEditor editor;
-		Pango.FontDescription fontDescription, fontInform;
-		Pango.Layout layout;
-		Pango.Layout informLayout;
-		
-		public static string CodeSegmentPreviewInformString { get; set; } = GettextCatalog.GetString ("Press F2 to focus");
 
-		public bool HideCodeSegmentPreviewInformString {
-			get;
-			private set;
-		}
+		static string CodeSegmentPreviewInformString { get; set; } = GettextCatalog.GetString ("Press F2 to focus");
+
+		public ISegment Segment { get; private set; }
+
+		public bool IsEmptyText => string.IsNullOrWhiteSpace (Text) && string.IsNullOrWhiteSpace (Markup);
 		
-		public ISegment Segment {
-			get;
-			private set;
-		}
-		
-		public bool IsEmptyText {
-			get {
-				return string.IsNullOrEmpty ((layout.Text ?? "").Trim ());
+		public CodeSegmentPreviewWindow (MonoTextEditor editor, bool hideFooter, ISegment segment, bool removeIndent = true)
+			: base (editor.GdkWindow, editor.Options.FontName, editor.Options.GetEditorTheme ())
+		{
+			if (!hideFooter) {
+				FooterText = CodeSegmentPreviewInformString;
 			}
-		}
-
-		public CodeSegmentPreviewWindow (MonoTextEditor editor, bool hideCodeSegmentPreviewInformString, ISegment segment, bool removeIndent = true) : this(editor, hideCodeSegmentPreviewInformString, segment, DefaultPreviewWindowWidth, DefaultPreviewWindowHeight, removeIndent)
-		{
-		}
-		
-		public CodeSegmentPreviewWindow (MonoTextEditor editor, bool hideCodeSegmentPreviewInformString, ISegment segment, int width, int height, bool removeIndent = true) : base (Gtk.WindowType.Popup)
-		{
-			this.HideCodeSegmentPreviewInformString = hideCodeSegmentPreviewInformString;
-			this.Segment = segment;
 			this.editor = editor;
-			this.AppPaintable = true;
-			this.SkipPagerHint = this.SkipTaskbarHint = true;
-			this.TypeHint = WindowTypeHint.Menu;
-			layout = PangoUtil.CreateLayout (this);
-			informLayout = PangoUtil.CreateLayout (this);
-			fontInform = Pango.FontDescription.FromString (editor.Options.FontName);
-			fontInform.Size = (int)(fontInform.Size * 0.7f);
-			informLayout.FontDescription = fontInform;
-			informLayout.SetText (CodeSegmentPreviewInformString);
-			
-			fontDescription = Pango.FontDescription.FromString (editor.Options.FontName);
-			fontDescription.Size = (int)(fontDescription.Size * 0.8f);
-			layout.FontDescription = fontDescription;
-			layout.Ellipsize = Pango.EllipsizeMode.End;
-			// setting a max size for the segment (40 lines should be enough), 
-			// no need to markup thousands of lines for a preview window
+
 			SetSegment (segment, removeIndent);
-			CalculateSize (width);
 		}
-		
-		const int maxLines = 40;
 		
 		public void SetSegment (ISegment segment, bool removeIndent)
 		{
+			this.Segment = segment;
+
+			// no need to markup thousands of lines for a preview window
 			int startLine = editor.Document.OffsetToLineNumber (segment.Offset);
 			int endLine = editor.Document.OffsetToLineNumber (segment.EndOffset);
 			
-			bool pushedLineLimit = endLine - startLine > maxLines;
+			bool pushedLineLimit = endLine - startLine > MaximumLineCount;
 			if (pushedLineLimit)
-				segment = new TextSegment (segment.Offset, editor.Document.GetLine (startLine + maxLines).Offset - segment.Offset);
-			layout.Ellipsize = Pango.EllipsizeMode.End;
-			layout.SetMarkup (editor.GetTextEditorData ().GetMarkup (segment.Offset, segment.Length, removeIndent) + (pushedLineLimit ? Environment.NewLine + "..." : ""));
-			QueueDraw ();
-		}
-		
-		public int PreviewInformStringHeight {
-			get; private set;
-		}
-		
-		public void CalculateSize (int defaultWidth = -1)
-		{
-			int w, h;
-			layout.GetPixelSize (out w, out h);
-			
-			if (!HideCodeSegmentPreviewInformString) {
-				int w2, h2;
-				informLayout.GetPixelSize (out w2, out h2); 
-				PreviewInformStringHeight = h2;
-				w = System.Math.Max (w, w2);
-				h += h2;
-			}
-			Gdk.Rectangle geometry = Screen.GetUsableMonitorGeometry (Screen.GetMonitorAtWindow (editor.GdkWindow));
-			this.SetSizeRequest (System.Math.Max (1, System.Math.Min (w + 3, geometry.Width * 2 / 5) + 5), 
-			                     System.Math.Max (1, System.Math.Min (h + 3, geometry.Height * 2 / 5)) + 5);
+				segment = new TextSegment (segment.Offset, editor.Document.GetLine (startLine + MaximumLineCount).Offset - segment.Offset);
+			Markup = editor.GetTextEditorData ().GetMarkup (segment.Offset, segment.Length, removeIndent) + (pushedLineLimit ? Environment.NewLine + "..." : "");
 		}
 		
 		protected override void OnDestroyed ()
 		{
-			layout = layout.Kill ();
-			informLayout = informLayout.Kill ();
-			fontDescription = fontDescription.Kill ();
-			fontInform = fontInform.Kill ();
-			if (textGC != null) {
-				textGC.Dispose ();
-				textBgGC.Dispose ();
-				foldGC.Dispose ();
-				foldBgGC.Dispose ();
-				textGC = textBgGC = foldGC = foldBgGC = null;
-			}
 			editor = null;
 			base.OnDestroyed ();
-		}
-		
-		protected override bool OnKeyPressEvent (EventKey evnt)
-		{
-//			Console.WriteLine (evnt.Key);
-			return base.OnKeyPressEvent (evnt);
-		}
-		
-		Gdk.GC textGC, foldGC, textBgGC, foldBgGC;
-		
-		protected override bool OnExposeEvent (Gdk.EventExpose ev)
-		{
-			if (textGC == null) {
-				var plainText = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.Foreground);
-				textGC = plainText.CreateGC (ev.Window);
-
-				plainText = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.Background);
-				textBgGC = plainText.CreateGC (ev.Window);
-
-				var collapsedText = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.CollapsedText);
-				foldGC = collapsedText.CreateGC (ev.Window);
-
-				collapsedText = SyntaxHighlightingService.GetColor (editor.EditorTheme, EditorThemeColors.Background);
-				foldBgGC = collapsedText.CreateGC (ev.Window);
-			}
-			
-			ev.Window.DrawRectangle (textBgGC, true, ev.Area);
-			ev.Window.DrawLayout (textGC, 5, 4, layout);
-			ev.Window.DrawRectangle (textBgGC, false, 1, 1, this.Allocation.Width - 3, this.Allocation.Height - 3);
-			ev.Window.DrawRectangle (foldGC, false, 0, 0, this.Allocation.Width - 1, this.Allocation.Height - 1);
-			
-			if (!HideCodeSegmentPreviewInformString) {
-				informLayout.SetText (CodeSegmentPreviewInformString);
-				int w, h;
-				informLayout.GetPixelSize (out w, out h); 
-				PreviewInformStringHeight = h;
-				ev.Window.DrawRectangle (foldBgGC, true, Allocation.Width - w - 3, Allocation.Height - h, w + 2, h - 1);
-				ev.Window.DrawLayout (foldGC, Allocation.Width - w - 4, Allocation.Height - h - 3, informLayout);
-			}
-			return true;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodeSegmentPreviewWindow.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/CodeSegmentPreviewWindow.cs
@@ -27,11 +27,9 @@
 //
 
 using System;
-
 using Gdk;
-using Gtk;
-using System.Collections.Generic;
 using MonoDevelop.Components;
+using MonoDevelop.Core;
 using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Editor.Highlighting;
 
@@ -46,11 +44,8 @@ namespace Mono.TextEditor
 		Pango.Layout layout;
 		Pango.Layout informLayout;
 		
-		public static string CodeSegmentPreviewInformString {
-			get;
-			set;
-		}
-		
+		public static string CodeSegmentPreviewInformString { get; set; } = GettextCatalog.GetString ("Press F2 to focus");
+
 		public bool HideCodeSegmentPreviewInformString {
 			get;
 			private set;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1663,7 +1663,7 @@ namespace Mono.TextEditor
 					dragContents.CopyData (textEditorData);
 					DragContext context = Gtk.Drag.Begin (this, ClipboardActions.CopyOperation.TargetList, DragAction.Move | DragAction.Copy, 1, e);
 					if (!Platform.IsMac) {
-						CodeSegmentPreviewWindow window = new CodeSegmentPreviewWindow (textEditorData.Parent, true, textEditorData.SelectionRange, 300, 300);
+						var window = new CodeSegmentPreviewWindow (textEditorData.Parent, true, textEditorData.SelectionRange);
 						Gtk.Drag.SetIconWidget (context, window, 0, 0);
 					}
 					selection = MainSelection;

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -2502,8 +2502,8 @@ namespace Mono.TextEditor
 			this.previewWindow.GdkWindow.GetOrigin (out x, out y);
 			int w = previewWindow.Allocation.Width;
 			int h = previewWindow.Allocation.Height;
-			if (!previewWindow.HideCodeSegmentPreviewInformString)
-				h -= previewWindow.PreviewInformStringHeight;
+			if (previewWindow.HasFooterText)
+				h -= previewWindow.FooterTextHeight;
 			CodeSegmentEditorWindow codeSegmentEditorWindow = new CodeSegmentEditorWindow (textEditor);
 			codeSegmentEditorWindow.Move (x, y);
 			codeSegmentEditorWindow.Resize (w, h);
@@ -2564,7 +2564,6 @@ namespace Mono.TextEditor
 
 				int x = hintRectangle.Right;
 				int y = hintRectangle.Bottom;
-				previewWindow.CalculateSize ();
 				var req = previewWindow.SizeRequest ();
 				int w = req.Width;
 				int h = req.Height;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
@@ -465,8 +465,7 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			public bool Run ()
 			{
 				strip.previewPopupTimeout = 0;
-				strip.previewWindow = new Mono.TextEditor.CodeSegmentPreviewWindow (strip.TextEditor, true, segment, w, -1, false);
-				strip.previewWindow.WidthRequest = w;
+				strip.previewWindow = new CodeSegmentPreviewWindow (strip.TextEditor, true, segment, false);
 				strip.previewWindow.Show ();
 				strip.PositionPreviewWindow (y);
 				return false;

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -306,6 +306,7 @@
     <Compile Include="MonoDevelop.SourceEditor.Braces\IBraceCompletionMetadata.cs" />
     <Compile Include="MonoDevelop.SourceEditor.Braces\IBraceCompletionStack.cs" />
     <Compile Include="MonoDevelop.SourceEditor\ClipboardRingService.cs" />
+    <Compile Include="Mono.TextEditor\Gui\CodePreviewWindow.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.SourceEditor.addin.xml" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -305,6 +305,7 @@
     <Compile Include="MonoDevelop.SourceEditor.Braces\IBraceCompletionAggregatorFactory.cs" />
     <Compile Include="MonoDevelop.SourceEditor.Braces\IBraceCompletionMetadata.cs" />
     <Compile Include="MonoDevelop.SourceEditor.Braces\IBraceCompletionStack.cs" />
+    <Compile Include="MonoDevelop.SourceEditor\ClipboardRingService.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.SourceEditor.addin.xml" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
@@ -1,0 +1,99 @@
+﻿//
+// Copyright (c) 2008 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+
+using Gtk;
+
+using Mono.TextEditor;
+using MonoDevelop.Core;
+using MonoDevelop.DesignerSupport.Toolbox;
+using MonoDevelop.Ide;
+
+namespace MonoDevelop.SourceEditor
+{
+	static class ClipboardRingService
+	{
+		const int clipboardRingSize = 20;
+		const int toolboxNameMaxLength = 16;
+		static readonly List<TextToolboxNode> clipboardRing = new List<TextToolboxNode> ();
+
+		public static event EventHandler Updated;
+
+		static ClipboardRingService ()
+		{
+			ClipboardActions.CopyOperation.Copy += AddToClipboardRing;
+		}
+
+		static void AddToClipboardRing (string text)
+		{
+			if (string.IsNullOrEmpty (text))
+				return;
+
+			//if already in ring, grab the existing node
+			TextToolboxNode newNode = null;
+			foreach (var node in clipboardRing) {
+				if (node.Text == text) {
+					clipboardRing.Remove (node);
+					newNode = node;
+					break;
+				}
+			}
+
+			clipboardRing.Add (newNode ?? CreateClipboardToolboxItem (text));
+
+			while (clipboardRing.Count > clipboardRingSize) {
+				clipboardRing.RemoveAt (0);
+			}
+
+			Updated?.Invoke (null, EventArgs.Empty);
+		}
+
+		static TextToolboxNode CreateClipboardToolboxItem (string text)
+		{
+			var item = new TextToolboxNode (text);
+			string [] lines = text.Split ('\n');
+			for (int i = 0; i < 3 && i < lines.Length; i++) {
+				if (i > 0)
+					item.Description += Environment.NewLine;
+				string line = lines [i];
+				if (line.Length > 16)
+					line = line.Substring (0, 16) + "...";
+				item.Description += line;
+			}
+
+			item.Category = GettextCatalog.GetString ("Clipboard Ring");
+			item.Icon = DesktopService.GetIconForFile ("a.txt", IconSize.Menu);
+
+			item.Name = text.Length > toolboxNameMaxLength ? text.Substring (0, toolboxNameMaxLength) + "..." : text;
+			item.Name = item.Name.Replace ("\t", "\\t");
+			item.Name = item.Name.Replace ("\n", "\\n");
+
+			return item;
+		}
+
+		public static IEnumerable<ItemToolboxNode> GetToolboxItems ()
+		{
+			return clipboardRing;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
@@ -26,6 +26,7 @@ using System.ComponentModel;
 using Gtk;
 
 using Mono.TextEditor;
+using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.DesignerSupport.Toolbox;
 using MonoDevelop.Ide;
@@ -55,7 +56,7 @@ namespace MonoDevelop.SourceEditor
 
 			// if too big, just reject it, truncation is unlikely to be useful
 			if (text.Length > clipboardRingItemMaxChars) {
-				LoggingService.LogWarning ($"Item '{EscapeAndTruncateName(text, 20)}...' is too big for clipboard ring");
+				LoggingService.LogWarning ($"Item '{EscapeAndTruncateName(text, 20)}...' exceeeds clipboard ring size limit");
 				return;
 			}
 
@@ -117,7 +118,7 @@ namespace MonoDevelop.SourceEditor
 			return clipboardRing;
 		}
 
-		class ClipboardToolboxNode : ItemToolboxNode, ITextToolboxNode
+		class ClipboardToolboxNode : ItemToolboxNode, ITextToolboxNode, ICustomTooltipToolboxNode
 		{
 			static readonly ToolboxItemFilterAttribute filterAtt = new ToolboxItemFilterAttribute ("text/plain", ToolboxItemFilterType.Allow);
 			static readonly string category = GettextCatalog.GetString ("Clipboard Ring");
@@ -159,6 +160,14 @@ namespace MonoDevelop.SourceEditor
 			public bool IsCompatibleWith (Document document)
 			{
 				return true;
+			}
+
+			public bool HasTooltip => true;
+
+			public Components.Window CreateTooltipWindow (Control parent)
+			{
+				var w = parent.GetNativeWidget<Widget> ()?.GdkWindow;
+				return new CodePreviewWindow (w) { Text = Text };
 			}
 		}
 	}

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
@@ -166,6 +166,13 @@ namespace MonoDevelop.SourceEditor
 
 			public Components.Window CreateTooltipWindow (Control parent)
 			{
+				//large amounts of text are expensive to lay out, and the preview window
+				//doesn't need all that much anyway
+				var txt = Text;
+				if (txt.Length > 4096) {
+					txt = txt.Substring (0, 4096) + "...";
+				}
+
 				var w = parent.GetNativeWidget<Widget> ()?.GdkWindow;
 				return new CodePreviewWindow (w) { Text = Text };
 			}

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.SourceEditor
 	static class ClipboardRingService
 	{
 		const int clipboardRingSize = 20;
-		const int toolboxNameMaxLength = 16;
+		const int toolboxNameMaxLength = 250;
 		static readonly List<TextToolboxNode> clipboardRing = new List<TextToolboxNode> ();
 
 		public static event EventHandler Updated;
@@ -70,7 +70,12 @@ namespace MonoDevelop.SourceEditor
 
 		static TextToolboxNode CreateClipboardToolboxItem (string text)
 		{
-			var item = new TextToolboxNode (text);
+			var item = new TextToolboxNode (text) {
+				Category = GettextCatalog.GetString ("Clipboard Ring"),
+				Icon = DesktopService.GetIconForFile ("a.txt", IconSize.Menu),
+				Name = EscapeAndTruncateName (text)
+			};
+
 			string [] lines = text.Split ('\n');
 			for (int i = 0; i < 3 && i < lines.Length; i++) {
 				if (i > 0)
@@ -81,14 +86,24 @@ namespace MonoDevelop.SourceEditor
 				item.Description += line;
 			}
 
-			item.Category = GettextCatalog.GetString ("Clipboard Ring");
-			item.Icon = DesktopService.GetIconForFile ("a.txt", IconSize.Menu);
-
-			item.Name = text.Length > toolboxNameMaxLength ? text.Substring (0, toolboxNameMaxLength) + "..." : text;
-			item.Name = item.Name.Replace ("\t", "\\t");
-			item.Name = item.Name.Replace ("\n", "\\n");
-
 			return item;
+		}
+
+		static string EscapeAndTruncateName (string text)
+		{
+			var sb = StringBuilderCache.Allocate ();
+			foreach (char ch in text) {
+				switch (ch) {
+				case '\t': sb.Append ("\\t"); break;
+				case '\r': sb.Append ("\\r"); break;
+				case '\n': sb.Append ("\\n"); break;
+				default: sb.Append (ch); break;
+				}
+				if (sb.Length >= toolboxNameMaxLength) {
+					break;
+				}
+			}
+			return StringBuilderCache.ReturnAndFree (sb);
 		}
 
 		public static IEnumerable<ItemToolboxNode> GetToolboxItems ()

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
@@ -70,30 +70,14 @@ namespace MonoDevelop.SourceEditor
 				}
 			}
 
-			clipboardRing.Add (newNode ?? CreateClipboardToolboxItem (text));
+			clipboardRing.Add (newNode ?? new ClipboardToolboxNode (text));
 
-			while (clipboardRing.Count > clipboardRingSize) {
-				clipboardRing.RemoveAt (0);
+			int overflow = clipboardRing.Count - clipboardRingSize;
+			if (overflow > 0) {
+				clipboardRing.RemoveRange (0, overflow);
 			}
 
 			Updated?.Invoke (null, EventArgs.Empty);
-		}
-
-		static ClipboardToolboxNode CreateClipboardToolboxItem (string text)
-		{
-			var item = new ClipboardToolboxNode (text);
-
-			string [] lines = text.Split ('\n');
-			for (int i = 0; i < 3 && i < lines.Length; i++) {
-				if (i > 0)
-					item.Description += Environment.NewLine;
-				string line = lines [i];
-				if (line.Length > 16)
-					line = line.Substring (0, 16) + "...";
-				item.Description += line;
-			}
-
-			return item;
 		}
 
 		static string EscapeAndTruncateName (string text, int truncateAt)


### PR DESCRIPTION
Fixes #5709. Item titles are no longer ellipsized to 16 chars, and the tooltip shows a decent sized snippet.

![image](https://user-images.githubusercontent.com/183285/44506656-6921b000-a675-11e8-992f-cd42c3cbcc10.png)
