### PR TITLE
[Ide] Fix text editor errors after creating new .NET Core project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -50,7 +50,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			bool added;
 			readonly object addLock = new object ();
 
-			internal List<MonoDevelop.Projects.DotNetProject> modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
 			SolutionData solutionData;
 
 			public ProjectSystemHandler (MonoDevelopWorkspace workspace, ProjectDataMap projectMap, ProjectionData projections)
@@ -181,8 +180,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			{
 				List<MonoDevelop.Projects.DotNetProject> modifiedWhileLoading;
 				lock (workspace.projectModifyLock) {
-					modifiedWhileLoading = modifiedProjects;
-					modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
+					modifiedWhileLoading = workspace.modifiedProjects;
+					workspace.modifiedProjects = new List<MonoDevelop.Projects.DotNetProject> ();
 				}
 
 				foreach (var project in modifiedWhileLoading) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -322,6 +322,11 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
+		internal void ReloadModifiedProject (MonoDevelop.Projects.Project project)
+		{
+			ProjectHandler.ReloadModifiedProject (project);
+		}
+
 		internal Task<SolutionInfo> TryLoadSolution (CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return ProjectHandler.CreateSolutionInfo (MonoDevelopSolution, CancellationTokenSource.CreateLinkedTokenSource (cancellationToken, src.Token).Token);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -347,6 +347,7 @@ namespace MonoDevelop.Ide.TypeSystem
 					else {
 						ws.OnProjectAdded (projectInfo);
 					}
+					ws.ReloadModifiedProject (project);
 				}
 			} catch (Exception ex) {
 				LoggingService.LogError ("OnSolutionItemAdded failed", ex);


### PR DESCRIPTION
 - Fixes type system not reloading solution when project modified
 - Fixes text editor errors on adding .NET Core project to solution
 - Fix text editor errors after creating new .NET Core project

Occasionally on creating a new .NET Core project the text editor
would show errors such as "Predefined type 'System.Object' is not
defined or imported." as though the project had no references. This
can also happen on adding a new .NET Core project to an existing
solution. Both of these seem to be caused by the type system being
out of sync since it did not always process project modify events
when they occurred.

Fixes VSTS #635423 - Error after creating new .NET Core project