### PR TITLE
Improve BuildOutput search's performance

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -431,23 +431,19 @@ namespace MonoDevelop.Ide.BuildOutputView
 			cancellation = new CancellationTokenSource ();
 			var token = cancellation.Token;
 			return Task.Run (() => {
-				Console.WriteLine ($"{DateTime.Now.ToString ()}: Starting search...");
 				if (!string.IsNullOrEmpty (pattern)) {
 					// Perform search
 					foreach (var root in rootNodes) {
 						if (token.IsCancellationRequested) break;
-						Console.WriteLine ($"{DateTime.Now.ToString ()}: Searching in {root.Message}");
 						root.Search (currentSearchMatches, currentSearchPattern, token);
 					}
 
 					if (currentSearchMatches.Count > 0 && !token.IsCancellationRequested) {
 						currentMatchIndex = 0;
-						Console.WriteLine ($"{DateTime.Now.ToString ()}: Search found {currentSearchMatches.Count} matches");
 						return currentSearchMatches [0];
 					}
 				}
 
-				if (token.IsCancellationRequested) Console.WriteLine ($"{DateTime.Now.ToString ()}: Search canceled");
 				return null;
 			});
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -431,19 +431,23 @@ namespace MonoDevelop.Ide.BuildOutputView
 			cancellation = new CancellationTokenSource ();
 			var token = cancellation.Token;
 			return Task.Run (() => {
+				Console.WriteLine ($"{DateTime.Now.ToString ()}: Starting search...");
 				if (!string.IsNullOrEmpty (pattern)) {
 					// Perform search
 					foreach (var root in rootNodes) {
-						if (token.IsCancellationRequested) return null;
-						root.Search (currentSearchMatches, currentSearchPattern);
+						if (token.IsCancellationRequested) break;
+						Console.WriteLine ($"{DateTime.Now.ToString ()}: Searching in {root.Message}");
+						root.Search (currentSearchMatches, currentSearchPattern, token);
 					}
 
 					if (currentSearchMatches.Count > 0 && !token.IsCancellationRequested) {
 						currentMatchIndex = 0;
+						Console.WriteLine ($"{DateTime.Now.ToString ()}: Search found {currentSearchMatches.Count} matches");
 						return currentSearchMatches [0];
 					}
 				}
 
+				if (token.IsCancellationRequested) Console.WriteLine ($"{DateTime.Now.ToString ()}: Search canceled");
 				return null;
 			});
 		}
@@ -483,6 +487,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			return currentSearchMatches [currentMatchIndex];
 		}
+
+		public bool IsCanceled => cancellation?.IsCancellationRequested ?? false;
 
 		public void Cancel () => cancellation?.Cancel ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutput.cs
@@ -434,7 +434,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 				if (!string.IsNullOrEmpty (pattern)) {
 					// Perform search
 					foreach (var root in rootNodes) {
-						if (token.IsCancellationRequested) break;
+						if (token.IsCancellationRequested)
+							break;
 						root.Search (currentSearchMatches, currentSearchPattern, token);
 					}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
@@ -343,7 +343,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			if (node.HasChildren) {
 				foreach (var child in node.Children) {
-					if (token.IsCancellationRequested) break;
+					if (token.IsCancellationRequested)
+						break;
 					Search (child, matches, pattern, token);
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputNode.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using System.Text;
 using Xwt;
 using MonoDevelop.Core;
+using System.Threading;
 
 namespace MonoDevelop.Ide.BuildOutputView
 {
@@ -334,7 +335,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			return null;
 		}
 
-		public static void Search (this BuildOutputNode node, List<BuildOutputNode> matches, string pattern)
+		public static void Search (this BuildOutputNode node, List<BuildOutputNode> matches, string pattern, CancellationToken token)
 		{
 			if ((node.Message?.IndexOf (pattern, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
 				matches.Add (node);
@@ -342,7 +343,8 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 			if (node.HasChildren) {
 				foreach (var child in node.Children) {
-					Search (child, matches, pattern);
+					if (token.IsCancellationRequested) break;
+					Search (child, matches, pattern, token);
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -524,7 +524,6 @@ namespace MonoDevelop.Ide.BuildOutputView
 				return;
 			}
 
-			Console.WriteLine ($"{DateTime.Now.ToString ()}: Refreshing tree");
 			foreach (var match in search.AllMatches) {
 				dataSource.RaiseNodeChanged (match);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -544,7 +544,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 
 				currentSearch = new BuildOutputDataSearch (dataSource.RootNodes);
 				var firstMatch = await currentSearch.FirstMatch (searchEntry.Entry.Text);
-				if (firstMatch != null && ! currentSearch.IsCanceled) {
+				if (firstMatch != null && !currentSearch.IsCanceled) {
 					RefreshSearchMatches (dataSource, currentSearch);
 					Find (firstMatch);
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -532,15 +532,18 @@ namespace MonoDevelop.Ide.BuildOutputView
 			using (Counters.SearchBuildLog.BeginTiming ()) {
 				// Cleanup previous search
 				if (currentSearch != null) {
+					currentSearch.Cancel ();
 					RefreshSearchMatches (dataSource, currentSearch);
 					Counters.SearchBuildLog.Trace ("Cleared previous search matches");
 				}
 
 				currentSearch = new BuildOutputDataSearch (dataSource.RootNodes);
 				var firstMatch = await currentSearch.FirstMatch (searchEntry.Entry.Text);
-				RefreshSearchMatches (dataSource, currentSearch);
+				if (firstMatch != null) {
+					RefreshSearchMatches (dataSource, currentSearch);
 
-				Find (firstMatch);
+					Find (firstMatch);
+				}
 			}
 		}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Projects;
 using MonoDevelop.Ide.Editor;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace MonoDevelop.Ide
 {
@@ -115,7 +116,7 @@ namespace MonoDevelop.Ide
 		{
 			var result = GetTestNodes ();
 			var results = new List<BuildOutputNode> ();
-			result [0].Search (results, "Error");
+			result [0].Search (results, "Error", CancellationToken.None);
 			Assert.AreEqual (2, results.Count, "#1");
 		}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/BuildOutputTests.cs
@@ -81,21 +81,41 @@ namespace MonoDevelop.Ide
 			Assert.AreEqual (1, node.Children.Count);
 		}
 
+		BuildOutput GenerateCustomBuild (int items)
+		{
+			var processor = new BuildOutputProcessor (null, false);
+
+			for (int i = 0; i < items; i++) {
+				var projectMsg = $"Project {i}";
+				processor.AddNode (BuildOutputNodeType.Project, projectMsg, projectMsg, true, DateTime.Now);
+				for (int j = 0; j < items * 10; j++) {
+					var targetMsg = $"Target {i}.{j}";
+					processor.AddNode (BuildOutputNodeType.Target, targetMsg, targetMsg, true, DateTime.Now);
+					for (int k = 0; k < items * 100; k++) {
+						var taskMsg = $"Task {i}.{j}.{k}";
+						processor.AddNode (BuildOutputNodeType.Task, taskMsg, taskMsg, true, DateTime.Now);
+
+						var msg = $"Message {i}.{j}.{k}";
+						processor.AddNode (BuildOutputNodeType.Message, msg, msg, false, DateTime.Now);
+
+						processor.EndCurrentNode (taskMsg, DateTime.Now);
+					}
+					processor.EndCurrentNode (targetMsg, DateTime.Now);
+				}
+				processor.EndCurrentNode (projectMsg, DateTime.Now);
+			}
+
+			var bo = new BuildOutput ();
+			bo.AddProcessor (processor);
+			return bo;
+		}
+
 		[Test]
 		public async Task CustomProject_DataSearch ()
 		{
-			var bo = new BuildOutput ();
-			var monitor = bo.GetProgressMonitor ();
-
-			monitor.LogObject (new BuildSessionStartedEvent ());
-			for (int i = 0; i < 100; i++) {
-				monitor.Log.WriteLine ($"Message {i + 1}");
-			}
-			monitor.Log.WriteLine ("Custom project built");
-			monitor.LogObject (new BuildSessionFinishedEvent ());
+			var bo = GenerateCustomBuild (1);
 
 			var nodes = bo.GetRootNodes (true);
-			var dataSource = new BuildOutputDataSource (nodes);
 			var search = new BuildOutputDataSearch (nodes);
 			int matches = 0;
 			var visited = new HashSet<BuildOutputNode> ();
@@ -108,7 +128,24 @@ namespace MonoDevelop.Ide
 				matches++;
 			}
 
-			Assert.That (matches, Is.EqualTo (100));
+			Assert.That (matches, Is.EqualTo (1000));
+		}
+
+		[Test]
+		public async Task CustomProject_SearchCanBeCanceled ()
+		{
+			BuildOutputNode firstMatch = null;
+
+			var bo = GenerateCustomBuild (10);
+
+			var search = new BuildOutputDataSearch (bo.GetRootNodes (true));
+			for (int i = 0; i < 100; i++) {
+				await Task.WhenAll (Task.Run (async () => firstMatch = await search.FirstMatch ("Message ")),
+									Task.Delay (100).ContinueWith (t => search.Cancel ()));
+
+				Assert.Null (firstMatch, "Got a first match while search was canceled");
+				Assert.True (search.IsCanceled, "Search was not canceled");
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes part of 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/632363 by adding quite a noticeable performance improvement, which at least clearly showed where the problem is (synchronous search of the whole tree, node by node, which, on a 16.4MB .binlog, took 18 of 19 seconds for the whole operation, including several searches being started/canceled and (a single) UI refresh).