### PR TITLE
Fixes vsts Bug 669030: [Feedback] VSMac 7.6 UI Blitz after pasting c#

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextPasteHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextPasteHandler.cs
@@ -41,6 +41,7 @@ using Microsoft.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.CSharp.Formatting
 {
@@ -102,7 +103,11 @@ namespace MonoDevelop.CSharp.Formatting
 			var formattingService = doc.GetLanguageService<IEditorFormattingService> ();
 			if (formattingService == null || !formattingService.SupportsFormatOnPaste)
 				return;
-
+			var text = await doc.GetTextAsync ();
+			if (offset + length > text.Length) {
+				LoggingService.LogError ($"CSharpTextPasteHandler.PostFormatPastedText out of range {offset}/{length} in a document of length {text.Length} (editor length {indent.Editor.Length}).");
+				return;
+			}
 			var changes = await formattingService.GetFormattingChangesOnPasteAsync (doc, new TextSpan (offset, length), default (CancellationToken));
 			if (changes == null)
 				return;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -142,7 +142,14 @@ namespace MonoDevelop.CodeActions
 
 			return Task.Run (async delegate {
 				try {
+					var root = await ad.GetSyntaxRootAsync (cancellationToken);
+					if (root.Span.End < span.End) {
+						LoggingService.LogError ($"Error in GetCurrentFixesAsync span {span.Start}/{span.Length} not inside syntax root {root.Span.End} document length {Editor.Length}.");
+						return CodeActionContainer.Empty;
+					}
+
 					var fixes = await codeFixService.GetFixesAsync (ad, span, true, cancellationToken);
+
 					var refactorings = await codeRefactoringService.GetRefactoringsAsync (ad, span, cancellationToken);
 
 					var codeActionContainer = new CodeActionContainer (fixes, refactorings);


### PR DESCRIPTION
code from docs sample

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/669030

Without beeing able to reprodue the issue I can only guard against the
span out of range case. Getting no refactorings at a position
shouldn't produce visible crashes.