### PR TITLE
[release-7.6][Core] Fix properties not being saved.

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -111,6 +111,7 @@
     <Compile Include="MonoDevelop.Core\InstrumentationTests.cs" />
     <Compile Include="MonoDevelop.FSW\PathTreeNodeTests.cs" />
     <Compile Include="MonoDevelop.FSW\PathTreeTests.cs" />
+    <Compile Include="MonoDevelop.Core\PropertyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MonoDevelop.Core\" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/PropertyTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/PropertyTests.cs
@@ -1,0 +1,101 @@
+//
+// PropertyTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Core
+{
+	[TestFixture]
+	public class PropertyTests
+	{
+		/// <summary>
+		/// Ensures that a Properties instance used as a property value can be saved
+		/// and re-loaded with the updated values.
+		/// </summary>
+		[Test]
+		public void PropertyIsPropertiesInstance_SaveAndReload ()
+		{
+			var mainProperties = new Properties ();
+			var properties = mainProperties.Get ("PropertyInstance", new Properties ());
+			var propertyDefaultValue = properties.Get<string> ("First");
+			properties.Set ("First", "Test");
+
+			FilePath directory = Util.CreateTmpDir ("PropertyInstanceTest");
+			var fileName = directory.Combine ("Properties.xml");
+			mainProperties.Save (fileName);
+
+			mainProperties = Properties.Load (fileName);
+			var savedProperties = mainProperties.Get ("PropertyInstance", new Properties ());
+			var savedFirstValue = savedProperties.Get<string> ("First");
+
+			Assert.IsNull (propertyDefaultValue);
+			Assert.AreEqual ("Test", savedFirstValue);
+		}
+
+		[Test]
+		public void BoolAndStringProperties_SaveAndReload ()
+		{
+			var properties = new Properties ();
+			var stringPropertyDefaultValue = properties.Get<string> ("FirstString");
+			properties.Set ("FirstString", "Test");
+			var defaultBoolValue = properties.Get ("FirstBool", true);
+			properties.Set ("FirstBool", false);
+
+			FilePath directory = Util.CreateTmpDir ("StringBoolPropertiesTests");
+			var fileName = directory.Combine ("Properties.xml");
+			properties.Save (fileName);
+
+			properties = Properties.Load (fileName);
+			var savedFirstStringValue = properties.Get<string> ("FirstString");
+			var savedFirstBoolValue = properties.Get ("FirstBool", true);
+
+			Assert.IsNull (stringPropertyDefaultValue);
+			Assert.AreEqual ("Test", savedFirstStringValue);
+			Assert.IsTrue (defaultBoolValue);
+			Assert.IsFalse (savedFirstBoolValue);
+		}
+
+		[Test]
+		public void PropertiesWithDefaultValues_SavedPropertiesFileDoesNotContainProperty ()
+		{
+			var mainProperties = new Properties ();
+			var properties = mainProperties.Get ("PropertyInstance", new Properties ());
+			var propertyDefaultValue = properties.Get<string> ("FirstProperties", "defaultValue");
+			var stringPropertyDefaultValue = properties.Get<string> ("FirstString", "Test");
+			var defaultBoolValue = properties.Get ("FirstBool", true);
+
+			FilePath directory = Util.CreateTmpDir ("PropertyWithDefaultValues");
+			var fileName = directory.Combine ("Properties.xml");
+			mainProperties.Save (fileName);
+
+			string text = File.ReadAllText (fileName);
+
+			Assert.IsFalse (text.Contains ("First"), "Default properties should not be saved.");
+		}
+	}
+}


### PR DESCRIPTION
Backport of #5762

If the property value was a Properties instance then the values
would not be saved if the original property did not exist in the
saved properties file. This was because the Properties class was
checking the property values against its list of default values and
not serializing them if there is a match. This check did not work
for values which are Properties since they are the default value
if the property did not originally exist. This resulted in the
value not being saved.

Changed the code to special case Properties being used as a value so
a check is made to see if it contains only default values instead
of not being saved.

Fixes VSTS #669533 - Editor font settings cannot be saved.