### PR TITLE
[Core] Fix null reference exception in FileStatusTracker

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -93,6 +93,7 @@ namespace MonoDevelop.Projects
 		{
 			itemExtension = ExtensionChain.GetExtension<SolutionItemExtension> ();
 			base.OnExtensionChainInitialized ();
+			fileStatusTracker.TrackFileChanges ();
 		}
 
 		SolutionItemExtension ItemExtension {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -162,6 +162,7 @@ namespace MonoDevelop.Projects
 		{
 			itemExtension = ExtensionChain.GetExtension<WorkspaceItemExtension> ();
 			base.OnExtensionChainInitialized ();
+			fileStatusTracker.TrackFileChanges ();
 		}
 
 		WorkspaceItemExtension itemExtension;
@@ -570,7 +571,6 @@ namespace MonoDevelop.Projects
 			lastSaveTime = new Dictionary<string,DateTime> ();
 			savingFlag = false;
 			reloadRequired = null;
-			FileService.FileChanged += HandleFileChanged;
 		}
 		
 		public void BeginSave ()
@@ -617,7 +617,13 @@ namespace MonoDevelop.Projects
 				return false;
 			}
 		}
-		
+
+		public void TrackFileChanges ()
+		{
+			FileService.FileChanged -= HandleFileChanged;
+			FileService.FileChanged += HandleFileChanged;
+		}
+
 		void HandleFileChanged (object sender, FileEventArgs e)
 		{
 			if (savingFlag || needsReload)


### PR DESCRIPTION
If a FileService FileChanged event fires before the item extension
is initialized a null reference exception can occur in the
FileStatusTracker.

System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.Projects.SolutionItem.GetItemFiles (System.Boolean includeReferencedFiles) [0x00000] in main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs:1270
  at MonoDevelop.Projects.FileStatusTracker`1[TEventArgs].HandleFileChanged (System.Object sender, MonoDevelop.Core.FileEventArgs e) [0x00011] in main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs:625
  at (wrapper delegate-invoke) System.EventHandler`1[MonoDevelop.Core.FileEventArgs].invoke_void_object_TEventArgs(object,MonoDevelop.Core.FileEventArgs)
  at MonoDevelop.Core.EventQueue+<>c__11`1[TArgs].<RaiseEvent>b__11_0 (System.Object state) [0x0001a] in main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs:967
  at MonoDevelop.Ide.DispatchService+GtkSynchronizationContext+TimeoutProxy.HandlerInternal (System.IntPtr data) [0x00014] in main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:77

Fixes VSTS #669419 - Exception in FileStatusTracker