### PR TITLE
[Ide] Fix NRE in CommentTasksView

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
@@ -83,7 +83,7 @@ namespace MonoDevelop.Ide.Tasks
 					return;
 
 				if (triggerLoad == null || triggerLoad.Invoke (cachedUntilViewCreated.Count)) {
-					var changes = cachedUntilViewCreated.Values.Select (x => x.ToCommentTaskChange ()).ToList ();
+					var changes = cachedUntilViewCreated.Values.Select (x => x.ToCommentTaskChange ()).Where (x => x != null).ToList ();
 					TaskService.InformCommentTasks (new CommentTasksChangedEventArgs (changes));
 					cachedUntilViewCreated = null;
 					triggerLoad = null;
@@ -146,7 +146,8 @@ namespace MonoDevelop.Ide.Tasks
 				return;
 
 			var change = ToCommentTaskChange (args);
-			TaskService.InformCommentTasks (new CommentTasksChangedEventArgs (new [] { change }));
+			if (change != null)
+				TaskService.InformCommentTasks (new CommentTasksChangedEventArgs (new [] { change }));
 		}
 
 		static async void OnSolutionLoaded (object sender, SolutionEventArgs args)


### PR DESCRIPTION
When notifying about comment tasks changes, some cached
tasks might have become invalid. Let the CommentTasksProvider
skip tasks with invalid document or project,
resulting in a null CommentTaskChange.

Fixes VSTS #670781