### PR TITLE
Fixes issue #5360 Not obvious which "fix all" is which The fix all

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -248,6 +248,8 @@ namespace MonoDevelop.CodeActions
 
 				var menuItem = new ContextMenuItem (item.Label);
 				menuItem.Context = item.Action;
+				if (item.Action == null)
+					menuItem.Sensitive = false;
 				var subMenu = item as CodeFixMenu;
 				if (subMenu != null) {
 					menuItem.SubMenu = CreateContextMenu (subMenu);

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeFixMenuService.cs
@@ -221,8 +221,10 @@ namespace MonoDevelop.CodeActions
 			// TODO: Add support for more than doc when we have global undo.
 			fixState = fixState?.WithScopeAndEquivalenceKey (FixAllScope.Document, fix.EquivalenceKey);
 			var fixAllMenuEntry = CreateFixAllMenuEntry (editor, fixState, ref mnemonic, token);
-			if (fixAllMenuEntry != null)
+			if (fixAllMenuEntry != null) {
+				fixAllMenu.Add (new CodeFixMenuEntry (fix.Message, null));
 				fixAllMenu.Add (fixAllMenuEntry);
+			}
 		}
 
 		static void AddNestedFixMenu (TextEditor editor, CodeFixMenu menu, CodeFixMenu fixAllMenu, CodeAction.CodeActionWithNestedActions fixes, FixAllState fixState, CancellationToken token)

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/QuickFixMenuHandler.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/QuickFixMenuHandler.cs
@@ -94,8 +94,10 @@ namespace MonoDevelop.Refactoring
 					AddItem (submenu.CommandInfos, subItem);
 				}
 				cis.Add (submenu, item.Action);
-			} else { 
-				cis.Add (new CommandInfo (item.Label), item.Action);
+			} else {
+				var info = new CommandInfo (item.Label);
+				info.Enabled = item.Action != null;
+				cis.Add (info, item.Action);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -178,16 +178,16 @@ namespace MonoDevelop.Components.Mac
 
 				var item = new MDExpandedArrayItem {
 					Info = ci,
-					Target = this,
-					Action = ActionSel,
+					Target = this
 				};
-
 				if (ci is CommandInfoSet) {
 					item.Submenu = new NSMenu ();
 					int i = 0;
 					PopulateArrayItems (((CommandInfoSet)ci).CommandInfos, item.Submenu, ref i);
 				}
 				SetItemValues (item, ci, true);
+				if (item.Enabled)
+					item.Action = ActionSel;
 
 				if (parent.Count > index)
 					parent.InsertItem (item, index);


### PR DESCRIPTION
text is generated by roslyn but it's possible to add a header item for
the fix all items. OTOH the items would become to large when using the
full title in one line.
Best solution would probably be to just move the code fixes & issues
out of the context menu to a custom popup dialog. But that's a user
impact that's beyond the scope of the bug report.