### PR TITLE
[MSBuild] Disable binlog writing in 7.6

### DIFF
--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.cs
@@ -122,18 +122,7 @@ namespace MonoDevelop.Projects.MSBuild
 				sessionLogWriter = logWriter;
 				loggerAdapter = new MSBuildLoggerAdapter (logWriter, verbosity);
 
-				if (!string.IsNullOrEmpty (binLogFilePath)) {
-					var binaryLogger = new BinaryLogger {
-						Parameters = binLogFilePath,
-						Verbosity = LoggerVerbosity.Diagnostic
-					};
-
-					var loggers = new List<ILogger> (loggerAdapter.Loggers);
-					loggers.Add (binaryLogger);
-					parameters.Loggers = loggers;
-				} else {
-					parameters.Loggers = loggerAdapter.Loggers;
-				}
+				parameters.Loggers = loggerAdapter.Loggers;
 
 				BuildManager.DefaultBuildManager.BeginBuild (parameters);
 			});


### PR DESCRIPTION
This disables binlog writing, as mono has a bug in deflatestream causing the builder to crash on finalization.
https://github.com/mono/mono/issues/9142

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/669032, but I've been unable to reliably repro it.