### PR TITLE
Fix 668995: [Feedback] Xaml Syntax Highlighting Has Reverted in 7.6 (2190)

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/VSCodeImport/xml/syntaxes/xaml.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/VSCodeImport/xml/syntaxes/xaml.json
@@ -368,7 +368,7 @@
 			"name": "comment.block.xml"
 		},
 		"markupExtension": {
-			"begin": "(^{)\\s*((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))\\s",
+			"begin": "({)\\s*((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))\\s",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.xml"
@@ -408,7 +408,7 @@
 		"property-name": {
 			"patterns": [
 				{
-					"match": "([_$[:alpha:]][_$[:alnum:.]]*)\\s*(=)",
+					"match": "([_$[:alpha:]]*[_$[:alnum:.]]*)\\s*(=)",
 					"captures": {
 						"1": {
 							"name": "entity.other.attribute-name.xml"


### PR DESCRIPTION
In 7.6 some logic was changed in SyntaxHighligthingService.cs to do `return name != null && scopeName != null;`(before it just returned `true`) since `xaml.json` has `scopeName` on 2nd line it failed... Hence now we read for new format also 1st and 2nd line.
Also some logic around regex changed so I made few changes to xaml.json to support new regex rules.