### PR TITLE
[AspNetCore] Change project template order in New Project dialog

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
@@ -70,63 +70,99 @@
 	<ConditionType id="AspNetCoreSdkInstalled" type="MonoDevelop.AspNetCore.AspNetCoreSdkInstalledCondition" />
 
 	<Extension path="/MonoDevelop/Ide/Templates">
-		<Condition id="AspNetCoreSdkInstalled" sdkVersion="1.*">
+		<!-- Order templates by newer SDK version first so the template order can be controlled easier
+		For example, .NET Core 1.1 SDK does not have a Razor template so having the 1.1 templates first
+		would cause the Razor template to be last in the New Project dialog if both 1.1 and 2.x templates
+		are available. -->
+		<Condition id="AspNetCoreSdkInstalled" sdkVersion="2.1">
 			<Template
 				id="Microsoft.Web.Empty.CSharp"
+				templateId="Microsoft.Web.Empty.CSharp.2.1"
 				_overrideName="ASP.NET Core Empty"
 				_overrideDescription="An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore1x=true"
+				condition="UseNetCore21=true"
 				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Empty.FSharp"
+				templateId="Microsoft.Web.Empty.FSharp.2.1"
 				_overrideName="ASP.NET Core Empty"
 				_overrideDescription="An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore1x=true"
+				condition="UseNetCore21=true"
 				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
-				id="Microsoft.Web.Mvc.CSharp"
-				_overrideName="ASP.NET Core Web App (MVC)"
-				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
+				id="Microsoft.Web.WebApi.CSharp"
+				templateId="Microsoft.Web.WebApi.CSharp.2.1"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore1x=true"
+				condition="UseNetCore21=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.WebApi.FSharp"
+				templateId="Microsoft.Web.WebApi.FSharp.2.1"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				supportedParameters="FSharpWebApi"
+				condition="UseNetCore21=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.RazorPages.CSharp"
+				templateId="Microsoft.Web.RazorPages.CSharp.2.1"
+				_overrideName="ASP.NET Core Web App"
+				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content."
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				supportedParameters="RazorPages"
+				condition="UseNetCore21=true"
+				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.Mvc.CSharp"
+				templateId="Microsoft.Web.Mvc.CSharp.2.1"
+				_overrideName="ASP.NET Core Web App (MVC)"
+				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore21=true"
 				category="netcore/app/aspnet"
 				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.FSharp"
+				templateId="Microsoft.Web.Mvc.FSharp.2.1"
 				_overrideName="ASP.NET Core Web App (MVC)"
 				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
+				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore1x=true"
+				condition="UseNetCore21=true"
 				category="netcore/app/aspnet"
 				formatExclude="*.min.css|*.min.js|*.map"
-				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.WebApi.CSharp"
-				_overrideName="ASP.NET Core Web API"
-				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore1x=true"
-				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 		</Condition>
 		<Condition id="AspNetCoreSdkInstalled" sdkVersion="2.0">
@@ -155,6 +191,45 @@
 				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
+				id="Microsoft.Web.WebApi.CSharp"
+				templateId="Microsoft.Web.WebApi.CSharp.2.0"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore20=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.WebApi.FSharp"
+				templateId="Microsoft.Web.WebApi.FSharp.2.0"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				supportedParameters="FSharpWebApi"
+				condition="UseNetCore20=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.RazorPages.CSharp"
+				templateId="Microsoft.Web.RazorPages.CSharp.2.0"
+				_overrideName="ASP.NET Core Web App"
+				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content."
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				supportedParameters="RazorPages"
+				condition="UseNetCore20=true"
+				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
 				id="Microsoft.Web.Mvc.CSharp"
 				templateId="Microsoft.Web.Mvc.CSharp.2.0"
 				_overrideName="ASP.NET Core Web App (MVC)"
@@ -180,135 +255,64 @@
 				category="netcore/app/aspnet"
 				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.RazorPages.CSharp"
-				templateId="Microsoft.Web.RazorPages.CSharp.2.0"
-				_overrideName="ASP.NET Core Web App"
-				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				supportedParameters="RazorPages"
-				condition="UseNetCore20=true"
-				category="netcore/app/aspnet"
-				formatExclude="*.min.css|*.min.js|*.map"
-				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.WebApi.CSharp"
-				templateId="Microsoft.Web.WebApi.CSharp.2.0"
-				_overrideName="ASP.NET Core Web API"
-				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore20=true"
-				category="netcore/app/aspnet"
-				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.WebApi.FSharp"
-				templateId="Microsoft.Web.WebApi.FSharp.2.0"
-				_overrideName="ASP.NET Core Web API"
-				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
-				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.2.0.1.0.0-beta2-20170727-301.nupkg"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				supportedParameters="FSharpWebApi"
-				condition="UseNetCore20=true"
-				category="netcore/app/aspnet"
-				defaultParameters="IncludeLaunchSettings=true" />
 		</Condition>
-		<Condition id="AspNetCoreSdkInstalled" sdkVersion="2.1">
+		<Condition id="AspNetCoreSdkInstalled" sdkVersion="1.*">
 			<Template
 				id="Microsoft.Web.Empty.CSharp"
-				templateId="Microsoft.Web.Empty.CSharp.2.1"
 				_overrideName="ASP.NET Core Empty"
 				_overrideDescription="An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore21=true"
+				condition="UseNetCore1x=true"
 				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Empty.FSharp"
-				templateId="Microsoft.Web.Empty.FSharp.2.1"
 				_overrideName="ASP.NET Core Empty"
 				_overrideDescription="An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore21=true"
+				condition="UseNetCore1x=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.WebApi.CSharp"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore1x=true"
 				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.CSharp"
-				templateId="Microsoft.Web.Mvc.CSharp.2.1"
 				_overrideName="ASP.NET Core Web App (MVC)"
 				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore21=true"
+				condition="UseNetCore1x=true"
 				category="netcore/app/aspnet"
 				formatExclude="*.min.css|*.min.js|*.map"
 				defaultParameters="IncludeLaunchSettings=true" />
 			<Template
 				id="Microsoft.Web.Mvc.FSharp"
-				templateId="Microsoft.Web.Mvc.FSharp.2.1"
 				_overrideName="ASP.NET Core Web App (MVC)"
 				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
+				path="Templates/Microsoft.DotNet.Web.ProjectTemplates.1.x.1.0.0-beta2-20170430-208.nupkg"
 				icon="md-netcore-empty-project"
 				imageId="md-netcore-empty-project"
 				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore21=true"
+				condition="UseNetCore1x=true"
 				category="netcore/app/aspnet"
 				formatExclude="*.min.css|*.min.js|*.map"
-				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.RazorPages.CSharp"
-				templateId="Microsoft.Web.RazorPages.CSharp.2.1"
-				_overrideName="ASP.NET Core Web App"
-				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				supportedParameters="RazorPages"
-				condition="UseNetCore21=true"
-				category="netcore/app/aspnet"
-				formatExclude="*.min.css|*.min.js|*.map"
-				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.WebApi.CSharp"
-				templateId="Microsoft.Web.WebApi.CSharp.2.1"
-				_overrideName="ASP.NET Core Web API"
-				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				condition="UseNetCore21=true"
-				category="netcore/app/aspnet"
-				defaultParameters="IncludeLaunchSettings=true" />
-			<Template
-				id="Microsoft.Web.WebApi.FSharp"
-				templateId="Microsoft.Web.WebApi.FSharp.2.1"
-				_overrideName="ASP.NET Core Web API"
-				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
-				path="${DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg}"
-				icon="md-netcore-empty-project"
-				imageId="md-netcore-empty-project"
-				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-				supportedParameters="FSharpWebApi"
-				condition="UseNetCore21=true"
-				category="netcore/app/aspnet"
 				defaultParameters="IncludeLaunchSettings=true" />
 		</Condition>
 	</Extension>


### PR DESCRIPTION
Change the order of the project templates to match Visual Studio 2017
on Windows.

From:

ASP.NET Core Empty
ASP.NET Core Web App (MVC)
ASP.NET Core Web API
ASP.NET Core Web App

To:

ASP.NET Core Empty
ASP.NET Core Web API
ASP.NET Core Web App
ASP.NET Core Web App (MVC)

Fixes VSTS #671649 - Update ordering of projects in New Project to
match ordering in VS2017