### PR TITLE
Fix VSTS 657666 (HTML: ArgumentOutOfRange when inserting new line between <div> and </div>)

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
@@ -183,7 +183,7 @@ namespace Mono.TextEditor
 
 			public TextBounds GetCharacterBounds(VirtualSnapshotPoint bufferPosition)
 			{
-				throw new System.NotImplementedException();
+				return GetCharacterBounds (bufferPosition.Position);
 			}
 
 			public TextBounds GetExtendedCharacterBounds(SnapshotPoint bufferPosition)
@@ -193,7 +193,13 @@ namespace Mono.TextEditor
 
 			public TextBounds GetExtendedCharacterBounds(VirtualSnapshotPoint bufferPosition)
 			{
-				throw new System.NotImplementedException();
+				// if the point is in virtual space, then it can't be next to any space negotiating adornments, 
+				// so just return its character bounds. If the point is not in virtual space, then use the regular
+				// GetExtendedCharacterBounds method for a non-virtual SnapshotPoint
+				if (bufferPosition.IsInVirtualSpace)
+					return this.GetCharacterBounds (bufferPosition);
+				else
+					return this.GetExtendedCharacterBounds (bufferPosition.Position);
 			}
 
 			public VirtualSnapshotPoint GetInsertionBufferPositionFromXCoordinate(double xCoordinate)

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.cs
@@ -50,10 +50,10 @@ namespace Mono.TextEditor
 			textEditor.TextViewModel.VisualBuffer.ChangedLowPriority += OnVisualBufferChanged;
 		}
 
-		internal void Add (int logicalLineNumber, DocumentLine line)
+		internal ITextViewLine Add (int logicalLineNumber, DocumentLine line)
 		{
 			if (line == null)
-				return;
+				return null;
 
 			if (Count == 0)
 				this.textSnapshot = textEditor.TextSnapshot;
@@ -64,7 +64,7 @@ namespace Mono.TextEditor
 			for (int i = 0; i < Count; i++) {
 				if (((MdTextViewLine)this [i]).LineNumber == logicalLineNumber) {
 					this [i] = newLine;
-					return;
+					return newLine;
 				}
 			}
 			int index = 0;
@@ -73,6 +73,7 @@ namespace Mono.TextEditor
 					break;
 			}
 			Insert (index, newLine);
+			return newLine;
 		}
 
 		internal void RemoveLinesBefore (int lineNumber)
@@ -153,15 +154,26 @@ namespace Mono.TextEditor
 
 			this.Clear ();
 
+			var newSnapshot = e.After;
 			foreach(MdTextViewLine line in reusedLinesCache) {
-				int lineNumber = line.LineNumber;
-				Add (lineNumber, textEditor.Document.GetLine (lineNumber));
+				var snapshotLine = textSnapshot.GetLineFromLineNumber (line.LineNumber - 1);
+				var lineStart = textSnapshot.CreateTrackingPoint (snapshotLine.Start, PointTrackingMode.Negative);
+				var newLineStart = lineStart.GetPosition (newSnapshot);
+				var newSnapshotLine = newSnapshot.GetLineFromPosition (newLineStart);
+				int lineNumber = newSnapshotLine.LineNumber + 1;
+				var documentLine = textEditor.Document.GetLine (lineNumber);
+
+				var newLine = new MdTextViewLine (this, textEditor, documentLine, lineNumber, textEditor.TextViewMargin.GetLayout (documentLine));
+				Add (newLine);
 			}
 
 			modifiedLinesCache.Clear ();
 			reusedLinesCache.Clear ();
 
-			textSnapshot = e.After;
+			textSnapshot = newSnapshot;
+
+			// we need this to synchronize MultiSelectionBroker to the new snapshot
+			this.textEditor.TextArea.RaiseLayoutChanged ();
 		}
 
 		public bool IsValid => version.CompareAge (textEditor.Document.Version) == 0;
@@ -212,17 +224,29 @@ namespace Mono.TextEditor
 
 		public ITextViewLine GetTextViewLineContainingBufferPosition (SnapshotPoint bufferPosition)
 		{
-			if (bufferPosition.Position < this [0].Start.Position)
-				return null;
-
+			if (textSnapshot == null)
 			{
-				//If the position starts on or after the start of the last line, then use the
-				//line's ContainsBufferPosition logic to handle the special case at the end of
-				//the buffer.
-				ITextViewLine lastLine = this [this.Count - 1];
+				textSnapshot = bufferPosition.Snapshot;
+			}
 
-				if (bufferPosition.Position >= lastLine.Start.Position)
-					return lastLine.ContainsBufferPosition (bufferPosition) ? lastLine : null;
+			if (bufferPosition.Snapshot != textSnapshot) {
+				throw new ArgumentOutOfRangeException ($"Requested snapshot version {bufferPosition.Snapshot.Version.VersionNumber} but the TextViewLineCollection currently contains snapshot version {textSnapshot.Version.VersionNumber}");
+			}
+
+			if (this.Count == 0 || bufferPosition.Position < this[0].Start.Position) {
+				return CreateAndAddLineFromPosition (bufferPosition);
+			}
+
+			//If the position starts on or after the start of the last line, then use the
+			//line's ContainsBufferPosition logic to handle the special case at the end of
+			//the buffer.
+			ITextViewLine lastLine = this [this.Count - 1];
+			if (bufferPosition.Position >= lastLine.Start.Position) {
+				if (lastLine.ContainsBufferPosition (bufferPosition)) {
+					return lastLine;
+				}
+
+				return CreateAndAddLineFromPosition (bufferPosition);
 			}
 
 			int low = 0;
@@ -237,7 +261,18 @@ namespace Mono.TextEditor
 					low = middle + 1;
 			}
 
-			return this[low - 1];
+			var result = this[low - 1];
+			if (!result.ContainsBufferPosition (bufferPosition)) {
+				result = CreateAndAddLineFromPosition (bufferPosition);
+			}
+
+			return result;
+		}
+
+		private ITextViewLine CreateAndAddLineFromPosition (SnapshotPoint position)
+		{
+			int lineNumber1Based = textSnapshot.GetLineNumberFromPosition (position) + 1;
+			return Add (lineNumber1Based, textEditor.Document.GetLine (lineNumber1Based));
 		}
 
 		public ITextViewLine GetTextViewLineContainingYCoordinate (double y)

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -179,6 +179,8 @@ namespace Mono.TextEditor
 			}
 		}
 
+		public ITextCaret TextCaret => Caret;
+
 		public bool HasAggregateFocus {
 			get {
 				return hasAggregateFocus;
@@ -536,9 +538,20 @@ namespace Mono.TextEditor
 			get {
 				if (multiSelectionBroker == null) {
 					multiSelectionBroker = factoryService.MultiSelectionBrokerFactory.CreateBroker (this);
+					multiSelectionBroker.MultiSelectionSessionChanged += OnMultiSelectionSessionChanged;
 				}
 
 				return multiSelectionBroker;
+			}
+		}
+
+		private void OnMultiSelectionSessionChanged (object sender, EventArgs e)
+		{
+			// The MultiSelectionBroker API has been updated, but currently in VSMac we still have a separate Caret concept.
+			// We need to manually synchronize our caret with what MultiSelectionBroker thinks the caret is.
+			// The other direction happens when we move our caret.
+			if (TextCaret.Position.VirtualBufferPosition != MultiSelectionBroker.PrimarySelection.InsertionPoint) {
+				TextCaret.MoveTo (MultiSelectionBroker.PrimarySelection.InsertionPoint);
 			}
 		}
 	}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -170,6 +170,9 @@ namespace Mono.TextEditor
 			//_visualBuffer.ChangedLowPriority += OnVisualBufferChanged;
 			//_visualBuffer.ContentTypeChanged += OnVisualBufferContentTypeChanged;
 
+			// instantiate the MultiSelectionBroker
+			var broker = MultiSelectionBroker;
+
 			hasInitializeBeenCalled = true;
 		}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1247,21 +1247,26 @@ namespace Mono.TextEditor
 
 		protected override bool OnKeyPressEvent (Gdk.EventKey evt)
 		{
-			if (currentFocus == FocusMargin.TextView) {
-				long time;
+			try {
+				if (currentFocus == FocusMargin.TextView) {
+					long time;
 #if MAC
-				time = (long)TimeSpan.FromSeconds (AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp).TotalMilliseconds;
+					time = (long)TimeSpan.FromSeconds (AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp).TotalMilliseconds;
 #else
-				// Warning, Gdk returns uint32 as time value, so this might overflow.
-				time = evt.Time;
+					// Warning, Gdk returns uint32 as time value, so this might overflow.
+					time = evt.Time;
 #endif
-				keyPressTimings.StartTimer (time);
-				return HandleTextKey (evt);
-			} else if (currentFocus != FocusMargin.None) {
-				return HandleMarginKeyCommand (evt);
-			}
+					keyPressTimings.StartTimer (time);
+					return HandleTextKey (evt);
+				} else if (currentFocus != FocusMargin.None) {
+					return HandleMarginKeyCommand (evt);
+				}
 
-			return base.OnKeyPressEvent (evt);
+				return base.OnKeyPressEvent (evt);
+			} catch (Exception ex) {
+				LoggingService.LogError ("Error in OnKeyPressEvent", ex);
+				return false;
+			}
 		}
 
 		bool HandleTextKey (EventKey evt)

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -2265,7 +2265,7 @@ namespace Mono.TextEditor
 				foreach (var drawer in margin.MarginDrawer)
 					drawer.Draw (cr, cairoRectangle);
 			}
-			LayoutChanged?.Invoke (this, EventArgs.Empty);
+			RaiseLayoutChanged ();
 			if (setLongestLine) 
 				SetHAdjustment ();
 		}
@@ -3619,6 +3619,11 @@ namespace Mono.TextEditor
 		
 		internal List<MonoTextEditor.EditorContainerChild> containerChildren = new List<MonoTextEditor.EditorContainerChild> ();
 		internal event EventHandler LayoutChanged;
+
+		internal void RaiseLayoutChanged ()
+		{
+			LayoutChanged?.Invoke (this, EventArgs.Empty);
+		}
 
 		public void AddTopLevelWidget (Gtk.Widget widget, int x, int y)
 		{

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/CaretImpl.ITextCaret.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/CaretImpl.ITextCaret.cs
@@ -113,6 +113,20 @@ namespace Mono.TextEditor
 			int position = TextEditor.Caret.Offset;
 			VirtualSnapshotPoint vsp = new VirtualSnapshotPoint (TextEditor.TextSnapshot, position);
 
+			// Synchronize the MultiSelectionBroker with Caret.
+			// In VS Editor 15.8 the MultiSelectionBroker is the single source of truth about carets and selections 
+			// (no selection / single caret, no selection / multiple carets, simple selection, block selection, multiple selections).
+			// In our world, we still have our own Caret and Selection, so when our Caret moves, we need to synchronize 
+			// the MultiSelectionBroker to our values, and when the MultiSelectionBroker changes 
+			// (e.g. as a result of EditorOperations such as InsertNewLine), we need to synchronize our caret and selection 
+			// to the MultiSelectionBroker values.
+			// Note that EditorOperations only updates the MultiSelectionBroker, it no longer moves caret or selection 
+			// (since in Editor 15.8 the Caret and Selection are shims implemented in terms of MultiSelectionBroker)
+			// TODO: synchronize all our selections as well.
+			TextEditorData.Parent.MultiSelectionBroker.PerformActionOnAllSelections (transformer => {
+				transformer.MoveTo (vsp, select: false, PositionAffinity.Successor);
+			});
+
 			insertionPoint = vsp;
 			if (args.CaretChangeReason == CaretChangeReason.Movement) {
 				oldCaretLocation = args.Location;


### PR DESCRIPTION
Fix VSTS 657666 (HTML: ArgumentOutOfRange when inserting new line between `<div>` and `</div>`)

There was a window after a buffer change where we didn't reuse any of the text view lines, so the text view line collection was empty. At that time someone was getting the line the caret was on, resulting in an argument out of range. We now check for that situation by inserting a line on demand when it is requested.

In VS the ITextView.GetTextViewLineContainingBufferPosition() always returns a text view line for a given position (as long as the requested position is on the current snapshot). In our world we were returning null in a lot of situations.

Synchronize the MultiSelectionBroker with Caret.

In VS Editor 15.8 the MultiSelectionBroker is the single source of truth about carets and selections (no selection/single caret, no selection/multiple carets, simple selection, block selection, multiple selections).

In our world, we still have our own Caret and Selection, so when our Caret moves, we need to synchronize the MultiSelectionBroker to our values, and when the MultiSelectionBroker changes (e.g. as a result of EditorOperations such as InsertNewLine), we need to synchronize our caret and selection to the MultiSelectionBroker values.

Note that EditorOperations only updates the MultiSelectionBroker, it no longer moves caret or selection (since in Editor 15.8 the Caret and Selection are shims implemented in terms of MultiSelectionBroker).
