### PR TITLE
[Core] Do not add facades if ImplicitlyExpandDesignTimeFacades is false

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -958,35 +958,38 @@ namespace MonoDevelop.Projects
 						result.Add (ar);
 				}
 			}
-			var addFacadeAssemblies = false;
-			foreach (var r in GetReferencedAssemblyProjects (configuration)) {
-				// Facade assemblies need to be referenced if this project is referencing a PCL or .NET Standard project.
-				if (r.IsPortableLibrary || r.TargetFramework.Id.Identifier == ".NETStandard") {
-					addFacadeAssemblies = true;
-					break;
-				}
-			}
-			if (!addFacadeAssemblies) {
-				foreach (var refFilename in result) {
-					string fullPath = null;
-					if (!Path.IsPathRooted (refFilename.FilePath)) {
-						fullPath = Path.Combine (Path.GetDirectoryName (FileName), refFilename.FilePath);
-					} else {
-						fullPath = Path.GetFullPath (refFilename.FilePath);
-					}
-					if (await SystemAssemblyService.RequiresFacadeAssembliesAsync (fullPath)) {
+			var expandDesignTimeFacades = MSBuildProject.EvaluatedProperties.GetValue ("ImplicitlyExpandDesignTimeFacades", true);
+			if (expandDesignTimeFacades) {
+				var addFacadeAssemblies = false;
+				foreach (var r in GetReferencedAssemblyProjects (configuration)) {
+					// Facade assemblies need to be referenced if this project is referencing a PCL or .NET Standard project.
+					if (r.IsPortableLibrary || r.TargetFramework.Id.Identifier == ".NETStandard") {
 						addFacadeAssemblies = true;
 						break;
 					}
 				}
-			}
+				if (!addFacadeAssemblies) {
+					foreach (var refFilename in result) {
+						string fullPath = null;
+						if (!Path.IsPathRooted (refFilename.FilePath)) {
+							fullPath = Path.Combine (Path.GetDirectoryName (FileName), refFilename.FilePath);
+						} else {
+							fullPath = Path.GetFullPath (refFilename.FilePath);
+						}
+						if (await SystemAssemblyService.RequiresFacadeAssembliesAsync (fullPath)) {
+							addFacadeAssemblies = true;
+							break;
+						}
+					}
+				}
 
-			if (addFacadeAssemblies) {
-				var facades = await ProjectExtension.OnGetFacadeAssemblies ();
-				if (facades != null) {
-					foreach (var facade in facades) {
-						if (!result.Contains (facade))
-							result.Add (facade);
+				if (addFacadeAssemblies) {
+					var facades = await ProjectExtension.OnGetFacadeAssemblies ();
+					if (facades != null) {
+						foreach (var facade in facades) {
+							if (!result.Contains (facade))
+								result.Add (facade);
+						}
 					}
 				}
 			}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -879,6 +879,46 @@ namespace MonoDevelop.Projects
 		}
 
 		/// <summary>
+		/// Checks that the facade assemblies are not returned as references when
+		/// ImplicitlyExpandDesignTimeFacades is false in the project. The project
+		/// references the System.Runtime NuGet package which will cause the project
+		/// model to reference the facade assemblies.
+		/// </summary>
+		[Test]
+		public async Task ImplicitlyExpandDesignTimeFacades ()
+		{
+			if (!Platform.IsMac) {
+				// NUnit platform attribute does not seem to work.
+				// Want to use nuget that is included with Mono to restore.
+				Assert.Ignore ("Only supported on Mac.");
+			}
+
+			FilePath solFile = Util.GetSampleProject ("expand-facades", "ExpandFacadesTest.sln");
+			CreateNuGetConfigFile (solFile.ParentDirectory);
+
+			var process = Process.Start ("nuget", $"restore -DisableParallelProcessing \"{solFile}\"");
+			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+			Assert.AreEqual (0, process.ExitCode);
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var expandFalseProject = (DotNetProject)sol.FindProjectByName ("ExpandFacadesFalse");
+				var expandTrueProject = (DotNetProject)sol.FindProjectByName ("ExpandFacadesTrue");
+
+				var expandFalseRefs = (await expandFalseProject.GetReferencedAssemblies (ConfigurationSelector.Default)).ToArray ();
+				var expandTrueRefs = (await expandTrueProject.GetReferencedAssemblies (ConfigurationSelector.Default)).ToArray ();
+
+				// ImplicitlyExpandDesignTimeFacades=true => should reference facades
+				var systemComponentModelAnnotationsFromFacadesRef = expandTrueRefs.FirstOrDefault (r => r.FilePath.FileName == "System.ComponentModel.Annotations.dll" && r.FilePath.ParentDirectory.FileName == "Facades");
+				Assert.IsNotNull (systemComponentModelAnnotationsFromFacadesRef);
+
+				// ImplicitlyExpandDesignTimeFacades=false => should not reference any facades
+				systemComponentModelAnnotationsFromFacadesRef = expandFalseRefs.FirstOrDefault (r => r.FilePath.FileName == "System.ComponentModel.Annotations.dll");
+				Assert.IsNull (systemComponentModelAnnotationsFromFacadesRef);
+				Assert.IsFalse (expandFalseRefs.Any (r => r.FilePath.ParentDirectory.FileName.Equals ("Facades", StringComparison.OrdinalIgnoreCase)));
+			}
+		}
+
+		/// <summary>
 		/// Clear all other package sources and just use the main NuGet package source when
 		/// restoring the packages for the project tests.
 		/// </summary>

--- a/main/tests/test-projects/expand-facades/ExpandFacadesFalse.csproj
+++ b/main/tests/test-projects/expand-facades/ExpandFacadesFalse.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BA998AF3-90D0-4E99-BC08-5D8A0D88DEDB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ExpandFacadesTest</RootNamespace>
+    <AssemblyName>ExpandFacadesFalse</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/expand-facades/ExpandFacadesTest.sln
+++ b/main/tests/test-projects/expand-facades/ExpandFacadesTest.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpandFacadesTrue", "ExpandFacadesTrue.csproj", "{CA998AF3-90D0-4E99-BC08-5D8A0D88DED5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpandFacadesFalse", "ExpandFacadesFalse.csproj", "{BA998AF3-90D0-4E99-BC08-5D8A0D88DEDB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA998AF3-90D0-4E99-BC08-5D8A0D88DED5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA998AF3-90D0-4E99-BC08-5D8A0D88DED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA998AF3-90D0-4E99-BC08-5D8A0D88DED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA998AF3-90D0-4E99-BC08-5D8A0D88DED5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA998AF3-90D0-4E99-BC08-5D8A0D88DEDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA998AF3-90D0-4E99-BC08-5D8A0D88DEDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA998AF3-90D0-4E99-BC08-5D8A0D88DEDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA998AF3-90D0-4E99-BC08-5D8A0D88DEDB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/expand-facades/ExpandFacadesTrue.csproj
+++ b/main/tests/test-projects/expand-facades/ExpandFacadesTrue.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CA998AF3-90D0-4E99-BC08-5D8A0D88DED5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ExpandFacadesTest</RootNamespace>
+    <AssemblyName>ExpandFacadesTrue</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/expand-facades/packages.config
+++ b/main/tests/test-projects/expand-facades/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net47" />
+</packages>


### PR DESCRIPTION
If a project sets ImplicitlyExpandDesignTimeFacades to false then
the facade assemblies are not included in the references for the
project. This is used by Unity projects when their API compatibility
level is set to .NET Standard 2.0.

Fixes VSTS #669795 - Unity projects targeting netstandard 2.0 have
busted intellisense