### PR TITLE
Fix VSTS 674296 - fix sync with MultiSelectionBroker.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -554,8 +554,7 @@ namespace Mono.TextEditor
 			// We need to manually synchronize our caret with what MultiSelectionBroker thinks the caret is.
 			// The other direction happens when we move our caret.
 			if (TextCaret.Position.VirtualBufferPosition != MultiSelectionBroker.PrimarySelection.InsertionPoint) {
-				// This sync breaks on type formatting/desired column calculation and some other things.
-				//	TextCaret.MoveTo (MultiSelectionBroker.PrimarySelection.InsertionPoint);
+				TextCaret.MoveTo (MultiSelectionBroker.PrimarySelection.InsertionPoint);
 			}
 		}
 	}


### PR DESCRIPTION
There was a problem in the logic where we synchronized the caret with the latest position of the MultiSelectionBroker.

We should first set the caret to the new position, then synchronize the MultiSelectionBroker to it. The ordering was wrong, causing smart indent not working.