### PR TITLE
Fix VSTS 669018. Tab to complete IntelliSense not working in .cshtml …

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -72,7 +72,8 @@ namespace Mono.TextEditor
 		{
 			get {
 				if (editorOperations == null) {
-					// TODO: *Someone* needs to call this to execute UndoHistoryRegistry.RegisterHistory -- VS does this via the ShimCompletionControllerFactory.
+					// *Someone* needs to call this to execute UndoHistoryRegistry.RegisterHistory -- VS does this via the ShimCompletionControllerFactory.
+					// See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/669018 for details.
 					editorOperations = factoryService.EditorOperationsProvider.GetEditorOperations (this);
 				}
 
@@ -157,6 +158,14 @@ namespace Mono.TextEditor
 			selection = new TextSelection (this);
 
 			//			this.Loaded += OnLoaded;
+
+			// We need to instantiate EditorOperations, because it in turn will register the UndoHistory
+			// for the buffer via:
+			// https://github.com/KirillOsenkov/vs-editor-api/blob/d06adf1581eb8e16242c8b6eabc7ba13ceaf0d54/src/Text/Impl/EditorOperations/EditorOperations.cs#L108
+			// Without Undo History Roslyn Completion bails via:
+			// https://github.com/dotnet/roslyn/blob/a107b43dcad83cf79addd47a9919590c7366d130/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs#L66
+			// See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/669018 for details.
+			var instantiateEditorOperations = EditorOperations;
 
 			connectionManager = new ConnectionManager (this, factoryService.TextViewConnectionListeners, factoryService.GuardedOperations);
 


### PR DESCRIPTION
…files.

We need to instantiate EditorOperations, because it in turn will register the UndoHistory
for the buffer via:
https://github.com/KirillOsenkov/vs-editor-api/blob/d06adf1581eb8e16242c8b6eabc7ba13ceaf0d54/src/Text/Impl/EditorOperations/EditorOperations.cs#L108

Without Undo History Roslyn Completion bails via:
https://github.com/dotnet/roslyn/blob/a107b43dcad83cf79addd47a9919590c7366d130/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs#L66

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/669018 for details.