### PR TITLE
Fix VSTS 634581 (triple """ in Json)

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
@@ -999,7 +999,12 @@ namespace MonoDevelop.Ide.CodeCompletion
 					if (selectedItem < 0 || (dataList != null && selectedItem >= dataList.Count)) {
 						return KeyActions.CloseWindow;
 					}
-					if (dataList [selectedItem].DisplayText.EndsWith (descriptor.KeyChar.ToString (), StringComparison.Ordinal)) {
+					var displayText = dataList[selectedItem].DisplayText;
+					// Workaround for Json bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/634581
+					// If the completion item is " " or { } or [ ] and the char is " or { or [ then don't commit
+					if ((displayText == "\" \"" || displayText == "{ }" || displayText == "[ ]") && (descriptor.KeyChar == '"' || descriptor.KeyChar == '{' || descriptor.KeyChar == '[')) {
+						return KeyActions.CloseWindow | KeyActions.Process;
+					} else if (displayText.EndsWith (descriptor.KeyChar.ToString (), StringComparison.Ordinal)) {
 						return KeyActions.Complete | KeyActions.CloseWindow | KeyActions.Ignore;
 					}
 				}


### PR DESCRIPTION
There was a special case where if the char is punctuation and the current completion list item ends in that char then it used to commit completion.

Now we detect the situation where if we're in a Json editor and the completion is one of three Json special completions " ", { } or [ ] and we press either " [ or { then we hide completion, send the char through to the editor and don't commit.

This fixes the problem because it lets Brace Completion commit the second character and lets user overtype it if they type it manually.