### PR TITLE
Fixing bug with copying build configuration

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -802,8 +802,14 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 			if (!added) {
 				if (insertAtEnd) {
-					var last = ChildNodes.FindLastIndex (g => g is MSBuildPropertyGroup);
-					if (last != -1) {
+
+                    var last = ChildNodes.FindLastIndex(g => g is MSBuildPropertyGroup &&
+                                         (g as MSBuildPropertyGroup).GetChildren()
+                                                                    .OfType<MSBuildProperty>()
+                                                                    .All(prop => prop.Name != "PreBuildEvent" &&
+                                                                                 prop.Name != "PostBuildEvent"));
+
+                    if (last != -1) {
 						ChildNodes = ChildNodes.Insert (last + 1, group);
 						added = true;
 					}


### PR DESCRIPTION
If project has:
  ```
<PropertyGroup>
    <PreBuildEvent>some command</PreBuildEvent>
  </PropertyGroup>
```
MonoDevelop adding new build config after it and this project can't build any more. 
My fix changes this situation, and adding new configuration in the right way.  