### PR TITLE
Fixes VSTS Bug 669421: CheckProjectIsInCurrentSolution Throws

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReference.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReference.cs
@@ -52,7 +52,11 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			foreach (var file in e) {
 				if (file.FileName == FilePath) {
-					UpdatedOnDisk?.Invoke (this, EventArgs.Empty);
+					try {
+						UpdatedOnDisk?.Invoke (this, EventArgs.Empty);
+					} catch (Exception ex) {
+						LoggingService.LogError ($"Error on MonoDevelopMetadataReference.OnUpdatedOnDisk with updating {FilePath}.", ex);
+					}
 					return;
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
@@ -29,6 +29,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using MonoDevelop.Core;
+using ICSharpCode.NRefactory.MonoCSharp;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
@@ -64,8 +65,9 @@ namespace MonoDevelop.Ide.TypeSystem
 				lock (workspace.updatingProjectDataLock) {
 					if (!RemoveMetadataReference_NoLock (reference, workspace))
 						return;
+					if (!workspace.CurrentSolution.ContainsProject (projectId))
+						return;
 					workspace.OnMetadataReferenceRemoved (projectId, reference.CurrentSnapshot);
-
 					reference.UpdateSnapshot ();
 					AddMetadataReference_NoLock (reference, workspace);
 					workspace.OnMetadataReferenceAdded (projectId, reference.CurrentSnapshot);


### PR DESCRIPTION
Exception

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/669421

It's unknown in which use case that happens but it shouldn't crash the
IDE. If a reference update doesn't reference to the current solution
some race is going on with project updates.
Skipping that event in that case is ok. 

In any case this patch catches exceptions in that update event so it no longer crashes the IDE.

As side effect that should also fix the IDE crash in:

Fixes Bug 669418: CheckProjectHasMetadataReference Exception