### PR TITLE
Fix 668301: [Feedback] Unable to change font colors for vb.net by Vis…

### DIFF
--- a/main/msbuild/ReferencesRoslyn.props
+++ b/main/msbuild/ReferencesRoslyn.props
@@ -49,6 +49,10 @@
       <HintPath>$(PackagesDirectory)\Microsoft.CodeAnalysis.VisualBasic.Features.$(NuGetVersionRoslyn)\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Features.dll</HintPath>
       <Private>$(ReferencesRoslynCopyToOutput)</Private>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures">
+      <HintPath>$(PackagesDirectory)\Microsoft.CodeAnalysis.EditorFeatures.$(NuGetVersionRoslyn)\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
+      <Private>$(ReferencesRoslynCopyToOutput)</Private>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
       <HintPath>$(PackagesDirectory)\Microsoft.CodeAnalysis.VisualBasic.Workspaces.$(NuGetVersionRoslyn)\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>$(ReferencesRoslynCopyToOutput)</Private>

--- a/main/src/addins/VBNetBinding/VBNetBinding.addin.xml
+++ b/main/src/addins/VBNetBinding/VBNetBinding.addin.xml
@@ -51,7 +51,7 @@
 	</Extension>
 	
 	<Extension path = "/MonoDevelop/Core/MimeTypes">
-		<MimeType id="text/x-vb" _description="Visual Basic source code" icon="md-vb-file" isText="true" roslynName="Visual Basic">
+		<MimeType id="text/x-basic" _description="Visual Basic source code" icon="md-vb-file" isText="true" roslynName="Visual Basic">
 			<File pattern="*.vb" />
 		</MimeType>
 	</Extension>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -421,6 +421,7 @@
 		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
 		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" />
 		<Assembly file="MonoDevelop.Ide.dll"/>
+		<Assembly file="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll"/>
 		<Assembly file="Microsoft.VisualStudio.Text.Implementation.dll"/>
 		<Assembly file="Microsoft.VisualStudio.Text.Logic.dll"/>
 		<Assembly file="Microsoft.VisualStudio.Text.UI.dll"/>


### PR DESCRIPTION
…ual Studio Community 2017 for Mac

@mkrueger I investigated why it's not working:
1) It was missing VB.EditorFeatures in MEF
2) ContentType mapping to VB in Roslyn didn't work because it has different mimeType then what MonoDevelop had.