### PR TITLE
Fix VSTS 641286: make snippet loading resilient

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateService.cs
@@ -302,7 +302,7 @@ namespace MonoDevelop.Ide.CodeTemplates
 			}
 		}*/
 		
-		static List<CodeTemplate> LoadTemplates (XmlReader reader)
+		static List<CodeTemplate> LoadTemplates (XmlReader reader, string filePathForDebugging = null)
 		{
 			List<CodeTemplate> result = new List<CodeTemplate> ();
 			
@@ -322,8 +322,8 @@ namespace MonoDevelop.Ide.CodeTemplates
 					}
 				}
 			} catch (Exception e) {
-				LoggingService.LogError ("CodeTemplateService: Exception while loading template.", e);
-				return null;
+				LoggingService.LogError ("CodeTemplateService: Exception while loading template: " + filePathForDebugging, e);
+				return result;
 			} finally {
 				reader.Close ();
 			}
@@ -342,8 +342,12 @@ namespace MonoDevelop.Ide.CodeTemplates
 			var builtinTemplates = LoadTemplates (XmlReader.Create (typeof (CodeTemplateService).Assembly.GetManifestResourceStream (ManifestResourceName)));
 			if (Directory.Exists (TemplatePath)) {
 				var result = new List<CodeTemplate> ();
-				foreach (string templateFile in Directory.GetFiles (TemplatePath, "*.xml")) {
-					result.AddRange (LoadTemplates (XmlReader.Create (templateFile)));
+				try {
+					foreach (string templateFile in Directory.GetFiles (TemplatePath, "*.xml")) {
+						result.AddRange (LoadTemplates (XmlReader.Create (templateFile), filePathForDebugging: templateFile));
+					}
+				} catch (Exception ex) {
+					LoggingService.LogError ("Exception when reading snippets from directory: " + TemplatePath, ex);
 				}
 				// merge user templates with built in templates
 				for (int i = 0; i < builtinTemplates.Count; i++) {


### PR DESCRIPTION
Previously if the user had a malformed snippet in the snippet directory we would end up not loading any snippets.

Now we tolerate a malformed snippet file, report which file is malformed and continue loading other snippets.

Also defend against other filesystem errors when reading snippets files.