### PR TITLE
[Ide] Fix solution being built when executing instead of startup items  …

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1354,6 +1354,9 @@ namespace MonoDevelop.Ide
 		internal static IBuildTarget[] GetBuildTargetsForExecution (IBuildTarget executionTarget, RunConfiguration runConfiguration)
 		{
 			if (executionTarget is Solution sol) {
+				if (runConfiguration == null) {
+					runConfiguration = sol.StartupConfiguration;
+				}
 				if (runConfiguration is SingleItemSolutionRunConfiguration src) {
 					return new [] { src.Item };
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1351,7 +1351,7 @@ namespace MonoDevelop.Ide
 			}
 		}
 
-		static IBuildTarget[] GetBuildTargetsForExecution (IBuildTarget executionTarget, RunConfiguration runConfiguration)
+		internal static IBuildTarget[] GetBuildTargetsForExecution (IBuildTarget executionTarget, RunConfiguration runConfiguration)
 		{
 			if (executionTarget is Solution sol) {
 				if (runConfiguration is SingleItemSolutionRunConfiguration src) {

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectOperationsTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectOperationsTests.cs
@@ -183,6 +183,40 @@ namespace MonoDevelop.Ide.Projects
 			}
 		}
 
+		[Test]
+		public void GetBuildTargetsForExecution_Solution_SingleStartupItem_NoRunConfigurationPassed ()
+		{
+			using (var project = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (project)) {
+				var runConfig = new SingleItemSolutionRunConfiguration (project, null);
+				sln.StartupConfiguration = runConfig;
+
+				var targets = ProjectOperations.GetBuildTargetsForExecution (sln, null);
+
+				Assert.AreEqual (project, sln.StartupItem);
+				Assert.AreEqual (project, targets.Single ());
+			}
+		}
+
+		[Test]
+		public void GetBuildTargetsForExecution_Solution_MultiStartupItems_NoRunConfigurationPassed ()
+		{
+			using (var executionDep = new ProjectWithExecutionDeps ("Dependency"))
+			using (var executing = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (executionDep, executing)) {
+				var runConfig = new MultiItemSolutionRunConfiguration ();
+				runConfig.Items.Add (new StartupItem (executing, null));
+				runConfig.Items.Add (new StartupItem (executionDep, null));
+				sln.StartupConfiguration = runConfig;
+
+				var targets = ProjectOperations.GetBuildTargetsForExecution (sln, null);
+
+				Assert.AreEqual (2, targets.Length);
+				Assert.AreEqual (executing, targets [0]);
+				Assert.AreEqual (executionDep, targets [1]);
+			}
+		}
+
 		[DebuggerDisplay ("Project {Name}")]
 		class ProjectWithExecutionDeps : Project
 		{

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectOperationsTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectOperationsTests.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
 using MonoDevelop.Projects;
@@ -126,6 +127,59 @@ namespace MonoDevelop.Ide.Projects
 				Assert.IsTrue (success);
 				Assert.IsFalse (executionDep.WasBuilt);
 				Assert.IsFalse (executing.WasBuilt);
+			}
+		}
+
+		[Test]
+		public void GetBuildTargetsForExecution_ProjectIsExecutionTarget ()
+		{
+			using (var project = new ProjectWithExecutionDeps ("Executing")) {
+				var targets = ProjectOperations.GetBuildTargetsForExecution (project, null);
+
+				Assert.AreEqual (project, targets.Single ());
+			}
+		}
+
+		[Test]
+		public void GetBuildTargetsForExecution_Solution_SingleItemRunConfiguration ()
+		{
+			using (var project = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (project)) {
+				var runConfig = new SingleItemSolutionRunConfiguration (project, null);
+				var targets = ProjectOperations.GetBuildTargetsForExecution (sln, runConfig);
+
+				Assert.AreEqual (project, targets.Single ());
+			}
+		}
+
+		[Test]
+		public void GetBuildTargetsForExecution_Solution_MultiItemRunConfiguration ()
+		{
+			using (var executionDep = new ProjectWithExecutionDeps ("Dependency"))
+			using (var executing = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (executionDep, executing)) {
+				var runConfig = new MultiItemSolutionRunConfiguration ();
+				runConfig.Items.Add (new StartupItem (executing, null));
+				runConfig.Items.Add (new StartupItem (executionDep, null));
+
+				var targets = ProjectOperations.GetBuildTargetsForExecution (sln, runConfig);
+
+				Assert.AreEqual (2, targets.Length);
+				Assert.AreEqual (executing, targets [0]);
+				Assert.AreEqual (executionDep, targets [1]);
+			}
+		}
+
+		[Test]
+		public void GetBuildTargetsForExecution_Solution_NoStartupItem_NoRunConfigurationPassed ()
+		{
+			using (var project = new ProjectWithExecutionDeps ("Executing"))
+			using (var sln = CreateSimpleSolutionWithItems (project)) {
+				sln.StartupConfiguration = null;
+				var targets = ProjectOperations.GetBuildTargetsForExecution (sln, null);
+
+				Assert.IsNull (sln.StartupItem);
+				Assert.AreEqual (sln, targets.Single ());
 			}
 		}
 


### PR DESCRIPTION
With a solution, containing multiple projects, that has a single
startup project configured, on running the solution the entire
solution would be built instead of just the startup project.

Fixes VSTS #676845 - Builds all projects instead of executable +
dependencies only