### PR TITLE
[DotNetCore] Support alternative project type guid used by Visual Studio

### DIFF
--- a/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
+++ b/main/src/addins/CSharpBinding/CSharpBinding.addin.xml
@@ -84,6 +84,7 @@
 
 	<Extension path = "/MonoDevelop/ProjectModel/MSBuildItemTypes">
 		<DotNetProjectType
+			id="MonoDevelop.CSharp.Project.CSharpProject"
 			language="C#"
 			extension="csproj"
 			guid="{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -334,6 +334,8 @@ namespace MonoDevelop.DotNetCore.Tests
 			// the restore to fail on Mono.
 			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solution.FileName}\"");
 			RunMSBuild ($"/t:Build \"{solution.FileName}\"");
+
+			CheckProjectTypeGuids (solution, GetProjectTypeGuid (template));
 		}
 
 		void RunMSBuild (string arguments)
@@ -341,6 +343,23 @@ namespace MonoDevelop.DotNetCore.Tests
 			var process = Process.Start ("msbuild", arguments);
 			Assert.IsTrue (process.WaitForExit (240000), "Timed out waiting for MSBuild.");
 			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed");
+		}
+
+		static void CheckProjectTypeGuids (Solution solution, string expectedProjectTypeGuid)
+		{
+			foreach (Project project in solution.GetAllProjects ()) {
+				Assert.AreEqual (expectedProjectTypeGuid, project.TypeGuid);
+			}
+		}
+
+		static string GetProjectTypeGuid (SolutionTemplate template)
+		{
+			string language = GetLanguage (template.Id);
+			if (language == "F#")
+				return "{f2a71f9b-5d33-465a-a702-920d77279786}";
+
+			// C#
+			return "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -407,5 +407,35 @@ namespace MonoDevelop.DotNetCore.Tests
 				Assert.IsTrue (p.HasFlavor<DotNetCoreProjectExtension> ());
 			}
 		}
+
+		[Test]
+		public async Task SolutionUsingCSharpProjectTypeGuid_SaveSolution_ProjectTypeGuidUnchanged ()
+		{
+			string solutionFileName = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-sdk-console.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllProjects ().Single ();
+			string solutionFileText = File.ReadAllText (solutionFileName);
+
+			await solution.SaveAsync (Util.GetMonitor ());
+
+			string newSolutionFileText = File.ReadAllText (solutionFileName);
+			Assert.AreEqual ("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", project.TypeGuid);
+			Assert.AreEqual (solutionFileText, newSolutionFileText);
+		}
+
+		[Test]
+		public async Task SolutionUsingAlternativeVisualStudioProjectTypeGuid_SaveSolution_ProjectTypeGuidUnchanged ()
+		{
+			string solutionFileName = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-alternative-guid.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllProjects ().Single ();
+			string solutionFileText = File.ReadAllText (solutionFileName);
+
+			await solution.SaveAsync (Util.GetMonitor ());
+
+			string newSolutionFileText = File.ReadAllText (solutionFileName);
+			Assert.AreEqual ("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}", project.TypeGuid);
+			Assert.AreEqual (solutionFileText, newSolutionFileText);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/AddinInfo.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/AddinInfo.cs
@@ -13,6 +13,7 @@ using Mono.Addins.Description;
 
 [assembly:AddinDependency ("Core", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("Ide", MonoDevelop.BuildInfo.Version)]
+[assembly:AddinDependency ("CSharpBinding", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("Debugger", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("Debugger.VsCodeDebugProtocol", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("PackageManagement", MonoDevelop.BuildInfo.Version)]

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -629,6 +629,7 @@
 			id="MonoDevelop.DotNetCore.CSharpProject"
 			insertbefore="MonoDevelop.CSharp.Project.CSharpProject"
 			language="C#"
+			alias="VisualStudioDotNetCoreCSharpProject"
 			isDefaultGuid="false"
 			guid="{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"
 			type="MonoDevelop.CSharp.Project.CSharpProject" />

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -629,6 +629,7 @@
 			id="MonoDevelop.DotNetCore.CSharpProject"
 			insertbefore="MonoDevelop.CSharp.Project.CSharpProject"
 			language="C#"
+			isDefaultGuid="false"
 			guid="{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"
 			type="MonoDevelop.CSharp.Project.CSharpProject" />
 	</Extension>

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -612,4 +612,24 @@
 				class="MonoDevelop.DotNetCore.Gui.DotNetCoreSdkLocationPanel" />
 		</Section>
 	</Extension>
+
+	<!--
+	Workaround Visual Studio 2017 problem where it sometimes changes the project type guid
+	for .NET Core projects. Setting the project's TypeGuid to match this alternative guid
+	prevents it from being changed when saving the solution file.
+
+	https://github.com/dotnet/project-system/issues/1821
+
+	Note that the extension is deliberately not set below to avoid new .NET Core projects
+	being created with this alternative guid instead of the correct C# project type guid
+	{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}.
+	-->
+	<Extension path = "/MonoDevelop/ProjectModel/MSBuildItemTypes">
+		<DotNetProjectType
+			id="MonoDevelop.DotNetCore.CSharpProject"
+			insertbefore="MonoDevelop.CSharp.Project.CSharpProject"
+			language="C#"
+			guid="{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"
+			type="MonoDevelop.CSharp.Project.CSharpProject" />
+	</Extension>
 </ExtensionModel>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/DotNetProjectTypeNode.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Extensions/DotNetProjectTypeNode.cs
@@ -44,7 +44,17 @@ namespace MonoDevelop.Projects.Extensions
 		public string Language {
 			get { return language; }
 		}
-		
+
+		[NodeAttribute]
+		bool isDefaultGuid = true;
+
+		/// <summary>
+		/// Indicates if the Guid specified is the default for the language.
+		/// </summary>
+		public bool IsDefaultGuid {
+			get { return isDefaultGuid; }
+		}
+
 		public DotNetProjectTypeNode ()
 		{
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -656,7 +656,7 @@ namespace MonoDevelop.Projects.MSBuild
 		internal static string GetLanguageGuid (string language)
 		{
 			foreach (var node in GetItemTypeNodes ().OfType<DotNetProjectTypeNode> ()) {
-				if (node.Language == language)
+				if (node.Language == language && node.IsDefaultGuid)
 					return node.Guid;
 			}
 			throw new InvalidOperationException ("Language not supported: " + language);

--- a/main/tests/test-projects/dotnetcore-console/dotnetcore-alternative-guid.sln
+++ b/main/tests/test-projects/dotnetcore-console/dotnetcore-alternative-guid.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.25806.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnetcore-sdk-console", "dotnetcore-console\dotnetcore-sdk-console.csproj", "{57E09661-7610-453D-8F3D-F4B68461DEFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetcore-sdk-console", "dotnetcore-console\dotnetcore-sdk-console.csproj", "{57E09661-7610-453D-8F3D-F4B68461DEFB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Visual Studio 2017 will sometimes change the project type guid used
in a solution file from the default C# project type guid to
9A19103F-16F7-4668-BE54-9A1E7A4F7556 due to a bug:

dotnet/project-system#1821

Visual Studio for Mac uses the C# project type guid which results in
the solution file being changed when it is saved. To avoid this a new
MSBuildItemType has been added for the alternative project type guid so
that the .NET Core project when loaded will have the correct project
type guid and when the solution file is saved the project type guid
will not be modified. Note that new C# .NET Core and .NET Standard
projects will continue to use the project type guid used by C#
projects AE04EC0-301F-11D3-BF4B-00C04F79EFBC which is also what Visual
Studio 2017 on Windows uses for new projects.

Fixes VSTS #677549 - Project GUID Changes When Building in VS2017 vs
Building in VS for Mac