### PR TITLE
[release-7.7] Add MonoDevelop.MonoDroid InternalsVisibleTo in MonoDevelop.Ide

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4291,6 +4291,7 @@
     <InternalsVisibleTo Include="Xamarin.AndroidDesigner.MonoDevelop" />
     <InternalsVisibleTo Include="Xamarin.iOSDesigner.MonoDevelop" />
     <InternalsVisibleTo Include="Xamarin.FormsPreviewer.MonoDevelop" />
+    <InternalsVisibleTo Include="MonoDevelop.MonoDroid" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=dbb8863f189610f3e1160f66496cae67c4189ec9
-DEP_BRANCH_AND_REMOTE[0]="release-7.7 origin/release-7.7"
+DEP_NEEDED_VERSION[0]=3bfaea1a3a2a6afd6b3b65ed4f71a05f2262720a
+DEP_BRANCH_AND_REMOTE[0]="release-7.7-openjdk origin/release-7.7-openjdk"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
This will be needed in order to use InfoBars by https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/646093

This is a release-7.7 backport of https://github.com/mono/monodevelop/pull/5671