### PR TITLE
Fix #5779: [VSfM] Wrong sections visually commented out with preprocessor directives

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -387,6 +387,7 @@ namespace MonoDevelop.Ide.TypeSystem
 					InternalInformDocumentOpen (linkedDoc, editor, context);
 				}
 			}
+			OnDocumentContextUpdated (documentId);
 		}
 
 		TextDocument InternalInformDocumentOpen (DocumentId documentId, TextEditor editor, DocumentContext context)


### PR DESCRIPTION
When opening document/switching between documents `InformDocumentOpen` is called which calls `InternalInformDocumentOpen` 1st on documentId with correct ProjectId(by correct I mean selected project, and then other projects) which results in Roslyn setting last project(so "not correct") as editing one... Which results in wrong highlighting... VS Window uses `OnDocumentContextUpdated` to update document when switching between projects, hence to keep changes to minimal and not rely on order of opening and hope that that will do right thing, we just call `OnDocumentContextUpdated` at end of opening sequence.