### PR TITLE
VSTS #669418 - CheckProjectHasMetadataReference Exception

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.Ide.TypeSystem
 {
 	public partial class MonoDevelopWorkspace
 	{
-		internal class ProjectData : IDisposable
+		internal class ProjectData
 		{
 			readonly WeakReference<MonoDevelopWorkspace> workspaceRef;
 			readonly ProjectId projectId;
@@ -88,7 +88,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				return metadataReferences.Remove (metadataReference);
 			}
 
-			public void Dispose ()
+			public void Disconnect ()
 			{
 				if (!workspaceRef.TryGetTarget (out var ws))
 					return;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
@@ -122,8 +122,10 @@ namespace MonoDevelop.Ide.TypeSystem
 			internal ProjectData RemoveData (ProjectId id)
 			{
 				lock (Workspace.updatingProjectDataLock) {
-					if (projectDataMap.TryGetValue (id, out ProjectData result))
+					if (projectDataMap.TryGetValue (id, out ProjectData result)) {
 						projectDataMap.Remove (id);
+						result.Disconnect ();
+					}
 					return result;
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -124,31 +124,31 @@ namespace MonoDevelop.Ide.TypeSystem
 
 				lock (workspace.updatingProjectDataLock) {
 					//when reloading e.g. after a save, preserve document IDs
-					using (var oldProjectData = projectMap.RemoveData (projectId)) {
-						var projectData = projectMap.CreateData (projectId, references);
+					var oldProjectData = projectMap.RemoveData (projectId);
+					var projectData = projectMap.CreateData (projectId, references);
 
-						var documents = CreateDocuments (projectData, p, token, sourceFiles, oldProjectData);
-						if (documents == null)
-							return null;
+					var documents = CreateDocuments (projectData, p, token, sourceFiles, oldProjectData);
+					if (documents == null)
+						return null;
 
-						// TODO: Pass in the WorkspaceMetadataFileReferenceResolver
-						var info = ProjectInfo.Create (
-							projectId,
-							VersionStamp.Create (),
-							p.Name,
-							fileName.FileNameWithoutExtension,
-							LanguageNames.CSharp,
-							p.FileName,
-							fileName,
-							cp?.CreateCompilationOptions (),
-							cp?.CreateParseOptions (config),
-							documents.Item1,
-							projectReferences,
-							references.Select (x => x.CurrentSnapshot),
-							additionalDocuments: documents.Item2
-						);
-						return info;
-					}
+					// TODO: Pass in the WorkspaceMetadataFileReferenceResolver
+					var info = ProjectInfo.Create (
+						projectId,
+						VersionStamp.Create (),
+						p.Name,
+						fileName.FileNameWithoutExtension,
+						LanguageNames.CSharp,
+						p.FileName,
+						fileName,
+						cp?.CreateCompilationOptions (),
+						cp?.CreateParseOptions (config),
+						documents.Item1,
+						projectReferences,
+						references.Select (x => x.CurrentSnapshot),
+						additionalDocuments: documents.Item2
+					);
+					return info;
+
 				}
 			}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataTests.cs
@@ -38,8 +38,9 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			var pid = ProjectId.CreateNewId ();
 
-			using (var workspace = new MonoDevelopWorkspace (null))
-			using (var data = new MonoDevelopWorkspace.ProjectData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty, workspace)) {
+			using (var workspace = new MonoDevelopWorkspace (null)) {
+				var data = new MonoDevelopWorkspace.ProjectData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty, workspace);
+				data.Disconnect ();
 				// Do nothing, we just want to see it construct and dispose properly.
 			}
 		}


### PR DESCRIPTION

[Ide] MetadataReferenceCache now removes the right snapshots

Previously, if the same metadata reference was reused between
multiple projects, we would fall in the problem of a snapshot
being updated on one metadata reference update, that means that
future metadata reference updates would try to remove the new one
from their store.

Send over the old and current snapshots to all event handler subscribers
to ensure we're removing and adding the right ones.