### PR TITLE
[Ide] Fix focus disappearing on tab key press in New Project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.GtkProjectFolderPreviewWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.GtkProjectFolderPreviewWidget.cs
@@ -55,6 +55,7 @@ namespace MonoDevelop.Ide.Projects
 			// Container child mainVBox.Gtk.Box+BoxChild
 			this.GtkScrolledWindow = new global::Gtk.ScrolledWindow ();
 			this.GtkScrolledWindow.Name = "GtkScrolledWindow";
+			this.GtkScrolledWindow.CanFocus = false;
 			this.GtkScrolledWindow.HscrollbarPolicy = ((global::Gtk.PolicyType)(2));
 			// Container child GtkScrolledWindow.Gtk.Container+ContainerChild
 			this.folderTreeView = new global::Gtk.TreeView ();


### PR DESCRIPTION
Tabbing on the final page of the New Project dialog would lose
the focus for one key press when tabbing from the text boxes and
check boxes on  the left hand side to the buttons at the bottom of
the page. The focus was being given to the scrolled window widget
in the folder preview. The scrolled window widget has been set to
no longer accept focus has so tabbing around the final page goes
from the text boxes/check boxes to the buttons on the bottom of the
page without losing visual indication where the focus is.

Fixes VSTS 646432 - Accessibility: Keyboard: Loss of focus is
observed in "Configure your new Audio Unit Extension" window