### PR TITLE
Fix VSTS 677075: JS triple "" inserted instead of two

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MimeTypes.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MimeTypes.addin.xml
@@ -97,9 +97,6 @@
 		<File pattern="*.targets" />
 	</MimeType>
 
-	<MimeType id="text/x-typescript" _description="typescript files" isText="true">
-		<File pattern="*.ts" />
-	</MimeType>
 </Extension>
 
 </ExtensionModel>


### PR DESCRIPTION
This was a MimeType inserted into MonoDevelop so that a unit-test passes without WebTools installed. However this has some pretty drastic consequences - a completely different mime type chain is created for .js and .ts files, bypassing the base x-vs content type. As a result, the WebTooling VSAutoInsertBracketHandler was not included in the chain, and counterintuitively, this resulted in 3 quotes being inserted, not 2.

This regressed with this commit:
https://github.com/mono/monodevelop/commit/39002a65cc594bf0b436f1d2c17f9770ea23984a
https://github.com/mono/monodevelop/pull/5734