### PR TITLE
[Ide] Improve roslyn logging infrastructure

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/RoslynFileLogger.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/RoslynFileLogger.cs
@@ -1,0 +1,59 @@
+//
+// RoslynFileLogger.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.Threading;
+using Microsoft.CodeAnalysis.Internal.Log;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide.RoslynServices
+{
+	class RoslynFileLogger : ILogger
+	{
+		readonly System.IO.TextWriter roslynLog;
+
+		public RoslynFileLogger ()
+		{
+			roslynLog = LoggingService.CreateLogFile ("roslyn");
+		}
+
+		public bool IsEnabled (FunctionId functionId) => true;
+
+		public void Log (FunctionId functionId, LogMessage logMessage)
+		{
+			roslynLog.WriteLine (string.Format ("[{0}] {1} - {2}", Thread.CurrentThread.ManagedThreadId, functionId.ToString (), logMessage.GetMessage ()));
+		}
+
+		public void LogBlockStart (FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
+		{
+			roslynLog.WriteLine (string.Format ("[{0}] Start({1}) : {2} - {3}", Thread.CurrentThread.ManagedThreadId, uniquePairId, functionId.ToString (), logMessage.GetMessage ()));
+		}
+
+		public void LogBlockEnd (FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
+		{
+			var functionString = functionId.ToString () + (cancellationToken.IsCancellationRequested ? " Canceled" : string.Empty);
+			roslynLog.WriteLine (string.Format ("[{0}] End({1}) : [{2}ms] {3}", Thread.CurrentThread.ManagedThreadId, uniquePairId, delta, functionString));
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/RoslynLogger.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/RoslynLogger.cs
@@ -1,24 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using MonoDevelop.Core;
 
-namespace MonoDevelop.Ide
+namespace MonoDevelop.Ide.RoslynServices
 {
 	class RoslynLogger : ILogger
 	{
-		static RoslynLogger ()
-		{
-			// Maybe we should crash here?
-			FatalError.Handler = exception => LoggingService.LogInternalError ("Roslyn fatal exception", exception);
-			FatalError.NonFatalHandler = exception => LoggingService.LogInternalError ("Roslyn non-fatal exception", exception);
-		}
-
 		public bool IsEnabled (FunctionId functionId)
 		{
 			// ? Maybe log more than these exceptions? http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Log/FunctionId.cs,8

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -3168,7 +3168,6 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\IMonoDevelopHostDocument.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopPersistentStorageLocationService.cs" />
     <Compile Include="MonoDevelop.Ide\ProjectOperations.SolutionItemBuildBatch.cs" />
-    <Compile Include="MonoDevelop.Ide\RoslynLogger.cs" />
     <Compile Include="MonoDevelop.Ide\Services.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.OptionPanels\TasksOptionsPanel.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\FileViewer.cs" />
@@ -4222,6 +4221,8 @@
     <Compile Include="MonoDevelop.Ide.Desktop\ThermalMonitor.cs" />
     <Compile Include="MonoDevelop.Ide\PlatformThermalStatusEventArgs.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopFrameworkAssemblyPathResolver.cs" />
+    <Compile Include="MonoDevelop.Ide.RoslynServices\RoslynLogger.cs" />
+    <Compile Include="MonoDevelop.Ide.RoslynServices\RoslynFileLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />


### PR DESCRIPTION
Move FatalError registration into RoslynService initialization.

Add a new RoslynFileLogger class that writes everything roslyn reports
into its own log file.

Keep the old one for database exceptions so we catch them in the ide log

Fixes VSTS #679463 - Log everything that roslyn reports to the log file