### PR TITLE
Report an error and avoid exception when snippet version is unsupported.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplateService.cs
@@ -312,8 +312,10 @@ namespace MonoDevelop.Ide.CodeTemplates
 						switch (reader.LocalName) {
 						case Node:
 							string fileVersion = reader.GetAttribute (VersionAttribute);
-							if (fileVersion != Version) 
-								return null;
+							if (fileVersion != Version) {
+								LoggingService.LogError ($"CodeTemplateService: unsupported fileVersion ({fileVersion}), supported is: {Version}");
+								return result;
+							}
 							break;
 						case CodeTemplate.Node:
 							result.Add (CodeTemplate.Read (reader));


### PR DESCRIPTION
I've noticed another case when reading a corrupted/unsupported snippet would throw and lose all other snippets.