### PR TITLE
[Ide][a11y] Fix Cancel button label in new project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -285,7 +285,7 @@ namespace MonoDevelop.Ide.Projects
 			cancelButton.Name = "cancelButton";
 			cancelButton.Accessible.Name = "cancelButton";
 			cancelButton.Accessible.Description = GettextCatalog.GetString ("Cancel the dialog");
-			cancelButton.Label = "gtk-cancel";
+			cancelButton.Label = GettextCatalog.GetString ("Cancel");
 			cancelButton.UseStock = true;
 			cancelButtonBox.PackStart (cancelButton, false, false, 0);
 			bottomHBox.PackStart (cancelButtonBox, false, false, 0);


### PR DESCRIPTION
New Project Dialog accessibility: Translate the cancel button label using `GettextCatalog` instead of using the built in Gtk translation.
> Fixes VSTS [#648956](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/648956)