### PR TITLE
Add missing main toolbar tooltips

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -97,11 +97,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				break;
 			case OperationIcon.Run:
 				title = GettextCatalog.GetString ("Run");
-				help = GettextCatalog.GetString ("Build and run the current solution");
+				help = GettextCatalog.GetString ("Run the project or projects in the active run configuration. Builds the projects in the active solution build configuration if necessary.");
 				break;
 			case OperationIcon.Build:
 				title = GettextCatalog.GetString ("Build");
-				help = GettextCatalog.GetString ("Build the current solution");
+				help = GettextCatalog.GetString ("Build the projects in the active solution build configuration.");
 				break;
 			}
 		}
@@ -139,7 +139,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			string help, title;
 			GetTitleAndHelpForIcon (out title, out help);
 
-			AccessibilityHelp = help;
+			ToolTip = AccessibilityHelp = help;
 			AccessibilityTitle = title;
 			AccessibilityEnabled = Enabled;
 			AccessibilitySubrole = NSAccessibilitySubroles.ToolbarButtonSubrole;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
@@ -144,6 +144,7 @@ namespace MonoDevelop.Components.MainToolbar
 			runConfigurationCombo.Model = runConfigurationStore;
 			runConfigurationCombo.PackStart (ctx, true);
 			runConfigurationCombo.AddAttribute (ctx, "text", 0);
+			runConfigurationCombo.TooltipText = GettextCatalog.GetString ("A project or named set of projects and execution options that should be launched when running or debugging the solution.");
 
 			var runConfigurationComboVBox = new VBox ();
 			runConfigurationComboVBox.PackStart (runConfigurationCombo, true, false, 0);
@@ -153,7 +154,8 @@ namespace MonoDevelop.Components.MainToolbar
 			configurationCombo.Model = configurationStore;
 			configurationCombo.PackStart (ctx, true);
 			configurationCombo.AddAttribute (ctx, "text", 0);
-		
+			configurationCombo.TooltipText = GettextCatalog.GetString ("A named set of projects and their configurations to be built when building the solution.");
+
 			var configurationComboVBox = new VBox ();
 			configurationComboVBox.PackStart (configurationCombo, true, false, 0);
 			configurationCombosBox.PackStart (configurationComboVBox, false, false, 0);
@@ -169,6 +171,7 @@ namespace MonoDevelop.Components.MainToolbar
 			runtimeCombo.PackStart (ctx, true);
 			runtimeCombo.SetCellDataFunc (ctx, RuntimeRenderCell);
 			runtimeCombo.RowSeparatorFunc = RuntimeIsSeparator;
+			runtimeCombo.TooltipText = GettextCatalog.GetString ("The device on which to deploy and launch the projects when running or debugging.");
 
 			var runtimeComboVBox = new VBox ();
 			runtimeComboVBox.PackStart (runtimeCombo, true, false, 0);
@@ -404,7 +407,23 @@ namespace MonoDevelop.Components.MainToolbar
 		}
 
 		public OperationIcon RunButtonIcon {
-			set { button.Icon = value; }
+			set {
+				button.Icon = value;
+				switch (value) {
+				case OperationIcon.Stop:
+					button.TooltipText = GettextCatalog.GetString ("Stop the executing solution");
+					break;
+				case OperationIcon.Run:
+					button.TooltipText = GettextCatalog.GetString ("Run the project or projects in the active run configuration. Builds the projects in the active solution build configuration if necessary.");
+					break;
+				case OperationIcon.Build:
+					button.TooltipText = GettextCatalog.GetString ("Build the projects in the active solution build configuration.");
+					break;
+				default:
+					button.TooltipText = string.Empty;
+					break;
+				}
+			}
 		}
 
 		public bool ConfigurationPlatformSensitivity {


### PR DESCRIPTION
As proposed in #4805 , this PR adds tooltips to the "Run" button and "Configuration" selectors (for Mac and Gtk) in the main toolbar. Additionally, the tooltip text is used for `AccessibilityHelp` on Mac.

Fixes issue #4805