### PR TITLE
Fix VSTS 669803: using vstool with Razor

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -313,7 +313,7 @@ namespace MonoDevelop.Core
 			}
 			set {
 				if (mainSynchronizationContext != null && value != null)
-					throw new InvalidOperationException ("The main synchronization context has already been set");
+					LoggingService.LogWarning ($"The main synchronization context is being changed from {mainSynchronizationContext} to {value}");
 
 				mainThread = Thread.CurrentThread;
 				mainSynchronizationContext = value;

--- a/main/src/tools/mdtool/src/mdtool.cs
+++ b/main/src/tools/mdtool/src/mdtool.cs
@@ -48,6 +48,7 @@ class MonoDevelopProcessHost
 		try {
 			var sc = new ConsoleSynchronizationContext ();
 			SynchronizationContext.SetSynchronizationContext (sc);
+			Runtime.MainSynchronizationContext = SynchronizationContext.Current;
 
 			string exeName = Path.GetFileNameWithoutExtension (Assembly.GetEntryAssembly ().Location);
 			if (!Platform.IsMac && !Platform.IsWindows)


### PR DESCRIPTION
vstool/mdtool was not setting the Runtime.MainSynchronizationContext, which in turn didn't set the MainTaskScheduler. Razor addin relies on the MainTaskScheduler being set. Repro: vstool build Foo.sln failed with ArgumentNullException.