### PR TITLE
Fix VSTS 673077: JS: incorrect line break/smart indent on ENTER

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
@@ -39,7 +39,11 @@ namespace MonoDevelop.SourceEditor
 		const string closingBrackets = "}])'\"";
 
 		static readonly string[] excludedMimeTypes = {
-			"text/fsharp", "text/x-csharp", "text/x-json"
+			"text/fsharp",
+			"text/x-csharp",
+			"text/x-json",
+			"text/x-javascript",
+			"text/x-typescript",
 		};
 
 		public override bool Handle (TextEditor editor, DocumentContext ctx, KeyDescriptor descriptor)


### PR DESCRIPTION
DefaultAutoInsertBracketHandler was conflicting with BraceCompletion for JS/TS.
Turn it off for JS and TS mime types to let BraceCompletion do its job.