### PR TITLE
Fix VSTS 673077: JS: incorrect line break/smart indent on ENTER

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/DefaultAutoInsertBracketHandler.cs
@@ -37,8 +37,15 @@ namespace MonoDevelop.SourceEditor
 		const string openBrackets = "{[('\"";
 		const string closingBrackets = "}])'\"";
 
+		static readonly string[] excludedMimeTypes = {
+			"text/x-javascript",
+			"text/x-typescript",
+		};
+
 		public override bool Handle (TextEditor editor, DocumentContext ctx, KeyDescriptor descriptor)
 		{
+			if (Array.IndexOf (excludedMimeTypes, editor.MimeType) >= 0)
+				return false;
 			if (descriptor.KeyChar == '\'' && editor.MimeType == "text/fsharp")
 				return false;
 			int braceIndex = openBrackets.IndexOf (descriptor.KeyChar);


### PR DESCRIPTION
DefaultAutoInsertBracketHandler was conflicting with BraceCompletion for JS/TS.
Turn it off for JS and TS mime types to let BraceCompletion do its job.

Porting https://github.com/mono/monodevelop/pull/5911 to release-7.6.