### PR TITLE
[release-7.7] [C#] Move Rename command into top level contextual menu

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Refactoring/RefactoryCommands.cs
@@ -69,18 +69,11 @@ namespace MonoDevelop.CSharp.Refactoring
 
 			var ext = doc.GetContent<CodeActionEditorExtension> ();
 
-			var ciset = new CommandInfoSet ();
-			ciset.Text = GettextCatalog.GetString ("Refactor");
-
 			bool canRename = RenameHandler.CanRename (info.Symbol ?? info.DeclaredSymbol);
 			if (canRename) {
-				ciset.CommandInfos.Add (IdeApp.CommandService.GetCommandInfo (MonoDevelop.Ide.Commands.EditCommands.Rename), new Action (async delegate {
+				ainfo.Add (IdeApp.CommandService.GetCommandInfo (MonoDevelop.Ide.Commands.EditCommands.Rename), new Action (async delegate {
 					await new MonoDevelop.Refactoring.Rename.RenameRefactoring ().Rename (info.Symbol ?? info.DeclaredSymbol);
 				}));
-			}
-
-			if (ciset.CommandInfos.Count > 0) {
-				ainfo.Add (ciset, null);
 			}
 
 			var gotoDeclarationSymbol = info.Symbol;


### PR DESCRIPTION
Backport of #5918.

/cc @Therzok

Fixes VSTS #677558 - Refactoring Contextual Menu Changes