### PR TITLE
[VCS] Improve counter infrastructure and logic behind it

### DIFF
--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -92,7 +92,10 @@ generate_fallback_path (const char *contentsDir)
 	if (value == NULL)
 		abort ();
 
-	/* Add Mono's lib dirs and Xcode's dev lib dir into the DYLD_FALLBACK_LIBRARY_PATH */
+	/* Add Xcode's CommandLineTools dev lib dir before Xcode's Developer dir */
+	value = str_append (value, "/Library/Developer/CommandLineTools/usr/lib:");
+
+	/* Add Xcode's dev lib dir into the DYLD_FALLBACK_LIBRARY_PATH */
 	if ((xcode_dev_path = xcode_get_dev_path ()) != NULL) {
 		xcode_dev_lib_path = str_append (xcode_dev_path, "/usr/lib:");
 		tmp = value;
@@ -102,6 +105,7 @@ generate_fallback_path (const char *contentsDir)
 		free (xcode_dev_lib_path);
 	}
 
+	/* Add Mono's lib lib dir */
 	result = str_append (value, "/Library/Frameworks/Mono.framework/Libraries:/lib:/usr/lib:/usr/local/lib");
 
 	free (lib_dir);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -73,9 +73,6 @@ namespace MonoDevelop.VersionControl.Git
 			Disposed = true;
 			base.Dispose ();
 
-			if (VersionControlSystem != null)
-				((GitVersionControl)VersionControlSystem).UnregisterRepo (this);
-
 			if (RootRepository != null)
 				RootRepository.Dispose ();
 			foreach (var rep in cachedSubmodules)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitVersionControl.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitVersionControl.cs
@@ -32,8 +32,6 @@ namespace MonoDevelop.VersionControl.Git
 {
 	abstract class GitVersionControl : VersionControlSystem
 	{
-		readonly Dictionary<FilePath,GitRepository> repositories = new Dictionary<FilePath,GitRepository> ();
-
 		public override string Name {
 			get { return "Git"; }
 		}
@@ -46,12 +44,7 @@ namespace MonoDevelop.VersionControl.Git
 
 		public override Repository GetRepositoryReference (FilePath path, string id)
 		{
-			GitRepository repo;
-			if (!repositories.TryGetValue (path.CanonicalPath, out repo) || repo.Disposed) {
-				repo = new GitRepository (this, path, null);
-				repositories [repo.RootPath.CanonicalPath] = repo;
-			}
-			return repo;
+			return new GitRepository (this, path, null);
 		}
 
 		protected override Repository OnCreateRepositoryInstance ()
@@ -73,12 +66,6 @@ namespace MonoDevelop.VersionControl.Git
 					repo = Path.GetDirectoryName (repo);
 			}
 			return repo;
-		}
-
-		internal void UnregisterRepo (GitRepository repo)
-		{
-			if (!repo.RootPath.IsNullOrEmpty)
-				repositories.Remove (repo.RootPath.CanonicalPath);
 		}
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -44,9 +44,9 @@ namespace MonoDevelop.VersionControl
 			VersionControlSystem = vcs;
 			var metadata = new RepositoryMetadata {
 				Type = vcs.Name,
-				TypeAndVersion = $"{vcs.Name} {vcs.Version}"
+				Version = vcs.Version,
 			};
-			Repositories.SetValue (Repositories.Count + 1, string.Format ("Repository #{0}", Repositories.Count + 1), metadata);
+			Repositories.Inc (metadata);
 		}
 
 		public override bool Equals (object obj)
@@ -1013,7 +1013,7 @@ namespace MonoDevelop.VersionControl
 			set => SetProperty (value);
 		}
 
-		public string TypeAndVersion {
+		public string Version {
 			get => GetProperty<string> ();
 			set => SetProperty (value);
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -16,8 +16,6 @@ namespace MonoDevelop.VersionControl
 	[DataItem (FallbackType=typeof(UnknownRepository))]
 	public abstract class Repository: IDisposable
 	{
-		static Counter<RepositoryMetadata> Repositories = InstrumentationService.CreateCounter<RepositoryMetadata> ("VersionControl.RepositoryOpened", "Version Control", id:"VersionControl.RepositoryOpened");
-
 		string name;
 		VersionControlSystem vcs;
 		
@@ -42,11 +40,6 @@ namespace MonoDevelop.VersionControl
 		protected Repository (VersionControlSystem vcs): this ()
 		{
 			VersionControlSystem = vcs;
-			var metadata = new RepositoryMetadata {
-				Type = vcs.Name,
-				Version = vcs.Version,
-			};
-			Repositories.Inc (metadata);
 		}
 
 		public override bool Equals (object obj)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -994,21 +994,4 @@ namespace MonoDevelop.VersionControl
 		IgnoreCache = 1,
 		IncludeRemoteStatus = 2
 	}
-
-	public class RepositoryMetadata : CounterMetadata
-	{
-		public RepositoryMetadata ()
-		{
-		}
-
-		public string Type {
-			get => GetProperty<string> ();
-			set => SetProperty (value);
-		}
-
-		public string Version {
-			get => GetProperty<string> ();
-			set => SetProperty (value);
-		}
-	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -16,6 +16,7 @@ using MonoDevelop.Core.Serialization;
 using Mono.Addins;
 using MonoDevelop.Ide;
 using MonoDevelop.Core.ProgressMonitoring;
+using MonoDevelop.Core.Instrumentation;
 
 namespace MonoDevelop.VersionControl
 {
@@ -225,6 +226,7 @@ namespace MonoDevelop.VersionControl
 			return repo;
 		}
 
+		internal static readonly Dictionary<FilePath,Repository> repositoryCache = new Dictionary<FilePath,Repository> ();
 		public static Repository GetRepositoryReference (string path, string id)
 		{
 			VersionControlSystem detectedVCS = null;
@@ -245,8 +247,16 @@ namespace MonoDevelop.VersionControl
 					}
 				}
 			}
+
+			bestMatch = bestMatch.CanonicalPath;
+			if (repositoryCache.TryGetValue (bestMatch, out var repository))
+				return repository;
+
 			try {
-				return detectedVCS?.GetRepositoryReference (bestMatch, id);
+				var repo = detectedVCS?.GetRepositoryReference (bestMatch, id);
+				if (repo != null)
+					repositoryCache.Add (bestMatch, repo);
+				return repo;
 			} catch (Exception e) {
 				LoggingService.LogError ($"Could not query {detectedVCS.Name} repository reference", e);
 				return null;
@@ -813,6 +823,7 @@ namespace MonoDevelop.VersionControl
 		public void Dispose ()
 		{
 			VersionControlService.referenceCache.Remove (repo);
+			VersionControlService.repositoryCache.Remove (repo.RootPath.CanonicalPath);
 			repo.Unref ();
 		}
 	}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -856,5 +856,8 @@ namespace MonoDevelop.VersionControl
 			get => GetProperty<string> ();
 			set => SetProperty (value);
 		}
+
+		[Obsolete ("Use Version and Type properties")]
+		public string TypeAndVersion { get; set; }
 	}
 }


### PR DESCRIPTION
This PR aims to add a few things:
* Counter support for VCS
* Unification of the code that handles repository creation, caching instances at the version control service layer (making number of Svn repositories created match the number of Git repositories in equivalent scenarios)
* Proper reporting of the Repositories counter.
* Removing the hard dependency of Xcode for svn support, allowing a fallback to CommandLineTools version