### PR TITLE
[DotNetCore] Allow opening existing VB.Net Projects

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/FilePathExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/FilePathExtensions.cs
@@ -32,7 +32,7 @@ namespace MonoDevelop.DotNetCore
 	{
 		public static bool HasSupportedDotNetCoreProjectFileExtension (this FilePath file)
 		{
-			return file.HasExtension (".csproj") || file.HasExtension (".fsproj");
+			return file.HasExtension (".csproj") || file.HasExtension (".fsproj") || file.HasExtension (".vbproj");
 		}
 
 		/// <summary>


### PR DESCRIPTION
After this change, any existing VB.Net .Net Core Project can be loaded, it can be fully edited, built (with a user custom “dotnet build” build action) and run.