### PR TITLE
Primitive IWaitIndicator implementation

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/RoslynWaitIndicator.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/RoslynWaitIndicator.cs
@@ -1,10 +1,13 @@
 using System;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using MonoDevelop.Ide.ProgressMonitoring;
 using MonoDevelop.Ide.TypeSystem;
 
 namespace MonoDevelop.Ide.Composition
@@ -12,77 +15,75 @@ namespace MonoDevelop.Ide.Composition
 	[Export (typeof (IWaitIndicator))]
 	internal class RoslynWaitIndicator : IWaitIndicator
 	{
-		public WaitIndicatorResult Wait (string title, string message, bool allowCancel, Action<IWaitContext> action)
-		{
-			using (var waitContext = StartWait (title, message, allowCancel)) {
-				action (waitContext);
-			}
-
-			return WaitIndicatorResult.Completed;
-		}
+		static readonly Func<string, string, string> s_messageGetter = (t, m) => string.Format ("{0} : {1}", t, m);
 
 		public WaitIndicatorResult Wait (string title, string message, bool allowCancel, bool showProgress, Action<IWaitContext> action)
 		{
+			using (Logger.LogBlock (FunctionId.Misc_VisualStudioWaitIndicator_Wait, s_messageGetter, title, message, CancellationToken.None))
 			using (var waitContext = StartWait (title, message, allowCancel, showProgress)) {
-				action (waitContext);
+				try {
+					action (waitContext);
+
+					return WaitIndicatorResult.Completed;
+				} catch (OperationCanceledException) {
+					return WaitIndicatorResult.Canceled;
+				} catch (AggregateException aggregate) when (aggregate.InnerExceptions.All (e => e is OperationCanceledException)) {
+					return WaitIndicatorResult.Canceled;
+				}
 			}
-
-			return WaitIndicatorResult.Completed;
-		}
-
-		public IWaitContext StartWait (string title, string message, bool allowCancel)
-		{
-			//FIXME: get IGlobalOperationNotificationService working
-			//var service = MonoDevelopWorkspace.HostServices.GetService<IGlobalOperationNotificationService> ();
-			return new WaitContext (null, title, message, allowCancel);
 		}
 
 		public IWaitContext StartWait (string title, string message, bool allowCancel, bool showProgress)
 		{
-			//var service = MonoDevelopWorkspace.HostServices.GetService<IGlobalOperationNotificationService> ();
-			return new WaitContext (null, title, message, allowCancel);
+			var service = TypeSystemService.emptyWorkspace.Services.GetService<IGlobalOperationNotificationService> ();
+			return new WaitContext (service, title, message, allowCancel, showProgress);
 		}
 
 		private sealed class WaitContext : IWaitContext
 		{
-			//private readonly GlobalOperationRegistration registration;
+			private readonly GlobalOperationRegistration registration;
+			readonly MessageDialogProgressMonitor monitor;
 
-			public WaitContext (IGlobalOperationNotificationService service, string title, string message, bool allowCancel)
+			public WaitContext (IGlobalOperationNotificationService service, string title, string message, bool allowCancel, bool showProgress)
 			{
-				//this.registration = service.Start (title);
+				this.registration = service.Start (title);
+
+				ProgressTracker = showProgress
+					? new ProgressTracker ((description, completedItems, totalItems) => UpdateProgress (description, completedItems, totalItems))
+					: new ProgressTracker ();
+
+				monitor = new MessageDialogProgressMonitor (showProgress, allowCancel, showDetails: false, hideWhenDone: true);
+				// TODO: only show if blocking for 2 seconds...
 			}
 
 			public CancellationToken CancellationToken {
-				get { return CancellationToken.None; }
-			}
-
-			public void UpdateProgress ()
-			{
+				get { return monitor.AllowCancel ? monitor.CancellationToken : CancellationToken.None; }
 			}
 
 			public bool AllowCancel {
-				get {
-					return false;
-				}
-
-				set {
-				}
+				get => monitor.AllowCancel;
+				set => monitor.AllowCancel = value;
 			}
 
 			public string Message {
-				get {
-					return "";
-				}
-
-				set {
-				}
+				get => monitor.Message;
+				set => monitor.Message = value;
 			}
 
-			public IProgressTracker ProgressTracker { get; } = new ProgressTracker ();
+			public IProgressTracker ProgressTracker { get; }
+
+			void UpdateProgress (string description, int completedItems, int totalItems)
+			{
+				monitor.Message = description;
+				// TODO: update progress here, step interface makes it hard
+			}
 
 			public void Dispose ()
 			{
-				//this.registration.Dispose ();
+				if (!monitor.AllowCancel || CancellationToken.IsCancellationRequested)
+					registration.Done ();
+
+				this.registration.Dispose ();
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ProgressDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ProgressDialog.cs
@@ -75,6 +75,11 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			buffer.TagTable.Add (tag);
 			tags.Add (tag);
 		}
+
+		internal bool AllowCancel {
+			get => btnCancel.Visible;
+			set => btnCancel.Visible = value;
+		}
 		
 		public CancellationTokenSource CancellationTokenSource {
 			get { return cancellationTokenSource; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
@@ -71,6 +71,16 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 			}
 		}
 
+		internal bool AllowCancel {
+			get => dialog.AllowCancel;
+			set => dialog.AllowCancel = value;
+		}
+
+		internal string Message {
+			get => dialog.Message;
+			set => dialog.Message = value;
+		}
+
 		protected override void OnWriteLog (string text)
 		{
 			if (dialog != null) {


### PR DESCRIPTION
This is a left-over from when I thought fix all required this. This is not needed until we go full stack code actions implemented in roslyn (which is out of scope for initial fix all dialog support)