### PR TITLE
[release-7.7] Fixes issue #6029 Cut and paste is broken in the editor

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextPasteHandler.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpTextPasteHandler.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.CSharp.Formatting
 				return text;
 			var sourceText = indent.Editor;
 			var syntaxRoot = indent.DocumentContext.AnalysisDocument.GetSyntaxRootAsync ().WaitAndGetResult ();
-			var token = syntaxRoot.FindToken (offset);
+			var token = syntaxRoot.FindTokenOnLeftOfPosition (offset);
 
 			if (copyData != null && copyData.Length == 1) {
 				var strategy = TextPasteUtils.Strategies [(PasteStrategy)copyData [0]];

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/Features/IndentationTests/TextPasteIndentEngineTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/Features/IndentationTests/TextPasteIndentEngineTests.cs
@@ -214,6 +214,26 @@ var foo = @""hello$"";
 		}
 
 
+		/// <summary>
+		/// Cut and paste is broken in the editor #6029
+		/// </summary>
+		[Test]
+		public async Task TestIssue6029 ()
+		{
+			var opt = FormattingOptionsFactory.CreateMono ();
+			using (var testCase = await CreateEngine (@"
+	string[] test = new [] {
+$		""foo"",
+		""foo"",
+	};
+")) {
+				var handler = CreateTextPasteIndentEngine (testCase, opt);
+				var text = handler.FormatPlainText (testCase.Content.CursorPosition, "\t\t\"foo\"", null);
+				Assert.AreEqual ("\t\t\"foo\"", text);
+			}
+		}
+
+
 		protected override IEnumerable<TextEditorExtension> GetEditorExtensions ()
 		{
 			yield return new CSharpTextEditorIndentation ();


### PR DESCRIPTION
Backport of #6030.

/cc @mkrueger