### PR TITLE
[Telemetry] Add timing information for the start up sequence

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -243,6 +243,13 @@ namespace MonoDevelop.Core.Instrumentation
 			this.properties = new Dictionary<string, object> (original.properties);
 		}
 
+		public void AddProperties (CounterMetadata original)
+		{
+			foreach (var kvp in original.Properties) {
+				properties [kvp.Key] = kvp.Value;
+			}
+		}
+
 		public CounterResult Result {
 			get {
 				var rs = GetProperty<string> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -804,6 +804,7 @@ namespace MonoDevelop.Ide.Gui
 			BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
 			
 			PropertyService.Set ("SharpDevelop.Workbench.WorkbenchMemento", this.Memento);
+
 			IdeApp.OnExited ();
 			OnClosed (null);
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -33,6 +33,7 @@ using MonoDevelop.Ide.Tasks;
 using MonoDevelop.Projects;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide.Editor.Extension;
+using System.Collections.Generic;
 
 namespace MonoDevelop.Ide
 {
@@ -118,6 +119,10 @@ namespace MonoDevelop.Ide
 
 	class StartupMetadata: AssetMetadata
 	{	
+		public StartupMetadata ()
+		{
+		}
+
 		public long CorrectedStartupTime {
 			get => GetProperty<long> ();
 			set => SetProperty (value);
@@ -140,6 +145,10 @@ namespace MonoDevelop.Ide
 		}
 		public long TimeSinceLogin {
 			get => GetProperty<long> ();
+			set => SetProperty (value);
+		}
+		public Dictionary<string, long> Timings {
+			get => GetProperty<Dictionary<string, long>> ();
 			set => SetProperty (value);
 		}
 	}


### PR DESCRIPTION
Adds timing information to the start up metadata, and copies the start up metadata into the time to code metadata as well, if necessary

Fixes VSTS #652027