### PR TITLE
[Core] Fix wrong write lock being used in Project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2578,11 +2578,9 @@ namespace MonoDevelop.Projects
 			NeedsReload = false;
 		}
 
-		AsyncCriticalSection writeProjectLock = new AsyncCriticalSection ();
-
 		internal async Task<string> WriteProjectAsync (ProgressMonitor monitor)
 		{
-			using (await writeProjectLock.EnterAsync ().ConfigureAwait (false)) {
+			using (await WriteLock ().ConfigureAwait (false)) {
 				return await Task.Run (() => {
 					WriteProject (monitor);
 					return sourceProject.SaveToString ();
@@ -4170,7 +4168,7 @@ namespace MonoDevelop.Projects
 		Task ReevaluateProject (ProgressMonitor monitor, bool resetCachedCompileItems)
 		{
 			return BindTask (ct => Runtime.RunInMainThread (async () => {
-				using (await writeProjectLock.EnterAsync ()) {
+				using (await WriteLock ()) {
 
 					if (modifiedInMemory) {
 						await Task.Run (() => WriteProject (monitor));

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -752,7 +752,7 @@ namespace MonoDevelop.Projects
 			SetFastBuildCheckDirty ();
 			modifiedInMemory = false;
 
-			string content = await WriteProjectAsync (monitor);
+			string content = await WriteProjectAsync_NoLock (monitor);
 
 			// Doesn't save the file to disk if the content did not change
 			if (await sourceProject.SaveAsync (FileName, content)) {
@@ -2581,11 +2581,16 @@ namespace MonoDevelop.Projects
 		internal async Task<string> WriteProjectAsync (ProgressMonitor monitor)
 		{
 			using (await WriteLock ().ConfigureAwait (false)) {
-				return await Task.Run (() => {
-					WriteProject (monitor);
-					return sourceProject.SaveToString ();
-				}).ConfigureAwait (false);
+				return await WriteProjectAsync_NoLock (monitor).ConfigureAwait (false);
 			}
+		}
+
+		Task<string> WriteProjectAsync_NoLock (ProgressMonitor monitor)
+		{
+			return Task.Run (() => {
+				WriteProject (monitor);
+				return sourceProject.SaveToString ();
+			});
 		}
 
 		ITimeTracker writeTimer;


### PR DESCRIPTION
Two different locks would cause races to happen on saving a project file

Fixes VSTS #660905 - Setting the linker to "Link SDK" and saving the
changes in WatchKitAppExtension fails with error "Index was outside the
bounds of the array"
Fixes VSTS #687075 - “System.IndexOutOfRangeException”
exception on changing  proprties in iOS Build Project Options