### PR TITLE
[Output Pad] Fix nothing being written and monitors not being reused

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -937,6 +937,8 @@ namespace MonoDevelop.Ide.Gui.Components
 			foreach (ProgressError msg in Errors)
 				outputPad.WriteError (this, msg.DisplayMessage + "\n");
 
+			base.OnCompleted ();
+
 			outputPad = null;
 
 			Completed?.Invoke (this, EventArgs.Empty);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -866,12 +866,13 @@ namespace MonoDevelop.Ide.Gui.Components
 		internal LogViewProgressMonitor (LogView pad, bool clearConsole): base (Runtime.MainSynchronizationContext)
 		{
 			outputPad = pad;
-			padCookie = pad.Cookie;
 
 			Indent = new IndentTracker ();
 
 			if (clearConsole)
 				outputPad.Clear ();
+
+			padCookie = pad.Cookie;
 			internalLogger.TextWritten += WriteConsoleLogText;
 			console = new LogViewProgressConsole (this);
 		}


### PR DESCRIPTION
The cookie was set before clear was called, making it not write anything.