### PR TITLE
Revert "[Core] Remove superfluous Task.Run"

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -2583,8 +2583,10 @@ namespace MonoDevelop.Projects
 		internal async Task<string> WriteProjectAsync (ProgressMonitor monitor)
 		{
 			using (await writeProjectLock.EnterAsync ().ConfigureAwait (false)) {
-				WriteProject (monitor);
-				return sourceProject.SaveToString ();
+				return await Task.Run (() => {
+					WriteProject (monitor);
+					return sourceProject.SaveToString ();
+				}).ConfigureAwait (false);
 			}
 		}
 


### PR DESCRIPTION
Reverts mono/monodevelop#6040

Ide tests hang, not sure why this makes an exception not leak anymore.