### PR TITLE
[Ide] Report virtual memory statistics on OS pressure event

### DIFF
--- a/main/src/addins/MacPlatform/Interop.cs
+++ b/main/src/addins/MacPlatform/Interop.cs
@@ -1,0 +1,92 @@
+//
+// Interop.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Runtime.InteropServices;
+
+namespace MacPlatform
+{
+	static class Interop
+	{
+		[DllImport ("libc")]
+		extern static int sysctlbyname (string name, IntPtr oldP, ref nint oldLen, IntPtr newP, nint newlen);
+
+		internal static int SysCtl (string name, out string result)
+		{
+			nint resultLen = 128;
+			var resultHandle = Marshal.AllocHGlobal ((int)resultLen);
+			var retval = sysctlbyname (name, resultHandle, ref resultLen, IntPtr.Zero, 0);
+
+			// resultLen includes the null terminal, so we want to cut it off
+			// but if resultLen < 2 then there's no characters
+			if (retval != 0 || resultLen < 2) {
+				result = "Unknown";
+				return retval;
+			}
+
+			result = Marshal.PtrToStringAuto (resultHandle, (int)resultLen - 1);
+
+			Marshal.FreeHGlobal (resultHandle);
+
+			return retval;
+		}
+
+		internal static int SysCtl (string name, out int result)
+		{
+			nint resultLen = 128;
+			var resultHandle = Marshal.AllocHGlobal ((int)resultLen);
+			var retval = sysctlbyname (name, resultHandle, ref resultLen, IntPtr.Zero, 0);
+
+			if (retval != 0) {
+				result = -1;
+				return retval;
+			}
+
+			result = Marshal.ReadInt32 (resultHandle);
+
+			Marshal.FreeHGlobal (resultHandle);
+
+			return retval;
+		}
+
+		internal static int SysCtl (string name, out long result)
+		{
+			nint resultLen = 128;
+			var resultHandle = Marshal.AllocHGlobal ((int)resultLen);
+			var retval = sysctlbyname (name, resultHandle, ref resultLen, IntPtr.Zero, 0);
+
+			if (retval != 0) {
+				result = -1;
+				return retval;
+			}
+
+			result = Marshal.ReadInt64 (resultHandle);
+
+			Marshal.FreeHGlobal (resultHandle);
+
+			return retval;
+		}
+	}
+}

--- a/main/src/addins/MacPlatform/KernelInterop.cs
+++ b/main/src/addins/MacPlatform/KernelInterop.cs
@@ -1,0 +1,95 @@
+//
+// KernelInterop.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Runtime.InteropServices;
+
+namespace MacPlatform
+{
+	static class KernelInterop
+	{
+		const int TASK_VM_INFO = 22;
+		const int KERN_SUCCESS = 0;
+
+		struct task_vm_info
+		{
+			public ulong virtual_size; /* virtual memory size (bytes) */
+			public int region_count; /* number of memory regions */
+			public int page_size;
+			public ulong resident_size; /* resident memory size (bytes) */
+			public ulong resident_size_peak; /* peak resident size (bytes) */
+
+			public ulong	device;
+			public ulong	device_peak;
+			public ulong	@internal;
+			public ulong	internal_peak;
+			public ulong	external;
+			public ulong	external_peak;
+			public ulong	reusable;
+			public ulong	reusable_peak;
+			public ulong	purgeable_volatile_pmap;
+			public ulong	purgeable_volatile_resident;
+			public ulong	purgeable_volatile_virtual;
+			public ulong	compressed;
+			public ulong	compressed_peak;
+			public ulong	compressed_lifetime;
+
+			/* added for rev1 */
+			public ulong	phys_footprint;
+
+			/* added for rev2 */
+			public ulong	min_address;
+			public ulong	max_address;
+		}
+
+		[DllImport ("/usr/lib/system/libsystem_kernel.dylib")]
+		static extern IntPtr mach_task_self ();
+
+		[DllImport ("/usr/lib/system/libsystem_kernel.dylib")]
+		static extern int task_info (IntPtr target_task, uint flavor, ref task_vm_info task_info_out, ref int size);
+
+		static bool TryGetTaskVMInfo (out task_vm_info vm_info)
+		{
+			vm_info = new task_vm_info ();
+			int size;
+			unsafe {
+				size = sizeof (task_vm_info);
+			}
+
+			int ret = task_info (mach_task_self (), TASK_VM_INFO, ref vm_info, ref size);
+			return ret == KERN_SUCCESS;
+		}
+
+		public static void GetCompressedMemoryInfo (out ulong compressedBytes, out ulong virtualBytes)
+		{
+			compressedBytes = virtualBytes = 0;
+
+			if (TryGetTaskVMInfo (out var info)) {
+				compressedBytes = info.compressed;
+				virtualBytes = info.virtual_size;
+			}
+		}
+	}
+}

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1165,7 +1165,13 @@ namespace MonoDevelop.MacIntegration
 				DispatchSource = new DispatchSource.MemoryPressure (notificationFlags, DispatchQueue.DefaultGlobalQueue);
 				DispatchSource.SetEventHandler (() => {
 					var platformMemoryStatus = GetPlatformMemoryStatus (DispatchSource.PressureFlags);
-					var args = new PlatformMemoryStatusEventArgs (platformMemoryStatus);
+
+					var metadata = new MacPlatformMemoryMetadata {
+						MemoryStatus = platformMemoryStatus,
+
+					};
+
+					var args = new PlatformMemoryStatusEventArgs (metadata);
 					OnStatusChanged (args);
 				});
 				DispatchSource.Resume ();
@@ -1193,6 +1199,10 @@ namespace MonoDevelop.MacIntegration
 					DispatchSource.Dispose ();
 					DispatchSource = null;
 				}
+			}
+
+			class MacPlatformMemoryMetadata : PlatformMemoryMetadata
+			{
 			}
 		}
 	}

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Dialogs\MacCommonFileDialogHandler.cs" />
     <Compile Include="MacTelemetryDetails.cs" />
     <Compile Include="Interop.cs" />
+    <Compile Include="KernelInterop.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Dialogs\MDAccessoryViewBox.cs" />
     <Compile Include="Dialogs\MacCommonFileDialogHandler.cs" />
     <Compile Include="MacTelemetryDetails.cs" />
+    <Compile Include="Interop.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -54,9 +54,9 @@ namespace MacPlatform
 		{
 			var result = new MacTelemetryDetails ();
 
-			SysCtl ("hw.machine", out result.arch);
-			SysCtl ("hw.cpufamily", out result.family);
-			SysCtl ("hw.cpufrequency", out result.freq);
+			Interop.SysCtl ("hw.machine", out result.arch);
+			Interop.SysCtl ("hw.cpufamily", out result.family);
+			Interop.SysCtl ("hw.cpufrequency", out result.freq);
 
 			var attrs = NSFileManager.DefaultManager.GetFileSystemAttributes ("/");
 			result.size = attrs.Size;
@@ -106,61 +106,7 @@ namespace MacPlatform
 
 		public PlatformHardDriveMediaType HardDriveOsMediaType => osType;
 
-		static int SysCtl (string name, out string result)
-		{
-			nint resultLen = 128;
-			var resultHandle = Marshal.AllocHGlobal ((int)resultLen);
-			var retval = sysctlbyname (name, resultHandle, ref resultLen, IntPtr.Zero, 0);
 
-			// resultLen includes the null terminal, so we want to cut it off
-			// but if resultLen < 2 then there's no characters
-			if (retval != 0 || resultLen < 2) {
-				result = "Unknown";
-				return retval;
-			}
-
-			result = Marshal.PtrToStringAuto (resultHandle, (int)resultLen - 1);
-
-			Marshal.FreeHGlobal (resultHandle);
-
-			return retval;
-		}
-
-		static int SysCtl (string name, out int result)
-		{
-			nint resultLen = 128;
-			var resultHandle = Marshal.AllocHGlobal ((int)resultLen);
-			var retval = sysctlbyname (name, resultHandle, ref resultLen, IntPtr.Zero, 0);
-
-			if (retval != 0) {
-				result = -1;
-				return retval;
-			}
-
-			result = Marshal.ReadInt32 (resultHandle);
-
-			Marshal.FreeHGlobal (resultHandle);
-
-			return retval;
-		}
-
-		static int SysCtl (string name, out long result)
-		{
-			nint resultLen = 128;
-			var resultHandle = Marshal.AllocHGlobal ((int)resultLen);
-			var retval = sysctlbyname (name, resultHandle, ref resultLen, IntPtr.Zero, 0);
-
-			if (retval != 0) {
-				result = -1;
-				return retval;
-			}
-
-			result = Marshal.ReadInt64 (resultHandle);
-
-			Marshal.FreeHGlobal (resultHandle);
-
-			return retval;
-		}
 
 		static PlatformHardDriveMediaType GetMediaType (string path)
 		{
@@ -250,9 +196,6 @@ namespace MacPlatform
 
 		[DllImport ("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
 		extern static IntPtr CFDictionaryGetValue (IntPtr handle, IntPtr keyHandle);
-
-		[DllImport ("libc")]
-		extern static int sysctlbyname (string name, IntPtr oldP, ref nint oldLen, IntPtr newP, nint newlen);
 
 		[StructLayout(LayoutKind.Explicit, Size = 304)]
 		struct LastLogX {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -41,7 +41,6 @@ namespace MonoDevelop.Ide
 	{
 		static PlatformService platformService;
 		static Xwt.Toolkit nativeToolkit;
-		static MemoryMonitor memoryMonitor;
 
 		static PlatformService PlatformService {
 			get {
@@ -69,8 +68,8 @@ namespace MonoDevelop.Ide
 			FileService.FileRemoved += NotifyFileRemoved;
 			FileService.FileRenamed += NotifyFileRenamed;
 
-			memoryMonitor = platformService.CreateMemoryMonitor ();
-			memoryMonitor.StatusChanged += OnMemoryStatusChanged;
+			MemoryMonitor = platformService.CreateMemoryMonitor ();
+			MemoryMonitor.StatusChanged += OnMemoryStatusChanged;
 
 			// Ensure we initialize the native toolkit on the UI thread immediately
 			// so that we can safely access this property later in other threads
@@ -412,7 +411,7 @@ namespace MonoDevelop.Ide
 
 		internal static string GetNativeRuntimeDescription () => PlatformService.GetNativeRuntimeDescription ();
 
-		public static MemoryMonitor MemoryMonitor => memoryMonitor.Value;
+		public static MemoryMonitor MemoryMonitor { get; private set; }
 		static readonly Lazy<IPlatformTelemetryDetails> platformTelemetryDetails = new Lazy<IPlatformTelemetryDetails> (() => PlatformService.CreatePlatformTelemetryDetails ());
 		public static IPlatformTelemetryDetails PlatformTelemetry => platformTelemetryDetails.Value; 
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.Ide
 	{
 		static PlatformService platformService;
 		static Xwt.Toolkit nativeToolkit;
-		static Lazy<MemoryMonitor> memoryMonitor = new Lazy<MemoryMonitor> (() => platformService.CreateMemoryMonitor ());
+		static MemoryMonitor memoryMonitor;
 
 		static PlatformService PlatformService {
 			get {
@@ -69,11 +69,19 @@ namespace MonoDevelop.Ide
 			FileService.FileRemoved += NotifyFileRemoved;
 			FileService.FileRenamed += NotifyFileRenamed;
 
+			memoryMonitor = platformService.CreateMemoryMonitor ();
+			memoryMonitor.StatusChanged += OnMemoryStatusChanged;
+
 			// Ensure we initialize the native toolkit on the UI thread immediately
 			// so that we can safely access this property later in other threads
 			GC.KeepAlive (NativeToolkit);
 
 			FontService.Initialize ();
+		}
+
+		static void OnMemoryStatusChanged (object sender, PlatformMemoryStatusEventArgs args)
+		{
+			Counters.MemoryPressure.Inc (args.CounterMetadata);
 		}
 
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -68,12 +68,12 @@ namespace MonoDevelop.Ide
 			FileService.FileRemoved += NotifyFileRemoved;
 			FileService.FileRenamed += NotifyFileRenamed;
 
-			MemoryMonitor = platformService.CreateMemoryMonitor ();
-			MemoryMonitor.StatusChanged += OnMemoryStatusChanged;
-
 			// Ensure we initialize the native toolkit on the UI thread immediately
 			// so that we can safely access this property later in other threads
 			GC.KeepAlive (NativeToolkit);
+
+			MemoryMonitor = platformService.CreateMemoryMonitor ();
+			MemoryMonitor.StatusChanged += OnMemoryStatusChanged;
 
 			FontService.Initialize ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/PlatformMemoryStatusEventArgs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/PlatformMemoryStatusEventArgs.cs
@@ -24,6 +24,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using MonoDevelop.Core.Instrumentation;
+using MonoDevelop.Ide.Desktop;
+
 namespace MonoDevelop.Ide
 {
 	public enum PlatformMemoryStatus
@@ -35,11 +38,25 @@ namespace MonoDevelop.Ide
 
 	public class PlatformMemoryStatusEventArgs : EventArgs
 	{
-		public PlatformMemoryStatus MemoryStatus { get; }
+		public PlatformMemoryMetadata CounterMetadata { get; }
+		public PlatformMemoryStatus MemoryStatus => CounterMetadata.MemoryStatus;
 
-		public PlatformMemoryStatusEventArgs (PlatformMemoryStatus status)
+		public PlatformMemoryStatusEventArgs (PlatformMemoryMetadata counterMetadata)
 		{
-			MemoryStatus = status;
+			CounterMetadata = counterMetadata;
+		}
+
+		[Obsolete ("Use the PlatformMemoryMetadata overload")]
+		public PlatformMemoryStatusEventArgs (PlatformMemoryStatus status) : this (new PlatformMemoryMetadata { MemoryStatus = status })
+		{
+		}
+	}
+
+	public class PlatformMemoryMetadata : CounterMetadata
+	{
+		public PlatformMemoryStatus MemoryStatus {
+			get => GetProperty<PlatformMemoryStatus> ();
+			set => SetProperty (value);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -71,6 +71,7 @@ namespace MonoDevelop.Ide
 		internal static Counter<TimeToCodeMetadata> TimeToCode = InstrumentationService.CreateCounter<TimeToCodeMetadata> ("Time To Code", "IDE", id: "Ide.TimeToCode");
 		internal static bool TrackingBuildAndDeploy;
 		internal static TimerCounter<CounterMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<CounterMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
+		internal static Counter<PlatformMemoryMetadata> MemoryPressure = InstrumentationService.CreateCounter<PlatformMemoryMetadata> ("Memory Pressure", "IDE", id: "Ide.MemoryPressure");
 
 		internal static Counter<UnhandledExceptionMetadata> UnhandledExceptions = InstrumentationService.CreateCounter<UnhandledExceptionMetadata> ("Unhandled Exceptions", "IDE", id: "Ide.UnhandledExceptions");
 		internal static class ParserService {


### PR DESCRIPTION
This commit adds the following data into the IDE:

* Application/System compressed memory
* System minimum memory until compression/swap is being used
* Application virtual memory and free system virtual memory

The following data can be used to create thresholds through which
to decide whether the application is suffering from memory pressure
or not.

Fixes VSTS #633545 - Telemetry: research memory pressure event