### PR TITLE
Improve shift-tab experience in the toolbar

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/KeyCodes.cs
+++ b/main/src/addins/MacPlatform/MacInterop/KeyCodes.cs
@@ -1,0 +1,39 @@
+//
+// KeyCodes.cs
+//
+// Author:
+//       iain <iaholmes@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace MonoDevelop.MacInterop
+{
+	// These are the keycodes values NSEvent.KeyCode
+	// To find the code for a key not here, you can use the Key Codes application
+	// available from https://manytricks.com/keycodes/
+	internal static class KeyCodes
+	{
+		internal const ushort Enter = 0x24;
+		internal const ushort Tab = 0x30;
+		internal const ushort Space = 0x31;
+	}
+}

--- a/main/src/addins/MacPlatform/MacPlatform.csproj
+++ b/main/src/addins/MacPlatform/MacPlatform.csproj
@@ -110,6 +110,7 @@
     <Compile Include="MacTelemetryDetails.cs" />
     <Compile Include="Interop.cs" />
     <Compile Include="KernelInterop.cs" />
+    <Compile Include="MacInterop\KeyCodes.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide;
 using Xwt.Mac;
 using MonoDevelop.Components;
+using MonoDevelop.MacInterop;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
@@ -161,6 +162,19 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			get {
 				return new CGSize (38, 25);
 			}
+		}
+
+		internal event EventHandler<EventArgs> UnfocusToolbar;
+		public override void KeyDown (NSEvent theEvent)
+		{
+			// 0x30 is Tab
+			if (theEvent.KeyCode == KeyCodes.Tab) {
+				if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
+					UnfocusToolbar?.Invoke (this, EventArgs.Empty);
+					return;
+				}
+			}
+			base.KeyDown (theEvent);
 		}
 	}
 

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -34,6 +34,7 @@ using MonoDevelop.Components.Mac;
 using MonoDevelop.Components.MainToolbar;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
+using MonoDevelop.MacInterop;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
@@ -575,13 +576,14 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			public override void KeyDown (NSEvent theEvent)
 			{
-				if(theEvent.KeyCode == 0x20) {
+				if (theEvent.KeyCode == KeyCodes.Space) {
 					var item = Cells [focusedCellIndex].Cell;
 					PopupMenuForCell (item);
 					return;
 				}
 
-				if (theEvent.KeyCode == 0x30) {
+				// 0x30 is Tab
+				if (theEvent.KeyCode == KeyCodes.Tab) {
 					if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
 						focusedCellIndex--;
 						if (focusedCellIndex < 0) {
@@ -631,7 +633,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				var currentEvent = NSApplication.SharedApplication.CurrentEvent;
 				// Check if the currentEvent that caused us to become first responder is a Tab or a Reverse Tab
 				if (currentEvent.Type == NSEventType.KeyDown) {
-					if (currentEvent.KeyCode == 0x30) {
+					if (currentEvent.KeyCode == KeyCodes.Tab) {
 						if ((currentEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
 							focusedCellIndex = Cells.Length - 1;
 						} else {

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -575,24 +575,37 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			public override void KeyDown (NSEvent theEvent)
 			{
-				if(theEvent.Characters == " ")
-				{
+				if(theEvent.KeyCode == 0x20) {
 					var item = Cells [focusedCellIndex].Cell;
 					PopupMenuForCell (item);
 					return;
 				}
 
-				if (theEvent.Characters == "\t") {
-					focusedCellIndex++;
-					if(focusedCellIndex >= VisibleCellIds.Length){
-						if (NextKeyView != null) {
+				if (theEvent.KeyCode == 0x30) {
+					if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
+						focusedCellIndex--;
+						if (focusedCellIndex < 0) {
+							if (PreviousKeyView != null) {
+								SetSelection ();
+								focusedCellIndex = 0;
+								focusedItem = null;
+							}
+						} else {
 							SetSelection ();
-							focusedCellIndex = 0;
-							focusedItem = null;
+							return;
 						}
 					} else {
-						SetSelection ();
-						return;
+						focusedCellIndex++;
+						if (focusedCellIndex >= VisibleCellIds.Length) {
+							if (NextKeyView != null) {
+								SetSelection ();
+								focusedCellIndex = 0;
+								focusedItem = null;
+							}
+						} else {
+							SetSelection ();
+							return;
+						}
 					}
 				}
 
@@ -604,7 +617,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				if (focusedItem != null) {
 					focusedItem.HasFocus = false;
 				}
-				if (focusedCellIndex < Cells.Length) {
+				if (focusedCellIndex >= 0 && focusedCellIndex < Cells.Length) {
 					var item = Cells [focusedCellIndex].Cell as NSPathComponentCellFocusable;
 					focusedItem = item;
 					if (item != null)
@@ -615,6 +628,17 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			public override bool BecomeFirstResponder ()
 			{
+				var currentEvent = NSApplication.SharedApplication.CurrentEvent;
+				// Check if the currentEvent that caused us to become first responder is a Tab or a Reverse Tab
+				if (currentEvent.Type == NSEventType.KeyDown) {
+					if (currentEvent.KeyCode == 0x30) {
+						if ((currentEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
+							focusedCellIndex = Cells.Length - 1;
+						} else {
+							focusedCellIndex = 0;
+						}
+					}
+				}
 				SetSelection ();
 				return base.BecomeFirstResponder ();
 			}

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -42,6 +42,7 @@ using MonoDevelop.Components.Mac;
 using System.Threading;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using MonoDevelop.MacInterop;
 
 namespace MonoDevelop.MacIntegration.MainToolbar
 {
@@ -1176,9 +1177,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		bool isFirstResponder;
 		public override void KeyDown (NSEvent theEvent)
 		{
-			// 36 is <Enter>
-			// 49 is <Space>
-			if (isFirstResponder && (theEvent.KeyCode == 36 || theEvent.KeyCode == 49)) {
+			if (isFirstResponder && (theEvent.KeyCode == KeyCodes.Enter || theEvent.KeyCode == KeyCodes.Space)) {
 				sourcePad?.BringToFront (true);
 				return;
 			}

--- a/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/WPFToolbar.cs
+++ b/main/src/addins/WindowsPlatform/WindowsPlatform/MainToolbar/WPFToolbar.cs
@@ -295,17 +295,11 @@ namespace WindowsPlatform.MainToolbar
 				PropertyChanged (this, new System.ComponentModel.PropertyChangedEventArgs (propName));
 		}
 
-		public void Focus ()
+		public void Focus (Gtk.DirectionType direction, Action<Gtk.DirectionType> exitAction)
 		{
 			FocusSearchBar ();
+			exitAction (direction);
 		}
-
-		public void Focus (System.Action exitAction)
-		{
-			FocusSearchBar ();
-			exitAction ();
-		}
-
 
 		public void ShowAccessibilityAnnouncement (string message)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IMainToolbarView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IMainToolbarView.cs
@@ -262,8 +262,7 @@ namespace MonoDevelop.Components.MainToolbar
 	/// </summary>
 	public interface IMainToolbarView : IRunButtonView, ISelectorView, ISearchEntryView, IStatusBarView, IButtonBarView
 	{
-		void Focus ();
-		void Focus (Action exitAction);
+		void Focus (Gtk.DirectionType direction, Action<Gtk.DirectionType> exitAction);
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
@@ -610,8 +610,7 @@ namespace MonoDevelop.Components.MainToolbar
 			buttonBar.Groups = groups;
 		}
 
-		public void Focus (){}
-		public void Focus (System.Action exitAction) {}
+		public void Focus (DirectionType direction, Action<DirectionType> exitAction) {}
 
 		public bool ButtonBarSensitivity {
 			set { buttonBar.Sensitive = value; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -1171,10 +1171,10 @@ namespace MonoDevelop.Ide.Gui
 			case DirectionType.TabForward:
 				if (!haveFocusedToolbar) {
 					haveFocusedToolbar = true;
-					toolbar.ToolbarView.Focus(() => {
-						if (!dock.ChildFocus(direction)) {
-							haveFocusedToolbar = false;
-							OnFocused(direction);
+					toolbar.ToolbarView.Focus(direction, (d) => {
+						haveFocusedToolbar = false;
+						if (!dock.ChildFocus(d)) {
+							OnFocused(d);
 						}
 					});
 				} else {
@@ -1187,8 +1187,13 @@ namespace MonoDevelop.Ide.Gui
 
 			case DirectionType.TabBackward:
 				if (!dock.ChildFocus(direction)) {
-					haveFocusedToolbar = false;
-					OnFocused(DirectionType.TabForward);
+					haveFocusedToolbar = true;
+					toolbar.ToolbarView.Focus (direction, (d) => {
+						haveFocusedToolbar = false;
+						if (!dock.ChildFocus (d)) {
+							OnFocused (d);
+						}
+					});
 				}
 				break;
 


### PR DESCRIPTION
Correctly implement shift-tab behaviour in the selector
Correctly shift tab into the toolbar, landing on the searchbar instead of the run button
Shift tab out of the toolbar, back into the Gtk widgets.

Fix VSTS #648190