### PR TITLE
[Core] Evaluate multi-valued MSBuild search path

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -1120,7 +1120,10 @@ namespace MonoDevelop.Projects.MSBuild
 					if (import.Project.IndexOf (prop.MSBuildProperty, propertyStart, StringComparison.OrdinalIgnoreCase) == -1)
 						continue;
 
-					files = GetImportFiles (project, context, import, prop.Property, prop.Path, out resolvedSdksPath, out keepSearching);
+					string evaluatedPath = context.Evaluate (prop.Path);
+					if (string.IsNullOrEmpty (evaluatedPath))
+						continue; // Skip undefined property path.
+					files = GetImportFiles (project, context, import, prop.Property, evaluatedPath, out resolvedSdksPath, out keepSearching);
 					if (files != null) {
 						foreach (var f in files)
 							ImportFile (project, context, import, f, resolvedSdksPath);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectService.cs
@@ -306,8 +306,11 @@ namespace MonoDevelop.Projects.MSBuild
 							var pathOs = (string)searchPaths.Attribute ("os")?.Value;
 							if (!string.IsNullOrEmpty (pathOs) && pathOs != os)
 								continue;
-							foreach (var property in searchPaths.Elements ("property"))
-								list.Add (new ImportSearchPathExtensionNode { Property = property.Attribute ("name").Value, Path = property.Attribute ("value").Value });
+							foreach (var property in searchPaths.Elements ("property")) {
+								string propertyValue = property.Attribute ("value").Value ?? string.Empty;
+								foreach (var path in propertyValue.Split (';'))
+									list.Add (new ImportSearchPathExtensionNode { Property = property.Attribute ("name").Value, Path = path });
+							}
 						}
 					}
 				}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildSearchPathTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildSearchPathTests.cs
@@ -226,5 +226,26 @@ namespace MonoDevelop.Projects
 				MonoDevelop.Projects.MSBuild.MSBuildProjectService.UnregisterProjectImportSearchPath ("MSBuildSDKsPath", sdkPath);
 			}
 		}
+
+		[Test]
+		public async Task ProjectUsingSdkImportThatNeedsEvaluation ()
+		{
+			const string msbuildPropertyName = "MSBuildSearchPathProjectUsingSdkImportThatNeedsEvaluation";
+			const string searchPathPropertyName = "TestEvaluationSearchPath";
+			string importPath = Util.GetSampleProjectPath ("msbuild-search-paths", "sdk-path-eval");
+			string searchPathValue = "$(" + msbuildPropertyName + ")";
+			try {
+				Environment.SetEnvironmentVariable (msbuildPropertyName, importPath);
+				MonoDevelop.Projects.MSBuild.MSBuildProjectService.RegisterProjectImportSearchPath (searchPathPropertyName, searchPathValue);
+
+				string projectFile = Util.GetSampleProject ("msbuild-search-paths", "EvalImportPath.csproj");
+				using (DotNetProject p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile) as DotNetProject) {
+					Assert.AreEqual ("Works!", p.MSBuildProject.EvaluatedProperties.GetValue ("BarProp"));
+				}
+			} finally {
+				Environment.SetEnvironmentVariable (msbuildPropertyName, null);
+				MonoDevelop.Projects.MSBuild.MSBuildProjectService.UnregisterProjectImportSearchPath (searchPathPropertyName, searchPathValue);
+			}
+		}
 	}
 }

--- a/main/tests/test-projects/msbuild-search-paths/EvalImportPath.csproj
+++ b/main/tests/test-projects/msbuild-search-paths/EvalImportPath.csproj
@@ -1,0 +1,42 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(TestEvaluationSearchPath)\import.props" />
+</Project>

--- a/main/tests/test-projects/msbuild-search-paths/MSBuild.dll.config
+++ b/main/tests/test-projects/msbuild-search-paths/MSBuild.dll.config
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  </configSections>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+  <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    <DisableFXClosureWalk enabled="true" />
+    <generatePublisherEvidence enabled="false" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Tasks.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Engine" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <!-- Redirects for facade assemblies -->
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <!-- Redirects for components dropped by Visual Studio -->
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+        <codeBase version="15.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+        <codeBase version="15.0.0.0" href=".\amd64\XamlBuildTask.dll" />
+      </dependentAssembly>
+      <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
+      <dependentAssembly>
+        <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Data.Common" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Globalization.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Sockets" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.SecureString" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Overlapped" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
+  <msbuildToolsets default="15.0">
+    <toolset toolsVersion="15.0">
+      <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentToolsDirectory())" />
+      <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
+      <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
+      <property name="MSBuildSdksPath" value="$([MSBuild]::GetToolsDirectory32())\Sdks" />
+      <property name="MSBuildRuntimeVersion" value="4.0.30319" />
+      <property name="VisualStudioVersion" value="15.0" />
+      <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+      <projectImportSearchPaths>
+        <searchPaths os="windows">
+          <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild" />
+          <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild" />
+          <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild" />
+          <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)" />
+        </searchPaths>
+        <searchPaths os="osx">
+          <property name="MSBuildExtensionsPath" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />
+          <property name="MSBuildExtensionsPath32" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />
+          <property name="MSBuildExtensionsPath64" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />
+          <property name="VSToolsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/Microsoft/VisualStudio/v$(VisualStudioVersion)" />
+        </searchPaths>
+      </projectImportSearchPaths>
+    </toolset>
+  </msbuildToolsets>
+</configuration>

--- a/main/tests/test-projects/msbuild-search-paths/sdk-path-eval/import.props
+++ b/main/tests/test-projects/msbuild-search-paths/sdk-path-eval/import.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<BarProp>Works!</BarProp>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
MSBuild, that is included with Mono 5.16, has an MSBuild.dll.config
file that contains search path values that are multi-valued and
also need evaluating.

```
<searchPaths os="osx">
  <property name="MSBuildExtensionsPath" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />
  <property name="MSBuildExtensionsPath32" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />
  <property name="MSBuildExtensionsPath64" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />
  <property name="VSToolsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/Microsoft/VisualStudio/v$(VisualStudioVersion)" />
</searchPaths>
```

The property/values are used when looking for MSBuild imports. The
value was being used as the full path without being evaluated and
without being split into two paths. This resulted in imports that
are in the External/xbuild directory, such as Xamarin.iOS, to not
be found.

Fixes VSTS #682034 - "Tabbed Xamarin Forms App" fails to build due to
error "Your project.json doesn't have a runtimes section. You should
add '"runtimes": { "win": { } }' to your project.json and then re-run
NuGet restore."