### PR TITLE
Fixes VSTS Bug 690182: [Feedback] sorting usings dosen't work on vs

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingProfileDialog.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingProfileDialog.cs
@@ -127,7 +127,6 @@ namespace MonoDevelop.CSharp.Formatting
 			comboboxCategories.AppendText (GettextCatalog.GetString ("New Lines"));
 			comboboxCategories.AppendText (GettextCatalog.GetString ("Spacing"));
 			comboboxCategories.AppendText (GettextCatalog.GetString ("Wrapping"));
-			comboboxCategories.AppendText (GettextCatalog.GetString ("Style"));
 			comboboxCategories.Changed += delegate {
 				texteditor.Text = "";
 				notebookCategories.Page = comboboxCategories.Active;


### PR DESCRIPTION
for mac

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/690182

Note: Style options are in the text editor c# options and not
policies. This category was a left over from nrefactory style options.