### PR TITLE
[release-7.7] Fix VSTS 611401: empty completion item description should not be shown.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
@@ -314,6 +314,9 @@ namespace MonoDevelop.Ide.CodeCompletion
 			var markup = StringBuilderCache.Allocate ();
 			var theme = SyntaxHighlightingService.GetIdeFittingTheme (DefaultSourceEditorOptions.Instance.GetEditorTheme ());
 			var taggedParts = description.TaggedParts;
+			if (taggedParts.Length == 0) {
+				return null;
+			}
 			int i = 0;
 			while (i < taggedParts.Length) {
 				if (taggedParts [i].Tag == "LineBreak")


### PR DESCRIPTION
Backport of #6080.

/cc @slluis