### PR TITLE
[Core] Fix css file added externally not shown in Solution window

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4446,7 +4446,10 @@ namespace MonoDevelop.Projects
 				return;
 			}
 
-			foreach (var it in globItems.Where (it => it.Metadata.GetProperties ().Count () == 0)) {
+			if (!UseAdvancedGlobSupport)
+				globItems = globItems.Where (it => it.Metadata.GetProperties ().Count () == 0);
+
+			foreach (var it in globItems) {
 				var eit = CreateFakeEvaluatedItem (sourceProject, it, include, null);
 				var pi = CreateProjectItem (eit);
 				pi.Read (this, eit);

--- a/main/tests/test-projects/DotNetCoreFileWatcherTests/DotNetCoreMetadataTests.sln
+++ b/main/tests/test-projects/DotNetCoreFileWatcherTests/DotNetCoreMetadataTests.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetadataNetStandard", "MetadataNetStandard\MetadataNetStandard.csproj", "{87B9046C-04BA-4094-A2AD-BD7AE730592F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87B9046C-04BA-4094-A2AD-BD7AE730592F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/DotNetCoreFileWatcherTests/MetadataNetStandard/MetadataNetStandard.csproj
+++ b/main/tests/test-projects/DotNetCoreFileWatcherTests/MetadataNetStandard/MetadataNetStandard.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+ <ItemGroup>
+    <Content Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+     <None Remove="wwwroot\**" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adding a .css file, outside the IDE, into a wwwroot subdirectory
would not display the file in the Solution window. Reloading the
solution would show the file in the Solution window. The problem was
that the file glob, for files inside the wwwroot directory that
matches .css files, contained MSBuild metadata "CopyToPublishDirectory"
and was being ignored. Only file globs without any extra metadata
were supported.

    <Content Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

If the project has opted in to use default metadata for new files
the file glob is no longer ignored if it has extra MSBuild metadata.

Fixes VSTS #660874 - Solution Pad not refreshing content when adding
files outside of the IDE