### PR TITLE
[NuGet] Support PackageReference with no Version  …

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNode.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNode.cs
@@ -134,6 +134,9 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 			if (PackageReference.IsFloating ()) {
 				return PackageReference.AllowedVersions.Float.ToString ();
 			}
+			if (Version == null) {
+				return GettextCatalog.GetString ("None");
+			}
 			return Version.ToString ();
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNode.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/ProjectPackagesFolderNode.cs
@@ -180,6 +180,9 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 		public virtual bool IsPackageInstalled (PackageReference reference)
 		{
 			if (IsNuGetIntegratedProject ()) {
+				if (!reference.PackageIdentity.HasVersion)
+					return true;
+
 				string path = packagePathResolver.GetHashPath (reference.PackageIdentity.Id, reference.PackageIdentity.Version);
 				return File.Exists (path);
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProject.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public void AddPackageReference (string id, string version, VersionRange versionRange = null)
 		{
-			var packageId = new PackageIdentity (id, new NuGetVersion (version));
+			var packageId = new PackageIdentity (id, GetNuGetVersion (version));
 			var packageReference = new PackageReference (
 				packageId,
 				new NuGetFramework ("net45"),
@@ -80,6 +80,14 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 				versionRange
 			);
 			InstalledPackages.Add (packageReference);
+		}
+
+		NuGetVersion GetNuGetVersion (string version)
+		{
+			if (string.IsNullOrEmpty (version))
+				return null;
+
+			return new NuGetVersion (version);
 		}
 
 		public List<NuGetProjectAction> ActionsPassedToOnBeforeUninstall;

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableCheckForNuGetPackageUpdatesTaskRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableCheckForNuGetPackageUpdatesTaskRunner.cs
@@ -41,6 +41,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		}
 
 		public FakeSolutionManager SolutionManager = new FakeSolutionManager ();
+		public List<Exception> ErrorsLogged = new List<Exception> ();
 
 		protected override IMonoDevelopSolutionManager GetSolutionManager (ISolution solution)
 		{
@@ -73,6 +74,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			CheckForUpdatesTask = base.CheckForUpdates (projects, sourceRepositoryProvider);
 			AfterCheckForUpdatesAction ();
 			return CheckForUpdatesTask;
+		}
+
+		protected override void LogError (string message, Exception ex)
+		{
+			ErrorsLogged.Add (ex);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableProjectPackageReference.cs
@@ -36,6 +36,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			Metadata.SetValue ("Version", version);
 		}
 
+		public TestableProjectPackageReference (string id)
+		{
+			Include = id;
+		}
+
 		public void CallWrite (MSBuildItem buildItem)
 		{
 			base.Write (null, buildItem);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNodeTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageReferenceNodeTests.cs
@@ -56,9 +56,17 @@ namespace MonoDevelop.PackageManagement.Tests
 			string packageVersion = "1.2.3",
 			bool requireReinstallation = false)
 		{
-			var version = new NuGetVersion (packageVersion);
+			var version = CreateNuGetVersion (packageVersion);
 			var identity = new PackageIdentity (packageId, version);
 			packageReference = new PackageReference (identity, null, true, false, requireReinstallation);
+		}
+
+		static NuGetVersion CreateNuGetVersion (string packageVersion)
+		{
+			if (string.IsNullOrEmpty (packageVersion))
+				return null;
+
+			return new NuGetVersion (packageVersion);
 		}
 
 		void CreatePackageReferenceWithProjectJsonWildcardVersion (string packageId, string version)
@@ -329,6 +337,17 @@ namespace MonoDevelop.PackageManagement.Tests
 			string label = node.GetPackageVersionLabel ();
 
 			Assert.AreEqual (label, "Version 1.2.3-*");
+		}
+
+		[Test]
+		public void GetVersionLabel_PackageWithoutVersion_NullReferenceExceptionIsNotThrown ()
+		{
+			CreatePackageReference ("MyPackage", packageVersion: null);
+			CreatePackageReferenceNode ();
+
+			string label = node.GetPackageVersionLabel ();
+
+			Assert.AreEqual (label, "Version None");
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
@@ -86,5 +86,17 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsFalse (reference.IsAtLeastVersion (new Version (3, 2, 1)));
 			Assert.IsFalse (reference.IsAtLeastVersion (new Version (3, 3)));
 		}
+
+		[Test]
+		public void NoVersionSpecified ()
+		{
+			var projectPackageReference = new TestableProjectPackageReference ("Test");
+			var packageReference = projectPackageReference.CreatePackageReference ();
+
+			Assert.AreEqual ("Test", packageReference.PackageIdentity.Id);
+			Assert.IsFalse (packageReference.PackageIdentity.HasVersion);
+			Assert.IsFalse (packageReference.HasAllowedVersions);
+			Assert.IsFalse (projectPackageReference.IsAtLeastVersion (new Version (3, 1)));
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForNuGetPackageUpdatesTaskRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForNuGetPackageUpdatesTaskRunner.cs
@@ -94,6 +94,7 @@ namespace MonoDevelop.PackageManagement
 				project,
 				sourceRepositoryProvider,
 				nugetProject,
+				LogError,
 				cancellationTokenSource.Token);
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementPathResolver.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementPathResolver.cs
@@ -64,6 +64,9 @@ namespace MonoDevelop.PackageManagement
 
 		public string GetPackageInstallPath (NuGetProject nugetProject, PackageIdentity package)
 		{
+			if (!package.HasVersion)
+				return string.Empty;
+
 			if (nugetProject is INuGetIntegratedProject) {
 				return pathResolver.GetPackageDirectory (package.Id, package.Version) ??
 					globalPackagesFolderResolver.GetInstallPath (package.Id, package.Version);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProjectOperations.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProjectOperations.cs
@@ -275,7 +275,7 @@ namespace MonoDevelop.PackageManagement
 		{
 			return new PackageManagementPackageReference (
 				package.Id,
-				package.Version.ToString (),
+				package.Version?.ToString (),
 				pathResolver.GetPackageInstallPath (nugetProject, package));
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
@@ -51,7 +51,7 @@ namespace MonoDevelop.PackageManagement
 			VersionRange version,
 			NuGetFramework framework)
 		{
-			if (!version.IsFloating)
+			if (version != null && !version.IsFloating)
 				version = null;
 
 			return new PackageReference (
@@ -64,12 +64,15 @@ namespace MonoDevelop.PackageManagement
 
 		PackageIdentity GetPackageIdentity (VersionRange version)
 		{
-			return new PackageIdentity (Include, version.MinVersion);
+			return new PackageIdentity (Include, version?.MinVersion);
 		}
 
 		VersionRange GetVersion ()
 		{
 			string version = Metadata.GetValue ("Version");
+			if (string.IsNullOrEmpty (version))
+				return null;
+
 			return VersionRange.Parse (version);
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesInWorkspace.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesInWorkspace.cs
@@ -135,6 +135,11 @@ namespace MonoDevelop.PackageManagement
 			GuiDispatch (() => result = action ());
 			return result;
 		}
+
+		protected virtual void LogError (string message, Exception ex)
+		{
+			LoggingService.LogError (message, ex);
+		}
 	}
 }
 


### PR DESCRIPTION
One problem affecting the OrchardCore solution.

A project can contain a PackageReference without a version:

    <ItemGroup>
      <PackageReference Include="Newtonsoft.Json" />
    </ItemGroup>

This will restore the lowest available version for the NuGet package.
Opening a project with a PackageReference without a Version attribute
would result in an ArgumentNullException being logged and the
Add Packages dialog could not be opened.

```
System.ArgumentNullException: Value cannot be null.
Parameter name: value
  at NuGet.Versioning.VersionRange.TryParse (System.String value, System.Boolean allowFloating, NuGet.Versioning.VersionRange& versionRange)
  at NuGet.Versioning.VersionRange.Parse (System.String value, System.Boolean allowFloating)
  at NuGet.Versioning.VersionRange.Parse (System.String value)
  at MonoDevelop.PackageManagement.ProjectPackageReference.GetVersion () in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs:73
  at MonoDevelop.PackageManagement.ProjectPackageReference.CreatePackageReference () in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs:43
  at MonoDevelop.PackageManagement.DotNetCoreNuGetProject+<>c.<GetPackageReferences>b__20_0 (MonoDevelop.PackageManagement.ProjectPackageReference projectItem) in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs:129
  at MonoDevelop.PackageManagement.DotNetCoreNuGetProject.GetPackageReferences ()  in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs:128
  at MonoDevelop.PackageManagement.DotNetCoreNuGetProject.GetInstalledPackagesAsync (System.Threading.CancellationToken token) in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs:123
  at MonoDevelop.PackageManagement.PackageManagementProjectOperations+<>c__DisplayClass21_1.<GetInstalledPackages>b__1 () in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProjectOperations.cs:
  at MonoDevelop.PackageManagement.PackageManagementProjectOperations+<>c__DisplayClass21_0+<<GetInstalledPackages>b__0>d.MoveNext () in main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProjectOperations.cs:211
```

Fixes VSTS #679760 - PackageReference with no Version is not supported