### PR TITLE
FsharpBinding: uppercase F# project GUID to be consistent with VS4win

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -37,7 +37,7 @@
   </Extension>
 
   <Extension path="/MonoDevelop/ProjectModel/MSBuildItemTypes">
-    <DotNetProjectType language="F#" extension="fsproj" guid="{f2a71f9b-5d33-465a-a702-920d77279786}" type="MonoDevelop.FSharp.FSharpProject"/>
+    <DotNetProjectType language="F#" extension="fsproj" guid="{F2A71F9B-5D33-465A-A702-920D77279786}" type="MonoDevelop.FSharp.FSharpProject"/>
   </Extension>
 
   <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -356,7 +356,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		{
 			string language = GetLanguage (template.Id);
 			if (language == "F#")
-				return "{f2a71f9b-5d33-465a-a702-920d77279786}";
+				return "{F2A71F9B-5D33-465A-A702-920D77279786}";
 
 			// C#
 			return "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";


### PR DESCRIPTION
Fixes #5976