### PR TITLE
[release-7.6][Core] Fix project in solution folder not reloaded

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -1029,7 +1029,7 @@ namespace MonoDevelop.Projects
 		
 		void OnItemReloadRequired (SolutionItemEventArgs e)
 		{
-			if (ParentFolder == null && ParentSolution != null)
+			if (ParentSolution != null)
 				ParentSolution.OnItemReloadRequired (e);
 			if (ItemReloadRequired != null)
 				ItemReloadRequired (this, e);

--- a/main/tests/test-projects/ProjectInSolutionFolder/ProjectInSolutionFolder.csproj
+++ b/main/tests/test-projects/ProjectInSolutionFolder/ProjectInSolutionFolder.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E56A0707-B497-4147-90C9-750CDA0AB1EC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ProjectInSolutionFolder</RootNamespace>
+    <AssemblyName>ProjectInSolutionFolder</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ProjectInSolutionFolder/ProjectInSolutionFolder.sln
+++ b/main/tests/test-projects/ProjectInSolutionFolder/ProjectInSolutionFolder.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFolder", "SolutionFolder", "{BB2F1272-77FE-4C48-ADF9-23B582718866}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectInSolutionFolder", "ProjectInSolutionFolder.csproj", "{E56A0707-B497-4147-90C9-750CDA0AB1EC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E56A0707-B497-4147-90C9-750CDA0AB1EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E56A0707-B497-4147-90C9-750CDA0AB1EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E56A0707-B497-4147-90C9-750CDA0AB1EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E56A0707-B497-4147-90C9-750CDA0AB1EC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E56A0707-B497-4147-90C9-750CDA0AB1EC} = {BB2F1272-77FE-4C48-ADF9-23B582718866}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Backport of #6078

When a project inside a solution folder was modified outside the IDE
it was not reloaded. The Solution's ItemReloadRequired event was not
fired for projects inside a solution folder so the workspace was not
reloading them.

Fixes VSTS #669787 - Switching branch outside of IDE does not trigger
project reload
Fixes #6013 - Modifying .csproj file that is inside SolutionFolder
doesn't reload project