### PR TITLE
Fixes issue #6014 [Regression] Unit-tests execution

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Gui/TestPad.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Gui/TestPad.cs
@@ -481,10 +481,15 @@ namespace MonoDevelop.UnitTesting
 		
 		void OnStopClicked (object sender, EventArgs args)
 		{
+			StopRunningTests ();
+		}
+
+		void StopRunningTests ()
+		{
 			if (runningTestOperation != null)
 				runningTestOperation.Cancel ();
 		}
-		
+
 		UnitTest GetSelectedTest ()
 		{
 			ITreeNavigator nav = TreeView.GetSelectedNode ();
@@ -538,6 +543,7 @@ namespace MonoDevelop.UnitTesting
 
 			if (bringToFront)
 				IdeApp.Workbench.GetPad<TestPad> ().BringToFront ();
+			StopRunningTests ();
 			runningTestOperation = UnitTestService.RunTests (tests, context);
 			runningTestOperation.Task.ContinueWith (t => OnTestSessionCompleted (), TaskScheduler.FromCurrentSynchronizationContext ());
 			return runningTestOperation;

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -129,9 +129,8 @@ namespace MonoDevelop.UnitTesting
 					if (t.OwnerObject is IBuildTarget bt)
 						build_targets.Add (bt);
 				}
-
 				var res = await IdeApp.ProjectOperations.CheckAndBuildForExecute (
-					build_targets, IdeApp.Workspace.ActiveConfiguration, IdeApp.Preferences.BuildBeforeRunningTests,
+					build_targets, IdeApp.Workspace.ActiveConfiguration, buildWithoutPrompting: !IdeApp.Preferences.BuildBeforeRunningTests, 
 					false, null, cs.Token);
 
 				if (!res)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -961,11 +961,13 @@ namespace MonoDevelop.Ide.Gui.Components
 		{
 			base.Dispose ();
 			console.Dispose ();
+			Disposed?.Invoke (this, EventArgs.Empty);
 		}
 
+		internal event EventHandler Disposed;
 		internal event EventHandler Completed;
 
-		class LogViewProgressConsole: OperationConsole
+		class LogViewProgressConsole : OperationConsole
 		{
 			LogViewProgressMonitor monitor;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/DefaultMonitorPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/DefaultMonitorPad.cs
@@ -165,7 +165,11 @@ namespace MonoDevelop.Ide.Gui.Pads
 				Window.IsWorking = true;
 				buttonStop.Sensitive = true;
 			});
-			
+			monitor.Disposed += delegate {
+				if (progressStarted)
+					EndProgress ();
+			};
+
 			monitor.Completed += delegate {
 				EndProgress ();
 			};


### PR DESCRIPTION
The multiple application output window got introduced by
65c5f17f86fc77f8add6c6090aa526c2cb2a6009 that introduced that an in
progress output window can't be re used. Ending the progress on
dispose as well fixes that issue for unit tests.