### PR TITLE
[Core] Fix pinned projects not being saved

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Properties.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Properties.cs
@@ -90,7 +90,7 @@ namespace MonoDevelop.Core
 
 		public object Get (string property, object defaultValue, Type type)
 		{
-			if (!defaultValues.ContainsKey (property))
+			if (!defaultValues.ContainsKey (property) && IsSupportedDefaultValueType (type))
 				defaultValues = defaultValues.SetItem (property, defaultValue);
 
 			if (GetPropertyValue (property, out object value, type))
@@ -99,7 +99,16 @@ namespace MonoDevelop.Core
 			return defaultValue;
 		}
 
-		
+		/// <summary>
+		/// Only value types, strings and Properties are supported when checking for default values.
+		/// Other reference types are not supported because on saving they will match the default value,
+		/// since it is the same instance, and not be written to the properties file.
+		/// </summary>
+		static bool IsSupportedDefaultValueType (Type type)
+		{
+			return type.IsValueType || type == typeof (string) || type == typeof (Properties);
+		}
+
 		public T Get<T> (string property, T defaultValue)
 		{
 			var result = Get (property, defaultValue, typeof (T));

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/PropertyTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/PropertyTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using UnitTests;
@@ -96,6 +97,30 @@ namespace MonoDevelop.Core
 			string text = File.ReadAllText (fileName);
 
 			Assert.IsFalse (text.Contains ("First"), "Default properties should not be saved.");
+		}
+
+		/// <summary>
+		/// Ensures that a List instance used as a property value can be saved
+		/// and re-loaded with the updated values.
+		/// </summary>
+		[Test]
+		public void PropertyIsListOfStrings_SaveAndReload ()
+		{
+			var mainProperties = new Properties ();
+			var list = mainProperties.Get ("ListInstance", new List<string> ());
+			list.Add ("FirstItem");
+			list.Add ("SecondItem");
+
+			FilePath directory = Util.CreateTmpDir ("ListInstance");
+			var fileName = directory.Combine ("Properties.xml");
+			mainProperties.Save (fileName);
+
+			mainProperties = Properties.Load (fileName);
+			var savedList = mainProperties.Get ("ListInstance", new List<string> ());
+
+			Assert.AreEqual (2, savedList.Count);
+			Assert.AreEqual ("FirstItem", savedList [0]);
+			Assert.AreEqual ("SecondItem", savedList [1]);
 		}
 	}
 }


### PR DESCRIPTION
If no projects were pinned on the welcome page when the IDE started,
pinning a project, then closing and re-opening the IDE, would result
in the project not being pinned on the welcome page. The problem
was that when there was no existing list of pinned projects stored
in the properties file a new list would be used as a default value.
On saving since the list object matched the default value it was
not saved in the properties file. To avoid this only value types,
strings and instances of the Properties class are supported as
default values.

Fixes VSTS #692381 - Pinned projects are no longer remaining pinned
after a restart