### PR TITLE
[Telemetry] Fix null reference when opening sln from command line 7.6

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -477,7 +477,6 @@ namespace MonoDevelop.Ide
 			}
 
 			timeToCodeTimer.Stop ();
-			timeToCodeTimer = null;
 			lock (ttcLock) {
 				ttcMetadata.SolutionLoadTime = timeToCodeTimer.ElapsedMilliseconds;
 
@@ -489,6 +488,7 @@ namespace MonoDevelop.Ide
 					IdeApp.ReportTimeToCode = false;
 				}
 			}
+			timeToCodeTimer = null;
 		}
 
 		static DateTime lastIdle;


### PR DESCRIPTION
Don't null the timer until after the time has been recorded

fixes VSTS #692948