### PR TITLE
[release-7.7] Fixes issue #6142 Completion still commits on ENTER when an item is

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/CompletionController.cs
@@ -880,12 +880,14 @@ namespace MonoDevelop.Ide.CodeCompletion
 				//tab always completes current item even if selection is disabled
 				if (!AutoSelect)
 					AutoSelect = true;
+				if (!AutoCompleteEmptyMatch)
+					AutoCompleteEmptyMatch = true;
 				goto case SpecialKey.Return;
 
 			case SpecialKey.Return:
 				if (descriptor.ModifierKeys != ModifierKeys.None && descriptor.ModifierKeys != ModifierKeys.Shift)
 					return KeyActions.CloseWindow;
-				if (dataList == null || dataList.Count == 0)
+				if (dataList == null || dataList.Count == 0 || !listWindow.SelectionEnabled)
 					return KeyActions.CloseWindow;
 				WasShiftPressed = (descriptor.ModifierKeys & ModifierKeys.Shift) == ModifierKeys.Shift;
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/CompletionListWindowTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/CompletionListWindowTests.cs
@@ -1565,5 +1565,21 @@ namespace MonoDevelop.Ide.Gui
 			Assert.IsFalse (visible);
 			Assert.IsFalse (listWindow.Visible);
 		}
+
+		/// <summary>
+		/// Completion still commits on ENTER when an item is soft-selected #6142
+		/// </summary>
+		[Test]
+		public void TestIssue6142 ()
+		{
+			CreateListWindow ("", false, true, false,
+				"foo",
+				"bar");
+
+			var word = SimulateInput ("b\b\n");
+			Assert.IsTrue (string.IsNullOrEmpty (word));
+
+		}
+
 	}
 }


### PR DESCRIPTION
Backport of #6148.

/cc @mkrueger @mkrueger

Description of #6148:
soft-selected