### PR TITLE
[release-7.7] Report _from_ version in addition to _to_ version

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
@@ -43,8 +43,6 @@ namespace MonoDevelop.DotNetCore
 
 		public override string ApplicationId => "c07628e8-5521-4c1a-aa3a-f860e664f0a9";
 
-		protected override string UpdateInfoFile => throw new NotImplementedException ();
-
 		public override UpdateInfo GetUpdateInfo ()
 		{
 			if (IsSierraOrHigher ())

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
@@ -34,16 +34,9 @@ namespace MonoDevelop.DotNetCore
 {
 	class DotNetCoreSystemInformation : ProductInformationProvider
 	{
-		public override string Title {
-			get { return GettextCatalog.GetString (".NET Core"); }
-		}
+		public override string Title => GettextCatalog.GetString (".NET Core");
 
-		public override string Description {
-			get {
-				return GetDescription ();
-			}
-		}
-
+		public override string Description => GetDescription ();
 
 		public override string Version => DotNetCoreSdk.Versions.FirstOrDefault().ToString ();
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
@@ -39,7 +39,7 @@ namespace MonoDevelop.DotNetCore
 
 		public override string Description => GetDescription ();
 
-		public override string Version => DotNetCoreSdk.Versions.FirstOrDefault().ToString ();
+		public override string Version => DotNetCoreSdk.Versions.FirstOrDefault()?.ToString ();
 
 		public override string ApplicationId => "c07628e8-5521-4c1a-aa3a-f860e664f0a9";
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
@@ -28,19 +28,51 @@ using System;
 using System.Linq;
 using System.Text;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.DotNetCore
 {
-	class DotNetCoreSystemInformation : ISystemInformationProvider
+	class DotNetCoreSystemInformation : ProductInformationProvider
 	{
-		public string Title {
+		public override string Title {
 			get { return GettextCatalog.GetString (".NET Core"); }
 		}
 
-		public string Description {
+		public override string Description {
 			get {
 				return GetDescription ();
 			}
+		}
+
+
+		public override string Version => DotNetCoreSdk.Versions.FirstOrDefault().ToString ();
+
+		public override string ApplicationId => "c07628e8-5521-4c1a-aa3a-f860e664f0a9";
+
+		protected override string UpdateInfoFile => throw new NotImplementedException ();
+
+		public override UpdateInfo GetUpdateInfo ()
+		{
+			if (IsSierraOrHigher ())
+				return GenerateDotNetCoreUpdateInfo ();
+			return null;
+		}
+
+		UpdateInfo GenerateDotNetCoreUpdateInfo ()
+		{
+			var latestSdkVersion = DotNetCoreSdk.Versions.FirstOrDefault ();
+			if (latestSdkVersion != null) {
+				return new UpdateInfo (ApplicationId, latestSdkVersion.Version);
+			}
+
+			// Return an UpdateInfo with version set to 0 if there is no .NET Core SDK installed.
+			// Without this no update will be available for .NET Core SDK in the Updates dialog.
+			return new UpdateInfo (ApplicationId, versionId: 0);
+		}
+
+		static bool IsSierraOrHigher ()
+		{
+			return Platform.IsMac && (Platform.OSVersion >= MacSystemInformation.Sierra);
 		}
 
 		string GetDescription ()

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSystemInformation.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Text;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
+using MonoDevelop.Ide.Updater;
 
 namespace MonoDevelop.DotNetCore
 {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetSystemInformation.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetSystemInformation.cs
@@ -43,6 +43,8 @@ namespace MonoDevelop.PackageManagement
 			}
 		}
 
+		public string Version => GetNuGetVersion ();
+
 		static string GetDescription ()
 		{
 			return GettextCatalog.GetString ("Version: {0}", GetNuGetVersion ());

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -256,6 +256,10 @@
 		<Class class = "MonoDevelop.Ide.IdeVersionInfo" />
 	</Extension>
 
+	<Extension path = "/MonoDevelop/Core/SystemInformation">
+		<Class class = "MonoDevelop.Ide.MonoVersionInfo" />
+	</Extension>
+
 	<Extension path = "/MonoDevelop/Ide/DisplayBindings">
 		<DisplayBinding id    = "DefaultDisplayBinding"
 		                class = "MonoDevelop.Ide.Gui.DefaultDisplayBinding"/>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -257,7 +257,7 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Core/SystemInformation">
-		<Class class = "MonoDevelop.Ide.MonoVersionInfo" />
+		<Class class = "MonoDevelop.Ide.RuntimeVersionInfo" />
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/DisplayBindings">

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MonoDevelop.Ide.addin.xml
@@ -254,9 +254,6 @@
 	
 	<Extension path = "/MonoDevelop/Core/SystemInformation">
 		<Class class = "MonoDevelop.Ide.IdeVersionInfo" />
-	</Extension>
-
-	<Extension path = "/MonoDevelop/Core/SystemInformation">
 		<Class class = "MonoDevelop.Ide.RuntimeVersionInfo" />
 	</Extension>
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateInfo.cs
@@ -33,12 +33,17 @@ namespace MonoDevelop.Ide.Updater
 		{
 		}
 
+		public string File { get; }
+		public string AppId { get; }
+		public long VersionId { get; }
+		public string SourceUrl { get; }
+
 		public UpdateInfo (string file, string appId, long versionId, string sourceUrl)
 		{
-			this.File = file;
-			this.AppId = appId;
-			this.VersionId = versionId;
-			this.SourceUrl = sourceUrl;
+			SourceUrl = sourceUrl;
+			VersionId = versionId;
+			AppId = appId;
+			File = file;
 		}
 
 		public UpdateInfo (string appId, Version version)
@@ -51,10 +56,7 @@ namespace MonoDevelop.Ide.Updater
 		{
 		}
 
-		public readonly string File;
-		public readonly string AppId;
-		public readonly long VersionId;
-		public readonly string SourceUrl;
+		const string sourceUrl = "source-url:";
 
 		public static UpdateInfo FromFile (string fileName)
 		{
@@ -64,9 +66,9 @@ namespace MonoDevelop.Ide.Updater
 				string url = null;
 				s = f.ReadLine ();
 				if (s != null) {
-					if (s.StartsWith ("source-url:"))
-						url = s.Substring (11).Trim ();
-
+					if (s.StartsWith (sourceUrl)) {
+						url = s.Substring (sourceUrl.Length).Trim ();
+					}
 				}
 				return new UpdateInfo (fileName, parts [0], long.Parse (parts [1]), url);//, xamarinProduct);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Updater/UpdateInfo.cs
@@ -25,7 +25,7 @@
 // THE SOFTWARE.
 using System;
 
-namespace MonoDevelop.Ide
+namespace MonoDevelop.Ide.Updater
 {
 	public class UpdateInfo
 	{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4199,8 +4199,8 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopAnalyzer.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\HostDiagnosticUpdateSource.cs" />
     <Compile Include="MonoDevelop.Ide\ProductInformationProvider.cs" />
-    <Compile Include="MonoDevelop.Ide\UpdateInfo.cs" />
     <Compile Include="MonoDevelop.Ide\RuntimeVersionInfo.cs" />
+    <Compile Include="MonoDevelop.Ide.Updater\UpdateInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4200,6 +4200,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\HostDiagnosticUpdateSource.cs" />
     <Compile Include="MonoDevelop.Ide\ProductInformationProvider.cs" />
     <Compile Include="MonoDevelop.Ide\UpdateInfo.cs" />
+    <Compile Include="MonoDevelop.Ide\RuntimeVersionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4198,6 +4198,8 @@
     <Compile Include="MonoDevelop.Ide.Gui.Components\IInfoBarHost.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopAnalyzer.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\HostDiagnosticUpdateSource.cs" />
+    <Compile Include="MonoDevelop.Ide\ProductInformationProvider.cs" />
+    <Compile Include="MonoDevelop.Ide\UpdateInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Ide
 
 			LoggingService.LogInfo ("Starting {0} {1}", BrandingService.ApplicationLongName, IdeVersionInfo.MonoDevelopVersion);
 			LoggingService.LogInfo ("Build Information{0}{1}", Environment.NewLine, SystemInformation.GetBuildInformation ());
-			LoggingService.LogInfo ("Running on {0}", IdeVersionInfo.GetRuntimeInfo ());
+			LoggingService.LogInfo ("Running on {0}", RuntimeVersionInfo.GetRuntimeInfo ());
 
 			//ensure native libs initialized before we hit anything that p/invokes
 			Platform.Initialize ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
@@ -26,36 +26,9 @@
 using System;
 using MonoDevelop.Core;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace MonoDevelop.Ide
 {
-	class MonoVersionInfo : ProductInformationProvider
-	{
-		public override string Title => "Mono Framework MDK";
-
-		static string GetMonoVersionNumber ()
-		{
-			var t = Type.GetType ("Mono.Runtime");
-			if (t == null)
-				return "unknown";
-			var mi = t.GetMethod ("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
-			if (mi == null) {
-				LoggingService.LogError ("No Mono.Runtime.GetDisplayName method found.");
-				return "error";
-			}
-			var displayName = (string)mi.Invoke (null, null);
-			//Convert from "5.14.0.177 (2018 - 04 / f3a2216b65a Fri Aug  3 09:28:16 EDT 2018)"
-			return Regex.Match (displayName, @"^[\d\.]+", RegexOptions.Compiled).Value;
-		}
-
-		public override string Version => GetMonoVersionNumber ();
-
-		public override string ApplicationId => "964ebddd-1ffe-47e7-8128-5ce17ffffb05";
-
-		protected override string UpdateInfoFile => "/Library/Frameworks/Mono.framework/Versions/Current/updateinfo";
-	}
-
 	class IdeVersionInfo : ProductInformationProvider
 	{
 		static bool IsMono ()
@@ -119,21 +92,6 @@ namespace MonoDevelop.Ide
 
 		}
 
-		public static string GetRuntimeInfo ()
-		{
-			string val;
-			if (IsMono ()) {
-				val = "Mono " + GetMonoVersionNumber ();
-			} else {
-				val = "Microsoft .NET " + Environment.Version;
-			}
-
-			if (IntPtr.Size == 8)
-				val += (" (64-bit)");
-
-			return val;
-		}
-
 		public override string Title => BrandingService.ApplicationLongName;
 
 		public override string Description {
@@ -145,10 +103,6 @@ namespace MonoDevelop.Ide
 				sb.Append ("Installation UUID: ");
 				sb.AppendLine (SystemInformation.InstallationUuid);
 							
-				sb.AppendLine ("Runtime:");
-				sb.Append ("\t");
-				sb.Append (GetRuntimeInfo ());
-				sb.AppendLine ();
 				sb.Append ("\tGTK+ ");
 				sb.Append (GetGtkVersion ());
 				var gtkTheme = GetGtkTheme ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeVersionInfo.cs
@@ -159,7 +159,7 @@ namespace MonoDevelop.Ide
 
 		public override string ApplicationId => "34937104-97FC-42A0-9159-D951135F72CA";
 
-		protected override string UpdateInfoFile => "../../../../../MacOS/updateinfo";
+		protected override FilePath UpdateInfoFile => "./Contents/MacOS/updateinfo";
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -1,0 +1,68 @@
+//
+// ProductInformationProvider.cs
+//
+// Author:
+//       jason <jaimison@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.IO;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide
+{
+	public abstract class ProductInformationProvider : ISystemInformationProvider
+	{
+		/// <summary>
+		/// Application ID used by the updater. Usually a GUID.
+		/// </summary>
+		public abstract string ApplicationId { get; }
+
+		public virtual string Title => ApplicationName;
+
+		public virtual string Description => GettextCatalog.GetString("Version: {0}", Version);
+
+		//public abstract string Version;// => "";
+
+		/// <summary>
+		/// Human readable version number
+		/// </summary>
+		public abstract string Version { get; }
+
+		/// <summary>
+		/// Version number used by the updater for comparison
+		/// </summary>
+		public string VersionID => null;
+
+		/// <summary>
+		/// Path to the updateinfo file.
+		/// </summary>
+		protected abstract string UpdateInfoFile { get; }
+
+		public virtual UpdateInfo GetUpdateInfo ()
+		{
+			if (UpdateInfoFile != null && File.Exists (UpdateInfoFile))
+				return UpdateInfo.FromFile (UpdateInfoFile);
+			return null;
+		}
+
+		public string ApplicationName => "";
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -45,11 +45,6 @@ namespace MonoDevelop.Ide
 		public abstract string Version { get; }
 
 		/// <summary>
-		/// Version number used by the updater for comparison
-		/// </summary>
-		public string VersionID => null;
-
-		/// <summary>
 		/// Path to the updateinfo file.
 		/// </summary>
 		protected abstract string UpdateInfoFile { get; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -48,12 +48,21 @@ namespace MonoDevelop.Ide
 		/// <summary>
 		/// Path to the updateinfo file.
 		/// </summary>
-		protected abstract string UpdateInfoFile { get; }
+		/// <remarks>Relative paths may be specified here. Relative paths need to be relative to the bundle root.</remarks>
+		protected virtual FilePath UpdateInfoFile { get; }
 
 		public virtual UpdateInfo GetUpdateInfo ()
 		{
-			if (UpdateInfoFile != null && File.Exists (UpdateInfoFile))
-				return UpdateInfo.FromFile (UpdateInfoFile);
+			var absolutePath = UpdateInfoFile;
+			if (absolutePath != null && !absolutePath.IsAbsolute) {
+				// relative paths are relative the bundle root
+				FilePath bundlePath = Foundation.NSBundle.MainBundle.BundlePath;
+				absolutePath = bundlePath.Combine (UpdateInfoFile);
+			}
+
+			if (File.Exists (absolutePath))
+				return UpdateInfo.FromFile (absolutePath);
+
 			return null;
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System.IO;
 using MonoDevelop.Core;
+using MonoDevelop.Ide.Updater;
 
 namespace MonoDevelop.Ide
 {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -55,9 +55,11 @@ namespace MonoDevelop.Ide
 		{
 			var absolutePath = UpdateInfoFile;
 			if (absolutePath != null && !absolutePath.IsAbsolute) {
+#if MAC
 				// relative paths are relative the bundle root
 				FilePath bundlePath = Foundation.NSBundle.MainBundle.BundlePath;
 				absolutePath = bundlePath.Combine (UpdateInfoFile);
+#endif
 			}
 
 			if (File.Exists (absolutePath))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -35,11 +35,9 @@ namespace MonoDevelop.Ide
 		/// </summary>
 		public abstract string ApplicationId { get; }
 
-		public virtual string Title => ApplicationName;
+		public abstract string Title { get; }
 
 		public virtual string Description => GettextCatalog.GetString("Version: {0}", Version);
-
-		//public abstract string Version;// => "";
 
 		/// <summary>
 		/// Human readable version number
@@ -62,7 +60,5 @@ namespace MonoDevelop.Ide
 				return UpdateInfo.FromFile (UpdateInfoFile);
 			return null;
 		}
-
-		public string ApplicationName => "";
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RuntimeVersionInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RuntimeVersionInfo.cs
@@ -1,0 +1,115 @@
+﻿// ProductInformationProvider.cs
+//
+// Author:
+//       jason <jaimison@microsoft.com>
+//
+// Copyright (c) 2018 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using MonoDevelop.Core;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace MonoDevelop.Ide
+{
+	class RuntimeVersionInfo : ProductInformationProvider
+	{
+		public override string Title => "Mono Framework MDK";
+
+		public override string Version => GetMonoVersionNumber ();
+
+		public override string ApplicationId => "964ebddd-1ffe-47e7-8128-5ce17ffffb05";
+
+		protected override string UpdateInfoFile => MonoUpdateInfoFile;
+
+		public override string Description {
+			get {
+				var sb = new System.Text.StringBuilder ();
+				sb.AppendLine ("Runtime:");
+				sb.Append ("\t");
+				sb.Append (GetRuntimeInfo ());
+				sb.AppendLine ();
+				if (Platform.IsMac && IsMono ()) {
+					var pkgVer = GetMonoUpdateInfo ();
+					if (!string.IsNullOrEmpty (pkgVer)) {
+						sb.Append ("\tPackage version: ");
+						sb.Append (pkgVer);
+					}
+				}
+				return sb.ToString ();
+			}
+		}
+
+		const string MonoUpdateInfoFile = "/Library/Frameworks/Mono.framework/Versions/Current/updateinfo";
+		static string GetMonoUpdateInfo ()
+		{
+			try {
+				FilePath mscorlib = typeof (object).Assembly.Location;
+				if (!System.IO.File.Exists (MonoUpdateInfoFile))
+					return null;
+				var s = System.IO.File.ReadAllText (MonoUpdateInfoFile).Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+				return s [s.Length - 1].Trim ();
+			} catch {
+			}
+			return null;
+		}
+
+		static string GetMonoDisplayName ()
+		{
+			var t = Type.GetType ("Mono.Runtime");
+			if (t == null)
+				return "unknown";
+			var mi = t.GetMethod ("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
+			if (mi == null) {
+				LoggingService.LogError ("No Mono.Runtime.GetDisplayName method found.");
+				return "error";
+			}
+			return (string)mi.Invoke (null, null);
+		}
+
+		static string GetMonoVersionNumber ()
+		{
+			var monoDisplayName = GetMonoDisplayName ();
+			// Convert from "5.14.0.177 (2018 - 04 / f3a2216b65a Fri Aug  3 09:28:16 EDT 2018)"
+			// to "5.4.0.177"
+			return Regex.Match (monoDisplayName, @"^[\d\.]+", RegexOptions.Compiled).Value;
+		}
+
+		static bool IsMono ()
+		{
+			return Type.GetType ("Mono.Runtime") != null;
+		}
+
+		public static string GetRuntimeInfo ()
+		{
+			string val;
+			if (IsMono ()) {
+				val = "Mono " + GetMonoDisplayName ();
+			} else {
+				val = "Microsoft .NET " + Environment.Version;
+			}
+
+			if (IntPtr.Size == 8)
+				val += (" (64-bit)");
+
+			return val;
+		}
+	}
+}
+

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RuntimeVersionInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RuntimeVersionInfo.cs
@@ -36,7 +36,7 @@ namespace MonoDevelop.Ide
 
 		public override string ApplicationId => "964ebddd-1ffe-47e7-8128-5ce17ffffb05";
 
-		protected override string UpdateInfoFile => MonoUpdateInfoFile;
+		protected override FilePath UpdateInfoFile => MonoUpdateInfoFile;
 
 		public override string Description {
 			get {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/UpdateInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/UpdateInfo.cs
@@ -1,0 +1,100 @@
+﻿//
+// UpdateInfo.cs
+//
+// Author:
+//       jason <jaimison@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace MonoDevelop.Ide
+{
+	public class UpdateInfo
+	{
+		UpdateInfo ()
+		{
+		}
+
+		public UpdateInfo (string file, string appId, long versionId, string sourceUrl)
+		{
+			this.File = file;
+			this.AppId = appId;
+			this.VersionId = versionId;
+			this.SourceUrl = sourceUrl;
+		}
+
+		public UpdateInfo (string appId, Version version)
+			: this (appId, GetVersionId (version))
+		{
+		}
+
+		public UpdateInfo (string appId, long versionId)
+			: this (null, appId, versionId, null)
+		{
+		}
+
+		public readonly string File;
+		public readonly string AppId;
+		public readonly long VersionId;
+		public readonly string SourceUrl;
+
+		public static UpdateInfo FromFile (string fileName)
+		{
+			using (var f = System.IO.File.OpenText (fileName)) {
+				var s = f.ReadLine ();
+				var parts = s.Split (' ');
+				string url = null;
+				s = f.ReadLine ();
+				if (s != null) {
+					if (s.StartsWith ("source-url:"))
+						url = s.Substring (11).Trim ();
+
+				}
+				return new UpdateInfo (fileName, parts [0], long.Parse (parts [1]), url);//, xamarinProduct);
+			}
+		}
+
+		static long GetVersionId (Version version)
+		{
+			string versionId = GetVersionIdText (version.Major, version.Minor, version.Build, version.Revision);
+			return long.Parse (versionId);
+		}
+
+		static string GetVersionIdText (int major, int minor, int build, int revision)
+		{
+			return FixVersionNumber (major) +
+				FixVersionNumber (minor).ToString ("00") +
+				FixVersionNumber (build).ToString ("00") +
+				FixVersionNumber (revision).ToString ("0000");
+		}
+
+		/// <summary>
+		/// Unspecified version numbers can be -1 so map this to 0 instead.
+		/// </summary>
+		static int FixVersionNumber (int number)
+		{
+			if (number == -1)
+				return 0;
+
+			return number;
+		}
+	}
+}


### PR DESCRIPTION
Backport of #6108.

/cc @nosami @nosami

Description of #6108:
Consolidating ISystemInformation, UpdateInfoExtensionNode and
IUpdateInfoGenerator into ProductInformationProvider so that we only
have one way to retrieve product information.

Fixes VSTS #664616