### PR TITLE
[release-7.7] [NuGet] Fix Update menu enabled when project has no PackageReferences

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackagesCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackagesCommandHandler.cs
@@ -98,5 +98,27 @@ namespace MonoDevelop.PackageManagement.Commands
 			}
 			return IdeApp.ProjectOperations.CurrentSelectedSolution;
 		}
+
+		protected bool CanUpdatePackagesForSelectedDotNetProject ()
+		{
+			DotNetProject project = GetSelectedDotNetProject ();
+			return project?.CanUpdatePackages () == true;
+		}
+
+		bool CanUpdatePackagesForSelectedDotNetSolution ()
+		{
+			Solution solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+			return solution?.CanUpdatePackages () == true;
+		}
+
+		protected bool CanUpdatePackagesForSelectedDotNetProjectOrSolution ()
+		{
+			if (IsDotNetProjectSelected ()) {
+				return CanUpdatePackagesForSelectedDotNetProject ();
+			} else if (IsDotNetSolutionSelected ()) {
+				return CanUpdatePackagesForSelectedDotNetSolution ();
+			}
+			return false;
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/UpdateAllPackagesInProjectHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/UpdateAllPackagesInProjectHandler.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		protected override void Update (CommandInfo info)
 		{
-			info.Enabled = SelectedDotNetProjectHasPackages ();
+			info.Enabled = CanUpdatePackagesForSelectedDotNetProject ();
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/UpdateAllPackagesInSolutionHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/UpdateAllPackagesInSolutionHandler.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		protected override void Update (CommandInfo info)
 		{
-			info.Enabled = SelectedDotNetProjectOrSolutionHasPackages ();
+			info.Enabled = CanUpdatePackagesForSelectedDotNetProjectOrSolution ();
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetAwareProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetAwareProject.cs
@@ -1,0 +1,58 @@
+//
+// FakeNuGetAwareProject.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.ProjectManagement;
+
+namespace MonoDevelop.PackageManagement.Tests.Helpers
+{
+	class FakeNuGetAwareProject : DummyDotNetProject, INuGetAwareProject
+	{
+		public NuGetProject CreateNuGetProject ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Task<bool> HasMissingPackages (IMonoDevelopSolutionManager solutionManager)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool HasPackagesReturnValue;
+
+		public bool HasPackages ()
+		{
+			return HasPackagesReturnValue;
+		}
+
+		public Task RestorePackagesAsync (IMonoDevelopSolutionManager solutionManager, INuGetProjectContext context, CancellationToken token)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -182,6 +182,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\DotNetCoreRestoreTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\RestoreTestBase.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\NuGetPackageAssetSourceFilesTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeNuGetAwareProject.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -314,5 +314,14 @@ namespace MonoDevelop.PackageManagement
 			return projectReference.ReferenceType == ReferenceType.Project &&
 				projectReference.ReferenceOutputAssembly;
 		}
+
+		public static bool CanUpdatePackages (this DotNetProject project)
+		{
+			var nugetAwareProject = project as INuGetAwareProject;
+			if (nugetAwareProject != null)
+				return nugetAwareProject.HasPackages ();
+
+			return HasPackages (project.BaseDirectory, project.Name) || project.Items.OfType<ProjectPackageReference> ().Any ();
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SolutionExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SolutionExtensions.cs
@@ -45,12 +45,19 @@ namespace MonoDevelop.PackageManagement
 		{
 			return solution
 				.GetAllDotNetProjects ()
-				.Where (DotNetProjectExtensions.HasPackages);
+				.Where (project => project.HasPackages ());
 		}
 
 		public static bool HasAnyProjectWithPackages (this Solution solution)
 		{
 			return solution.GetAllProjectsWithPackages ().Any ();
+		}
+
+		public static bool CanUpdatePackages (this Solution solution)
+		{
+			return solution
+				.GetAllDotNetProjects ()
+				.Any (project => project.CanUpdatePackages ());
 		}
 	}
 }


### PR DESCRIPTION
Backport of #6166.

/cc @mrward @mrward

Description of #6166:
The Update menu was enabled if the project used PackageReferences but
had none in the project. Without any PackageReferences in the
project there is nothing to update. The check to see if the Update
menu is enabled has been changed to make sure the project has
PackageReferences in the project file, not just imported
PackageReferences. Also extended this logic to be used by the Update
NuGet Packages menu which is used to update packages for the solution.

Fixes VSTS #656994 - Update and restore button/menu should be disabled
for SDK NuGet for .NET core projects