### PR TITLE
[Telemetry] Classify Build/Run events by project type

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -240,7 +240,11 @@ namespace MonoDevelop.Core.Instrumentation
 
 		public CounterMetadata (CounterMetadata original)
 		{
-			this.properties = new Dictionary<string, object> (original.properties);
+			if (original != null) {
+				this.properties = new Dictionary<string, object> (original.properties);
+			} else {
+				this.properties = new Dictionary<string, object> ();
+			}
 		}
 
 		public void AddProperties (CounterMetadata original)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -235,12 +235,16 @@ namespace MonoDevelop.Core.Instrumentation
 
 		public CounterMetadata (IDictionary<string, object> properties)
 		{
-			this.properties = properties;
+			if (properties == null) {
+				this.properties = new Dictionary<string, object> ();
+			} else {
+				this.properties = properties;
+			}
 		}
 
 		public CounterMetadata (CounterMetadata original)
 		{
-			if (original != null) {
+			if (original != null && original.properties != null) {
 				this.properties = new Dictionary<string, object> (original.properties);
 			} else {
 				this.properties = new Dictionary<string, object> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -809,6 +809,20 @@ namespace MonoDevelop.Projects
 			}
 			metadata.ProjectTypes = sb.ToString ();
 
+			metadata.ProjectID = ItemId;
+			metadata.ProjectType = TypeGuid;
+			metadata.ProjectFlavor = FlavorGuids.FirstOrDefault () ?? TypeGuid;
+
+			var capabilities = GetProjectCapabilities ();
+			if (capabilities.Any ())
+				metadata.Capabilities = string.Join (" ", capabilities);
+
+			var c = GetConfiguration (configurationSelector);
+			if (c != null) {
+				metadata.Configuration = c.Id;
+				metadata.Platform = GetExplicitPlatform (c);
+			}
+
 			return metadata;
 		}
 
@@ -1465,19 +1479,6 @@ namespace MonoDevelop.Projects
 			metadata.BuildTypeString = target;
 
 			metadata.FirstBuild = IsFirstBuild;
-			metadata.ProjectID = ItemId;
-			metadata.ProjectType = TypeGuid;
-			metadata.ProjectFlavor = FlavorGuids.FirstOrDefault () ?? TypeGuid;
-
-			var capabilities = GetProjectCapabilities ();
-			if (capabilities.Any ())
-				metadata.Capabilities = string.Join (" ", capabilities);
-
-			var c = GetConfiguration (configuration);
-			if (c != null) {
-				metadata.Configuration = c.Id;
-				metadata.Platform = GetExplicitPlatform (c);
-			}
 
 			bool success = false;
 			bool cancelled = false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1069,9 +1069,15 @@ namespace MonoDevelop.Ide
 			ProjectEventMetadata eventMetadata = null;
 
 			if (entry is Solution solution) {
-				if (runConfiguration == null || runConfiguration is SingleItemSolutionRunConfiguration) {
-					var startupProject = solution.StartupItem;
-					eventMetadata = startupProject.CreateProjectEventMetadata (configuration);
+				SolutionItem solutionItem = null;
+				if (runConfiguration == null) {
+					solutionItem = solution.StartupItem;
+				} else if (runConfiguration is SingleItemSolutionRunConfiguration singleItemSolution) {
+					solutionItem = singleItemSolution.Item;
+				}
+
+				if (solutionItem != null) {
+					eventMetadata = solutionItem.CreateProjectEventMetadata (configuration);
 				}
 			} else if (entry is SolutionItem item) {
 				eventMetadata = item.CreateProjectEventMetadata (configuration);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Ide
 		internal static Counter<CompletionStatisticsMetadata> CodeCompletionStats = InstrumentationService.CreateCounter<CompletionStatisticsMetadata> ("Code Completion Statistics", "IDE", id:"Ide.CodeCompletionStatistics");
 		internal static Counter<TimeToCodeMetadata> TimeToCode = InstrumentationService.CreateCounter<TimeToCodeMetadata> ("Time To Code", "IDE", id: "Ide.TimeToCode");
 		internal static bool TrackingBuildAndDeploy;
-		internal static TimerCounter<CounterMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<CounterMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
+		internal static TimerCounter<BuildAndDeployMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<BuildAndDeployMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
 		internal static Counter<PlatformMemoryMetadata> MemoryPressure = InstrumentationService.CreateCounter<PlatformMemoryMetadata> ("Memory Pressure", "IDE", id: "Ide.MemoryPressure");
 
 		internal static Counter<UnhandledExceptionMetadata> UnhandledExceptions = InstrumentationService.CreateCounter<UnhandledExceptionMetadata> ("Unhandled Exceptions", "IDE", id: "Ide.UnhandledExceptions");
@@ -176,6 +176,26 @@ namespace MonoDevelop.Ide
 	{
 		public System.Exception Exception {
 			get => GetProperty<System.Exception> ();
+			set => SetProperty (value);
+		}
+	}
+
+	class BuildAndDeployMetadata : CounterMetadata
+	{
+		public BuildAndDeployMetadata ()
+		{
+		}
+
+		public BuildAndDeployMetadata (CounterMetadata clone) : base (clone)
+		{
+		}
+
+		public bool BuildWithoutPrompting {
+			get => GetProperty<bool> ();
+			set => SetProperty (value);
+		}
+		public long BuildTime {
+			get => GetProperty<long> ();
 			set => SetProperty (value);
 		}
 	}


### PR DESCRIPTION
Includes extra metadata on the buildanddeploy event:
 - ProjectID
 - ProjectType
 - ProjectFlavor
 - BuildTime

BuildTime is the length of time the build process took.

Fixes VSTS #675546