### PR TITLE
[release-7.7] [Telemetry] Classify Build/Run events by project type

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Ide
 		internal static Counter<CompletionStatisticsMetadata> CodeCompletionStats = InstrumentationService.CreateCounter<CompletionStatisticsMetadata> ("Code Completion Statistics", "IDE", id:"Ide.CodeCompletionStatistics");
 		internal static Counter<TimeToCodeMetadata> TimeToCode = InstrumentationService.CreateCounter<TimeToCodeMetadata> ("Time To Code", "IDE", id: "Ide.TimeToCode");
 		internal static bool TrackingBuildAndDeploy;
-		internal static TimerCounter<CounterMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<CounterMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
+		internal static TimerCounter<BuildAndDeployMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<BuildAndDeployMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
 		internal static Counter<PlatformMemoryMetadata> MemoryPressure = InstrumentationService.CreateCounter<PlatformMemoryMetadata> ("Memory Pressure", "IDE", id: "Ide.MemoryPressure");
 
 		internal static Counter<UnhandledExceptionMetadata> UnhandledExceptions = InstrumentationService.CreateCounter<UnhandledExceptionMetadata> ("Unhandled Exceptions", "IDE", id: "Ide.UnhandledExceptions");
@@ -176,6 +176,29 @@ namespace MonoDevelop.Ide
 	{
 		public System.Exception Exception {
 			get => GetProperty<System.Exception> ();
+			set => SetProperty (value);
+		}
+	}
+
+	class BuildAndDeployMetadata : CounterMetadata
+	{
+		public string ProjectID {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string ProjectType {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public string ProjectFlavor {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
+		public long BuildTime {
+			get => GetProperty<long> ();
 			set => SetProperty (value);
 		}
 	}


### PR DESCRIPTION
Backport of #6178.

/cc @iainx @iainx

Description of #6178:
Includes extra metadata on the buildanddeploy event:
 - ProjectID
 - ProjectType
 - ProjectFlavor
 - BuildTime

BuildTime is the length of time the build process took.

Fixes VSTS #6775546