### PR TITLE
[release-7.7] Display project subcategories as children of categories

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -55,8 +55,8 @@ namespace MonoDevelop.Ide.Projects
 		const int TemplateCategoryNameColumn = 0;
 		const int TemplateCategoryIconColumn = 1;
 		const int TemplateCategoryColumn = 2;
-		ListStore templateCategoriesListStore =
-			new ListStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(TemplateCategory));
+		TreeStore templateCategoriesListStore =
+			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(TemplateCategory));
 		TreeView templatesTreeView;
 		const int TemplateNameColumn = 0;
 		const int TemplateIconColumn = 1;
@@ -176,6 +176,8 @@ namespace MonoDevelop.Ide.Projects
 			templateCategoriesTreeView.HeadersVisible = false;
 			templateCategoriesTreeView.Model = templateCategoriesListStore;
 			templateCategoriesTreeView.SearchColumn = -1; // disable the interactive search
+			templateCategoriesTreeView.ShowExpanders = false;
+
 			templateCategoriesTreeView.AppendColumn (CreateTemplateCategoriesTreeViewColumn ());
 			templateCategoriesScrolledWindow.Add (templateCategoriesTreeView);
 			templateCategoriesBgBox.Add (templateCategoriesScrolledWindow);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -58,6 +58,7 @@ namespace MonoDevelop.Ide.Projects
 
 			templateCategoriesTreeView.Selection.Changed += TemplateCategoriesTreeViewSelectionChanged;
 			templateCategoriesTreeView.Selection.SelectFunction = TemplateCategoriesTreeViewSelection;
+
 			templatesTreeView.Selection.Changed += TemplatesTreeViewSelectionChanged;
 			templatesTreeView.ButtonPressEvent += TemplatesTreeViewButtonPressed;
 			templatesTreeView.Selection.SelectFunction = TemplatesTreeViewSelection;
@@ -322,19 +323,21 @@ namespace MonoDevelop.Ide.Projects
 			Xwt.Drawing.Image icon = GetIcon (category.IconId ?? "md-platform-other", IconSize.Menu);
 			categoryTextRenderer.CategoryIconWidth = (int)icon.Width;
 
-			templateCategoriesListStore.AppendValues (
+			var iter = templateCategoriesListStore.AppendValues (
 				MarkupTopLevelCategoryName (category.Name),
 				icon,
 				category);
 
 			foreach (TemplateCategory subCategory in category.Categories) {
-				AddSubTemplateCategory (subCategory);
+				AddSubTemplateCategory (iter, subCategory);
 			}
+			templateCategoriesTreeView.ExpandAll ();
 		}
 
-		void AddSubTemplateCategory (TemplateCategory category)
+		void AddSubTemplateCategory (TreeIter iter, TemplateCategory category)
 		{
 			templateCategoriesListStore.AppendValues (
+				iter,
 				GLib.Markup.EscapeText (category.Name),
 				null,
 				category);


### PR DESCRIPTION
Backport of #6185.

/cc @slluis @nosami

Description:
So that Voiceover announces the relation between categories and
subcategories.

Fixes VSTS #648743