### PR TITLE
[release-7.7] [DotNetCore] Support .NETStandard 2.0 when new enough Mono is installed

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
@@ -26,91 +26,35 @@
 
 using NUnit.Framework;
 using System.Linq;
+using System;
 
 namespace MonoDevelop.DotNetCore.Tests
 {
 	[TestFixture]
 	class DotNetCoreProjectSupportedTargetFrameworksTests : DotNetCoreVersionsRestorerTestBase
 	{
-		[Test]
-		public void GetNetStandardTargetFrameworks_NetCore20RuntimeInstalled ()
+		static string[] netStandardVersions = { "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
+
+		[TestCase ("5.2.0", "2.0", "2.0.5")]
+		[TestCase ("5.1.99", "1.6", new string[0])]
+		[TestCase ("5.2.0", "2.0", new string[0])]
+		[TestCase ("4.8.0", "1.6", "1.1")]
+		[TestCase ("4.8.0", "2.0", "2.2.0")]
+		[TestCase ("5.1.1", "2.0", "2.1.0")]
+		[TestCase ("5.16.0", "2.0", "1.1")]
+		public void GetNetStandardTargetFrameworks_MonoAndSdkInstalled (string monoVersion, string maxNetStandardVersion, params string[] sdkVersions)
 		{
-			DotNetCoreRuntimesInstalled ("2.0.5");
+			DotNetCoreRuntimesInstalled (sdkVersions);
+			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version (monoVersion);
 
 			var frameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().ToList ();
 
-			Assert.AreEqual (".NETStandard,Version=v2.0", frameworks [0].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.6", frameworks [1].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.5", frameworks [2].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.4", frameworks [3].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.3", frameworks [4].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.2", frameworks [5].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.1", frameworks [6].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.0", frameworks [7].Id.ToString ());
-			Assert.AreEqual (8, frameworks.Count);
-		}
-
-		[Test]
-		public void GetNetStandardTargetFrameworks_NetCore11RuntimeInstalled ()
-		{
-			DotNetCoreRuntimesInstalled ("1.1");
-
-			var frameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().ToList ();
-
-			Assert.AreEqual (".NETStandard,Version=v1.6", frameworks [0].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.5", frameworks [1].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.4", frameworks [2].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.3", frameworks [3].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.2", frameworks [4].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.1", frameworks [5].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.0", frameworks [6].Id.ToString ());
-			Assert.AreEqual (7, frameworks.Count);
-		}
-
-		[Test]
-		public void GetNetStandardTargetFrameworks_NoRuntimeInstalled ()
-		{
-			DotNetCoreRuntimesInstalled (new string [0]);
-
-			var frameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().ToList ();
-
-			Assert.AreEqual (0, frameworks.Count);
-		}
-
-		[Test]
-		public void GetNetStandardTargetFrameworks_NetCore22RuntimeInstalled ()
-		{
-			DotNetCoreRuntimesInstalled ("2.2.0");
-
-			var frameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().ToList ();
-
-			Assert.AreEqual (".NETStandard,Version=v2.0", frameworks[0].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.6", frameworks[1].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.5", frameworks[2].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.4", frameworks[3].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.3", frameworks[4].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.2", frameworks[5].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.1", frameworks[6].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.0", frameworks[7].Id.ToString ());
-			Assert.AreEqual (8, frameworks.Count);
-		}
-
-		[Test]
-		public void GetNetStandardTargetFrameworks_NetCore21RuntimeInstalled ()
-		{
-			DotNetCoreRuntimesInstalled ("2.1.0");
-
-			var frameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().ToList ();
-
-			Assert.AreEqual (".NETStandard,Version=v2.0", frameworks [0].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.6", frameworks [1].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.5", frameworks [2].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.4", frameworks [3].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.3", frameworks [4].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.2", frameworks [5].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.1", frameworks [6].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.0", frameworks [7].Id.ToString ());
-			Assert.AreEqual (8, frameworks.Count);
+			int start = netStandardVersions.IndexOf (maxNetStandardVersion);
+			Assert.That (start, Is.GreaterThanOrEqualTo (0));
+			Assert.That (frameworks.Count, Is.EqualTo (netStandardVersions.Length - start));
+			for (int i = start; i < netStandardVersions.Length; i++) {
+				Assert.AreEqual ($".NETStandard,Version=v{netStandardVersions[i]}", frameworks[i - start].Id.ToString ());
+			}
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
@@ -35,12 +35,12 @@ namespace MonoDevelop.DotNetCore.Tests
 	{
 		static string[] netStandardVersions = { "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
 
-		[TestCase ("5.2.0", "2.0", "2.0.5")]
-		[TestCase ("5.1.99", "1.6", new string[0])]
-		[TestCase ("5.2.0", "2.0", new string[0])]
+		[TestCase ("5.4.0", "2.0", "2.0.5")]
+		[TestCase ("5.3.99", "1.6", new string[0])]
+		[TestCase ("5.4.0", "2.0", new string[0])]
 		[TestCase ("4.8.0", "1.6", "1.1")]
 		[TestCase ("4.8.0", "2.0", "2.2.0")]
-		[TestCase ("5.1.1", "2.0", "2.1.0")]
+		[TestCase ("5.3.1", "2.0", "2.1.0")]
 		[TestCase ("5.16.0", "2.0", "1.1")]
 		public void GetNetStandardTargetFrameworks_MonoAndSdkInstalled (string monoVersion, string maxNetStandardVersion, params string[] sdkVersions)
 		{

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateWizardTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateWizardTests.cs
@@ -121,7 +121,7 @@ namespace MonoDevelop.DotNetCore.Tests
 			CreateWizard ();
 			AddSupportedParameters ("NetStandard");
 			DotNetCoreRuntimesInstalled (new string[0]);
-			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version ("5.1.99");
+			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version ("5.4.0");
 
 			int pages = wizard.TotalPages;
 
@@ -131,20 +131,21 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.IsFalse (WizardHasParameter ("UseNetCore20"));
 			Assert.IsFalse (WizardHasParameter ("UseNetCore1x"));
 			Assert.IsFalse (WizardHasParameter ("framework"));
-			Assert.AreEqual (".NETStandard,Version=v1.6", wizard.TargetFrameworks [0].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.5", wizard.TargetFrameworks [1].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.4", wizard.TargetFrameworks [2].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.3", wizard.TargetFrameworks [3].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.2", wizard.TargetFrameworks [4].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.1", wizard.TargetFrameworks [5].Id.ToString ());
-			Assert.AreEqual (".NETStandard,Version=v1.0", wizard.TargetFrameworks [6].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v2.0", wizard.TargetFrameworks [0].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.6", wizard.TargetFrameworks [1].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.5", wizard.TargetFrameworks [2].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.4", wizard.TargetFrameworks [3].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.3", wizard.TargetFrameworks [4].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.2", wizard.TargetFrameworks [5].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.1", wizard.TargetFrameworks [6].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.0", wizard.TargetFrameworks [7].Id.ToString ());
 
 			var page = wizard.GetPage (1);
-			Assert.AreEqual ("netstandard1.6", wizard.Parameters ["Framework"]);
+			Assert.AreEqual ("netstandard2.0", wizard.Parameters ["Framework"]);
 			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetCore20"));
 			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetCore1x"));
-			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetStandard20"));
-			Assert.IsTrue (wizard.Parameters.GetBoolValue ("UseNetStandard1x"));
+			Assert.IsTrue (wizard.Parameters.GetBoolValue ("UseNetStandard20"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetStandard1x"));
 		}
 
 		/// <summary>
@@ -156,18 +157,19 @@ namespace MonoDevelop.DotNetCore.Tests
 			CreateWizard ();
 			AddSupportedParameters ("NetStandard;FSharpNetStandard");
 			DotNetCoreRuntimesInstalled (new string[0]);
-			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version ("4.8.0");
+			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version ("5.16.0");
 
 			int pages = wizard.TotalPages;
 
-			Assert.AreEqual (0, pages);
+			Assert.AreEqual (1, pages);
 			Assert.IsFalse (WizardHasParameter ("UseNetStandard20"));
-			Assert.IsTrue (wizard.Parameters.GetBoolValue ("UseNetStandard1x"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetStandard1x"));
 			Assert.IsFalse (WizardHasParameter ("UseNetCore20"));
 			Assert.IsFalse (WizardHasParameter ("UseNetCore1x"));
 			Assert.IsFalse (WizardHasParameter ("framework"));
-			Assert.AreEqual (".NETStandard,Version=v1.6", wizard.TargetFrameworks [0].Id.ToString ());
-			Assert.AreEqual (1, wizard.TargetFrameworks.Count);
+			Assert.AreEqual (".NETStandard,Version=v2.0", wizard.TargetFrameworks [0].Id.ToString ());
+			Assert.AreEqual (".NETStandard,Version=v1.6", wizard.TargetFrameworks [1].Id.ToString ());
+			Assert.AreEqual (2, wizard.TargetFrameworks.Count);
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateWizardTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateWizardTests.cs
@@ -29,6 +29,7 @@ using MonoDevelop.Core.StringParsing;
 using MonoDevelop.DotNetCore.Templating;
 using MonoDevelop.Ide.Templates;
 using NUnit.Framework;
+using System;
 
 namespace MonoDevelop.DotNetCore.Tests
 {
@@ -120,6 +121,7 @@ namespace MonoDevelop.DotNetCore.Tests
 			CreateWizard ();
 			AddSupportedParameters ("NetStandard");
 			DotNetCoreRuntimesInstalled (new string[0]);
+			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version ("5.1.99");
 
 			int pages = wizard.TotalPages;
 
@@ -154,6 +156,7 @@ namespace MonoDevelop.DotNetCore.Tests
 			CreateWizard ();
 			AddSupportedParameters ("NetStandard;FSharpNetStandard");
 			DotNetCoreRuntimesInstalled (new string[0]);
+			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version ("4.8.0");
 
 			int pages = wizard.TotalPages;
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkInstalledConditionTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSdkInstalledConditionTests.cs
@@ -35,29 +35,30 @@ namespace MonoDevelop.DotNetCore.Tests
 	[TestFixture]
 	class DotNetCoreSdkInstalledConditionTests : DotNetCoreVersionsRestorerTestBase
 	{
-		[TestCase ("<Condition sdkVersion='2.*' />", "2.1.4", true)]
-		[TestCase ("<Condition sdkVersion='2.*' />", "2.0.3", true)]
-		[TestCase ("<Condition sdkVersion='2.*' />", "2.0.0", true)]
-		[TestCase ("<Condition sdkVersion='2.*' />", "1.0.0", false)]
-		[TestCase ("<Condition sdkVersion='1.*' />", "1.0.0", true)]
-		[TestCase ("<Condition sdkVersion='1.*' />", "1.1.0", true)]
-		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.4", true)]
-		[TestCase ("<Condition sdkVersion='2.0' />", "2.0.3", true)]
+		[TestCase ("<Condition sdkVersion='2.*' />", "2.1.4", "4.8.0", true)]
+		[TestCase ("<Condition sdkVersion='2.*' />", "2.0.3", "5.1.99", true)]
+		[TestCase ("<Condition sdkVersion='2.*' />", "2.0.0", "5.1.99", true)]
+		[TestCase ("<Condition sdkVersion='2.*' />", "1.0.0", "5.1.99", false)]
+		[TestCase ("<Condition sdkVersion='1.*' />", "1.0.0", "5.1.99", true)]
+		[TestCase ("<Condition sdkVersion='1.*' />", "1.1.0", "5.4.0", true)]
+		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.4", "5.4.0", true)]
+		[TestCase ("<Condition sdkVersion='2.0' />", "2.0.3", "5.4.0", true)]
 
 		// Here the sdkVersion is the logical version and not the actual version
 		// .NET Core SDK 2.1.4 supports .NET Core 2.0 so this is treated as the '2.0' SDK.
 		// .NET Core SDK 2.1.300 supports .NET Core 2.1 so this is treated as '2.1' SDK.
-		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.3", true)]
-		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.4", false)]
-		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.300", true)]
-		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.301", true)]
-		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.200", false)]
-		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.200", true)]
-		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.299", false)]
-		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.299", true)]
-		public void DotNetCoreSdkInstalled (string conditionXml, string sdk, bool expected)
+		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.3", "5.4.0", true)]
+		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.4", "4.8.0", false)]
+		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.300", "5.4.0", true)]
+		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.301", "5.1.0", true)]
+		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.200", "4.8.0", false)]
+		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.200", "5.0.0", true)]
+		[TestCase ("<Condition sdkVersion='2.1' />", "2.1.299", "4.6.0", false)]
+		[TestCase ("<Condition sdkVersion='2.0' />", "2.1.299", "5.16.0", true)]
+		public void DotNetCoreSdkInstalled (string conditionXml, string sdk, string monoVersion, bool expected)
 		{
 			DotNetCoreSdksInstalled (new [] { sdk });
+			MonoRuntimeInfoExtensions.CurrentRuntimeVersion = new Version (monoVersion);
 
 			bool result = EvaluateCondition (conditionXml);
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -110,6 +110,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Gui\DotNetCoreSdkLocationWidget.UI.cs">
       <DependentUpon>DotNetCoreSdkLocationWidget.cs</DependentUpon>
     </Compile>
+    <Compile Include="MonoDevelop.DotNetCore\MonoRuntimeInfoExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -62,13 +62,11 @@ namespace MonoDevelop.DotNetCore
 
 		public static IEnumerable<TargetFramework> GetNetStandardTargetFrameworks ()
 		{
-			if (DotNetCoreRuntime.IsNetCore2xInstalled ())
+			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ())
 				yield return CreateTargetFramework (".NETStandard", "2.0");
 
-			if (DotNetCoreRuntime.IsNetCore2xInstalled () || DotNetCoreRuntime.IsNetCore1xInstalled ()) {
-				foreach (var targetFramework in GetTargetFrameworksVersion1x (".NETStandard", HighestNetStandard1xMinorVersionSupported).Reverse ())
-					yield return targetFramework;
-			}
+			foreach (var targetFramework in GetTargetFrameworksVersion1x (".NETStandard", HighestNetStandard1xMinorVersionSupported).Reverse ())
+				yield return targetFramework;
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -35,6 +35,8 @@ namespace MonoDevelop.DotNetCore
 {
 	public static class DotNetCoreSdk
 	{
+		static readonly Version DotNetCoreVersion2_1 = new Version (2, 1, 0);
+
 		static DotNetCoreSdk ()
 		{
 			var sdkPaths = new DotNetCoreSdkPaths ();
@@ -116,8 +118,8 @@ namespace MonoDevelop.DotNetCore
 			if (versions.Any (sdkVersion => IsSupported (projectFramework, projectFrameworkVersion, sdkVersion)))
 				return true;
 
-			// .NET Core 1.x is supported by the MSBuild .NET Core SDKs if they are installed with Mono.
-			if (projectFrameworkVersion.Major == 1)
+			// .NET Core <= 2.1 is supported by the MSBuild .NET Core SDKs if they are installed with Mono.
+			if (projectFrameworkVersion <= DotNetCoreVersion2_1)
 				return msbuildSdksInstalled;
 
 			return false;

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -82,9 +82,9 @@ namespace MonoDevelop.DotNetCore
 			if (requiredSdkversion == "2.2") {
 				return versions.Any (IsNetCoreSdk22);
 			} else if (requiredSdkversion == "2.1") {
-				return versions.Any (IsNetCoreSdk21) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ();
+				return versions.Any (IsNetCoreSdk21) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
 			} else if (requiredSdkversion == "2.0") {
-				return versions.Any (IsNetCoreSdk20) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ();
+				return versions.Any (IsNetCoreSdk20) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
 			}
 
 			requiredSdkversion = requiredSdkversion.Replace ("*", string.Empty);
@@ -92,7 +92,7 @@ namespace MonoDevelop.DotNetCore
 		}
 
 		/// <summary>
-		/// 2.2.100 is the lowest version that supports .NET Core 2.2 projects.
+		/// 2.2 is the lowest version that supports .NET Core 2.2 projects.
 		/// </summary>
 		static bool IsNetCoreSdk22 (DotNetCoreVersion version)
 		{

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Linq;
 using Mono.Addins;
+using MonoDevelop.Core.Assemblies;
 
 namespace MonoDevelop.DotNetCore
 {
@@ -81,9 +82,9 @@ namespace MonoDevelop.DotNetCore
 			if (requiredSdkversion == "2.2") {
 				return versions.Any (IsNetCoreSdk22);
 			} else if (requiredSdkversion == "2.1") {
-				return versions.Any (IsNetCoreSdk21);
+				return versions.Any (IsNetCoreSdk21) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ();
 			} else if (requiredSdkversion == "2.0") {
-				return versions.Any (IsNetCoreSdk20);
+				return versions.Any (IsNetCoreSdk20) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ();
 			}
 
 			requiredSdkversion = requiredSdkversion.Replace ("*", string.Empty);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
@@ -31,13 +31,19 @@ namespace MonoDevelop.DotNetCore
 {
 	static class MonoRuntimeInfoExtensions
 	{
-		static readonly Version MonoVersion5_2 = new Version (5, 2, 0);
+		static readonly Version MonoVersion5_4 = new Version (5, 4, 0);
+		static readonly Version DotNetCore2_1 = new Version (2, 1);
 
 		internal static Version CurrentRuntimeVersion { get; set; } = MonoRuntimeInfo.FromCurrentRuntime ().RuntimeVersion;
 
 		public static bool SupportsNetStandard20 (this Version monoVersion)
 		{
-			return monoVersion >= MonoVersion5_2;
+			return monoVersion >= MonoVersion5_4;
+		}
+
+		public static bool SupportsNetCore (this Version monoVersion, string netCoreVersion)
+		{
+			return monoVersion >= MonoVersion5_4 && Version.Parse (netCoreVersion) <= DotNetCore2_1;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
@@ -1,0 +1,43 @@
+//
+// MonoRuntimeInfoExtensions.cs
+//
+// Author:
+//       Rodrigo Moya <rodrigo.moya@xamarin.com>
+//
+// Copyright (c) 2018, Microsoft, Inc (http://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using MonoDevelop.Core.Assemblies;
+
+namespace MonoDevelop.DotNetCore
+{
+	static class MonoRuntimeInfoExtensions
+	{
+		static readonly Version MonoVersion5_2 = new Version (5, 2, 0);
+
+		internal static Version CurrentRuntimeVersion { get; set; } = MonoRuntimeInfo.FromCurrentRuntime ().RuntimeVersion;
+
+		public static bool SupportsNetStandard20 (this Version monoVersion)
+		{
+			return monoVersion >= MonoVersion5_2;
+		}
+	}
+}


### PR DESCRIPTION
Backport of #6154.

/cc @rodrmoya 

Description:
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/694494