### PR TITLE
[release-7.7] [TextEditor] Handle syntax mode changes on main thread

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -310,8 +310,10 @@ namespace Mono.TextEditor
 
 		void HandleSyntaxModeChanged(object sender, EventArgs e)
 		{
-			PurgeLayoutCache ();
-			textEditor.Document.CommitUpdateAll ();
+			Runtime.RunInMainThread (() => {
+				PurgeLayoutCache ();
+				textEditor.Document.CommitUpdateAll ();
+			});
 		}
 
 		void TextEditor_HighlightSearchPatternChanged (object sender, EventArgs e)


### PR DESCRIPTION
Backport of #6160.

/cc @slluis @iainx

Description:
Handle the syntax mode changes on the main thread so that DisposeLayoutDict is called from the main thread and it won't throw an exception

Fixes VSTS #694980