### PR TITLE
[release-7.6] [Telemetry] Time to Code for file open

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -377,7 +377,8 @@ namespace MonoDevelop.Ide
 
 			// Start this timer to limit the time to decide if the app was opened by a file manager
 			IdeApp.StartFMOpenTimer (FMOpenTimerExpired);
-			IdeApp.Workspace.FirstWorkspaceItemOpened += CompleteTimeToCode;
+			IdeApp.Workspace.FirstWorkspaceItemOpened += CompleteSolutionTimeToCode;
+			IdeApp.Workbench.DocumentOpened += CompleteFileTimeToCode;
 
 			CreateStartupMetadata (startupInfo, sectionTimings);
 
@@ -403,7 +404,9 @@ namespace MonoDevelop.Ide
 
 		void FMOpenTimerExpired ()
 		{
-			IdeApp.Workspace.FirstWorkspaceItemOpened -= CompleteTimeToCode;
+			IdeApp.Workspace.FirstWorkspaceItemOpened -= CompleteSolutionTimeToCode;
+			IdeApp.Workbench.DocumentOpened -= CompleteFileTimeToCode;
+
 			timeToCodeTimer.Stop ();
 			timeToCodeTimer = null;
 
@@ -476,9 +479,26 @@ namespace MonoDevelop.Ide
 			IdeApp.OnStartupCompleted ();
 		}
 
-		static void CompleteTimeToCode (object sender, EventArgs args)
+		enum TimeToCodeFileType
 		{
-			IdeApp.Workspace.FirstWorkspaceItemOpened -= CompleteTimeToCode;
+			Solution,
+			Document
+		}
+
+		static void CompleteSolutionTimeToCode (object sender, EventArgs args)
+		{
+			CompleteTimeToCode (TimeToCodeMetadata.DocumentType.Solution);
+		}
+
+		static void CompleteFileTimeToCode (object sender, EventArgs args)
+		{
+			CompleteTimeToCode (TimeToCodeMetadata.DocumentType.File);
+		}
+
+		static void CompleteTimeToCode (TimeToCodeMetadata.DocumentType type)
+		{
+			IdeApp.Workspace.FirstWorkspaceItemOpened -= CompleteSolutionTimeToCode;
+			IdeApp.Workbench.DocumentOpened -= CompleteFileTimeToCode;
 
 			if (timeToCodeTimer == null) {
 				return;
@@ -489,7 +509,7 @@ namespace MonoDevelop.Ide
 				ttcMetadata.SolutionLoadTime = timeToCodeTimer.ElapsedMilliseconds;
 
 				ttcMetadata.CorrectedDuration = ttcMetadata.StartupTime + ttcMetadata.SolutionLoadTime;
-
+			ttcMetadata.Type = type;
 
 				if (IdeApp.ReportTimeToCode) {
 					Counters.TimeToCode.Inc ("SolutionLoaded", ttcMetadata);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -155,6 +155,11 @@ namespace MonoDevelop.Ide
 
 	class TimeToCodeMetadata : CounterMetadata
 	{
+		public enum DocumentType {
+			Solution,
+			File
+		};
+
 		public long CorrectedDuration {
 			get => GetProperty<long> ();
 			set => SetProperty (value);
@@ -167,6 +172,11 @@ namespace MonoDevelop.Ide
 
 		public long SolutionLoadTime {
 			get => GetProperty<long> ();
+			set => SetProperty (value);
+		}
+
+		public DocumentType Type {
+			get => GetProperty<DocumentType> ();
 			set => SetProperty (value);
 		}
 	}


### PR DESCRIPTION
Backport of #6193.

/cc @iainx 

Description:
Include Time to code event if a file is opened as well

Fixes VSTS #684796