### PR TITLE
[release-7.7] [Telemetry] Time to Code for file open

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -156,6 +156,11 @@ namespace MonoDevelop.Ide
 
 	class TimeToCodeMetadata : CounterMetadata
 	{
+		public enum DocumentType {
+			Solution,
+			File
+		};
+
 		public long CorrectedDuration {
 			get => GetProperty<long> ();
 			set => SetProperty (value);
@@ -168,6 +173,11 @@ namespace MonoDevelop.Ide
 
 		public long SolutionLoadTime {
 			get => GetProperty<long> ();
+			set => SetProperty (value);
+		}
+
+		public DocumentType Type {
+			get => GetProperty<DocumentType> ();
 			set => SetProperty (value);
 		}
 	}


### PR DESCRIPTION
Backport of #6193.

/cc @iainx 

Description:
Include Time to code event if a file is opened as well

Fixes VSTS #684796