### PR TITLE
Fixes VSTS Bug 695076: Highlighting delay moving lines up or down in

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.Platform
 			int start = snapshotSpan.Start.Position;
 			int end = snapshotSpan.End.Position;
 
-			IList<ClassificationSpan> classifications = this.classifier.GetClassificationSpans (snapshotSpan);
+			IList<ClassificationSpan> classifications = this.classifier.GetAllClassificationSpans (snapshotSpan, cancellationToken);
 
 			int lastClassifiedOffsetEnd = start;
 			ScopeStack scopeStack;


### PR DESCRIPTION
.cs file

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/695076

Now the classification call gets properly canceled.