### PR TITLE
[Core] Fix error adding files when project item uses Windows path

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -207,8 +207,11 @@ namespace MonoDevelop.Projects
 
 			var directories = new HashSet<FilePath> ();
 			foreach (FilePath file in GetItemFiles (true)) {
+				var parentDirectory = file.ParentDirectory;
+				if (parentDirectory.IsNullOrEmpty)
+					continue;
 				if (!directories.Any (directory => file.IsChildPathOf (directory)))
-					directories.Add (file.ParentDirectory);
+					directories.Add (parentDirectory);
 			}
 
 			rootDirectories = directories;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileWatcherTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileWatcherTests.cs
@@ -869,5 +869,25 @@ namespace MonoDevelop.Projects
 			Assert.IsTrue (p.NeedsReload);
 			Assert.AreEqual (p, reloadRequiredEventFiredProject);
 		}
+
+		[Test]
+		public async Task GetRootDirectories_WindowsPathUsedForProjectItem_EmptyDirectoryNotIncluded ()
+		{
+			if (Platform.IsWindows)
+				Assert.Ignore ("Not valid on Windows");
+
+			FilePath solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+			var p = (DotNetProject)sol.Items [0];
+			var fileName = @"C:\Program Files (x86)\Microsoft Visual Studio\2017\MSBuild\MSBuild.dll";
+			var reference = ProjectReference.CreateAssemblyFileReference (fileName);
+			p.References.Add (reference);
+
+			var directories = sol.GetRootDirectories ();
+			Assert.IsFalse (directories.Contains (FilePath.Empty));
+			Assert.IsFalse (directories.Contains (FilePath.Null));
+			Assert.AreEqual (1, directories.Count);
+			Assert.IsTrue (directories.First () == sol.BaseDirectory);
+		}
 	}
 }


### PR DESCRIPTION
When a project had a Reference item that used a Windows file path
the file watcher would cause an exception when it tried to determine
the root directories to monitor. This was because the FilePath's
ParentDirectory is empty when a Windows path is used on a non-Windows
operating system. This is now handled.

    <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
      <SpecificVersion>False</SpecificVersion>
      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\Microsoft.NET.Build.Extensions\net461\ref\System.Net.Http.dll</HintPath>
    </Reference>

Fixes VSTS #697655 - Can't create new files for a solution