### PR TITLE
[RFC] Host CPU load counters

### DIFF
--- a/main/src/addins/MacPlatform/KernelInterop.cs
+++ b/main/src/addins/MacPlatform/KernelInterop.cs
@@ -97,7 +97,9 @@ namespace MacPlatform
 		#region Host CPU load
 		unsafe struct host_load_info
 		{
-			public fixed int avenrun[3];
+			public int avenrun_5;
+			public int avenrun_30;
+			public int avenrun_60;
 			public fixed int mach_factor[3];
 		}
 
@@ -125,9 +127,7 @@ namespace MacPlatform
 				return false;
 			}
 
-			unsafe {
-				percentLast5 = (double)loadInfo.avenrun [0] / 1000;
-			}
+			percentLast5 = (double)loadInfo.avenrun_5 / 1000;
 			return true;
 		}
 		#endregion

--- a/main/src/addins/MacPlatform/KernelInterop.cs
+++ b/main/src/addins/MacPlatform/KernelInterop.cs
@@ -30,6 +30,7 @@ namespace MacPlatform
 {
 	static class KernelInterop
 	{
+		#region Virtual memory
 		const int TASK_VM_INFO = 22;
 		const int KERN_SUCCESS = 0;
 
@@ -91,5 +92,44 @@ namespace MacPlatform
 				virtualBytes = info.virtual_size;
 			}
 		}
+		#endregion
+
+		#region Host CPU load
+		unsafe struct host_load_info
+		{
+			public fixed int avenrun[3];
+			public fixed int mach_factor[3];
+		}
+
+		const int HOST_LOAD_INFO = 1;
+		const int LOAD_SCALE = 1000;
+
+
+		[DllImport ("/usr/lib/system/libsystem_kernel.dylib")]
+		static extern IntPtr mach_host_self ();
+
+		[DllImport ("/usr/lib/system/libsystem_kernel.dylib")]
+		static extern int host_statistics (IntPtr host_priv, int flavor, ref host_load_info host_info_out, ref int host_info_outCnt);
+
+		public static bool TrySampleHostCpu (out double percentLast5)
+		{
+			var loadInfo = new host_load_info ();
+			int count;
+			unsafe {
+				count = sizeof (host_load_info) / sizeof (int);
+			}
+
+			int ret = host_statistics (mach_host_self (), HOST_LOAD_INFO, ref loadInfo, ref count);
+			if (ret != KERN_SUCCESS) {
+				percentLast5 = 0;
+				return false;
+			}
+
+			unsafe {
+				percentLast5 = (double)loadInfo.avenrun [0] / 1000;
+			}
+			return true;
+		}
+		#endregion
 	}
 }

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -39,7 +39,6 @@ namespace MacPlatform
 	{
 		int family;
 		int coreCount;
-		int threadCount;
 		long freq;
 		string arch;
 		ulong size;
@@ -60,7 +59,6 @@ namespace MacPlatform
 			Interop.SysCtl ("hw.cpufamily", out result.family);
 			Interop.SysCtl ("hw.cpufrequency", out result.freq);
 			Interop.SysCtl ("hw.physicalcpu", out result.coreCount);
-			Interop.SysCtl ("hw.logicalcpu", out result.threadCount);
 
 			var attrs = NSFileManager.DefaultManager.GetFileSystemAttributes ("/");
 			result.size = attrs.Size;
@@ -98,6 +96,8 @@ namespace MacPlatform
 
 		public int CpuCount => (int)NSProcessInfo.ProcessInfo.ActiveProcessorCount;
 
+		public int PhysicalCpuCount => coreCount;
+
 		public int CpuFamily => family;
 
 		public long CpuFrequency => freq;
@@ -109,10 +109,6 @@ namespace MacPlatform
 		public ulong RamTotal => NSProcessInfo.ProcessInfo.PhysicalMemory;
 
 		public PlatformHardDriveMediaType HardDriveOsMediaType => osType;
-
-		public int CpuCoresCount => coreCount;
-
-		public int CpuThreadCount => threadCount;
 
 		static PlatformHardDriveMediaType GetMediaType (string path)
 		{

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -38,6 +38,8 @@ namespace MacPlatform
 	internal class MacTelemetryDetails : IPlatformTelemetryDetails
 	{
 		int family;
+		int coreCount;
+		int threadCount;
 		long freq;
 		string arch;
 		ulong size;
@@ -57,6 +59,8 @@ namespace MacPlatform
 			Interop.SysCtl ("hw.machine", out result.arch);
 			Interop.SysCtl ("hw.cpufamily", out result.family);
 			Interop.SysCtl ("hw.cpufrequency", out result.freq);
+			Interop.SysCtl ("hw.physicalcpu", out result.coreCount);
+			Interop.SysCtl ("hw.logicalcpu", out result.threadCount);
 
 			var attrs = NSFileManager.DefaultManager.GetFileSystemAttributes ("/");
 			result.size = attrs.Size;
@@ -106,7 +110,9 @@ namespace MacPlatform
 
 		public PlatformHardDriveMediaType HardDriveOsMediaType => osType;
 
+		public int CpuCoreCount => coreCount;
 
+		public int CpuThreadCount => threadCount;
 
 		static PlatformHardDriveMediaType GetMediaType (string path)
 		{

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -110,7 +110,7 @@ namespace MacPlatform
 
 		public PlatformHardDriveMediaType HardDriveOsMediaType => osType;
 
-		public int CpuCoreCount => coreCount;
+		public int CpuCoresCount => coreCount;
 
 		public int CpuThreadCount => threadCount;
 

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -222,5 +222,10 @@ namespace MacPlatform
 
 		[DllImport ("libc")]
 		extern static IntPtr getlastlogxbyname (string name, ref LastLogX ll);
+
+		public bool TrySampleHostCpuLoad (out double value)
+		{
+			return KernelInterop.TrySampleHostCpu (out value);
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
@@ -50,5 +50,7 @@ namespace MonoDevelop.Ide.Desktop
 		PlatformHardDriveMediaType HardDriveOsMediaType { get; }
 		int CpuCoresCount { get; }
 		int CpuThreadCount { get; }
+
+		bool TrySampleHostCpuLoad (out double value);
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
@@ -41,6 +41,7 @@ namespace MonoDevelop.Ide.Desktop
 		TimeSpan UserTime { get; }
 
 		string CpuArchitecture { get; }
+		int PhysicalCpuCount { get; }
 		int CpuCount { get; }
 		int CpuFamily { get; }
 		long CpuFrequency { get; }
@@ -48,8 +49,6 @@ namespace MonoDevelop.Ide.Desktop
 		ulong HardDriveFreeVolumeSize { get; }
 		ulong RamTotal { get; }
 		PlatformHardDriveMediaType HardDriveOsMediaType { get; }
-		int CpuCoresCount { get; }
-		int CpuThreadCount { get; }
 
 		bool TrySampleHostCpuLoad (out double value);
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
@@ -48,5 +48,7 @@ namespace MonoDevelop.Ide.Desktop
 		ulong HardDriveFreeVolumeSize { get; }
 		ulong RamTotal { get; }
 		PlatformHardDriveMediaType HardDriveOsMediaType { get; }
+		int CpuCoresCount { get; }
+		int CpuThreadCount { get; }
 	}
 }


### PR DESCRIPTION
This PR has a few changes:
* Keeps track of the number of physical and logical CPU cores
* We now have a way on the mac host to query the current CPU load information
* Expose the API into IPlatformTelemetryDetails so it can be queried.