### PR TITLE
[a11y] Don't expand preference categories automatically

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OptionsDialog.cs
@@ -598,11 +598,6 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 					((Notebook)c).Page = 0;
 			}
 
-			if (!DesktopService.AccessibilityInUse) {
-				// Don't automatically expand trees if using accessibility
-				// as it can be confusing with screen readers
-				tree.ExpandToPath (store.GetPath (page.Iter));
-			}
 			tree.Selection.SelectIter (page.Iter);
 		}
 		


### PR DESCRIPTION
This is an alternative and more radical fix for #5540 and disables automatic expansion completely, Instead of disabling it just when accessibility tools are enabled.

It improves the usability when navigating with the keyboard, however, due to the underlying design of the dialog, it's visually slightly confusing if a category has no own panel assigned to it. In this case, the focus remains at the category node, but the selection must move to the first child in order to show the next panel.

![preferences no autoexpand](https://user-images.githubusercontent.com/951587/46521361-a20d9100-c87f-11e8-9bef-e32ec4796fcc.gif)

TBH I'm not sure which behaviour is better. @alanjclark what do you think?

> Fixes VSTS [#646431](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646431)