### PR TITLE
[Mac] Use NSAppleScript instead of Carbon to spawn the terminal process

### DIFF
--- a/main/src/addins/MacPlatform/MacExternalConsoleProcess.cs
+++ b/main/src/addins/MacPlatform/MacExternalConsoleProcess.cs
@@ -160,9 +160,8 @@ bash pause on exit trick
 				appleScript = string.Format ("tell app \"{0}\" to do script \"bash -c '{1}'; exit\"", TERMINAL_APP, Escape (sb.ToString ()));
 			}
 			var ret = AppleScript.Run (appleScript);
-			int i = ret.IndexOf ("of", StringComparison.Ordinal);
-			tabId = ret.Substring (0, i -1);
-			windowId = ret.Substring (i + 3);
+			tabId = $"tab {ret ["indx"]}";
+			windowId = $"window id {ret ["ID  "]}";
 
 			//rename tab and give it focus
 			sb.Clear ();
@@ -201,11 +200,6 @@ end tell", TERMINAL_APP, windowId);
 			} catch (AppleScriptException) {
 				//it may already have closed
 			}
-		}
-
-		static bool TabExists (string tabId, string windowId)
-		{
-			return AppleScript.Run ("tell app \"{0}\" to get exists of {1} of {2}", TERMINAL_APP, tabId, windowId) == "true";
 		}
 
 		#endregion

--- a/main/src/addins/MacPlatform/MacInterop/AppleScript.cs
+++ b/main/src/addins/MacPlatform/MacInterop/AppleScript.cs
@@ -24,183 +24,69 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
+
+using Foundation;
 
 namespace MonoDevelop.MacInterop
 {
 	public static class AppleScript
 	{
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSADoScript (ComponentInstance scriptingComponent, ref AEDesc sourceData,
-		                                    OsaId contextID, DescType desiredType, OsaMode modeFlags,
-		                                    ref AEDesc resultingText);
-
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSAExecute (ComponentInstance scriptingComponent, OsaId compiledScriptID,
-		                                   OsaId contextID, OsaMode modeFlags, out OsaId resultingScriptValueID);
-
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSADispose (ComponentInstance scriptingComponent, OsaId scriptID);
-
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSADisplay (ComponentInstance scriptingComponent, OsaId scriptValueID,
-		                                   DescType desiredType, OsaMode modeFlags, out AEDesc resultingText);
-
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSACompile (ComponentInstance scriptingComponent, ref AEDesc sourceData,
-		                                   OsaMode modeFlags, ref OsaId previousAndResultingScriptID);
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSALoad (ComponentInstance scriptingComponent, ref AEDesc sourceData,
-		                                OsaMode modeFlags, ref OsaId previousAndResultingScriptID);
-		
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSACompileExecute (ComponentInstance scriptingComponent, ref AEDesc sourceData,
-		                                           OsaId contextID, OsaMode modeFlags, ref OsaId resultingScriptValueID);
-		
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSALoadExecute (ComponentInstance scriptingComponent, ref AEDesc scriptData,
-		                                       OsaId contextID, OsaMode modeFlags, ref OsaId resultingScriptValueID);
-		
-		[DllImport (Carbon.CarbonLib)]
-		static extern OsaError OSAScriptError (ComponentInstance scriptingComponent, OsaErrorSelector selector,
-		                                       DescType desiredType, out AEDesc resultingErrorDescription);
-		
-		public static string Run (string scriptSourceFormat, params object[] args)
+		public static Dictionary<string, string> Run (string scriptSourceFormat, params object[] args)
 		{
 			return Run (string.Format (scriptSourceFormat, args));
 		}
-		
-		public static string Run (string scriptSource)
-		{
-			AEDesc sourceData = new AEDesc ();
 
-			try {
-				AppleEvent.AECreateDescUtf8 (scriptSource, out sourceData);
-				return Run (true, ref sourceData);
-			} catch (AppleScriptException ex) {
-				MonoDevelop.Core.LoggingService.LogWarning (
-					"Applescript failure: {0}\n[[\n{1}\n]]",
-					ex.Message,
-					scriptSource);
-				throw;
-			} finally {
-				AppleEvent.AEDisposeDesc (ref sourceData);
-			}
-		}
-		
-		public static string Run (byte[] compiledBytes)
+		// A simplistic method of decoding the descriptors
+		// descriptors are made up of 3 parts followed by another descriptor or a null descriptor
+		// [1] a 4 character parameter name (eg: 'indx' or 'ID  '
+		// [2] a 4 letter object type (eg 'ttab') indicating the type of the object the parameter is on
+		// [3] a value
+		// [4] descriptor
+		//
+		// This simplistic method ignores the object type, we don't need it at the moment
+		// because the parameter names we are looking for are unique.
+		static void DecodeDescriptor (NSAppleEventDescriptor descriptor, Dictionary<string, string> valuePairs)
 		{
-			AEDesc sourceData = new AEDesc ();
-			try {
-				AppleEvent.AECreateDesc ((OSType)(int)OsaType.OsaGenericStorage, compiledBytes, out sourceData);
-				return Run (false, ref sourceData);
-			} finally {
-				AppleEvent.AEDisposeDesc (ref sourceData);
-			}
-		}
-		
-		static string Run (bool compile, ref AEDesc scriptData)
-		{
-			string value;
-			var ret = Run (compile, ref scriptData, out value);
-			
-			switch (ret) {
-			case OsaError.Success:
-				return value;
-			case OsaError.Timeout:
-				throw new TimeoutException ("The AppleScript command timed out.");
-			default:
-				throw new AppleScriptException (ret, value);
-			}
-		}
-		
-		static OsaError Run (bool compile, ref AEDesc scriptData, out string value)
-		{
-			var component = ComponentManager.OpenDefaultComponent ((OSType)(int)OsaType.OsaComponent, (OSType)(int)OsaType.AppleScript);
-			if (component.IsNull)
-				throw new AppleScriptException (OsaError.GeneralError, "Could not load component");
-			AEDesc resultData = new AEDesc ();
-			OsaId contextId = new OsaId (), scriptId = new OsaId (), resultId = new OsaId ();
-			try {
-				AppleEvent.AECreateDescNull (out resultData);
-				//apparently UnicodeText doesn't work
-				var resultType = new DescType () { Value = (OSType)"TEXT" };
-				
-				//var result = OSADoScript (component, ref sourceData, contextId, resultType, OsaMode.Default, ref resultData);
-				
-				OsaError result;
-				if (compile)
-					result = OSACompile (component, ref scriptData, OsaMode.Default, ref scriptId);
-				else
-					result = OSALoad (component, ref scriptData, OsaMode.Default, ref scriptId);
-				
-				if (result == OsaError.Success) {
-					result = OSAExecute (component, scriptId, contextId, OsaMode.Default, out resultId);
-					if (result == OsaError.Success) {
-						result = OSADisplay (component, resultId, resultType, OsaMode.Default, out resultData);
-						if (result == OsaError.Success) {
-							value = AppleEvent.GetStringFromAEDesc (ref resultData);
-							return result;
-						}
+			string key = null;
+
+			// Descriptor indices start at 1
+			for (nint i = 1; i <= descriptor.NumberOfItems; i++) {
+				var desc = descriptor.DescriptorAtIndex (i);
+				if (desc == null) {
+					continue;
+				}
+
+				if (!string.IsNullOrEmpty (desc.StringValue)) {
+					if (key == null) {
+						key = desc.StringValue;
+					} else {
+						valuePairs [key] = desc.StringValue;
 					}
 				}
-				var errorDesc = new AEDesc ();
-				try {
-					AppleEvent.AECreateDescNull (out resultData);
-					if (OsaError.Success == OSAScriptError (component, OsaErrorSelector.Message, resultType, out errorDesc)) {
-						value = AppleEvent.GetStringFromAEDesc (ref errorDesc);
-						return result;
-					}
-					throw new AppleScriptException (result, null);
-				} finally {
-					AppleEvent.AEDisposeDesc (ref errorDesc);
+
+				if (desc.NumberOfItems > 1) {
+					DecodeDescriptor (desc, valuePairs);
 				}
-			} finally {
-				AppleEvent.AEDisposeDesc (ref scriptData);
-				AppleEvent.AEDisposeDesc (ref resultData);
-				if (!contextId.IsZero)
-					OSADispose (component, contextId);
-				if (!scriptId.IsZero)
-					OSADispose (component, scriptId);
-				if (!resultId.IsZero)
-					OSADispose (component, resultId);
-				if (!component.IsNull)
-					ComponentManager.CloseComponent (component);
 			}
 		}
-	}
-	
-	[StructLayout (LayoutKind.Sequential,Pack=2)]
-	struct OsaId : IEquatable<OsaId>
-	{
-		IntPtr value;
-		
-		public IntPtr Value {
-			get { return value; }
-		}
-		
-		public bool Equals (OsaId other)
+
+		public static Dictionary<string, string> Run (string scriptSource)
 		{
-			return other.value == value;
-		}
-		
-		public bool IsZero {
-			get { return value == IntPtr.Zero; }
+			var script = new NSAppleScript (scriptSource);
+			var result = script.ExecuteAndReturnError (out var errorInfo);
+
+			var dict = new Dictionary<string, string> ();
+			DecodeDescriptor (result, dict);
+
+			if (result == null) {
+				throw new AppleScriptException (errorInfo);
+			}
+
+			return dict;
 		}
 	}
-	
-	enum OsaErrorSelector
-	{
-		Number = 1701999214, // = keyErrorNumber = 'errn'
-		Message = 1701999219, // = keyErrorString = 'errs'
-		BriefMessage = 1701999202, //'errb'
-		App = 1701994864, // 'erap'
-		PartialResult = 1886678130, // 'ptlr'
-		OffendingObject = 1701998434, // 'erob'
-		ExpectedType = 1701999220, // 'errt'
-		Range = 1701998183, // 'erng'
-	}
-	
+
 	public enum OsaError : int //this is a ComponentResult typedef - is it long on int64? Many of these values can be gotten from MacErrors.h
 	{
 		Success = 0,
@@ -252,57 +138,61 @@ namespace MonoDevelop.MacInterop
 		CantAssign = -10006,
 	}
 	
-	enum OsaType : int
-	{
-		OsaComponent	 = 0x6f736120, // 'osa '
-		OsaGenericScriptingComponent = 0x73637074, // 'scpt'
-		OsaFile = 0x6f736173, // 'osas'
-		AppleScript = 1634952050, // 'ascr'
-		OsaGenericStorage = OsaGenericScriptingComponent,
-		OsaResource = OsaGenericScriptingComponent,
-	}
-	
-	[Flags]
-	enum OsaMode {
-		Default = 0,
-		PreventGetSource = 0x00000001,
-		NeverInteract = 0x00000010,
-		CanInteract = 0x00000020,
-		AlwaysInteract = 0x00000030,
-		DontReconnect = 0x00000080,
-		CantSwitchLayer = 0x00000040,
-		DoRecord = 0x00001000,
-		CompileIntoContext = 0x00000002,
-		AugmentContext = 0x00000004,
-		DisplayForHumans = 0x00000008,
-		DontStoreParent = 0x00010000,
-		DispatchToDirectObject = 0x00020000,
-		DontGetDataForArguments = 0x00040000,
-		FullyQualifyDescriptors = 0x00080000,
-	}
-	
 	public class AppleScriptException : Exception
 	{
-		public AppleScriptException (OsaError error, string returnValue)
-			: base (GetFullMessage (error, returnValue))
+		static class NSAppleScriptError
 		{
-			ErrorCode = error;
-			ReturnValue = returnValue;
+			public const string Number = "NSAppleScriptErrorNumber";
+			public const string Message = "NSAppleScriptErrorMessage";
+			public const string BriefMessage = "NSAppleScriptErrorBriefMessage";
+			public const string AppName = "NSAppleScriptErrorAppName";
 		}
 
-		static string GetFullMessage (OsaError error, string returnValue)
+		public AppleScriptException (NSDictionary errorDict)
+			: base (GetFullMessage (errorDict))
 		{
-			if (!string.IsNullOrEmpty (returnValue)) {
-				return string.Format ("{0}: {1}", error, returnValue);
-			}
-			return error.ToString ();
+			ErrorCode = (OsaError)IntFromNSDictionary (errorDict, NSAppleScriptError.Number);
+			ErrorMessage = StringFromNSDictionary (errorDict, NSAppleScriptError.Message);
+			AppName = StringFromNSDictionary (errorDict, NSAppleScriptError.AppName);
 		}
-		
+
+		static string GetFullMessage (NSDictionary errorDict)
+		{
+			string message = StringFromNSDictionary (errorDict, NSAppleScriptError.BriefMessage);
+			return message ?? StringFromNSDictionary (errorDict, NSAppleScriptError.Message);
+		}
+
+		static string StringFromNSDictionary (NSDictionary dict, string key)
+		{
+			if (dict.TryGetValue ((NSString)key, out var errorObject)) {
+				if (errorObject is NSString errorString) {
+					return errorString;
+				}
+			}
+
+			return null;
+		}
+
+		static int IntFromNSDictionary (NSDictionary dict, string key)
+		{
+			if (dict.TryGetValue ((NSString)key, out var errorObject)) {
+				if (errorObject is NSNumber errorNumber) {
+					return errorNumber.Int32Value;
+				}
+			}
+
+			return -1;
+		}
+
 		public OsaError ErrorCode {
 			get; private set;
 		}
 
-		public string ReturnValue {
+		public string AppName {
+			get; private set;
+		}
+
+		public string ErrorMessage {
 			get; private set;
 		}
 	}


### PR DESCRIPTION
Uses Cocoa's NSAppleScript class to do all the heavy lifting of compiling and executing the AppleScript code