### PR TITLE
[Mac, Ide] Add ThermalMonitor implementation.

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1259,11 +1259,12 @@ namespace MonoDevelop.MacIntegration
 			return new MacThermalMonitor ();
 		}
 
-		class MacThermalMonitor : ThermalMonitor
+		internal class MacThermalMonitor : ThermalMonitor, IDisposable
 		{
+			NSObject observer;
 			public MacThermalMonitor ()
 			{
-				NSProcessInfo.Notifications.ObserveThermalStateDidChange ((o, args) => {
+				observer = NSProcessInfo.Notifications.ObserveThermalStateDidChange ((o, args) => {
 					var metadata = new PlatformThermalMetadata {
 						ThermalStatus = ToPlatform (NSProcessInfo.ProcessInfo.ThermalState),
 					};
@@ -1288,6 +1289,14 @@ namespace MonoDevelop.MacIntegration
 				default:
 					LoggingService.LogError ("Unknown NSProcessInfoThermalState value {0}", status.ToString ());
 					return PlatformThermalStatus.Normal;
+				}
+			}
+
+			public void Dispose ()
+			{
+				if (observer != null) {
+					NSNotificationCenter.DefaultCenter.RemoveObserver (observer);
+					observer = null;
 				}
 			}
 		}

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1250,6 +1250,47 @@ namespace MonoDevelop.MacIntegration
 				}
 			}
 		}
+
+		internal override ThermalMonitor CreateThermalMonitor ()
+		{
+			if (MacSystemInformation.OsVersion < new Version (10, 10, 3))
+				return base.CreateThermalMonitor ();
+
+			return new MacThermalMonitor ();
+		}
+
+		class MacThermalMonitor : ThermalMonitor
+		{
+			public MacThermalMonitor ()
+			{
+				NSProcessInfo.Notifications.ObserveThermalStateDidChange ((o, args) => {
+					var metadata = new PlatformThermalMetadata {
+						ThermalStatus = ToPlatform (NSProcessInfo.ProcessInfo.ThermalState),
+					};
+
+					var thermalArgs = new PlatformThermalStatusEventArgs (metadata);
+					OnStatusChanged (thermalArgs);
+				});
+			}
+
+			static PlatformThermalStatus ToPlatform (NSProcessInfoThermalState status)
+			{
+				switch (status)
+				{
+				case NSProcessInfoThermalState.Nominal:
+					return PlatformThermalStatus.Normal;
+				case NSProcessInfoThermalState.Fair:
+					return PlatformThermalStatus.Fair;
+				case NSProcessInfoThermalState.Critical:
+					return PlatformThermalStatus.Critical;
+				case NSProcessInfoThermalState.Serious:
+					return PlatformThermalStatus.Serious;
+				default:
+					LoggingService.LogError ("Unknown NSProcessInfoThermalState value {0}", status.ToString ());
+					return PlatformThermalStatus.Normal;
+				}
+			}
+		}
 	}
 
 	public class ThemedMacWindowBackend : Xwt.Mac.WindowBackend

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -599,9 +599,15 @@ namespace MonoDevelop.Ide.Desktop
 		}
 
 		internal virtual MemoryMonitor CreateMemoryMonitor () => new NullMemoryMonitor ();
+		internal virtual ThermalMonitor CreateThermalMonitor () => new NullThermalMonitor ();
 
 		internal class NullMemoryMonitor : MemoryMonitor
 		{
+		}
+
+		internal class NullThermalMonitor : ThermalMonitor
+		{
+
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/ThermalMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/ThermalMonitor.cs
@@ -1,0 +1,44 @@
+//
+// ThermalMonitor.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace MonoDevelop.Ide.Desktop
+{
+	public abstract class ThermalMonitor
+	{
+		/// <summary>
+		/// Notify that the platform thermal status has changed.
+		/// </summary>
+		protected virtual void OnStatusChanged (PlatformThermalStatusEventArgs args)
+		{
+			StatusChanged?.Invoke (this, args);
+		}
+
+		/// <summary>
+		/// Occurs then the OS signals that the thermal status has changed.
+		/// </summary>
+		public event EventHandler<PlatformThermalStatusEventArgs> StatusChanged;
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4195,6 +4195,8 @@
     <Compile Include="MonoDevelop.Ide\ProductInformationProvider.cs" />
     <Compile Include="MonoDevelop.Ide\RuntimeVersionInfo.cs" />
     <Compile Include="MonoDevelop.Ide.Updater\UpdateInfo.cs" />
+    <Compile Include="MonoDevelop.Ide.Desktop\ThermalMonitor.cs" />
+    <Compile Include="MonoDevelop.Ide\PlatformThermalStatusEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -75,12 +75,20 @@ namespace MonoDevelop.Ide
 			MemoryMonitor = platformService.CreateMemoryMonitor ();
 			MemoryMonitor.StatusChanged += OnMemoryStatusChanged;
 
+			ThermalMonitor = platformService.CreateThermalMonitor ();
+			ThermalMonitor.StatusChanged += OnThermalStatusChanged;
+
 			FontService.Initialize ();
 		}
 
 		static void OnMemoryStatusChanged (object sender, PlatformMemoryStatusEventArgs args)
 		{
 			Counters.MemoryPressure.Inc (args.CounterMetadata);
+		}
+
+		static void OnThermalStatusChanged (object sender, PlatformThermalStatusEventArgs args)
+		{
+			Counters.ThermalNotification.Inc (args.CounterMetadata);
 		}
 
 		/// <summary>
@@ -417,6 +425,7 @@ namespace MonoDevelop.Ide
 
 		internal static string GetNativeRuntimeDescription () => PlatformService.GetNativeRuntimeDescription ();
 
+		public static ThermalMonitor ThermalMonitor { get; private set; }
 		public static MemoryMonitor MemoryMonitor { get; private set; }
 		static readonly Lazy<IPlatformTelemetryDetails> platformTelemetryDetails = new Lazy<IPlatformTelemetryDetails> (() => PlatformService.CreatePlatformTelemetryDetails ());
 		public static IPlatformTelemetryDetails PlatformTelemetry => platformTelemetryDetails.Value; 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/PlatformThermalStatusEventArgs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/PlatformThermalStatusEventArgs.cs
@@ -1,0 +1,56 @@
+//
+// PlatformThermalStatusEventArgs.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using MonoDevelop.Core.Instrumentation;
+
+namespace MonoDevelop.Ide
+{
+	public enum PlatformThermalStatus
+	{
+		Normal,
+		Fair,
+		Critical,
+		Serious
+	}
+
+	public class PlatformThermalStatusEventArgs : EventArgs
+	{
+		public PlatformThermalMetadata CounterMetadata { get; }
+
+		public PlatformThermalStatusEventArgs (PlatformThermalMetadata counterMetadata)
+		{
+			CounterMetadata = counterMetadata;
+		}
+	}
+
+	public class PlatformThermalMetadata : CounterMetadata
+	{
+		public PlatformThermalStatus ThermalStatus {
+			get => GetProperty<PlatformThermalStatus> ();
+			set => SetProperty (value);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -72,6 +72,7 @@ namespace MonoDevelop.Ide
 		internal static bool TrackingBuildAndDeploy;
 		internal static TimerCounter<BuildAndDeployMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<BuildAndDeployMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
 		internal static Counter<PlatformMemoryMetadata> MemoryPressure = InstrumentationService.CreateCounter<PlatformMemoryMetadata> ("Memory Pressure", "IDE", id: "Ide.MemoryPressure");
+		internal static Counter<PlatformThermalMetadata> ThermalNotification = InstrumentationService.CreateCounter<PlatformThermalMetadata> ("Thermal Notification", "IDE", id: "Ide.ThermalNotification");
 
 		internal static Counter<UnhandledExceptionMetadata> UnhandledExceptions = InstrumentationService.CreateCounter<UnhandledExceptionMetadata> ("Unhandled Exceptions", "IDE", id: "Ide.UnhandledExceptions");
 		internal static class ParserService {

--- a/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
+++ b/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="CarbonTests.cs" />
     <Compile Include="MimeMapLoaderTests.cs" />
     <Compile Include="MemoryMonitorTests.cs" />
+    <Compile Include="ThermalMonitorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\addins\MacPlatform\MacPlatform.csproj">

--- a/main/tests/MacPlatform.Tests/ThermalMonitorTests.cs
+++ b/main/tests/MacPlatform.Tests/ThermalMonitorTests.cs
@@ -1,0 +1,49 @@
+//
+// ThermalMonitorTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Foundation;
+using MonoDevelop.Ide;
+using MonoDevelop.MacIntegration;
+using NUnit.Framework;
+
+namespace MacPlatform.Tests
+{
+	[TestFixture]
+	public class ThermalMonitorTests : IdeTestBase
+	{
+		[Test]
+		public void TestNotificationsAreMapped ()
+		{
+			using (var monitor = new MacPlatformService.MacThermalMonitor ()) {
+				bool hit = false;
+				monitor.StatusChanged += (o, args) => hit = true;
+				NSNotificationCenter.DefaultCenter.PostNotificationName (NSProcessInfo.ThermalStateDidChangeNotification, new NSObject ());
+
+				Assert.IsTrue (hit);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This monitor is used to tell the application when the host's fan
rotation speed changes due to temperature increase

Fixes VSTS #698542 - Use Thermal monitoring and battery source to improve performance

TODO: tests