### PR TITLE
Fixed VSTS Bug 694579: [Feedback] The file '[redacted]' could not be

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -613,8 +613,8 @@ namespace Mono.TextEditor
 			markerLayout.FontDescription = markerLayoutFont;
 
 			// Gutter font may be bigger
-			GetFontMetrics (textEditor.Options.GutterFont, textEditor.Options.GutterFontName, out double gutterFontLineHeight, out double fontCharWidth, out underlinePosition, out underLineThickness);
-			GetFontMetrics (textEditor.Options.Font, textEditor.Options.FontName, out double fontLineHeight, out fontCharWidth, out underlinePosition, out underLineThickness);
+			GetFontMetrics (textEditor.Options.GutterFont, out double gutterFontLineHeight, out double fontCharWidth, out underlinePosition, out underLineThickness);
+			GetFontMetrics (textEditor.Options.Font, out double fontLineHeight, out fontCharWidth, out underlinePosition, out underLineThickness);
 			this.textEditor.GetTextEditorData ().LineHeight = fontLineHeight;
 			this.charWidth = fontCharWidth;
 
@@ -665,14 +665,15 @@ namespace Mono.TextEditor
 		public int UnderlinePosition => underlinePosition;
 		public int UnderLineThickness => underLineThickness;
 
-		void GetFontMetrics(Pango.FontDescription font, string fontName, out double lineHeight, out double charWidth, out int underlinePosition, out int underLineThickness)
+		void GetFontMetrics (Pango.FontDescription font, out double lineHeight, out double charWidth, out int underlinePosition, out int underLineThickness)
 		{
 			using (var metrics = textEditor.PangoContext.GetMetrics(font, textEditor.PangoContext.Language)) {
 #if MAC
 				double baseHeight;
-				if (fontName != null) {
-					baseHeight = OSXEditor.GetLineHeight(fontName) * textEditor.Options.Zoom;
-				} else {
+				try {
+					baseHeight = OSXEditor.GetLineHeight(font.ToString ()) * textEditor.Options.Zoom;
+				} catch (Exception e) {
+					LoggingService.LogError ("Error while getting the macOS font metrics for " + font, e);
 					baseHeight = (metrics.Ascent + metrics.Descent) / Pango.Scale.PangoScale;
 				}
 				lineHeight = System.Math.Ceiling (0.5 + baseHeight);


### PR DESCRIPTION
opened.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/694579

The pango font is always valid - it fails back to a default version.
Using the font name is not safe.