### PR TITLE
[release-7.7] Fixes issue #5994 ArgumentNull: entity in

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Tooltips/LanguageItemTooltipProvider.cs
@@ -166,6 +166,8 @@ namespace MonoDevelop.SourceEditor
 
 		public static Task<TooltipInformation> CreateTooltipInformation (CancellationToken ctoken, MonoDevelop.Ide.Editor.TextEditor editor, MonoDevelop.Ide.Editor.DocumentContext ctx, ISymbol entity, bool smartWrap, bool createFooter = false, SemanticModel model = null)
 		{
+			if (entity == null)
+				return TaskUtil.Default<TooltipInformation> ();
 			var tooltipInfo = new TooltipInformation ();
 
 			var sig = new SignatureMarkupCreator (ctx, editor != null ? editor.CaretOffset : 0);


### PR DESCRIPTION
Backport of #6226.

/cc @mkrueger 

Description:
SignatureMarkupCreator.cs:238 Shouldn't happen in monodevelop core
since entity is checked in c# ambience (the only point where this
method is called in monodevelop).