### PR TITLE
[VSTest] improve VSTest project loading

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestAdapter.cs
@@ -93,9 +93,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 						cache = false;
 						continue;
 					}
-					foreach (var path in Directory.GetFiles (folder, "*.TestAdapter.dll", SearchOption.AllDirectories))
-						result += path + ";";
-					foreach (var path in Directory.GetFiles (folder, "*.testadapter.dll", SearchOption.AllDirectories))
+					foreach (var path in Directory.EnumerateFiles (folder, "*.testadapter.dll", SearchOption.AllDirectories))
 						if (!result.Contains (path))
 							result += path + ";";
 				}


### PR DESCRIPTION
GetFiles by itself would take up to 852ms (I imagine not much of an improvement here), but we were doing it twice!

It looks like some code was duplicated and not cleaned up after.