### PR TITLE
Revert "Fixes VSTS Bug 695076: Highlighting delay moving lines up or …

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.Platform
 			int start = snapshotSpan.Start.Position;
 			int end = snapshotSpan.End.Position;
 
-			IList<ClassificationSpan> classifications = this.classifier.GetAllClassificationSpans (snapshotSpan, cancellationToken);
+			IList<ClassificationSpan> classifications = this.classifier.GetClassificationSpans (snapshotSpan);
 
 			int lastClassifiedOffsetEnd = start;
 			ScopeStack scopeStack;


### PR DESCRIPTION
…down in"

This reverts commit e6d4394074ebbf287ace192c09dc6dd4f047e3f4.

This patch seems to make the editor slower.