### PR TITLE
[Core] Reduce the number of times we do IO on trying to find an assembly's referenced items

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionFolder.cs
@@ -565,20 +565,25 @@ namespace MonoDevelop.Projects
 		public SolutionItem FindSolutionItem (string fileName)
 		{
 			string path = Path.GetFullPath (fileName);
-			foreach (SolutionFolderItem it in Items) {
+
+			return FindSolutionItemRecursive (items, path);
+		}
+
+		static SolutionItem FindSolutionItemRecursive (SolutionFolderItemCollection items, string fullPath)
+		{
+			foreach (SolutionFolderItem it in items) {
 				if (it is SolutionFolder sf) {
-					SolutionItem r = sf.FindSolutionItem (fileName);
+					SolutionItem r = FindSolutionItemRecursive (sf.Items, fullPath);
 					if (r != null)
 						return r;
-				}
-				else if (it is SolutionItem se) {
-					if (!string.IsNullOrEmpty (se.FileName) && path == Path.GetFullPath (se.FileName))
+				} else if (it is SolutionItem se) {
+					if (!string.IsNullOrEmpty (se.FileName) && fullPath == Path.GetFullPath (se.FileName))
 						return (SolutionItem)it;
 				}
 			}
 			return null;
 		}
-		
+
 		public Project FindProjectByName (string name)
 		{
 			foreach (SolutionFolderItem it in Items) {


### PR DESCRIPTION
Fixes VSTS #700045 - AssemblyReference.GetReferencedItems can be improved