### PR TITLE
[Editor] Fix some performance issue happening on classification changes

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -197,28 +197,19 @@ namespace Microsoft.VisualStudio.Platform
 			}
 		}
 
-        private void OnClassificationChanged (object sender, ClassificationChangedEventArgs args)
-		{
-			var handler = _highlightingStateChanged;
-			if (handler != null) {
-				foreach (Mono.TextEditor.MdTextViewLineCollection.MdTextViewLine line in textView.TextViewLines) {
-					if (line.Start.Position > args.ChangeSpan.End.Position || line.End.Position < args.ChangeSpan.Start)
-						continue;
-					var oldSegments = line.layoutWrapper.HighlightedLine.Segments;
-					var newSegments = GetHighlightedLineAsync (line.line, CancellationToken.None).Result.Segments;
-					if (oldSegments.Count != newSegments.Count) {
-						handler (this, new LineEventArgs (line.line));
-						continue;
-					}
-					for (int i = 0; i < oldSegments.Count; i++) {
-						if (newSegments [i].ColorStyleKey != oldSegments [i].ColorStyleKey) {
-							handler (this, new LineEventArgs (line.line));
-							break;
-						}
-					}
-				}
-			}
-		}
+        private void OnClassificationChanged(object sender, ClassificationChangedEventArgs args)
+        {
+            var handler = _highlightingStateChanged;
+            if (handler != null)
+            {
+                foreach (Mono.TextEditor.MdTextViewLineCollection.MdTextViewLine line in textView.TextViewLines)
+                {
+                    if (line.Start.Position > args.ChangeSpan.End.Position || line.End.Position < args.ChangeSpan.Start)
+                        continue;
+                    handler(this, new LineEventArgs(line.line));
+                }
+            }
+        }
 
 		private ScopeStack GetScopeStackFromClassificationType (IClassificationType classificationType)
 		{


### PR DESCRIPTION
Fixes VSTS #700077 - Listening to batched tags changed causes way too many line updates

A trace like:
```
1.33%   HandlerInternal  •  2,414 ms  •  161 calls  •  MonoDevelop.Ide.DispatchService+GtkSynchronizationContext+TimeoutProxy.HandlerInternal(IntPtr)
  1.08%   cctor>b__20_0  •  1,961 ms  •  24 calls  •  Microsoft.VisualStudio.Threading.JoinableTaskFactory+SingleExecuteProtector+<>c.cctor>b__20_0(Object)
    1.08%   MoveNext  •  1,960 ms  •  24 calls  •  Microsoft.VisualStudio.Utilities.JoinableTaskHelper+<>c__DisplayClass4_0+<<RunOnUIThread>b__0>d.MoveNext
      1.08%   RaiseBatchedTagsChanged  •  1,959 ms  •  24 calls  •  Microsoft.VisualStudio.Text.Tagging.Implementation.TagAggregator`1.RaiseBatchedTagsChanged
        1.08%   RaiseEvent  •  1,959 ms  •  24 calls  •  Microsoft.VisualStudio.Text.Utilities.GuardedOperations.RaiseEvent(Object, EventHandler, TArgs)
          1.08%   OnBatchedTagsChanged  •  1,959 ms  •  24 calls  •  Microsoft.VisualStudio.Text.Classification.Implementation.ClassifierAggregator.OnBatchedTagsChanged(Object, BatchedTagsChangedEventArgs)
            1.08%   OnClassificationChanged  •  1,958 ms  •  31 calls  •  Microsoft.VisualStudio.Platform.TagBasedSyntaxHighlighting.OnClassificationChanged(Object, ClassificationChangedEventArgs)
              1.04%   GetHighlightedLineAsync  •  1,876 ms  •  1,784 calls  •  Microsoft.VisualStudio.Platform.TagBasedSyntaxHighlighting.GetHighlightedLineAsync(IDocumentLine, CancellationToken)
                ►0.97%   GetClassificationSpans  •  1,759 ms  •  1,784 calls  •  Microsoft.VisualStudio.Text.Classification.Implementation.ClassifierAggregator.GetClassificationSpans(SnapshotSpan)
                 0.03%   25 functions hidden  •  47 ms total  •  181398 calls total
                ►0.01%   GetScopeStackFromClassificationType  •  14 ms  •  7,789 calls  •  Microsoft.VisualStudio.Platform.TagBasedSyntaxHighlighting.GetScopeStackFromClassificationType(IClassificationType)
                ►0.01%   ScanAndAddComment  •  13 ms  •  625 calls  •  Microsoft.VisualStudio.Platform.TagBasedSyntaxHighlighting.ScanAndAddComment(List, Int32, ScopeStack, ClassificationSpan)
                ►0.01%   op_Subtraction  •  11 ms  •  11,412 calls  •  Microsoft.VisualStudio.Text.SnapshotPoint.op_Subtraction(SnapshotPoint, Int32)
                ►0.01%   get_End  •  9 ms  •  9,573 calls  •  Microsoft.VisualStudio.Text.SnapshotSpan.get_End
               0.01%   21 functions hidden  •  27 ms total  •  80727 calls total
              ►0.01%   get_ColorStyleKey  •  26 ms  •  22,432 calls  •  MonoDevelop.Ide.Editor.Highlighting.ColoredSegment.get_ColorStyleKey
              ►0.01%   SyntaxMode_HighlightingStateChanged  •  18 ms  •  139 calls  •  Mono.TextEditor.TextDocument.SyntaxMode_HighlightingStateChanged(Object, LineEventArgs)
             0.00%   8 functions hidden  •  0 ms total  •  289 calls total
           0.00%   3 functions hidden  •  0 ms total  •  72 calls total
         0.00%   6 functions hidden  •  0 ms total  •  131 calls total
       0.00%   5 functions hidden  •  2 ms total  •  120 calls total
  ►0.16%   PostCallback  •  283 ms  •  102 calls  •  MonoDevelop.Core.SynchronizationContextTaskScheduler.PostCallback(Object)
  ►0.09%   <RaiseEvent>b__11_0  •  168 ms  •  13 calls  •  MonoDevelop.Core.EventQueue+<>c__11`1.<RaiseEvent>b__11_0(Object)
   0.00%   4 functions hidden  •  1 ms total  •  344 calls total
```

Is reduced to:
```
0.22%   HandlerInternal  •  356 ms  •  109 calls  •  MonoDevelop.Ide.DispatchService+GtkSynchronizationContext+TimeoutProxy.HandlerInternal(IntPtr)
  ►0.09%   <RaiseEvent>b__11_0  •  144 ms  •  12 calls  •  MonoDevelop.Core.EventQueue+<>c__11`1.<RaiseEvent>b__11_0(Object)
  0.07%   cctor>b__20_0  •  123 ms  •  19 calls  •  Microsoft.VisualStudio.Threading.JoinableTaskFactory+SingleExecuteProtector+<>c.cctor>b__20_0(Object)
    0.07%   MoveNext  •  122 ms  •  19 calls  •  Microsoft.VisualStudio.Utilities.JoinableTaskHelper+<>c__DisplayClass4_0+<<RunOnUIThread>b__0>d.MoveNext
      0.07%   RaiseBatchedTagsChanged  •  121 ms  •  19 calls  •  Microsoft.VisualStudio.Text.Tagging.Implementation.TagAggregator`1.RaiseBatchedTagsChanged
        0.07%   RaiseEvent  •  121 ms  •  19 calls  •  Microsoft.VisualStudio.Text.Utilities.GuardedOperations.RaiseEvent(Object, EventHandler, TArgs)
          ►0.07%   OnBatchedTagsChanged  •  121 ms  •  19 calls  •  Microsoft.VisualStudio.Text.Classification.Implementation.ClassifierAggregator.OnBatchedTagsChanged(Object, BatchedTagsChangedEventArgs)
          ►0.00%   BeforeCallingEventHandler  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Text.Utilities.GuardedOperations.BeforeCallingEventHandler(Delegate)
          ►0.00%   AfterCallingEventHandler  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Text.Utilities.GuardedOperations.AfterCallingEventHandler(Delegate)
           0.00%   GetInvocationList  •  0 ms  •  19 calls  •  System.MulticastDelegate.GetInvocationList
         0.00%   BatchedTagsChangedEventArgs..ctor  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Text.Tagging.BatchedTagsChangedEventArgs..ctor(IList)
         0.00%   Add  •  0 ms  •  25 calls  •  System.Collections.Generic.List`1.Add(T)
         0.00%   List`1..ctor  •  0 ms  •  19 calls  •  System.Collections.Generic.List`1..ctor(Int32)
         0.00%   get_IsClosed  •  0 ms  •  19 calls  •  Mono.TextEditor.MonoTextEditor.get_IsClosed
         0.00%   get_InLayout  •  0 ms  •  19 calls  •  Mono.TextEditor.MonoTextEditor.get_InLayout
        ►0.00%   get_Count  •  0 ms  •  4 calls  •  Microsoft.VisualStudio.Text.Tagging.Implementation.TagAggregator+MappingSpanLink`1.get_Count
       0.00%   SetResult  •  1 ms  •  19 calls  •  System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetResult(Task)
       0.00%   SwitchToMainThreadAsync  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Threading.JoinableTaskFactory.SwitchToMainThreadAsync(CancellationToken)
       0.00%   GetResult  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Threading.JoinableTaskFactory+MainThreadAwaiter.GetResult
       0.00%   GetAwaiter  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Threading.JoinableTaskFactory+MainThreadAwaitable.GetAwaiter
       0.00%   get_IsCompleted  •  0 ms  •  19 calls  •  Microsoft.VisualStudio.Threading.JoinableTaskFactory+MainThreadAwaiter.get_IsCompleted
  ►0.05%   PostCallback  •  87 ms  •  56 calls  •  MonoDevelop.Core.SynchronizationContextTaskScheduler.PostCallback(Object)
   0.00%   4 functions hidden  •  3 ms total  •  240 calls total
```