### PR TITLE
[WelcomePage] Show it when the app goes idle

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -600,7 +600,7 @@ namespace MonoDevelop.MacIntegration
 
 				ApplicationEvents.OpenDocuments += delegate (object sender, ApplicationDocumentEventArgs e) {
 					//OpenFiles may pump the mainloop, but can't do that from an AppleEvent, so use a brief timeout
-					GLib.Timeout.Add (10, delegate {
+					GLib.Timeout.Add (0, delegate {
 						IdeApp.ReportTimeToCode = true;
 						IdeApp.OpenFiles (e.Documents.Select (
 							doc => new FileOpenInformation (doc.Key, null, doc.Value, 1, OpenDocumentOptions.DefaultInternal))
@@ -611,7 +611,7 @@ namespace MonoDevelop.MacIntegration
 				};
 
 				ApplicationEvents.OpenUrls += delegate (object sender, ApplicationUrlEventArgs e) {
-					GLib.Timeout.Add (10, delegate {
+					GLib.Timeout.Add (0, delegate {
 						IdeApp.ReportTimeToCode = true;
 						// Open files via the monodevelop:// URI scheme, compatible with the
 						// common TextMate scheme: http://blog.macromates.com/2007/the-textmate-url-scheme/

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -117,32 +117,35 @@ namespace MonoDevelop.Ide.Gui
 				monitor.EndTask ();
 			}
 		}
-		
-		internal void Show (string workbenchMemento)
+
+		internal void Realize (string workbenchMemento)
 		{
 			Counters.Initialization.Trace ("Realizing Root Window");
 			RootWindow.Realize ();
+
 			Counters.Initialization.Trace ("Loading memento");
 			var memento = PropertyService.Get (workbenchMemento, new Properties ());
 			Counters.Initialization.Trace ("Setting memento");
 			workbench.Memento = memento;
 
-			// Very important: see https://github.com/mono/monodevelop/pull/6064
-			// Otherwise the editor may not be focused on IDE startup and can't be
-			// focused even by clicking with the mouse.
-			RootWindow.Visible = true;
 			Counters.Initialization.Trace ("Setting layout");
 			workbench.CurrentLayout = "Solution";
-			
+
 			// now we have an layout set notify it
 			Counters.Initialization.Trace ("Setting layout");
 			if (LayoutChanged != null)
 				LayoutChanged (this, EventArgs.Empty);
-			
+
 			Counters.Initialization.Trace ("Initializing monitors");
 			monitors.Initialize ();
+		}
 
-			Counters.Initialization.Trace ("Making visible");
+		internal void Show ()
+		{
+			// Very important: see https://github.com/mono/monodevelop/pull/6064
+			// Otherwise the editor may not be focused on IDE startup and can't be
+			// focused even by clicking with the mouse.
+			RootWindow.Visible = true;
 			Present ();
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -205,7 +205,7 @@ namespace MonoDevelop.Ide
 			}
 		}
 
-		public static void Initialize (ProgressMonitor monitor)
+		public static void Initialize (ProgressMonitor monitor, bool hideWelcomePage)
 		{
 			// Already done in IdeSetup, but called again since unit tests don't use IdeSetup.
 			DispatchService.Initialize ();
@@ -233,8 +233,8 @@ namespace MonoDevelop.Ide
 			};
 			
 			FileService.ErrorHandler = FileServiceErrorHandler;
-		
-			monitor.BeginTask (GettextCatalog.GetString("Loading Workbench"), 6);
+
+			monitor.BeginTask (GettextCatalog.GetString("Loading Workbench"), 5);
 			Counters.Initialization.Trace ("Loading Commands");
 			
 			commandService.LoadCommands ("/MonoDevelop/Ide/Commands");
@@ -248,10 +248,9 @@ namespace MonoDevelop.Ide
 			Counters.Initialization.Trace ("Initializing Workbench");
 			workbench.Initialize (monitor);
 			monitor.Step (1);
-			
-			MonoDevelop.Ide.WelcomePage.WelcomePageService.Initialize ();
-			MonoDevelop.Ide.WelcomePage.WelcomePageService.ShowWelcomePage ();
 
+			Counters.Initialization.Trace ("Initializing WelcomePage service");
+			MonoDevelop.Ide.WelcomePage.WelcomePageService.Initialize ();
 			monitor.Step (1);
 
 			Counters.Initialization.Trace ("Restoring Workbench State");
@@ -261,7 +260,7 @@ namespace MonoDevelop.Ide
 			Counters.Initialization.Trace ("Flushing GUI events");
 			DispatchService.RunPendingEvents ();
 			Counters.Initialization.Trace ("Flushed GUI events");
-			
+
 			MessageService.RootWindow = workbench.RootWindow;
 			Xwt.MessageDialog.RootWindow = Xwt.Toolkit.CurrentEngine.WrapWindow (workbench.RootWindow);
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -255,8 +255,8 @@ namespace MonoDevelop.Ide
 			MonoDevelop.Ide.WelcomePage.WelcomePageService.Initialize ();
 			monitor.Step (1);
 
-			Counters.Initialization.Trace ("Restoring Workbench State");
-			workbench.Show ("SharpDevelop.Workbench.WorkbenchMemento");
+			Counters.Initialization.Trace ("Realizing Workbench Window");
+			workbench.Realize ("SharpDevelop.Workbench.WorkbenchMemento");
 			monitor.Step (1);
 			
 			Counters.Initialization.Trace ("Flushing GUI events");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -205,7 +205,9 @@ namespace MonoDevelop.Ide
 			}
 		}
 
-		public static void Initialize (ProgressMonitor monitor, bool hideWelcomePage)
+		public static void Initialize (ProgressMonitor monitor) => Initialize (monitor, false);
+
+		internal static void Initialize (ProgressMonitor monitor, bool hideWelcomePage)
 		{
 			// Already done in IdeSetup, but called again since unit tests don't use IdeSetup.
 			DispatchService.Initialize ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -258,10 +258,6 @@ namespace MonoDevelop.Ide
 			Counters.Initialization.Trace ("Realizing Workbench Window");
 			workbench.Realize ("SharpDevelop.Workbench.WorkbenchMemento");
 			monitor.Step (1);
-			
-			Counters.Initialization.Trace ("Flushing GUI events");
-			DispatchService.RunPendingEvents ();
-			Counters.Initialization.Trace ("Flushed GUI events");
 
 			MessageService.RootWindow = workbench.RootWindow;
 			Xwt.MessageDialog.RootWindow = Xwt.Toolkit.CurrentEngine.WrapWindow (workbench.RootWindow);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -455,12 +455,14 @@ namespace MonoDevelop.Ide
 		static bool OnIdle ()
 		{
 			Composition.CompositionManager.InitializeAsync ().Ignore ();
+
 			// OpenDocuments appears when the app is idle.
-			LoggingService.LogWarning ("Showing welcome page");
 			if (!hideWelcomePage) {
 				WelcomePage.WelcomePageService.ShowWelcomePage ();
 				Counters.Initialization.Trace ("Showed welcome page");
 			}
+
+			IdeApp.Workbench.Show ();
 			return false;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -367,6 +367,10 @@ namespace MonoDevelop.Ide
 			AddinManager.AddExtensionNodeHandler("/MonoDevelop/Ide/InitCompleteHandlers", OnExtensionChanged);
 			StartLockupTracker ();
 
+			// This call is important so the current event loop is run before we run the main loop.
+			// On Mac, the OpenDocuments event gets handled here, so we need to get the timeout
+			// it queues before the OnIdle event so we can start opening a solution before
+			// we show the main window.
 			DispatchService.RunPendingEvents ();
 
 			sectionTimings ["PumpEventLoop"] = startupSectionTimer.ElapsedMilliseconds;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -71,6 +71,7 @@ namespace MonoDevelop.Ide
 		static Stopwatch startupSectionTimer = new Stopwatch ();
 		static Stopwatch timeToCodeTimer = new Stopwatch ();
 		static Dictionary<string, long> sectionTimings = new Dictionary<string, long> ();
+		static bool hideWelcomePage;
 
 		static TimeToCodeMetadata ttcMetadata;
 
@@ -278,8 +279,9 @@ namespace MonoDevelop.Ide
 				// which is then replaced with a second empty Apple menu.
 				// XBC #33699
 				Counters.Initialization.Trace ("Initializing IdeApp");
-				IdeApp.Initialize (monitor);
 
+				hideWelcomePage = startupInfo.HasFiles;
+				IdeApp.Initialize (monitor, hideWelcomePage);
 				sectionTimings ["AppInitialization"] = startupSectionTimer.ElapsedMilliseconds;
 				startupSectionTimer.Restart ();
 
@@ -453,6 +455,12 @@ namespace MonoDevelop.Ide
 		static bool OnIdle ()
 		{
 			Composition.CompositionManager.InitializeAsync ().Ignore ();
+			// OpenDocuments appears when the app is idle.
+			LoggingService.LogWarning ("Showing welcome page");
+			if (!hideWelcomePage) {
+				WelcomePage.WelcomePageService.ShowWelcomePage ();
+				Counters.Initialization.Trace ("Showed welcome page");
+			}
 			return false;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -367,6 +367,9 @@ namespace MonoDevelop.Ide
 			AddinManager.AddExtensionNodeHandler("/MonoDevelop/Ide/InitCompleteHandlers", OnExtensionChanged);
 			StartLockupTracker ();
 
+			DispatchService.RunPendingEvents ();
+
+			sectionTimings ["PumpEventLoop"] = startupSectionTimer.ElapsedMilliseconds;
 			startupTimer.Stop ();
 			startupSectionTimer.Stop ();
 


### PR DESCRIPTION
Do not trigger showing the welcome page until the app is idle,
so as to not load the welcome page when a solution is passed to the app.

This improves startup time for solutions/documents loaded from finder

Fixes VSTS #652347 - Welcome page should not show when loading a solution from finder