### PR TITLE
[Ide] Add a way for the infobar to deduplicate items

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/IInfoBarHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/IInfoBarHost.cs
@@ -35,6 +35,7 @@ namespace MonoDevelop.Ide.Gui.Components
 	{
 		public string Description { get; }
 		public InfoBarItem[] Items { get; set; }
+		public object Id { get; set; }
 
 		public InfoBarOptions (string description)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -38,10 +38,13 @@ namespace MonoDevelop.Ide.Gui.Components
 		static Image closeImageInactive = Image.FromResource ("pad-close-9.png").WithAlpha (0.5);
 
 		readonly Label descriptionLabel;
+		Action onDispose;
 		Size minTextSize = Size.Zero;
 
-		public XwtInfoBar (string description, params InfoBarItem[] items)
+		public XwtInfoBar (string description, Action onDispose, params InfoBarItem[] items)
 		{
+			this.onDispose = onDispose;
+
 			var mainBox = new HBox {
 				BackgroundColor = Styles.NotificationBar.BarBackgroundColor,
 			};
@@ -108,6 +111,14 @@ namespace MonoDevelop.Ide.Gui.Components
 			} else {
 				Content = mainBox;
 			}
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			onDispose?.Invoke ();
+			onDispose = null;
+
+			base.Dispose (disposing);
 		}
 
 		protected override void OnBoundsChanged ()


### PR DESCRIPTION
Deduplicate infobar items from showing. This allows for users
to safely use AddInfoBar at any point.

Fixes VSTS #685084 - Limit and deduplicate refactoring error info bars