### PR TITLE
Fixed Bug 694576: [Feedback] Pressing "Arrow Down" to choose the

### DIFF
--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -527,6 +527,10 @@ namespace MonoDevelop.Xml.Editor
 				//and is used to show </Element> completion, user can either confirm(Return/Tab keys) this completion
 				//or just start typing inner content of element, in which case we want current completion to be aborted
 				//so we always want to CloseWindow action in PostProcess.
+				if (descriptor.SpecialKey == SpecialKey.Up || descriptor.SpecialKey == SpecialKey.Down) {
+					keyAction = KeyActions.None;
+					return false;
+				}
 				keyAction = KeyActions.CloseWindow;
 				return true;
 			}


### PR DESCRIPTION
closing tag completion in XAML IntelliSense closes the completion
window

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/694576

That behavior was implemented on purpose for some reason but I agree
to the bug reporter that changing the behavior that way there is not
wanted.