### PR TITLE
[release-7.7] Prevent esc key propagation in Visualizer dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/ValueVisualizerDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/ValueVisualizerDialog.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Mono.Debugging.Client;
 using Gtk;
+using Gdk;
 
 namespace MonoDevelop.Debugger.Viewers
 {
@@ -76,6 +77,20 @@ namespace MonoDevelop.Debugger.Viewers
 				buttonCancel.Label = Gtk.Stock.Close;
 				buttonSave.Hide ();
 			}
+		}
+
+		protected override bool OnKeyPressEvent (EventKey evnt)
+		{
+			if (evnt.Key == Gdk.Key.Escape) {
+				GLib.Timeout.Add (100, delegate {
+					this.Destroy ();
+					return false;
+				});
+
+				// Prevent the escape key from propagating down to the ExceptionCaughtDialog
+				return false;
+			}
+			return base.OnKeyPressEvent (evnt);
 		}
 
 		protected virtual void OnComboVisualizersChanged (object sender, EventArgs e)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/ValueVisualizerDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/ValueVisualizerDialog.cs
@@ -82,13 +82,9 @@ namespace MonoDevelop.Debugger.Viewers
 		protected override bool OnKeyPressEvent (EventKey evnt)
 		{
 			if (evnt.Key == Gdk.Key.Escape) {
-				GLib.Timeout.Add (100, delegate {
-					this.Destroy ();
-					return false;
-				});
-
+				Respond (Gtk.ResponseType.Cancel);
 				// Prevent the escape key from propagating down to the ExceptionCaughtDialog
-				return false;
+				return true;
 			}
 			return base.OnKeyPressEvent (evnt);
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -732,13 +732,13 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			}
 		}
 
-		protected override bool OnKeyReleaseEvent (Gdk.EventKey evnt)
+		protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
 		{
 			if (evnt.Key == Gdk.Key.Escape) {
 				this.Destroy ();
 				return true;
 			}
-			return base.OnKeyReleaseEvent (evnt);
+			return base.OnKeyPressEvent (evnt);
 		}
 	}
 


### PR DESCRIPTION
Backport of #6267.

/cc @nosami 

Description:
Stop the escape key closing both the Value Visualizer dialog and the
Exception caught dialog

Fixes VSTS #648194