### PR TITLE
[Core] Add a simple race checker, that detects when lock contention happens on a resource

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -737,6 +737,7 @@
     <Compile Include="MonoDevelop.FSW\PathTreeNode.cs" />
     <Compile Include="MemoryExtensions.cs" />
     <Compile Include="MonoDevelop.Core.Instrumentation\BucketTimings.cs" />
+    <Compile Include="MonoDevelop.Utilities\RaceChecker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="BuildVariables.cs.in" />
@@ -773,6 +774,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.Core.Tests" />
     <InternalsVisibleTo Include="MonoDevelop.Ide.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="MonoDevelop.Utilities\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild" Inputs="BuildVariables.cs.in; $(MSBuildProjectDirectory)\..\..\..\..\version.config" Outputs="BuildVariables.cs" Condition="Exists('$(MSBuildProjectDirectory)\..\..\..\..\version.config')">

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/RaceChecker.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/RaceChecker.cs
@@ -1,0 +1,84 @@
+//
+// RaceChecker.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Threading;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Utilities
+{
+	abstract class RaceChecker
+	{
+		string lockHolderStacktrace;
+		readonly object lockObject;
+		readonly Disposer lockRelease;
+
+		protected RaceChecker ()
+		{
+			lockObject = new object ();
+			lockRelease = new Disposer (lockObject);
+		}
+
+		public IDisposable Lock ()
+		{
+			if (Monitor.TryEnter (lockObject)) {
+				lockHolderStacktrace = Environment.StackTrace;
+			} else {
+				Monitor.Enter (lockObject);
+				var thisTrace = Environment.StackTrace;
+				OnRace (lockHolderStacktrace, thisTrace);
+				lockHolderStacktrace = thisTrace;
+			}
+
+			return lockRelease;
+		}
+
+		protected abstract void OnRace (string trace1, string trace2);
+
+		class Disposer : IDisposable
+		{
+			readonly object lockObject;
+
+			public Disposer (object lockObject)
+			{
+				this.lockObject = lockObject;
+			}
+
+			public void Dispose ()
+			{
+				Monitor.Pulse (lockObject);
+				Monitor.Exit (lockObject);
+			}
+		}
+	}
+
+	class LoggingRaceChecker : RaceChecker
+	{
+		protected override void OnRace (string trace1, string trace2)
+		{
+			LoggingService.LogError ($"Detected race:{Environment.NewLine}Stacktrace 1:{Environment.NewLine}{trace1}{Environment.NewLine}Stacktrace 2:{Environment.NewLine}{trace2}");
+		}
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="MonoDevelop.Core\PropertyTests.cs" />
     <Compile Include="MonoDevelop.Projects\GetAnalyzerFilesAsyncTests.cs" />
     <Compile Include="MonoDevelop.Core.Instrumentation\BucketTimingsTests.cs" />
+    <Compile Include="MonoDevelop.Utilities\RaceCheckerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
@@ -148,6 +149,7 @@
   <ItemGroup>
     <Folder Include="MonoDevelop.FSW\" />
     <Folder Include="MonoDevelop.Core.Instrumentation\" />
+    <Folder Include="MonoDevelop.Utilities\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Utilities/RaceCheckerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Utilities/RaceCheckerTests.cs
@@ -1,0 +1,68 @@
+//
+// RaceCheckerTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace MonoDevelop.Utilities
+{
+	[TestFixture]
+	public class RaceCheckerTests
+	{
+		class CaptureRaceChecker : RaceChecker
+		{
+			public List<(string, string)> Traces = new List<(string, string)> ();
+
+			protected override void OnRace (string trace1, string trace2)
+			{
+				Traces.Add ((trace1, trace2));
+			}
+		}
+
+		[Test]
+		public async Task CheckRaceDetected ()
+		{
+			const int count = 3;
+
+			var tasks = new Task [count];
+			var raceChecker = new CaptureRaceChecker ();
+
+			for (int i = 0; i < count; ++i) {
+				tasks [i] = Task.Run (() => {
+					using (raceChecker.Lock ()) {
+						// Do not use await Task.Delay, as we need to be on the same thread.
+						Thread.Sleep (100);
+					}
+				});
+			}
+
+			await Task.WhenAll (tasks);
+			Assert.AreEqual (2, raceChecker.Traces.Count);
+		}
+	}
+}


### PR DESCRIPTION
In non-async code, it can be used to monitor which threads are using a given resource.

It might be useful to debug unwanted races.

A LoggingRaceChecker is added by default.

The 2nd commit is there to be able to diagnose the msbuild property group race.