### PR TITLE
[Mac] Make stub launcher configure mono hybrid suspend

### DIFF
--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -12,6 +12,10 @@ MONOSTUB_DEFINES=-DXM_REGISTRAR
 MONOSTUB_STATIC_LINK=$(EXTERNAL)/Xamarin.Mac.registrar.full.a
 EXTERN_C_XM_REGISTRAR_DEFINE=$(shell ./check-xm-extern.sh)
 
+if !RELEASE_BUILDS
+HYBRID_SUSPEND_ABORT=-DHYBRID_SUSPEND_ABORT
+endif
+
 #SDK_PATH=$(shell xcrun --sdk macosx10.8 --show-sdk-path)
 
 PACKAGE_UPDATE_ID=$(shell $(MD_CONFIGURE) get-releaseid)
@@ -39,10 +43,10 @@ libsystemnative.dylib: System_Native.o
 	cp $@ ../bin
 
 monostub.o: monostub.mm $(MONOSTUB_EXTRA_SOURCES)
-	g++ -g $(EXTERN_C_XM_REGISTRAR_DEFINE) $(MONOSTUB_DEFINES) -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
+	g++ -g $(EXTERN_C_XM_REGISTRAR_DEFINE) $(MONOSTUB_DEFINES) $(HYBRID_SUSPEND_ABORT) -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub-nogui.o: monostub.mm $(MONOSTUB_EXTRA_SOURCES)
-	g++ -g $(EXTERN_C_XM_REGISTRAR_DEFINE) $(MONOSTUB_DEFINES) -DNOGUI -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
+	g++ -g $(EXTERN_C_XM_REGISTRAR_DEFINE) $(MONOSTUB_DEFINES) $(HYBRID_SUSPEND_ABORT) -DNOGUI -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub: monostub.o $(MONOSTUB_STATIC_LINK)
 	clang++ -g -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -350,6 +350,9 @@ int main (int argc, char **argv)
 	}
 
 	setenv ("MONO_GC_PARAMS", "major=marksweep-conc,nursery-size=8m", 0);
+#if HYBRID_SUSPEND_ABORT
+	setenv ("MONO_SLEEP_ABORT_LIMIT", "5000", 0);
+#endif
 
 	// To be removed: https://github.com/mono/monodevelop/issues/6326
 	setenv ("MONO_THREADS_SUSPEND", "preemptive", 0);


### PR DESCRIPTION
This commit tells mono to report any kind of hang in mono
due to gc hybrid suspend, as opposed to just hanging, as it currently does.

Usable to report bugs to runtime time team about hybrid suspend.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/703564

> [Fixes  VSTS #703564](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/703564)