### PR TITLE
[7.7][Ide] Add a way for the infobar to deduplicate items

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/IInfoBarHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/IInfoBarHost.cs
@@ -35,6 +35,7 @@ namespace MonoDevelop.Ide.Gui.Components
 	{
 		public string Description { get; }
 		public InfoBarItem[] Items { get; set; }
+		public object Id { get; set; }
 
 		public InfoBarOptions (string description)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -37,19 +37,17 @@ namespace MonoDevelop.Ide.Gui.Components
 		static Image closeImage = Image.FromResource ("pad-close-9.png");
 		static Image closeImageInactive = Image.FromResource ("pad-close-9.png").WithAlpha (0.5);
 
-		public XwtInfoBar (string description, params InfoBarItem[] items)
-		{
-			Build (description, items);
-		}
+		readonly Label descriptionLabel;
+		Size minTextSize = Size.Zero;
 
-		void Build (string description, params InfoBarItem[] items)
+		public XwtInfoBar (string description, params InfoBarItem[] items)
 		{
 			var mainBox = new HBox {
 				BackgroundColor = Styles.NotificationBar.BarBackgroundColor,
 			};
 
 			mainBox.PackStart (new ImageView (ImageService.GetIcon (Stock.Information, Gtk.IconSize.Menu)), marginLeft: 11);
-			mainBox.PackStart (new Label (description));
+			mainBox.PackStart (descriptionLabel = new Label (description));
 
 			if (items.Length > 0) {
 				mainBox.PackStart (new Label ("–"));
@@ -110,6 +108,27 @@ namespace MonoDevelop.Ide.Gui.Components
 			} else {
 				Content = mainBox;
 			}
+		}
+
+		protected override void OnBoundsChanged ()
+		{
+			if (minTextSize.IsZero && !string.IsNullOrEmpty (descriptionLabel.Text)) {
+				var measureLayout = new TextLayout {
+					Text = descriptionLabel.Text,
+					Font = descriptionLabel.Font
+				};
+				minTextSize = measureLayout.GetSize ();
+			}
+			if (descriptionLabel.Size.Width < minTextSize.Width) {
+				TooltipText = descriptionLabel.Text;
+				descriptionLabel.Ellipsize = EllipsizeMode.End;
+				descriptionLabel.ExpandHorizontal = true;
+			} else {
+				TooltipText = string.Empty;
+				descriptionLabel.Ellipsize = EllipsizeMode.None;
+				descriptionLabel.ExpandHorizontal = false;
+			}
+			base.OnBoundsChanged ();
 		}
 
 		sealed class InfoBarCloseButton : InfoBarButton

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -38,10 +38,13 @@ namespace MonoDevelop.Ide.Gui.Components
 		static Image closeImageInactive = Image.FromResource ("pad-close-9.png").WithAlpha (0.5);
 
 		readonly Label descriptionLabel;
+		Action onDispose;
 		Size minTextSize = Size.Zero;
 
-		public XwtInfoBar (string description, params InfoBarItem[] items)
+		public XwtInfoBar (string description, Action onDispose, params InfoBarItem[] items)
 		{
+			this.onDispose = onDispose;
+
 			var mainBox = new HBox {
 				BackgroundColor = Styles.NotificationBar.BarBackgroundColor,
 			};
@@ -108,6 +111,14 @@ namespace MonoDevelop.Ide.Gui.Components
 			} else {
 				Content = mainBox;
 			}
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			onDispose?.Invoke ();
+			onDispose = null;
+
+			base.Dispose (disposing);
 		}
 
 		protected override void OnBoundsChanged ()


### PR DESCRIPTION

Deduplicate infobar items from showing. This allows for users
to safely use AddInfoBar at any point.

Fixes VSTS #685084 - Limit and deduplicate refactoring error info bars
