### PR TITLE
[NUnit] Workaround assembly loading errors

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/ExternalTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/ExternalTestRunner.cs
@@ -48,7 +48,11 @@ namespace MonoDevelop.UnitTesting.NUnit.External
 		IRemoteEventListener listener;
 		readonly string assemblyDirectory;
 
-		public ExternalTestRunner (string assemblyDirectory = null)
+		public ExternalTestRunner ()
+		{
+		}
+
+		public ExternalTestRunner (string assemblyDirectory)
 		{
 			this.assemblyDirectory = assemblyDirectory;
 		}

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/ExternalTestRunner.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/ExternalTestRunner.cs
@@ -46,15 +46,17 @@ namespace MonoDevelop.UnitTesting.NUnit.External
 	{
 		RemoteProcessConnection connection;
 		IRemoteEventListener listener;
+		readonly string assemblyDirectory;
 
-		public ExternalTestRunner ()
+		public ExternalTestRunner (string assemblyDirectory = null)
 		{
+			this.assemblyDirectory = assemblyDirectory;
 		}
 
 		public Task Connect (NUnitVersion version, IExecutionHandler executionHandler = null, OperationConsole console = null)
 		{
 			var exePath = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), version.ToString (), "NUnitRunner.exe");
-			connection = new RemoteProcessConnection (exePath, executionHandler, console, Runtime.MainSynchronizationContext);
+			connection = new RemoteProcessConnection (exePath, assemblyDirectory, executionHandler, console, Runtime.MainSynchronizationContext);
 			connection.AddListener (this);
 			return connection.Connect ();
 		}

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitAssemblyTestSuite.cs
@@ -332,7 +332,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 
 				try {
 					if (File.Exists (ld.Path)) {
-						runner = new ExternalTestRunner ();
+						runner = new ExternalTestRunner (Path.GetDirectoryName (ld.Path));
 						runner.Connect (ld.NUnitVersion).Wait ();
 						var supportAssemblies = new List<string> (ld.SupportAssemblies.Result);
 						ld.Info = runner.GetTestInfo (ld.Path, supportAssemblies).Result;
@@ -397,7 +397,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 			var console = testContext.ExecutionContext.ConsoleFactory.CreateConsole (
 				OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle (GettextCatalog.GetString ("Unit Tests")));
 
-			ExternalTestRunner runner = new ExternalTestRunner ();
+			ExternalTestRunner runner = new ExternalTestRunner (Path.GetDirectoryName (AssemblyPath));
 			runner.Connect (NUnitVersion, testContext.ExecutionContext.ExecutionHandler, console).Wait ();
 			LocalTestMonitor localMonitor = new LocalTestMonitor (testContext, test, suiteName, testName != null);
 

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitProjectTestSuite.cs
@@ -212,6 +212,10 @@ namespace MonoDevelop.UnitTesting.NUnit
 		protected override async Task<IEnumerable<string>> GetSupportAssembliesAsync ()
 		{
 			if (project != null) {
+				// Check to see if the project doesn't want to have support assemblies loaded (e.g. if it ensures every dependency is available in the output folder)
+				if (project.ProjectProperties.GetValue ("NUnitDisableSupportAssemblies", false))
+					return Enumerable.Empty<string> ();
+
 				var references = await project.GetReferences (IdeApp.Workspace.ActiveConfiguration).ConfigureAwait (false);
 				// Referenced assemblies which are not in the gac and which are not localy copied have to be preloaded
 				var supportAssemblies = new HashSet<string> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
@@ -25,7 +25,7 @@ namespace MonoDevelop.Core.Execution
 		List<MessageListener> listeners = new List<MessageListener> ();
 		object listenersLock = new object ();
 
-		string exePath;
+		string exePath, workingDirectory;
 
 		// This class will ping the remote process every PingPeriod milliseconds
 		// If the remote process doesn't get a message in PingPeriod*2 it assumes
@@ -69,6 +69,12 @@ namespace MonoDevelop.Core.Execution
 			this.syncContext = syncContext;
 			this.console = console;
 			mainCancelSource = new CancellationTokenSource ();
+		}
+
+		public RemoteProcessConnection (string exePath, string workingDirectory, IExecutionHandler executionHandler = null, OperationConsole console = null, SynchronizationContext syncContext = null)
+			: this (exePath, executionHandler, console, syncContext)
+		{
+			this.workingDirectory = workingDirectory;
 		}
 
 		public ConnectionStatus Status {
@@ -284,6 +290,8 @@ namespace MonoDevelop.Core.Execution
 			return Task.Run (() => {
 				var cmd = Runtime.ProcessService.CreateCommand (exePath);
 				cmd.Arguments = ((IPEndPoint)listener.LocalEndpoint).Port + " " + DebugMode;
+				if (!string.IsNullOrEmpty (workingDirectory))
+					cmd.WorkingDirectory = workingDirectory;
 
 				// Explicitly propagate the PATH var to the process. It ensures that tools required
 				// to run XS are also in the PATH for remote processes.


### PR DESCRIPTION
This PR adds a workaround to be able to successfully execute the designer unit-tests.

The core of the problem is described in https://github.com/mono/monodevelop/commit/4a01d159b935a4d454d326a6f149b9959b8268ce as in the current logic for `IsSupportAssembly` doesn't take into account PackageReference binaries quite well since it cannot accurately determine with the availble information if such a reference will end up being copied to the output directory or not.

This causes a lot of assemblies to be loaded in the running process mistakenly which in our case cause AssemblyLoad errors to happen (we invoke a bunch of things like MSBuild which are disrupted by those spurious imports).

Note: I added an extra constructor parameter to `RemoteProcessConnection` as an optional parameter which keeps API but not ABI compatibility. Since this is a public class, do we care about this?