### PR TITLE
[release-7.6] [Ide][Mac] Fix Popup rendering on Mojave

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Xwt/XwtThemedPopup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Xwt/XwtThemedPopup.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using Xwt;
 using Xwt.Backends;
 using Xwt.Drawing;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components
 {
@@ -54,7 +55,9 @@ namespace MonoDevelop.Components
 		{
 			base.Content = container = new XwtPopoverCanvas ();
 			BackgroundColor = Xwt.Drawing.Colors.Transparent;
-			Decorated = true;
+			// background rendering of undecorated windows is broken in HighSierra and previous versions
+			if (MacSystemInformation.OsVersion <= MacSystemInformation.HighSierra)
+				Decorated = true;
 			Theme.TargetPosition = CurrentPosition;
 		}
 


### PR DESCRIPTION
Backport of #6145.

/cc @sevoku 

Description:
Requires mono/xwt#856

Fixes VSTS #690353

![grafik](https://user-images.githubusercontent.com/951587/46244667-781d2000-c3e2-11e8-8208-947a221e89ec.png)
