### PR TITLE
[release-7.7] [Editor] Fix negative values in SessionLength

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextEditorKeyPressTimings.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextEditorKeyPressTimings.cs
@@ -189,7 +189,7 @@ namespace Mono.TextEditor
 				PercentDrawMargin = totalTimeMarginDrawing.TotalMilliseconds / totalMillis * 100,
 				PercentExtensionKeypress = totalTimeExtensionKeyPress.TotalMilliseconds / totalMillis * 100,
 				SessionKeypressCount = count,
-				SessionLength = openTime.TotalMilliseconds - GetCurrentTime ().TotalMilliseconds,
+				SessionLength = GetCurrentTime ().TotalMilliseconds - openTime.TotalMilliseconds,
 				LengthAtStart = lengthAtStart,
 				LengthDelta = lengthAtEnd - lengthAtStart,
 				LineCountAtStart = lineCountAtStart,

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorKeyPressTimingsTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorKeyPressTimingsTests.cs
@@ -50,6 +50,7 @@ namespace Mono.TextEditor.Tests
 			var metadata = timings.GetTypingTimingMetadata (null, null, 0, 0);
 			Assert.That (metadata.First, Is.GreaterThanOrEqualTo (800.0));
 			Assert.That (metadata.First, Is.LessThanOrEqualTo (1600));
+			Assert.That (metadata.SessionLength, Is.GreaterThanOrEqualTo (0));
 		}
 	}
 }


### PR DESCRIPTION
Backport of #6315.

/cc @Therzok 

Description:
Fixes VSTS #705917 - "XS.Editor.TextCommandTiming.SessionLength" Telemetry event is logged with -ve value