### PR TITLE
[Ide] Properly handle symlinks at workbench level

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -272,7 +272,10 @@ namespace MonoDevelop.Ide.Gui
 					}
 				}
 
-				var pf = project.GetProjectFile ((string)OriginalFileName ?? FileName);
+				ProjectFile pf = project.GetProjectFile (OriginalFileName);
+				if (pf == null)
+					pf = project.GetProjectFile (FileName);
+
 				return pf != null && pf.BuildAction != BuildAction.None;
 			}
 		}
@@ -1187,9 +1190,12 @@ namespace MonoDevelop.Ide.Gui
 			var parser = TypeSystemService.GetParser (Editor.MimeType);
 			if (parser == null)
 				return null;
-			var projectFile = Project.GetProjectFile ((string)OriginalFileName ?? Editor.FileName);
-			if (projectFile == null)
-				return null;
+			var projectFile = Project.GetProjectFile (OriginalFileName);
+			if (projectFile == null) {
+				projectFile = Project.GetProjectFile (Editor.FileName);
+				if (projectFile == null)
+					return null;
+			}
 			if (!parser.CanGenerateProjection (Editor.MimeType, projectFile.BuildAction, Project.SupportedLanguages))
 				return null;
 			try {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -207,6 +207,14 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
+		internal FilePath OriginalFileName {
+			get {
+				if (Window == null || !Window.ViewContent.IsFile)
+					return null;
+				return Window.ViewContent.OriginalContentName;
+			}
+		}
+
 		internal event EventHandler FileNameChanged;
 
 		void OnFileNameChanged ()
@@ -264,7 +272,7 @@ namespace MonoDevelop.Ide.Gui
 					}
 				}
 
-				var pf = project.GetProjectFile (FileName);
+				var pf = project.GetProjectFile ((string)OriginalFileName ?? FileName);
 				return pf != null && pf.BuildAction != BuildAction.None;
 			}
 		}
@@ -1179,7 +1187,7 @@ namespace MonoDevelop.Ide.Gui
 			var parser = TypeSystemService.GetParser (Editor.MimeType);
 			if (parser == null)
 				return null;
-			var projectFile = Project.GetProjectFile (Editor.FileName);
+			var projectFile = Project.GetProjectFile ((string)OriginalFileName ?? Editor.FileName);
 			if (projectFile == null)
 				return null;
 			if (!parser.CanGenerateProjection (Editor.MimeType, projectFile.BuildAction, Project.SupportedLanguages))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewContent.cs
@@ -55,9 +55,12 @@ namespace MonoDevelop.Ide.Gui
 				if (value != contentName) {
 					contentName = value;
 					OnContentNameChanged ();
+					OriginalContentName = null;
 				}
 			}
 		}
+
+		internal string OriginalContentName { get; set; }
 
 		public bool IsUntitled {
 			get { return (ContentName == null); }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -1082,7 +1082,8 @@ namespace MonoDevelop.Ide.Gui
 				if (project == null)
 					project = GetProjectContainingFile (openFileInfo.OriginalFileName);
 				openFileInfo.Project = project;
-			}
+			} else
+				project = openFileInfo.Project;
 			
 			if (openFileInfo.DisplayBinding != null) {
 				binding = viewBinding = openFileInfo.DisplayBinding;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -1071,12 +1071,18 @@ namespace MonoDevelop.Ide.Gui
 			
 			IDisplayBinding binding = null;
 			IViewDisplayBinding viewBinding = null;
+			Project project = null;
 			if (openFileInfo.Project == null) {
 				// Set the project if one can be found. The project on the FileOpenInformation
 				// is used to add project metadata to the OpenDocumentTimer counter.
-				openFileInfo.Project = GetProjectContainingFile (fileName);
+				project = GetProjectContainingFile (fileName);
+
+				// In some cases, the file may be a symlinked file. We cannot find the resolved symlink path
+				// in the project, so we should try looking up the original file.
+				if (project == null)
+					project = GetProjectContainingFile (openFileInfo.OriginalFileName);
+				openFileInfo.Project = project;
 			}
-			Project project = openFileInfo.Project;
 			
 			if (openFileInfo.DisplayBinding != null) {
 				binding = viewBinding = openFileInfo.DisplayBinding;
@@ -1197,8 +1203,10 @@ namespace MonoDevelop.Ide.Gui
 
 		static DocumentUserPrefs CreateDocumentPrefs (UserPreferencesEventArgs args, Document document)
 		{
+			string path = (string)document.OriginalFileName ?? document.FileName;
+
 			var dp = new DocumentUserPrefs ();
-			dp.FileName = FileService.AbsoluteToRelativePath (args.Item.BaseDirectory, document.FileName);
+			dp.FileName = FileService.AbsoluteToRelativePath (args.Item.BaseDirectory, path);
 			if (document.Editor != null) {
 				dp.Line = document.Editor.CaretLine;
 				dp.Column = document.Editor.CaretColumn;
@@ -1452,6 +1460,8 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
+		internal FilePath OriginalFileName { get; set; }
+
 		public OpenDocumentOptions Options { get; set; }
 
 		int offset = -1;
@@ -1480,6 +1490,7 @@ namespace MonoDevelop.Ide.Gui
 		[Obsolete("Use FileOpenInformation (FilePath filePath, Project project, int line, int column, OpenDocumentOptions options)")]
 		public FileOpenInformation (string fileName, int line, int column, OpenDocumentOptions options) 
 		{
+			this.OriginalFileName = fileName;
 			this.FileName = fileName;
 			this.Line = line;
 			this.Column = column;
@@ -1489,6 +1500,7 @@ namespace MonoDevelop.Ide.Gui
 
 		public FileOpenInformation (FilePath filePath, Project project = null)
 		{
+			this.OriginalFileName = filePath;
 			this.FileName = filePath;
 			this.Project = project;
 			this.Options = OpenDocumentOptions.Default;
@@ -1496,6 +1508,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public FileOpenInformation (FilePath filePath, Project project, int line, int column, OpenDocumentOptions options) 
 		{
+			this.OriginalFileName = filePath;
 			this.FileName = filePath;
 			this.Project = project;
 			this.Line = line;
@@ -1505,6 +1518,7 @@ namespace MonoDevelop.Ide.Gui
 
 		public FileOpenInformation (FilePath filePath, Project project, bool bringToFront)
 		{
+			this.OriginalFileName = filePath;
 			this.FileName = filePath;
 			this.Project = project;
 			this.Options = OpenDocumentOptions.Default;
@@ -1600,6 +1614,7 @@ namespace MonoDevelop.Ide.Gui
 
 				try {
 					await newContent.Load (fileInfo);
+					newContent.OriginalContentName = fileInfo.OriginalFileName;
 				} catch (InvalidEncodingException iex) {
 					monitor.ReportError (GettextCatalog.GetString ("The file '{0}' could not opened. {1}", fileName, iex.Message), null);
 					return false;


### PR DESCRIPTION
When working with symlinked on disk files in a project, there's a
few things which were not handled correctly.

When a project references a symlink, we should keep the original
symlink information around so that it can be used when looking up
a for a Project containing a file or a file in general in a project.

Added in an OriginalFile property that is used to recover the original
file name, before resolving a symlink, that can be used by the typesystem
to figure out which project the file belongs to.

Fixes VSTS #700204 - Symlinked files do not have correct define constants