### PR TITLE
[release-7.6] [Mac] Disable hybrid suspend until the XamMac GC hang is fixed

### DIFF
--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -351,6 +351,9 @@ int main (int argc, char **argv)
 
 	setenv ("MONO_GC_PARAMS", "major=marksweep-conc,nursery-size=8m", 0);
 
+	// To be removed: https://github.com/mono/monodevelop/issues/6326
+	setenv ("MONO_THREADS_SUSPEND", "preemptive", 0);
+
   NSString *exePath;
   char **extra_argv;
   int extra_argc;


### PR DESCRIPTION
Backport of #6327.

/cc @slluis @Therzok

Description:
Fixes VSTS #705976 - Temporarily disable Mono hybrid suspend