### PR TITLE
[Ide][TextEditor] Tweaks to bracket matching colors for better a11y

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/DarkStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/DarkStyle.json
@@ -1,6 +1,6 @@
 ﻿{
 	"name": "Dark",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "A dark scheme using colors from the Tango Project",
 	"originator": "Xamarin Inc. (http://xamarin.com)",
 
@@ -69,7 +69,7 @@
 		{ "name": "Quick Diff(Dirty)", "color": "butter2" },
 		{ "name": "Quick Diff(Changed)", "color": "chameleon2" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "aluminium4", "secondcolor": "aluminium4" },
+		{ "name": "Brace Matching(Rectangle)", "color": "#476a93", "secondcolor": "#476a93" },
 		{ "name": "Usages(Rectangle)", "color": "skyblue3", "secondcolor": "skyblue3", "bordercolor": "skyblue2" },
 		{ "name": "Changing usages(Rectangle)", "color": "chameleon4", "secondcolor": "chameleon4", "bordercolor": "chameleon3" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/GruvboxStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/GruvboxStyle.json
@@ -1,6 +1,6 @@
 {
 	"name": "Gruvbox",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "A retro groove color scheme",
 	"originator": "https://github.com/morhetz/gruvbox",
 
@@ -57,7 +57,7 @@
 		{ "name": "Quick Diff(Dirty)", "color": "bright-green" },
 		{ "name": "Quick Diff(Changed)", "color": "#A4E22E" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "#6699CC", "secondcolor": "#AACCEE" },
+		{ "name": "Brace Matching(Rectangle)", "color": "#517297", "secondcolor": "#517297" },
 		{ "name": "Usages(Rectangle)", "color": "#527F99", "secondcolor": "#527F99", "bordercolor": "#527F99" },
 		{ "name": "Changing usages(Rectangle)", "color": "#996E75", "secondcolor": "#996E75", "bordercolor": "#996E75" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/HCDarkStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/HCDarkStyle.json
@@ -1,6 +1,6 @@
 ﻿﻿{
     "name": "High Contrast Dark",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "High Contrast Dark Style",
     "originator": "Microsoft (http://microsoft.com)",
 
@@ -44,7 +44,7 @@
 
     "colors": [
         { "name": "Bookmarks", "color": "aluminium1", "secondcolor": "aluminium4" },
-        { "name": "Brace Matching(Rectangle)", "color": "aluminium4", "secondcolor": "aluminium4" },
+        { "name": "Brace Matching(Rectangle)", "color": "#305684", "secondcolor": "#305684" },
         { "name": "Breakpoint Marker", "color": "#6f3535", "bordercolor": "#6f3535" },
         { "name": "Breakpoint Marker(Disabled)", "color": "#4d4d4d", "bordercolor": "#4d4d4d" },
         { "name": "Breakpoint Marker(Invalid)", "color": "#604343", "bordercolor": "#604343" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/HCLightStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/HCLightStyle.json
@@ -1,6 +1,6 @@
 ﻿﻿{
     "name": "High Contrast Light",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "High Contrast Light Style",
     "originator": "Microsoft (http://microsoft.com)",
 
@@ -40,7 +40,9 @@
         { "name": "Message Bubble Warning Tooltip", "color": "text" },
 
         { "name": "Search result background (highlighted)", "color": "search-result" },
-        { "name": "Search result background", "color": "search-result" }
+        { "name": "Search result background", "color": "search-result" },
+
+        { "name": "Brace Matching(Rectangle)", "color": "#e2e6d6", "secondcolor": "#e2e6d6" }
     ],
 
     "text": [

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/MonokaiStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/MonokaiStyle.json
@@ -1,6 +1,6 @@
 {
 	"name": "Monokai",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "A smooth, dusky scheme",
 	"originator": "Xamarin Inc. (http://xamarin.com)",
 
@@ -65,7 +65,7 @@
 		{ "name": "Quick Diff(Dirty)", "color": "monokai-string" },
 		{ "name": "Quick Diff(Changed)", "color": "#A4E22E" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "#517297", "secondcolor": "#517297" },
+		{ "name": "Brace Matching(Rectangle)", "color": "#517295", "secondcolor": "#517295" },
 		{ "name": "Usages(Rectangle)", "color": "#527F99", "secondcolor": "#527F99", "bordercolor": "#527F99" },
 		{ "name": "Changing usages(Rectangle)", "color": "#996E75", "secondcolor": "#996E75", "bordercolor": "#996E75" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/NightshadeStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/NightshadeStyle.json
@@ -1,6 +1,6 @@
 {
 	"name": "Nightshade",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "An inky scheme with vibrant highlights",
 	"originator": "Anirudh Sanjeev <anirudh@anirudhsanjeev.org>",
 
@@ -77,7 +77,7 @@
 		{ "name": "Quick Diff(Dirty)", "color": "butter2" },
 		{ "name": "Quick Diff(Changed)", "color": "StringVim" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "#517297", "secondcolor": "#517297" },
+		{ "name": "Brace Matching(Rectangle)", "color": "#305684", "secondcolor": "#305684" },
 		{ "name": "Usages(Rectangle)", "color": "#527F99", "secondcolor": "#527F99", "bordercolor": "#527F99" },
 		{ "name": "Changing usages(Rectangle)", "color": "#996E75", "secondcolor": "#996E75", "bordercolor": "#996E75" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/OblivionStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/OblivionStyle.json
@@ -1,6 +1,6 @@
 {
 	"name": "Oblivion",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "‘...where the soul at last is lost in utter peace’",
 	"originator": "Xamarin Inc. (http://xamarin.com)",
 
@@ -69,7 +69,7 @@
 		{ "name": "Quick Diff(Dirty)", "color": "butter2" },
 		{ "name": "Quick Diff(Changed)", "color": "chameleon2" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "#5b9bc1", "secondcolor": "#5b9bc1" },
+		{ "name": "Brace Matching(Rectangle)", "color": "#55789e", "secondcolor": "#55789e" },
 		{ "name": "Usages(Rectangle)", "color": "#527F99", "secondcolor": "#527F99", "bordercolor": "#527F99" },
 		{ "name": "Changing usages(Rectangle)", "color": "#996E75", "secondcolor": "#996E75", "bordercolor": "#996E75" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedDarkStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedDarkStyle.json
@@ -1,6 +1,6 @@
 {
 	"name": "Solarized Dark",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "An artful, dark scheme that's easy on the eyes",
 	"originator": "Xamarin Inc. (http://xamarin.com)",
 
@@ -63,7 +63,7 @@
 		{ "name": "Quick Diff(Dirty)", "color": "yellow" },
 		{ "name": "Quick Diff(Changed)", "color": "green" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "#0e5465", "secondcolor": "#0e5465" },
+		{ "name": "Brace Matching(Rectangle)", "color": "#134760", "secondcolor": "#134760" },
 		{ "name": "Usages(Rectangle)", "color": "#527F99", "secondcolor": "#527F99", "bordercolor": "#527F99" },
 		{ "name": "Changing usages(Rectangle)", "color": "#996E75", "secondcolor": "#996E75", "bordercolor": "#996E75" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
@@ -1,6 +1,6 @@
 {
 	"name": "Visual Studio",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Reminiscent of Microsoft Visual Studio's default colors",
 	"originator": "Jeffrey Stedfast <fejj@novell.com>",
 
@@ -23,7 +23,9 @@
 		{ "name": "Indicator Margin", "color": "#f6f6f6" },
 		{ "name": "Indicator Margin(Separator)", "color": "#f6f6f6" },
 
-		{ "name": "Message Bubble Warning IconMargin", "color": "#e68100", "bordercolor": "#e68100" }
+		{ "name": "Message Bubble Warning IconMargin", "color": "#e68100", "bordercolor": "#e68100" },
+
+		{ "name": "Brace Matching(Rectangle)", "color": "#e2e6d6", "secondcolor": "#e2e6d6" }
 	],
 
 	"text": [


### PR DESCRIPTION
Minor updates to themes: bracket matching colors.

Left: before, right: after.

Visual Studio:
![image](https://user-images.githubusercontent.com/4982/47025549-ff4cf080-d163-11e8-84a4-379035fd666a.png)

High Contrast Light:
![image](https://user-images.githubusercontent.com/4982/47025585-1095fd00-d164-11e8-99b5-81451be46c8a.png)

Solarized Light:
![image](https://user-images.githubusercontent.com/4982/47025664-30c5bc00-d164-11e8-8e31-117866092195.png)

Dark:
![image](https://user-images.githubusercontent.com/4982/47025674-38856080-d164-11e8-8192-4b4b2283541d.png)

Gruvbox:
![image](https://user-images.githubusercontent.com/4982/47025688-41763200-d164-11e8-85c7-7fb1cd870c90.png)

Monokai:
![image](https://user-images.githubusercontent.com/4982/47025712-4b983080-d164-11e8-8499-f46b9d9a766f.png)

High Contrast Dark:
![image](https://user-images.githubusercontent.com/4982/47025728-55ba2f00-d164-11e8-8c8b-b7f0e73a091e.png)

Nightshade:
![image](https://user-images.githubusercontent.com/4982/47025752-610d5a80-d164-11e8-9804-ec904a6656d2.png)

Solarized Dark:
![image](https://user-images.githubusercontent.com/4982/47025780-6b2f5900-d164-11e8-8054-ed07b5520a82.png)

Oblivion:
![image](https://user-images.githubusercontent.com/4982/47025794-73879400-d164-11e8-89fd-2fa1acbf5779.png)

_Light_  and _Tango_ didn't need any change.

@sayedihashimi: This fixes the problem with highlighted tags.