### PR TITLE
Fixes exception for aspnet app when debugging

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
@@ -36,6 +36,8 @@ using MonoDevelop.Projects;
 using MonoDevelop.Ide;
 using System.Linq;
 using System.IO;
+using MonoDevelop.Core.Execution;
+using MonoDevelop.Ide.Commands;
 
 namespace MonoDevelop.Debugger
 {
@@ -77,11 +79,18 @@ namespace MonoDevelop.Debugger
 			return IdeApp.ProjectOperations.CurrentSelectedSolution ?? IdeApp.ProjectOperations.CurrentSelectedBuildTarget;
 		}
 
-		protected override void Run ()
+		protected async override void Run ()
 		{
 			if (DebuggingService.IsPaused) {
 				DebuggingService.Resume ();
 				return;
+			}
+
+			if (!IdeApp.ProjectOperations.CurrentRunOperation.IsCompleted) {
+				if (!MessageService.Confirm (GettextCatalog.GetString ("An application is already running. Do you want to stop it?"), AlertButton.Stop))
+					return;
+				StopHandler.StopBuildOperations ();
+				await IdeApp.ProjectOperations.CurrentRunOperation.Task;
 			}
 
 			if (IdeApp.Workspace.IsOpen) {
@@ -97,16 +106,23 @@ namespace MonoDevelop.Debugger
 				info.Enabled = false;
 				return;
 			}
+
 			if (DebuggingService.IsPaused) {
 				info.Enabled = true;
 				info.Text = GettextCatalog.GetString ("_Continue Debugging");
 				info.Description = GettextCatalog.GetString ("Continue the execution of the application");
 				return;
 			}
+
 			if (DebuggingService.IsDebugging) {
 				info.Enabled = false;
 				return;
 			}
+
+			if ((IdeApp.Workspace.IsOpen) && (!IdeApp.ProjectOperations.CurrentRunOperation.IsCompleted))
+				info.Text = GettextCatalog.GetString ("Restart With Debugging");
+			else
+				info.Text = GettextCatalog.GetString ("Start Debugging");
 
 			var target = GetRunTarget ();
 			info.Enabled = target != null && IdeApp.ProjectOperations.CanDebug (target);


### PR DESCRIPTION
Start Without Debugging followed by Start Debugging for an aspnet
app was failing because the original application was still running
in the background on port 5001.
This fixes that by requesting to stop the original application before
launching the new one.

Fixes VSTS #664768