### PR TITLE
Fixes VSTS Bug 685144: Invoking some snippets from toolbox in .cs

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplate.cs
@@ -446,11 +446,14 @@ namespace MonoDevelop.Ide.CodeTemplates
 		public void Insert (TextEditor editor, DocumentContext context)
 		{
 			var handler = context.GetContent<ICodeTemplateHandler> ();
-			if (handler != null) {
-				handler.InsertTemplate (this, editor, context);
-			} else {
-				InsertTemplateContents (editor, context);
-			}	
+			using (var undo = editor.OpenUndoGroup ()) {
+				editor.EnsureCaretIsNotVirtual ();
+				if (handler != null) {
+					handler.InsertTemplate (this, editor, context);
+				} else {
+					InsertTemplateContents (editor, context);
+				}
+			}
 		}
 		
 		/// <summary>
@@ -459,7 +462,6 @@ namespace MonoDevelop.Ide.CodeTemplates
 		public TemplateResult InsertTemplateContents (TextEditor editor, DocumentContext context)
 		{
 			var data = editor;
-			
 			int offset = data.CaretOffset;
 //			string leadingWhiteSpace = GetLeadingWhiteSpace (editor, editor.CursorLine);
 			


### PR DESCRIPTION
files leads to poorly formatted code

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/685144

Couldn't reproduce the issue however the screencast shows that the
start indentation is not corrected - this change forces the correction
beforehand and should prevent what's seen in the screencast.