### PR TITLE
Visual Studio text model tweaks

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -2387,6 +2387,8 @@ namespace MonoDevelop.SourceEditor
 				return TextEditor.GetTextEditorData ();
 			if (type.Equals (typeof (IDocumentReloadPresenter)))
 				return widget;
+			if (type.Equals (typeof (Microsoft.VisualStudio.Text.ITextDocument)))
+				return Document.VsTextDocument;
 			return base.OnGetContent (type);
 		}
 

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -246,8 +246,10 @@ namespace Mono.TextEditor
 			this.TextBuffer.ContentTypeChanged -= this.OnTextBufferContentTypeChanged;
 			this.TextBuffer.Properties.RemoveProperty(typeof(ITextDocument));
 			this.VsTextDocument.FileActionOccurred -= this.OnTextDocumentFileActionOccurred;
-			this.VsTextDocument.Dispose ();
 			SyntaxMode = null;
+
+			// Dispose this after SyntaxMode is set, otherwise we'll query the VsTextDocument when setting SyntaxMode.
+			this.VsTextDocument.Dispose ();
 		}
 
 		private void OnTextBufferChangedImmediate (object sender, Microsoft.VisualStudio.Text.TextContentChangedEventArgs args)

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -246,6 +246,7 @@ namespace Mono.TextEditor
 			this.TextBuffer.ContentTypeChanged -= this.OnTextBufferContentTypeChanged;
 			this.TextBuffer.Properties.RemoveProperty(typeof(ITextDocument));
 			this.VsTextDocument.FileActionOccurred -= this.OnTextDocumentFileActionOccurred;
+			this.VsTextDocument.Dispose ();
 			SyntaxMode = null;
 		}
 


### PR DESCRIPTION
This PR adds two tweaks to the current integration with the Visual Studio text model:

- It integrates with the `GetContent<T>` machinery so that an underlying `ITextDocument` instance can be queried from a `TextEditor` instance
- If fixes `ITextDocument` lifecycle when the parent document is disposed so that the corresponding event in `ITextDocumentFactoryService` is fired properly

Ultimately those two changes help us share our integration code between Visual Studio Windows and VSMac.