### PR TITLE
Bump roslyn

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -6,7 +6,7 @@
     <ReferencesRoslyn>$(RootDirectory)\msbuild\ReferencesRoslyn.props</ReferencesRoslyn>
     <ReferencesVSEditor>$(RootDirectory)\msbuild\ReferencesVSEditor.props</ReferencesVSEditor>
     <ReferencesGtk>$(RootDirectory)\msbuild\ReferencesGtk.props</ReferencesGtk>
-    <NuGetVersionRoslyn>2.10.0-beta2-63315-04</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>2.10.0-beta2-63410-10</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.8.519</NuGetVersionVSEditor>
   </PropertyGroup>
 

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -1,23 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net461" />
   <package id="ICSharpCode.Decompiler" version="3.2.0.3856" targetFramework="net471" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
   <package id="Microsoft.Build.MSBuildLocator" version="1.0.1-preview-g6cd9a57801" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis" version="2.10.0-beta2-63315-04" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis" version="2.10.0-beta2-63410-10" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net471" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.10.0-beta2-63315-04" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.10.0-beta2-63410-10" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Elfie" version="1.0.0-rc9" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Features" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.10.0-beta2-63315-04" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.10.0-beta2-63315-04" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Features" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.10.0-beta2-63410-10" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.10.0-beta2-63410-10" targetFramework="net461" />
   <package id="Microsoft.Composition" version="1.0.31" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net461" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net461" />


### PR DESCRIPTION
Brings in fix for multi-line code fix at caret.

https://github.com/dotnet/roslyn/compare/750236a7562d8fd0d5efe311c52ae0703093165f...45b371170fd8f9f3e9c14ea2a71d17db9469f8b7

I don't think we have a VSTS bug on our side