### PR TITLE
[release-7.7] [Core] Add binding redirects for NuGet assemblies

### DIFF
--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -167,6 +167,74 @@
 				<bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="15.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Commands" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Credentials" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.DependencyResolver.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Indexing" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.LibraryModel" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.PackageManagement" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Packaging.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.ProjectModel" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Protocol" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Resolver" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.7.0.5" newVersion="4.7.0.5" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="SQLitePCLRaw.core" publicKeyToken="1488e028ca7ab535" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.1.11.121" newVersion="1.1.11.121" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
 			</dependentAssembly>
@@ -174,7 +242,7 @@
 				<assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
 			</dependentAssembly>
-			 <dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="SQLitePCLRaw.batteries_v2" publicKeyToken="8226ea5df37bcae9" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.1.11.121" newVersion="1.1.11.121" />
 			</dependentAssembly>


### PR DESCRIPTION
Backport of #6379.

/cc @Therzok 

Description:
MonoDevelop.MSBuildEditor references nuget assemblies, so we need
to add binding redirects in order for that to work

Fixes VSTS #708240 - Missing binding redirects for NuGet.*