### PR TITLE
[release-7.7] Add YamlDotNet binding redirects

### DIFF
--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -250,6 +250,10 @@
 				<assemblyIdentity name="SQLitePCLRaw.core" publicKeyToken="1488e028ca7ab535" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.1.11.121" newVersion="1.1.11.121" />
 			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="YamlDotNet" publicKeyToken="ec19458f3c15af5e" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 </configuration>


### PR DESCRIPTION
Backport of #6394.

/cc @Therzok 

Description:
Fixes VSTS #708456 - Missing binding redirect after yamldotnet bump