### PR TITLE
Fixes VSTS Bug 709690: [Feedback] Unable to open Specflow feature fil…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/SyntaxHighlightingService.cs
@@ -306,7 +306,8 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 									if (stream.CanDecompressEntry) {
 										byte[] data = new byte[entry.Size];
 										stream.Read (data, 0, (int)entry.Size);
-										LoadFile (newBundle, entry.Name, () => new MemoryStream (data), () => new MemoryStreamProvider (data, entry.Name));
+										var provider = new MemoryStreamProvider (data, entry.Name);
+										LoadFile (newBundle, entry.Name, provider.Open, () => provider);
 									}
 								}
 							} catch (Exception e) {


### PR DESCRIPTION
…e in VS2017 7.6 (for MAC)

https://dev.azure.com/devdiv/DevDiv/_workitems/edit/709690

On first glance it looks like a mono/.NET bug - but that solves it.