### PR TITLE
Fixes VSTS Bug 709557: [Feedback] Copy and paste sometimes fails on VS

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
@@ -422,7 +422,6 @@ namespace Mono.TextEditor
 					offset = version.MoveOffsetTo (data.Document.Version, offset);
 					inserted = data.PasteText (offset, text, copyData, ref undo);
 				}
-				data.FixVirtualIndentation (startLine);
 			} finally {
 				undo.Dispose ();
 			}

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/Features/IndentationTests/TextPasteIndentEngineTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/Features/IndentationTests/TextPasteIndentEngineTests.cs
@@ -38,6 +38,7 @@ using MonoDevelop.Ide;
 using System.Collections.Generic;
 using MonoDevelop.Ide.Editor.Extension;
 using System.Threading.Tasks;
+using Gtk;
 
 namespace ICSharpCode.NRefactory6.IndentationTests
 {
@@ -233,6 +234,39 @@ $		""foo"",
 			}
 		}
 
+		/// <summary>
+		/// Bug 709557: [Feedback] Copy and paste sometimes fails on VS for mac
+		/// </summary>
+		[Test]
+		public async Task TestVSTS709557 ()
+		{
+			using (var testCase = await CreateEngine (@"
+class Foo
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine();
+        Console.WriteLine();
+$
+    }
+}")) {
+				var clipboard = Clipboard.Get (Mono.TextEditor.ClipboardActions.CopyOperation.CLIPBOARD_ATOM);
+				clipboard.Text = @"
+        Console.WriteLine();";
+				testCase.Document.Editor.EditorOperations.Paste ();
+				Assert.AreEqual (@"
+class Foo
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine();
+        Console.WriteLine();
+
+        Console.WriteLine();
+    }
+}", testCase.Document.Editor.Text);
+			}
+		}
 
 		protected override IEnumerable<TextEditorExtension> GetEditorExtensions ()
 		{

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.ValueTuple">
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Features\ParameterHinting\ParameterHintingTests.cs" />


### PR DESCRIPTION
for mac

https://dev.azure.com/devdiv/DevDiv/_workitems/edit/709557

It's a race condition that sometimes happens. That does fix it - the
post formatting corrects the virtual indent.