### PR TITLE
[IDE] Fix a crash when closing a docknotebook tab

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -1354,8 +1354,14 @@ namespace MonoDevelop.Ide.Gui
 		
 		internal void CloseClicked (object o, TabEventArgs e)
 		{
-			if (e.Tab.Content != null && e.Tab.Content is SdiWorkspaceWindow sdiWorkspace) {
-				sdiWorkspace.CloseWindow (false, true).Ignore ();
+			if (e.Tab.Content != null) {
+				if (e.Tab.Content is SdiWorkspaceWindow sdiWorkspace) {
+					sdiWorkspace.CloseWindow (false, true).Ignore ();
+				} else {
+					LoggingService.LogError ($"Tab content is not an SdiWorkspaceWindow, is {e.Tab.Content.GetType ()}");
+				}
+			} else {
+				LoggingService.LogError ("Tab content is null");
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -1354,7 +1354,9 @@ namespace MonoDevelop.Ide.Gui
 		
 		internal void CloseClicked (object o, TabEventArgs e)
 		{
-			((SdiWorkspaceWindow)e.Tab.Content).CloseWindow (false, true).Ignore();
+			if (e.Tab.Content != null && e.Tab.Content is SdiWorkspaceWindow sdiWorkspace) {
+				sdiWorkspace.CloseWindow (false, true).Ignore ();
+			}
 		}
 
 		internal void RemoveTab (DockNotebook tabControl, int pageNum, bool animate)


### PR DESCRIPTION
The crash trace listed in the bug report doesn't say what the exception that caused the crash was, and I've
not been able to reproduce it, so I'll added a null check and a type check.

Fixes VSTS #706884