### PR TITLE
[build] Don't use the API which has been obsoleted

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -425,7 +425,7 @@ namespace MonoDevelop.MacIntegration
 				return;
 			var m = NSApplication.SharedApplication.MainMenu;
 			if (m != null) {
-				foreach (NSMenuItem item in m.ItemArray ()) {
+				foreach (NSMenuItem item in m.Items) {
 					var submenu = item.Submenu as MDMenu;
 					if (submenu != null && submenu.FlashIfContainsCommand (args.CommandId))
 						return;


### PR DESCRIPTION
WarnAsError is on so we should make this change to avoid
breaking the build.