### PR TITLE
Dark .gtkrc update: default button color contrast increase (for better a11y)

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -172,7 +172,7 @@ style "dialog-button" = "button" {
     GtkButton::inner-border = { 7, 7, 3, 4 }
 
     engine "xamarin" {
-        default_button_color = "#51ADF3"
+        default_button_color = "#397cae"
     }
 }
 


### PR DESCRIPTION
<img width="1001" alt="tmp" src="https://user-images.githubusercontent.com/4982/47219142-40d0dc00-d3ae-11e8-98cf-4779766851cf.png">

Fixes VSTS #612428