### PR TITLE
[NuGet] Show summary of NuGet restore errors

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageManagementLoggerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageManagementLoggerTests.cs
@@ -75,6 +75,20 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			AssertOnPackageOperationMessageLoggedCalled (MessageLevel.Info, "Test C");
 		}
+
+		[Test]
+		public void Log_ErrorMessageLogged_CaptureErrorsForSummary ()
+		{
+			CreateLogger ();
+			logger.SaveErrors = true;
+
+			logger.Log (MessageLevel.Error, "test");
+			messagesLoggedEventArgs.Clear ();
+
+			logger.LogSavedErrors ();
+
+			AssertOnPackageOperationMessageLoggedCalled (MessageLevel.Info, "test");
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementLogger.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementLogger.cs
@@ -26,6 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.ProjectManagement;
@@ -43,6 +44,9 @@ namespace MonoDevelop.PackageManagement
 		
 		public void Log(MessageLevel level, string message, params object[] args)
 		{
+			if (SaveErrors && (level == MessageLevel.Error)) {
+				AddError (string.Format (message, args));
+			}
 			packageManagementEvents.OnPackageOperationMessageLogged(level, message, args);
 		}
 
@@ -129,6 +133,27 @@ namespace MonoDevelop.PackageManagement
 			case LogLevel.Warning:
 				LogWarning (data);
 				break;
+			}
+		}
+
+		public bool SaveErrors { get; set; }
+
+		public void LogSavedErrors ()
+		{
+			foreach (string error in errors) {
+				LogInformation (error);
+			}
+		}
+
+		object locker = new object ();
+		List<string> errors;
+
+		void AddError (string error)
+		{
+			lock (locker) {
+				if (errors == null)
+					errors = new List<string> ();
+				errors.Add (error);
 			}
 		}
 	}


### PR DESCRIPTION
Creating an xUnit .NET Core test projet named 'xunit' would fail to
restore since there is a package reference cycle between the project
and the xunit NuGet package. Whilst the error message has been
improved in NuGet 4.7 to show there is a cycle this information is
buried in the Package Console output and all you would see was just
Restore failed. Now the error information is shown at the end of the
Package Console as a summary of the failures to make it easier to
see what failed. Now for the xunit project you will see the following
at the end of the Package Console output:

    Cycle detected.
      xunit -> xunit (>= 2.3.1).
    Restore failed.

Fixes VSTS #650078 - Restore failed for xunit.