### PR TITLE
Updated reference to xamarin/md-addins@1b16d82

### DIFF
--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=3a9afc960ba73e5862829e8a0cd9369bcca43d70
+DEP_NEEDED_VERSION[0]=1b16d828c3e9d9b1a8d31c461183a060655215bb
 DEP_BRANCH_AND_REMOTE[0]="release-7.6-xcode10.1 origin/release-7.6-xcode10.1"
 
 # heap-shot


### PR DESCRIPTION
Updated reference to xamarin/md-addins@1b16d82

https://github.com/xamarin/ios-sim-sharp/compare/ba9197fd6ea9c2ee7c912cea9cb871b0bd6117af...452bd90ccd751c70c55e43f1b30d5aa445690a0e

[452bd90](https://github.com/xamarin/ios-sim-sharp/commit/452bd90ccd751c70c55e43f1b30d5aa445690a0e) [build] re-default to setting MODERN_XCODE_ONLY on Mojave
[c06b737](https://github.com/xamarin/ios-sim-sharp/commit/c06b7372b63a3af5340b385cd0fdc588e74136d4) Revert "[build] Default MODERN_XCODE_ONLY when on Mojave"
