### PR TITLE
[DotNetCore] Fix missing sections in project options

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -847,6 +847,21 @@
 				_label="Build"
 				class="MonoDevelop.DotNetCore.DummyMSBuildOptionsPanel" />
 		</Condition>
+		<Condition id="ProjectTypeId" value="VisualStudioDotNetCoreCSharpProject">
+			<Panel
+				id="VisualStudioDotNetCoreCSharpCompilerOptionsPanel"
+				_label="C#"
+				class="MonoDevelop.CSharp.Project.CompilerOptionsPanel" />
+		</Condition>
+	</Extension>
+
+	<Extension path="/MonoDevelop/ProjectModel/Gui/ItemOptionPanels/Build/Compiler">
+		<Condition id="ProjectTypeId" value="VisualStudioDotNetCoreCSharpProject">
+			<Panel
+				id="VisualStudioDotNetCoreCSharpCodeGenerationPanel"
+				_label="Compiler"
+				class="MonoDevelop.CSharp.Project.CodeGenerationPanel" />
+		</Condition>
 	</Extension>
 	
 	<Extension path = "/MonoDevelop/Ide/Commands">


### PR DESCRIPTION
In project options the Build - General page was missing the
Code Generation and Language Options sections. The Build - Compiler
page was missing completely. Affected .NET Core projects where
the solution was using the Visual Studio on Windows guid for
.NET Core projects 9A19103F-16F7-4668-BE54-9A1E7A4F7556. Using this
guid meant the projects were not being identified as C# projects
so the project options dialog was missing some sections.

Fixes VSTS #712224 - .NET Core project options panel missing sections