### PR TITLE
[release-7.6] [DotNetCore] Handle implicit package reference versions

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -51,6 +51,39 @@ namespace MonoDevelop.DotNetCore
 		public DotNetCoreProjectExtension ()
 		{
 			DotNetCoreProjectReloadMonitor.Initialize ();
+			if (IsDotNetCoreSdk22Installed ())
+				DotNetProjectProxy.ModifyImplicitPackageReferenceVersion = ModifyImplicitPackageReference;
+		}
+
+		static bool IsDotNetCoreSdk22Installed ()
+		{
+			return DotNetCoreSdk.Versions.Any (version => version.Major == 2 && version.Minor == 2);
+		}
+
+		/// <summary>
+		/// HACK: Handle implicit package versions defined by .NET Core 2.2 SDK.
+		/// </summary>
+		static void ModifyImplicitPackageReference (ProjectPackageReference packageReference, DotNetProject project)
+		{
+			bool targetLatestRuntimePatch = project.MSBuildProject.EvaluatedProperties.GetValue ("TargetLatestRuntimePatch", false);
+			string targetFrameworkVersion = project.TargetFramework.Id.Version;
+
+			foreach (IMSBuildItemEvaluated item in project.MSBuildProject.EvaluatedItems) {
+				if (!IsImplicitPackageReferenceMatch (item, packageReference, targetFrameworkVersion))
+					continue;
+
+				string versionProperty = targetLatestRuntimePatch ? "LatestVersion" : "DefaultVersion";
+				string version = item.Metadata.GetValue (versionProperty) ?? string.Empty;
+				packageReference.Metadata.SetValue ("Version", version);
+				return;
+			}
+		}
+
+		static bool IsImplicitPackageReferenceMatch (IMSBuildItemEvaluated item, ProjectPackageReference packageReference, string targetFrameworkVersion)
+		{
+			return item.Name == "ImplicitPackageReferenceVersion" &&
+				StringComparer.OrdinalIgnoreCase.Equals (item.Include, packageReference.Include) &&
+				targetFrameworkVersion == item.Metadata.GetValue ("TargetFrameworkVersion");
 		}
 
 		protected override bool SupportsObject (WorkspaceObject item)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectProxy.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectProxy.cs
@@ -166,12 +166,24 @@ namespace MonoDevelop.PackageManagement
 		public IEnumerable<ProjectPackageReference> GetPackageReferences ()
 		{
 			foreach (var item in DotNetProject.Items.OfType<ProjectPackageReference> ()) {
+				OnModifyPackageReference (item);
 				yield return item;
 			}
 			foreach (var item in DotNetProject.MSBuildProject.GetImportedPackageReferences (DotNetProject)) {
+				OnModifyPackageReference (item);
 				yield return item;
 			}
 		}
+
+		void OnModifyPackageReference (ProjectPackageReference item)
+		{
+			if (!string.IsNullOrEmpty (item.Version))
+				return;
+
+			ModifyImplicitPackageReferenceVersion?.Invoke (item, DotNetProject);
+		}
+
+		public static Action<ProjectPackageReference, DotNetProject> ModifyImplicitPackageReferenceVersion;
 	}
 }
 


### PR DESCRIPTION
Backport of #6415.

/cc @slluis @mrward

Description:
.NET Core 2.2 preview 3 SDK now uses implicit package versions.
The package references loaded by the project model do not have the
version metadata directly applied. This results in the wrong version
being restored by NuGet. For a .NET Core 2.1 project this resulted in
a restore warning:

```
Project dependency Microsoft.NETCore.App does not contain an inclusive
lower bound. Include a lower bound in the dependency version to ensure
consistent restore results.
```

And a build error:

```
Error: NETSDK1061: The project was restored using Microsoft.NETCore.App
version 1.0.0, but with current settings, version 2.1.0 would be used
instead.
```

Added a workaround to find the implicit version and apply it to the
package reference so the correct version is restored by NuGet.

Fixes VSTS #707944 - After installing .net core 2.2 preview, .net
core 2.1 projects no longer build