### PR TITLE
[Ide] Show all files option is not remembered for solution

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -1528,7 +1528,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				globalOptions[opt.Id] = val;
 			}
 			globalOptions.Pad = this;
-			RefreshTree ();
+			RefreshRoots ();
 		}
 
 		TypeNodeBuilder GetTypeNodeBuilder (Type type)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IPadContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/IPadContainer.cs
@@ -277,12 +277,6 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 		
-		internal IMementoCapable GetMementoCapable ()
-		{
-			// Don't create the content if not already created
-			return content as IMementoCapable;
-		}
-		
 		internal void NotifyShown (VisibilityChangeEventArgs args)
 		{
 			PadShown?.Invoke (this, args);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Pad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Pad.cs
@@ -143,8 +143,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		internal IMementoCapable GetMementoCapable ()
 		{
-			PadWindow pw = (PadWindow) window;
-			return pw.GetMementoCapable ();
+			return content?.PadContent as IMementoCapable;
 		}
 		
 		public void Destroy ()


### PR DESCRIPTION
No pad user preferences were being saved. This was because the
preferences were being requested from the PadWindow through its
GetMementoCapable method. This was generally returning null since the
PadWindow's content field is not set. Changed the Pad so it checks
the PadCodon's Content implements IMementoCapable instead. This
ensures pad user preferences are stored with the solution's user
preferences.

Fixes VSTS #699562 - Show All Files is not persisted