### PR TITLE
[release-7.7] Support sub-millisecond precision for editor telemetry event timing

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1263,14 +1263,7 @@ namespace Mono.TextEditor
 		{
 			try {
 				if (currentFocus == FocusMargin.TextView) {
-					long time;
-#if MAC
-					time = (long)TimeSpan.FromSeconds (AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp).TotalMilliseconds;
-#else
-					// Warning, Gdk returns uint32 as time value, so this might overflow.
-					time = evt.Time;
-#endif
-					keyPressTimings.StartTimer (time);
+					keyPressTimings.StartTimer (evt);
 					return HandleTextKey (evt);
 				} else if (currentFocus != FocusMargin.None) {
 					return HandleMarginKeyCommand (evt);

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextEditorKeyPressTimings.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextEditorKeyPressTimings.cs
@@ -29,6 +29,7 @@ using MonoDevelop.Ide;
 using System.Collections.Immutable;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Ide.Editor;
+using MonoDevelop.Ide.Desktop;
 
 namespace Mono.TextEditor
 {
@@ -59,13 +60,14 @@ namespace Mono.TextEditor
 		//
 
 		const int numberOfCountSpaces = 100;
-		long[] activeCounts = new long[numberOfCountSpaces];
+		readonly TimeSpan [] activeCounts = new TimeSpan [numberOfCountSpaces];
 		int activeCountIndex = 0;
 		int droppedEvents = 0;
 
+		readonly IPlatformTelemetryDetails telemetry;
+
 		public TimeSpan GetCurrentTime ()
 		{
-			var telemetry = DesktopService.PlatformTelemetry;
 			if (telemetry == null) {
 				return TimeSpan.Zero;
 			}
@@ -74,6 +76,8 @@ namespace Mono.TextEditor
 
 		public TextEditorKeyPressTimings (TextDocument document)
 		{
+			telemetry = DesktopService.PlatformTelemetry;
+
 			openTime = GetCurrentTime ();
 
 			if (document != null) {
@@ -102,7 +106,15 @@ namespace Mono.TextEditor
 			totalTimeCaretDrawing += duration;
 		}
 
-		public void StartTimer (long eventTime)
+		public void StartTimer (Gdk.EventKey eventKey)
+		{
+			if (telemetry == null)
+				StartTimer (TimeSpan.FromMilliseconds (eventKey.Time));
+			else
+				StartTimer (telemetry.GetEventTime (eventKey));
+		}
+
+		public void StartTimer (TimeSpan eventTime)
 		{
 			if (activeCountIndex == numberOfCountSpaces) {
 				// just drop these events now
@@ -152,26 +164,15 @@ namespace Mono.TextEditor
 				return;
 			}
 
-			// Gdk key events are wrapped to uint32, so if we use longs here, we will get keypresses that
-			// seemingly last for days.
-			var sinceStartup = (long)currentTime.TotalMilliseconds;
-
 			if (complete) {
-				for (int i = 0; i < activeCountIndex; i++) {
-					var ts = activeCounts[i];
-					var durationMs = sinceStartup - ts;
-
-					AddTime (new TimeSpan (durationMs * TimeSpan.TicksPerMillisecond));
-				}
+				for (int i = 0; i < activeCountIndex; i++)
+					AddTime (currentTime - activeCounts[i]);
 
 				activeCountIndex = 0;
 			} else {
 				// Some keypresses do not trigger a draw event, so we process them once
 				// they are finished and remove them from the activeCounts list
-				var ts = activeCounts[--activeCountIndex];
-				var durationMs = sinceStartup - ts;
-
-				AddTime (new TimeSpan (durationMs * TimeSpan.TicksPerMillisecond));
+				AddTime (currentTime - activeCounts[--activeCountIndex]);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
@@ -51,5 +51,7 @@ namespace MonoDevelop.Ide.Desktop
 		PlatformHardDriveMediaType HardDriveOsMediaType { get; }
 
 		bool TrySampleHostCpuLoad (out double value);
+
+		TimeSpan GetEventTime (Gdk.EventKey eventKey);
 	}
 }

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorKeyPressTimingsTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests/TextEditorKeyPressTimingsTests.cs
@@ -44,8 +44,7 @@ namespace Mono.TextEditor.Tests
 			if (telemetry == null)
 				Assert.Ignore ("Platform does not implement telemetry details");
 
-			var time = (long)telemetry.TimeSinceMachineStart.TotalMilliseconds;
-			timings.StartTimer (time);
+			timings.StartTimer (telemetry.TimeSinceMachineStart);
 			action ();
 			timings.EndTimer ();
 


### PR DESCRIPTION
Backport of #6452.

/cc @Therzok @abock

Description:
Read each commit and commit message separately as details are layered in.

* Implement a test to assert/ensure event times with sub-millisecond precision
* Allow `IPlatformTelemetryDetails` to provide event times
* Support sub-millisecond precision when dealing with time accumulation in `TextEditorKeyPressTimings`

**TL;DR:** Telemetry timings now have sub-millisecond precision on macOS (e.g. an event that was previously truncated to 2ms may now be more accurately reported as say 2.9708ms).

Fixes VSTS #714180