### PR TITLE
[release-7.7] [AspNetCore] Checks publish profiles directory 

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Commands/PublishToFolderProfilesCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Commands/PublishToFolderProfilesCommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
@@ -17,6 +18,9 @@ namespace MonoDevelop.AspNetCore.Commands
 			if (!ProjectSupportsFolderPublishing (project)) {
 				return;
 			}
+
+			if (!Directory.Exists (project.BaseDirectory.Combine ("Properties", "PublishProfiles")))
+				return;
 
 			var profiles = project.GetPublishProfiles ();
 			foreach (var profile in profiles.OrderBy (x => x.Name)) {

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Commands/PublishToFolderProfilesCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Commands/PublishToFolderProfilesCommandHandler.cs
@@ -19,7 +19,7 @@ namespace MonoDevelop.AspNetCore.Commands
 				return;
 			}
 
-			if (!Directory.Exists (project.BaseDirectory.Combine ("Properties", "PublishProfiles")))
+			if (!project.GetPublishProfilesDirectory ().Exists)
 				return;
 
 			var profiles = project.GetPublishProfiles ();

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ProjectExtensions.cs
@@ -11,10 +11,10 @@ namespace MonoDevelop.AspNetCore
 	{
 		public static IEnumerable<ProjectPublishProfile> GetPublishProfiles (this DotNetProject project)
 		{
-			var profileFiles = Directory.EnumerateFiles (project.BaseDirectory.Combine ("Properties", "PublishProfiles"), "*.pubxml");
+			var profileFiles = project.GetPublishProfilesDirectory ().EnumerateFiles ("*.pubxml");
 
 			foreach (var file in profileFiles) {
-				var profile = ProjectPublishProfile.ReadModel (file);
+				var profile = ProjectPublishProfile.ReadModel (file.FullName);
 				if (profile != null)
 					yield return profile;
 			}
@@ -52,7 +52,7 @@ namespace MonoDevelop.AspNetCore
 
 		static string GetNextPubXmlFileName (this DotNetProject project)
 		{
-			var baseDirectory = project.BaseDirectory.Combine ("Properties", "PublishProfiles");
+			var baseDirectory = project.GetPublishProfilesDirectory ().FullName;
 			var identifier = string.Empty;
 			var count = default (int);
 			var file = $"{ProjectPublishProfile.ProjectPublishProfileKey}{identifier}.pubxml";
@@ -64,5 +64,8 @@ namespace MonoDevelop.AspNetCore
 
 			return Path.Combine (baseDirectory, file);
 		}
+
+		public static DirectoryInfo GetPublishProfilesDirectory (this DotNetProject project)
+			=> new DirectoryInfo (project.BaseDirectory.Combine ("Properties", "PublishProfiles"));
 	}
 }

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ProjectExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
 using MonoDevelop.AspNetCore.Commands;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects;


### PR DESCRIPTION
Backport of #6461.

/cc @rodrmoya @jtorres

Description:
- This prevents a DirectoryNotFound exception since we are always enumerating (and assuming) that such directory exists.