### PR TITLE
Delay accessibility updates

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/FoldMarkerMargin.cs
@@ -369,6 +369,11 @@ namespace Mono.TextEditor
 			foldings = null;
 			drawer = null;
 
+			if (updateAccessibilityId > 0) {
+				GLib.Source.Remove (updateAccessibilityId);
+				updateAccessibilityId = 0;
+			}
+
 			if (accessibles != null) {
 				foreach (var a in accessibles.Values) {
 					Accessible.RemoveAccessibleChild (a.Accessible);


### PR DESCRIPTION
Delay the accessibility updating for the quick task strip for 5 seconds to prevent unnecessary updates