### PR TITLE
Master optimize drawing

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -369,13 +369,12 @@ namespace MonoDevelop.AnalysisCore.Gui
 						return false;
 					var oldMarker = oldMarkers [oldMarkerIndex++];
 
-					if (results [curResult].Equals((Result)oldMarker.Tag)) {
+					if (results [curResult].Equals ((Result)oldMarker.Tag, oldMarker.Offset)) {
 						oldMarker.Tag = results [curResult];
 						newMarkers.Add (oldMarker);
 						curResult++;
 						continue;
 					}
-
 					editor.RemoveMarker (oldMarker);
 				}
 

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -93,8 +93,8 @@ namespace MonoDevelop.AnalysisCore.Gui
 			CancelUpdateTimout ();
 			AnalysisOptions.AnalysisEnabled.Changed -= AnalysisOptionsChanged;
 			foreach (var queue in markers) {
-				while (queue.Value.Count > 0)
-					Editor.RemoveMarker (queue.Value.Dequeue ());
+				foreach (var marker in queue.Value)
+					Editor.RemoveMarker (marker);
 			}
 			disposed = true;
 			base.Dispose ();
@@ -212,13 +212,14 @@ namespace MonoDevelop.AnalysisCore.Gui
 			
 			if (e.DocumentId != cad.Id || e.ProjectId != cad.Project.Id)
 				return;
-
 			var token = CancelUpdateTimeout (e.Id);
 			var ad = new AnalysisDocument (Editor, DocumentContext);
 			try {
 				var result = await CodeDiagnosticRunner.Check (ad, token, e.Diagnostics).ConfigureAwait (false);
-				var updater = new ResultsUpdater (this, result, e.Id, token);
-				updater.Update ();
+				if (result is IReadOnlyList<Result> resultList) {
+					var updater = new ResultsUpdater (this, resultList, e.Id, token);
+					updater.Update ();
+				}
 			} catch (Exception) {
 			}
 		}
@@ -253,12 +254,34 @@ namespace MonoDevelop.AnalysisCore.Gui
 			readonly CancellationToken cancellationToken;
 			
 			//the number of markers at the head of the queue that need tp be removed
-			int oldMarkers;
-			IEnumerator<Result> enumerator;
+			int oldMarkerIndex;
+			readonly List<IGenericTextSegmentMarker> oldMarkers;
+
+			int curResult = 0;
+			IReadOnlyList<Result> results;
+
+			private List<IGenericTextSegmentMarker> newMarkers;
 			ImmutableArray<QuickTask>.Builder builder;
 			object id;
-			
-			public ResultsUpdater (ResultsEditorExtension ext, IEnumerable<Result> results, object resultsId, CancellationToken cancellationToken)
+
+			const int MaxCacheSize = 200;
+			readonly static Queue<List<IGenericTextSegmentMarker>> listCache = new Queue<List<IGenericTextSegmentMarker>> ();
+
+			static List<IGenericTextSegmentMarker> GetCachedList ()
+			{
+				if (listCache.Count == 0)
+					return new List<IGenericTextSegmentMarker> ();
+				return listCache.Dequeue ();
+			}
+
+			static void PutBackCachedList (List<IGenericTextSegmentMarker> list)
+			{
+				list.Clear ();
+				if (listCache.Count < MaxCacheSize)
+					listCache.Enqueue (list);
+			}
+
+			public ResultsUpdater (ResultsEditorExtension ext, IReadOnlyList<Result> results, object resultsId, CancellationToken cancellationToken)
 			{
 				if (ext == null)
 					throw new ArgumentNullException ("ext");
@@ -268,17 +291,16 @@ namespace MonoDevelop.AnalysisCore.Gui
 				id = resultsId;
 				this.cancellationToken = cancellationToken;
 
-				Queue<IGenericTextSegmentMarker> oldMarkers;
 				if (resultsId != null) {
 					if (!ext.markers.TryGetValue (id, out oldMarkers))
-						ext.markers [id] = oldMarkers = new Queue<IGenericTextSegmentMarker> ();
-					this.oldMarkers = oldMarkers.Count;
+						ext.markers [id] = oldMarkers = GetCachedList ();
 				}
 				
 				builder = ImmutableArray<QuickTask>.Empty.ToBuilder ();
-				enumerator = results.GetEnumerator ();
+				this.results = results;
+				newMarkers = GetCachedList ();
 			}
-			
+
 			public void Update ()
 			{
 				if (cancellationToken.IsCancellationRequested)
@@ -324,13 +346,17 @@ namespace MonoDevelop.AnalysisCore.Gui
 				var editor = ext.Editor;
 				if (editor == null)
 					return false;
-
 				if (id == null) {
 					foreach (var markerQueue in ext.markers) {
-						while (markerQueue.Value.Count != 0)
-							editor.RemoveMarker (markerQueue.Value.Dequeue ());
+						foreach (var marker in markerQueue.Value) {
+							editor.RemoveMarker (marker);
+						}
+						PutBackCachedList (markerQueue.Value);
 					}
 					ext.markers.Clear ();
+				}
+
+				if (id == null) {
 					lock (ext.tasks)
 						ext.tasks.Clear ();
 					ext.OnTasksUpdated (EventArgs.Empty);
@@ -338,30 +364,42 @@ namespace MonoDevelop.AnalysisCore.Gui
 				}
 
 				//clear the old results out at the same rate we add in the new ones
-				for (int i = 0; oldMarkers > 0 && i < UPDATE_COUNT; i++) {
+				for (int i = 0; oldMarkerIndex < oldMarkers.Count && i < UPDATE_COUNT; i++) {
 					if (cancellationToken.IsCancellationRequested)
 						return false;
-					editor.RemoveMarker (ext.markers [id].Dequeue ());
-					oldMarkers--;
+					var oldMarker = oldMarkers [oldMarkerIndex++];
+
+					if (results [curResult].Equals((Result)oldMarker.Tag)) {
+						oldMarker.Tag = results [curResult];
+						newMarkers.Add (oldMarker);
+						curResult++;
+						continue;
+					}
+
+					editor.RemoveMarker (oldMarker);
 				}
 
 				//add in the new markers
 				for (int i = 0; i < UPDATE_COUNT; i++) {
-					if (!enumerator.MoveNext ()) {
+					if (curResult >= results.Count) {
 						lock (ext.tasks)
 							ext.tasks [id] = builder.ToImmutable ();
 						ext.OnTasksUpdated (EventArgs.Empty);
 						// remove remaining old markers
-						while (oldMarkers > 0) {
-							editor.RemoveMarker (ext.markers [id].Dequeue ());
-							oldMarkers--;
+						while (oldMarkerIndex < oldMarkers.Count) {
+							editor.RemoveMarker (oldMarkers[oldMarkerIndex]);
+							oldMarkerIndex++;
 						}
+
+						PutBackCachedList (ext.markers [id]);
+						ext.markers [id] = newMarkers;
 
 						return false;
 					}
+
 					if (cancellationToken.IsCancellationRequested)
 						return false;
-					var currentResult = (Result)enumerator.Current;
+					var currentResult = results [curResult++];
 					if (currentResult.InspectionMark != IssueMarker.None) {
 						int start = currentResult.Region.Start;
 						int end = currentResult.Region.End;
@@ -381,18 +419,17 @@ namespace MonoDevelop.AnalysisCore.Gui
 							marker.IsVisible &= currentResult.Level != DiagnosticSeverity.Hidden;
 						}
 						editor.AddMarker (marker);
-						ext.markers [id].Enqueue (marker);
+						newMarkers.Add (marker);
 					}
 					builder.Add (new QuickTask (currentResult.Message, currentResult.Region.Start, currentResult.Level));
 				}
-				
 				return true;
 			}
 		}
-		
+
 		//all markers known to be in the editor
 		// Roslyn groups diagnostics by their provider. In this case, we rely on the id passed in to group markers by their id.
-		Dictionary<object, Queue<IGenericTextSegmentMarker>> markers = new Dictionary<object, Queue<IGenericTextSegmentMarker>> ();
+		Dictionary<object, List<IGenericTextSegmentMarker>> markers = new Dictionary<object, List<IGenericTextSegmentMarker>> ();
 		Dictionary<object, CancellationTokenSource> cancellations = new Dictionary<object, CancellationTokenSource> ();
 		
 		const int UPDATE_COUNT = 20;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -369,7 +369,7 @@ namespace MonoDevelop.AnalysisCore.Gui
 						return false;
 					var oldMarker = oldMarkers [oldMarkerIndex++];
 
-					if (results [curResult].Equals ((Result)oldMarker.Tag, oldMarker.Offset)) {
+					if (curResult < results.Count && results [curResult].Equals ((Result)oldMarker.Tag, oldMarker.Offset)) {
 						oldMarker.Tag = results [curResult];
 						newMarkers.Add (oldMarker);
 						curResult++;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Result.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Result.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.AnalysisCore
 		
 		public bool Underline { get; private set; }
 
-		public bool Equals (Result other)
+		internal bool Equals (Result other, int correctedOffset)
 		{
 			if (ReferenceEquals (this, other))
 				return true;
@@ -76,7 +76,8 @@ namespace MonoDevelop.AnalysisCore
 				return false;
 			return Level == other.Level &&
 				InspectionMark == other.InspectionMark &&
-				Region.Equals (other.Region) &&
+				Region.Start == correctedOffset &&
+				Region.Length == other.Region.Length &&
 				Message == other.Message;
 		}
 

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Result.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Result.cs
@@ -67,5 +67,18 @@ namespace MonoDevelop.AnalysisCore
 		public TextSpan Region { get; private set; }
 		
 		public bool Underline { get; private set; }
+
+		public bool Equals (Result other)
+		{
+			if (ReferenceEquals (this, other))
+				return true;
+			if (other == null)
+				return false;
+			return Level == other.Level &&
+				InspectionMark == other.InspectionMark &&
+				Region.Equals (other.Region) &&
+				Message == other.Message;
+		}
+
 	}
 }

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -3368,6 +3368,11 @@ namespace Mono.TextEditor
 		void OnDocumentStateChanged (object s, TextChangeEventArgs args)
 		{
 			HideTooltip ();
+			if (editor.Document.SyntaxMode is ISyntaxHighlighting2 sh2) {
+				if (sh2.IsUpdatingOnTextChange)
+					return;
+			}
+
 			for (int i = 0; i < args.TextChanges.Count; ++i) {
 				var change = args.TextChanges[i];
 				var start = editor.Document.OffsetToLineNumber (change.NewOffset);

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -31,30 +31,31 @@ using MonoDevelop.Ide.Tasks;
 
 namespace Microsoft.VisualStudio.Platform
 {
-	[Export (typeof (ITagBasedSyntaxHighlightingFactory))]
-	internal sealed class TagBasedSyntaxHighlightingFactory : ITagBasedSyntaxHighlightingFactory
-	{
-		public ISyntaxHighlighting CreateSyntaxHighlighting (ITextView textView)
-		{
-			return new TagBasedSyntaxHighlighting (textView, null);
-		}
+    [Export(typeof(ITagBasedSyntaxHighlightingFactory))]
+    internal sealed class TagBasedSyntaxHighlightingFactory : ITagBasedSyntaxHighlightingFactory
+    {
+        public ISyntaxHighlighting CreateSyntaxHighlighting(ITextView textView)
+        {
+            return new TagBasedSyntaxHighlighting(textView, null);
+        }
 
-		public ISyntaxHighlighting CreateSyntaxHighlighting (ITextView textView, string defaultScope)
-		{
-			return new TagBasedSyntaxHighlighting (textView, defaultScope);
-		}
-	}
+        public ISyntaxHighlighting CreateSyntaxHighlighting(ITextView textView, string defaultScope)
+        {
+            return new TagBasedSyntaxHighlighting(textView, defaultScope);
+        }
+    }
 
-	internal sealed class TagBasedSyntaxHighlighting : ISyntaxHighlighting
-	{
-		private ITextView textView { get; }
-		private IAccurateClassifier classifier { get; set; }
-		readonly Dictionary<string, ScopeStack> classificationMap;
-		Dictionary<IClassificationType, ScopeStack> classificationTypeToScopeCache = new Dictionary<IClassificationType, ScopeStack> ();
-		ScopeStack defaultScopeStack;
-		private MonoDevelop.Ide.Editor.ITextDocument textDocument { get; }
+    internal sealed class TagBasedSyntaxHighlighting : ISyntaxHighlighting2
+    {
+        private ITextView textView { get; }
+        private IAccurateClassifier classifier { get; set; }
+        readonly Dictionary<string, ScopeStack> classificationMap;
+        Dictionary<IClassificationType, ScopeStack> classificationTypeToScopeCache = new Dictionary<IClassificationType, ScopeStack>();
+        ScopeStack defaultScopeStack;
+        private MonoDevelop.Ide.Editor.ITextDocument textDocument { get; }
+        public bool IsUpdatingOnTextChange { get { return true; } }
 
-		internal TagBasedSyntaxHighlighting (ITextView textView, string defaultScope)
+        internal TagBasedSyntaxHighlighting (ITextView textView, string defaultScope)
 		{
 			this.textView = textView;
 			this.textDocument = textView.GetTextEditor ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/ISyntaxHighlighting.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/ISyntaxHighlighting.cs
@@ -80,6 +80,11 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 		event EventHandler<LineEventArgs> HighlightingStateChanged;
 	}
 
+	interface ISyntaxHighlighting2 : ISyntaxHighlighting
+	{
+		bool IsUpdatingOnTextChange { get; }
+	}
+
 	public sealed class DefaultSyntaxHighlighting : ISyntaxHighlighting
 	{
 		public static readonly DefaultSyntaxHighlighting Instance = new DefaultSyntaxHighlighting ();


### PR DESCRIPTION
Found 2 problems:

+ Tag based syntax highlighting always updates on text change 
+ Analysis Markers don't reuse objects and creates a lot of allocations and markers. Reusing markers helps a lot every add/remove causes redrawing.  

This PR only reuses the markers before the text change - however markers beyond the text change could be reused as well but I need more time implementing that - I'll update on this PR.