### PR TITLE
Expose InformLoadComplete in `TextEditor` needed to fix VSTS 706004

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -486,6 +486,12 @@ namespace MonoDevelop.Ide.Editor
 				StartCaretPulseAnimation ();
 		}
 
+		public void InformLoadComplete ()
+		{
+			Runtime.AssertMainThread ();
+			textEditorImpl.InformLoadComplete ();
+		}
+
 		public void ClearSelection ()
 		{
 			Runtime.AssertMainThread ();


### PR DESCRIPTION
VSTS issue: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/706004

Related PR:
https://github.com/xamarin/designer/pull/1353