### PR TITLE
[Core] Try using a hashset to add item results

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -539,9 +539,7 @@ namespace MonoDevelop.Projects
 			var evaluatedCompileItems = coreCompileResult.SourceFiles;
 
 			var results = new HashSet<ProjectFile> (evaluatedItems, ProjectFileFilePathComparer.Instance);
-			foreach (var item in evaluatedCompileItems) {
-				results.Add (item);
-			}
+			results.UnionWith (evaluatedCompileItems);
 
 			return results.ToArray ();
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -532,18 +532,27 @@ namespace MonoDevelop.Projects
 		protected virtual async Task<ProjectFile[]> OnGetSourceFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			// pre-load the results with the current list of files in the project
-			var results = new List<ProjectFile> ();
-
 			var evaluatedItems = await GetEvaluatedSourceFiles (configuration);
-			results.AddRange (evaluatedItems);
 
 			// add in any compile items that we discover from running the CoreCompile dependencies
 			var coreCompileResult = await compileEvaluator.GetItemsFromCoreCompileDependenciesAsync (this, monitor, configuration);
 			var evaluatedCompileItems = coreCompileResult.SourceFiles;
-			var addedItems = evaluatedCompileItems.Where (i => results.All (pi => pi.FilePath != i.FilePath)).ToList ();
-			results.AddRange (addedItems);
+
+			var results = new HashSet<ProjectFile> (evaluatedItems, ProjectFileFilePathComparer.Instance);
+			foreach (var item in evaluatedCompileItems) {
+				results.Add (item);
+			}
 
 			return results.ToArray ();
+		}
+
+		class ProjectFileFilePathComparer : IEqualityComparer<ProjectFile>
+		{
+			public readonly static ProjectFileFilePathComparer Instance = new ProjectFileFilePathComparer ();
+
+			public bool Equals (ProjectFile x, ProjectFile y) => x.FilePath == y.FilePath;
+
+			public int GetHashCode (ProjectFile obj) => obj.FilePath.GetHashCode ();
 		}
 
 		object evaluatedSourceFilesLock = new object ();


### PR DESCRIPTION
10 seconds of CPU time is spent in the All LINQ call which does a lot
of work to figure out whether an item is in the list (with the result
from CoreCompileDependsOn running containing a lot of items).

Try using a HashSet which would make this an O(1), not O(n). This
should take down OnGetSourceFiles time on Main.sln by 14s of CPU time.

Fixes VSTS #719932 - OnGetSourceFilesAsync can be optimized