### PR TITLE
[Ide] De-asynchronify Creating startup metadata

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -473,9 +473,9 @@ namespace MonoDevelop.Ide
 			return false;
 		}
 
-		async void CreateStartupMetadata (StartupInfo startupInfo, Dictionary<string, long> timings)
+		void CreateStartupMetadata (StartupInfo startupInfo, Dictionary<string, long> timings)
 		{
-			var result = await Task.Run (() => DesktopService.PlatformTelemetry);
+			var result = DesktopService.PlatformTelemetry;
 			if (result == null) {
 				return;
 			}


### PR DESCRIPTION
It is already requested in one of the InitComplete handlers,
thus it is already computed. No need to create a task just
for querying a lazy value.