### PR TITLE
Fix GetFocussableWidgets()

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -361,24 +361,21 @@ namespace MonoDevelop.Ide.Gui
 		
 		static IEnumerable<Gtk.Widget> GetFocussableWidgets (Gtk.Widget widget)
 		{
-			var c = widget as Container;
-
 			if (widget.CanFocus) {
 				yield return widget;
 			}
 
-			if (c != null) {
+			if (widget is Container c) {
 				foreach (var f in c.FocusChain.SelectMany (GetFocussableWidgets).Where (y => y != null)) {
 					yield return f;
 				}
-			}
 
-			if (c?.Children?.Length != 0) {
-				foreach (var f in c.Children) {
-					var container = f as Container;
-					if (container != null) {
-						foreach (var child in GetFocussableChildren (container)) {
-							yield return child;
+				if (c.Children is var children) {
+					foreach (var f in children) {
+						if (f is Container container) {
+							foreach (var child in GetFocussableChildren (container)) {
+								yield return child;
+							}
 						}
 					}
 				}
@@ -392,8 +389,7 @@ namespace MonoDevelop.Ide.Gui
 			}
 
 			foreach (var f in container.Children) {
-				var c = f as Container;
-				if (c != null) {
+				if (f is Container c) {
 					foreach (var child in GetFocussableChildren (c)) {
 						yield return child;
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -347,7 +347,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			Widget first = null;
 
-			foreach (var f in GetFocussableWidgets (widget)) {
+			foreach (var f in GetFocusableWidgets (widget)) {
 				if (f.HasFocus)
 					return;
 				
@@ -359,21 +359,21 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 		
-		static IEnumerable<Gtk.Widget> GetFocussableWidgets (Gtk.Widget widget)
+		static IEnumerable<Gtk.Widget> GetFocusableWidgets (Gtk.Widget widget)
 		{
 			if (widget.CanFocus) {
 				yield return widget;
 			}
 
 			if (widget is Container c) {
-				foreach (var f in c.FocusChain.SelectMany (GetFocussableWidgets).Where (y => y != null)) {
+				foreach (var f in c.FocusChain.SelectMany (GetFocusableWidgets).Where (y => y != null)) {
 					yield return f;
 				}
 
 				if (c.Children is var children) {
 					foreach (var f in children) {
 						if (f is Container container) {
-							foreach (var child in GetFocussableChildren (container)) {
+							foreach (var child in GetFocusableChildren (container)) {
 								yield return child;
 							}
 						}
@@ -382,7 +382,7 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
-		static IEnumerable<Gtk.Widget> GetFocussableChildren (Gtk.Container container)
+		static IEnumerable<Gtk.Widget> GetFocusableChildren (Gtk.Container container)
 		{
 			if (container.CanFocus) {
 				yield return container;
@@ -390,7 +390,7 @@ namespace MonoDevelop.Ide.Gui
 
 			foreach (var f in container.Children) {
 				if (f is Container c) {
-					foreach (var child in GetFocussableChildren (c)) {
+					foreach (var child in GetFocusableChildren (c)) {
 						yield return child;
 					}
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/SdiWorkspaceWindow.cs
@@ -366,7 +366,7 @@ namespace MonoDevelop.Ide.Gui
 			}
 
 			if (widget is Container c) {
-				foreach (var f in c.FocusChain.SelectMany (GetFocusableWidgets).Where (y => y != null)) {
+				foreach (var f in c.FocusChain.SelectMany (x => GetFocusableWidgets (x))) {
 					yield return f;
 				}
 


### PR DESCRIPTION
When a widget is not a container, c?.Children?.Length != 0 is true (because Length is `null` which is not 0), and so we were falling through to the `foreach` and null ref-ing on `c.Children`.

Also use pattern matching to simplify code a bit while I'm here.

Rename `GetFocussableWidgets` -> `GetFocusableWidgets`.