### PR TITLE
[release-7.7] [Ide] Properly handle symlinks at workbench level

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -272,7 +272,10 @@ namespace MonoDevelop.Ide.Gui
 					}
 				}
 
-				var pf = project.GetProjectFile ((string)OriginalFileName ?? FileName);
+				ProjectFile pf = project.GetProjectFile (OriginalFileName);
+				if (pf == null)
+					pf = project.GetProjectFile (FileName);
+
 				return pf != null && pf.BuildAction != BuildAction.None;
 			}
 		}
@@ -1187,9 +1190,12 @@ namespace MonoDevelop.Ide.Gui
 			var parser = TypeSystemService.GetParser (Editor.MimeType);
 			if (parser == null)
 				return null;
-			var projectFile = Project.GetProjectFile ((string)OriginalFileName ?? Editor.FileName);
-			if (projectFile == null)
-				return null;
+			var projectFile = Project.GetProjectFile (OriginalFileName);
+			if (projectFile == null) {
+				projectFile = Project.GetProjectFile (Editor.FileName);
+				if (projectFile == null)
+					return null;
+			}
 			if (!parser.CanGenerateProjection (Editor.MimeType, projectFile.BuildAction, Project.SupportedLanguages))
 				return null;
 			try {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -207,6 +207,14 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
+		internal FilePath OriginalFileName {
+			get {
+				if (Window == null || !Window.ViewContent.IsFile)
+					return null;
+				return Window.ViewContent.OriginalContentName;
+			}
+		}
+
 		internal event EventHandler FileNameChanged;
 
 		void OnFileNameChanged ()
@@ -264,7 +272,7 @@ namespace MonoDevelop.Ide.Gui
 					}
 				}
 
-				var pf = project.GetProjectFile (FileName);
+				var pf = project.GetProjectFile ((string)OriginalFileName ?? FileName);
 				return pf != null && pf.BuildAction != BuildAction.None;
 			}
 		}
@@ -1179,7 +1187,7 @@ namespace MonoDevelop.Ide.Gui
 			var parser = TypeSystemService.GetParser (Editor.MimeType);
 			if (parser == null)
 				return null;
-			var projectFile = Project.GetProjectFile (Editor.FileName);
+			var projectFile = Project.GetProjectFile ((string)OriginalFileName ?? Editor.FileName);
 			if (projectFile == null)
 				return null;
 			if (!parser.CanGenerateProjection (Editor.MimeType, projectFile.BuildAction, Project.SupportedLanguages))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewContent.cs
@@ -55,9 +55,12 @@ namespace MonoDevelop.Ide.Gui
 				if (value != contentName) {
 					contentName = value;
 					OnContentNameChanged ();
+					OriginalContentName = null;
 				}
 			}
 		}
+
+		internal string OriginalContentName { get; set; }
 
 		public bool IsUntitled {
 			get { return (ContentName == null); }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -1079,7 +1079,8 @@ namespace MonoDevelop.Ide.Gui
 				if (project == null)
 					project = GetProjectContainingFile (openFileInfo.OriginalFileName);
 				openFileInfo.Project = project;
-			}
+			} else
+				project = openFileInfo.Project;
 			
 			if (openFileInfo.DisplayBinding != null) {
 				binding = viewBinding = openFileInfo.DisplayBinding;


### PR DESCRIPTION
Backport of #6331.

/cc @slluis @Therzok

Description:
When working with symlinked on disk files in a project, there's a
few things which were not handled correctly.

When a project references a symlink, we should keep the original
symlink information around so that it can be used when looking up
a for a Project containing a file or a file in general in a project.

Added in an OriginalFile property that is used to recover the original
file name, before resolving a symlink, that can be used by the typesystem
to figure out which project the file belongs to.

Fixes VSTS #700204 - Symlinked files do not have correct define constants