### PR TITLE
[Ide] Reset LogView cookie only when cleared for reusing

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -497,10 +497,6 @@ namespace MonoDevelop.Ide.Gui.Components
 
 		public void Clear ()
 		{
-			unchecked {
-				Cookie++;
-			}
-
 			lock (updates) {
 				updates.Clear ();
 				lastTextWrite = null;
@@ -869,8 +865,12 @@ namespace MonoDevelop.Ide.Gui.Components
 
 			Indent = new IndentTracker ();
 
-			if (clearConsole)
+			if (clearConsole) {
+				unchecked {
+					outputPad.Cookie++;
+				}
 				outputPad.Clear ();
+			}
 
 			padCookie = pad.Cookie;
 			internalLogger.TextWritten += WriteConsoleLogText;


### PR DESCRIPTION
The `Cookie` should not be reset on a regular `Clear()` (i.e. Clear pad button clicked) but only when the pad is being cleared by a new consumer wanting to reuse an existing output pad.

Fixes VSTS #705935