### PR TITLE
[Git] Remove superfluous {0} from label

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.CredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.CredentialsDialog.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.VersionControl.Git
 			this.labelTop = new global::Gtk.Label ();
 			this.labelTop.Name = "labelTop";
 			this.labelTop.Xalign = 0F;
-			this.labelTop.LabelProp = global::Mono.Unix.Catalog.GetString ("Credentials required for the repository: {0}");
+			this.labelTop.LabelProp = global::Mono.Unix.Catalog.GetString ("Credentials required for the repository:");
 			this.vbox.Add (this.labelTop);
 			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox [this.labelTop]));
 			w2.Position = 0;


### PR DESCRIPTION
There's a label right below it which contains the URL

Fixes VSTS #720573 - Git Credentials Pop up Window Text Defect