### PR TITLE
[IDE] Wrap the PropertyCell Value getter in a try catch block

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyEditorCell.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyEditorCell.cs
@@ -31,6 +31,7 @@ using System.ComponentModel;
 using Gdk;
 using Gtk;
 using MonoDevelop.Ide.Fonts;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.PropertyGrid
 {
@@ -115,7 +116,14 @@ namespace MonoDevelop.Components.PropertyGrid
 		}
 		
 		public object Value {
-			get { return Instance != null ? Property.GetValue (Instance) : null; }
+			get {
+				try {
+					return Instance != null ? Property.GetValue (Instance) : null;
+				} catch (Exception e) {
+					LoggingService.LogInternalError ($"Bug 706892: {GetType ()}", e);
+				}
+				return null;
+			}
 		}
 		
 		protected virtual void Initialize ()


### PR DESCRIPTION
There is a crash in the PropertyCell value getter, which this try catch will
work around

Fixes VSTS #706892