### PR TITLE
[Core] Add Analyzers to be used in the MD build

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -8,6 +8,8 @@
     <ReferencesGtk>$(RootDirectory)\msbuild\ReferencesGtk.props</ReferencesGtk>
     <NuGetVersionRoslyn>2.10.0-beta2-63315-04</NuGetVersionRoslyn>
     <NuGetVersionVSEditor>15.8.519</NuGetVersionVSEditor>
+    <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
+    <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
   </PropertyGroup>
 
 </Project>

--- a/main/msbuild/MonoDevelop.AfterCommon.props
+++ b/main/msbuild/MonoDevelop.AfterCommon.props
@@ -34,4 +34,13 @@
 			<LogicalName>%(Filename)%(Extension)</LogicalName>
 		</EmbeddedResource>
 	</ItemDefinitionGroup>
+
+	<ItemGroup Condition=" '$(MD_PERF_ANALYZERS_ENABLED)' == 'true' ">
+		<!-- ErrorProne.NET.Structs -->
+		<Analyzer Include="$(PackagesDirectory)\ErrorProne.NET.Structs.$(NuGetVersionErrorProneNetStructs)\analyzers\dotnet\cs\ErrorProne.Net.StructAnalyzers.dll" />
+
+		<!-- ClrHeapAllocationAnalyzer -->
+		<Analyzer Include="$(PackagesDirectory)\ClrHeapAllocationAnalyzer.$(NuGetVersionAllocationAnalyzer)\analyzers\dotnet\cs\ClrHeapAllocationAnalyzer.dll" />
+	</ItemGroup>
+
 </Project>

--- a/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/ButtonBar.cs
@@ -53,7 +53,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			public override void DrawWithFrame (CGRect cellFrame, NSView inView)
 			{
 				if (IdeApp.Preferences.UserInterfaceTheme == Theme.Dark) {
+#pragma warning disable EPS06 // Hidden struct copy operation
 					var inset = cellFrame.Inset (0.25f, 0.25f);
+#pragma warning restore EPS06 // Hidden struct copy operation
 					inset = new CGRect (inset.X, inset.Y + 2, inset.Width, inset.Height - 2);
 
 					var path = NSBezierPath.FromRoundedRect (inset, 3, 3);

--- a/main/src/addins/MacPlatform/MainToolbar/ButtonBarContainer.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/ButtonBarContainer.cs
@@ -125,7 +125,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				var frame = new CGRect (nextX, y, extraPadding + (bar.SegmentCount * SegmentWidth), height);
 				bar.Frame = frame;
 
+#pragma warning disable EPS06 // Hidden struct copy operation
 				nextX = frame.GetMaxX () + buttonBarSpacing;
+#pragma warning restore EPS06 // Hidden struct copy operation
 			}
 
 			SetFrameSize (new CGSize (nextX - buttonBarSpacing, height));

--- a/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/RunButton.cs
@@ -183,7 +183,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public override void DrawBezelWithFrame (CGRect frame, NSView controlView)
 		{
 			if (IdeApp.Preferences.UserInterfaceTheme == Theme.Dark) {
+#pragma warning disable EPS06 // Hidden struct copy operation
 				var inset = frame.Inset (0.25f, 0.25f);
+#pragma warning restore EPS06 // Hidden struct copy operation
 
 				var path = NSBezierPath.FromRoundedRect (inset, 3, 3);
 				path.LineWidth = 0.5f;

--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -52,7 +52,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			public override void DrawWithFrame (CGRect cellFrame, NSView inView)
 			{
 				if (IdeApp.Preferences.UserInterfaceTheme == Theme.Dark) {
+#pragma warning disable EPS06 // Hidden struct copy operation
 					var inset = cellFrame.Inset (0.25f, 0.25f);
+#pragma warning restore EPS06 // Hidden struct copy operation
 					if (!ShowsFirstResponder) {
 						var path = NSBezierPath.FromRoundedRect (inset, 3, 3);
 						path.LineWidth = 0.5f;

--- a/main/src/addins/MonoDevelop.Refactoring/AddinInfo.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/AddinInfo.cs
@@ -3,7 +3,7 @@ using System;
 using Mono.Addins;
 using Mono.Addins.Description;
 
-[assembly:Addin ("Refactoring", 
+[assembly:Addin ("Refactoring",
         Namespace = "MonoDevelop",
         Version = MonoDevelop.BuildInfo.Version,
         Category = "IDE extensions")]
@@ -16,7 +16,3 @@ using Mono.Addins.Description;
 [assembly:AddinDependency ("DesignerSupport", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("SourceEditor2", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("RegexToolkit", MonoDevelop.BuildInfo.Version)]
-
-#if DEBUG
-[assembly: ImportAddinAssembly ("ClrHeapAllocationAnalyzer.dll", Scan = false)]
-#endif

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/MonoDevelopWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/MonoDevelopWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -43,8 +43,6 @@ namespace MonoDevelop.AnalysisCore
 		static readonly AnalyzerAssemblyLoader analyzerAssemblyLoader = new AnalyzerAssemblyLoader ();
 		readonly static string diagnosticAnalyzerAssembly = typeof (DiagnosticAnalyzerAttribute).Assembly.GetName ().Name;
 
-		const bool ClrHeapEnabled = false;
-
 		private TaskCompletionSource<OptionsTable> optionsCompletionSource = new TaskCompletionSource<OptionsTable> ();
 		internal Task<OptionsTable> GetOptionsAsync () => optionsCompletionSource.Task;
 		readonly Task<ImmutableArray<HostDiagnosticAnalyzerPackage>> hostDiagnosticAnalyzerInfoTask;
@@ -83,12 +81,6 @@ namespace MonoDevelop.AnalysisCore
 					var assemblyName = asm.GetName ().Name;
 					if (Array.IndexOf (RuntimeEnabledAssemblies, assemblyName) == -1) {
 						switch (assemblyName) {
-						case "ClrHeapAllocationAnalyzer":
-							if (!ClrHeapEnabled)
-								continue;
-							#pragma warning disable 162 // Unreachable
-							break;
-							#pragma warning restore 162
 						//blacklist
 						case "FSharpBinding":
 							continue;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/AbstractOptionPreviewViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/AbstractOptionPreviewViewModel.cs
@@ -47,7 +47,6 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.CodeStyle;
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide.Composition;
 using MonoDevelop.Core.Text;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -101,11 +101,6 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'DebugMac' ">
-    <Reference Include="ClrHeapAllocationAnalyzer">
-      <HintPath>..\..\..\packages\ClrHeapAllocationAnalyzer.1.0.0.8\analyzers\dotnet\cs\ClrHeapAllocationAnalyzer.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="MonoDevelop.AnalysisCore\Gui\ResultsEditorExtension.cs" />
@@ -304,7 +299,6 @@
     <None Include="MonoDevelop.CodeIssues\Pad\AnalysisState.cs" />
     <None Include="MonoDevelop.CodeIssues\Pad\AnalysisStateChangeEventArgs.cs" />
     <None Include="MonoDevelop.CodeIssues\Pad\CategoryGroupingProvider.cs" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/src/addins/MonoDevelop.Refactoring/packages.config
+++ b/main/src/addins/MonoDevelop.Refactoring/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="ClrHeapAllocationAnalyzer" version="1.0.0.8" targetFramework="net461" developmentDependency="true" />
-</packages>

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ClrHeapAllocationAnalyzer" version="1.0.0.9" targetFramework="net471" />
+  <package id="ErrorProne.NET.Structs" version="0.1.2" targetFramework="net471" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net461" />
   <package id="ICSharpCode.Decompiler" version="3.2.0.3856" targetFramework="net471" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />


### PR DESCRIPTION
ClrHeapAllocationAnalyzer that is enabled behind an env var,
because of a few reasons:
a) the analyzer is verbose
b) the analyzers shows warnings for most cases, so the build
will fail when WarnAserror is true

ErrorProne.Net.Structs which helps with struct APIs.

Fixes VSTS #719111 - Enable RoslynClrHeapAnalyzer behind an env var
Fixes VSTS #719110 - Add ErrorProne.NET analyzers to Main.sln