### PR TITLE
[Dev] Add analyzer which picks up strings which should be localized

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -10,6 +10,7 @@
     <NuGetVersionVSEditor>15.8.519</NuGetVersionVSEditor>
     <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
+    <NuGetVersionMonoDevelopAnalyzers>0.1.0</NuGetVersionMonoDevelopAnalyzers>
   </PropertyGroup>
 
 </Project>

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -10,7 +10,7 @@
     <NuGetVersionVSEditor>15.8.519</NuGetVersionVSEditor>
     <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
-    <NuGetVersionMonoDevelopAnalyzers>0.1.0</NuGetVersionMonoDevelopAnalyzers>
+    <NuGetVersionMonoDevelopAnalyzers>0.1.0.1</NuGetVersionMonoDevelopAnalyzers>
   </PropertyGroup>
 
 </Project>

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Gui/MonoDevelop.FSharp.Gui.FSharpSettingsWidget.cs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Gui/MonoDevelop.FSharp.Gui.FSharpSettingsWidget.cs
@@ -74,7 +74,7 @@ namespace MonoDevelop.FSharp.Gui
 			w2.Fill = false;
 			// Container child vbox1.Gtk.Box+BoxChild
 			this.advanceToNextLineCheckbox = new global::Gtk.CheckButton();
-			this.advanceToNextLineCheckbox.TooltipMarkup = "When sending a line or an empty selection to F# interactive this property automatically advances to the next line.";
+			this.advanceToNextLineCheckbox.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("When sending a line or an empty selection to F# interactive this property automatically advances to the next line.");
 			this.advanceToNextLineCheckbox.CanFocus = true;
 			this.advanceToNextLineCheckbox.Name = "advanceToNextLineCheckbox";
 			this.advanceToNextLineCheckbox.Label = global::Mono.Unix.Catalog.GetString("Advance to next line");
@@ -110,7 +110,7 @@ namespace MonoDevelop.FSharp.Gui
 			this.hbox1.Spacing = 6;
 			// Container child hbox1.Gtk.Box+BoxChild
 			this.label2 = new global::Gtk.Label();
-			this.label2.TooltipMarkup = "This is only used when xbuild is not being used.";
+			this.label2.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("This is only used when xbuild is not being used.");
 			this.label2.Name = "label2";
 			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString("<b>F# Default Compiler</b>");
 			this.label2.UseMarkup = true;

--- a/main/msbuild/MonoDevelop.AfterCommon.props
+++ b/main/msbuild/MonoDevelop.AfterCommon.props
@@ -43,7 +43,11 @@
 		<Analyzer Include="$(PackagesDirectory)\ClrHeapAllocationAnalyzer.$(NuGetVersionAllocationAnalyzer)\analyzers\dotnet\cs\ClrHeapAllocationAnalyzer.dll" />
 	</ItemGroup>
 
+	<PropertyGroup>
+		<MonoDevelopDevAnalyzer>$(PackagesDirectory)\MonoDevelopDev.Analyzers.$(NugetVersionMonoDevelopAnalyzers)\analyzers\dotnet\cs\MonoDevelop.Analyzers.dll</MonoDevelopDevAnalyzer>
+	</PropertyGroup>
+
 	<ItemGroup>
-		<Analyzer Include="$(PackagesDirectory)\MonoDevelopDev.Analyzers.$(NugetVersionMonoDevelopAnalyzers)\analyzers\dotnet\cs\MonoDevelop.Analyzers.dll" />
+		<Analyzer Include="$(MonoDevelopDevAnalyzer)" Condition="Exists('$(MonoDevelopDevAnalyzer)')" />
 	</ItemGroup>
 </Project>

--- a/main/msbuild/MonoDevelop.AfterCommon.props
+++ b/main/msbuild/MonoDevelop.AfterCommon.props
@@ -43,4 +43,7 @@
 		<Analyzer Include="$(PackagesDirectory)\ClrHeapAllocationAnalyzer.$(NuGetVersionAllocationAnalyzer)\analyzers\dotnet\cs\ClrHeapAllocationAnalyzer.dll" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Analyzer Include="$(PackagesDirectory)\MonoDevelopDev.Analyzers.$(NugetVersionMonoDevelopAnalyzers)\analyzers\dotnet\cs\MonoDevelop.Analyzers.dll" />
+	</ItemGroup>
 </Project>

--- a/main/src/addins/AspNet/Execution/XspOptionsPanelWidget.cs
+++ b/main/src/addins/AspNet/Execution/XspOptionsPanelWidget.cs
@@ -62,15 +62,19 @@ namespace MonoDevelop.AspNet.Execution
 			//index should be equivalent to XspSslProtocol enum
 			((ListStore) sslProtocol.Model).Clear ();
 			sslProtocol.AppendText (GettextCatalog.GetString ("Default"));
+#pragma warning disable MD0005
 			sslProtocol.AppendText ("TLS");
 			sslProtocol.AppendText ("SSL 2");
 			sslProtocol.AppendText ("SSL 3");
-			
+#pragma warning restore MD0005
+
 			((ListStore) keyType.Model).Clear ();
 			keyType.AppendText (GettextCatalog.GetString ("None"));
+#pragma warning disable MD0005
 			keyType.AppendText ("Pkcs12");
 			keyType.AppendText ("PVK");
-			
+#pragma warning restore MD0005
+
 			((ListStore) passwordOptions.Model).Clear ();
 			passwordOptions.AppendText (GettextCatalog.GetString ("None"));
 			passwordOptions.AppendText (GettextCatalog.GetString ("Ask"));

--- a/main/src/addins/ChangeLogAddIn/Gui/MonoDevelop.ChangeLogAddIn.ProjectOptionPanelWidget.cs
+++ b/main/src/addins/ChangeLogAddIn/Gui/MonoDevelop.ChangeLogAddIn.ProjectOptionPanelWidget.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.ChangeLogAddIn
 			this.vbox2.Spacing = 6;
 			this.vbox2.BorderWidth = ((uint)(6));
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.noneRadioButton = new global::Gtk.RadioButton ("radiobutton1");
+			this.noneRadioButton = new global::Gtk.RadioButton ("1");
 			this.noneRadioButton.CanFocus = true;
 			this.noneRadioButton.Name = "noneRadioButton";
 			this.noneRadioButton.Active = true;

--- a/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/Gui/MonoDevelop.Deployment.Linux.DesktopPanelWidget.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment.Linux/Gui/MonoDevelop.Deployment.Linux.DesktopPanelWidget.cs
@@ -26,7 +26,6 @@ namespace MonoDevelop.Deployment.Linux
 			this.label6 = new global::Gtk.Label ();
 			this.label6.CanFocus = true;
 			this.label6.Name = "label6";
-			this.label6.LabelProp = "page1";
 			this.notebook2.SetTabLabel (w1, this.label6);
 			this.label6.ShowAll ();
 			this.Add (this.notebook2);

--- a/main/src/addins/Deployment/MonoDevelop.Deployment/Gui/MonoDevelop.Deployment.Gui.DeployDialog.cs
+++ b/main/src/addins/Deployment/MonoDevelop.Deployment/Gui/MonoDevelop.Deployment.Gui.DeployDialog.cs
@@ -203,7 +203,6 @@ namespace MonoDevelop.Deployment.Gui
 			// Notebook tab
 			this.label2 = new global::Gtk.Label ();
 			this.label2.Name = "label2";
-			this.label2.LabelProp = "page5";
 			this.notebook.SetTabLabel (this.vbox3, this.label2);
 			this.label2.ShowAll ();
 			// Container child notebook.Gtk.Notebook+NotebookChild
@@ -252,7 +251,6 @@ namespace MonoDevelop.Deployment.Gui
 			// Notebook tab
 			this.label3 = new global::Gtk.Label ();
 			this.label3.Name = "label3";
-			this.label3.LabelProp = "page3";
 			this.notebook.SetTabLabel (this.pageSelectProject, this.label3);
 			this.label3.ShowAll ();
 			// Container child notebook.Gtk.Notebook+NotebookChild
@@ -319,7 +317,6 @@ namespace MonoDevelop.Deployment.Gui
 			// Notebook tab
 			this.label6 = new global::Gtk.Label ();
 			this.label6.Name = "label6";
-			this.label6.LabelProp = "page2";
 			this.notebook.SetTabLabel (this.vbox4, this.label6);
 			this.label6.ShowAll ();
 			// Container child notebook.Gtk.Notebook+NotebookChild
@@ -556,7 +553,6 @@ namespace MonoDevelop.Deployment.Gui
 			// Notebook tab
 			this.label8 = new global::Gtk.Label ();
 			this.label8.Name = "label8";
-			this.label8.LabelProp = "page4";
 			this.notebook.SetTabLabel (this.pageSave, this.label8);
 			this.label8.ShowAll ();
 			this.hbox1.Add (this.notebook);

--- a/main/src/addins/MonoDevelop.Autotools/MakefileOptionPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Autotools/MakefileOptionPanelWidget.cs
@@ -354,7 +354,7 @@ namespace MonoDevelop.Autotools
 			foreach (string s in MakefileData.CompilerMessageRegex.Keys)
 				comboMessageType.AppendText (s);
 				
-			comboMessageType.AppendText ("Custom");		
+			comboMessageType.AppendText (GettextCatalog.GetString ("Custom"));		
 			comboMessageType.Active = 0;
 		}
 
@@ -720,7 +720,7 @@ namespace MonoDevelop.Autotools
 				List<string> list = new List<string> (vars);
 				list.Sort ();
 				
-				comboFilesVar.AppendText ("(None)");
+				comboFilesVar.AppendText (GettextCatalog.GetString ("(None)"));
 				foreach (string item in list)
 					combos [0].AppendText (item);
 

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/CustomSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/CustomSoftDebuggerEngine.cs
@@ -218,11 +218,11 @@ namespace MonoDevelop.Debugger.Soft
 				table.BorderWidth = 6;
 				VBox.PackStart (table, true, true, 0);
 				
-				table.Attach (new Gtk.Label ("Command:") { Xalign = 0 },   0, 1, 0, 1);
-				table.Attach (new Gtk.Label ("Arguments:") { Xalign = 0 }, 0, 1, 1, 2);
-				table.Attach (new Gtk.Label ("IP:") { Xalign = 0 },        0, 1, 2, 3);
-				table.Attach (new Gtk.Label ("Port:") { Xalign = 0 },      0, 1, 3, 4);
-				table.Attach (new Gtk.Label ("Output:") { Xalign = 0 },    0, 1, 4, 5);
+				table.Attach (new Gtk.Label (GettextCatalog.GetString ("Command:")) { Xalign = 0 },   0, 1, 0, 1);
+				table.Attach (new Gtk.Label (GettextCatalog.GetString ("Arguments:")) { Xalign = 0 }, 0, 1, 1, 2);
+				table.Attach (new Gtk.Label (GettextCatalog.GetString ("IP:")) { Xalign = 0 },        0, 1, 2, 3);
+				table.Attach (new Gtk.Label (GettextCatalog.GetString ("Port:")) { Xalign = 0 },      0, 1, 3, 4);
+				table.Attach (new Gtk.Label (GettextCatalog.GetString ("Output:")) { Xalign = 0 },    0, 1, 4, 5);
 				
 				table.Attach (commandEntry,     1, 2, 0, 1);
 				table.Attach (argsEntry,        1, 2, 1, 2);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.PreviewVisualizers/PreviewVisualizerWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.PreviewVisualizers/PreviewVisualizerWindow.cs
@@ -81,7 +81,7 @@ namespace MonoDevelop.Debugger
 
 			if (DebuggingService.HasValueVisualizers (val)) {
 				var openButton = new Button ();
-				openButton.Label = "Open";
+				openButton.Label = GettextCatalog.GetString ("Open");
 				openButton.Relief = ReliefStyle.Half;
 				openButton.Clicked += delegate {
 					PreviewWindowManager.DestroyWindow ();

--- a/main/src/addins/MonoDevelop.Gettext/Gui/MonoDevelop.Gettext.TranslationProjectOptionsDialog.cs
+++ b/main/src/addins/MonoDevelop.Gettext/Gui/MonoDevelop.Gettext.TranslationProjectOptionsDialog.cs
@@ -189,7 +189,6 @@ namespace MonoDevelop.Gettext
 			this.labelInitString = new global::Gtk.Label ();
 			this.labelInitString.Name = "labelInitString";
 			this.labelInitString.Xalign = 0F;
-			this.labelInitString.LabelProp = "Mono.Unix.Catalog.Init (\"i18n\", \"./locale\");";
 			this.GtkAlignment4.Add (this.labelInitString);
 			this.frame3.Add (this.GtkAlignment4);
 			this.vbox4.Add (this.frame3);

--- a/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.Editor/POEditorWidget.cs
+++ b/main/src/addins/MonoDevelop.Gettext/MonoDevelop.Gettext.Editor/POEditorWidget.cs
@@ -525,7 +525,7 @@ namespace MonoDevelop.Gettext
 
 			Gtk.Menu result = new Gtk.Menu ();
 			
-			Gtk.MenuItem item = new Gtk.MenuItem ("Delete");
+			Gtk.MenuItem item = new Gtk.MenuItem (GettextCatalog.GetString ("Delete"));
 			item.Sensitive = entry.References.Length == 0;
 			item.Activated += delegate {
 				RemoveEntry (entry);

--- a/main/src/addins/MonoDevelop.GtkCore/libstetic/editor/ActionGroupEditor.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/libstetic/editor/ActionGroupEditor.cs
@@ -41,7 +41,7 @@ namespace Stetic.Editor
 			Gtk.VBox vbox = new Gtk.VBox ();
 			Gtk.Label grpLabel = new Gtk.Label ();
 			grpLabel.Xalign = 0;
-			grpLabel.Markup = "<small><i>Action Group</i></small>";
+			grpLabel.Markup = string.Format ("<small><i>{0}</i></small>", Catalog.GetString ("Action Group"));
 //			vbox.PackStart (grpLabel, false, false, 0);
 			vbox.PackStart (headerLabel, false, false, 3);
 			vbox.BorderWidth = 12;

--- a/main/src/addins/MonoDevelop.GtkCore/libstetic/editor/Translatable.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/libstetic/editor/Translatable.cs
@@ -45,27 +45,27 @@ namespace Stetic.Editor {
 			
 			menu = new Gtk.Menu ();
 
-			markItem = new Gtk.CheckMenuItem ("Mark for Translation");
+			markItem = new Gtk.CheckMenuItem (Mono.Unix.Catalog.GetString ("Mark for Translation"));
 			markItem.Toggled += ToggleMark;
 			markItem.Show ();
 			menu.Add (markItem);
 			
-			addContextItem = new Gtk.MenuItem ("Add Translation Context Hint");
+			addContextItem = new Gtk.MenuItem (Mono.Unix.Catalog.GetString ("Add Translation Context Hint"));
 			addContextItem.Activated += AddContext;
 			menu.Add (addContextItem);
-			remContextItem = new Gtk.MenuItem ("Remove Translation Context Hint");
+			remContextItem = new Gtk.MenuItem (Mono.Unix.Catalog.GetString ("Remove Translation Context Hint"));
 			remContextItem.Activated += RemoveContext;
 			menu.Add (remContextItem);
 			
-			addCommentItem = new Gtk.MenuItem ("Add Comment for Translators");
+			addCommentItem = new Gtk.MenuItem (Mono.Unix.Catalog.GetString ("Add Comment for Translators"));
 			addCommentItem.Activated += AddComment;
 			menu.Add (addCommentItem);
-			remCommentItem = new Gtk.MenuItem ("Remove Comment for Translators");
+			remCommentItem = new Gtk.MenuItem (Mono.Unix.Catalog.GetString ("Remove Comment for Translators"));
 			remCommentItem.Activated += RemoveComment;
 			menu.Add (remCommentItem);
 			
 			contextBox = new Gtk.HBox (false, 6);
-			Gtk.Label contextLabel = new Gtk.Label ("Translation context");
+			Gtk.Label contextLabel = new Gtk.Label (Mono.Unix.Catalog.GetString ("Translation context"));
 			contextLabel.Xalign = 0.0f;
 			contextBox.PackStart (contextLabel, false, false, 0);
 			contextEntry = new Gtk.Entry ();
@@ -75,7 +75,7 @@ namespace Stetic.Editor {
 			contextEntry.Changed += ContextChanged;
 
 			commentBox = new Gtk.VBox (false, 3);
-			Gtk.Label commentLabel = new Gtk.Label ("Comment for Translators:");
+			Gtk.Label commentLabel = new Gtk.Label (Mono.Unix.Catalog.GetString ("Comment for Translators:"));
 			commentLabel.Xalign = 0.0f;
 			commentBox.PackStart (commentLabel, false, false, 0);
 			commentText = new TextBox (3);

--- a/main/src/addins/MonoDevelop.GtkCore/libstetic/wrapper/MenuBar.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/libstetic/wrapper/MenuBar.cs
@@ -233,15 +233,15 @@ namespace Stetic.Wrapper
 			this.node = node;
 			Spacing = 3;
 			if (node.Type == Gtk.UIManagerItemType.Menu) {
-				PackStart (new Gtk.Label ("Menu"), true, true, 0);
+				PackStart (new Gtk.Label (Mono.Unix.Catalog.GetString ("Menu")), true, true, 0);
 			} else if (node.Action != null && node.Action.GtkAction != null) {
 				if (node.Action.GtkAction.StockId != null)
 					PackStart (node.Action.CreateIcon (Gtk.IconSize.Menu), true, true, 0);
 				PackStart (new Gtk.Label (node.Action.GtkAction.Label), true, true, 0);
 			} else if (node.Type == Gtk.UIManagerItemType.Separator) {
-				PackStart (new Gtk.Label ("Separator"), true, true, 0);
+				PackStart (new Gtk.Label (Mono.Unix.Catalog.GetString ("Separator")), true, true, 0);
 			} else {
-				PackStart (new Gtk.Label ("Empty Action"), true, true, 0);
+				PackStart (new Gtk.Label (Mono.Unix.Catalog.GetString ("Empty Action")), true, true, 0);
 			}
 			ShowAll ();
 		}

--- a/main/src/addins/MonoDevelop.GtkCore/libsteticui/PropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/libsteticui/PropertyGrid.cs
@@ -26,7 +26,7 @@ namespace Stetic {
 			PackStart (header, false, false, 0);
 			
 			Label lab = new Label ();
-			lab.Markup = "<i>No selection</i>";
+			lab.Markup = Mono.Unix.Catalog.GetString ("<i>No selection</i>");
 			PackStart (lab, false, false, 0);
 			noSelection = lab;
 			

--- a/main/src/addins/MonoDevelop.SourceEditor2/Gui/MonoDevelop.SourceEditor.OptionPanels.CompletionOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Gui/MonoDevelop.SourceEditor.OptionPanels.CompletionOptionsPanel.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			this.vbox5.Spacing = 6;
 			// Container child vbox5.Gtk.Box+BoxChild
 			this.autoCodeCompletionCheckbutton = new global::Gtk.CheckButton ();
-			this.autoCodeCompletionCheckbutton.TooltipMarkup = "Automatic Completion with Enter or Tab keys";
+			this.autoCodeCompletionCheckbutton.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("Automatic Completion with Enter or Tab keys");
 			this.autoCodeCompletionCheckbutton.CanFocus = true;
 			this.autoCodeCompletionCheckbutton.Name = "autoCodeCompletionCheckbutton";
 			this.autoCodeCompletionCheckbutton.Label = global::Mono.Unix.Catalog.GetString ("_Show completion list after a character is typed");
@@ -92,7 +92,7 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			w2.Padding = ((uint)(6));
 			// Container child hbox6.Gtk.Box+BoxChild
 			this.automaticCompletionModeCheckbutton = new global::Gtk.CheckButton ();
-			this.automaticCompletionModeCheckbutton.TooltipMarkup = "Enables automatic completion with the Space key or Punctuation";
+			this.automaticCompletionModeCheckbutton.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("Enables automatic completion with the Space key or Punctuation");
 			this.automaticCompletionModeCheckbutton.CanFocus = true;
 			this.automaticCompletionModeCheckbutton.Name = "automaticCompletionModeCheckbutton";
 			this.automaticCompletionModeCheckbutton.Label = global::Mono.Unix.Catalog.GetString ("Complete with Space or Punctuation");

--- a/main/src/addins/MonoDevelop.WebReferences/Gui/MonoDevelop.WebReferences.Dialogs.UserPasswordDialog.cs
+++ b/main/src/addins/MonoDevelop.WebReferences/Gui/MonoDevelop.WebReferences.Dialogs.UserPasswordDialog.cs
@@ -34,7 +34,6 @@ namespace MonoDevelop.WebReferences.Dialogs
 			this.labelServer = new global::Gtk.Label ();
 			this.labelServer.Name = "labelServer";
 			this.labelServer.Xalign = 0F;
-			this.labelServer.LabelProp = "Server info";
 			this.vbox2.Add (this.labelServer);
 			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.labelServer]));
 			w2.Position = 0;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.MergeDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.MergeDialog.cs
@@ -63,7 +63,6 @@ namespace MonoDevelop.VersionControl.Git
 			this.labelOper.WidthRequest = 443;
 			this.labelOper.Name = "labelOper";
 			this.labelOper.Xalign = 0F;
-			this.labelOper.LabelProp = "The remote branch <b>origin/blablabla</b> will be merged into the branch <b>master</b>.";
 			this.labelOper.UseMarkup = true;
 			this.labelOper.Wrap = true;
 			this.vbox2.Add (this.labelOper);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.UserInfoConflictDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.UserInfoConflictDialog.cs
@@ -66,7 +66,6 @@ namespace MonoDevelop.VersionControl.Git
 			this.labelMD = new global::Gtk.Label ();
 			this.labelMD.Name = "labelMD";
 			this.labelMD.Xalign = 0F;
-			this.labelMD.LabelProp = "name <email>";
 			this.alignment1.Add (this.labelMD);
 			this.vbox2.Add (this.alignment1);
 			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.alignment1]));
@@ -108,7 +107,6 @@ namespace MonoDevelop.VersionControl.Git
 			this.labelGit = new global::Gtk.Label ();
 			this.labelGit.Name = "labelGit";
 			this.labelGit.Xalign = 0F;
-			this.labelGit.LabelProp = "name <email>";
 			this.alignment2.Add (this.labelGit);
 			this.vbox2.Add (this.alignment2);
 			global::Gtk.Box.BoxChild w10 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.alignment2]));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.ClientCertificateDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.ClientCertificateDialog.cs
@@ -47,7 +47,7 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelRealm = new global::Gtk.Label ();
 			this.labelRealm.Name = "labelRealm";
 			this.labelRealm.Xalign = 0F;
-			this.labelRealm.LabelProp = "Realm";
+			this.labelRealm.LabelProp = global::Mono.Unix.Catalog.GetString ("Realm");
 			this.vbox2.Add (this.labelRealm);
 			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.labelRealm]));
 			w3.Position = 1;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.ClientCertificatePasswordDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.ClientCertificatePasswordDialog.cs
@@ -47,7 +47,7 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelRealm = new global::Gtk.Label ();
 			this.labelRealm.Name = "labelRealm";
 			this.labelRealm.Xalign = 0F;
-			this.labelRealm.LabelProp = "Realm";
+			this.labelRealm.LabelProp = global::Mono.Unix.Catalog.GetString ("Realm");
 			this.vbox2.Add (this.labelRealm);
 			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.labelRealm]));
 			w3.Position = 1;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.SslServerTrustDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.SslServerTrustDialog.cs
@@ -207,7 +207,6 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelFprint = new global::Gtk.Label ();
 			this.labelFprint.Name = "labelFprint";
 			this.labelFprint.Xalign = 0F;
-			this.labelFprint.LabelProp = "label14";
 			this.table1.Add (this.labelFprint);
 			global::Gtk.Table.TableChild w13 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelFprint]));
 			w13.TopAttach = ((uint)(5));
@@ -220,7 +219,6 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelFrom = new global::Gtk.Label ();
 			this.labelFrom.Name = "labelFrom";
 			this.labelFrom.Xalign = 0F;
-			this.labelFrom.LabelProp = "label12";
 			this.table1.Add (this.labelFrom);
 			global::Gtk.Table.TableChild w14 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelFrom]));
 			w14.TopAttach = ((uint)(3));
@@ -233,7 +231,6 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelHost = new global::Gtk.Label ();
 			this.labelHost.Name = "labelHost";
 			this.labelHost.Xalign = 0F;
-			this.labelHost.LabelProp = "label10";
 			this.table1.Add (this.labelHost);
 			global::Gtk.Table.TableChild w15 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelHost]));
 			w15.TopAttach = ((uint)(1));
@@ -246,7 +243,6 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelIssuer = new global::Gtk.Label ();
 			this.labelIssuer.Name = "labelIssuer";
 			this.labelIssuer.Xalign = 0F;
-			this.labelIssuer.LabelProp = "label11";
 			this.table1.Add (this.labelIssuer);
 			global::Gtk.Table.TableChild w16 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelIssuer]));
 			w16.TopAttach = ((uint)(2));
@@ -259,7 +255,6 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelRealm = new global::Gtk.Label ();
 			this.labelRealm.Name = "labelRealm";
 			this.labelRealm.Xalign = 0F;
-			this.labelRealm.LabelProp = "label9";
 			this.table1.Add (this.labelRealm);
 			global::Gtk.Table.TableChild w17 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelRealm]));
 			w17.LeftAttach = ((uint)(1));
@@ -269,7 +264,6 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelUntil = new global::Gtk.Label ();
 			this.labelUntil.Name = "labelUntil";
 			this.labelUntil.Xalign = 0F;
-			this.labelUntil.LabelProp = "label13";
 			this.table1.Add (this.labelUntil);
 			global::Gtk.Table.TableChild w18 = ((global::Gtk.Table.TableChild)(this.table1 [this.labelUntil]));
 			w18.TopAttach = ((uint)(4));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.UserPasswordDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/Gui/MonoDevelop.VersionControl.Subversion.Gui.UserPasswordDialog.cs
@@ -51,7 +51,7 @@ namespace MonoDevelop.VersionControl.Subversion.Gui
 			this.labelRealm = new global::Gtk.Label ();
 			this.labelRealm.Name = "labelRealm";
 			this.labelRealm.Xalign = 0F;
-			this.labelRealm.LabelProp = "Realm";
+			this.labelRealm.LabelProp = global::Mono.Unix.Catalog.GetString ("Realm");
 			this.vbox2.Add (this.labelRealm);
 			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.labelRealm]));
 			w3.Position = 1;

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -40,7 +40,7 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0" targetFramework="net471" />
-  <package id="MonoDevelopDev.Analyzers" version="0.1.0" targetFramework="net471" developmentDependency="true" />
+  <package id="MonoDevelopDev.Analyzers" version="0.1.0.1" targetFramework="net471" developmentDependency="true" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -40,6 +40,7 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0" targetFramework="net471" />
+  <package id="MonoDevelopDev.Analyzers" version="0.1.0" targetFramework="net471" developmentDependency="true" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.FindInFiles.FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.FindInFiles.FindInFilesDialog.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			this.hbox3.Spacing = 6;
 			// Container child hbox3.Gtk.Box+BoxChild
 			this.toggleFindInFiles = new global::Gtk.RadioButton (global::Mono.Unix.Catalog.GetString ("Find in Files"));
-			this.toggleFindInFiles.TooltipMarkup = "Switch to Find in Files";
+			this.toggleFindInFiles.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("Switch to Find in Files");
 			this.toggleFindInFiles.CanFocus = true;
 			this.toggleFindInFiles.Name = "toggleFindInFiles";
 			this.toggleFindInFiles.Active = true;
@@ -90,7 +90,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			w3.Fill = false;
 			// Container child hbox3.Gtk.Box+BoxChild
 			this.toggleReplaceInFiles = new global::Gtk.RadioButton (global::Mono.Unix.Catalog.GetString ("Replace in Files"));
-			this.toggleReplaceInFiles.TooltipMarkup = "Switch to Replace in Files";
+			this.toggleReplaceInFiles.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("Switch to Replace in Files");
 			this.toggleReplaceInFiles.CanFocus = true;
 			this.toggleReplaceInFiles.Name = "toggleReplaceInFiles";
 			this.toggleReplaceInFiles.DrawIndicator = false;

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.Dialogs.ProgressDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.Dialogs.ProgressDialog.cs
@@ -36,7 +36,6 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			this.label = new global::Gtk.Label ();
 			this.label.Name = "label";
 			this.label.Xalign = 0F;
-			this.label.LabelProp = "label";
 			this.vbox2.Add (this.label);
 			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.label]));
 			w2.Position = 0;

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.Dialogs.TipOfTheDayWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.Dialogs.TipOfTheDayWindow.cs
@@ -32,7 +32,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			MonoDevelop.Components.Gui.Initialize (this);
 			// Widget MonoDevelop.Ide.Gui.Dialogs.TipOfTheDayWindow
 			this.Name = "MonoDevelop.Ide.Gui.Dialogs.TipOfTheDayWindow";
-			this.Title = "Tip of the Day";
+			this.Title = global::Mono.Unix.Catalog.GetString ("Tip of the Day");
 			this.WindowPosition = ((global::Gtk.WindowPosition)(1));
 			this.BorderWidth = ((uint)(6));
 			// Container child MonoDevelop.Ide.Gui.Dialogs.TipOfTheDayWindow.Gtk.Container+ContainerChild

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.OptionPanels.IDEStyleOptionsPanelWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Gui.OptionPanels.IDEStyleOptionsPanelWidget.cs
@@ -103,7 +103,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			this.btnRestart.CanFocus = true;
 			this.btnRestart.Name = "btnRestart";
 			this.btnRestart.UseUnderline = true;
-			this.btnRestart.Label = "Restart {0}";
+			this.btnRestart.Label = global::Mono.Unix.Catalog.GetString ("Restart {0}:");
 			this.tableRestart.Add (this.btnRestart);
 			global::Gtk.Table.TableChild w7 = ((global::Gtk.Table.TableChild)(this.tableRestart [this.btnRestart]));
 			w7.TopAttach = ((uint)(1));
@@ -124,7 +124,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 			// Container child tableRestart.Gtk.Table+TableChild
 			this.labelRestart = new global::Gtk.Label ();
 			this.labelRestart.Name = "labelRestart";
-			this.labelRestart.LabelProp = "These preferences will take effect next time you start {0}";
+			this.labelRestart.LabelProp = global::Mono.Unix.Catalog.GetString ("These preferences will take effect next time you start {0}");
 			this.tableRestart.Add (this.labelRestart);
 			global::Gtk.Table.TableChild w9 = ((global::Gtk.Table.TableChild)(this.tableRestart [this.labelRestart]));
 			w9.LeftAttach = ((uint)(1));

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.ConfirmProjectDeleteDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.ConfirmProjectDeleteDialog.cs
@@ -72,7 +72,6 @@ namespace MonoDevelop.Ide.Projects
 			this.labelProjectDir = new global::Gtk.Label ();
 			this.labelProjectDir.Name = "labelProjectDir";
 			this.labelProjectDir.Xalign = 0F;
-			this.labelProjectDir.LabelProp = "label2";
 			this.alignment1.Add (this.labelProjectDir);
 			this.vbox2.Add (this.alignment1);
 			global::Gtk.Box.BoxChild w5 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.alignment1]));

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.GtkProjectFolderPreviewWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.GtkProjectFolderPreviewWidget.cs
@@ -32,7 +32,7 @@ namespace MonoDevelop.Ide.Projects
 			// Container child previewLabelHBox.Gtk.Box+BoxChild
 			this.previewLabel = new global::Gtk.Label ();
 			this.previewLabel.Name = "previewLabel";
-			this.previewLabel.LabelProp = "<span weight='bold' foreground='#555555'>PREVIEW</span>";
+			this.previewLabel.LabelProp = string.Format ("<span weight='bold' foreground='#555555'>{0}</span>", global::Mono.Unix.Catalog.GetString ("PREVIEW"));
 			this.previewLabel.UseMarkup = true;
 			this.previewLabelHBox.Add (this.previewLabel);
 			global::Gtk.Box.BoxChild w1 = ((global::Gtk.Box.BoxChild)(this.previewLabelHBox [this.previewLabel]));

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.ProjectFileSelectorDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.ProjectFileSelectorDialog.cs
@@ -91,7 +91,7 @@ namespace MonoDevelop.Ide.Projects
 			this.hbox2.Spacing = 6;
 			// Container child hbox2.Gtk.Box+BoxChild
 			this.AddFileButton = new global::Gtk.Button ();
-			this.AddFileButton.TooltipMarkup = "Add existing files to the project";
+			this.AddFileButton.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("Add existing files to the project");
 			this.AddFileButton.CanFocus = true;
 			this.AddFileButton.Name = "AddFileButton";
 			this.AddFileButton.Relief = ((global::Gtk.ReliefStyle)(2));

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.SelectReferenceDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.SelectReferenceDialog.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.Ide.Projects
 			w3.Fill = false;
 			// Container child hbox2.Gtk.Box+BoxChild
 			this.RemoveReferenceButton = new global::Gtk.Button ();
-			this.RemoveReferenceButton.TooltipMarkup = "Remove";
+			this.RemoveReferenceButton.TooltipMarkup = global::Mono.Unix.Catalog.GetString ("Remove");
 			this.RemoveReferenceButton.Name = "RemoveReferenceButton";
 			this.RemoveReferenceButton.FocusOnClick = false;
 			this.RemoveReferenceButton.Relief = ((global::Gtk.ReliefStyle)(2));

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.SelectEncodingsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.SelectEncodingsDialog.cs
@@ -50,7 +50,7 @@ namespace MonoDevelop.Ide
 			MonoDevelop.Components.Gui.Initialize (this);
 			// Widget MonoDevelop.Ide.SelectEncodingsDialog
 			this.Name = "MonoDevelop.Ide.SelectEncodingsDialog";
-			this.Title = "Select Text Encodings";
+			this.Title = global::Mono.Unix.Catalog.GetString ("Select Text Encodings");
 			this.TypeHint = ((global::Gdk.WindowTypeHint)(1));
 			this.Modal = true;
 			this.BorderWidth = ((uint)(6));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/IEditorThemeProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/IEditorThemeProvider.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 				return theme;
 			} catch (Exception e) {
 				if (faultedThemes.Add (Name)) {
-					MessageService.ShowError (GettextCatalog.GetString ("Error while loading theme :" + Name), e);
+					MessageService.ShowError (GettextCatalog.GetString ("Error while loading theme: {0}", Name), e);
 					LoggingService.LogError ("Error while loading theme :" + Name, e);
 				}
 				return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.TextMate/TextMateBundleOptionsPanelWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.TextMate/TextMateBundleOptionsPanelWidget.cs
@@ -96,7 +96,7 @@ namespace MonoDevelop.Ide.Editor.TextMate
 					}
 					FillBundles ();
 				} else {
-					MessageService.ShowError (GettextCatalog.GetString ("Invalid bundle: " + dialog.SelectedFile.FileName));
+					MessageService.ShowError (GettextCatalog.GetString ("Invalid bundle: {0}", dialog.SelectedFile.FileName));
 					try {
 						File.Delete (newFileName);
 					} catch (Exception) {}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/VersionInformationTabPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/VersionInformationTabPage.cs
@@ -130,7 +130,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		{
 			var box = new Gtk.VBox ();
 			box.PackStart (new Gtk.Label () {
-				Markup = "<b>LoadedAssemblies</b>",
+				Markup = string.Format ("<b>{0}</b>", GettextCatalog.GetString ("Loaded Assemblies")),
 				Xalign = 0
 			});
 			var table = new Gtk.Table (0, 0, false);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/D152AccessibilityPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.OptionPanels/D152AccessibilityPanel.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Ide.Gui.OptionPanels
 		{
 			NSUserDefaults defaults = NSUserDefaults.StandardUserDefaults;
 
-			enabled = new CheckButton ("Enable Accessibility");
+			enabled = new CheckButton (GettextCatalog.GetString ("Enable Accessibility"));
 			enabled.Active = originalSetting = defaults.BoolForKey (EnabledKey);
 			enabled.Visible = true;
 


### PR DESCRIPTION
Also fix up instances of said strings throughout the codebase.

First version is really robust:
* Only offers GettextCatalog.GetString as an option
* Only works on Gtk.Widget and special cased functions

Future versions will provide:
a) Configuration of catalog via attribute
b) Cocoa/Atk support
c) Detection of string.Format patterns.

Fixes VSTS #683875 - Enable MD specific analyzers in the repository and build