### PR TITLE
Bump vs-editor-api to 15.2.3-pre.

### DIFF
--- a/main/msbuild/ReferencesVSEditor.props
+++ b/main/msbuild/ReferencesVSEditor.props
@@ -34,7 +34,7 @@
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Implementation">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.2.2-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.2.3-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -28,7 +28,7 @@
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Data" version="15.8.519" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.2.2-pre" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.2.3-pre" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Internal" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.8.519" targetFramework="net45" />


### PR DESCRIPTION
This is to fix a bug found by @garuma where we were attempting to call a native Windows API on a Mac.

https://github.com/KirillOsenkov/vs-editor-api/commit/9b4947b378c3ffc21c59b0197b5ee3cab3fd08d1