### PR TITLE
Fixes issue #6559 Caret location in quick fix margin is incorrect

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultsEditorExtension.cs
@@ -429,11 +429,22 @@ namespace MonoDevelop.AnalysisCore.Gui
 			if (handler != null)
 				handler (this, e);
 		}
-		
+
 		public ImmutableArray<QuickTask> QuickTasks {
 			get {
-				lock (tasks)
-					return tasks.SelectMany(x => x.Value).AsImmutable ();
+				Runtime.AssertMainThread ();
+
+				lock (tasks) {
+					int capacity = 0;
+					foreach (var task in tasks) {
+						capacity += task.Value.Length;
+					}
+					var builder = ArrayBuilder<QuickTask>.GetInstance (capacity);
+					foreach (var task in tasks) {
+						builder.AddRange (task.Value);
+					}
+					return builder.ToImmutableAndFree ();
+				}
 			}
 		}
 		

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.QuickTasks/QuickTaskOverviewMode.cs
@@ -190,8 +190,7 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 		void CaretPositionChanged (object sender, EventArgs e)
 		{
 			if (drawnCaretLine != TextEditor.Caret.Line) {
-				int caretY = (int)GetYPosition (TextEditor.Caret.Line);
-				QueueDrawArea (0, Math.Min (caretY, drawnCaretY) - 1, Allocation.Width, Math.Abs (caretY - drawnCaretY) + 2);
+				QueueDraw ();
 			}
 		}
 
@@ -566,7 +565,7 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 
 		internal virtual double IndicatorHeight {
 			get {
-				return MonoDevelop.Core.Platform.IsWindows ? Allocation.Width : 3 + 8 + 3;
+				return errorImage.Height;
 			}
 		}
 
@@ -700,7 +699,6 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 			var q = Math.Max (TextEditor.GetTextEditorData ().TotalHeight, TextEditor.Allocation.Height)
 				+ TextEditor.Allocation.Height
 				- TextEditor.LineHeight;
-
 			return IndicatorHeight + h * p / q;
 		}
 
@@ -711,16 +709,16 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 		}
 
 		int drawnCaretLine, drawnCaretY;
-		protected void DrawCaret (Cairo.Context cr)
+		protected void DrawCaret (Cairo.Context cr, double displayScale)
 		{
 			if (TextEditor.EditorTheme == null)
 				return;
 			drawnCaretLine = TextEditor.Caret.Line;
-			drawnCaretY = (int)GetYPosition (drawnCaretLine);
+			drawnCaretY = (int)((GetYPosition (drawnCaretLine) - 1) * displayScale);
 
 			cr.SetSourceColor (SyntaxHighlightingService.GetColor (TextEditor.EditorTheme, EditorThemeColors.Foreground));
 			var w = Math.Floor (Allocation.Width * 0.618);
-			cr.Rectangle (Allocation.Width - w, drawnCaretY - 1, w, 2);
+			cr.Rectangle (Allocation.Width - w, drawnCaretY, w, 2);
 			cr.Fill ();
 		}
 
@@ -959,7 +957,7 @@ namespace MonoDevelop.SourceEditor.QuickTasks
 				if (TextEditor == null)
 					return true;
 
-				DrawCaret (cr);
+				DrawCaret (cr, displayScale);
 				if (QuickTaskStrip.MergeScrollBarAndQuickTasks)
 					DrawBar (cr);
 


### PR DESCRIPTION
QuickTaskMargin is drawed in a background buffer which blit shouldn't take much time anyways.