### PR TITLE
[DotNetCore.Tests] Fix old NuGet.Versioning being used by tests

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -16,7 +16,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="NuGet.Versioning">
-      <HintPath>..\..\..\..\external\nuget-binary\NuGet.Versioning.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NuGet.Versioning.4.7.0\lib\net46\NuGet.Versioning.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This was causing none of the NuGet addin tests to be run. In the
unit test output from running vstool would show an error about
failing to load NuGet.Versioning since the .NET Core tests were
copying the old assembly into the build/tests directory:

```
Could not load file or assembly 'NuGet.Versioning, Version=4.7.0.5,
Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its
dependencies.
```