### PR TITLE
[release-7.7] Fixes issue #6482 Cannot rename public types This prevents that the

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -350,8 +350,9 @@ namespace MonoDevelop.CodeActions
 
 		void Editor_EndAtomicUndoOperation (object sender, EventArgs e)
 		{
-			if (beginVersion.CompareAge (Editor.Version) != 0)
+			if (beginVersion != null && beginVersion.CompareAge (Editor.Version) != 0)
 				RemoveWidget ();
+			beginVersion = null;
 		}
 
 		void Editor_TextChanged (object sender, MonoDevelop.Core.Text.TextChangeEventArgs e)

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/Change.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/Change.cs
@@ -97,6 +97,10 @@ namespace MonoDevelop.Refactoring
 		{
 			if (IdeApp.Workbench == null)
 				return null;
+			foreach (var editor in textEditorDatas) {
+				if (editor.FileName.Equals (fileName))
+					return editor;
+			}
 			foreach (var doc in IdeApp.Workbench.Documents) {
 				if (doc.FileName == fileName) {
 					var result = doc.Editor;


### PR DESCRIPTION
same editor is added twice to the refactoring operation and balances
out undo groups.

Backport of #6490.

/cc @slluis @mkrueger