### PR TITLE
[Editor] Fix runtime toggling of insert matching brace

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Braces/BraceCompletionManager.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Braces/BraceCompletionManager.cs
@@ -281,6 +281,7 @@ namespace MonoDevelop.SourceEditor.Braces
 		{
 			_textView.Closed += textView_Closed;
 			_textView.Options.OptionChanged += Options_OptionChanged;
+			DefaultSourceEditorOptions.Instance.Changed += EditorOptions_OptionChanged;
 		}
 
 		private void textView_Closed (object sender, EventArgs e)
@@ -292,6 +293,12 @@ namespace MonoDevelop.SourceEditor.Braces
 		{
 			_textView.Closed -= textView_Closed;
 			_textView.Options.OptionChanged -= Options_OptionChanged;
+			DefaultSourceEditorOptions.Instance.Changed -= EditorOptions_OptionChanged;
+		}
+
+		private void EditorOptions_OptionChanged (object sender, EventArgs args)
+		{
+			GetOptions ();
 		}
 
 		private void Options_OptionChanged (object sender, EditorOptionChangedEventArgs e)


### PR DESCRIPTION
VSEditor model did not reflect the changes done to the matching brace in the
IDE preferences

Fixes VSTS #703893 - Matching brace is inserted even though option is disabled