### PR TITLE
[Ide] Don't add a hyphen if the first item is not a hyperlink

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Ide.Gui.Components
 			mainBox.PackStart (new ImageView (ImageService.GetIcon (Stock.Information, Gtk.IconSize.Menu)), marginLeft: 11);
 			mainBox.PackStart (descriptionLabel = new Label (description));
 
-			if (items.Length > 0) {
+			if (items.Length > 0 && items[0].Kind == InfoBarItemKind.Hyperlink) {
 				mainBox.PackStart (new Label ("–"));
 			}
 


### PR DESCRIPTION
The hyphen should only be added when the item is a hyperlink
following the description

Fixes VSTS #723318 - InfoBar shows a hyphen between the text and the first item if that item is a link