### PR TITLE
Fixes VSTS Bug 729384: [Feedback] C# syntax highlight doesn't work for

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TagBasedSyntaxHighlighting.cs
@@ -388,8 +388,9 @@ namespace Microsoft.VisualStudio.Platform
 				[ClassificationTypeNames.Comment] = MakeScope (baseScopeStack, "comment." + scope),
 				[ClassificationTypeNames.ExcludedCode] = MakeScope (baseScopeStack, "comment.excluded." + scope),
 				[ClassificationTypeNames.Identifier] = MakeScope (baseScopeStack, scope),
-				[ClassificationTypeNames.Keyword] = MakeScope (baseScopeStack, "keyword." + scope),
-				[ClassificationTypeNames.NumericLiteral] = MakeScope (baseScopeStack, "constant.numeric." + scope),
+                [ClassificationTypeNames.Keyword] = MakeScope(baseScopeStack, "keyword." + scope),
+                ["identifier - keyword - (TRANSIENT)"] = MakeScope(baseScopeStack, "keyword." + scope), // required for highlighting of some context specific keywords like 'nameof'
+                [ClassificationTypeNames.NumericLiteral] = MakeScope (baseScopeStack, "constant.numeric." + scope),
 				[ClassificationTypeNames.Operator] = MakeScope (baseScopeStack, scope),
 				[ClassificationTypeNames.PreprocessorKeyword] = MakeScope (baseScopeStack, "meta.preprocessor." + scope),
 				[ClassificationTypeNames.StringLiteral] = MakeScope (baseScopeStack, "string." + scope),


### PR DESCRIPTION
some of the keywords

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/729384