### PR TITLE
Fixes VSTS Bug 729414: [Feedback] When adding an attribute via

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -348,13 +348,13 @@ namespace MonoDevelop.CSharp.Completion
 							}
 							if (extensionMethodImport) {
 								if (type.MightContainExtensionMethods)
-									AddImportExtensionMethodCompletionData (result, type, extensionMethodReceiverType, extMethodDict);
+									AddImportExtensionMethodCompletionData (result, ctx, type, extensionMethodReceiverType, extMethodDict);
 							} else {
 								if (!typeDict.TryGetValue (type.ContainingNamespace, out var existingTypeHashSet)) {
 									typeDict.Add (type.ContainingNamespace, existingTypeHashSet = new HashSet<string> ());
 								}
 								if (!existingTypeHashSet.Contains (type.Name)) {
-									result.Add (new ImportSymbolCompletionData (this, type, false));
+									result.Add (new ImportSymbolCompletionData (this, ctx, type, false));
 									existingTypeHashSet.Add (type.Name);
 								}
 							}
@@ -366,7 +366,7 @@ namespace MonoDevelop.CSharp.Completion
 			}
 		}
 
-		void AddImportExtensionMethodCompletionData (CompletionDataList result, INamedTypeSymbol fromType, ITypeSymbol receiverType, Dictionary<INamespaceSymbol, List<ImportSymbolCompletionData>> extMethodDict)
+		void AddImportExtensionMethodCompletionData (CompletionDataList result, CSharpSyntaxContext ctx, INamedTypeSymbol fromType, ITypeSymbol receiverType, Dictionary<INamespaceSymbol, List<ImportSymbolCompletionData>> extMethodDict)
 		{
 			try {
 				foreach (var extMethod in fromType.GetMembers ().OfType<IMethodSymbol> ().Where (method => method.IsExtensionMethod)) {
@@ -375,7 +375,7 @@ namespace MonoDevelop.CSharp.Completion
 						if (!extMethodDict.TryGetValue (fromType.ContainingNamespace, out var importSymbolList))
 							extMethodDict.Add (fromType.ContainingNamespace, importSymbolList = new List<ImportSymbolCompletionData> ());
 
-						var newData = new ImportSymbolCompletionData (this, reducedMethod, false);
+						var newData = new ImportSymbolCompletionData (this, ctx, reducedMethod, false);
 						ImportSymbolCompletionData existingItem = null;
 						foreach (var data in importSymbolList) {
 							if (data.Symbol.Name == extMethod.Name) {

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/ImportSymbolCompletionData.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // ImportSymbolCompletionData.cs
 //
 // Author:
@@ -30,12 +30,20 @@ using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Ide.Editor;
 using System.Text;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Threading.Tasks;
+using System.Threading;
+using MonoDevelop.Ide.Editor.Highlighting;
+using MonoDevelop.Ide.Fonts;
+using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace MonoDevelop.CSharp.Completion
 {
 	class ImportSymbolCompletionData : CompletionData
 	{
 		CSharpCompletionTextEditorExtension completionExt;
+		readonly Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery.CSharpSyntaxContext ctx;
 		ISymbol type;
 		string displayText;//This is just for caching, because Sorting completion list can call DisplayText many times
 		bool useFullName;
@@ -51,18 +59,22 @@ namespace MonoDevelop.CSharp.Completion
         public override CompletionItemRules Rules => rules;
 		public override string DisplayText {
 			get {
-				if (displayText == null)
-					displayText = type.Name;
+				if (displayText == null) {
+					if (!CommonCompletionUtilities.TryRemoveAttributeSuffix (type, ctx, out displayText)) {
+						displayText = type.Name;
+					}
+				}
 				return displayText;
 			}
 		}
-		public override string CompletionText { get =>  useFullName ? type.ContainingNamespace.GetFullName () + "." + type.Name : type.Name; }
+		public override string CompletionText { get =>  useFullName ? type.ContainingNamespace.GetFullName () + "." + type.Name : DisplayText; }
 
         public override int PriorityGroup { get { return int.MinValue; } }
 
-		public ImportSymbolCompletionData (CSharpCompletionTextEditorExtension ext, ISymbol type, bool useFullName) 
+		public ImportSymbolCompletionData (CSharpCompletionTextEditorExtension ext, Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery.CSharpSyntaxContext ctx, ISymbol type, bool useFullName)
 		{
 			this.completionExt = ext;
+			this.ctx = ctx;
 			this.useFullName = useFullName;
 			this.type = type;
 			this.DisplayFlags |= DisplayFlags.IsImportCompletion;
@@ -76,7 +88,7 @@ namespace MonoDevelop.CSharp.Completion
 			if (initialized)
 				return;
 			initialized = true;
-			if (type.ContainingNamespace == null) 
+			if (type.ContainingNamespace == null)
 				return;
 			generateUsing = !useFullName;
 			insertNamespace = useFullName;
@@ -84,7 +96,7 @@ namespace MonoDevelop.CSharp.Completion
 
 		public override string GetDisplayTextMarkup ()
 		{
-			return useFullName ? type.ToDisplayString (Ambience.NameFormat) : type.Name;
+			return useFullName ? type.ToDisplayString (Ambience.NameFormat) : DisplayText;
 		}
 
 		static string GetDefaultDisplaySelection (string description, bool isSelected)
@@ -160,8 +172,8 @@ namespace MonoDevelop.CSharp.Completion
 
 				foreach (var trivia in node.GetLeadingTrivia ()) {
 					if (last.IsKind (Microsoft.CodeAnalysis.CSharp.SyntaxKind.SingleLineCommentTrivia)||
-						last.IsKind (Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefineDirectiveTrivia) || 
-						last.IsKind (Microsoft.CodeAnalysis.CSharp.SyntaxKind.MultiLineCommentTrivia) || 
+						last.IsKind (Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefineDirectiveTrivia) ||
+						last.IsKind (Microsoft.CodeAnalysis.CSharp.SyntaxKind.MultiLineCommentTrivia) ||
 						last.IsKind (Microsoft.CodeAnalysis.CSharp.SyntaxKind.SingleLineDocumentationCommentTrivia))
 						result = trivia.Span.End;
 					last = trivia;
@@ -177,6 +189,57 @@ namespace MonoDevelop.CSharp.Completion
 		{
 			return commitChars.IndexOf (keyChar) >= 0;
 		}
+
+		public override async Task<TooltipInformation> CreateTooltipInformation (bool smartWrap, CancellationToken cancelToken)
+		{
+			CompletionDescription description;
+			var doc = completionExt.DocumentContext;
+			var completionService = doc.AnalysisDocument.GetLanguageService<CompletionService> ();
+			if (completionService == null)
+				return null;
+			var semanticModel = await doc.AnalysisDocument.GetSemanticModelAsync (cancelToken);
+			description = await CommonCompletionUtilities.CreateDescriptionAsync (doc.RoslynWorkspace, semanticModel, completionExt.Editor.CaretOffset, new [] { type }, null, cancelToken).ConfigureAwait (false);
+
+			var markup = StringBuilderCache.Allocate ();
+			var theme = SyntaxHighlightingService.GetIdeFittingTheme (DefaultSourceEditorOptions.Instance.GetEditorTheme ());
+			var taggedParts = description.TaggedParts;
+			if (taggedParts.Length == 0) {
+				return null;
+			}
+			int i = 0;
+			while (i < taggedParts.Length) {
+				if (taggedParts [i].Tag == TextTags.LineBreak)
+					break;
+				i++;
+			}
+			if (i + 1 >= taggedParts.Length) {
+				markup.AppendTaggedText (theme, taggedParts);
+			} else {
+				markup.AppendTaggedText (theme, taggedParts.Take (i));
+				markup.Append ("<span font='");
+				markup.Append (FontService.SansFontName);
+				markup.Append ("' size='small'>");
+				markup.AppendLine ();
+				markup.AppendLine ();
+				markup.AppendTaggedText (theme, taggedParts.Skip (i + 1));
+				markup.Append ("</span>");
+			}
+			markup.AppendLine ();
+			markup.AppendLine ();
+			markup.Append ("<span font='");
+			markup.Append (FontService.SansFontName);
+			markup.Append ("' size='small'>");
+			markup.AppendLine (GettextCatalog.GetString ("Note: creates an using for namespace:"));
+			markup.Append ("<b>");
+			markup.Append (Ambience.EscapeText (type.ContainingNamespace.ToDisplayString ()));
+			markup.Append ("</b>");
+			markup.Append ("</span>");
+
+			return new TooltipInformation {
+				SignatureMarkup = StringBuilderCache.ReturnAndFree (markup)
+			};
+		}
+
 		#endregion
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
@@ -319,7 +319,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 			}
 			int i = 0;
 			while (i < taggedParts.Length) {
-				if (taggedParts [i].Tag == "LineBreak")
+				if (taggedParts [i].Tag == TextTags.LineBreak)
 					break;
 				i++;
 			}
@@ -327,7 +327,9 @@ namespace MonoDevelop.Ide.CodeCompletion
 				markup.AppendTaggedText (theme, taggedParts);
 			} else {
 				markup.AppendTaggedText (theme, taggedParts.Take (i));
-				markup.Append ("<span font='" + FontService.SansFontName + "' size='small'>");
+				markup.Append ("<span font='");
+				markup.Append (FontService.SansFontName);
+				markup.Append ("' size='small'>");
 				markup.AppendLine ();
 				markup.AppendLine ();
 				markup.AppendTaggedText (theme, taggedParts.Skip (i + 1));


### PR DESCRIPTION
Intellisense, it does not trim the Attribute name

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/729414

During investigating that bug I've seen that the import symbol
completion data doesn't have the tooltip code implemented. Added
tooltip code for this kind of completion data in conjunction with the
bug fix.