### PR TITLE
[Git] Fix prompt over and over for keychain items

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -304,7 +304,7 @@ namespace MonoDevelop.MacInterop
 				attrs[n++] = new SecKeychainAttribute (SecItemAttr.AuthType, (uint) 4,            (IntPtr) authPtr);
 				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Server,   (uint) host.Length,  (IntPtr) hostPtr);
 				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Port,     (uint) 4,            (IntPtr) portPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Path,     (uint) path.Length,  (IntPtr) pathPtr);
+				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Path,     (uint) Math.Max (path.Length - 1, 0),  (IntPtr) pathPtr);
 
 				SecKeychainAttributeList attrList = new SecKeychainAttributeList (n, (IntPtr) attrs);
 

--- a/main/tests/MacPlatform.Tests/KeychainTests.cs
+++ b/main/tests/MacPlatform.Tests/KeychainTests.cs
@@ -54,13 +54,19 @@ namespace MacPlatform.Tests
 
 		const string site = "http://google.com";
 		const string siteWithUser = "http://user@google.com";
+		const string siteWithPath = site + "/path";
+		const string siteWithUserAndPath = siteWithUser + "/path";
 
 		[TestCase(site, site, "", null)]
 		[TestCase(site, site, "user", "user")]
 		[TestCase(site, site, null, null)]
+		[TestCase(siteWithPath, siteWithPath, "", null)]
+		[TestCase(siteWithPath, siteWithPath, "user", "user")]
+		[TestCase(siteWithPath, siteWithPath, null, null)]
 		[TestCase(siteWithUser, siteWithUser, null, "user")]
 		[TestCase(siteWithUser, siteWithUser, "user", "user")]
-		//[TestCase(siteWithUser, "http://user2@google.com", "user2", "user2")] Need to figure this one out first
+		[TestCase(siteWithUserAndPath, siteWithUserAndPath, null, "user")]
+		[TestCase(siteWithUserAndPath, siteWithUserAndPath, "user", "user")]
 		public void InternetPassword_AddFindRemove (string url, string probeUrl, string user, string expectedUsername)
 		{
 			var uri = new Uri (url);


### PR DESCRIPTION
When requesting a keychain item, we need to append a null byte.
When adding one, we don't.

Fixes VSTS #729363 - Visual Studio for Mac prompts for Git Credentials every time "Update Solution" or "Push Changes" is called