### PR TITLE
[release-7.8] Fixes VSTS Bug 723420: Light bulb - Numerous light bulbs show up

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -128,6 +128,8 @@ namespace MonoDevelop.CodeActions
 		{
 			var loc = Editor.CaretOffset;
 			var ad = DocumentContext.AnalysisDocument;
+			var line = Editor.GetLine (Editor.CaretLine);
+
 			if (ad == null) {
 				return Task.FromResult (CodeActionContainer.Empty);
 			}
@@ -147,10 +149,11 @@ namespace MonoDevelop.CodeActions
 						return CodeActionContainer.Empty;
 					}
 
-					var fixes = await codeFixService.GetFixesAsync (ad, span, true, cancellationToken);
+					var lineSpan = new TextSpan (line.Offset, line.Length);
+					var fixes = await codeFixService.GetFixesAsync (ad, lineSpan, true, cancellationToken);
+					fixes = await Runtime.RunInMainThread(() => FilterOnUIThread (fixes, DocumentContext.RoslynWorkspace));
 
 					var refactorings = await codeRefactoringService.GetRefactoringsAsync (ad, span, cancellationToken);
-
 					var codeActionContainer = new CodeActionContainer (fixes, refactorings);
 					Application.Invoke ((o, args) => {
 						if (cancellationToken.IsCancellationRequested)
@@ -175,6 +178,45 @@ namespace MonoDevelop.CodeActions
 				}
 
 			}, cancellationToken);
+		}
+
+		ImmutableArray<CodeFixCollection> FilterOnUIThread (
+			  ImmutableArray<CodeFixCollection> collections, Workspace workspace)
+		{
+			Runtime.AssertMainThread ();
+			var caretOffset = Editor.CaretOffset;
+			return collections.Select (c => FilterOnUIThread (c, workspace)).Where(x => x != null).OrderBy(x => GetDistance (x, caretOffset)).ToImmutableArray ();
+		}
+
+		static int GetDistance (CodeFixCollection fixCollection, int caretOffset)
+		{
+			return fixCollection.TextSpan.End < caretOffset ? caretOffset - fixCollection.TextSpan.End : fixCollection.TextSpan.Start - caretOffset;
+		}
+
+		static CodeFixCollection FilterOnUIThread (
+			CodeFixCollection collection,
+			Workspace workspace)
+		{
+			Runtime.AssertMainThread ();
+
+			var applicableFixes = collection.Fixes.WhereAsArray (f => IsApplicable (f.Action, workspace));
+			return applicableFixes.Length == 0
+				? null
+				: applicableFixes.Length == collection.Fixes.Length
+					? collection
+					: new CodeFixCollection (
+						collection.Provider, collection.TextSpan, applicableFixes,
+						collection.FixAllState, collection.SupportedScopes, collection.FirstDiagnostic);
+		}
+
+		static bool IsApplicable (Microsoft.CodeAnalysis.CodeActions.CodeAction action, Workspace workspace)
+		{
+			if (!action.PerformFinalApplicabilityCheck) {
+				return true;
+			}
+
+			Runtime.AssertMainThread ();
+			return action.IsApplicable (workspace);
 		}
 
 		internal async void PopupQuickFixMenu (Gdk.EventButton evt, Action<CodeFixMenu> menuAction, Xwt.Point? point = null)


### PR DESCRIPTION
incorrectly for a single line of recommendations

https://dev.azure.com/devdiv/DevDiv/_workitems/edit/723420

VS.NET takes the whole line into account for fixes - but for
refactorings it's using the caret position.
The fixes are sorted by the distance of the caret position.

Backport of #6620.

/cc @mkrueger 