### PR TITLE
[Ide] Fix new folder not being selected in Solution pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
@@ -179,6 +179,22 @@ namespace MonoDevelop.Components
 			return res;
 		}
 
+		/// <summary>
+		/// Force the tree view's SelectFunction to be reset so nodes an be selected. Sometimes a OnButtonPressEvent
+		/// occurs without any corresponding OnButtonReleaseEvent which prevent a tree node from being selected
+		/// by the TreeNodeNavigator.
+		/// </summary>
+		internal void ClearSelectOnRelease ()
+		{
+			selectOnRelease = false;
+			Selection.SelectFunction = DefaultTreeSelectFunction;
+		}
+
+		static bool DefaultTreeSelectFunction (Gtk.TreeSelection selection, Gtk.TreeModel model, Gtk.TreePath path, bool selected)
+		{
+			return true;
+		}
+
 		void PerformShowMenu (object sender, EventArgs args)
 		{
 			OnPopupMenu ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuTreeView.cs
@@ -92,9 +92,7 @@ namespace MonoDevelop.Components
 			// SelectFunction to block selection then it doesn't seem to always get
 			// properly unset.
 			//   https://bugzilla.xamarin.com/show_bug.cgi?id=40469
-			this.Selection.SelectFunction = (s, m, p, b) => {
-				return true;
-			};
+			Selection.SelectFunction = DefaultTreeSelectFunction;
 			base.OnRowActivated (path, column);
 		}
 
@@ -122,9 +120,7 @@ namespace MonoDevelop.Components
 						return false;
 					};
 				} else {
-					this.Selection.SelectFunction = (s, m, p, b) => {
-						return true;
-					};
+					Selection.SelectFunction = DefaultTreeSelectFunction;
 				}
 				return base.OnButtonPressEvent (evnt);
 			}
@@ -145,9 +141,7 @@ namespace MonoDevelop.Components
 
 		protected override bool OnButtonReleaseEvent (Gdk.EventButton evnt)
 		{
-			this.Selection.SelectFunction = (s, m, p, b) => {
-				return true;
-			};
+			Selection.SelectFunction = DefaultTreeSelectFunction;
 			Gtk.TreePath buttonReleasePath;
 			//If OnButtonPressEvent attempted on making deselection and dragging was not started
 			//check if we are on same item as when we clicked(could be different if dragging is disabled)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -2190,6 +2190,15 @@ namespace MonoDevelop.Ide.Gui.Components
 			return widget.Parent;
 		}
 
+		/// <summary>
+		/// Forces the select on release feature to be disabled since the ContextMenuTreeView
+		/// does not always reset the SelectFunction for the tree.
+		/// </summary>
+		internal void ClearSelectOnRelease ()
+		{
+			tree.ClearSelectOnRelease ();
+		}
+
 		internal class PadCheckMenuItem: Gtk.CheckMenuItem
 		{
 			internal string Id;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/TreeNodeNavigator.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/TreeNodeNavigator.cs
@@ -108,6 +108,7 @@ namespace MonoDevelop.Ide.Gui.Components
 					if (value != Selected) {
 						ExpandToNode ();
 						try {
+							pad.ClearSelectOnRelease ();
 							tree.Selection.SelectIter (currentIter);
 							tree.SetCursor (store.GetPath (currentIter), pad.CompleteColumn, false);
 						} catch (Exception) {}


### PR DESCRIPTION
Sometimes when right clicking the project and selecting Add - New
Folder the project tree node is selected and made editable instead
of the new folder. The ContextMenuTreeView registers a tree view
SelectFunction in its OnButtonPressEvent which disables selection.
Sometimes there is no corresponding OnButtonReleaseEvent to undo
this SelectFunction so the TreeNodeNavigator cannot select the
new folder node that has been added. Now the TreeNodeNavigator
forces the SelectFunction to be reset before selecting a
tree node.

Fixes VSTS #721437 - Can't focus on a folder and name it during
creation.