### PR TITLE
[Core] Fix ProgressMonitor dispose synchronization

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
@@ -277,9 +277,6 @@ module Refactoring =
           |> List.map (fun p -> p.FileName.ToString() )
       with _ -> []
 
-    let disposeMonitor (monitor:SearchProgressMonitor) =
-        Runtime.RunInMainThread(fun() -> monitor.Dispose()) |> ignore
-
     let findReferences (editor:TextEditor, ctx:DocumentContext, symbolUse:FSharpSymbolUse, lastIdent) =
         let monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)
         async {
@@ -296,7 +293,7 @@ module Refactoring =
             for (filename, startOffset, endOffset) in distinctRefs do
                 let sr = SearchResult (FileProvider (filename), startOffset, endOffset-startOffset)
                 monitor.ReportResult sr
-        } |> Async.StartInThreadpoolWithContinuation(fun () -> disposeMonitor monitor)
+        } |> Async.StartInThreadpoolWithContinuation(fun () -> monitor.Dispose ())
 
     let findDerivedReferences (editor:TextEditor, ctx:DocumentContext, symbolUse:FSharpSymbolUse, lastIdent) =
         let monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)
@@ -314,7 +311,7 @@ module Refactoring =
             for (filename, startOffset, endOffset) in distinctRefs do
                 let sr = SearchResult (FileProvider (filename), startOffset, endOffset-startOffset)
                 monitor.ReportResult sr
-        } |> Async.StartInThreadpoolWithContinuation(fun () -> disposeMonitor monitor)
+        } |> Async.StartInThreadpoolWithContinuation(fun () -> monitor.Dispose ())
 
     let findOverloads (editor:TextEditor, _ctx:DocumentContext, symbolUse:FSharpSymbolUse, _lastIdent) =
         let monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)
@@ -338,7 +335,7 @@ module Refactoring =
             for (filename, startOffset, endOffset) in distinctRefs do
                 let sr = SearchResult (FileProvider (filename), startOffset, endOffset-startOffset)
                 monitor.ReportResult sr
-        } |> Async.StartInThreadpoolWithContinuation(fun () -> disposeMonitor monitor)
+        } |> Async.StartInThreadpoolWithContinuation(fun () -> monitor.Dispose ())
 
     let findExtensionMethods (editor:TextEditor, ctx:DocumentContext, symbolUse:FSharpSymbolUse, lastIdent) =
         let monitor = IdeApp.Workbench.ProgressMonitors.GetSearchProgressMonitor (true, true)
@@ -356,7 +353,7 @@ module Refactoring =
             for (filename, startOffset, endOffset) in distinctRefs do
                 let sr = SearchResult (FileProvider (filename), startOffset, endOffset-startOffset)
                 monitor.ReportResult sr
-        } |> Async.StartInThreadpoolWithContinuation(fun () -> disposeMonitor monitor)
+        } |> Async.StartInThreadpoolWithContinuation(fun () -> monitor.Dispose ())
 
     module Operations =
         let canRename (symbolUse:FSharpSymbolUse) fileName project =

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProgressMonitor.cs
@@ -115,9 +115,9 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public AsyncOperation AsyncOperation { get; set; }
 		public object SyncRoot { get; set; }
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
-			base.Dispose ();
+			base.OnDispose (disposing);
 			IsDisposed = true;
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementProgressMonitor.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.PackageManagement
 			consoleMonitor.ErrorLog.Write (message);
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
 			consoleMonitorReg.Dispose ();
 			statusMonitorReg.Dispose ();
@@ -88,7 +88,7 @@ namespace MonoDevelop.PackageManagement
 
 			consoleMonitor.Dispose ();
 
-			base.Dispose ();
+			base.OnDispose (disposing);
 		}
 
 		void ReportAllWarningsButLastToConsole ()

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -70,8 +70,7 @@ namespace MonoDevelop.VersionControl
 		public void Wakeup() {
 			try {
 				tracker.EndTask();
-				// Remove this when https://github.com/mono/monodevelop/issue/4751 is fixed.
-				Runtime.MainSynchronizationContext.Post (o => ((ProgressMonitor)o).Dispose (), tracker);
+				tracker.Dispose ();
 			} finally {
 				Finished();
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/AggregatedProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/AggregatedProgressMonitor.cs
@@ -192,9 +192,9 @@ namespace MonoDevelop.Core.ProgressMonitoring
 					info.Monitor.ReportError (message, exception);
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
-			base.Dispose ();
+			base.OnDispose (disposing);
             foreach (MonitorInfo info in monitors) {
 				if ((info.ActionMask & MonitorAction.Dispose) != 0)
 					info.Monitor.Dispose ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/ConsoleProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/ConsoleProgressMonitor.cs
@@ -69,12 +69,12 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		{
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
 			if (!leaveOpen)
 				writer.Dispose ();
 
-			base.Dispose ();
+			base.OnDispose (disposing);
 		}
 		
 		public bool EnableTimeStamp {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/ProjectLoadProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/ProjectLoadProgressMonitor.cs
@@ -43,10 +43,10 @@ namespace MonoDevelop.Core
 		{
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
 			CurrentSolution = null;
-			base.Dispose ();
+			base.OnDispose (disposing);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
@@ -131,7 +131,15 @@ namespace MonoDevelop.Core
 			ReportGlobalDataToParent = true;
 		}
 
-		public virtual void Dispose ()
+		public void Dispose ()
+		{
+			if (context != null)
+				context.Send (o => ((ProgressMonitor)o).OnDispose (true), this);
+			else
+				OnDispose (true);
+		}
+
+		protected virtual void OnDispose (bool disposing)
 		{
 			if (disposed)
 				return;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -957,9 +957,9 @@ namespace MonoDevelop.Ide.Gui.Components
 			return new InvalidOperationException ("Output progress monitor already disposed.");
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
-			base.Dispose ();
+			base.OnDispose (disposing);
 			console.Dispose ();
 			Disposed?.Invoke (this, EventArgs.Empty);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BackgroundProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/BackgroundProgressMonitor.cs
@@ -68,10 +68,10 @@ namespace MonoDevelop.Ide.Gui
 					icon.ToolTip = tip;
 			});
 		}
-		
-		public override void Dispose()
+
+		protected override void OnDispose (bool disposing)
 		{
-			base.Dispose ();
+			base.OnDispose (disposing);
 			Application.Invoke ((o, args) => {
 				if (icon != null) {
 					icon.Dispose ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProjectLoadProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProjectLoadProgressMonitor.cs
@@ -40,10 +40,10 @@ namespace MonoDevelop.Ide.Gui
 			AddFollowerMonitor (monitor);
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
 			CurrentSolution = null;
-			base.Dispose ();
+			base.OnDispose (disposing);
 		}
 		
 		public override MigrationType ShouldMigrateProject ()

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/ProgressMonitorTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/ProgressMonitorTests.cs
@@ -130,8 +130,8 @@ namespace MonoDevelop.Core
 					mon.Log.Flush ();
 					Assert.AreEqual (9, ctx.CallCount);
 				}
-				// Once for completed, Dispose needs API break to be done on the right context.
-				Assert.AreEqual (10, ctx.CallCount);
+				// Once for completed, once for Dispose.
+				Assert.AreEqual (11, ctx.CallCount);
 			}
 		}
 	}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/ProgressMonitorTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/ProgressMonitorTests.cs
@@ -144,10 +144,10 @@ namespace MonoDevelop.Core
 			Log = underlyingLog = new CustomWriter (ctx);
 		}
 
-		public override void Dispose ()
+		protected override void OnDispose (bool disposing)
 		{
 			underlyingLog.Dispose ();
-			base.Dispose ();
+			base.OnDispose (disposing);
 		}
 
 		class CustomWriter : System.IO.TextWriter


### PR DESCRIPTION
This change aims to fix problems with users of ProgressMonitors knowing
which synchronization context to call dispose on, by handling it itself.

It does a sync wait on disposing

Fixes VSTS #612543 - [ProgressMonitors] Dispose is not called on the right
sync context