### PR TITLE
[Ide] Improve error handling when loading project templates

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngine.cs
@@ -52,16 +52,8 @@ namespace MonoDevelop.Ide.Templates
 	{
 		static EngineEnvironmentSettings environmentSettings = new EngineEnvironmentSettings (new MyTemplateEngineHost (), (env) => new SettingsLoader (env));
 		static TemplateCreator templateCreator = new TemplateCreator (environmentSettings);
-
+		static bool initialized;
 		static bool dontUpdateCache = true;
-
-		static MicrosoftTemplateEngine ()
-		{
-			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/Templates", OnProjectTemplateExtensionChanged);
-			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/ItemTemplates", OnItemTemplateExtensionChanged);
-			dontUpdateCache = false;
-			UpdateCache ();
-		}
 
 		static List<MicrosoftTemplateEngineSolutionTemplate> projectTemplates = new List<MicrosoftTemplateEngineSolutionTemplate> ();
 		static List<MicrosoftTemplateEngineItemTemplate> itemTemplates = new List<MicrosoftTemplateEngineItemTemplate> ();
@@ -139,12 +131,29 @@ namespace MonoDevelop.Ide.Templates
 
 		public static IEnumerable<SolutionTemplate> GetProjectTemplates ()
 		{
+			EnsureInitialized ();
 			return projectTemplates;
 		}
 
 		public static IEnumerable<ItemTemplate> GetItemTemplates ()
 		{
+			EnsureInitialized ();
 			return itemTemplates;
+		}
+
+		static void EnsureInitialized ()
+		{
+			if (initialized)
+				return;
+
+			Runtime.AssertMainThread ();
+
+			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/Templates", OnProjectTemplateExtensionChanged);
+			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/ItemTemplates", OnItemTemplateExtensionChanged);
+			dontUpdateCache = false;
+			UpdateCache ();
+
+			initialized = true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Failing to access the ~/.templateengine folder due to permissions
or not owning the files would result in the New Project dialog not
opening when trying to create a new project. Now a message dialog
is displayed showing the error before the New Project dialog is
opened.

Also moved the initialization of the templating engine out of the
constructor, to prevent the underlying error being hidden by a
TypeInitializationException. Initialization is now attempted each
time the templates are accessed in case the underlying error has
been fixed whilst the IDE is running.

Fixes VSTS #725161 - Failed to open New Project Dialog. Access to the
path "/Users/user/.templateengine/Visual Studio/7.0/..." is denied.