### PR TITLE
[release-7.7] [NuGet] Modify reference in place on updating a NuGet package

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
@@ -62,6 +62,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public CancellationToken ExecutedCancellationToken;
 
 		public Action BeforeExecuteAction = () => { };
+		public Func<Task> BeforeExecuteActionTask;
 
 		public Task ExecuteNuGetProjectActionsAsync (
 			NuGetProject nuGetProject,
@@ -76,6 +77,9 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			ExecutedCancellationToken = token;
 
 			BeforeExecuteAction ();
+
+			if (BeforeExecuteActionTask != null)
+				return BeforeExecuteActionTask.Invoke ();
 
 			return Task.FromResult (0);
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProject.cs
@@ -39,7 +39,7 @@ using NuGet.Versioning;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
-	class FakeNuGetProject : NuGetProject, IBuildIntegratedNuGetProject, IHasDotNetProject
+	class FakeNuGetProject : NuGetProject, IBuildIntegratedNuGetProject, IHasDotNetProject, IHasProjectReferenceMaintainer
 	{
 		public FakeNuGetProject (IDotNetProject project)
 		{
@@ -50,6 +50,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		}
 
 		public IDotNetProject Project { get; private set; }
+		public IProjectReferenceMaintainer ProjectReferenceMaintainer { get; set; }
 
 		public List<PackageReference> InstalledPackages = new List<PackageReference> ();
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -184,6 +184,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\NuGetPackageAssetSourceFilesTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeNuGetAwareProject.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\NuGetSdkResolverTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\AssemblyReferenceWithConditionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -185,6 +185,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\FakeNuGetAwareProject.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\NuGetSdkResolverTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\AssemblyReferenceWithConditionTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectReferenceMaintainerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\NuGetSdkResolverTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\AssemblyReferenceWithConditionTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\ProjectReferenceMaintainerTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\FullyQualifiedReferencePathTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/AssemblyReferenceWithConditionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/AssemblyReferenceWithConditionTests.cs
@@ -1,0 +1,83 @@
+//
+// AssemblyReferenceWithConditionTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class AssemblyReferenceWithConditionTests : RestoreTestBase
+	{
+		[Test]
+		public async Task UpdatePackage_ReferenceInsideItemGroupWithCondition_ReferenceRemainsInsideItemGroupAfterUpdate ()
+		{
+			string solutionFileName = Util.GetSampleProject ("ReferenceCondition", "PackageAssemblyReferenceCondition.sln");
+			using (solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName)) {
+				CreateNuGetConfigFile (solution.BaseDirectory);
+				var project = (DotNetProject)solution.FindProjectByName ("PackageAssemblyReferenceCondition");
+
+				var restoreResult = await RestoreNuGetPackages (solution);
+				Assert.IsTrue (restoreResult.Restored);
+				Assert.AreEqual (1, restoreResult.RestoredPackages.Count ());
+
+				// Update NuGet package
+				await UpdateNuGetPackage (project, "Test.Xam.NetStandard");
+
+				string expectedXml = File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved"));
+				string actualXml = File.ReadAllText (project.FileName);
+				Assert.AreEqual (expectedXml, actualXml);
+			}
+		}
+
+		Task UpdateNuGetPackage (DotNetProject project, string packageId)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (project.ParentSolution);
+			var context = new FakeNuGetProjectContext {
+				LogToConsole = true
+			};
+			var packageManager = new MonoDevelopNuGetPackageManager (solutionManager);
+
+			var action = new UpdateNuGetPackageAction (
+				solutionManager,
+				new DotNetProjectProxy (project),
+				context,
+				packageManager,
+				PackageManagementServices.PackageManagementEvents) {
+				PackageId = packageId
+			};
+
+			return Task.Run (() => {
+				action.Execute ();
+			});
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/AssemblyReferenceWithConditionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/AssemblyReferenceWithConditionTests.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.PackageManagement.Tests
 				// Update NuGet package
 				await UpdateNuGetPackage (project, "Test.Xam.NetStandard");
 
-				string expectedXml = File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved"));
+				string expectedXml = Util.ToSystemEndings (File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved")));
 				string actualXml = File.ReadAllText (project.FileName);
 				Assert.AreEqual (expectedXml, actualXml);
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/FullyQualifiedReferencePathTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/FullyQualifiedReferencePathTests.cs
@@ -1,0 +1,94 @@
+//
+// FullyQualifiedReferencePathTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using MonoDevelop.Projects.MSBuild;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class FullyQualifiedReferencePathTests : RestoreTestBase
+	{
+		[Test]
+		public async Task UpdatePackage_ReferenceHasFullyQualifiedPath_ReferenceHasFullyQualifiedPathAfterUpdate ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("ReferenceFullPath", "ReferenceFullPath.sln");
+			FilePath projectFileName = solutionFileName.ParentDirectory.Combine ("ReferenceFullPath.csproj");
+			FilePath packagesDirectory = solutionFileName.ParentDirectory.Combine ("packages");
+			string projectXml = File.ReadAllText (projectFileName);
+			string solutionDirectory = MSBuildProjectService.ToMSBuildPath (null, solutionFileName.ParentDirectory);
+			string updatedProjectXml = projectXml.Replace ("$(SolutionDir)", solutionDirectory);
+			File.WriteAllText (projectFileName, updatedProjectXml);
+
+			using (solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName)) {
+				CreateNuGetConfigFile (solution.BaseDirectory);
+				var project = (DotNetProject)solution.FindProjectByName ("ReferenceFullPath");
+
+				var restoreResult = await RestoreNuGetPackages (solution);
+				Assert.IsTrue (restoreResult.Restored);
+				Assert.AreEqual (1, restoreResult.RestoredPackages.Count ());
+
+				// Update NuGet package
+				await UpdateNuGetPackage (project, "Test.Xam.NetStandard");
+
+				string expectedXml = File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved"));
+				expectedXml = expectedXml.Replace ("$(SolutionDir)", solutionDirectory);
+
+				string actualXml = File.ReadAllText (project.FileName);
+				Assert.AreEqual (expectedXml, actualXml);
+			}
+		}
+
+		Task UpdateNuGetPackage (DotNetProject project, string packageId)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (project.ParentSolution);
+			var context = new FakeNuGetProjectContext {
+				LogToConsole = true
+			};
+			var packageManager = new MonoDevelopNuGetPackageManager (solutionManager);
+
+			var action = new UpdateNuGetPackageAction (
+				solutionManager,
+				new DotNetProjectProxy (project),
+				context,
+				packageManager,
+				PackageManagementServices.PackageManagementEvents) {
+				PackageId = packageId
+			};
+
+			return Task.Run (() => {
+				action.Execute ();
+			});
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/FullyQualifiedReferencePathTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/FullyQualifiedReferencePathTests.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.PackageManagement.Tests
 				// Update NuGet package
 				await UpdateNuGetPackage (project, "Test.Xam.NetStandard");
 
-				string expectedXml = File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved"));
+				string expectedXml = Util.ToSystemEndings (File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved")));
 				expectedXml = expectedXml.Replace ("$(SolutionDir)", solutionDirectory);
 
 				string actualXml = File.ReadAllText (project.FileName);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectReferenceMaintainerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectReferenceMaintainerTests.cs
@@ -1,0 +1,182 @@
+//
+// ProjectReferenceMaintainerTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class ProjectReferenceMaintainerTests
+	{
+		ProjectReferenceMaintainer maintainer;
+		FakeDotNetProject project;
+		FakeNuGetProject nugetProject;
+
+		void CreateProject ()
+		{
+			project = new FakeDotNetProject (@"d:\projects\MyProject\MyProject.csproj".ToNativePath ());
+			nugetProject = new FakeNuGetProject (project);
+		}
+
+		void CreateProjectReferenceMaintainer (FakeNuGetProject fakeNuGetProject)
+		{
+			maintainer = new ProjectReferenceMaintainer (fakeNuGetProject);
+		}
+
+		void CreateProjectReferenceMaintainer ()
+		{
+			CreateProject ();
+			maintainer = new ProjectReferenceMaintainer (nugetProject);
+		}
+
+		async Task<ProjectReference> AddAssemblyReferenceToMaintainer (string hintPath)
+		{
+			var reference = ProjectReference.CreateAssemblyFileReference (hintPath);
+			await maintainer.AddReference (reference);
+			return reference;
+		}
+
+		ProjectReference AddReferenceToProject (string hintPath)
+		{
+			var reference = ProjectReference.CreateAssemblyFileReference (hintPath);
+			project.References.Add (reference);
+			return reference;
+		}
+
+		[Test]
+		public async Task OneReferenceAdded_ReferenceAddedToProject ()
+		{
+			CreateProjectReferenceMaintainer ();
+			string hintPath = @"d:\projects\MyProject\packages\Test.dll".ToNativePath ();
+			await AddAssemblyReferenceToMaintainer (hintPath);
+
+			await maintainer.ApplyChanges ();
+
+			var reference = project.References.Single ();
+			Assert.AreEqual ("Test", reference.Reference);
+			Assert.AreEqual (hintPath, reference.HintPath.ToString ());
+		}
+
+		[Test]
+		public async Task OneReferenceRemoved_ReferenceRemovedFromProject ()
+		{
+			CreateProjectReferenceMaintainer ();
+			string hintPath = @"d:\projects\MyProject\packages\Test.dll".ToNativePath ();
+			var reference = AddReferenceToProject (hintPath);
+			await maintainer.RemoveReference (reference);
+
+			await maintainer.ApplyChanges ();
+
+			Assert.AreEqual (0, project.References.Count);
+		}
+
+		[Test]
+		public async Task ReferenceRemovedReferenceAdded_ReferenceUpdatedInProject ()
+		{
+			CreateProjectReferenceMaintainer ();
+			string hintPath1 = @"d:\projects\MyProject\packages\1.0\Test.dll".ToNativePath ();
+			var referenceToRemove = AddReferenceToProject (hintPath1);
+			await maintainer.RemoveReference (referenceToRemove);
+			string hintPath2 = @"d:\projects\MyProject\packages\1.1\Test.dll".ToNativePath ();
+			await AddAssemblyReferenceToMaintainer (hintPath2);
+
+			await maintainer.ApplyChanges ();
+
+			var reference = project.References.Single ();
+			Assert.AreEqual ("Test", reference.Reference);
+			Assert.AreEqual (hintPath2, reference.HintPath.ToString ());
+			Assert.AreSame (referenceToRemove, reference);
+		}
+
+		[Test]
+		public async Task ReferenceRemovedReferenceAdded_DifferentReferenceCase_ReferenceUpdatedInProject ()
+		{
+			CreateProjectReferenceMaintainer ();
+			string hintPath1 = @"d:\projects\MyProject\packages\1.0\Test.dll".ToNativePath ();
+			var referenceToRemove = AddReferenceToProject (hintPath1);
+			await maintainer.RemoveReference (referenceToRemove);
+			string hintPath2 = @"d:\projects\MyProject\packages\1.1\TEST.dll".ToNativePath ();
+			await AddAssemblyReferenceToMaintainer (hintPath2);
+
+			await maintainer.ApplyChanges ();
+
+			var reference = project.References.Single ();
+			Assert.AreEqual (hintPath2, reference.HintPath.ToString ());
+			Assert.AreSame (referenceToRemove, reference);
+		}
+
+		[Test]
+		public async Task OneReferenceAdded_ProjectThrowsOnSaveDuringApplyChanges_ExceptionThrown ()
+		{
+			CreateProjectReferenceMaintainer ();
+			string hintPath = @"d:\projects\MyProject\packages\Test.dll".ToNativePath ();
+			await AddAssemblyReferenceToMaintainer (hintPath);
+			var expectedException = new ApplicationException ("Error");
+			project.SaveAction = () => throw expectedException;
+
+			try {
+				await maintainer.ApplyChanges ();
+				Assert.Fail ("Expected an exception.");
+			} catch (Exception ex) {
+				Assert.AreEqual (expectedException, ex);
+			}
+		}
+
+		[Test]
+		public async Task References_OneReferenceRemoved ()
+		{
+			CreateProject ();
+			string hintPath = @"d:\projects\MyProject\packages\Test.dll".ToNativePath ();
+			var reference = AddReferenceToProject (hintPath);
+			CreateProjectReferenceMaintainer (nugetProject);
+
+			Assert.AreEqual (maintainer.GetReferences ().Single (), reference);
+
+			await maintainer.RemoveReference (reference);
+
+			Assert.AreEqual (0, maintainer.GetReferences ().Count ());
+		}
+
+		[Test]
+		public async Task References_OneReferenceAdded ()
+		{
+			CreateProjectReferenceMaintainer ();
+
+			Assert.AreEqual (0, maintainer.GetReferences ().Count ());
+
+			string hintPath = @"d:\projects\MyProject\packages\Test.dll".ToNativePath ();
+			await AddAssemblyReferenceToMaintainer (hintPath);
+
+			var reference = maintainer.GetReferences ().Single ();
+			Assert.AreEqual (hintPath, reference.HintPath.ToString ());
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateNuGetPackageActionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateNuGetPackageActionTests.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
 using NuGet.Configuration;
@@ -49,9 +50,10 @@ namespace MonoDevelop.PackageManagement.Tests
 		IPackageManagementEvents packageManagementEvents;
 		FakeFileRemover fileRemover;
 
-		void CreateAction (string packageId = "Test")
+		void CreateAction (string packageId = "Test", params ProjectReference[] projectReferences)
 		{
 			project = new FakeDotNetProject (@"d:\projects\MyProject\MyProject.csproj");
+			project.References.AddRange (projectReferences);
 			solutionManager = new FakeSolutionManager ();
 			nugetProject = new FakeNuGetProject (project);
 			solutionManager.NuGetProjects[project] = nugetProject;
@@ -211,65 +213,86 @@ namespace MonoDevelop.PackageManagement.Tests
 		[Test]
 		public void Execute_ReferenceBeingUpdatedHasLocalCopyTrueButCaseIsDifferent_ReferenceAddedHasLocalCopyTrue ()
 		{
-			CreateAction ();
+			var originalProjectReference = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "nunit.framework");
+			originalProjectReference.LocalCopy = true;
+			CreateAction ("Test", originalProjectReference);
 			AddInstallPackageIntoProjectAction ("Test", "1.2");
 			var firstReferenceBeingAdded = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NewAssembly");
 			var secondReferenceBeingAdded = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NUnit.Framework");
-			packageManager.BeforeExecuteAction = () => {
-				var referenceBeingRemoved = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "nunit.framework");
-				referenceBeingRemoved.LocalCopy = true;
-				packageManagementEvents.OnReferenceRemoving (referenceBeingRemoved);
+			packageManager.BeforeExecuteActionTask = async () => {
+				await nugetProject.ProjectReferenceMaintainer.RemoveReference (originalProjectReference);
+				packageManagementEvents.OnReferenceRemoving (originalProjectReference);
+
 				packageManagementEvents.OnReferenceAdding (firstReferenceBeingAdded);
+				await nugetProject.ProjectReferenceMaintainer.AddReference (firstReferenceBeingAdded);
+
 				packageManagementEvents.OnReferenceAdding (secondReferenceBeingAdded);
+				await nugetProject.ProjectReferenceMaintainer.AddReference (secondReferenceBeingAdded);
 			};
 
 			action.Execute ();
 
-			Assert.IsTrue (firstReferenceBeingAdded.LocalCopy);
-			Assert.IsTrue (secondReferenceBeingAdded.LocalCopy);
+			var nunitFrameworkReference = project.References.FirstOrDefault (r => r.Reference == originalProjectReference.Reference);
+			var newReference = project.References.FirstOrDefault (r => r.Reference == "NewAssembly");
+			Assert.IsTrue (newReference.LocalCopy);
+			Assert.IsTrue (nunitFrameworkReference.LocalCopy);
 		}
 
 		[Test]
 		public void Execute_ReferenceBeingUpdatedHasLocalCopyFalse_ReferenceAddedHasLocalCopyFalse ()
 		{
-			CreateAction ();
+			var originalProjectReference = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NUnit.Framework");
+			originalProjectReference.LocalCopy = false;
+			CreateAction ("Test", originalProjectReference);
 			AddInstallPackageIntoProjectAction ("Test", "1.2");
 			var firstReferenceBeingAdded = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NewAssembly");
 			firstReferenceBeingAdded.LocalCopy = true;
 			var secondReferenceBeingAdded = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NUnit.Framework");
-			packageManager.BeforeExecuteAction = () => {
-				var referenceBeingRemoved = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NUnit.Framework");
-				referenceBeingRemoved.LocalCopy = false;
-				packageManagementEvents.OnReferenceRemoving (referenceBeingRemoved);
+			packageManager.BeforeExecuteActionTask = async () => {
+				packageManagementEvents.OnReferenceRemoving (originalProjectReference);
+				await nugetProject.ProjectReferenceMaintainer.RemoveReference (originalProjectReference);
+
 				packageManagementEvents.OnReferenceAdding (firstReferenceBeingAdded);
+				await nugetProject.ProjectReferenceMaintainer.AddReference (firstReferenceBeingAdded);
+
 				packageManagementEvents.OnReferenceAdding (secondReferenceBeingAdded);
+				await nugetProject.ProjectReferenceMaintainer.AddReference (secondReferenceBeingAdded);
 			};
 			action.Execute ();
 
-			Assert.IsTrue (firstReferenceBeingAdded.LocalCopy);
-			Assert.IsFalse (secondReferenceBeingAdded.LocalCopy);
+			var nunitFrameworkReference = project.References.FirstOrDefault (r => r.Reference == originalProjectReference.Reference);
+			var newReference = project.References.FirstOrDefault (r => r.Reference == "NewAssembly");
+			Assert.IsTrue (newReference.LocalCopy);
+			Assert.IsFalse (nunitFrameworkReference.LocalCopy);
 		}
 
 		[Test]
 		public void Execute_ReferenceBeingUpdatedHasLocalCopyFalseButCaseIsDifferent_ReferenceAddedHasLocalCopyFalse ()
 		{
-			CreateAction ();
+			var originalProjectReference = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "nunit.framework");
+			originalProjectReference.LocalCopy = false;
+			CreateAction ("Test", originalProjectReference);
 			AddInstallPackageIntoProjectAction ("Test", "1.2");
 			var firstReferenceBeingAdded = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NewAssembly");
 			firstReferenceBeingAdded.LocalCopy = true;
 			var secondReferenceBeingAdded = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "NUnit.Framework");
-			packageManager.BeforeExecuteAction = () => {
-				var referenceBeingRemoved = ProjectReference.CreateCustomReference (ReferenceType.Assembly, "nunit.framework");
-				referenceBeingRemoved.LocalCopy = false;
-				packageManagementEvents.OnReferenceRemoving (referenceBeingRemoved);
+			packageManager.BeforeExecuteActionTask = async () => {
+				packageManagementEvents.OnReferenceRemoving (originalProjectReference);
+				await nugetProject.ProjectReferenceMaintainer.RemoveReference (originalProjectReference);
+
 				packageManagementEvents.OnReferenceAdding (firstReferenceBeingAdded);
+				await nugetProject.ProjectReferenceMaintainer.AddReference (firstReferenceBeingAdded);
+
 				packageManagementEvents.OnReferenceAdding (secondReferenceBeingAdded);
+				await nugetProject.ProjectReferenceMaintainer.AddReference (secondReferenceBeingAdded);
 			};
 
 			action.Execute ();
 
-			Assert.IsTrue (firstReferenceBeingAdded.LocalCopy);
-			Assert.IsFalse (secondReferenceBeingAdded.LocalCopy);
+			var nunitFrameworkReference = project.References.FirstOrDefault (r => r.Reference == originalProjectReference.Reference);
+			var newReference = project.References.FirstOrDefault (r => r.Reference == "NewAssembly");
+			Assert.IsTrue (newReference.LocalCopy);
+			Assert.IsFalse (nunitFrameworkReference.LocalCopy);
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -377,6 +377,9 @@
     <Compile Include="MonoDevelop.PackageManagement\ItemTemplateNuGetPackageInstaller.cs" />
     <Compile Include="Gui\MonoDevelop.PackageManagement.PackageManagementOptionsWidget.cs" />
     <Compile Include="Gui\MonoDevelop.PackageManagement.PackageSourcesWidget.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\ProjectReferenceMaintainer.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\IProjectReferenceMaintainer.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\IHasProjectReferenceMaintainer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IHasProjectReferenceMaintainer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IHasProjectReferenceMaintainer.cs
@@ -1,10 +1,10 @@
-﻿//
-// MonoDevelopMSBuildNuGetProject.cs
+//
+// IHasProjectReferenceMaintainer.cs
 //
 // Author:
-//       Matt Ward <matt.ward@xamarin.com>
+//       Matt Ward <matt.ward@microsoft.com>
 //
-// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2018 Microsoft
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,37 +24,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Threading.Tasks;
-using NuGet.ProjectManagement;
-
 namespace MonoDevelop.PackageManagement
 {
-	class MonoDevelopMSBuildNuGetProject : MSBuildNuGetProject, IHasDotNetProject, IHasProjectReferenceMaintainer
+	interface IHasProjectReferenceMaintainer
 	{
-		MonoDevelopMSBuildNuGetProjectSystem projectSystem;
-
-		public MonoDevelopMSBuildNuGetProject (
-			MonoDevelopMSBuildNuGetProjectSystem projectSystem,
-			string folderNuGetProjectFullPath,
-			string packagesConfigFolderPath)
-			: base (projectSystem, folderNuGetProjectFullPath, packagesConfigFolderPath)
-		{
-			this.projectSystem = projectSystem;
-		}
-
-		public Task SaveProject ()
-		{
-			return projectSystem.SaveProject ();
-		}
-
-		public IDotNetProject Project {
-			get { return projectSystem.Project; }
-		}
-
-		public IProjectReferenceMaintainer ProjectReferenceMaintainer {
-			get { return projectSystem.ProjectReferenceMaintainer; }
-			set { projectSystem.ProjectReferenceMaintainer = value; }
-		}
+		IProjectReferenceMaintainer ProjectReferenceMaintainer { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IProjectReferenceMaintainer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IProjectReferenceMaintainer.cs
@@ -1,10 +1,10 @@
-﻿//
-// MonoDevelopMSBuildNuGetProject.cs
+//
+// IProjectReferenceMaintainer.cs
 //
 // Author:
-//       Matt Ward <matt.ward@xamarin.com>
+//       Matt Ward <matt.ward@microsoft.com>
 //
-// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2018 Microsoft
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,37 +24,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuGet.ProjectManagement;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.PackageManagement
 {
-	class MonoDevelopMSBuildNuGetProject : MSBuildNuGetProject, IHasDotNetProject, IHasProjectReferenceMaintainer
+	interface IProjectReferenceMaintainer
 	{
-		MonoDevelopMSBuildNuGetProjectSystem projectSystem;
-
-		public MonoDevelopMSBuildNuGetProject (
-			MonoDevelopMSBuildNuGetProjectSystem projectSystem,
-			string folderNuGetProjectFullPath,
-			string packagesConfigFolderPath)
-			: base (projectSystem, folderNuGetProjectFullPath, packagesConfigFolderPath)
-		{
-			this.projectSystem = projectSystem;
-		}
-
-		public Task SaveProject ()
-		{
-			return projectSystem.SaveProject ();
-		}
-
-		public IDotNetProject Project {
-			get { return projectSystem.Project; }
-		}
-
-		public IProjectReferenceMaintainer ProjectReferenceMaintainer {
-			get { return projectSystem.ProjectReferenceMaintainer; }
-			set { projectSystem.ProjectReferenceMaintainer = value; }
-		}
+		IEnumerable<ProjectReference> GetReferences ();
+		Task AddReference (ProjectReference reference);
+		Task RemoveReference (ProjectReference reference);
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/InstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/InstallNuGetPackageAction.cs
@@ -166,13 +166,17 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			using (IDisposable fileMonitor = CreateFileMonitor ()) {
-				using (IDisposable referenceMaintainer = CreateLocalCopyReferenceMaintainer ()) {
+				using (var referenceMaintainer = CreateProjectReferenceMaintainer ()) {
 					await packageManager.ExecuteNuGetProjectActionsAsync (
 						project,
 						actions,
 						context,
 						resolutionContext.SourceCacheContext,
 						cancellationToken);
+
+					if (referenceMaintainer != null) {
+						await referenceMaintainer.ApplyChanges ();
+					}
 				}
 			}
 
@@ -242,13 +246,13 @@ namespace MonoDevelop.PackageManagement
 			return new LicenseAcceptanceService ();
 		}
 
-		IDisposable CreateLocalCopyReferenceMaintainer ()
+		ProjectReferenceMaintainer CreateProjectReferenceMaintainer ()
 		{
 			if (PreserveLocalCopyReferences) {
-				return new LocalCopyReferenceMaintainer (packageManagementEvents);
+				return new ProjectReferenceMaintainer (project);
 			}
 
-			return new NullDisposable ();
+			return null;
 		}
 
 		public IEnumerable<NuGetProjectAction> GetNuGetProjectActions ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopMSBuildNuGetProjectSystem.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopMSBuildNuGetProjectSystem.cs
@@ -36,7 +36,7 @@ using NuGet.ProjectManagement;
 
 namespace MonoDevelop.PackageManagement
 {
-	internal class MonoDevelopMSBuildNuGetProjectSystem : IMSBuildProjectSystem
+	internal class MonoDevelopMSBuildNuGetProjectSystem : IMSBuildProjectSystem, IProjectReferenceMaintainer
 	{
 		IDotNetProject project;
 		NuGetFramework targetFramework;
@@ -76,6 +76,8 @@ namespace MonoDevelop.PackageManagement
 			this.guiSyncDispatcher = guiSyncDispatcher;
 			this.guiSyncDispatcherFunc = guiSyncDispatcherFunc;
 			this.guiSyncDispatcherFuncReturnBool = guiSyncDispatcherFuncReturnBool;
+
+			ProjectReferenceMaintainer = this;
 		}
 
 		public INuGetProjectContext NuGetProjectContext { get; set; }
@@ -260,8 +262,7 @@ namespace MonoDevelop.PackageManagement
 
 		async Task AddReferenceToProject (ProjectReference assemblyReference)
 		{
-			project.References.Add (assemblyReference);
-			await project.SaveAsync ();
+			await ProjectReferenceMaintainer.AddReference (assemblyReference);
 			LogAddedReferenceToProject (assemblyReference);
 		}
 
@@ -400,7 +401,7 @@ namespace MonoDevelop.PackageManagement
 		ProjectReference FindReference (string name)
 		{
 			string referenceName = GetReferenceName (name);
-			foreach (ProjectReference referenceProjectItem in project.References) {
+			foreach (ProjectReference referenceProjectItem in ProjectReferenceMaintainer.GetReferences ()) {
 				string projectReferenceName = GetProjectReferenceName (referenceProjectItem.Reference);
 				if (IsMatchIgnoringCase (projectReferenceName, referenceName)) {
 					return referenceProjectItem;
@@ -509,8 +510,7 @@ namespace MonoDevelop.PackageManagement
 				ProjectReference referenceProjectItem = FindReference (name);
 				if (referenceProjectItem != null) {
 					packageManagementEvents.OnReferenceRemoving (referenceProjectItem);
-					project.References.Remove (referenceProjectItem);
-					await project.SaveAsync ();
+					await ProjectReferenceMaintainer.RemoveReference (referenceProjectItem);
 					LogRemovedReferenceFromProject (referenceProjectItem);
 				}
 			});
@@ -578,6 +578,25 @@ namespace MonoDevelop.PackageManagement
 		}
 
 		public dynamic VSProject4 { get; private set; }
+
+		internal IProjectReferenceMaintainer ProjectReferenceMaintainer { get; set; }
+
+		IEnumerable<ProjectReference> IProjectReferenceMaintainer.GetReferences ()
+		{
+			return project.References;
+		}
+
+		async Task IProjectReferenceMaintainer.AddReference (ProjectReference reference)
+		{
+			project.References.Add (reference);
+			await project.SaveAsync ();
+		}
+
+		async Task IProjectReferenceMaintainer.RemoveReference (ProjectReference reference)
+		{
+			project.References.Remove (reference);
+			await project.SaveAsync ();
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectReferenceMaintainer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectReferenceMaintainer.cs
@@ -1,0 +1,169 @@
+//
+// ProjectReferenceMaintainer.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NuGet.ProjectManagement;
+
+namespace MonoDevelop.PackageManagement
+{
+	/// <summary>
+	/// Keeps a record of references added and removed from a project without applying the changes until the
+	/// ApplyChanges is called. This allows the conversion of a reference being removed and then a new reference
+	/// being added for the same reference but with a different hint path to be converted into an update of the
+	/// original reference. This prevents references from being moved around the project file.
+	///
+	/// On an error NuGet will rollback the changes by applying the opposite actions (e.g. install => uninstall).
+	/// There is no logic in the ProjectReferenceMaintainer class to handle a rollback
+	/// since on a rollback an exception will be thrown by NuGet so any changes recorded in the
+	/// ProjectReferenceMaintainer will not be applied since ApplyChanges will not be called.
+	/// </summary>
+	class ProjectReferenceMaintainer : IProjectReferenceMaintainer, IDisposable
+	{
+		NuGetProject project;
+		IDotNetProject dotNetProject;
+		IHasProjectReferenceMaintainer hasProjectReferenceMaintainer;
+		IProjectReferenceMaintainer originalProjectReferenceMaintainer;
+		List<ProjectReference> references;
+		List<ProjectReference> removedReferences = new List<ProjectReference> ();
+		List<ProjectReference> addedReferences = new List<ProjectReference> ();
+		List<UpdatedProjectReference> updatedReferences = new List<UpdatedProjectReference> ();
+
+		public ProjectReferenceMaintainer (NuGetProject project)
+		{
+			this.project = project;
+			dotNetProject = project.GetDotNetProject ();
+
+			hasProjectReferenceMaintainer = project as IHasProjectReferenceMaintainer;
+			if (hasProjectReferenceMaintainer != null) {
+				originalProjectReferenceMaintainer = hasProjectReferenceMaintainer.ProjectReferenceMaintainer;
+				hasProjectReferenceMaintainer.ProjectReferenceMaintainer = this;
+				references = new List<ProjectReference> (dotNetProject.References);
+			}
+		}
+
+		public IEnumerable<ProjectReference> GetReferences ()
+		{
+			return references;
+		}
+
+		public void Dispose ()
+		{
+			if (hasProjectReferenceMaintainer == null)
+				return;
+
+			hasProjectReferenceMaintainer.ProjectReferenceMaintainer = originalProjectReferenceMaintainer;
+		}
+
+		public async Task ApplyChanges ()
+		{
+			if (hasProjectReferenceMaintainer == null)
+				return;
+
+			if (!AnyChanges ())
+				return;
+
+			await Runtime.RunInMainThread (() => ApplyChangesInternal ());
+		}
+
+		async Task ApplyChangesInternal ()
+		{
+			foreach (ProjectReference removedReference in removedReferences) {
+				dotNetProject.References.Remove (removedReference);
+			}
+
+			foreach (ProjectReference addedReference in addedReferences) {
+				dotNetProject.References.Add (addedReference);
+			}
+
+			foreach (UpdatedProjectReference updatedReference in updatedReferences) {
+				updatedReference.ApplyChanges ();
+			}
+
+			await dotNetProject.SaveAsync ();
+		}
+
+		public Task RemoveReference (ProjectReference reference)
+		{
+			references.Remove (reference);
+			removedReferences.Add (reference);
+
+			return Task.CompletedTask;
+		}
+
+		public Task AddReference (ProjectReference reference)
+		{
+			references.Add (reference);
+
+			ProjectReference removedReference = FindMatchingRemovedReference (reference);
+			if (removedReference != null) {
+				var updatedReference = new UpdatedProjectReference (removedReference, reference);
+				updatedReferences.Add (updatedReference);
+				removedReferences.Remove (removedReference);
+			} else {
+				addedReferences.Add (reference);
+			}
+
+			return Task.CompletedTask;
+		}
+
+		ProjectReference FindMatchingRemovedReference (ProjectReference reference)
+		{
+			return removedReferences.FirstOrDefault (removedReference => IsMatch (reference, removedReference));
+		}
+
+		static bool IsMatch (ProjectReference x, ProjectReference y)
+		{
+			return StringComparer.OrdinalIgnoreCase.Equals (x.Reference, y.Reference);
+		}
+
+		bool AnyChanges ()
+		{
+			return removedReferences.Any () || addedReferences.Any () || updatedReferences.Any ();
+		}
+
+		class UpdatedProjectReference
+		{
+			public UpdatedProjectReference (ProjectReference oldReference, ProjectReference newReference)
+			{
+				OldReference = oldReference;
+				NewReference = newReference;
+			}
+
+			public ProjectReference OldReference { get; }
+			public ProjectReference NewReference { get; }
+
+			public void ApplyChanges ()
+			{
+				OldReference.HintPath = NewReference.HintPath;
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
@@ -124,17 +124,15 @@ namespace MonoDevelop.PackageManagement
 			await CheckLicenses (cancellationToken);
 
 			using (IDisposable fileMonitor = CreateFileMonitor ()) {
-				using (IDisposable referenceMaintainer = CreateLocalCopyReferenceMaintainer ()) {
-					using (var maintainer = new ProjectReferenceMaintainer (project)) {
-						await packageManager.ExecuteNuGetProjectActionsAsync (
-							project,
-							actions,
-							context,
-							resolutionContext.SourceCacheContext,
-							cancellationToken);
+				using (var referenceMaintainer = new ProjectReferenceMaintainer (project)) {
+					await packageManager.ExecuteNuGetProjectActionsAsync (
+						project,
+						actions,
+						context,
+						resolutionContext.SourceCacheContext,
+						cancellationToken);
 
-						await maintainer.ApplyChanges ();
-					}
+					await referenceMaintainer.ApplyChanges ();
 				}
 			}
 
@@ -222,11 +220,6 @@ namespace MonoDevelop.PackageManagement
 		protected virtual ILicenseAcceptanceService GetLicenseAcceptanceService ()
 		{
 			return new LicenseAcceptanceService ();
-		}
-
-		LocalCopyReferenceMaintainer CreateLocalCopyReferenceMaintainer ()
-		{
-			return new LocalCopyReferenceMaintainer (packageManagementEvents);
 		}
 
 		IDisposable CreateFileMonitor ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
@@ -125,12 +125,16 @@ namespace MonoDevelop.PackageManagement
 
 			using (IDisposable fileMonitor = CreateFileMonitor ()) {
 				using (IDisposable referenceMaintainer = CreateLocalCopyReferenceMaintainer ()) {
-					await packageManager.ExecuteNuGetProjectActionsAsync (
-						project,
-						actions,
-						context,
-						resolutionContext.SourceCacheContext,
-						cancellationToken);
+					using (var maintainer = new ProjectReferenceMaintainer (project)) {
+						await packageManager.ExecuteNuGetProjectActionsAsync (
+							project,
+							actions,
+							context,
+							resolutionContext.SourceCacheContext,
+							cancellationToken);
+
+						await maintainer.ApplyChanges ();
+					}
 				}
 			}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateNuGetPackageAction.cs
@@ -119,17 +119,15 @@ namespace MonoDevelop.PackageManagement
 			SetDirectInstall ();
 
 			using (IDisposable fileMonitor = CreateFileMonitor ()) {
-				using (IDisposable referenceMaintainer = CreateLocalCopyReferenceMaintainer ()) {
-					using (var maintainer = new ProjectReferenceMaintainer (project)) {
-						await packageManager.ExecuteNuGetProjectActionsAsync (
-							project,
-							actions,
-							context,
-							resolutionContext.SourceCacheContext,
-							cancellationToken);
+				using (var referenceMaintainer = new ProjectReferenceMaintainer (project)) {
+					await packageManager.ExecuteNuGetProjectActionsAsync (
+						project,
+						actions,
+						context,
+						resolutionContext.SourceCacheContext,
+						cancellationToken);
 
-						await maintainer.ApplyChanges ();
-					}
+					await referenceMaintainer.ApplyChanges ();
 				}
 			}
 
@@ -182,11 +180,6 @@ namespace MonoDevelop.PackageManagement
 		protected virtual ILicenseAcceptanceService GetLicenseAcceptanceService ()
 		{
 			return new LicenseAcceptanceService ();
-		}
-
-		LocalCopyReferenceMaintainer CreateLocalCopyReferenceMaintainer ()
-		{
-			return new LocalCopyReferenceMaintainer (packageManagementEvents);
 		}
 
 		public IEnumerable<NuGetProjectAction> GetNuGetProjectActions ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateNuGetPackageAction.cs
@@ -120,12 +120,16 @@ namespace MonoDevelop.PackageManagement
 
 			using (IDisposable fileMonitor = CreateFileMonitor ()) {
 				using (IDisposable referenceMaintainer = CreateLocalCopyReferenceMaintainer ()) {
-					await packageManager.ExecuteNuGetProjectActionsAsync (
-						project,
-						actions,
-						context,
-						resolutionContext.SourceCacheContext,
-						cancellationToken);
+					using (var maintainer = new ProjectReferenceMaintainer (project)) {
+						await packageManager.ExecuteNuGetProjectActionsAsync (
+							project,
+							actions,
+							context,
+							resolutionContext.SourceCacheContext,
+							cancellationToken);
+
+						await maintainer.ApplyChanges ();
+					}
 				}
 			}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -329,7 +329,12 @@ namespace MonoDevelop.Projects
 			buildItem.Metadata.SetValue ("Private", LocalCopy, DefaultLocalCopy);
 
 			if (hintPathChanged) {
-				buildItem.Metadata.SetValue ("HintPath", HintPath);
+				bool useFullPathForHintPath = false;
+				if (buildItem.Metadata.TryGetPathValue ("HintPath", out FilePath relativePath, relativeToProject: false) &&
+					buildItem.Metadata.TryGetPathValue ("HintPath", out FilePath fullPath, relativeToProject: true)) {
+					useFullPathForHintPath = relativePath == fullPath;
+				}
+				buildItem.Metadata.SetValue ("HintPath", HintPath, relativeToProject: !useFullPathForHintPath);
 				hintPathChanged = false;
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -75,6 +75,7 @@ namespace MonoDevelop.Projects
 		SystemPackage cachedPackage;
 		string customError;
 		FilePath hintPath;
+		bool hintPathChanged;
 		bool hasBeenRead;
 
 		string originalMSBuildReferenceHintPath;
@@ -326,6 +327,11 @@ namespace MonoDevelop.Projects
 			}
 
 			buildItem.Metadata.SetValue ("Private", LocalCopy, DefaultLocalCopy);
+
+			if (hintPathChanged) {
+				buildItem.Metadata.SetValue ("HintPath", HintPath);
+				hintPathChanged = false;
+			}
 		}
 
 		bool ReferenceStringHasVersion (string asmName)
@@ -529,6 +535,12 @@ namespace MonoDevelop.Projects
 
 		public FilePath HintPath {
 			get { return hintPath; }
+			set {
+				hintPath = value;
+				hintPathChanged = true;
+				if (ownerProject != null)
+					ownerProject.NotifyModified ("References");
+			}
 		}
 		
 		string GetVersionNum (string asmName)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -76,6 +76,7 @@ namespace MonoDevelop.Projects
 		string customError;
 		FilePath hintPath;
 		bool hintPathChanged;
+		bool useFullPathForHintPath;
 		bool hasBeenRead;
 
 		string originalMSBuildReferenceHintPath;
@@ -250,6 +251,8 @@ namespace MonoDevelop.Projects
 				} else {
 					var type = File.Exists (path) ? ReferenceType.Assembly : ReferenceType.Package;
 					Init (type, buildItem.Include, path);
+					if (buildItem.Metadata.TryGetPathValue ("HintPath", out FilePath relativePath, relativeToProject: false))
+						useFullPathForHintPath = relativePath == path;
 				}
 			} else {
 				string asm = buildItem.Include;
@@ -328,15 +331,8 @@ namespace MonoDevelop.Projects
 
 			buildItem.Metadata.SetValue ("Private", LocalCopy, DefaultLocalCopy);
 
-			if (hintPathChanged) {
-				bool useFullPathForHintPath = false;
-				if (buildItem.Metadata.TryGetPathValue ("HintPath", out FilePath relativePath, relativeToProject: false) &&
-					buildItem.Metadata.TryGetPathValue ("HintPath", out FilePath fullPath, relativeToProject: true)) {
-					useFullPathForHintPath = relativePath == fullPath;
-				}
+			if (hintPathChanged)
 				buildItem.Metadata.SetValue ("HintPath", HintPath, relativeToProject: !useFullPathForHintPath);
-				hintPathChanged = false;
-			}
 		}
 
 		bool ReferenceStringHasVersion (string asmName)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -682,6 +682,32 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task UpdateHintPath ()
+		{
+			// Check that the in-memory project data is used when the builder is loaded for the first time.
+
+			string projectFile = Util.GetSampleProject ("hintpath-tests", "ConsoleProject.csproj");
+			using (var p = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var reference = p.References.Single (r => r.Reference == "Test");
+				reference.HintPath = reference.HintPath.ParentDirectory.Combine ("Test2.dll");
+
+				await p.SaveAsync (Util.GetMonitor ());
+
+				var savedXml = File.ReadAllText (p.FileName.ChangeExtension (".csproj-saved"));
+				var refXml = File.ReadAllText (p.FileName);
+
+				Assert.AreEqual (refXml, savedXml);
+
+				// Save again. Checks that old hint path is not put back again.
+				await p.SaveAsync (Util.GetMonitor ());
+				savedXml = File.ReadAllText (p.FileName);
+
+				Assert.AreEqual (refXml, savedXml);
+			}
+		}
+
+		[Test]
 		public async Task ChangeBuildAction ()
 		{
 			// Check that the in-memory project data is used when the builder is loaded for the first time.

--- a/main/tests/test-projects/ReferenceCondition/PackageAssemblyReferenceCondition.csproj
+++ b/main/tests/test-projects/ReferenceCondition/PackageAssemblyReferenceCondition.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>PackageAssemblyReferenceCondition</RootNamespace>
+    <AssemblyName>PackageAssemblyReferenceCondition</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Reference Include="Xam.Test.NetStandard">
+      <HintPath>packages\Test.Xam.NetStandard.1.0.0\lib\netstandard16\Xam.Test.NetStandard.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ReferenceCondition/PackageAssemblyReferenceCondition.csproj-saved
+++ b/main/tests/test-projects/ReferenceCondition/PackageAssemblyReferenceCondition.csproj-saved
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>PackageAssemblyReferenceCondition</RootNamespace>
+    <AssemblyName>PackageAssemblyReferenceCondition</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Reference Include="Xam.Test.NetStandard">
+      <HintPath>packages\Test.Xam.NetStandard.1.0.1\lib\netstandard17\Xam.Test.NetStandard.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ReferenceCondition/PackageAssemblyReferenceCondition.sln
+++ b/main/tests/test-projects/ReferenceCondition/PackageAssemblyReferenceCondition.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageAssemblyReferenceCondition", "PackageAssemblyReferenceCondition.csproj", "{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ReferenceCondition/packages.config
+++ b/main/tests/test-projects/ReferenceCondition/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Test.Xam.NetStandard" version="1.0.0" targetFramework="net47" />
+</packages>

--- a/main/tests/test-projects/ReferenceFullPath/ReferenceFullPath.csproj
+++ b/main/tests/test-projects/ReferenceFullPath/ReferenceFullPath.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ReferenceFullPath</RootNamespace>
+    <AssemblyName>ReferenceFullPath</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Reference Include="Xam.Test.NetStandard">
+      <HintPath>$(SolutionDir)\packages\Test.Xam.NetStandard.1.0.0\lib\netstandard16\Xam.Test.NetStandard.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ReferenceFullPath/ReferenceFullPath.csproj-saved
+++ b/main/tests/test-projects/ReferenceFullPath/ReferenceFullPath.csproj-saved
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ReferenceFullPath</RootNamespace>
+    <AssemblyName>ReferenceFullPath</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Reference Include="Xam.Test.NetStandard">
+      <HintPath>$(SolutionDir)\packages\Test.Xam.NetStandard.1.0.1\lib\netstandard17\Xam.Test.NetStandard.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ReferenceFullPath/ReferenceFullPath.sln
+++ b/main/tests/test-projects/ReferenceFullPath/ReferenceFullPath.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceFullPath", "ReferenceFullPath.csproj", "{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B6F1AAA-AB1A-406A-899B-096A4ACAA905}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ReferenceFullPath/packages.config
+++ b/main/tests/test-projects/ReferenceFullPath/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Test.Xam.NetStandard" version="1.0.0" targetFramework="net47" />
+</packages>

--- a/main/tests/test-projects/hintpath-tests/ConsoleProject.csproj
+++ b/main/tests/test-projects/hintpath-tests/ConsoleProject.csproj
@@ -1,0 +1,38 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HintPathTest</RootNamespace>
+    <AssemblyName>HintPathTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="Test">
+      <HintPath>lib\Test.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/hintpath-tests/ConsoleProject.csproj-saved
+++ b/main/tests/test-projects/hintpath-tests/ConsoleProject.csproj-saved
@@ -1,0 +1,38 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HintPathTest</RootNamespace>
+    <AssemblyName>HintPathTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="Test">
+      <HintPath>lib\Test2.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
On updating a NuGet package in a project that uses a packages.config
the old NuGet package is uninstalled and the new one is installed.
This removes the old references and adds new references. If the
references are in an ItemGroup with a condition then the new
reference can be added into a different ItemGroup if there are other
ItemGroups with references. To prevent this from happening the
changes to made to references are cached and not applied to the
project until the NuGet actions have all been run. This allows
a reference remove followed by an reference being added to be
converted into an update of the original reference's HintPath so its
location in the project file is not changed.

Fixes VSTS #697600 - Sometimes updating package changes its Reference
ItemGroup

Keep fully qualifed hint path on updating reference

Updating a NuGet package, where the project had been modified so the
original reference had a fully qualified hint path, would result in
a relative path used for the hint path on updating the reference.
Now if the original hint path was fully qualified then if the hint
path for the reference is changed it is saved using a fully qualified
path.

Fixes VSTS #697601 - Updating package reference adds relative path to
HintPath

Backport of #6650.

/cc @mrward 