### PR TITLE
[release-7.8] Fixes VSTS Bug 734863: Inverted comma (one more character) is also

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MdTextViewLineCollection.MdTextViewLine.cs
@@ -242,9 +242,9 @@ namespace Mono.TextEditor
 				}
 
 				var c = textEditor.GetCharAt (bufferPosition.Position);
-				if ((c & CaretMoveActions.LowSurrogateMarker) == CaretMoveActions.LowSurrogateMarker)
+				if (CaretMoveActions.IsLowSurrogateMarkerSet (c))
 					return new SnapshotSpan (bufferPosition.Snapshot, bufferPosition.Position, 2);
-				if ((c & CaretMoveActions.HighSurrogateMarker) == CaretMoveActions.HighSurrogateMarker)
+				if (CaretMoveActions.IsHighSurrogateMarkerSet (c))
 					return new SnapshotSpan (bufferPosition.Snapshot, bufferPosition.Position - 1, 2);
 				return new SnapshotSpan (bufferPosition, 1);
 			}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -3368,7 +3368,7 @@ namespace Mono.TextEditor
 
 						if (snapCharacters && !IsNearX1 (xp, xp1, xp2)) {
 							index++;
-							if (index < layoutWrapper.Text.Length  && (layoutWrapper.Text[index] & CaretMoveActions.LowSurrogateMarker) == CaretMoveActions.LowSurrogateMarker)
+							if (index < layoutWrapper.Text.Length  && CaretMoveActions.IsLowSurrogateMarkerSet (layoutWrapper.Text [index]))
 								index++;
 						}
 						return true;

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/DeleteActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/DeleteActions.cs
@@ -318,7 +318,7 @@ namespace Mono.TextEditor
 				return;
 			var version = data.Version;
 			var o = data.Caret.Offset;
-			if (((ushort)data.GetCharAt (offset - 1) & CaretMoveActions.LowSurrogateMarker) == CaretMoveActions.LowSurrogateMarker) {
+			if (CaretMoveActions.IsLowSurrogateMarkerSet (data.GetCharAt (offset - 1))) {
 				data.Remove (offset - 2, 2);
 			} else {
 				data.Remove (offset - 1, 1);
@@ -388,7 +388,7 @@ namespace Mono.TextEditor
 					}
 				} else {
 					var o = data.Caret.Offset;
-					if (((ushort)data.GetCharAt (o) & CaretMoveActions.HighSurrogateMarker) == CaretMoveActions.HighSurrogateMarker) {
+					if (CaretMoveActions.IsHighSurrogateMarkerSet (data.GetCharAt (o))) {
 						data.Remove (o, 2);
 					} else {
 						data.Remove (o, 1);

--- a/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests.DefaultEditActions/CaretMoveActionTests.cs
+++ b/main/src/core/MonoDevelop.TextEditor.Tests/Mono.TextEditor.Tests.DefaultEditActions/CaretMoveActionTests.cs
@@ -500,5 +500,16 @@ IEnumerable<string> GetFileExtensions (string filename)
 🚀$
 12");
 		}
+
+		/// <summary>
+		/// Bug 734863: Inverted comma (one more character) is also getting deleted when trying to delete keywords︐ ,︒,︑,︓,︔ ,︕ ,︖ ,︗ ,︘,︙, from keyboard
+		/// </summary>
+		[Test]
+		public void TestBug734863 ()
+		{
+			var data = Create (@"︐$");
+			CaretMoveActions.Left (data);
+			Check (data, @"$︐");
+		}
 	}
 }


### PR DESCRIPTION
getting deleted when trying to delete keywords︐ ,︒,︑,︓,︔ ,︕ ,︖ ,︗
,︘,︙, from keyboard

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/734863

The utf32 surrogate check was a bit more complex.

Backport of #6662.

/cc @mkrueger 