### PR TITLE
[Ide] Add support for Welcome dialog providers

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -709,7 +709,7 @@ namespace MonoDevelop.MacIntegration
 		static void HandleDeleteEvent (object o, Gtk.DeleteEventArgs args)
 		{
 			args.RetVal = true;
-			NSApplication.SharedApplication.Hide (NSApplication.SharedApplication);
+			IdeApp.Workbench.RootWindow.Visible = false;
 		}
 
 		public static Gdk.Pixbuf GetPixbufFromNSImageRep (NSImageRep rep, int width, int height)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
@@ -132,7 +132,7 @@ namespace MonoDevelop.Ide.Commands
 	{
 		protected override void Run ()
 		{
-			IdeApp.ProjectOperations.NewSolution ();
+			IdeApp.ProjectOperations.NewSolution ().Ignore ();
 		}
 	}
 	
@@ -141,7 +141,7 @@ namespace MonoDevelop.Ide.Commands
 	{
 		protected override void Run ()
 		{
-			IdeApp.ProjectOperations.NewSolution ("MonoDevelop.Workspace");
+			IdeApp.ProjectOperations.NewSolution ("MonoDevelop.Workspace").Ignore ();
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/IdeCustomizer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/IdeCustomizer.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Ide.Extensions
 		/// <summary>
 		/// Called when the Ide has been initialized
 		/// </summary>
-		internal protected virtual void OnIdeInitialized ()
+		internal protected virtual void OnIdeInitialized (bool hideWelcomePage)
 		{
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -840,7 +840,7 @@ namespace MonoDevelop.Ide.Gui
 			if (lastActive == ActiveWorkbenchWindow)
 				return;
 
-			WelcomePage.WelcomePageService.HideWelcomePage ();
+			WelcomePage.WelcomePageService.HideWelcomePageOrWindow ();
 
 			if (lastActive != null)
 				((SdiWorkspaceWindow)lastActive).OnDeactivated ();
@@ -1421,7 +1421,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public void ActivatePad (PadCodon padContent, bool giveFocus)
 		{
-			WelcomePage.WelcomePageService.HideWelcomePage ();
+			WelcomePage.WelcomePageService.HideWelcomePageOrWindow ();
 
 			DockItem item = GetDockItem (padContent);
 			if (item != null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -758,7 +758,7 @@ namespace MonoDevelop.Ide.Gui
 
 		public void ShowGlobalPreferencesDialog (Window parentWindow, string panelId, Action<OptionsDialog> configurationAction = null)
 		{
-			if (parentWindow == null)
+			if (parentWindow == null && IdeApp.Workbench.RootWindow.Visible)
 				parentWindow = IdeApp.Workbench.RootWindow;
 
 			OptionsDialog ops = new OptionsDialog (

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -107,7 +107,9 @@ namespace MonoDevelop.Ide.Projects
 			Name = "wizard_dialog";
 			Title = GettextCatalog.GetString ("New Project");
 			WindowPosition = WindowPosition.CenterOnParent;
-			TransientFor = IdeApp.Workbench.RootWindow;
+			if (IdeApp.Workbench.RootWindow.Visible) {
+				TransientFor = IdeApp.Workbench.RootWindow;
+			}
 
 			projectConfigurationWidget = new GtkProjectConfigurationWidget ();
 			projectConfigurationWidget.Name = "projectConfigurationWidget";

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/IWelcomeWindowProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/IWelcomeWindowProvider.cs
@@ -1,24 +1,21 @@
-// 
-// WelcomePageCommands.cs
-//  
+//
+// IWelcomeDialogProvider.cs
+//
 // Author:
-//       Michael Hutchinson <mhutch@xamarin.com>
-//       Scott Ellington
-// 
-// Copyright (c) 2011 Xamarin Inc.
-// Copyright (c) 2005-2010 Novell, Inc.
-// Copyright (c) 2005 Scott Ellington
-// 
+//       Rodrigo Moya <rodrigo.moya@xamarin.com>
+//
+// Copyright (c) 2018 Microsoft Inc. (http://microsoft.com)
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,31 +23,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-using MonoDevelop.Core;
-using MonoDevelop.Components.Commands;
-using MonoDevelop.Ide.Gui;
-using MonoDevelop.Ide;
-using System.Linq;
+using System;
+using MonoDevelop.Components;
+using Mono.Addins;
 
 namespace MonoDevelop.Ide.WelcomePage
 {
-	class ShowWelcomePageHandler : CommandHandler
+	[TypeExtensionPoint]
+	public interface IWelcomeWindowProvider
 	{
-		public static void Show ()
-		{
-			WelcomePageService.ShowWelcomePageOrWindow ();
-		}
-		
-		protected override void Run()
-		{
-			Show ();
-		}
-		
-		protected override void Update (CommandInfo info)
-		{
-			info.Text = WelcomePageService.HasWindowImplementation ? GettextCatalog.GetString ("Start Window") : GettextCatalog.GetString ("Welcome Page");
-			base.Update (info);
-		}
+		Window CreateWindow ();
+		void ShowWindow (Window window);
+		void HideWindow (Window window);
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -27,6 +27,7 @@ using System;
 using MonoDevelop.Ide.Gui;
 using Mono.Addins;
 using System.Linq;
+using MonoDevelop.Components;
 
 namespace MonoDevelop.Ide.WelcomePage
 {
@@ -34,29 +35,60 @@ namespace MonoDevelop.Ide.WelcomePage
 	{
 		static bool visible;
 		static WelcomePageFrame welcomePage;
+		static IWelcomeWindowProvider welcomeWindowProvider;
+		static Window welcomeWindow;
 
 		public static event EventHandler WelcomePageShown;
 		public static event EventHandler WelcomePageHidden;
 
 		internal static void Initialize ()
 		{
+			IdeApp.Workbench.RootWindow.Hidden += (sender, e) => {
+				if (!IdeApp.IsExiting && HasWindowImplementation) {
+					ShowWelcomeWindow ();
+				}
+			};
 			IdeApp.Workspace.FirstWorkspaceItemOpened += delegate {
-				HideWelcomePage ();
+				HideWelcomePageOrWindow ();
 			};
 			IdeApp.Workspace.LastWorkspaceItemClosed += delegate {
-				ShowWelcomePage ();
+				if (!IdeApp.IsExiting && !IdeApp.Workspace.WorkspaceItemIsOpening) {
+					ShowWelcomePageOrWindow ();
+				}
 			};
 			IdeApp.Workbench.DocumentOpened += delegate {
-				HideWelcomePage ();
+				HideWelcomePageOrWindow ();
 			};
 			IdeApp.Workbench.DocumentClosed += delegate {
-				if (IdeApp.Workbench.Documents.Count == 0 && !IdeApp.Workspace.IsOpen)
-					ShowWelcomePage ();
+				if (!IdeApp.IsExiting && IdeApp.Workbench.Documents.Count == 0 && !IdeApp.Workspace.IsOpen) {
+					ShowWelcomePageOrWindow ();
+				}
 			};
 		}
 
-		public static bool WelcomePageVisible {
-			get { return visible; }
+		public static bool WelcomePageVisible => visible;
+
+		public static bool WelcomeWindowVisible => welcomeWindow != null && visible;
+
+		public static bool HasWindowImplementation => AddinManager.GetExtensionObjects<IWelcomeWindowProvider> ().Any ();
+
+		public static void ShowWelcomePageOrWindow (bool animate = false)
+		{
+			// Try to get a dialog version of the "welcome screen" first
+			if (!ShowWelcomeWindow ()) {
+				ShowWelcomePage ();
+			}
+		}
+
+		public static void HideWelcomePageOrWindow (bool animate = false)
+		{
+			if (HasWindowImplementation && welcomeWindowProvider != null && welcomeWindow != null) {
+				welcomeWindowProvider.HideWindow (welcomeWindow);
+			} else {
+				HideWelcomePage (animate);
+			}
+
+			visible = false;
 		}
 
 		public static void ShowWelcomePage (bool animate = false)
@@ -83,6 +115,26 @@ namespace MonoDevelop.Ide.WelcomePage
 				((DefaultWorkbench)IdeApp.Workbench.RootWindow).DockFrame.RemoveOverlayWidget (animate);
 			}
 			WelcomePageHidden?.Invoke (welcomePage, EventArgs.Empty);
+		}
+
+		public static bool ShowWelcomeWindow ()
+		{
+			if (welcomeWindowProvider == null) {
+				welcomeWindowProvider = AddinManager.GetExtensionObjects<IWelcomeWindowProvider> ().FirstOrDefault ();
+				if (welcomeWindowProvider == null)
+					return false;
+			}
+
+			if (welcomeWindow == null) {
+				welcomeWindow = welcomeWindowProvider.CreateWindow ();
+				if (welcomeWindow == null)
+					return false;
+			}
+
+			welcomeWindowProvider.ShowWindow (welcomeWindow);
+			visible = true;
+
+			return true;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4224,6 +4224,7 @@
     <Compile Include="MonoDevelop.Ide.RoslynServices\RoslynLogger.cs" />
     <Compile Include="MonoDevelop.Ide.RoslynServices\RoslynFileLogger.cs" />
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />
+    <Compile Include="MonoDevelop.Ide.WelcomePage\IWelcomeWindowProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -265,7 +265,7 @@ namespace MonoDevelop.Ide
 			commandService.EnableIdleUpdate = true;
 
 			if (Customizer != null)
-				Customizer.OnIdeInitialized ();
+				Customizer.OnIdeInitialized (hideWelcomePage);
 			
 			// Startup commands
 			Counters.Initialization.Trace ("Running Startup Commands");
@@ -465,16 +465,20 @@ namespace MonoDevelop.Ide
 			get { return isMainRunning; }
 		}
 
+		public static bool IsExiting { get; private set; }
+
 		/// <summary>
 		/// Exits MonoDevelop. Returns false if the user cancels exiting.
 		/// </summary>
 		public static async Task<bool> Exit ()
 		{
+			IsExiting = true;
 			if (await workbench.Close ()) {
 				Gtk.Application.Quit ();
 				isMainRunning = false;
 				return true;
 			}
+			IsExiting = false;
 			return false;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -465,12 +465,12 @@ namespace MonoDevelop.Ide
 			Composition.CompositionManager.InitializeAsync ().Ignore ();
 
 			// OpenDocuments appears when the app is idle.
-			if (!hideWelcomePage) {
+			if (!hideWelcomePage && !WelcomePage.WelcomePageService.HasWindowImplementation) {
 				WelcomePage.WelcomePageService.ShowWelcomePage ();
 				Counters.Initialization.Trace ("Showed welcome page");
+				IdeApp.Workbench.Show ();
 			}
 
-			IdeApp.Workbench.Show ();
 			return false;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -310,17 +310,6 @@ namespace MonoDevelop.Ide
 		{
 			// if dialog is modal, make sure it's parented on any existing modal dialog
 			Gtk.Dialog dialog = dlg;
-			if (dialog.Modal) {
-				parent = GetDefaultModalParent ();
-			}
-
-			//ensure the dialog has a parent
-			if (parent == null) {
-				parent = dialog.TransientFor ?? RootWindow;
-			}
-
-			dialog.TransientFor = parent;
-			dialog.DestroyWithParent = true;
 			MonoDevelop.Components.IdeTheme.ApplyTheme (dialog);
 
 			if (dialog.Title == null)
@@ -335,6 +324,18 @@ namespace MonoDevelop.Ide
 				else
 					PlaceDialog (dialog, parent);
 			}).Wait ();
+			#else
+			if (dialog.Modal) {
+				parent = GetDefaultModalParent ();
+			}
+
+			//ensure the dialog has a parent
+			if (parent == null) {
+				parent = dialog.TransientFor ?? RootWindow;
+			}
+
+			dialog.TransientFor = parent;
+			dialog.DestroyWithParent = true;
 			#endif
 
 			try {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Components.Extensions;
 using MonoDevelop.Ide.Gui;
 using System.Threading.Tasks;
+using MonoDevelop.Ide.WelcomePage;
 
 #if MAC
 using AppKit;
@@ -310,6 +311,21 @@ namespace MonoDevelop.Ide
 		{
 			// if dialog is modal, make sure it's parented on any existing modal dialog
 			Gtk.Dialog dialog = dlg;
+			if (WelcomePageService.WelcomeWindowVisible && (dialog.TransientFor == (Gtk.Window)RootWindow || dialog.TransientFor == null)) {
+				dialog.TransientFor = null;
+			} else {
+				if (dialog.Modal) {
+					parent = GetDefaultModalParent ();
+				}
+
+				//ensure the dialog has a parent
+				if (parent == null) {
+					parent = dialog.TransientFor ?? RootWindow;
+				}
+
+				dialog.TransientFor = parent;
+				dialog.DestroyWithParent = true;
+			}
 			MonoDevelop.Components.IdeTheme.ApplyTheme (dialog);
 
 			if (dialog.Title == null)
@@ -324,18 +340,6 @@ namespace MonoDevelop.Ide
 				else
 					PlaceDialog (dialog, parent);
 			}).Wait ();
-			#else
-			if (dialog.Modal) {
-				parent = GetDefaultModalParent ();
-			}
-
-			//ensure the dialog has a parent
-			if (parent == null) {
-				parent = dialog.TransientFor ?? RootWindow;
-			}
-
-			dialog.TransientFor = parent;
-			dialog.DestroyWithParent = true;
 			#endif
 
 			try {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -692,27 +692,27 @@ namespace MonoDevelop.Ide
 				}
 			}
 		}
-		
-		public void NewSolution ()
+
+		public Task<bool> NewSolution ()
 		{
-			NewSolution (null);
-		}
-		
-		public void NewSolution (string defaultTemplate)
-		{
-			NewSolution (defaultTemplate, true);
+			return NewSolution (null);
 		}
 
-		public async void NewSolution (string defaultTemplate, bool showTemplateSelection)
+		public Task<bool> NewSolution (string defaultTemplate)
+		{
+			return NewSolution (defaultTemplate, true);
+		}
+
+		public async Task<bool> NewSolution (string defaultTemplate, bool showTemplateSelection)
 		{
 			if (!await IdeApp.Workbench.SaveAllDirtyFiles ())
-				return;
+				return false;
 
 			var newProjectDialog = new NewProjectDialogController ();
 			newProjectDialog.OpenSolution = true;
 			newProjectDialog.SelectedTemplateId = defaultTemplate;
 			newProjectDialog.ShowTemplateSelection = showTemplateSelection;
-			newProjectDialog.Show ();
+			return newProjectDialog.Show ();
 		}
 		
 		public Task<WorkspaceItem> AddNewWorkspaceItem (Workspace parentWorkspace)


### PR DESCRIPTION
If there's a dialog provider for the welcome page, prefer that, and only use
Widget version of it as a fallback. And when so, give control to that
window, hiding the main window.

Also fixes behavior of closing the main window on Mac, which should keep
the app menu bar available to the user.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/561910