### PR TITLE
[NuGet] Fix null reference exception in compatiblity checker

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageCompatibilityHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageCompatibilityHandler.cs
@@ -37,14 +37,16 @@ namespace MonoDevelop.PackageManagement
 
 		void ProjectTargetFrameworkChanged (object sender, ProjectTargetFrameworkChangedEventArgs e)
 		{
-			if (e.Project.HasPackagesConfig ()) {
-				var runner = new PackageCompatibilityRunner (e.Project);
-				runner.Run ();
+			if (e.Project is INuGetAwareProject) {
+				// Ignore.
 			} else if (DotNetCoreNuGetProject.CanCreate (e.Project.DotNetProject)) {
 				// Ignore - .NET Core project target framework changes are handled
 				// by the DotNetCoreProjectExtension.
 			} else if (PackageReferenceNuGetProject.CanCreate (e.Project.DotNetProject)) {
 				RestorePackagesInProjectHandler.Run (e.Project.DotNetProject);
+			} else if (e.Project.HasPackagesConfig ()) {
+				var runner = new PackageCompatibilityRunner (e.Project);
+				runner.Run ();
 			}
 		}
 	}


### PR DESCRIPTION
If a project had both a PackageReference and a packages.config file
the package compatiblity checker would run and fail with a null
reference exception. It was treating the project as though it was
using a packages.config file, when it should be treated as a
PackageReference project.

Fixes VSTS #734876 - NRE in package manager when updating target
framework