### PR TITLE
 Process markup from formatted text to attributedstring in MacToolboxViewItems

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/Helpers/NativeViewHelper.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/Helpers/NativeViewHelper.cs
@@ -41,6 +41,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			TranslatesAutoresizingMaskIntoConstraints = false
 		};
 
+		public static NSAttributedString GetAttributedStringFromFormattedText (string formattedText)
+		{
+			formattedText = formattedText.Replace ("&amp;", "&");
+			var formated = Xwt.FormattedText.FromMarkup (formattedText);
+			return Xwt.Mac.Util.ToAttributedString (formated);
+		}
+
 		public static NSAttributedString GetAttributedString (string text, NSColor foregroundColor, NSFont font)
 		{
 			//There is no need create NSStringAttributes element

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxViewItems.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxViewItems.cs
@@ -34,6 +34,7 @@ using MonoDevelop.Ide;
 using MonoDevelop.Components;
 using MonoDevelop.DesignerSupport.Toolbox.NativeViews;
 using CoreAnimation;
+using Xwt.Mac;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
@@ -98,6 +99,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		public LabelCollectionViewItem (IntPtr handle) : base (handle)
 		{
+		}
+
+		public void SetText (string formattedText) 
+		{
+			TextField.AttributedStringValue = NativeViewHelper.GetAttributedStringFromFormattedText (formattedText);
 		}
 
 		public override void Refresh ()
@@ -194,6 +200,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			Focused?.Invoke (this, EventArgs.Empty);
 			return base.BecomeFirstResponder ();
+		}
+
+		public void SetText (string formattedText)
+		{
+			TitleTextField.AttributedStringValue = NativeViewHelper.GetAttributedStringFromFormattedText (formattedText);
 		}
 
 		public HeaderCollectionViewItem (IntPtr handle) : base (handle)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxViewItems.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxViewItems.cs
@@ -35,6 +35,7 @@ using MonoDevelop.Components;
 using MonoDevelop.DesignerSupport.Toolbox.NativeViews;
 using CoreAnimation;
 using Xwt.Mac;
+using System.Text.RegularExpressions;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
@@ -205,6 +206,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public void SetText (string formattedText)
 		{
 			TitleTextField.AttributedStringValue = NativeViewHelper.GetAttributedStringFromFormattedText (formattedText);
+			TitleTextField.AccessibilityTitle = Regex.Replace (formattedText, @"<[^>]*>", string.Empty);
 		}
 
 		public HeaderCollectionViewItem (IntPtr handle) : base (handle)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidgetDataSource.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidgetDataSource.cs
@@ -6,6 +6,7 @@ using MonoDevelop.Components;
 using Foundation;
 using System.Linq;
 using CoreGraphics;
+using System.Text.RegularExpressions;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
@@ -54,7 +55,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				imgView.Refresh ();
 			}
 
-			collectionViewItem.View.AccessibilityTitle = widgetItem.Text ?? "";
+			collectionViewItem.View.AccessibilityTitle = Regex.Replace (widgetItem.Text, @"<[^>]*>", string.Empty);
 			return collectionViewItem;
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidgetDataSource.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidgetDataSource.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (collectionViewItem is LabelCollectionViewItem itmView) {
 				itmView.SetCollectionView (collectionView);
 				itmView.View.ToolTip = widgetItem.Tooltip ?? "";
-				itmView.TextField.StringValue = widgetItem.Text;
+				itmView.SetText (widgetItem.Text);
 				itmView.Image = catchedImages.Image;
 				itmView.SelectedImage = catchedImages.SelectedImage;
 				itmView.Refresh ();
@@ -78,7 +78,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}
 			if (collectionView.MakeSupplementaryView (NSCollectionElementKind.SectionHeader, "HeaderCollectionViewItem", indexPath) is HeaderCollectionViewItem button) {
 				var section = toolboxWidget.CategoryVisibilities [(int)indexPath.Section].Category;
-				button.TitleTextField.StringValue = section.Text.Replace ("&amp;", "&");
+				button.SetText (section.Text);
 				button.AccessibilityTitle = button.TitleTextField.StringValue;
 				button.IndexPath = indexPath;
 				button.CollectionView = toolboxWidget;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -17,6 +17,11 @@
         <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
         <Private>False</Private>
       </Reference>
+      <ProjectReference Include="..\..\..\external\xwt\Xwt.XamMac\Xwt.XamMac.csproj">
+      <Project>{B7C1673E-5124-4BE5-8D21-EC8B12F85B6B}</Project>
+        <Name>Xwt.XamMac</Name>
+        <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
    <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Toolbox allows items with markup. In this PR we added support for cover this, this introduces a new problem with accessibility, we need remove the formatted tags to read correctly the content over VoiceOver.

Fixes Bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/735244

![image](https://user-images.githubusercontent.com/1587480/49139491-392c1d80-f2f2-11e8-802a-133954a8b767.png)
