### PR TITLE
[release-8.0] UpdateInfo can be null when the app bundle is not being used

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProductInformationProvider.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.Ide
 		/// <summary>
 		/// Application ID used by the updater. Usually a GUID.
 		/// </summary>
-		public virtual string ApplicationId { get { return GetUpdateInfo ().AppId; } }
+		public virtual string ApplicationId { get { return GetUpdateInfo ()?.AppId; } }
 
 		public abstract string Title { get; }
 


### PR DESCRIPTION


Backport of #6686.

/cc @nosami 