### PR TITLE
[Ide] Prevent duplicate solution in Solution pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/SolutionPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/SolutionPad.cs
@@ -57,7 +57,8 @@ namespace MonoDevelop.Ide.Gui.Pads
 		
 		protected virtual void OnOpenWorkspace (object sender, WorkspaceItemEventArgs e)
 		{
-			treeView.AddChild (e.Item);
+			if (treeView.GetNodeAtObject (e.Item) == null)
+				treeView.AddChild (e.Item);
 		}
 
 		protected virtual void OnCloseWorkspace (object sender, WorkspaceItemEventArgs e)


### PR DESCRIPTION
If the SolutionPad is initialized when the RootWorkspace's
FirstWorkspaceItemOpened event is fired a solution would be opened
twice in the Solution pad. When the SolutionPad is initialized it
adds the RootWorkspace Items to the tree view. When the RootWorkspace's
WorkspaceItemOpened is fired the SolutionPad then adds that item to
the tree view. To handle this a check is now made to ensure the
item opened is not already in the tree.

Fixes VSTS #736893 - Solution/project duplicated in project tree