### PR TITLE
 Improves the number of calls resizing ToolboxItems

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -255,6 +255,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			base.SetFrameSize (newSize);
 			var frame = messageTextField.Frame;
 			messageTextField.Frame = new CGRect (frame.Location, newSize);
+			RedrawItems (true, false);
 		}
 
 		public override void MouseDown (NSEvent theEvent)
@@ -344,12 +345,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			RegisterClassForItem (typeof (HeaderCollectionViewItem), HeaderViewItemName);
 			RegisterClassForItem (typeof (LabelCollectionViewItem), LabelViewItemName);
 			RegisterClassForItem (typeof (ImageCollectionViewItem), ImageViewItemName);
-
-			NSNotificationCenter.DefaultCenter.AddObserver (FrameChangedNotification, (s => {
-				if (s.Object == this) {
-					RedrawItems (true, false);
-				}
-			}));
 		}
 
 		protected override void Dispose (bool disposing)


### PR DESCRIPTION
FrameChangedNotification executes more often than the normal expected with the frame change. 

Because this problem we changed to use SetFrameSize method which is called the times we expect.

The average time it takes to load is not very significant, since elements are virtualized and only the ones on the screen are rendered, but something improves.

NOTE: in the screenshots "RedrawItems" = Frame Resize Items

Before:
<img width="645" alt="screen shot 2018-11-30 at 17 51 20" src="https://user-images.githubusercontent.com/1587480/49309930-2295ea00-f4dd-11e8-95c3-0252fbb8d558.png">

After:
<img width="595" alt="screen shot 2018-11-30 at 17 59 34" src="https://user-images.githubusercontent.com/1587480/49309939-29bcf800-f4dd-11e8-8e30-ff1be580a0c9.png">

