### PR TITLE
[master] [Editor] Fix brace completion options not working

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Braces/BraceCompletionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Braces/BraceCompletionEditorExtension.cs
@@ -129,7 +129,7 @@ namespace MonoDevelop.SourceEditor.Braces
 		private IBraceCompletionManager Manager {
 			get {
 				if (_manager == null
-					&& !View.Properties.TryGetProperty ("BraceCompletionManager", out _manager)) {
+					&& !View.Properties.TryGetProperty ("BraceCompletionManagerMD", out _manager)) {
 					_manager = null;
 				}
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Braces/BraceCompletionManagerFactory.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Braces/BraceCompletionManagerFactory.cs
@@ -35,7 +35,7 @@ namespace MonoDevelop.SourceEditor.Braces
 
 		public void TextViewCreated (ITextView textView)
 		{
-			textView.Properties.AddProperty ("BraceCompletionManager",
+			textView.Properties.AddProperty ("BraceCompletionManagerMD",
 				new BraceCompletionManager (textView,
 					new BraceCompletionStack (textView, _adornmentServiceFactory, _guardedOperations), _aggregatorFactory, _guardedOperations));
 		}


### PR DESCRIPTION
For some reason, MS.VS.Text.Impl brace completion manager ended up
being used.

Changing the property key ensures our brace completion manager is used.

Fixes VSTS #738348 - [Feedback] VS for Mac is inserting matching braces even though the option is disabled.

Backport of #6711.

/cc @Therzok 