### PR TITLE
[Ide] Fix failing tests in MetadataReferenceManager

### DIFF
--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs
@@ -64,6 +64,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			try {
 				using (var sol = (MonoDevelop.Projects.Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 				using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
+					await FileWatcherService.Add (sol);
+
 					var manager = ws.MetadataReferenceManager;
 					var item = manager.GetOrCreateMetadataReference (tempPath, MetadataReferenceProperties.Assembly);
 					Assert.IsNotNull (item);
@@ -124,7 +126,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			var tcs = new TaskCompletionSource<MetadataReferenceUpdatedEventArgs> ();
 			var cts = new CancellationTokenSource ();
-			cts.Token.Register (() => tcs.TrySetResult (null));
+			cts.Token.Register (() => tcs.TrySetCanceled ());
 			item.SnapshotUpdated += (sender, args) => {
 				// This routes through file service
 				tcs.TrySetResult (args);


### PR DESCRIPTION
Not sure how this test ever passed. The logging of the test suite
shows that the workspace item was never added to the filewatcher
cone.