### PR TITLE
[release-7.7] Fixes VSTS Bug 736871: TextEditor lightbulb menu popover: low-res icon

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultTooltipProvider.FloatingQuickFixIconWidget.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultTooltipProvider.FloatingQuickFixIconWidget.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Components;
 using MonoDevelop.CodeActions;
 using Gdk;
 using System.Windows.Input;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.AnalysisCore.Gui
 {
@@ -58,8 +59,7 @@ namespace MonoDevelop.AnalysisCore.Gui
 				TypeHint = Gdk.WindowTypeHint.Utility;
 				var fr = new Gtk.HBox ();
 				fr.BorderWidth = 2;
-				var view = new Gtk.Image ();
-				view.Pixbuf = SmartTagMarginMarker.GetIcon (fixes.GetSmartTagSeverity ()).ToPixbuf ();
+				var view = new ImageView (SmartTagMarginMarker.GetIconId (fixes.GetSmartTagSeverity ()), Gtk.IconSize.Menu);
 				fr.PackStart (view, false, false, 0);
 				fr.PackEnd (new RectangleMarker (), false, false, 0);
 				Add (fr);

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/TextMarker/SmartTagMarginMarker.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/TextMarker/SmartTagMarginMarker.cs
@@ -67,16 +67,21 @@ namespace MonoDevelop.SourceEditor
 			PopupPosition = new Xwt.Point (metrics.X, metrics.Y);
 		}
 
-		public static Xwt.Drawing.Image GetIcon (SmartTagSeverity severity)
+		public static string GetIconId (SmartTagSeverity severity)
 		{
 			switch (severity) {
 			case SmartTagSeverity.Fixes:
-				return ImageService.GetIcon ("md-lightbulb", Gtk.IconSize.Menu);
+				return "md-lightbulb";
 			case SmartTagSeverity.ErrorFixes:
-				return ImageService.GetIcon ("md-lightbulb-error", Gtk.IconSize.Menu);
+				return "md-lightbulb-error";
 			default:
-				return ImageService.GetIcon ("md-lightbulb-screwdriver", Gtk.IconSize.Menu);
+				return "md-lightbulb-screwdriver";
 			}
+		}
+
+		public static Xwt.Drawing.Image GetIcon (SmartTagSeverity severity)
+		{
+			return ImageService.GetIcon (GetIconId (severity), Gtk.IconSize.Menu);
 		}
 
 		public override void InformMousePress (MonoTextEditor editor, Margin margin, MarginMouseEventArgs args)


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/736871

Backport of #6722.

/cc @mkrueger 