### PR TITLE
[release-7.7] Make sure MD.Refactoring builds on Windows.

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultTooltipProvider.RectangleMarker.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Gui/ResultTooltipProvider.RectangleMarker.cs
@@ -24,6 +24,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if WIN32
+// Mono.Cairo.dll on Windows doesn't have Context.SetSourceColor() so we have to emulate it
+// using an extension method so that MonoDevelop can build on Windows.
+using MonoDevelop.Components;
+#endif
+
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide.Editor.Highlighting;
 

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.csproj
@@ -11,6 +11,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugMac|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseMac|AnyCPU' " />
+  <PropertyGroup Condition=" $(OS) == 'Windows_NT'">
+    <DefineConstants>WIN32</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />


### PR DESCRIPTION
Mono.Cairo.dll on Windows doesn't have Context.SetSourceColor() so we have to emulate it using an extension method so that MonoDevelop can build on Windows.

Backport of #6424.

/cc @KirillOsenkov 