### PR TITLE
Fixes VSTS Bug 740691: [Feedback] Regression (C#): When I move a

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpIndentationTracker.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpIndentationTracker.cs
@@ -66,10 +66,11 @@ namespace MonoDevelop.CSharp.Formatting
 			var snapshot = editor.TextView.TextBuffer.CurrentSnapshot;
 			var caretLine = snapshot.GetLineFromLineNumber (lineNumber - 1);
 			int? indentation = smartIndentationService.GetDesiredIndentation (editor.TextView, caretLine);
-			if (indentation.HasValue && indentation.Value > 0)
+			if (indentation.HasValue && indentation.Value > 0) {
 				return CalculateIndentationString (indentation.Value);
-
-			return editor.GetLineIndent (lineNumber);
+			}
+			Console.WriteLine (Environment.StackTrace);
+			return editor.GetLineIndent (lineNumber) + CalculateIndentationString (editor.Options.IndentationSize);
 		}
 
 		string CalculateIndentationString (int spaceCount)

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpIndentationTracker.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpIndentationTracker.cs
@@ -69,7 +69,6 @@ namespace MonoDevelop.CSharp.Formatting
 			if (indentation.HasValue && indentation.Value > 0) {
 				return CalculateIndentationString (indentation.Value);
 			}
-			Console.WriteLine (Environment.StackTrace);
 			return editor.GetLineIndent (lineNumber) + CalculateIndentationString (editor.Options.IndentationSize);
 		}
 

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpTextEditorIndentationTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpTextEditorIndentationTests.cs
@@ -602,5 +602,27 @@ namespace MyLibrary
 			}
 		}
 
+		/// <summary>
+		/// Bug 740691: [Feedback] Regression (C#): When I move a method parameter to a new line, it no longer aligns the parameter to the previous parameters column.
+		/// </summary>
+		[Test]
+		public async Task TestVSTS740691 ()
+		{
+			using (var data = await Create (@"
+using System;
+
+namespace MyLibrary
+{
+	public class MyClass
+	{
+		public void DoStuff(string message,
+$)
+	}
+}", createWithProject: true)) {
+				var tracker = new CSharpIndentationTracker (data.Document.Editor, data.Document);
+				var indent = tracker.GetIndentationString (data.Document.Editor.CaretLine);
+				Assert.AreEqual ("\t\t\t", indent);
+			}
+		}
 	}
 }


### PR DESCRIPTION
method parameter to a new line, it no longer aligns the parameter to
the previous parameters column.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/740691
See feedback ticket:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/740051

This behavior +1 indent is correct - it's the same than in vs.net.