### PR TITLE
[release-7.7] Fixes VSTS Bug 729387: [Feedback] Broken text editor unit test

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitTestCase.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitTestCase.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 			this.className = className;
 			this.pathName = tinfo.PathName;
 			this.rootSuite = rootSuite;
-			this.TestId = tinfo.TestId;
+			this.TestSourceCodeDocumentId = this.TestId = tinfo.TestId;
 			this.IsExplicit = tinfo.IsExplicit;
 		}
 		

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/MonoDevelop.UnitTesting.NUnit/NUnitTestSuite.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.UnitTesting.NUnit
 			fullName = !string.IsNullOrEmpty (tinfo.PathName) ? tinfo.PathName + "." + tinfo.Name : tinfo.Name;
 			this.testInfo = tinfo;
 			this.rootSuite = rootSuite;
-			this.TestId = tinfo.TestId;
+			this.TestSourceCodeDocumentId = this.TestId = tinfo.TestId;
 			this.canMergeWithParent =  !string.IsNullOrEmpty (tinfo.PathName) &&
 									   string.IsNullOrEmpty (tinfo.FixtureTypeName) &&
 									   string.IsNullOrEmpty (tinfo.FixtureTypeNamespace);

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/VsTestUnitTestTests.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/VsTestUnitTestTests.cs
@@ -84,6 +84,17 @@ namespace MonoDevelop.UnitTesting.Tests
 			grp.AddTest (new MyVsTestUnitTest ("Test", "Test", "TestCase1"));
 			grp.AddTest (new MyVsTestUnitTest ("Test", "Test.Test", "TestCase1"));
 		}
+
+		/// <summary>
+		/// VSTS Bug 729387: [Feedback] Broken text editor unit test #6735
+		/// </summary>
+		[Test]
+		public void TestVSTS729387 ()
+		{
+			var test = CreateVsUnitTest ("Namespace.MyTest.Test1", "Test1");
+			Assert.AreEqual ("Namespace.MyTest.Test1", test.TestSourceCodeDocumentId);
+		}
+
 		class MyVsTestUnitTest : VsTestUnitTest
 		{
 			public MyVsTestUnitTest (string displayName, string fixtureTypeNamespace, string fixtureTypeName) : base(displayName)

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestNamespaceTestGroup.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestNamespaceTestGroup.cs
@@ -67,7 +67,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			string childNamespace = VsTestTest.GetChildNamespace (FixtureTypeNamespace);
 			if (string.IsNullOrEmpty (childNamespace)) {
 				if (currentClass == null || currentClass.FixtureTypeName != VsTestTest.FixtureTypeName) {
-					currentClass = new VsTestTestClass (testRunner, Project, VsTestTest.FixtureTypeName);
+					currentClass = new VsTestTestClass (testRunner, Project, VsTestTest);
 					Tests.Add (currentClass);
 				}
 				currentClass.Tests.Add (VsTestTest);

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestTestClass.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestTestClass.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 			this.Project = project;
 			this.testRunner = testRunner;
 			FixtureTypeName = vsTestUnit.FixtureTypeName;
-			TestId = string.IsNullOrEmpty (vsTestUnit.FixtureTypeNamespace) ? FixtureTypeName : vsTestUnit.FixtureTypeNamespace + "." + FixtureTypeName;
+			TestSourceCodeDocumentId = string.IsNullOrEmpty (vsTestUnit.FixtureTypeNamespace) ? FixtureTypeName : vsTestUnit.FixtureTypeNamespace + "." + FixtureTypeName;
 		}
 
 		protected override UnitTestResult OnRun (TestContext testContext)

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestTestClass.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestTestClass.cs
@@ -37,12 +37,13 @@ namespace MonoDevelop.UnitTesting.VsTest
 		public Project Project { get; private set; }
 		IVsTestTestRunner testRunner;
 
-		public VsTestTestClass (IVsTestTestRunner testRunner, Project project, string name)
-			: base (name)
+		public VsTestTestClass (IVsTestTestRunner testRunner, Project project, VsTestUnitTest vsTestUnit)
+			: base (vsTestUnit.FixtureTypeName)
 		{
 			this.Project = project;
 			this.testRunner = testRunner;
-			FixtureTypeName = name;
+			FixtureTypeName = vsTestUnit.FixtureTypeName;
+			TestId = string.IsNullOrEmpty (vsTestUnit.FixtureTypeNamespace) ? FixtureTypeName : vsTestUnit.FixtureTypeNamespace + "." + FixtureTypeName;
 		}
 
 		protected override UnitTestResult OnRun (TestContext testContext)

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
@@ -59,7 +59,8 @@ namespace MonoDevelop.UnitTesting.VsTest
 
 		void Init ()
 		{
-			TestId = test.FullyQualifiedName;
+			TestId = test.Id.ToString ();
+			TestSourceCodeDocumentId = test.FullyQualifiedName;
 			if (!string.IsNullOrEmpty (test.CodeFilePath))
 				sourceCodeLocation = new SourceCodeLocation (test.CodeFilePath, test.LineNumber, 0);
 			else {

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
@@ -59,7 +59,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 
 		void Init ()
 		{
-			TestId = test.Id.ToString ();
+			TestId = test.FullyQualifiedName;
 			if (!string.IsNullOrEmpty (test.CodeFilePath))
 				sourceCodeLocation = new SourceCodeLocation (test.CodeFilePath, test.LineNumber, 0);
 			else {

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/AbstractUnitTestEditorExtension.cs
@@ -152,7 +152,7 @@ namespace MonoDevelop.UnitTesting
 
 			public override Xwt.Drawing.Image GetStatusIcon (string unitTestIdentifier, string caseId = null)
 			{
-				var test = UnitTestService.SearchTestById (unitTestIdentifier + caseId);
+				var test = UnitTestService.SearchTestByDocumentId (unitTestIdentifier + caseId);
 				if (test != null)
 					return test.StatusIcon;
 				return TestStatusIcon.None;
@@ -160,7 +160,7 @@ namespace MonoDevelop.UnitTesting
 
 			public override bool IsFailure (string unitTestIdentifier, string caseId = null)
 			{
-				var test = UnitTestService.SearchTestById (unitTestIdentifier + caseId);
+				var test = UnitTestService.SearchTestByDocumentId (unitTestIdentifier + caseId);
 				if (test != null) {
 					var result = test.GetLastResult ();
 					if (result != null)
@@ -171,7 +171,7 @@ namespace MonoDevelop.UnitTesting
 
 			public override string GetMessage (string unitTestIdentifier, string caseId = null)
 			{
-				var test = UnitTestService.SearchTestById (unitTestIdentifier + caseId);
+				var test = UnitTestService.SearchTestByDocumentId (unitTestIdentifier + caseId);
 				if (test != null) {
 					var result = test.GetLastResult ();
 					if (result != null)
@@ -182,7 +182,7 @@ namespace MonoDevelop.UnitTesting
 
 			public override bool HasResult (string unitTestIdentifier, string caseId = null)
 			{
-				return UnitTestService.SearchTestById (unitTestIdentifier + caseId) != null;
+				return UnitTestService.SearchTestByDocumentId (unitTestIdentifier + caseId) != null;
 			}
 
 			public override void PopupContextMenu (UnitTestLocation unitTest, int x, int y)
@@ -240,7 +240,7 @@ namespace MonoDevelop.UnitTesting
 
 							var label = "Test" + id;
 							string tooltip = null;
-							var test = UnitTestService.SearchTestById (unitTest.UnitTestIdentifier + id);
+							var test = UnitTestService.SearchTestByDocumentId (unitTest.UnitTestIdentifier + id);
 							if (test != null) {
 								var result = test.GetLastResult ();
 								if (result != null && result.IsFailure) {
@@ -292,7 +292,7 @@ namespace MonoDevelop.UnitTesting
 
 				bool TimeoutHandler ()
 				{
-					var test = UnitTestService.SearchTestById (testCase);
+					var test = UnitTestService.SearchTestByDocumentId (testCase);
 					if (test != null) {
 						RunTest (test); 
 						timeoutHandler = 0;
@@ -308,7 +308,7 @@ namespace MonoDevelop.UnitTesting
 						IdeApp.ProjectOperations.IsRunning (IdeApp.ProjectOperations.CurrentSelectedSolution))
 						return;
 
-					var foundTest = UnitTestService.SearchTestById (testCase);
+					var foundTest = UnitTestService.SearchTestByDocumentId (testCase);
 					if (foundTest != null) {
 						RunTest (foundTest);
 						return;
@@ -321,7 +321,7 @@ namespace MonoDevelop.UnitTesting
 						await UnitTestService.RefreshTests (CancellationToken.None);
 					}
 
-					foundTest = UnitTestService.SearchTestById (testCase);
+					foundTest = UnitTestService.SearchTestByDocumentId (testCase);
 					if (foundTest != null)
 						RunTest (foundTest);
 					else
@@ -330,7 +330,7 @@ namespace MonoDevelop.UnitTesting
 
 				internal void Select (object sender, EventArgs e)
 				{
-					var test = UnitTestService.SearchTestById (testCase);
+					var test = UnitTestService.SearchTestByDocumentId (testCase);
 					if (test == null)
 						return;
 					UnitTestService.CurrentSelectedTest = test;

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTest.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTest.cs
@@ -238,7 +238,16 @@ namespace MonoDevelop.UnitTesting
 			get;
 			protected set;
 		}
-		
+
+		/// <summary>
+		/// Used for the text editor integration to identify the source code member connected to the unit test.
+		/// </summary>
+		public string TestSourceCodeDocumentId {
+			get;
+			protected set;
+		}
+
+
 		public string FullName {
 			get {
 				if (parent != null)

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -243,6 +243,16 @@ namespace MonoDevelop.UnitTesting
 			return null;
 		}
 
+		public static UnitTest SearchTestByDocumentId (string id)
+		{
+			foreach (UnitTest t in RootTests) {
+				UnitTest r = SearchTestByDocumentId (t, id);
+				if (r != null)
+					return r;
+			}
+			return null;
+		}
+
 
 		static UnitTest SearchTest (UnitTest test, string fullName)
 		{
@@ -270,9 +280,27 @@ namespace MonoDevelop.UnitTesting
 				return test;
 
 			UnitTestGroup group = test as UnitTestGroup;
-			if (group != null)  {
+			if (group != null) {
 				foreach (UnitTest t in group.Tests) {
 					UnitTest result = SearchTestById (t, id);
+					if (result != null)
+						return result;
+				}
+			}
+			return null;
+		}
+
+		static UnitTest SearchTestByDocumentId (UnitTest test, string id)
+		{
+			if (test == null)
+				return null;
+			if (test.TestSourceCodeDocumentId == id)
+				return test;
+
+			UnitTestGroup group = test as UnitTestGroup;
+			if (group != null) {
+				foreach (UnitTest t in group.Tests) {
+					UnitTest result = SearchTestByDocumentId (t, id);
 					if (result != null)
 						return result;
 				}


### PR DESCRIPTION
integration ("Unit test [name] could not be loaded")

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/723605

TestID is not arbitrary or optional. It's the fully qualified test
name in the source code.

Backport of #6735.

/cc @mkrueger 