### PR TITLE
[release-7.8] [Telemetry] Pass the total number of milliseconds for TimeSinceLogin

### DIFF
--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -74,6 +74,7 @@ namespace MacPlatform
 
 					var timeSinceEpoch = DateTimeOffset.UtcNow - epoch;
 					var loginSinceEpoch = login - epoch;
+
 					result.sinceLogin = timeSinceEpoch - loginSinceEpoch;
 				}
 			} catch (Exception e) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -917,8 +917,8 @@ namespace MonoDevelop.Ide
 				AssetTypeName = assetType.Name,
 				IsInitialRun = IdeApp.IsInitialRun,
 				IsInitialRunAfterUpgrade = IdeApp.IsInitialRunAfterUpgrade,
-				TimeSinceMachineStart = platformDetails.TimeSinceMachineStart.Seconds,
-				TimeSinceLogin = platformDetails.TimeSinceLogin.Seconds,
+				TimeSinceMachineStart = (long)platformDetails.TimeSinceMachineStart.TotalMilliseconds,
+				TimeSinceLogin = (long)platformDetails.TimeSinceLogin.TotalMilliseconds,
 				Timings = timings
 			};
 		}


### PR DESCRIPTION
TimeSinceLogin and TimeSinceMachineStart were passing the seconds portion of
the count instead of the total number of seconds. This has been changed to
milliseconds now report milliseconds as well.

Fixes VSTS #720395

Backport of #6741.

/cc @iainx 