### PR TITLE
[netcore30] Implements netcoreapp30

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreCertificateManager.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreCertificateManager.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.AspNetCore
 				return false;
 			}
 
-			return project.TargetFramework.IsNetCoreApp21 () &&
+			return project.TargetFramework.IsNetCoreApp ("2.1") &&
 				IsNetCoreSdk21Installed () &&
 				UsingHttps (runConfiguration);
 		}

--- a/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Properties/MonoDevelop.AspNetCore.addin.xml
@@ -79,6 +79,97 @@
 		For example, .NET Core 1.1 SDK does not have a Razor template so having the 1.1 templates first
 		would cause the Razor template to be last in the New Project dialog if both 1.1 and 2.x templates
 		are available. -->
+			<Condition id="AspNetCoreSdkInstalled" sdkVersion="3.0">
+			<Template
+				id="Microsoft.Web.Empty.CSharp"
+				templateId="Microsoft.Web.Empty.CSharp.3.0"
+				_overrideName="ASP.NET Core Empty"
+				_overrideDescription="An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.Empty.FSharp"
+				templateId="Microsoft.Web.Empty.FSharp.3.0"
+				_overrideName="ASP.NET Core Empty"
+				_overrideDescription="An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.WebApi.CSharp"
+				templateId="Microsoft.Web.WebApi.CSharp.3.0"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.WebApi.FSharp"
+				templateId="Microsoft.Web.WebApi.FSharp.3.0"
+				_overrideName="ASP.NET Core Web API"
+				_overrideDescription="A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				supportedParameters="FSharpWebApi"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.RazorPages.CSharp"
+				templateId="Microsoft.Web.RazorPages.CSharp.3.0"
+				_overrideName="ASP.NET Core Web App"
+				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				supportedParameters="RazorPages"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.Mvc.CSharp"
+				templateId="Microsoft.Web.Mvc.CSharp.3.0"
+				_overrideName="ASP.NET Core Web App (MVC)"
+				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
+				defaultParameters="IncludeLaunchSettings=true" />
+			<Template
+				id="Microsoft.Web.Mvc.FSharp"
+				templateId="Microsoft.Web.Mvc.FSharp.3.0"
+				_overrideName="ASP.NET Core Web App (MVC)"
+				_overrideDescription="A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
+				path="${DotNetCoreSdk.3.0.Templates.Web.ProjectTemplates.nupkg}"
+				icon="md-netcore-empty-project"
+				imageId="md-netcore-empty-project"
+				wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+				condition="UseNetCore30=true"
+				category="netcore/app/aspnet"
+				formatExclude="*.min.css|*.min.js|*.map"
+				defaultParameters="IncludeLaunchSettings=true" />
+		</Condition>
 		<Condition id="AspNetCoreSdkInstalled" sdkVersion="2.2">
 			<Template
 				id="Microsoft.Web.Empty.CSharp"

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationPanel.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationPanel.cs
@@ -86,8 +86,8 @@ namespace MonoDevelop.DotNetCore.Gui
 
 		static DotNetCoreSdkPaths GetSdkPaths (DotNetCorePath path)
 		{
-			var sdkPaths = new DotNetCoreSdkPaths ();
-			sdkPaths.FindMSBuildSDKsPath (path.FileName);
+			var sdkPaths = new DotNetCoreSdkPaths (path.FileName);
+			sdkPaths.ResolveSDK ();
 			return sdkPaths;
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateStringTagProvider.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateStringTagProvider.cs
@@ -126,12 +126,10 @@ namespace MonoDevelop.DotNetCore.Templating
 		{
 			DotNetCoreVersion dotNetCoreSdk = null;
 
-			if (tag.StartsWith ("DotNetCoreSdk.3.0", StringComparison.OrdinalIgnoreCase)) {
-				dotNetCoreSdk = GetDotNetCoreSdk30Version ();
-			} else if (tag.StartsWith ("DotNetCoreSdk.2.2", StringComparison.OrdinalIgnoreCase)) {
-				dotNetCoreSdk = GetDotNetCoreSdk22Version ();
-			} else if (tag.StartsWith ("DotNetCoreSdk.2.1", StringComparison.OrdinalIgnoreCase)) {
-				dotNetCoreSdk = GetDotNetCoreSdk21Version ();
+			foreach (var sdk in SupportedSDK) {
+				if (tag.StartsWith ($"DotNetCoreSdk.{sdk}", StringComparison.OrdinalIgnoreCase)) {
+					dotNetCoreSdk = GetDotNetCoreSdkVersion (DotNetCoreVersion.Parse (sdk));
+				}
 			}
 
 			if (dotNetCoreSdk == null)
@@ -150,22 +148,15 @@ namespace MonoDevelop.DotNetCore.Templating
 			return string.Empty;
 		}
 
-		DotNetCoreVersion GetDotNetCoreSdk30Version ()
+		DotNetCoreVersion GetDotNetCoreSdkVersion (DotNetCoreVersion version)
 		{
-			return DotNetCoreSdk.Versions
-				.FirstOrDefault (v => v.Major == 3 && v.Minor == 0);
-		}
+			//special case 2.1
+			if (version.Major == 2 && version.Minor == 1)
+				return DotNetCoreSdk.Versions
+				.FirstOrDefault (v => v.Major == version.Major && v.Minor == version.Minor && v.Patch >= 300);
 
-		DotNetCoreVersion GetDotNetCoreSdk22Version ()
-		{
 			return DotNetCoreSdk.Versions
-				.FirstOrDefault (v => v.Major == 2 && v.Minor == 2);
-		}
-
-		DotNetCoreVersion GetDotNetCoreSdk21Version ()
-		{
-			return DotNetCoreSdk.Versions
-				.FirstOrDefault (v => v.Major == 2 && v.Minor == 1 && v.Patch >= 300);
+				.FirstOrDefault (v => v.Major == version.Major && v.Minor == version.Minor);
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateStringTagProvider.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateStringTagProvider.cs
@@ -56,9 +56,8 @@ namespace MonoDevelop.DotNetCore.Templating
 					$"DotNetCoreSdk.{SupportedSDK [i]}.Templates.Web.ProjectTemplates.nupkg",
 					GettextCatalog.GetString (string.Format (".NET Core SDK {0} Web Project Templates NuGet package path", SupportedSDK[i]))
 				);
-
-				//TODO: Ask why 2.1 does not support NUnit
-				if (i >0 ) { //2.2 and before 
+					
+				if (i > 0 ) { //2.2 and before 
 					yield return new StringTagDescription (
 						$"DotNetCoreSdk.{SupportedSDK [i]}.Templates.NUnit3.DotNetNew.Template.nupkg",
 						GettextCatalog.GetString (string.Format (".NET Core SDK {0} NUnit Project Templates NuGet package path", SupportedSDK [i]))

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateStringTagProvider.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateStringTagProvider.cs
@@ -37,44 +37,34 @@ namespace MonoDevelop.DotNetCore.Templating
 	[Extension]
 	class DotNetCoreProjectTemplateStringTagProvider : IStringTagProvider
 	{
+		string [] SupportedSDK = { "2.1", "2.2", "3.0" };
+
 		public IEnumerable<StringTagDescription> GetTags (Type type)
 		{
-			// 2.1 templates
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.1.Templates.Common.ProjectTemplates.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.1 Common Project Templates NuGet package path")
-			);
+			for (var i = 0; i < SupportedSDK.Length; i++) {
+				yield return new StringTagDescription (
+					$"DotNetCoreSdk.{SupportedSDK[i]}.Templates.Common.ProjectTemplates.nupkg",
+					GettextCatalog.GetString (string.Format (".NET Core SDK {0} Common Project Templates NuGet package path", SupportedSDK [i]))
+				);
 
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.1.Templates.Test.ProjectTemplates.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.1 Test Project Templates NuGet package path")
-			);
+				yield return new StringTagDescription (
+					$"DotNetCoreSdk.{SupportedSDK [i]}.Templates.Test.ProjectTemplates.nupkg",
+					GettextCatalog.GetString (string.Format (".NET Core SDK {0} Test Project Templates NuGet package path", SupportedSDK[i]))
+				);
 
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.1.Templates.Web.ProjectTemplates.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.1 Web Project Templates NuGet package path")
-			);
+				yield return new StringTagDescription (
+					$"DotNetCoreSdk.{SupportedSDK [i]}.Templates.Web.ProjectTemplates.nupkg",
+					GettextCatalog.GetString (string.Format (".NET Core SDK {0} Web Project Templates NuGet package path", SupportedSDK[i]))
+				);
 
-			// 2.2 templates
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.2.Templates.Common.ProjectTemplates.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.2 Common Project Templates NuGet package path")
-			);
-
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.2.Templates.Test.ProjectTemplates.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.2 Test Project Templates NuGet package path")
-			);
-
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.2.Templates.Web.ProjectTemplates.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.2 Web Project Templates NuGet package path")
-			);
-
-			yield return new StringTagDescription (
-				"DotNetCoreSdk.2.2.Templates.NUnit3.DotNetNew.Template.nupkg",
-				GettextCatalog.GetString (".NET Core SDK 2.2 NUnit Project Templates NuGet package path")
-			);
+				//TODO: Ask why 2.1 does not support NUnit
+				if (i >0 ) { //2.2 and before 
+					yield return new StringTagDescription (
+						$"DotNetCoreSdk.{SupportedSDK [i]}.Templates.NUnit3.DotNetNew.Template.nupkg",
+						GettextCatalog.GetString (string.Format (".NET Core SDK {0} NUnit Project Templates NuGet package path", SupportedSDK [i]))
+					);
+				}
+			}
 		}
 
 		public object GetTagValue (object instance, string tag)
@@ -131,16 +121,18 @@ namespace MonoDevelop.DotNetCore.Templating
 		}
 
 		/// <summary>
-		/// Only .NET Core SDKs 2.1/2.2 are supported.
+		/// Only .NET Core SDKs 2.1/2.2/3.0 are supported.
 		/// </summary>
 		string GetDotNetCoreSdkTemplatesDirectory (string tag)
 		{
 			DotNetCoreVersion dotNetCoreSdk = null;
 
-			if (tag.StartsWith ("DotNetCoreSdk.2.1", StringComparison.OrdinalIgnoreCase)) {
-				dotNetCoreSdk = GetDotNetCoreSdk21Version ();
+			if (tag.StartsWith ("DotNetCoreSdk.3.0", StringComparison.OrdinalIgnoreCase)) {
+				dotNetCoreSdk = GetDotNetCoreSdk30Version ();
 			} else if (tag.StartsWith ("DotNetCoreSdk.2.2", StringComparison.OrdinalIgnoreCase)) {
 				dotNetCoreSdk = GetDotNetCoreSdk22Version ();
+			} else if (tag.StartsWith ("DotNetCoreSdk.2.1", StringComparison.OrdinalIgnoreCase)) {
+				dotNetCoreSdk = GetDotNetCoreSdk21Version ();
 			}
 
 			if (dotNetCoreSdk == null)
@@ -157,6 +149,12 @@ namespace MonoDevelop.DotNetCore.Templating
 			}
 
 			return string.Empty;
+		}
+
+		DotNetCoreVersion GetDotNetCoreSdk30Version ()
+		{
+			return DotNetCoreSdk.Versions
+				.FirstOrDefault (v => v.Major == 3 && v.Minor == 0);
 		}
 
 		DotNetCoreVersion GetDotNetCoreSdk22Version ()

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
@@ -129,7 +129,9 @@ namespace MonoDevelop.DotNetCore.Templating
 				if (!SupportsNetCore1x ()) {
 					var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
 					if (highestFramework != null) {
-						if (highestFramework.IsNetCoreApp22 ()) {
+						if (highestFramework.IsNetCoreApp30 ()) {
+							Parameters ["UseNetCore30"] = "true";
+						} else if (highestFramework.IsNetCoreApp22 ()) {
 							Parameters ["UseNetCore22"] = "true";
 						} else if (highestFramework != null && highestFramework.IsNetCoreApp21 ()) {
 							Parameters ["UseNetCore21"] = "true";
@@ -142,8 +144,10 @@ namespace MonoDevelop.DotNetCore.Templating
 				} else {
 					var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
 					if (highestFramework != null) {
-						if (highestFramework.IsNetCoreApp22 ()) {
-							Parameters["UseNetCore22"] = "true";
+						if (highestFramework.IsNetCoreApp30 ()) {
+							Parameters["UseNetCore30"] = "true";
+						} else if (highestFramework.IsNetCoreApp22 ()) {
+							Parameters ["UseNetCore22"] = "true";
 						} else if (highestFramework.IsNetCoreApp21 ()) {
 							Parameters ["UseNetCore21"] = "true";
 						} else if (highestFramework.IsNetCoreApp20 ()) {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
@@ -123,7 +123,7 @@ namespace MonoDevelop.DotNetCore.Templating
 			} else {
 				if (!SupportsNetCore1x ()) {
 					var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
-					if (highestFramework != null) {
+					if (highestFramework != null && highestFramework.IsNetCoreAppOrHigher (DotNetCoreVersion.Parse ("2.0"))) {
 						var parameter = highestFramework.GetParameterName ();
 						if (!string.IsNullOrEmpty (parameter))
 							Parameters [parameter] = "true";

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizard.cs
@@ -33,6 +33,9 @@ namespace MonoDevelop.DotNetCore.Templating
 {
 	class DotNetCoreProjectTemplateWizard : TemplateWizard
 	{
+		const string defaultParameterNetCore20 = "UseNetCore20";
+		const string defaultParameterNetCore1x = "UseNetCore1x";
+
 		List<TargetFramework> targetFrameworks;
 
 		public override WizardPage GetPage (int pageNumber)
@@ -42,17 +45,11 @@ namespace MonoDevelop.DotNetCore.Templating
 			return page;
 		}
 
-		public override int TotalPages {
-			get { return GetTotalPages (); }
-		}
+		public override int TotalPages => GetTotalPages ();
 
-		public override string Id {
-			get { return "MonoDevelop.DotNetCore.ProjectTemplateWizard"; }
-		}
+		public override string Id => "MonoDevelop.DotNetCore.ProjectTemplateWizard";
 
-		internal IList<TargetFramework> TargetFrameworks {
-			get { return targetFrameworks; }
-		}
+		internal IList<TargetFramework> TargetFrameworks => targetFrameworks;
 
 		/// <summary>
 		/// When only .NET Core 2.0 is installed there is only one option in the drop down
@@ -120,43 +117,27 @@ namespace MonoDevelop.DotNetCore.Templating
 			if (IsSupportedParameter ("NetStandard")) {
 				var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetStandardTargetFrameworks ().FirstOrDefault ();
 
-				if (highestFramework != null && highestFramework.IsNetStandard20 ()) {
-					Parameters ["UseNetStandard20"] = "true";
-				} else {
-					Parameters ["UseNetStandard1x"] = "true";
-				}
+				var parameter = highestFramework.GetParameterName ();
+				if (!string.IsNullOrEmpty (parameter))
+					Parameters [parameter] = "true";
 			} else {
 				if (!SupportsNetCore1x ()) {
 					var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
 					if (highestFramework != null) {
-						if (highestFramework.IsNetCoreApp30 ()) {
-							Parameters ["UseNetCore30"] = "true";
-						} else if (highestFramework.IsNetCoreApp22 ()) {
-							Parameters ["UseNetCore22"] = "true";
-						} else if (highestFramework != null && highestFramework.IsNetCoreApp21 ()) {
-							Parameters ["UseNetCore21"] = "true";
-						} else {
-							Parameters ["UseNetCore20"] = "true";
-						}
+						var parameter = highestFramework.GetParameterName ();
+						if (!string.IsNullOrEmpty (parameter))
+							Parameters [parameter] = "true";
 					} else {
-						Parameters ["UseNetCore20"] = "true";
+						Parameters [defaultParameterNetCore20] = "true";
 					}
 				} else {
 					var highestFramework = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().FirstOrDefault ();
 					if (highestFramework != null) {
-						if (highestFramework.IsNetCoreApp30 ()) {
-							Parameters["UseNetCore30"] = "true";
-						} else if (highestFramework.IsNetCoreApp22 ()) {
-							Parameters ["UseNetCore22"] = "true";
-						} else if (highestFramework.IsNetCoreApp21 ()) {
-							Parameters ["UseNetCore21"] = "true";
-						} else if (highestFramework.IsNetCoreApp20 ()) {
-							Parameters ["UseNetCore20"] = "true";
-						} else {
-							Parameters ["UseNetCore1x"] = "true";
-						}
+						var parameter = highestFramework.GetParameterName ();
+						if (!string.IsNullOrEmpty (parameter))
+							Parameters [parameter] = "true";
 					} else {
-						Parameters ["UseNetCore1x"] = "true";
+						Parameters [defaultParameterNetCore1x] = "true";
 					}
 				}
 				ConfigureDefaultNetCoreAppFramework ();

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizardPage.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Templating/DotNetCoreProjectTemplateWizardPage.cs
@@ -96,11 +96,13 @@ namespace MonoDevelop.DotNetCore.Templating
 			TargetFramework framework = targetFrameworks [selectedTargetFrameworkIndex];
 			wizard.Parameters ["Framework"] = framework.Id.GetShortFrameworkName ();
 
+			wizard.Parameters ["UseNetCore30"] = framework.IsNetCoreApp30 ().ToString ();
 			wizard.Parameters ["UseNetCore22"] = framework.IsNetCoreApp22 ().ToString ();
 			wizard.Parameters ["UseNetCore21"] = framework.IsNetCoreApp21 ().ToString ();
 			wizard.Parameters ["UseNetCore20"] = framework.IsNetCoreApp20 ().ToString ();
 			wizard.Parameters ["UseNetCore1x"] = framework.IsNetCoreApp1x ().ToString ();
 
+			wizard.Parameters ["UseNetStandard21"] = framework.IsNetStandard21 ().ToString ();
 			wizard.Parameters ["UseNetStandard20"] = framework.IsNetStandard20 ().ToString ();
 			wizard.Parameters ["UseNetStandard1x"] = framework.IsNetStandard1x ().ToString ();
 		}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -36,6 +36,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreProjectTemplateWizardTests.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreProjectTemplateStringTagProviderTests.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\DependencyNodeTests.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Tests\DotNetCoreSDKResolverTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.DotNetCore.Tests
 	[TestFixture]
 	class DotNetCoreProjectSupportedTargetFrameworksTests : DotNetCoreVersionsRestorerTestBase
 	{
-		static string[] netStandardVersions = { "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
+		static string[] netStandardVersions = { "2.1", "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
 
 		[TestCase ("5.4.0", "2.0", "2.0.5")]
 		[TestCase ("5.3.99", "1.6", new string[0])]
@@ -78,6 +78,17 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.AreEqual (".NETCoreApp,Version=v1.1", frameworks [0].Id.ToString ());
 			Assert.AreEqual (".NETCoreApp,Version=v1.0", frameworks [1].Id.ToString ());
 			Assert.AreEqual (2, frameworks.Count);
+		}
+
+		[Test]
+		public void GetNetCoreAppTargetFrameworks_NetCore30RuntimeInstalled ()
+		{
+			DotNetCoreRuntimesInstalled ("3.0.0");
+
+			var frameworks = DotNetCoreProjectSupportedTargetFrameworks.GetNetCoreAppTargetFrameworks ().ToList ();
+
+			Assert.AreEqual (".NETCoreApp,Version=v3.0", frameworks [0].Id.ToString ());
+			Assert.AreEqual (1, frameworks.Count);
 		}
 
 		[Test]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.DotNetCore.Tests
 	[TestFixture]
 	class DotNetCoreProjectSupportedTargetFrameworksTests : DotNetCoreVersionsRestorerTestBase
 	{
-		static string[] netStandardVersions = { "2.1", "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
+		static string[] netStandardVersions = { "3.0", "2.1", "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
 
 		[TestCase ("5.4.0", "2.0", "2.0.5")]
 		[TestCase ("5.3.99", "1.6", new string[0])]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectSupportedTargetFrameworksTests.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.DotNetCore.Tests
 	[TestFixture]
 	class DotNetCoreProjectSupportedTargetFrameworksTests : DotNetCoreVersionsRestorerTestBase
 	{
-		static string[] netStandardVersions = { "3.0", "2.1", "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
+		static string[] netStandardVersions = { "2.0", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
 
 		[TestCase ("5.4.0", "2.0", "2.0.5")]
 		[TestCase ("5.3.99", "1.6", new string[0])]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -101,6 +101,18 @@ namespace MonoDevelop.DotNetCore.Tests
 		}
 
 		[Test]
+		[TestCase ("Microsoft.Common.Library.CSharp", "UseNetStandard20=true")]
+		[TestCase ("Microsoft.Common.Library.FSharp", "UseNetStandard20=true")]
+		public async Task NetStandard21 (string templateId, string parameters)
+		{
+			if (!IsDotNetCoreSdk2xInstalled ()) {
+				Assert.Ignore (".NET Core 3 SDK is not installed - required by project template.");
+			}
+
+			await CreateFromTemplateAndBuild ("NetStandard21", templateId, parameters);
+		}
+
+		[Test]
 		public async Task NetStandard20_VBNet ()
 		{
 			if (IsDotNetCoreSdk21Installed () || IsDotNetCoreSdk22Installed ()) {
@@ -179,6 +191,34 @@ namespace MonoDevelop.DotNetCore.Tests
 			await CreateFromTemplateAndBuild ("NetCore2x", templateId, parameters);
 		}
 
+		[TestCase ("Microsoft.Common.Console.CSharp", "UseNetCore22=true")]
+		[TestCase ("Microsoft.Common.Library.CSharp-netcoreapp", "UseNetCore22=true;Framework=netcoreapp2.2")]
+		[TestCase ("Microsoft.Test.xUnit.CSharp", "UseNetCore22=true")]
+		[TestCase ("Microsoft.Test.MSTest.CSharp", "UseNetCore22=true")]
+
+		[TestCase ("Microsoft.Common.Console.FSharp", "UseNetCore22=true")]
+		[TestCase ("Microsoft.Common.Library.FSharp-netcoreapp", "UseNetCore22=true;Framework=netcoreapp2.2")]
+		[TestCase ("Microsoft.Test.xUnit.FSharp", "UseNetCore22=true")]
+		[TestCase ("Microsoft.Test.MSTest.FSharp", "UseNetCore22=true")]
+
+		[TestCase ("Microsoft.Common.Console.VisualBasic", "UseNetCore22=true")]
+		[TestCase ("Microsoft.Common.Library.VisualBasic-netcoreapp", "UseNetCore22=true;Framework=netcoreapp2.2")]
+		[TestCase ("Microsoft.Test.xUnit.VisualBasic", "UseNetCore22=true")]
+		[TestCase ("Microsoft.Test.MSTest.VisualBasic", "UseNetCore22=true")]
+
+		// NUnit3 templates come with .NET Core 2.2, but they only support .NET Core 2.1 framework
+		[TestCase ("NUnit3.DotNetNew.Template.CSharp", "UseNetCore21=true")]
+		[TestCase ("NUnit3.DotNetNew.Template.FSharp", "UseNetCore21=true")]
+		[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore21=true")]
+		public async Task NetCore30 (string templateId, string parameters)
+		{
+			if (!IsDotNetCoreSdk30Installed ()) {
+				Assert.Ignore (".NET Core 3.0 SDK is not installed - required by project template.");
+			}
+
+			await CreateFromTemplateAndBuild ("NetCore30", templateId, parameters);
+		}
+
 		[TestCase ("Microsoft.Web.Empty.CSharp", "UseNetCore1x=true;Framework=netcoreapp1.0")]
 		[TestCase ("Microsoft.Web.Empty.CSharp", "UseNetCore1x=true;Framework=netcoreapp1.1")]
 
@@ -250,6 +290,22 @@ namespace MonoDevelop.DotNetCore.Tests
 			await CreateFromTemplateAndBuild ("NetCore2x", templateId, parameters);
 		}
 
+		[TestCase ("Microsoft.Web.Empty.CSharp", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Web.Empty.FSharp", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Web.Mvc.CSharp", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Web.Mvc.FSharp", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Web.RazorPages.CSharp", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Web.WebApi.CSharp", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Web.WebApi.FSharp", "UseNetCore30=true")]
+		public async Task AspNetCore30 (string templateId, string parameters)
+		{
+			if (!IsDotNetCoreSdk22Installed ()) {
+				Assert.Ignore (".NET Core 3.0 SDK is not installed - required by project template.");
+			}
+
+			await CreateFromTemplateAndBuild ("NetCore30", templateId, parameters);
+		}
+
 		static bool IsDotNetCoreSdk2xInstalled ()
 		{
 			return DotNetCoreSdk.Versions.Any (version => version.Major == 2);
@@ -267,6 +323,11 @@ namespace MonoDevelop.DotNetCore.Tests
 		}
 
 		static bool IsDotNetCoreSdk22Installed ()
+		{
+			return DotNetCoreSdk.Versions.Any (version => version.Major == 2 && version.Minor == 2);
+		}
+
+		static bool IsDotNetCoreSdk30Installed ()
 		{
 			return DotNetCoreSdk.Versions.Any (version => version.Major == 2 && version.Minor == 2);
 		}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -100,6 +100,7 @@ namespace MonoDevelop.DotNetCore.Tests
 			await CreateFromTemplateAndBuild ("NetStandard2x", templateId, parameters);
 		}
 
+		[Ignore (".NET Standard 2.1 still not supported")]
 		[Test]
 		[TestCase ("Microsoft.Common.Library.CSharp", "UseNetStandard21=true")]
 		[TestCase ("Microsoft.Common.Library.FSharp", "UseNetStandard21=true")]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -299,7 +299,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		[TestCase ("Microsoft.Web.WebApi.FSharp", "UseNetCore30=true")]
 		public async Task AspNetCore30 (string templateId, string parameters)
 		{
-			if (!IsDotNetCoreSdk22Installed ()) {
+			if (!IsDotNetCoreSdk30Installed ()) {
 				Assert.Ignore (".NET Core 3.0 SDK is not installed - required by project template.");
 			}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -291,6 +291,7 @@ namespace MonoDevelop.DotNetCore.Tests
 			await CreateFromTemplateAndBuild ("NetCore2x", templateId, parameters);
 		}
 
+		[Ignore ("Requires .NET Core App 3.0 runtime")]
 		[TestCase ("Microsoft.Web.Empty.CSharp", "UseNetCore30=true")]
 		[TestCase ("Microsoft.Web.Empty.FSharp", "UseNetCore30=true")]
 		[TestCase ("Microsoft.Web.Mvc.CSharp", "UseNetCore30=true")]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -350,7 +350,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		static void CheckProjectTypeGuids (Solution solution, string expectedProjectTypeGuid)
 		{
 			foreach (Project project in solution.GetAllProjects ()) {
-				Assert.AreEqual (expectedProjectTypeGuid, project.TypeGuid);
+				Assert.AreEqual (expectedProjectTypeGuid, project.TypeGuid, $"For project: {project.Name} Expected Type is {expectedProjectTypeGuid} and is returning {project.TypeGuid}");
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -101,8 +101,8 @@ namespace MonoDevelop.DotNetCore.Tests
 		}
 
 		[Test]
-		[TestCase ("Microsoft.Common.Library.CSharp", "UseNetStandard20=true")]
-		[TestCase ("Microsoft.Common.Library.FSharp", "UseNetStandard20=true")]
+		[TestCase ("Microsoft.Common.Library.CSharp", "UseNetStandard21=true")]
+		[TestCase ("Microsoft.Common.Library.FSharp", "UseNetStandard21=true")]
 		public async Task NetStandard21 (string templateId, string parameters)
 		{
 			if (!IsDotNetCoreSdk2xInstalled ()) {
@@ -207,9 +207,9 @@ namespace MonoDevelop.DotNetCore.Tests
 		[TestCase ("Microsoft.Test.MSTest.VisualBasic", "UseNetCore22=true")]
 
 		// NUnit3 templates come with .NET Core 2.2, but they only support .NET Core 2.1 framework
-		[TestCase ("NUnit3.DotNetNew.Template.CSharp", "UseNetCore21=true")]
-		[TestCase ("NUnit3.DotNetNew.Template.FSharp", "UseNetCore21=true")]
-		[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore21=true")]
+		[TestCase ("NUnit3.DotNetNew.Template.CSharp", "UseNetCore30=true")]
+		[TestCase ("NUnit3.DotNetNew.Template.FSharp", "UseNetCore30=true")]
+		[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore30=true")]
 		public async Task NetCore30 (string templateId, string parameters)
 		{
 			if (!IsDotNetCoreSdk30Installed ()) {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -330,7 +330,7 @@ namespace MonoDevelop.DotNetCore.Tests
 
 		static bool IsDotNetCoreSdk30Installed ()
 		{
-			return DotNetCoreSdk.Versions.Any (version => version.Major == 2 && version.Minor == 2);
+			return DotNetCoreSdk.Versions.Any (version => version.Major == 3 && version.Minor == 0);
 		}
 
 		static async Task CreateFromTemplateAndBuild (string basename, string templateId, string parameters)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateWizardTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateWizardTests.cs
@@ -431,6 +431,38 @@ namespace MonoDevelop.DotNetCore.Tests
 		}
 
 		[Test]
+		public void NetCoreApp_NetCore30Installed ()
+		{
+			CreateWizard ();
+			DotNetCoreRuntimesInstalled ("3.0.0");
+
+			int pages = wizard.TotalPages;
+
+			Assert.AreEqual (0, pages);
+			Assert.IsFalse (WizardHasParameter ("UseNetStandard21"));
+			Assert.IsFalse (WizardHasParameter ("UseNetStandard20"));
+			Assert.IsFalse (WizardHasParameter ("UseNetStandard1x"));
+			Assert.IsTrue (wizard.Parameters.GetBoolValue ("UseNetCore30"));
+			Assert.IsFalse (WizardHasParameter ("UseNetCore22"));
+			Assert.IsFalse (WizardHasParameter ("UseNetCore21"));
+			Assert.IsFalse (WizardHasParameter ("UseNetCore20"));
+			Assert.IsFalse (WizardHasParameter ("UseNetCore1x"));
+			Assert.IsFalse (WizardHasParameter ("framework"));
+			Assert.AreEqual (".NETCoreApp,Version=v3.0", wizard.TargetFrameworks [0].Id.ToString ());
+			Assert.AreEqual (1, wizard.TargetFrameworks.Count);
+
+			var page = wizard.GetPage (1);
+			Assert.AreEqual ("netcoreapp3.0", wizard.Parameters ["Framework"]);
+			Assert.IsTrue (wizard.Parameters.GetBoolValue ("UseNetCore30"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetCore21"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetCore21"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetCore20"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetCore1x"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetStandard20"));
+			Assert.IsFalse (wizard.Parameters.GetBoolValue ("UseNetStandard1x"));
+		}
+
+		[Test]
 		public void NetCoreApp_NetCore22Installed ()
 		{
 			CreateWizard ();

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -107,7 +107,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		public void WhenDotNetCorePathIsNull_ThenItReturnsLatestSdk ()
 		{
 			var resolver = CreateResolver (string.Empty, mockSdkVersions: true);
-			var expectedVersion = resolver.GetLatesSdk (null);
+			var expectedVersion = resolver.GetLatestSdk ();
 			var expectedResult = Path.Combine (resolver.SdkRootPath, expectedVersion.OriginalString, "Sdks");
 
 			resolver.ResolveSDK ();
@@ -128,7 +128,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		public void WhenNoGlobalJson_ThenItReturnsLatestSdk ()
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
-			var expectedVersion = resolver.GetLatesSdk (null);
+			var expectedVersion = resolver.GetLatestSdk ();
 			var expectedResult = Path.Combine (resolver.SdkRootPath, expectedVersion.OriginalString, "Sdks");
 
 			resolver.ResolveSDK ();
@@ -147,7 +147,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, expectedVersion.OriginalString);
 
-				resolver.ResolveSDK (expectedVersion, workingDirectory);
+				resolver.ResolveSDK (workingDirectory);
 
 				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
@@ -165,7 +165,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				resolver.ResolveSDK (versionThatDoesNotExists, workingDirectory);
+				resolver.ResolveSDK (workingDirectory);
 
 				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
@@ -183,7 +183,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				resolver.ResolveSDK (versionThatDoesNotExists, workingDirectory);
+				resolver.ResolveSDK (workingDirectory);
 
 				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
@@ -194,14 +194,14 @@ namespace MonoDevelop.DotNetCore.Tests
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
 			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.2.3");
-			var versionThatShouldReturn = resolver.GetLatesSdk (versionThatDoesNotExists);
+			var versionThatShouldReturn = resolver.GetLatestSdk ();
 			var expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
 
 			using (var solution = await GetSolution ()) {
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				Assert.Throws<Exception> (() => resolver.ResolveSDK (versionThatDoesNotExists, workingDirectory));
+				Assert.Throws<Exception> (() => resolver.ResolveSDK (workingDirectory));
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -1,0 +1,222 @@
+//
+// DotNetCoreSDKResolverTests.cs
+//
+// Author:
+//       josemiguel <jostor@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.DotNetCore.Tests
+{
+	[TestFixture]
+	public class DotNetCoreSDKResolverTests
+	{
+		readonly DotNetCoreVersion [] SdkVersions = {
+				DotNetCoreVersion.Parse ("1.1.1"),
+				DotNetCoreVersion.Parse ("1.0.5"),
+				DotNetCoreVersion.Parse ("1.1.2"),
+				DotNetCoreVersion.Parse ("2.0.0-preview1"),
+				DotNetCoreVersion.Parse ("2.0.0-preview2"),
+				DotNetCoreVersion.Parse ("2.0.0"),
+				DotNetCoreVersion.Parse ("1.0.7"),
+				DotNetCoreVersion.Parse ("1.1.4"),
+				DotNetCoreVersion.Parse ("1.0.8"),
+				DotNetCoreVersion.Parse ("1.1.5"),
+				DotNetCoreVersion.Parse ("2.0.3"),
+				DotNetCoreVersion.Parse ("2.0.4"),
+				DotNetCoreVersion.Parse ("1.0.9"),
+				DotNetCoreVersion.Parse ("1.1.6"),
+				DotNetCoreVersion.Parse ("2.0.5"),
+				DotNetCoreVersion.Parse ("2.1-preview1"),
+				DotNetCoreVersion.Parse ("1.0.10"),
+				DotNetCoreVersion.Parse ("2.0.6"),
+				DotNetCoreVersion.Parse ("2.1-preview2"),
+				DotNetCoreVersion.Parse ("1.0.11"),
+				DotNetCoreVersion.Parse ("1.1.7"),
+				DotNetCoreVersion.Parse ("1.1.8"),
+				DotNetCoreVersion.Parse ("2.0.7"),
+				DotNetCoreVersion.Parse ("2.1-rc1"),
+				DotNetCoreVersion.Parse ("2.0.7-2"),
+				DotNetCoreVersion.Parse ("2.1.0"),
+				DotNetCoreVersion.Parse ("2.1.1"),
+				DotNetCoreVersion.Parse ("1.0.12"),
+				DotNetCoreVersion.Parse ("1.1.9"),
+				DotNetCoreVersion.Parse ("2.0.9"),
+				DotNetCoreVersion.Parse ("2.1.2"),
+				DotNetCoreVersion.Parse ("2.1.3"),
+				DotNetCoreVersion.Parse ("2.2.0-preview1"),
+				DotNetCoreVersion.Parse ("2.1.4"),
+				DotNetCoreVersion.Parse ("2.2.0-preview2"),
+				DotNetCoreVersion.Parse ("2.1.5"),
+				DotNetCoreVersion.Parse ("1.0.13"),
+				DotNetCoreVersion.Parse ("1.1.10"),
+				DotNetCoreVersion.Parse ("2.2.0-preview3"),
+				DotNetCoreVersion.Parse ("2.1.6"),
+				DotNetCoreVersion.Parse ("3.0.100-preview-009790"),
+
+				DotNetCoreVersion.Parse ("2.2.0"),
+				DotNetCoreVersion.Parse ("2.2.2"),
+
+			};
+	
+		DotNetCoreSdkPaths CreateResolver (string dotnetCorePath, bool mockSdkVersions = true)
+		{
+			if (string.IsNullOrEmpty (DotNetCoreRuntime.FileName))
+				Assert.Inconclusive ($"'DotNetCoreRuntime.FileName' is empty. Unable to run the test. DotNetCore installed? {DotNetCoreRuntime.IsInstalled}");
+
+			var resolver = new DotNetCoreSdkPaths (dotnetCorePath);
+			if (mockSdkVersions)
+				resolver.SdkVersions = this.SdkVersions;
+
+			return resolver;
+		}
+
+		async Task<Solution> GetSolution ()
+		{
+			var solutionFileName = Util.GetSampleProject ("dotnetcore-console", "dotnetcore-sdk-console.sln");
+			return (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+		}
+
+		[Test]
+		public void WhenDotNetCorePathIsNull_ThenItReturnsLatestSdk ()
+		{
+			var resolver = CreateResolver (string.Empty, mockSdkVersions: true);
+			var expectedVersion = resolver.GetLatesSdk (null);
+			var expectedResult = Path.Combine (resolver.SdkRootPath, expectedVersion.OriginalString, "Sdks");
+
+			resolver.ResolveSDK ();
+
+			Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
+		}
+
+		[Test]
+		public void WhenDotNetCorePathDoesNotExist_ThenItReturnsNull ()
+		{
+			var resolver = CreateResolver ("/usr/fake_folder/dotnet", mockSdkVersions: false);
+			resolver.ResolveSDK ();
+
+			Assert.That (resolver.MSBuildSDKsPath, Is.Null);
+		}
+
+		[Test]
+		public void WhenNoGlobalJson_ThenItReturnsLatestSdk ()
+		{
+			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
+			var expectedVersion = resolver.GetLatesSdk (null);
+			var expectedResult = Path.Combine (resolver.SdkRootPath, expectedVersion.OriginalString, "Sdks");
+
+			resolver.ResolveSDK ();
+
+			Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
+		}
+
+		[Test]
+		public async Task WhenGlobalJsonAndVersionMatches_ThenItReturnsThatVersion ()
+		{
+			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
+			var expectedVersion = DotNetCoreVersion.Parse ("2.1.0");
+			var expectedResult = Path.Combine (resolver.SdkRootPath, expectedVersion.OriginalString, "Sdks");
+
+			using (var solution = await GetSolution ()) {
+				var workingDirectory = Path.GetDirectoryName (solution.FileName);
+				var globalJsonPath = CreateGlobalJson (workingDirectory, expectedVersion.OriginalString);
+
+				resolver.ResolveSDK (expectedVersion, workingDirectory);
+
+				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
+			}
+		}
+
+		[Test]
+		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionLessThan21_ThenItReturnsLatestPatchVersion ()
+		{
+			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
+			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("1.0.6");
+			var versionThatShouldReturn = DotNetCoreVersion.Parse ("1.0.13");
+			var expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
+
+			using (var solution = await GetSolution ()) {
+				var workingDirectory = Path.GetDirectoryName (solution.FileName);
+				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
+
+				resolver.ResolveSDK (versionThatDoesNotExists, workingDirectory);
+
+				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
+			}
+		}
+
+		[Test]
+		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionIs21OrBefore_ThenItReturnsLatestPatchVersion ()
+		{
+			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
+			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.2.1");
+			var versionThatShouldReturn = DotNetCoreVersion.Parse ("2.2.2");
+			var expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
+
+			using (var solution = await GetSolution ()) {
+				var workingDirectory = Path.GetDirectoryName (solution.FileName);
+				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
+
+				resolver.ResolveSDK (versionThatDoesNotExists, workingDirectory);
+
+				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
+			}
+		}
+
+		[Test]
+		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionIs21OrBefore_ThenItReturnsLatestPatchVersion2 ()
+		{
+			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
+			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.2.3");
+			var versionThatShouldReturn = resolver.GetLatesSdk (versionThatDoesNotExists);
+			var expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
+
+			using (var solution = await GetSolution ()) {
+				var workingDirectory = Path.GetDirectoryName (solution.FileName);
+				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
+
+				Assert.Throws<Exception> (() => resolver.ResolveSDK (versionThatDoesNotExists, workingDirectory));
+			}
+		}
+
+		string CreateGlobalJson (string workingDirectory, string version)
+		{
+			try {
+				var GlobalJsonContent = $"\n\t{{\n\t\t\"sdk\": {{\n\t\t\t\"version\": \"{version}\"\n\t\t}}\n\t}}";
+				var GlobalJsonLocation = Path.Combine (workingDirectory, "global.json");
+
+				File.WriteAllText (GlobalJsonLocation, GlobalJsonContent);
+
+				return GlobalJsonLocation;
+			} catch (Exception) {
+				return string.Empty;
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -190,7 +190,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		}
 
 		[Test]
-		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionIs21OrBefore_ThenItReturnsLatestPatchVersion2 ()
+		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionIs21OrBefore_ThenItReturnsIsNotSupported ()
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
 			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.2.3");
@@ -201,7 +201,9 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				Assert.Throws<Exception> (() => resolver.ResolveSDK (workingDirectory));
+				resolver.ResolveSDK (workingDirectory);
+
+				Assert.True (resolver.IsUnsupportedSdkVersion);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -160,7 +160,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, expectedVersion.OriginalString);
 
-				resolver.ResolveSDK (workingDirectory);
+				resolver.ResolveSDK (workingDirectory, true);
 
 				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
@@ -178,7 +178,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				resolver.ResolveSDK (workingDirectory);
+				resolver.ResolveSDK (workingDirectory, true);
 
 				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
@@ -196,7 +196,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				resolver.ResolveSDK (workingDirectory);
+				resolver.ResolveSDK (workingDirectory, true);
 
 				Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
@@ -212,7 +212,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				resolver.ResolveSDK (workingDirectory);
+				resolver.ResolveSDK (workingDirectory, true);
 
 				Assert.True (resolver.IsUnsupportedSdkVersion);
 			}
@@ -246,7 +246,7 @@ namespace MonoDevelop.DotNetCore.Tests
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
 
-				resolver.ResolveSDK (workingDirectory);
+				resolver.ResolveSDK (workingDirectory, true);
 
 				Assert.That (resolver.IsUnsupportedSdkVersion, Is.EqualTo (!isSupported));
 				if (isSupported)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -38,50 +38,64 @@ namespace MonoDevelop.DotNetCore.Tests
 	public class DotNetCoreSDKResolverTests
 	{
 		readonly DotNetCoreVersion [] SdkVersions = {
-				DotNetCoreVersion.Parse ("1.1.1"),
 				DotNetCoreVersion.Parse ("1.0.5"),
-				DotNetCoreVersion.Parse ("1.1.2"),
-				DotNetCoreVersion.Parse ("2.0.0-preview1"),
-				DotNetCoreVersion.Parse ("2.0.0-preview2"),
-				DotNetCoreVersion.Parse ("2.0.0"),
 				DotNetCoreVersion.Parse ("1.0.7"),
-				DotNetCoreVersion.Parse ("1.1.4"),
 				DotNetCoreVersion.Parse ("1.0.8"),
-				DotNetCoreVersion.Parse ("1.1.5"),
-				DotNetCoreVersion.Parse ("2.0.3"),
-				DotNetCoreVersion.Parse ("2.0.4"),
 				DotNetCoreVersion.Parse ("1.0.9"),
-				DotNetCoreVersion.Parse ("1.1.6"),
-				DotNetCoreVersion.Parse ("2.0.5"),
-				DotNetCoreVersion.Parse ("2.1-preview1"),
 				DotNetCoreVersion.Parse ("1.0.10"),
-				DotNetCoreVersion.Parse ("2.0.6"),
-				DotNetCoreVersion.Parse ("2.1-preview2"),
 				DotNetCoreVersion.Parse ("1.0.11"),
+				DotNetCoreVersion.Parse ("1.0.12"),
+				DotNetCoreVersion.Parse ("1.0.13"),
+				DotNetCoreVersion.Parse ("1.1.1"),
+				DotNetCoreVersion.Parse ("1.1.2"),
+				DotNetCoreVersion.Parse ("1.1.4"),
+				DotNetCoreVersion.Parse ("1.1.5"),
+				DotNetCoreVersion.Parse ("1.1.6"),
 				DotNetCoreVersion.Parse ("1.1.7"),
 				DotNetCoreVersion.Parse ("1.1.8"),
-				DotNetCoreVersion.Parse ("2.0.7"),
-				DotNetCoreVersion.Parse ("2.1-rc1"),
-				DotNetCoreVersion.Parse ("2.0.7-2"),
-				DotNetCoreVersion.Parse ("2.1.0"),
-				DotNetCoreVersion.Parse ("2.1.1"),
-				DotNetCoreVersion.Parse ("1.0.12"),
 				DotNetCoreVersion.Parse ("1.1.9"),
-				DotNetCoreVersion.Parse ("2.0.9"),
-				DotNetCoreVersion.Parse ("2.1.2"),
-				DotNetCoreVersion.Parse ("2.1.3"),
-				DotNetCoreVersion.Parse ("2.2.0-preview1"),
-				DotNetCoreVersion.Parse ("2.1.4"),
-				DotNetCoreVersion.Parse ("2.2.0-preview2"),
-				DotNetCoreVersion.Parse ("2.1.5"),
-				DotNetCoreVersion.Parse ("1.0.13"),
 				DotNetCoreVersion.Parse ("1.1.10"),
-				DotNetCoreVersion.Parse ("2.2.0-preview3"),
-				DotNetCoreVersion.Parse ("2.1.6"),
-				DotNetCoreVersion.Parse ("3.0.100-preview-009790"),
-
+				//.Net Core v 2.0
+				DotNetCoreVersion.Parse ("2.0.0-preview1-005977"),
+				DotNetCoreVersion.Parse ("2.0.0-preview2-006497"),
+				DotNetCoreVersion.Parse ("2.0.0"),
+				DotNetCoreVersion.Parse ("2.0.3"),
+				DotNetCoreVersion.Parse ("2.1.2"),
+				DotNetCoreVersion.Parse ("2.1.4"),
+				DotNetCoreVersion.Parse ("2.1.100"),
+				DotNetCoreVersion.Parse ("2.1.101"),
+				DotNetCoreVersion.Parse ("2.1.102"),
+				DotNetCoreVersion.Parse ("2.1.103"),
+				DotNetCoreVersion.Parse ("2.1.104"),
+				DotNetCoreVersion.Parse ("2.1.105"),
+				DotNetCoreVersion.Parse ("2.1.200"),
+				DotNetCoreVersion.Parse ("2.1.201"),
+				DotNetCoreVersion.Parse ("2.1.202"),
+				//.Net Core v 2.1
+				DotNetCoreVersion.Parse ("2.1.300-preview1"),
+				DotNetCoreVersion.Parse ("2.1.300-preview2"),
+				DotNetCoreVersion.Parse ("2.1.300-rc1"),
+				DotNetCoreVersion.Parse ("2.1.300"),
+				DotNetCoreVersion.Parse ("2.1.301"),
+				DotNetCoreVersion.Parse ("2.1.302"),
+				DotNetCoreVersion.Parse ("2.1.400"),
+				DotNetCoreVersion.Parse ("2.1.401"),
+				DotNetCoreVersion.Parse ("2.1.402"),
+				DotNetCoreVersion.Parse ("2.1.403"),
+				DotNetCoreVersion.Parse ("2.1.500"),
+				DotNetCoreVersion.Parse ("2.1.502"),
+				//.Net Core v 2.2
+				DotNetCoreVersion.Parse ("2.2.100-preview1"),
+				DotNetCoreVersion.Parse ("2.2.100-preview2"),
+				DotNetCoreVersion.Parse ("2.2.100-preview3"),
+				DotNetCoreVersion.Parse ("2.2.100"),
+				DotNetCoreVersion.Parse ("2.2.101"),
+				//.Net Core 3.0
+				DotNetCoreVersion.Parse ("3.0.100-preview-009812"),
+				//. Fake versions
 				DotNetCoreVersion.Parse ("2.2.0"),
 				DotNetCoreVersion.Parse ("2.2.2"),
+				DotNetCoreVersion.Parse ("2.1.399"),
 
 			};
 	
@@ -140,7 +154,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		public async Task WhenGlobalJsonAndVersionMatches_ThenItReturnsThatVersion ()
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
-			var expectedVersion = DotNetCoreVersion.Parse ("2.1.0");
+			var expectedVersion = DotNetCoreVersion.Parse ("2.1.500");
 			var expectedResult = Path.Combine (resolver.SdkRootPath, expectedVersion.OriginalString, "Sdks");
 
 			using (var solution = await GetSolution ()) {
@@ -175,8 +189,8 @@ namespace MonoDevelop.DotNetCore.Tests
 		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionIs21OrBefore_ThenItReturnsLatestPatchVersion ()
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
-			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.2.1");
-			var versionThatShouldReturn = DotNetCoreVersion.Parse ("2.2.2");
+			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.1.310");
+			var versionThatShouldReturn = DotNetCoreVersion.Parse ("2.1.399");
 			var expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
 
 			using (var solution = await GetSolution ()) {
@@ -193,10 +207,8 @@ namespace MonoDevelop.DotNetCore.Tests
 		public async Task WhenGlobalJsonAndVersionNotMatches_AndVersionIs21OrBefore_ThenItReturnsIsNotSupported ()
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
-			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.2.3");
-			var versionThatShouldReturn = resolver.GetLatestSdk ();
-			var expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
-
+			var versionThatDoesNotExists = DotNetCoreVersion.Parse ("2.1.503");
+		
 			using (var solution = await GetSolution ()) {
 				var workingDirectory = Path.GetDirectoryName (solution.FileName);
 				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
@@ -204,6 +216,34 @@ namespace MonoDevelop.DotNetCore.Tests
 				resolver.ResolveSDK (workingDirectory);
 
 				Assert.True (resolver.IsUnsupportedSdkVersion);
+			}
+		}
+
+		//versionRequested, versionReturned, IsSupported?
+		[TestCase ("2.1.303", "", false)]
+		[TestCase ("2.1.301", "2.1.302", true)]
+		[TestCase ("2.1.501", "", false)]
+		public async Task WhenGlobalJsonAndVersionNotMatches (string requestedVersion, string expectedVersion, bool isSupported)
+		{
+			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);
+			var versionThatDoesNotExists = DotNetCoreVersion.Parse (requestedVersion);
+			DotNetCoreVersion versionThatShouldReturn;
+			string expectedResult = string.Empty;
+
+			if (!string.IsNullOrEmpty (expectedVersion)) {
+				versionThatShouldReturn = DotNetCoreVersion.Parse (expectedVersion);
+				expectedResult = Path.Combine (resolver.SdkRootPath, versionThatShouldReturn.OriginalString, "Sdks");
+			}
+
+			using (var solution = await GetSolution ()) {
+				var workingDirectory = Path.GetDirectoryName (solution.FileName);
+				var globalJsonPath = CreateGlobalJson (workingDirectory, versionThatDoesNotExists.OriginalString);
+
+				resolver.ResolveSDK (workingDirectory);
+
+				Assert.That (resolver.IsUnsupportedSdkVersion, Is.EqualTo (!isSupported));
+				if (isSupported)
+					Assert.That (resolver.MSBuildSDKsPath, Is.EqualTo (expectedResult));
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -80,7 +80,6 @@ namespace MonoDevelop.DotNetCore.Tests
 				DotNetCoreVersion.Parse ("2.1.302"),
 				DotNetCoreVersion.Parse ("2.1.400"),
 				DotNetCoreVersion.Parse ("2.1.401"),
-				DotNetCoreVersion.Parse ("2.1.402"),
 				DotNetCoreVersion.Parse ("2.1.403"),
 				DotNetCoreVersion.Parse ("2.1.500"),
 				DotNetCoreVersion.Parse ("2.1.502"),
@@ -219,10 +218,18 @@ namespace MonoDevelop.DotNetCore.Tests
 			}
 		}
 
-		//versionRequested, versionReturned, IsSupported?
-		[TestCase ("2.1.303", "", false)]
-		[TestCase ("2.1.301", "2.1.302", true)]
-		[TestCase ("2.1.501", "", false)]
+		[TestCase ("2.1.303", "2.1.399", true, 
+			Description = "WHEN we set the global.json to SDK=2.1.303 and it does not exist " 
+						+ " since version is 2.1.100 or higher THEN Resolver should return that IsSupported AND the latest patch that in this case is 2.1.399")]
+		[TestCase ("2.1.402", "2.1.403", true,
+			Description ="WHEN we set the global.json to SDK=2.1.402 and it does not exist " 
+						+ " since version is 2.1.100 or higher THEN Resolver should return that IsSupported AND the latest patch that in this case is 2.1.403")]
+		[TestCase ("2.1.503", "", false, 
+			Description = "WHEN we set the global.json to SDK=2.1.503 and it does not exist " 
+						+ "THEN since there is no higher patch installed it should return that NOT IsSupported AND empty expected version")]
+ 		[TestCase ("2.0.4", "2.0.3", true,
+			Description = "WHEN we set the global.json to SDK=2.0.4 and it does not exist "
+						+ " since version before 2.1.100 THEN Resolver should return that IsSupported AND the latest patch that in this case is 2.0.3")]
 		public async Task WhenGlobalJsonAndVersionNotMatches (string requestedVersion, string expectedVersion, bool isSupported)
 		{
 			var resolver = CreateResolver (DotNetCoreRuntime.FileName, mockSdkVersions: true);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
@@ -37,12 +37,15 @@ namespace MonoDevelop.DotNetCore
 		public static readonly string DotNetCore20DownloadUrl = "https://aka.ms/vs/mac/install-netcore2";
 		public static readonly string DotNetCore21DownloadUrl = "https://aka.ms/vs/mac/install-netcore21";
 		public static readonly string DotNetCore22DownloadUrl = "https://aka.ms/vs/mac/install-netcore22";
+		//FIXME: aka.ms is not available yet for netcore30 (https://dotnet.microsoft.com/download/dotnet-core/3.0)
+		public static readonly string DotNetCore30DownloadUrl = "https://aka.ms/vs/mac/install-netcore30";
 
 		static readonly string defaultMessage = GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build and run .NET Core projects.");
 		static readonly string unsupportedMessage = GettextCatalog.GetString ("The .NET Core SDK installed is not supported. Please install a more recent version.");
 		static readonly string dotNetCore20Message = GettextCatalog.GetString (".NET Core 2.0 SDK is not installed. This is required to build and run .NET Core 2.0 projects.");
 		static readonly string dotNetCore21Message = GettextCatalog.GetString (".NET Core 2.1 SDK is not installed. This is required to build and run .NET Core 2.1 projects.");
 		static readonly string dotNetCore22Message = GettextCatalog.GetString (".NET Core 2.2 SDK is not installed. This is required to build and run .NET Core 2.2 projects.");
+		static readonly string dotNetCore30Message = GettextCatalog.GetString (".NET Core 3.0 SDK is not installed. This is required to build and run .NET Core 3.0 projects.");
 
 		GenericMessage message;
 		AlertButton downloadButton;
@@ -92,6 +95,9 @@ namespace MonoDevelop.DotNetCore
 			} else if (RequiresDotNetCore22) {
 				Message = dotNetCore22Message;
 				downloadUrl = DotNetCore22DownloadUrl;
+			} else if (RequiresDotNetCore30) {
+				Message = dotNetCore30Message;
+				downloadUrl = DotNetCore30DownloadUrl;
 			}
 
 			MessageService.GenericAlert (message);
@@ -106,5 +112,6 @@ namespace MonoDevelop.DotNetCore
 		public bool RequiresDotNetCore20 { get; set; }
 		public bool RequiresDotNetCore21 { get; set; }
 		public bool RequiresDotNetCore22 { get; set; }
+		public bool RequiresDotNetCore30 { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
@@ -33,19 +33,30 @@ namespace MonoDevelop.DotNetCore
 {
 	class DotNetCoreNotInstalledDialog : IDisposable
 	{
-		public static readonly string DotNetCoreDownloadUrl = "https://aka.ms/vs/mac/install-netcore";
-		public static readonly string DotNetCore20DownloadUrl = "https://aka.ms/vs/mac/install-netcore2";
-		public static readonly string DotNetCore21DownloadUrl = "https://aka.ms/vs/mac/install-netcore21";
-		public static readonly string DotNetCore22DownloadUrl = "https://aka.ms/vs/mac/install-netcore22";
+		static readonly string DotNetCoreDownloadUrl = "https://aka.ms/vs/mac/install-netcore{0}";
+
 		//FIXME: aka.ms is not available yet for netcore30 (https://dotnet.microsoft.com/download/dotnet-core/3.0)
-		public static readonly string DotNetCore30DownloadUrl = "https://aka.ms/vs/mac/install-netcore30";
+		public static string GetDotNetCoreDownloadUrl (string version = "")
+		{
+			if (string.IsNullOrEmpty (version))
+				return string.Format (DotNetCoreDownloadUrl, string.Empty);
+
+			//special case for 2.0, 3.0, ..
+			if (version.EndsWith (".0", StringComparison.InvariantCulture))
+				version = version.Replace (".0", string.Empty);
+
+			return string.Format (DotNetCoreDownloadUrl, version.Replace (".", string.Empty));
+		}
 
 		static readonly string defaultMessage = GettextCatalog.GetString (".NET Core SDK is not installed. This is required to build and run .NET Core projects.");
 		static readonly string unsupportedMessage = GettextCatalog.GetString ("The .NET Core SDK installed is not supported. Please install a more recent version.");
-		static readonly string dotNetCore20Message = GettextCatalog.GetString (".NET Core 2.0 SDK is not installed. This is required to build and run .NET Core 2.0 projects.");
-		static readonly string dotNetCore21Message = GettextCatalog.GetString (".NET Core 2.1 SDK is not installed. This is required to build and run .NET Core 2.1 projects.");
-		static readonly string dotNetCore22Message = GettextCatalog.GetString (".NET Core 2.2 SDK is not installed. This is required to build and run .NET Core 2.2 projects.");
-		static readonly string dotNetCore30Message = GettextCatalog.GetString (".NET Core 3.0 SDK is not installed. This is required to build and run .NET Core 3.0 projects.");
+		public static string GetDotNetCoreMessage (string version = "")
+		{
+			if (string.IsNullOrEmpty (version))
+				return unsupportedMessage;
+
+			return GettextCatalog.GetString (".NET Core {0} SDK is not installed. This is required to build and run .NET Core {0} projects.", version);
+		}
 
 		GenericMessage message;
 		AlertButton downloadButton;
@@ -85,19 +96,10 @@ namespace MonoDevelop.DotNetCore
 		public void Show ()
 		{
 			if (IsUnsupportedVersion)
-				Message = unsupportedMessage;
-			else if (RequiresDotNetCore20) {
-				Message = dotNetCore20Message;
-				downloadUrl = DotNetCore20DownloadUrl;
-			} else if (RequiresDotNetCore21) {
-				Message = dotNetCore21Message;
-				downloadUrl = DotNetCore21DownloadUrl;
-			} else if (RequiresDotNetCore22) {
-				Message = dotNetCore22Message;
-				downloadUrl = DotNetCore22DownloadUrl;
-			} else if (RequiresDotNetCore30) {
-				Message = dotNetCore30Message;
-				downloadUrl = DotNetCore30DownloadUrl;
+				Message = GetDotNetCoreMessage ();
+			else {
+				Message = GetDotNetCoreMessage (RequiredDotNetCoreVersion.OriginalString);
+				downloadUrl = GetDotNetCoreDownloadUrl (RequiredDotNetCoreVersion.OriginalString);
 			}
 
 			MessageService.GenericAlert (message);
@@ -109,9 +111,6 @@ namespace MonoDevelop.DotNetCore
 		}
 
 		public bool IsUnsupportedVersion { get; set; }
-		public bool RequiresDotNetCore20 { get; set; }
-		public bool RequiresDotNetCore21 { get; set; }
-		public bool RequiresDotNetCore22 { get; set; }
-		public bool RequiresDotNetCore30 { get; set; }
+		public DotNetCoreVersion RequiredDotNetCoreVersion { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreNotInstalledDialog.cs
@@ -95,7 +95,7 @@ namespace MonoDevelop.DotNetCore
 
 		public void Show ()
 		{
-			if (IsUnsupportedVersion)
+			if (IsUnsupportedVersion || IsNetStandard) //for .net standard we'll show generic message
 				Message = GetDotNetCoreMessage ();
 			else {
 				Message = GetDotNetCoreMessage (RequiredDotNetCoreVersion.OriginalString);
@@ -111,6 +111,7 @@ namespace MonoDevelop.DotNetCore
 		}
 
 		public bool IsUnsupportedVersion { get; set; }
+		public bool IsNetStandard { get; set; }
 		public DotNetCoreVersion RequiredDotNetCoreVersion { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.DotNetCore
 			if (!isGlobalJsonItem)
 				return;
 
-			DetectSDK ();
+			DetectSDK (true);
 		}
 
 
@@ -368,7 +368,7 @@ namespace MonoDevelop.DotNetCore
 		{
 			sdkPaths.ResolveSDK (Project.ParentSolution.BaseDirectory);
 			DotNetCoreSdk.Update (sdkPaths);
-			if (restore)
+			if (restore && sdkPaths.Exist)
 				ReevaluateAllOpenDotNetCoreProjects ().Ignore ();
 		}
 
@@ -437,7 +437,7 @@ namespace MonoDevelop.DotNetCore
 			if (ProjectNeedsRestore ()) {
 				return CreateNuGetRestoreRequiredBuildResult ();
 			}
-			if (HasSdk && !IsDotNetCoreSdkInstalled ()) {
+			if ((HasSdk && !IsDotNetCoreSdkInstalled ()) || sdkPaths.IsUnsupportedSdkVersion) {
 				return CreateDotNetCoreSdkRequiredBuildResult ();
 			}
 			return null;

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -406,7 +406,6 @@ namespace MonoDevelop.DotNetCore
 
 			// Need to re-evaluate before restoring to ensure the implicit package references are correct after
 			// the target framework has changed.
-			RestorePackagesInProjectHandler.Run (Project, restoreTransitiveProjectReferences: true, reevaluateBeforeRestore: true);
 			DetectSDK (true);
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -59,13 +59,8 @@ namespace MonoDevelop.DotNetCore
 			var globalJson = e.FirstOrDefault (x => x.FileName.ToString ().Contains ("global.json") && !x.FileName.IsDirectory);
 			if (globalJson == null)
 				return;
-
-			if (Path.GetFileName (globalJson.FileName).IndexOf ("global.json", StringComparison.OrdinalIgnoreCase) == 0)
-				Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] = globalJson.FileName.ToString ();
-			else //i.e. global.json has been renamed
-				Project.ParentSolution.ExtendedProperties.Remove (GlobalJsonPathExtendedPropertyName);
-
-			DetectSDK (true);
+					
+			DetectSDK (restore: true);
 		}
 
 		protected override bool SupportsObject (WorkspaceObject item)
@@ -335,11 +330,11 @@ namespace MonoDevelop.DotNetCore
 
 		void DetectSDK (bool restore = false)
 		{
-			if (Project.ParentSolution.ExtendedProperties.Contains (GlobalJsonPathExtendedPropertyName)
-				&& File.Exists ((string)Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName]))
-				sdkPaths.GlobalJsonPath = (string)Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName];
-			else
+			if (Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] is string globalJsonPathProperty && File.Exists (globalJsonPathProperty)) {
+				sdkPaths.GlobalJsonPath = globalJsonPathProperty;
+			} else {
 				sdkPaths.GlobalJsonPath = string.Empty;
+			}
 
 			sdkPaths.ResolveSDK (Project.ParentSolution.BaseDirectory);
 			DotNetCoreSdk.Update (sdkPaths);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -325,11 +325,11 @@ namespace MonoDevelop.DotNetCore
 				return;
 
 			//detect globaljson
-			var globalJsonPath = new DirectoryInfo (Project.ParentSolution.BaseDirectory).GetFiles ("global.json", SearchOption.AllDirectories).FirstOrDefault ();
+			var globalJsonPath = sdkPaths.LookUpGlobalJson (Project.ParentSolution.BaseDirectory); 
 			if (globalJsonPath == null)
 				return;
 
-			Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] = globalJsonPath.FullName;
+			Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] = globalJsonPath;
 			DetectSDK ();
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -243,6 +243,7 @@ namespace MonoDevelop.DotNetCore
 				using (var dialog = new DotNetCoreNotInstalledDialog ()) {
 					dialog.IsUnsupportedVersion = unsupportedSdkVersion;
 					dialog.RequiredDotNetCoreVersion = DotNetCoreVersion.Parse (Project.TargetFramework.Id.Version);
+					dialog.IsNetStandard = Project.TargetFramework.Id.IsNetStandard ();
 					dialog.Show ();
 				}
 			});

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.DotNetCore
 
 		void FileService_FileChanged (object sender, FileEventArgs e)
 		{
-			var globalJson = e.FirstOrDefault (x => x.FileName.ToString ().Contains ("global.json") && !x.FileName.IsDirectory);
+			var globalJson = e.FirstOrDefault (x => x.FileName.FileName.IndexOf ("global.json", StringComparison.OrdinalIgnoreCase) == 0 && !x.FileName.IsDirectory);
 			if (globalJson == null)
 				return;
 					

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -59,8 +59,12 @@ namespace MonoDevelop.DotNetCore
 			var globalJson = e.FirstOrDefault (x => x.FileName.FileName.IndexOf ("global.json", StringComparison.OrdinalIgnoreCase) == 0 && !x.FileName.IsDirectory);
 			if (globalJson == null)
 				return;
-					
-			DetectSDK (restore: true);
+
+			// make sure the global.json file that has been changed is the one we got when loading the project
+			if (Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] is string globalJsonPath 
+				&& globalJsonPath.IndexOf (globalJson.FileName, StringComparison.OrdinalIgnoreCase) == 0) {
+				DetectSDK (restore: true);
+			}
 		}
 
 		protected override bool SupportsObject (WorkspaceObject item)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -93,8 +93,8 @@ namespace MonoDevelop.DotNetCore
 		public static IEnumerable<TargetFramework> GetNetCoreAppTargetFrameworks ()
 		{
 			foreach (Version runtimeVersion in GetMajorRuntimeVersions ()) {
-				if (runtimeVersion.Major == 2 && runtimeVersion.Minor > 2) {
-					// Skip versions > 2.2 since this is not currently supported.
+				if (runtimeVersion.Major == 3 && runtimeVersion.Minor > 0) {
+					// Skip versions > 3.0 since this is not currently supported.
 					continue;
 				}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -64,10 +64,7 @@ namespace MonoDevelop.DotNetCore
 		{
 			if (DotNetCoreRuntime.IsNetCore30Installed () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
 				yield return CreateTargetFramework (".NETStandard", "2.1");
-
-			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
-				yield return CreateTargetFramework (".NETStandard", "2.0");
-
+				
 			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ())
 				yield return CreateTargetFramework (".NETStandard", "2.0");
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.DotNetCore
 				yield return CreateTargetFramework (".NETStandard", "2.1");
 
 			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
-				yield return CreateTargetFramework (".NETStandard", "2.1");
+				yield return CreateTargetFramework (".NETStandard", "2.0");
 
 			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ())
 				yield return CreateTargetFramework (".NETStandard", "2.0");

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -62,6 +62,12 @@ namespace MonoDevelop.DotNetCore
 
 		public static IEnumerable<TargetFramework> GetNetStandardTargetFrameworks ()
 		{
+			if (DotNetCoreRuntime.IsNetCore30Installed () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
+				yield return CreateTargetFramework (".NETStandard", "2.1");
+
+			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
+				yield return CreateTargetFramework (".NETStandard", "2.1");
+
 			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ())
 				yield return CreateTargetFramework (".NETStandard", "2.0");
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -62,7 +62,7 @@ namespace MonoDevelop.DotNetCore
 
 		public static IEnumerable<TargetFramework> GetNetStandardTargetFrameworks ()
 		{
-			// NOTA: .NET Standard is still not available
+			// NOTE: .NET Standard is still not available
 			//if (DotNetCoreRuntime.IsNetCore30Installed () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
 			//	yield return CreateTargetFramework (".NETStandard", "2.1");
 				

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -62,8 +62,9 @@ namespace MonoDevelop.DotNetCore
 
 		public static IEnumerable<TargetFramework> GetNetStandardTargetFrameworks ()
 		{
-			if (DotNetCoreRuntime.IsNetCore30Installed () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
-				yield return CreateTargetFramework (".NETStandard", "2.1");
+			// NOTA: .NET Standard is still not available
+			//if (DotNetCoreRuntime.IsNetCore30Installed () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
+			//	yield return CreateTargetFramework (".NETStandard", "2.1");
 				
 			if (DotNetCoreRuntime.IsNetCore2xInstalled () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard20 ())
 				yield return CreateTargetFramework (".NETStandard", "2.0");

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectSupportedTargetFrameworks.cs
@@ -62,7 +62,7 @@ namespace MonoDevelop.DotNetCore
 
 		public static IEnumerable<TargetFramework> GetNetStandardTargetFrameworks ()
 		{
-			// NOTE: .NET Standard is still not available
+			// NOTE: .NET Standard 2.1 is still not available
 			//if (DotNetCoreRuntime.IsNetCore30Installed () || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetStandard21 ())
 			//	yield return CreateTargetFramework (".NETStandard", "2.1");
 				

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreRuntime.cs
@@ -119,6 +119,12 @@ namespace MonoDevelop.DotNetCore
 			return Versions.Any (version => version.Major == 2);
 		}
 
+		internal static bool IsNetCore30Installed ()
+		{
+			return Versions.Any (version => version.Major == 3 && version.Minor == 0);
+		}
+
+
 		/// <summary>
 		/// Used by unit tests to fake having different .NET Core sdks installed.
 		/// </summary>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdk.cs
@@ -36,23 +36,23 @@ namespace MonoDevelop.DotNetCore
 	public static class DotNetCoreSdk
 	{
 		static readonly Version DotNetCoreVersion2_1 = new Version (2, 1, 0);
+		static readonly DotNetCoreSdkPaths sdkPaths;
 
 		static DotNetCoreSdk ()
 		{
-			var sdkPaths = new DotNetCoreSdkPaths ();
-			sdkPaths.FindMSBuildSDKsPath ();
-
+			sdkPaths = new DotNetCoreSdkPaths ();
+			sdkPaths.ResolveSDK ();
 			Update (sdkPaths);
 		}
 
-		internal static void Update (DotNetCoreSdkPaths sdkPaths)
+		internal static void Update (DotNetCoreSdkPaths dotNetCoreSdkPaths)
 		{
-			RegisterProjectImportSearchPath (MSBuildSDKsPath, sdkPaths.MSBuildSDKsPath);
+			RegisterProjectImportSearchPath (MSBuildSDKsPath, dotNetCoreSdkPaths.MSBuildSDKsPath);
 
-			MSBuildSDKsPath = sdkPaths.MSBuildSDKsPath;
-			SdkRootPath = sdkPaths.SdkRootPath;
+			MSBuildSDKsPath = dotNetCoreSdkPaths.MSBuildSDKsPath;
+			SdkRootPath = dotNetCoreSdkPaths.SdkRootPath;
 			IsInstalled = !string.IsNullOrEmpty (MSBuildSDKsPath);
-			Versions = sdkPaths.SdkVersions ?? Array.Empty<DotNetCoreVersion> ();
+			Versions = dotNetCoreSdkPaths.SdkVersions ?? Array.Empty<DotNetCoreVersion> ();
 
 			if (!IsInstalled)
 				LoggingService.LogInfo (".NET Core SDK not found.");
@@ -84,10 +84,7 @@ namespace MonoDevelop.DotNetCore
 
 		internal static DotNetCoreSdkPaths FindSdkPaths (string sdk)
 		{
-			var sdkPaths = new DotNetCoreSdkPaths ();
-			sdkPaths.MSBuildSDKsPath = MSBuildSDKsPath;
 			sdkPaths.FindSdkPaths (sdk);
-
 			return sdkPaths;
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -74,20 +74,20 @@ namespace MonoDevelop.DotNetCore
 			if (string.IsNullOrEmpty (requiredSdkversion))
 				return true;
 
+			// Special case '2.1' and '2.0'.
+			if (requiredSdkversion == "2.1") {
+				return versions.Any (IsNetCoreSdk21) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
+			}
+			if (requiredSdkversion == "2.0") {
+				return versions.Any (IsNetCoreSdk20) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
+			}
+
 			requiredSdkversion = requiredSdkversion.Replace ("*", string.Empty);
 			DotNetCoreVersion requiredDotNetCoreVersion;
 			DotNetCoreVersion.TryParse (requiredSdkversion, out requiredDotNetCoreVersion);
 
 			if (requiredDotNetCoreVersion == null)
 				return versions.Any (version => version.ToString ().StartsWith (requiredSdkversion, StringComparison.OrdinalIgnoreCase));
-
-			// Special case '2.1' and '2.0'.
-			if (requiredSdkversion == "2.1") {
-				return versions.Any (IsNetCoreSdk21) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
-			} 
-			if (requiredSdkversion == "2.0") {
-				return versions.Any (IsNetCoreSdk20) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
-			}
 
 			return versions.Any (version => version.Major == requiredDotNetCoreVersion.Major && version.Minor == requiredDotNetCoreVersion.Minor);
 		}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkInstalledCondition.cs
@@ -79,7 +79,9 @@ namespace MonoDevelop.DotNetCore
 				return true;
 
 			// Special case '2.2', '2.1' and '2.0'.
-			if (requiredSdkversion == "2.2") {
+			if (requiredSdkversion == "3.0") {
+				return versions.Any (IsNetCoreSdk30);
+			} else if (requiredSdkversion == "2.2") {
 				return versions.Any (IsNetCoreSdk22);
 			} else if (requiredSdkversion == "2.1") {
 				return versions.Any (IsNetCoreSdk21) || MonoRuntimeInfoExtensions.CurrentRuntimeVersion.SupportsNetCore (requiredSdkversion);
@@ -89,6 +91,14 @@ namespace MonoDevelop.DotNetCore
 
 			requiredSdkversion = requiredSdkversion.Replace ("*", string.Empty);
 			return versions.Any (version => version.ToString ().StartsWith (requiredSdkversion, StringComparison.OrdinalIgnoreCase));
+		}
+
+		/// <summary>
+		/// 3.0 is the lowest version that supports .NET Core 3.0 projects.
+		/// </summary>
+		static bool IsNetCoreSdk30 (DotNetCoreVersion version)
+		{
+			return version.Major == 3 && version.Minor == 0;
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -206,11 +206,14 @@ namespace MonoDevelop.DotNetCore
 
 		string ReadGlobalJson (string workingDir)
 		{
-			var globalJsonPath = Path.Combine (workingDir, "global.json");
-			if (!File.Exists (globalJsonPath))
+			if (string.IsNullOrEmpty (workingDir))
 				return string.Empty;
 
-			using (var r = new StreamReader (globalJsonPath)) {
+			var globalJsonPath = new DirectoryInfo (workingDir).GetFiles ("global.json", SearchOption.AllDirectories).FirstOrDefault ();
+			if (globalJsonPath == null)
+				return string.Empty;
+
+			using (var r = new StreamReader (globalJsonPath.FullName)) {
 				try {
 					var token = JObject.Parse (r.ReadToEnd ());
 					if (token == null)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.DotNetCore
 		}
 
 		//https://docs.microsoft.com/en-us/dotnet/core/tools/global-json
-		public void ResolveSDK (DotNetCoreVersion dotNetCoreVersion = null, string workingDir = "")
+		public void ResolveSDK (string workingDir = "")
 		{
 			if (!SdkVersions.Any ())
 				return;
@@ -72,7 +72,7 @@ namespace MonoDevelop.DotNetCore
 
 			//if !global.json, returns latest
 			if (string.IsNullOrEmpty (specificVersion)) {
-				msbuildSDKsPath = GetSdksParentDirectory (GetLatesSdk (dotNetCoreVersion));
+				msbuildSDKsPath = GetSdksParentDirectory (GetLatestSdk ());
 				Exist = true;
 				return;
 			}
@@ -215,13 +215,6 @@ namespace MonoDevelop.DotNetCore
 				.Where (version => version != null);
 		}
 
-		internal DotNetCoreVersion GetLatesSdk (DotNetCoreVersion version)
-		{
-			if (version == null)
-				return SdkVersions.OrderByDescending (v => v).FirstOrDefault ();
-
-			return SdkVersions.Where (v => v.Major == version.Major && v.Minor == version.Minor)
-								.OrderByDescending (v => v).FirstOrDefault ();
-		}
+		internal DotNetCoreVersion GetLatestSdk () => SdkVersions.OrderByDescending (v => v).FirstOrDefault ();
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -209,12 +209,21 @@ namespace MonoDevelop.DotNetCore
 			return Path.Combine (SdksParentDirectory, "Sdks");
 		}
 
-		string LookUpGlobalJson (string workingDir)
+		public string LookUpGlobalJson (string workingDir)
 		{
 			if (string.IsNullOrEmpty (workingDir))
 				return string.Empty;
 
-			var globalJsonPath = new DirectoryInfo (workingDir).GetFiles ("global.json", SearchOption.AllDirectories).FirstOrDefault ();
+			var workingDirInfo = new DirectoryInfo (workingDir);
+			var globalJsonPath = workingDirInfo.GetFiles ("global.json", SearchOption.TopDirectoryOnly).FirstOrDefault ();
+			while (globalJsonPath == null) {
+				if (workingDirInfo.Parent == null)
+					break;
+
+				workingDirInfo = workingDirInfo.Parent;
+				globalJsonPath = workingDirInfo.GetFiles ("global.json", SearchOption.TopDirectoryOnly).FirstOrDefault ();
+			}
+
 			if (globalJsonPath == null)
 				return string.Empty;
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -91,11 +91,13 @@ namespace MonoDevelop.DotNetCore
 			targetVersion = SdkVersions.FirstOrDefault (x => x.OriginalString.IndexOf (specificVersion, StringComparison.InvariantCulture) == 0);
 			if (targetVersion == null) {
 				//if global.json exists and !matches then:
-				if (requiredVersion.Major == 2 && requiredVersion.Minor >= 1) {
+				if (requiredVersion >= DotNetCoreVersion.Parse ("2.1")) {
 					targetVersion = SdkVersions.Where (version => version.Major == requiredVersion.Major
-																	&& version.Minor == requiredVersion.Minor
-																	&& version.Patch > requiredVersion.Patch)
-												.OrderByDescending (version => version.Patch).FirstOrDefault ();
+																	&& version.Minor == requiredVersion.Minor)
+												.OrderByDescending (version => version.Patch).FirstOrDefault (x => {
+												return (x.Patch / 100 == requiredVersion.Patch / 100) &&
+														(x.Patch % 100 >= requiredVersion.Patch % 100);
+												});
 				} else {
 					targetVersion = SdkVersions.Where (version => version.Major == requiredVersion.Major && version.Minor == requiredVersion.Minor)
 												.OrderByDescending (version => version.Patch).FirstOrDefault ();

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
@@ -41,6 +41,12 @@ namespace MonoDevelop.DotNetCore
 			return monoVersion >= MonoVersion5_4;
 		}
 
+		public static bool SupportsNetStandard21 (this Version monoVersion)
+		{
+			//FIXME: update this: which Mono version will support .NET Standadrd 2.1
+			return monoVersion >= MonoVersion5_4;
+		}
+
 		public static bool SupportsNetCore (this Version monoVersion, string netCoreVersion)
 		{
 			return monoVersion >= MonoVersion5_4 && Version.Parse (netCoreVersion) <= DotNetCore2_1;

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/MonoRuntimeInfoExtensions.cs
@@ -44,7 +44,7 @@ namespace MonoDevelop.DotNetCore
 		public static bool SupportsNetStandard21 (this Version monoVersion)
 		{
 			//FIXME: update this: which Mono version will support .NET Standadrd 2.1
-			return monoVersion >= MonoVersion5_4;
+			return false;
 		}
 
 		public static bool SupportsNetCore (this Version monoVersion, string netCoreVersion)

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -79,6 +79,16 @@ namespace MonoDevelop.DotNetCore
 			return framework.Id.IsNetCoreApp () && framework.Id.Version.IndexOf (version, StringComparison.InvariantCulture) == 0;
 		}
 
+		public static bool IsNetCoreAppOrHigher (this TargetFramework framework, DotNetCoreVersion version)
+		{
+			DotNetCoreVersion dotNetCoreVersion;
+			DotNetCoreVersion.TryParse (framework.Id.Version, out dotNetCoreVersion);
+			if (dotNetCoreVersion == null)
+				return false;
+
+			return framework.Id.IsNetCoreApp () && dotNetCoreVersion >= version;
+		}
+
 		public static bool IsNetFramework (this TargetFramework framework) => framework.Id.IsNetFramework ();
 
 		public static bool IsNetStandard20OrNetCore20 (this TargetFramework framework) => framework.IsNetStandard ("2.0") || framework.IsNetCoreApp ("2.0");

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -31,87 +31,57 @@ namespace MonoDevelop.DotNetCore
 {
 	static class TargetFrameworkExtensions
 	{
-		public static bool IsNetStandard (this TargetFramework framework)
+		public static string GetParameterName (this TargetFramework framework)
 		{
-			return framework.Id.IsNetStandard ();
+			var parameter = framework.Id.Version;
+
+			//special case for 1.x
+			if (framework.IsVersion1x ())
+				parameter = "1x";
+
+			parameter = parameter.Replace (".", string.Empty);
+
+			if (framework.IsNetCoreApp ()) {
+				return $"UseNetCore{parameter}";
+			} 
+
+			if (framework.IsNetStandard ())
+				return $"UseNetStandard{parameter}";
+
+			return string.Empty;
 		}
 
-		public static bool IsNetStandard21 (this TargetFramework framework)
-		{
-			return framework.IsNetStandard () &&
-				framework.Id.Version == "2.1";
-		}
+		public static bool IsNetStandard (this TargetFramework framework) => framework.Id.IsNetStandard ();
 
-		public static bool IsNetStandard20 (this TargetFramework framework)
+		public static bool IsNetStandard (this TargetFramework framework, string version)
 		{
-			return framework.IsNetStandard () &&
-				framework.Id.Version == "2.0";
-		}
-
-		public static bool IsNetStandard1x (this TargetFramework framework)
-		{
-			return framework.IsNetStandard () &&
-				framework.IsVersion1x ();
+			return framework.Id.IsNetStandard () && framework.Id.Version.IndexOf (version, StringComparison.InvariantCulture) == 0;
 		}
 
 		public static bool IsLowerThanNetStandard16 (this TargetFramework framework)
 		{
-			if (framework.IsNetStandard20 ())
+			if (framework.IsNetStandard ("2.0"))
 				return false;
 
-			return framework.IsNetStandard1x () &&
-				framework.Id.Version != "1.6"; 
+			return framework.IsNetStandard1x () && framework.Id.Version != "1.6"; 
 		}
 
-		static bool IsVersion1x (this TargetFramework framework)
+		public static bool IsNetStandard1x (this TargetFramework framework) => framework.IsNetStandard() && framework.IsVersion1x();
+
+		public static bool IsNetCoreApp1x (this TargetFramework framework) => framework.IsNetCoreApp () && framework.IsVersion1x ();
+
+		static bool IsVersion1x (this TargetFramework framework) => framework.Id.Version.StartsWith ("1.", StringComparison.Ordinal);
+
+		public static bool IsNetCoreApp (this TargetFramework framework) => framework.Id.IsNetCoreApp ();
+
+		public static bool IsNetCoreApp (this TargetFramework framework, string version)
 		{
-			return framework.Id.Version.StartsWith ("1.", StringComparison.Ordinal);
+			return framework.Id.IsNetCoreApp () && framework.Id.Version.IndexOf (version, StringComparison.InvariantCulture) == 0;
 		}
 
-		public static bool IsNetCoreApp (this TargetFramework framework)
-		{
-			return framework.Id.IsNetCoreApp ();
-		}
+		public static bool IsNetFramework (this TargetFramework framework) => framework.Id.IsNetFramework ();
 
-		public static bool IsNetCoreApp30 (this TargetFramework framework)
-		{
-			return framework.IsNetCoreApp () &&
-				framework.Id.Version == "3.0";
-		}
-
-		public static bool IsNetCoreApp22 (this TargetFramework framework)
-		{
-			return framework.IsNetCoreApp () &&
-				framework.Id.Version == "2.2";
-		}
-
-		public static bool IsNetCoreApp21 (this TargetFramework framework)
-		{
-			return framework.IsNetCoreApp () &&
-				framework.Id.Version == "2.1";
-		}
-
-		public static bool IsNetCoreApp20 (this TargetFramework framework)
-		{
-			return framework.IsNetCoreApp () &&
-				framework.Id.Version == "2.0";
-		}
-
-		public static bool IsNetCoreApp1x (this TargetFramework framework)
-		{
-			return framework.IsNetCoreApp () &&
-				framework.IsVersion1x ();
-		}
-
-		public static bool IsNetFramework (this TargetFramework framework)
-		{
-			return framework.Id.IsNetFramework ();
-		}
-
-		public static bool IsNetStandard20OrNetCore20 (this TargetFramework framework)
-		{
-			return framework.IsNetStandard20 () || framework.IsNetCoreApp20 ();
-		}
+		public static bool IsNetStandard20OrNetCore20 (this TargetFramework framework) => framework.IsNetStandard ("2.0") || framework.IsNetCoreApp ("2.0");
 
 		public static string GetDisplayName (this TargetFramework framework)
 		{

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -36,6 +36,12 @@ namespace MonoDevelop.DotNetCore
 			return framework.Id.IsNetStandard ();
 		}
 
+		public static bool IsNetStandard21 (this TargetFramework framework)
+		{
+			return framework.IsNetStandard () &&
+				framework.Id.Version == "2.1";
+		}
+
 		public static bool IsNetStandard20 (this TargetFramework framework)
 		{
 			return framework.IsNetStandard () &&
@@ -65,6 +71,12 @@ namespace MonoDevelop.DotNetCore
 		public static bool IsNetCoreApp (this TargetFramework framework)
 		{
 			return framework.Id.IsNetCoreApp ();
+		}
+
+		public static bool IsNetCoreApp30 (this TargetFramework framework)
+		{
+			return framework.IsNetCoreApp () &&
+				framework.Id.Version == "3.0";
 		}
 
 		public static bool IsNetCoreApp22 (this TargetFramework framework)

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -941,7 +941,7 @@
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetCore21=true"
+			condition="UseNetCore22=true"
 			category="netcore/test/general" />
 		<Template
 			id="NUnit3.DotNetNew.Template.FSharp"
@@ -952,7 +952,7 @@
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetCore21=true"
+			condition="UseNetCore22=true"
 			category="netcore/test/general" />
 		<Template
 			id="NUnit3.DotNetNew.Template.VisualBasic"
@@ -964,7 +964,7 @@
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetCore21=true"
+			condition="UseNetCore22=true"
 			category="netcore/test/general" />
 		</Condition>
 		<Condition id="DotNetCoreSdkInstalled" sdkVersion="3.0">

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -23,7 +23,7 @@
 
 	<Extension path="/MonoDevelop/Ide/Templates">
 		<!--
-			Use the same Template/@id for both the 1.x and 2.0 templates to prevent duplicate items
+			Use the same Template/@id for both the 1.x, 2.0 and 3.0 templates to prevent duplicate items
 			in the recent templates list in the New Project dialog.
 		-->
 		<Condition id="DotNetCoreSdkInstalled" sdkVersion="1.*">
@@ -144,6 +144,43 @@
 			condition="UseNetCore22=true"
 			category="netcore/app/general"/>
 		</Condition>
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="3.0">
+		<Template
+			id="Microsoft.Common.Console.CSharp"
+			templateId="Microsoft.Common.Console.CSharp.3.0"
+			_overrideName="Console Application"
+			_overrideDescription="Creates a new .NET Core console project."
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-console-project"
+			imageId="md-netcore-console-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/app/general"/>
+		<Template
+			id="Microsoft.Common.Console.FSharp"
+			templateId="Microsoft.Common.Console.FSharp.3.0"
+			_overrideName="Console Application"
+			_overrideDescription="Creates a new .NET Core console project."
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-console-project"
+			imageId="md-netcore-console-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/app/general"/>
+		<Template
+			id="Microsoft.Common.Console.VisualBasic"
+			templateId="Microsoft.Common.Console.VisualBasic.3.0"
+			_overrideName="Console Application"
+			_overrideDescription="Creates a new .NET Core console project."
+			overrideLanguage="VBNet"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-console-project"
+			imageId="md-netcore-console-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/app/general"/>
+		</Condition>
+		
 		<!--
 			.NET Standard library project in Multiplatform - Library category.
 			Displayed if Mono's MSBuild includes the .NET Core SDK. The .NET Core
@@ -278,6 +315,46 @@
 			condition="UseNetStandard20=true"
 			category="multiplat/library/general" />
 		</Condition>
+		<Condition id="DotNetCoreSdkInstalled" requiresRuntime="false" sdkVersion="3.0">
+		<Template
+			_overrideName=".NET Standard Library"
+			_overrideDescription="Creates a new .NET Standard class library project."
+			id="Microsoft.Common.Library.CSharp"
+			templateId="Microsoft.Common.Library.CSharp.3.0"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-crossplatform-library-project"
+			imageId="md-crossplatform-library-project"
+			supportedParameters="NetStandard"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetStandard30=true"
+			category="multiplat/library/general" />
+		<Template
+			_overrideName=".NET Standard Library"
+			_overrideDescription="Creates a new .NET Standard class library project."
+			id="Microsoft.Common.Library.FSharp"
+			templateId="Microsoft.Common.Library.FSharp.3.0"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-crossplatform-library-project"
+			imageId="md-crossplatform-library-project"
+			supportedParameters="NetStandard;FSharpNetStandard"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetStandard30=true"
+			category="multiplat/library/general" />
+		<Template
+			_overrideName=".NET Standard Library"
+			_overrideDescription="Creates a new .NET Standard class library project."
+			overrideLanguage="VBNet"
+			id="Microsoft.Common.Library.VisualBasic"
+			templateId="Microsoft.Common.Library.VisualBasic.3.0"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-crossplatform-library-project"
+			imageId="md-crossplatform-library-project"
+			supportedParameters="NetStandard"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetStandard30=true"
+			category="multiplat/library/general" />
+		</Condition>
+		
 		<!--
 			.NET Standard library project in .NET Core - Library category.
 			Not displayed if .NET Core SDK or runtime is not installed unlike the
@@ -411,6 +488,45 @@
 			condition="UseNetStandard20=true"
 			category="netcore/library/general" />
 		</Condition>
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="3.0">
+		<Template
+			_overrideName=".NET Standard Library"
+			_overrideDescription="Creates a new .NET Standard class library project."
+			id="Microsoft.Common.Library.CSharp"
+			templateId="Microsoft.Common.Library.CSharp.3.0"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-empty-project"
+			imageId="md-netcore-empty-project"
+			supportedParameters="NetStandard"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetStandard30=true"
+			category="netcore/library/general" />
+		<Template
+			_overrideName=".NET Standard Library"
+			_overrideDescription="Creates a new .NET Standard class library project."
+			id="Microsoft.Common.Library.FSharp"
+			templateId="Microsoft.Common.Library.FSharp.3.0"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-empty-project"
+			imageId="md-netcore-empty-project"
+			supportedParameters="NetStandard;FSharpNetStandard"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetStandard30=true"
+			category="netcore/library/general" />
+		<Template
+			_overrideName=".NET Standard Library"
+			_overrideDescription="Creates a new .NET Standard class library project."
+			overrideLanguage="VBNet"
+			id="Microsoft.Common.Library.VisualBasic"
+			templateId="Microsoft.Common.Library.VisualBasic.3.0"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-empty-project"
+			imageId="md-netcore-empty-project"
+			supportedParameters="NetStandard"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetStandard30=true"
+			category="netcore/library/general" />
+		</Condition>		
 		<!--
 			.NET Core class library project in .NET Core - Library category.
 			Template id and group ids have been changed to keep them unique so both
@@ -545,6 +661,48 @@
 			supportedParameters="NetCoreLibrary"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 			condition="UseNetCore22=true"
+			category="netcore/library/general" />
+		</Condition>
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="3.0">
+		<Template
+			_overrideName="Class Library"
+			_overrideDescription="Creates a new .NET Core class library project."
+			id="Microsoft.Common.Library.CSharp-netcoreapp"
+			templateId="Microsoft.Common.Library.CSharp.3.0"
+			groupId="Microsoft.Common.Library-netcoreapp"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-empty-project"
+			imageId="md-netcore-empty-project"
+			supportedParameters="NetCoreLibrary"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/library/general" />
+		<Template
+			_overrideName="Class Library"
+			_overrideDescription="Creates a new .NET Core class library project."
+			id="Microsoft.Common.Library.FSharp-netcoreapp"
+			templateId="Microsoft.Common.Library.FSharp.3.0"
+			groupId="Microsoft.Common.Library-netcoreapp"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-empty-project"
+			imageId="md-netcore-empty-project"
+			supportedParameters="FSharpNetCoreLibrary;NetCoreLibrary"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/library/general" />
+		<Template
+			_overrideName="Class Library"
+			_overrideDescription="Creates a new .NET Core class library project."
+			overrideLanguage="VBNet"
+			id="Microsoft.Common.Library.VisualBasic-netcoreapp"
+			templateId="Microsoft.Common.Library.VisualBasic.3.0"
+			groupId="Microsoft.Common.Library-netcoreapp"
+			path="${DotNetCoreSdk.3.0.Templates.Common.ProjectTemplates.nupkg}"
+			icon="md-netcore-empty-project"
+			imageId="md-netcore-empty-project"
+			supportedParameters="NetCoreLibrary"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
 			category="netcore/library/general" />
 		</Condition>
 		<Condition id="DotNetCoreSdkInstalled" sdkVersion="1.*">
@@ -807,6 +965,110 @@
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
 			condition="UseNetCore21=true"
+			category="netcore/test/general" />
+		</Condition>
+		<Condition id="DotNetCoreSdkInstalled" sdkVersion="3.0">
+		<Template
+			id="Microsoft.Test.xUnit.CSharp"
+			templateId="Microsoft.Test.xUnit.CSharp.3.0"
+			_overrideName="xUnit Test Project"
+			_overrideDescription="Creates a new xUnit test project."
+			path="${DotNetCoreSdk.3.0.Templates.Test.ProjectTemplates.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="Microsoft.Test.xUnit.FSharp"
+			templateId="Microsoft.Test.xUnit.FSharp.3.0"
+			_overrideName="xUnit Test Project"
+			_overrideDescription="Creates a new xUnit test project."
+			path="${DotNetCoreSdk.3.0.Templates.Test.ProjectTemplates.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="Microsoft.Test.xUnit.VisualBasic"
+			templateId="Microsoft.Test.xUnit.VisualBasic.3.0"
+			_overrideName="xUnit Test Project"
+			_overrideDescription="Creates a new xUnit test project."
+			overrideLanguage="VBNet"
+			path="${DotNetCoreSdk.3.0.Templates.Test.ProjectTemplates.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="Microsoft.Test.MSTest.CSharp"
+			templateId="Microsoft.Test.MSTest.CSharp.3.0"
+			_overrideName="MSTest Project"
+			_overrideDescription="Creates a new MSTest project."
+			path="${DotNetCoreSdk.3.0.Templates.Test.ProjectTemplates.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="Microsoft.Test.MSTest.FSharp"
+			templateId="Microsoft.Test.MSTest.FSharp.3.0"
+			_overrideName="MSTest Project"
+			_overrideDescription="Creates a new MSTest project."
+			path="${DotNetCoreSdk.3.0.Templates.Test.ProjectTemplates.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="Microsoft.Test.MSTest.VisualBasic"
+			templateId="Microsoft.Test.MSTest.VisualBasic.3.0"
+			_overrideName="MSTest Project"
+			_overrideDescription="Creates a new MSTest project."
+			overrideLanguage="VBNet"
+			path="${DotNetCoreSdk.3.0.Templates.Test.ProjectTemplates.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="NUnit3.DotNetNew.Template.CSharp"
+			templateId="NUnit3.DotNetNew.Template.CSharp"
+			_overrideName="NUnit Test Project"
+			_overrideDescription="Creates a new NUnit test project."
+			path="${DotNetCoreSdk.3.0.Templates.NUnit3.DotNetNew.Template.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="NUnit3.DotNetNew.Template.FSharp"
+			templateId="NUnit3.DotNetNew.Template.FSharp"
+			_overrideName="NUnit Test Project"
+			_overrideDescription="Creates a new NUnit test project."
+			path="${DotNetCoreSdk.3.0.Templates.NUnit3.DotNetNew.Template.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
+			category="netcore/test/general" />
+		<Template
+			id="NUnit3.DotNetNew.Template.VisualBasic"
+			templateId="NUnit3.DotNetNew.Template.VisualBasic"
+			_overrideName="NUnit Test Project"
+			_overrideDescription="Creates a new NUnit test project."
+			overrideLanguage="VBNet"
+			path="${DotNetCoreSdk.3.0.Templates.NUnit3.DotNetNew.Template.nupkg}"
+			icon="md-netcore-test-project"
+			imageId="md-netcore-test-project"
+			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
+			condition="UseNetCore30=true"
 			category="netcore/test/general" />
 		</Condition>
 	</Extension>

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -326,7 +326,7 @@
 			imageId="md-crossplatform-library-project"
 			supportedParameters="NetStandard"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetStandard30=true"
+			condition="UseNetStandard21=true"
 			category="multiplat/library/general" />
 		<Template
 			_overrideName=".NET Standard Library"
@@ -338,7 +338,7 @@
 			imageId="md-crossplatform-library-project"
 			supportedParameters="NetStandard;FSharpNetStandard"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetStandard30=true"
+			condition="UseNetStandard21=true"
 			category="multiplat/library/general" />
 		<Template
 			_overrideName=".NET Standard Library"
@@ -351,7 +351,7 @@
 			imageId="md-crossplatform-library-project"
 			supportedParameters="NetStandard"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetStandard30=true"
+			condition="UseNetStandard21=true"
 			category="multiplat/library/general" />
 		</Condition>
 		
@@ -499,7 +499,7 @@
 			imageId="md-netcore-empty-project"
 			supportedParameters="NetStandard"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetStandard30=true"
+			condition="UseNetStandard21=true"
 			category="netcore/library/general" />
 		<Template
 			_overrideName=".NET Standard Library"
@@ -511,7 +511,7 @@
 			imageId="md-netcore-empty-project"
 			supportedParameters="NetStandard;FSharpNetStandard"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetStandard30=true"
+			condition="UseNetStandard21=true"
 			category="netcore/library/general" />
 		<Template
 			_overrideName=".NET Standard Library"
@@ -524,7 +524,7 @@
 			imageId="md-netcore-empty-project"
 			supportedParameters="NetStandard"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetStandard30=true"
+			condition="UseNetStandard21=true"
 			category="netcore/library/general" />
 		</Condition>		
 		<!--

--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -941,7 +941,7 @@
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetCore22=true"
+			condition="UseNetCore21=true"
 			category="netcore/test/general" />
 		<Template
 			id="NUnit3.DotNetNew.Template.FSharp"
@@ -952,7 +952,7 @@
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetCore22=true"
+			condition="UseNetCore21=true"
 			category="netcore/test/general" />
 		<Template
 			id="NUnit3.DotNetNew.Template.VisualBasic"
@@ -964,7 +964,7 @@
 			icon="md-netcore-test-project"
 			imageId="md-netcore-test-project"
 			wizard="MonoDevelop.DotNetCore.ProjectTemplateWizard"
-			condition="UseNetCore22=true"
+			condition="UseNetCore21=true"
 			category="netcore/test/general" />
 		</Condition>
 		<Condition id="DotNetCoreSdkInstalled" sdkVersion="3.0">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
@@ -118,9 +118,9 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			return context;
 		}
 
-		protected class PackagManagementEventsConsoleLogger : IDisposable
+		protected class PackageManagementEventsConsoleLogger : IDisposable
 		{
-			public PackagManagementEventsConsoleLogger ()
+			public PackageManagementEventsConsoleLogger ()
 			{
 				PackageManagementServices.PackageManagementEvents.PackageOperationMessageLogged += PackageOperationMessageLogged;
 			}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
@@ -63,13 +63,13 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
-		public async Task OfflineRestore_NetCore21Project ()
+		public async Task OfflineRestore_NetCore22Project ()
 		{
 			FilePath solutionFileName = Util.GetSampleProject ("restore-netcore-offline", "dotnetcoreconsole.sln");
 			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = solution.GetAllDotNetProjects ().Single ();
 
-			using (var logger = new PackagManagementEventsConsoleLogger ()) {
+			using (var logger = new PackageManagementEventsConsoleLogger ()) {
 				await RestoreDotNetCoreNuGetPackages (solution);
 			}
 

--- a/main/tests/IdeUnitTests/ProjectTemplateTest.cs
+++ b/main/tests/IdeUnitTests/ProjectTemplateTest.cs
@@ -99,9 +99,16 @@ namespace IdeUnitTests
 
 		void RunMSBuild (string arguments)
 		{
-			var process = Process.Start ("msbuild", arguments);
+			var process = new Process ();
+			process.StartInfo = new ProcessStartInfo ("msbuild", arguments) {
+				RedirectStandardOutput = true,
+				UseShellExecute = false
+			};
+			process.Start ();
+			var standardError = $"Error: {process.StandardOutput.ReadToEnd ()}";
+
 			Assert.IsTrue (process.WaitForExit (240000), "Timed out waiting for MSBuild.");
-			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed");
+			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed. Exit code: {process.ExitCode}. {standardError}");
 		}
 
 		static void CreateNuGetConfigFile (FilePath directory)


### PR DESCRIPTION
*NOTE: Work In Progress....*
*Rebased (Dec. 18th)*

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/695014
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/729967
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/729979
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/727333
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/729984
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/752729
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/757629

# Known issues
- when global.json is renamed to ie.e global1.json it's not caught by `FileChanged`
# FIXME
- .NET core 3.0 aka.ms is still not available [here](https://github.com/mono/monodevelop/compare/netcoreapp30?expand=1#diff-45fb0e36ce58ce6f9f6622d7a63f948eR41)
- Mono runtime version is missing  [here](https://github.com/mono/monodevelop/pull/6750/files#diff-433a7fd2cf020622736651e84dc9295cR47)
- .NET Standard 2.1 is still not available (templates, core...)
- Better global.json FileRenamed / Added / Removed handling
- Improve Test based on specific .NET Core SDK version + refactoring
- Better Restoring at Sol level according to [this](https://github.com/mono/monodevelop/pull/6750#discussion_r245921876).  
