### PR TITLE
Fixes VSTS Bug 731943: [Feedback] xUnit Fact DisplayName not shown in

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/VsTestUnitTestTests.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.Tests/MonoDevelop.UnitTesting.Tests/VsTestUnitTestTests.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.UnitTesting.Tests
 		[TestCase ("A.B.MyTest", "A.B.MyTestDisplayName", "A", "B", "MyTestDisplayName")]
 		[TestCase ("A.B.MyTest", "A.B.MyTest(text: \"ab\")", "A", "B", "MyTest(text: \"ab\")")]
 		[TestCase ("A.B.MyTest", "A.B.MyTest(text: \"a.b\")", "A", "B", "MyTest(text: \"a.b\")")]
+		[TestCase ("MyClass.MyTest", "Name with dot.", "", "MyClass", "Name with dot.")]
 		public void TestName (
 			string fullyQualifiedName,
 			string displayName,

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestUnitTest.cs
@@ -91,7 +91,6 @@ namespace MonoDevelop.UnitTesting.VsTest
 					sourceCodeLocation = new SourceCodeLocation (source.SourceTree.FilePath, line.StartLinePosition.Line, line.StartLinePosition.Character);
 				}).Ignore ();
 			}
-
 			int index = test.FullyQualifiedName.LastIndexOf ('.');
 			if (index > 0) {
 				FixtureTypeName = test.FullyQualifiedName.Substring (0, index);
@@ -107,18 +106,10 @@ namespace MonoDevelop.UnitTesting.VsTest
 				FixtureTypeNamespace = string.Empty;
 				FixtureTypeName = string.Empty;
 			}
-
-			int openBraceIndex = test.DisplayName.IndexOf ('(');
-			if (openBraceIndex == -1) {
-				index = test.DisplayName.LastIndexOf ('.');
-			} else {
-				index = test.DisplayName.LastIndexOf ('.', openBraceIndex);
-			}
-
-			if (index > 0) {
-				name = test.DisplayName.Substring (index + 1);
-			} else {
-				name = test.DisplayName;
+			name = test.DisplayName;
+			var obsoletePrefix = string.IsNullOrEmpty (FixtureTypeNamespace) ? FixtureTypeName : FixtureTypeNamespace + "." + FixtureTypeName;
+			if (test.DisplayName.StartsWith(obsoletePrefix, StringComparison.Ordinal) && test.DisplayName [obsoletePrefix.Length] == '.') {
+				name = test.DisplayName.Substring (obsoletePrefix.Length + 1);
 			}
 		}
 


### PR DESCRIPTION
test explorer if string has a period at the end.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/731943