### PR TITLE
[Ide] Fix new folder not selected after refresh

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
@@ -284,7 +284,7 @@ namespace MonoDevelop.Projects
 			// The native file watcher sometimes generates a Changed, Created and Deleted event in
 			// that order from a single native file event. So check the file has been deleted before raising
 			// a FileRemoved event.
-			if (!File.Exists (e.FullPath))
+			if (!File.Exists (e.FullPath) && !Directory.Exists (e.FullPath))
 				FileService.NotifyFileRemoved (e.FullPath);
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4569,7 +4569,7 @@ namespace MonoDevelop.Projects
 
 		void OnFileDeletedExternally (string fileName)
 		{
-			if (File.Exists (fileName)) {
+			if (File.Exists (fileName) || Directory.Exists (fileName)) {
 				// File has not been deleted. The delete event could have been due to
 				// the file being saved. Saving with TextFileUtility will result in
 				// FileService.SystemRename being called to move a temporary file

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -545,6 +545,10 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		[CommandHandler (ProjectCommands.NewFolder)]
 		public async void AddNewFolder ()
 		{
+			// Expand the project node before adding the file to the project. This fixes a problem where if the
+			// project node is collapsed and Refresh was used the project node would not expand and the new folder
+			// node would not be selected.
+			CurrentNode.Expanded = true;
 			Project project = CurrentNode.GetParentDataItem (typeof(Project), true) as Project;
 			
 			string baseFolderPath = GetFolderPath (CurrentNode.DataItem);
@@ -565,7 +569,6 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			newFolder.Subtype = Subtype.Directory;
 			project.Files.Add (newFolder);
 
-			CurrentNode.Expanded = true;
 			Tree.AddNodeInsertCallback (new ProjectFolder (directoryName, project), new TreeNodeCallback (OnFileInserted));
 
 			await IdeApp.ProjectOperations.SaveAsync (project);


### PR DESCRIPTION
Second attempt at fixing the VSTS #721437. Cannot reproduce the behaviour that some people are seeing so this fixes the problems I can reproduce.

1) Collapsing a project folder node in the Solution window, then
selecting Refresh from the context menu for that project, then
selecting Add - New Folder, would result in the project node not
expanding and the new folder node was not selected.

Expanding the project node before adding the file to the project
fixes this problem.

2) Fix new folder disappearring in sdk project

Adding a new folder to a SDK style project would sometimes result
in the folder briefly appearring and then being removed. This was
because the file watcher generates a created and then a deleted
event for the new folder. The folder would then be removed from the
project and removed from the Solution window.

Fixes VSTS #721437 - Can't focus on a folder and name it during
creation.