### PR TITLE
[release-7.7] Set Roslyn Language Name for F# projects

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -27,6 +27,9 @@ module Project =
 
 type FSharpProject() as self =
     inherit DotNetProject()
+    do
+        self.RoslynLanguageName <- Microsoft.CodeAnalysis.LanguageNames.FSharp
+
     // Keep the platforms combo of CodeGenerationPanelWidget in sync with this list
     let supportedPlatforms = [| "anycpu"; "x86"; "x64"; "Itanium" |]
 


### PR DESCRIPTION
Fixes VSTS #748732 (#6757)

Backport of #6764.

/cc @nosami 