### PR TITLE
[NuGet] Add offline .NET Core project restore test

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -92,10 +93,6 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		protected static Task RestoreDotNetCoreNuGetPackages (Solution solution)
 		{
 			var solutionManager = new MonoDevelopSolutionManager (solution);
-			var context = new FakeNuGetProjectContext {
-				LogToConsole = true
-			};
-
 			var restoreManager = new MonoDevelopBuildIntegratedRestorer (solutionManager);
 
 			var projects = solution.GetAllDotNetProjects ().Select (p => new DotNetCoreNuGetProject (p));
@@ -119,6 +116,24 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 				//logger);
 
 			return context;
+		}
+
+		protected class PackagManagementEventsConsoleLogger : IDisposable
+		{
+			public PackagManagementEventsConsoleLogger ()
+			{
+				PackageManagementServices.PackageManagementEvents.PackageOperationMessageLogged += PackageOperationMessageLogged;
+			}
+
+			public void Dispose ()
+			{
+				PackageManagementServices.PackageManagementEvents.PackageOperationMessageLogged -= PackageOperationMessageLogged;
+			}
+
+			void PackageOperationMessageLogged (object sender, PackageOperationMessageLoggedEventArgs e)
+			{
+				Console.WriteLine (e.Message.ToString ());
+			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,6 +58,22 @@ namespace MonoDevelop.PackageManagement.Tests
 			var fsharpCore = dependencies.SingleOrDefault (d => d.Name == "FSharp.Core");
 
 			Assert.AreEqual ("4.5.0", fsharpCore.Version);
+		}
+
+		[Test]
+		public async Task OfflineRestore_NetCore21Project ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("restore-netcore-offline", "dotnetcoreconsole.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			using (var logger = new PackagManagementEventsConsoleLogger ()) {
+				await RestoreDotNetCoreNuGetPackages (solution);
+			}
+
+			var packagesDirectory = solution.BaseDirectory.Combine ("packages-cache");
+			Assert.IsFalse (Directory.Exists (packagesDirectory));
+			Assert.IsTrue (File.Exists (project.BaseDirectory.Combine ("obj", "project.assets.json")));
 		}
 	}
 }

--- a/main/tests/test-projects/restore-netcore-offline/NuGet.config
+++ b/main/tests/test-projects/restore-netcore-offline/NuGet.config
@@ -1,0 +1,8 @@
+<configuration>
+    <config>
+        <add key="globalPackagesFolder" value="packages-cache" />
+    </config>
+    <packageSources>
+        <clear />
+    </packageSources>
+</configuration>

--- a/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.csproj
+++ b/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.sln
+++ b/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnetcoreconsole", "dotnetcoreconsole.csproj", "{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E8688F7-4FB5-4E0C-A64D-DA2B8E039CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Tests for the regression in NuGet 4.9 so it is found earlier than
during a manual test. NuGet restore should not go online to download
packages for a .NET Core 2.1 project when the 2.1 sdk is installed.
The NuGet fallback folder should be used. This test disables all
online nuget package sources, changes the global packages cache to
a temporary directory, and then tries to restore a .NET Core 2.1
console project. With NuGet 4.9 this new test fails to restore
with the error:

    Unable to resolve 'Microsoft.NETCore.App (>= 2.1.0)' for '.NETCoreApp,Version=v2.1'.