### PR TITLE
[NuGet] Fix NuGet sdk resolver

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/NuGetSdkResolverTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/NuGetSdkResolverTests.cs
@@ -23,29 +23,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
-using System.IO;
+
 using System.Threading.Tasks;
 using MonoDevelop.Projects;
 using NUnit.Framework;
 using UnitTests;
+
 namespace MonoDevelop.PackageManagement.Tests
 {
 	[TestFixture]
 	class NuGetSdkResolverTests : TestBase
 	{
-		[TestFixtureSetUp]
-		public void SetUp ()
-		{
-			ConfigureNuGetSdkResolver ();
-		}
-
-		static void ConfigureNuGetSdkResolver ()
-		{
-			string directory = Path.GetDirectoryName (typeof (PackageManagementServices).Assembly.Location);
-			Environment.SetEnvironmentVariable ("MSBUILD_NUGET_PATH", directory);
-		}
-
 		[Test]
 		public async Task ProjectUsingMSBuildSdkFromNuGet ()
 		{

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -6,6 +6,8 @@
 		<Import assembly="NuGet.Packaging.dll" />
 		<Import assembly="NuGet.Frameworks.dll" />
 		<Import assembly="NuGet.Versioning.dll" />
+		<Import assembly="NuGet.Commands.dll" />
+		<Import assembly="NuGet.LibraryModel.dll" />
 	</Runtime>
 
 	<Extension path = "/MonoDevelop/Ide/Commands">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementServices.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementServices.cs
@@ -68,8 +68,6 @@ namespace MonoDevelop.PackageManagement
 			credentialService = new PackageManagementCredentialService ();
 			credentialService.Initialize ();
 
-			ConfigureNuGetSdkResolver ();
-
 			PackageManagementBackgroundDispatcher.Initialize ();
 
 			nuGetConfigFileChangedMonitor.MonitorFileChanges ();
@@ -81,17 +79,6 @@ namespace MonoDevelop.PackageManagement
 		internal static void InitializeCredentialService ()
 		{
 			credentialService.Initialize ();
-		}
-
-		/// <summary>
-		/// Tell the NuGet SDK resolver included with MSBuild to look at the NuGet addin directory when
-		/// resolving the NuGet assemblies. The NuGet SDK resolver will download NuGet packages for
-		/// .NET Core projects that use SDKs provided by a NuGet package.
-		/// </summary>
-		static void ConfigureNuGetSdkResolver ()
-		{
-			string directory = Path.GetDirectoryName (typeof (PackageManagementServices).Assembly.Location);
-			Environment.SetEnvironmentVariable ("MSBUILD_NUGET_PATH", directory);
 		}
 
 		internal static PackageManagementOptions Options {


### PR DESCRIPTION
Opening a project that required the NuGet sdk resolver would
fail with an error about failing to load a NuGet assembly.

    Could not load file or assembly 'NuGet.Commands, Version=4.8.0.1,
    Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its
    dependencies.

The MSBUILD_NUGET_PATH environment variable is not supported in
a more recent NuGet sdk resolver, after it moved out of MSBuild
source code repository into NuGet's source code repository.
Before the NuGet 4.8 update the NuGet sdk resolver would find
the NuGet assemblies that it required, and were not already
loaded by the IDE, in its working directory. Latest NuGet sdk
resolvers are now included in the msbuild bin directory next to
the NuGet assemblies. Now after updating to NuGet 4.8 the sdk
resolver would fail to load the NuGet assemblies. To fix this
the NuGet addin now loads the NuGet assemblies with an import
so the NuGet sdk resolver can find them.

Fixes VSTS #751992 - NuGet sdk resolver fails to find assembly