### PR TITLE
[Ide] Try fixing random crasher in gdk event finalizer

### DIFF
--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -234,6 +234,8 @@ namespace MacPlatform
 
 		public TimeSpan GetEventTime (Gdk.EventKey eventKey)
 		{
+			// Gtk.Application.CurrentEvent and other copied gdk_events seem to have a problem
+			// when used as they use gdk_event_copy which seems to crash on de-allocating the private slice.
 			IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
 			bool equals = currentEvent == eventKey.Handle;
 			GtkWorkarounds.FreeEvent (currentEvent);

--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 
 using CoreFoundation;
 using Foundation;
-
+using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Desktop;
 
@@ -226,12 +226,22 @@ namespace MacPlatform
 			return KernelInterop.TrySampleHostCpu (out value);
 		}
 
+		[DllImport("libgtk-win32-2.0-0.dll", CallingConvention=CallingConvention.Cdecl)]
+		static extern IntPtr gtk_get_current_event ();
+
+		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void gdk_event_free (IntPtr raw);
+
 		public TimeSpan GetEventTime (Gdk.EventKey eventKey)
 		{
+			IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
+			bool equals = currentEvent == eventKey.Handle;
+			GtkWorkarounds.FreeEvent (currentEvent);
+
 			// If this GDK event is the current Gtk.Application event, assume that NSApplication's
 			// current event is the event from which the GDK event was created and use its timestamp
 			// instead, which has a much higher precision than the GDK time.
-			if (Gtk.Application.CurrentEvent == eventKey)
+			if (equals)
 				return FromNSTimeInterval (AppKit.NSApplication.SharedApplication.CurrentEvent.Timestamp);
 
 			return TimeSpan.FromMilliseconds (eventKey.Time);

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -86,6 +86,8 @@ namespace MonoDevelop.DesignerSupport
 
 					Gtk.Drag.SourceUnset (widget);
 
+					// Gtk.Application.CurrentEvent and other copied gdk_events seem to have a problem
+					// when used as they use gdk_event_copy which seems to crash on de-allocating the private slice.
 					IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
 					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent));
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -85,7 +85,12 @@ namespace MonoDevelop.DesignerSupport
 				if (!isDragging) {
 
 					Gtk.Drag.SourceUnset (widget);
-					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, Gtk.Global.CurrentEvent ?? new Gdk.Event (IntPtr.Zero));
+
+					IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
+					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent));
+
+					// gtk_drag_begin does not store the event, so we're okay
+					GtkWorkarounds.FreeEvent (currentEvent);
 
 				}
 			};

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1529,6 +1529,16 @@ namespace MonoDevelop.Components
 			GLib.Signal.Emit(container, "remove", child);
 #endif
 		}
+
+		[DllImport ("libgtk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gtk_get_current_event ();
+
+		public static IntPtr GetCurrentEventHandle () => gtk_get_current_event ();
+
+		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		static extern void gdk_event_free (IntPtr raw);
+
+		public static void FreeEvent (IntPtr raw) => gdk_event_free (raw);
 	}
 
 	public readonly struct KeyboardShortcut : IEquatable<KeyboardShortcut>


### PR DESCRIPTION
Fixes VSTS #739030 - [Feedback] Visual Studio Community 7.7 for Mac - crahses when holding down cursor key