### PR TITLE
[A11y] Make the headers on the error pad accessible from the keyboard

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -330,8 +330,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			foreach (TaskListEntry t in TaskService.Errors) {
 				AddTask (t);
 			}
-
-			control.FocusChain = new Gtk.Widget [] { logView };
 		}
 
 		public override void Dispose ()


### PR DESCRIPTION
Normally in Gtk if you focus a table and shift-tab the focus goes to the headers
but in the Errors pad, because the focus chain for the pad is set to be the
logView, the shift-tab focus breaks.

unsetting the focus chain fixes the header navigation issue, but stops the
logView being automatically focused. I have tried about 5 different ways to
make the logView still be the default focus, but none of them worked.
Discussing it with Sevo, we decided that making the logView the default focus
didn't really make sense anyway, so I've removed that.

Fixes VSTS #515118