### PR TITLE
[release-7.7] [C#] Fix NRE in completion querying

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -284,8 +284,8 @@ namespace MonoDevelop.CSharp.Completion
 
 				if (extensionMethodImport) {
 					if (ctx.TargetToken.Parent is MemberAccessExpressionSyntax memberAccess) {
-						var symbolInfo = ctx.SemanticModel.GetSymbolInfo (memberAccess.Expression);
-						if (symbolInfo.Symbol.Kind == SymbolKind.NamedType)
+						var symbol = ctx.SemanticModel.GetSymbolInfo (memberAccess.Expression).Symbol;
+						if (symbol != null && symbol.Kind == SymbolKind.NamedType)
 							return;
 						extensionMethodReceiverType = ctx.SemanticModel.GetTypeInfo (memberAccess.Expression).Type;
 						if (extensionMethodReceiverType == null) 


### PR DESCRIPTION
The semantic model might not contain a valid symbol at a given
syntax node which can happen in code that's not compilable.

Prevent that by adding a nullcheck

Fixes VSTS #714055 - AddImportCompletionData null reference exception

Backport of #6781.

/cc @Therzok 