### PR TITLE
[MEF] Add metadata about referenced assemblies into the MEF cache

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -273,7 +273,9 @@ namespace MonoDevelop.Ide.Composition
 							GatherDependencies (dependencyAssembly);
 						} catch (FileNotFoundException) {
 							// Discard in case the assembly is not found, this will be reported by MEF discovery anyway.
-							LoggingService.LogInfo ("Could not find dependency {0}, possibly missing Runtime import", dependencyName.FullName);
+							LoggingService.LogInfo ("Could not find dependency '{0}' referenced by '{1}', possibly missing Runtime import", dependencyName.FullName, currentAssembly.FullName);
+						} catch (Exception e) {
+							LoggingService.LogError ("Could not load assembly for MEF", e);
 						}
 					}
 				}


### PR DESCRIPTION
All assemblies now register their referenced assemblies into the composition cache file
(with the exception of assemblies which cannot be found, which will be reported
anyway by the MEF discovery error reporting).

With this, we can now invalidate the cache on assembly dependency changes and
on GAC changes (i.e. mono upgrade)

Fixes VSTS #734010 - MEF cache should invalidate on framework or dependency changes