### PR TITLE
[release-8.0-p1.1] [DesignerSupport] Fix Crasher when disposing the Toolbox

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -107,8 +107,17 @@ namespace MonoDevelop.DesignerSupport
 		bool isDragging = false;
 		public override void Dispose ()
 		{
-			widget.KeyPressEvent -= toolbox.OnKeyPressed;
-			widget.KeyReleaseEvent -= toolbox.KeyReleased;
+			if (widget != null) {
+				widget.KeyPressEvent -= toolbox.OnKeyPressed;
+				widget.KeyReleaseEvent -= toolbox.KeyReleased;
+				widget.Destroy ();
+				widget.Dispose ();
+				widget = null;
+			}
+			if (toolbox != null) {
+				toolbox.Dispose ();
+				toolbox = null;
+			}
 			base.Dispose ();
 		}
 #endif


### PR DESCRIPTION
If something fails during toolbox initialization, the event unsubscription might also fail. However it's not necessary to unsubscribe events, we should simply dispose the widgets being used.

@Therzok I'm not sure about all the event handlers, but it might still leak, could you take a quick look if you have time?

Fixes VSTS #753355

Backport of #6789.

/cc @sevoku 