### PR TITLE
[CodeCompletion] Fixes IndexOutOfBounds exception

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/AbstractGenerateAction.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.CodeGeneration/AbstractGenerateAction.cs
@@ -164,6 +164,7 @@ namespace MonoDevelop.CodeGeneration
 				data.EnsureCaretIsNotVirtual ();
 				int offset = data.CaretOffset;
 				var text = StringBuilderCache.ReturnAndFree (output).TrimStart ();
+				data.InsertAtCaret (text);				
 				var formattingService = options.DocumentContext?.AnalysisDocument?.GetLanguageService<IEditorFormattingService> ();
 				if (formattingService != null) {
 					var changes = formattingService.GetFormattingChangesAsync (options.DocumentContext.AnalysisDocument, new TextSpan (offset, text.Length), CancellationToken.None).WaitAndGetResult (CancellationToken.None);


### PR DESCRIPTION
 - In this [commit](https://github.com/mono/monodevelop/commit/6afd30f28a114ac5c717b52eba08e2876e29707f) we removed insert the data at caret, as a results CodeCompletion was throwing a unhandled exception due to a IndexOutOfBounds exception when calling `formattingService.GetFormattingChangesAsync`

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/752764