### PR TITLE
[Nuget] Add import NuGet.common.dll

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -8,6 +8,7 @@
 		<Import assembly="NuGet.Versioning.dll" />
 		<Import assembly="NuGet.Commands.dll" />
 		<Import assembly="NuGet.LibraryModel.dll" />
+		<Import assembly="NuGet.Common.dll" />
 	</Runtime>
 
 	<Extension path = "/MonoDevelop/Ide/Commands">


### PR DESCRIPTION
Xamarin.Ide uses this assembly and may need it to be registered. When running some tests via `mdtool` I have seen a failure to load the ide addin because this was not found.