### PR TITLE
[Mac] Add NSAppleEventsUsageDescription key

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -294,5 +294,7 @@
 		<string>zh-Hans</string>
 		<string>zh-Hant</string>
 	</array>
+	<key>NSAppleEventsUsageDescription</key>
+        <string>@APP_NAME@ needs to control applications through AppleScript</string>
 </dict>
 </plist>


### PR DESCRIPTION
With Mojave, an application cannot use AppleScript without the user granting it
permission, and the application will not ask for permission without this key
being present

Fixes VSTS #762097