### PR TITLE
[Ide] Make InfoBar API return a Control

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/IInfoBarHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/IInfoBarHost.cs
@@ -24,11 +24,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using MonoDevelop.Components;
+
 namespace MonoDevelop.Ide.Gui.Components
 {
 	interface IInfoBarHost
 	{
-		void AddInfoBar (InfoBarOptions options);
+		Control AddInfoBar (InfoBarOptions options);
 	}
 
 	public class InfoBarOptions

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -332,12 +332,13 @@ namespace MonoDevelop.Ide.Gui
 		}
 
 		readonly HashSet<object> deduplicationMap = new HashSet<object> ();
-		public void AddInfoBar (InfoBarOptions options)
+		public Control AddInfoBar (InfoBarOptions options)
 		{
 			var dedupId = options.Id ?? options.Description;
 			if (!deduplicationMap.Add (dedupId))
-				return;
+				return null;
 
+			Widget gtkWidget;
 #if NATIVE_INFO_BAR
 			// disabled for now, needs a patch in gtk.
 			Xwt.Widget infoBar = null;
@@ -345,14 +346,17 @@ namespace MonoDevelop.Ide.Gui
 				infoBar = new XwtInfoBar (options.Description, OnDispose, options.Items);
 			});
 			var widget = Xwt.Toolkit.CurrentEngine.WrapWidget (infoBar);
-			var gtkWidget = widget.ToGtkWidget ();
+			gtkWidget = widget.ToGtkWidget ();
 			infoBarFrame.Add (gtkWidget);
 #else
 			var infoBar = new XwtInfoBar (options.Description, OnDispose, options.Items);
-			infoBarFrame.Add (infoBar.ToGtkWidget ());
+			gtkWidget = infoBar.ToGtkWidget ();
+			infoBarFrame.Add (gtkWidget);
 #endif
 
 			void OnDispose () => deduplicationMap.Remove (dedupId);
+
+			return gtkWidget;
 		}
 		
 		public void CloseContent (ViewContent content)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -312,7 +312,7 @@ namespace MonoDevelop.Ide.Gui
 			workbench.Toolbar.HideCommandBar (barId);
 		}
 
-		public void ShowInfoBar (bool inActiveView, InfoBarOptions options)
+		public Control ShowInfoBar (bool inActiveView, InfoBarOptions options)
 		{
 			IInfoBarHost infoBarHost = null;
 			if (inActiveView) {
@@ -323,7 +323,7 @@ namespace MonoDevelop.Ide.Gui
 			if (infoBarHost == null)
 				infoBarHost = IdeApp.Workbench.RootWindow as IInfoBarHost;
 
-			infoBarHost?.AddInfoBar (options);
+			return infoBarHost?.AddInfoBar (options);
 		}
 
 		internal MonoDevelop.Components.MainToolbar.MainToolbarController Toolbar {


### PR DESCRIPTION
Right now there is no way to remove an InfoBar programmatically once it
has been added. This can be a problem for addins that show an InfoBar.
For example, iOS and Android addins each show an infobar in certain
situations. If Android addin shows the infobar and the developer closes
the solution without hiding the infobar, then loads a different solution
without an Android project the Android infobar will re-appear.

If we return a Control for the addin to reference then the addin can
dispose of it when it's no longer needed.