### PR TITLE
[WIP] Fix test failure due to stray FSW

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml
@@ -4,6 +4,7 @@
 		<Import assembly="Newtonsoft.Json.dll" />
 		<Import assembly="System.Collections.Immutable.dll" />
 		<Import assembly="System.Reflection.Metadata.dll" />
+		<Import assembly="System.Memory.dll" />
 	</Runtime>
 	
 	<ConditionType id="PackageInstalled" type="MonoDevelop.Core.AddIns.PackageInstalledCondition" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTree.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTree.cs
@@ -23,6 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+using System;
 using System.Collections.Generic;
 using System.IO;
 using MonoDevelop.Core;
@@ -111,16 +112,25 @@ namespace MonoDevelop.FSW
 			var currentNode = parent.FirstChild;
 			previousNode = null;
 
+			var remainingSegments = path.AsSpan ().TrimEnd (Path.DirectorySeparatorChar);
+
 			while (currentNode != null)
 			{
-				int currentIndex = path.IndexOf(Path.DirectorySeparatorChar, lastIndex);
-				int comparisonResult = string.Compare(currentNode.FullPath, currentNode.Start, path, lastIndex, currentNode.Length, FilePath.PathComparison);
+				var currentSegment = currentNode.GetSegment ();
 
+				// Chunk by directory separator
+				int currentIndex = remainingSegments.IndexOf (Path.DirectorySeparatorChar);
+
+				int segmentLength = currentIndex == -1 ? remainingSegments.Length : currentIndex;
+
+				var toAddSegment = remainingSegments.Slice (0, segmentLength);
+
+				int comparisonResult = currentSegment.CompareTo (toAddSegment, FilePath.PathComparison);
 				// We need to insert in this node's position.
 				if (comparisonResult > 0)
 					break;
 
-				// Keep searching.
+				// Keep searching if we still have items.
 				if (comparisonResult < 0)
 				{
 					previousNode = currentNode;
@@ -129,10 +139,11 @@ namespace MonoDevelop.FSW
 				}
 
 				// We found this segment in the tree.
-				lastIndex = currentIndex + 1;
+				remainingSegments = remainingSegments.Slice (Math.Min (currentIndex + 1, remainingSegments.Length));
+				lastIndex += currentIndex + 1;
 
 				// We found the node already, register the ID.
-				if (currentIndex == -1 || lastIndex == path.Length)
+				if (currentIndex == -1 || remainingSegments.Length == 0)
 				{
 					result = currentNode;
 					return true;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTree.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTree.cs
@@ -114,7 +114,7 @@ namespace MonoDevelop.FSW
 			while (currentNode != null)
 			{
 				int currentIndex = path.IndexOf(Path.DirectorySeparatorChar, lastIndex);
-				int comparisonResult = string.Compare(currentNode.FullPath, currentNode.Start, path, lastIndex, currentNode.Length);
+				int comparisonResult = string.Compare(currentNode.FullPath, currentNode.Start, path, lastIndex, currentNode.Length, FilePath.PathComparison);
 
 				// We need to insert in this node's position.
 				if (comparisonResult > 0)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTreeNode.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTreeNode.cs
@@ -12,15 +12,18 @@ namespace MonoDevelop.FSW
 		public PathTreeNode Next { get; set; }
 		public int ChildrenCount { get; set; }
 
+		readonly string fullPath;
+		readonly int start;
+		readonly int length;
+
 		readonly List<object> ids = new List<object> ();
 		internal void RegisterId (object id) => ids.Add (id);
 		internal bool UnregisterId (object id) => ids.Remove (id);
-		public bool IsLive => ids.Count != 0;
 
-		public ReadOnlySpan<char> GetPath () => DangerousPath.AsSpan (0, Start + Length);
-		internal string DangerousPath { get; }
-		internal int Start { get; }
-		internal int Length { get; }
+		public bool IsLive => ids.Count != 0;
+		public ReadOnlySpan<char> GetPath () => fullPath.AsSpan (0, start + length);
+		internal ReadOnlySpan<char> GetSegment () => fullPath.AsSpan (start, length);
+		internal string Segment => fullPath.Substring (start, length);
 
 		internal PathTreeNode LastChild {
 			get {
@@ -30,14 +33,12 @@ namespace MonoDevelop.FSW
 				return child;
 			}
 		}
-		internal ReadOnlySpan<char> GetSegment () => DangerousPath.AsSpan (Start, Length);
-		internal string Segment => DangerousPath.Substring (Start, Length);
 
 		public PathTreeNode (string fullPath, int start, int length)
 		{
-			DangerousPath = fullPath;
-			Start = start;
-			Length = length;
+			this.fullPath = fullPath;
+			this.start = start;
+			this.length = length;
 		}
 
 		internal static (PathTreeNode root, PathTreeNode leaf) CreateSubTree (string path, int start)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTreeNode.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.FSW/PathTreeNode.cs
@@ -17,9 +17,10 @@ namespace MonoDevelop.FSW
 		internal bool UnregisterId (object id) => ids.Remove (id);
 		public bool IsLive => ids.Count != 0;
 
-		public string FullPath { get; }
-		public int Start { get; }
-		public int Length { get; }
+		public ReadOnlySpan<char> GetPath () => DangerousPath.AsSpan (0, Start + Length);
+		internal string DangerousPath { get; }
+		internal int Start { get; }
+		internal int Length { get; }
 
 		internal PathTreeNode LastChild {
 			get {
@@ -29,11 +30,12 @@ namespace MonoDevelop.FSW
 				return child;
 			}
 		}
-		internal string Segment => FullPath.Substring (Start, Length);
+		internal ReadOnlySpan<char> GetSegment () => DangerousPath.AsSpan (Start, Length);
+		internal string Segment => DangerousPath.Substring (Start, Length);
 
 		public PathTreeNode (string fullPath, int start, int length)
 		{
-			FullPath = fullPath;
+			DangerousPath = fullPath;
 			Start = start;
 			Length = length;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Projects
 				if (token.IsCancellationRequested)
 					return;
 
-				var newPathsToWatch = tree.Normalize (maxWatchers).Select (node => (FilePath)node.FullPath);
+				var newPathsToWatch = tree.Normalize (maxWatchers).Select (node => (FilePath)node.GetPath ().ToString ());
 				var newWatchers = new HashSet<FilePath> (newPathsToWatch.Where (dir => Directory.Exists (dir)));
 				if (newWatchers.Count == 0 && watchers.Count == 0) {
 					// Unchanged.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -2129,7 +2129,18 @@ namespace MonoDevelop.Components.Commands
 				}
 			}
 
+#if MAC
+			if (!hasFocus) {
+				var nsWindow = AppKit.NSApplication.SharedApplication.KeyWindow;
+				hasFocus = nsWindow != null;
+				lastFocused = win = Mac.GtkMacInterop.GetGtkWindow (nsWindow);
+			} else {
+				lastFocused = newFocused;
+			}
+#else
 			lastFocused = newFocused;
+#endif
+
 			UpdateAppFocusStatus (hasFocus, lastFocusedExists);
 			
 			if (win != null && win.IsRealized) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
@@ -153,6 +153,7 @@ namespace MonoDevelop.Ide.Editor
 				FileService.FileRenamed -= FileService_FileMoved;
 				FileService.FileRemoved -= FileService_FileRemoved;
 				FileService.FileChanged -= FileService_FileChanged;
+				FileWatcherService.WatchDirectories (this, null).Ignore ();
 				lock (watchedFiles) {
 					watchedFiles = null;
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
@@ -97,7 +97,7 @@ namespace MonoDevelop.Ide.Editor
 
 		class ConventionsFileManager : IFileWatcher
 		{
-			HashSet<string> watchedFiles = new HashSet<string> ();
+			HashSet<FilePath> watchedFiles = new HashSet<FilePath> ();
 
 			public event ConventionsFileChangedAsyncEventHandler ConventionFileChanged;
 			public event ContextFileMovedAsyncEventHandler ContextFileMoved;
@@ -116,8 +116,9 @@ namespace MonoDevelop.Ide.Editor
 					foreach (var file in e) {
 						if (watchedFiles.Remove (file.SourceFile)) {
 							ContextFileMoved?.Invoke (this, new ContextFileMovedEventArgs (file.SourceFile, file.TargetFile));
-							if (file.SourceFile.FileName == file.TargetFile.FileName)
+							if (file.SourceFile == file.TargetFile) {
 								StartWatching (file.TargetFile.FileName, file.TargetFile.ParentDirectory);
+							}
 						}
 					}
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.MetadataReferenceCache.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.MetadataReferenceCache.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
@@ -38,6 +39,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			readonly Dictionary<string, Dictionary<MetadataReferenceProperties, MonoDevelopMetadataReference>> cacheWithCustomProperties = new Dictionary<string, Dictionary<MetadataReferenceProperties, MonoDevelopMetadataReference>> ();
 			public MonoDevelopMetadataReference GetOrCreate (MonoDevelopMetadataReferenceManager provider, string path, MetadataReferenceProperties properties)
 			{
+				path = new FilePath (path).ResolveLinks ();
+
 				if (properties == MetadataReferenceProperties.Assembly) {
 					// fast path for no custom properties
 					return GetOrCreate (cacheAssemblyProperties, path, provider, path, properties);

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/EditorConfigTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Editor/EditorConfigTests.cs
@@ -57,9 +57,13 @@ namespace MonoDevelop.Ide.Editor
 				var editor = TextEditorFactory.CreateNewEditor ();
 				var viewContent = editor.GetViewContent ();
 				string fileName = Path.Combine (tempPath, "a.cs");
-				using (var ctx = await EditorConfigService.GetEditorConfigContext (fileName)) {
-					((DefaultSourceEditorOptions)editor.Options).SetContext (ctx);
-					test (editor);
+				try {
+					using (var ctx = await EditorConfigService.GetEditorConfigContext (fileName)) {
+						((DefaultSourceEditorOptions)editor.Options).SetContext (ctx);
+						test (editor);
+					}
+				} finally {
+					await EditorConfigService.RemoveEditConfigContext (fileName);
 				}
 			} finally {
 				Directory.Delete (tempPath, true);

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.MetadataReferenceCacheTests.cs
@@ -64,8 +64,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			try {
 				using (var sol = (MonoDevelop.Projects.Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 				using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
-					await FileWatcherService.Add (sol);
-
 					var manager = ws.MetadataReferenceManager;
 					var item = manager.GetOrCreateMetadataReference (tempPath, MetadataReferenceProperties.Assembly);
 					Assert.IsNotNull (item);
@@ -89,7 +87,7 @@ namespace MonoDevelop.Ide.TypeSystem
 					Assert.AreNotEqual (initialId, item.CurrentSnapshot.GetMetadataId ());
 
 					var taskForOldAsm = WaitForSnapshotChange (item);
-					File.Copy (newAsm, tempPath, true);
+					File.Copy (oldAsm, tempPath, true);
 
 					var argsForOldAsm = await taskForOldAsm;
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceTests.cs
@@ -77,6 +77,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			var messagingAsm = assemblies.Single (x => x.Metadata.GetValue<string> ("Filename") == name);
 			var metadataReference = manager.GetOrCreateMetadataReference (messagingAsm.FilePath, MetadataReferenceProperties.Assembly);
 
+			await FileWatcherService.Update ();
+
 			var roslynProj = ws.GetProjectId (to);
 
 			var oldRefs = ws.CurrentSolution.GetProject (roslynProj).MetadataReferences;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -53,6 +53,7 @@
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoDevelop.Core\BacktrackingStringMatcherTests.cs" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -53,7 +53,10 @@
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+    <Reference Include="System.Memory">
+      <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoDevelop.Core\BacktrackingStringMatcherTests.cs" />

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.FSW/PathTreeTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.FSW/PathTreeTests.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.FSW
 
 			if (!Platform.IsWindows) {
 				node = node.FirstChild;
-				Assert.AreEqual ("/", node.FullPath);
+				Assert.AreEqual ("/", node.DangerousPath);
 			}
 
 			Assert.IsNull (node.FirstChild);
@@ -423,6 +423,7 @@ namespace MonoDevelop.FSW
 		/// Parent 'lib' directory was being dropped since the PathTree considered it to be a child of the mmp directory.
 		/// </summary>
 		[Test]
+		[Platform (Exclude = "Win")]
 		public void NormalizeTwoDirectories_FirstIsChildOfSecondDirectoryAdded ()
 		{
 			var tree = new PathTree ();
@@ -431,7 +432,7 @@ namespace MonoDevelop.FSW
 			tree.AddNode ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mmp", id1);
 			tree.AddNode ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib", id1);
 
-			var folders = tree.Normalize (10).Select (node => (FilePath)node.FullPath);
+			var folders = tree.Normalize (10).Select (node => (FilePath)node.GetPath ().ToString ());
 			var set = new HashSet <FilePath> (folders);
 
 			Assert.IsTrue (set.Contains ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib"), "Set: " + string.Join ("\n", set));
@@ -442,6 +443,7 @@ namespace MonoDevelop.FSW
 		/// being ignored. The PathTree considers them children of the gac/System directory.
 		/// </summary>
 		[Test]
+		[Platform(Exclude="Win")]
 		public void NormalizeSeveralDirectories_CommonBaseDirectory ()
 		{
 			var tree = new PathTree ();
@@ -459,7 +461,7 @@ namespace MonoDevelop.FSW
 				tree.AddNode (path, id1);
 			}
 
-			var folders = tree.Normalize (10).Select (node => (FilePath)node.FullPath);
+			var folders = tree.Normalize (10).Select (node => (FilePath)node.GetPath ().ToString ());
 			var set = new HashSet<FilePath> (folders);
 
 			foreach (var path in paths) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.FSW/PathTreeTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.FSW/PathTreeTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using MonoDevelop.Core;
@@ -416,6 +417,54 @@ namespace MonoDevelop.FSW
 			nodes = tree.Normalize (7).ToArray ();
 			Assert.AreEqual (1, nodes.Length);
 			Assert.AreEqual ("a", nodes [0].Segment);
+		}
+
+		/// <summary>
+		/// Parent 'lib' directory was being dropped since the PathTree considered it to be a child of the mmp directory.
+		/// </summary>
+		[Test]
+		public void NormalizeTwoDirectories_FirstIsChildOfSecondDirectoryAdded ()
+		{
+			var tree = new PathTree ();
+			var id1 = new object ();
+
+			tree.AddNode ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mmp", id1);
+			tree.AddNode ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib", id1);
+
+			var folders = tree.Normalize (10).Select (node => (FilePath)node.FullPath);
+			var set = new HashSet <FilePath> (folders);
+
+			Assert.IsTrue (set.Contains ("/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib"), "Set: " + string.Join ("\n", set));
+		}
+
+		/// <summary>
+		/// All /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/gac/System.* subdirectories are
+		/// being ignored. The PathTree considers them children of the gac/System directory.
+		/// </summary>
+		[Test]
+		public void NormalizeSeveralDirectories_CommonBaseDirectory ()
+		{
+			var tree = new PathTree ();
+			var id1 = new object ();
+
+			var paths = new string[] {
+				"/Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/4.5",
+				"/Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/gac/System/4.0.0.0__b77a5c561934e089",
+				"/Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/gac/System.Core/4.0.0.0__b77a5c561934e089",
+				"/Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/gac/System.Data/4.0.0.0__b77a5c561934e089",
+				"/Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/gac/System.Xml/4.0.0.0__b77a5c561934e089"
+			};
+
+			foreach (var path in paths) {
+				tree.AddNode (path, id1);
+			}
+
+			var folders = tree.Normalize (10).Select (node => (FilePath)node.FullPath);
+			var set = new HashSet<FilePath> (folders);
+
+			foreach (var path in paths) {
+				Assert.IsTrue (set.Contains (path), "Set: " + string.Join ("\n", set));
+			}
 		}
 
 		[Test]

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.FSW/PathTreeTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.FSW/PathTreeTests.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.FSW
 
 			if (!Platform.IsWindows) {
 				node = node.FirstChild;
-				Assert.AreEqual ("/", node.DangerousPath);
+				Assert.AreEqual ("", node.GetPath ().ToString ());
 			}
 
 			Assert.IsNull (node.FirstChild);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileServiceTests.cs
@@ -118,17 +118,20 @@ namespace MonoDevelop.Projects
 		{
 			FileService.FreezeEvents ();
 
-			var tmp = System.IO.Path.GetTempFileName ();
-			FileService.NotifyFileChanged (tmp);
+			try {
+				var tmp = System.IO.Path.GetTempFileName ();
+				FileService.NotifyFileChanged (tmp);
 
-			FileService.CopyFile (tmp, tmp + ".tmp");
-			FileService.DeleteFile (tmp);
-			FileService.DeleteFile (tmp + ".tmp");
+				FileService.CopyFile (tmp, tmp + ".tmp");
+				FileService.DeleteFile (tmp);
+				FileService.DeleteFile (tmp + ".tmp");
 
-			FileService.NotifyFileRemoved (tmp);
-			FileService.NotifyFileRemoved (tmp + ".tmp");
+				FileService.NotifyFileRemoved (tmp);
+				FileService.NotifyFileRemoved (tmp + ".tmp");
+			} finally {
+				FileService.ThawEvents ();
 
-			FileService.ThawEvents ();
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes VSTS #761524 - Test failure: MonoDevelopMetadataReferenceManagerMetadataReferenceCacheTests.ReferenceCacheSnapshotUpdates)
Fixes VSTS #738457 - FileWatcherService stops monitoring solution directory
Fixes VSTS #755011 - FileSystemWatcher is not watching the correct directories