### PR TITLE
[DotNetCore] Fix type resolution errors for signed projects

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -18,6 +18,10 @@
     <Reference Include="NuGet.Versioning">
       <HintPath>..\..\..\..\packages\NuGet.Versioning.4.9.0-rtm.5658\lib\net46\NuGet.Versioning.dll</HintPath>
     </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\..\..\build\bin\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTests.cs
@@ -437,5 +437,31 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.AreEqual ("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}", project.TypeGuid);
 			Assert.AreEqual (solutionFileText, newSolutionFileText);
 		}
+
+		[Test]
+		public async Task NetStandard_EnsureGeneratedAssemblyInfoAvailableToTypeSystem ()
+		{
+			var solFile = Util.GetSampleProject ("netstandard-sdk", "netstandard-sdk.sln");
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (Project)sol.Items [0];
+
+				var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
+				Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+				Assert.AreEqual (0, process.ExitCode);
+
+				var debugConfig = new SolutionConfigurationSelector ("Debug");
+				var debugSourceFiles = await p.GetSourceFilesAsync (Util.GetMonitor (), debugConfig);
+
+				var releaseConfig = new SolutionConfigurationSelector ("Release");
+				var releaseSourceFiles = await p.GetSourceFilesAsync (Util.GetMonitor (), releaseConfig);
+
+				var expectedDebugAssemblyInfoFile = p.BaseIntermediateOutputPath.Combine ("Debug", "netstandard1.4", "netstandard-sdk.AssemblyInfo.cs");
+				var expectedReleaseAssemblyInfoFile = p.BaseIntermediateOutputPath.Combine ("Release", "netstandard1.4", "netstandard-sdk.AssemblyInfo.cs");
+
+				Assert.IsTrue (debugSourceFiles.Any (f => f.FilePath == expectedDebugAssemblyInfoFile));
+				Assert.IsTrue (releaseSourceFiles.Any (f => f.FilePath == expectedReleaseAssemblyInfoFile));
+			}
+		}
 	}
 }

--- a/main/tests/test-projects/netstandard-sdk/Class1.cs
+++ b/main/tests/test-projects/netstandard-sdk/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace netstandard_sdk
+{
+	public class Class1
+	{
+	}
+}

--- a/main/tests/test-projects/netstandard-sdk/netstandard-sdk.csproj
+++ b/main/tests/test-projects/netstandard-sdk/netstandard-sdk.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/netstandard-sdk/netstandard-sdk.sln
+++ b/main/tests/test-projects/netstandard-sdk/netstandard-sdk.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netstandard-sdk", "netstandard-sdk.csproj", "{5B443F8D-6C84-443F-A395-5429E8F4A47D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
With two sdk projects, Lib1 and Lib2, where Lib1 has its output
assembly signed, then in Lib2 any use of any types from Lib1 would
show errors in the text editor after the solution was built. Errors
similar to:

    The type 'Class1' exists in both 'Lib1, Version=0.0.0.0, Culture=Neutral, PublicKeyToken='
    and 'Lib2, Version=1.0.0.0, Culture=neutral, PublicKeyToken='

This was because the generated AssemblyInfo.cs file which exists in
the obj directory was available to the type system so there was a
mismatch in the assembly information from the assembly .dll on disk
and the project information which resulted in Roslyn creating two
references. The generated AssemblyInfo.cs file is now returned to
the type system when it calls Project.GetSourceFilesAsync.

Fixes VSTS #753821 - Inline type resolution errors when project
references are public signed