### PR TITLE
Revert "Use an exclusive scheduler for FileWatchers"

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
@@ -40,8 +40,6 @@ namespace MonoDevelop.Projects
 	{
 		// We don't want more than 8 threads for FileSystemWatchers.
 		const int maxWatchers = 8;
-		static readonly ConcurrentExclusiveSchedulerPair pair = new ConcurrentExclusiveSchedulerPair ();
-		static readonly TaskFactory exclusiveFactory = new TaskFactory (pair.ExclusiveScheduler);
 
 		static readonly PathTree tree = new PathTree ();
 		static readonly Dictionary<FilePath, FileWatcherWrapper> watchers = new Dictionary<FilePath, FileWatcherWrapper> ();
@@ -78,7 +76,7 @@ namespace MonoDevelop.Projects
 			cancellationTokenSource = new CancellationTokenSource ();
 			CancellationToken token = cancellationTokenSource.Token;
 
-			return exclusiveFactory.StartNew (() => UpdateWatchers (token), token);
+			return Task.Run (() => UpdateWatchers (token));
 		}
 
 		static void UpdateWatchers (CancellationToken token)


### PR DESCRIPTION
This reverts commit 8828c71e82a7d252d6bcec7c47e11d9325f31a22.

Fixes VSTS #758567