### PR TITLE
[Ide] Draw focus rect for ImageView

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
@@ -131,8 +131,8 @@ namespace MonoDevelop.Components
 
 					if (HasFocus) {
 						ctx.SetSourceColor (Styles.BaseSelectionBackgroundColor.ToCairoColor ());
-						ctx.LineWidth = 1.0;
-						ctx.Rectangle (x - Xpad, y - Ypad, image.Width + Xpad, Image.Height + Ypad);
+						ctx.LineWidth = 2.0;
+						ctx.RoundedRectangle (x, y, image.Width, Image.Height, 4.0);
 						ctx.Stroke ();
 					}
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using Gdk;
+using MonoDevelop.Ide.Gui;
 
 namespace MonoDevelop.Components
 {
@@ -127,6 +128,13 @@ namespace MonoDevelop.Components
 					ctx.Save ();
 					ctx.DrawImage (this, IsParentDisabled () ? image.WithAlpha (0.4) : image, x, y);
 					ctx.Restore ();
+
+					if (HasFocus) {
+						ctx.SetSourceColor (Styles.BaseSelectionBackgroundColor.ToCairoColor ());
+						ctx.LineWidth = 1.0;
+						ctx.Rectangle (x, y, image.Width - 1, Image.Height - 1);
+						ctx.Stroke ();
+					}
 				}
 			}
 			return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ImageView.cs
@@ -132,7 +132,7 @@ namespace MonoDevelop.Components
 					if (HasFocus) {
 						ctx.SetSourceColor (Styles.BaseSelectionBackgroundColor.ToCairoColor ());
 						ctx.LineWidth = 1.0;
-						ctx.Rectangle (x, y, image.Width - 1, Image.Height - 1);
+						ctx.Rectangle (x - Xpad, y - Ypad, image.Width + Xpad, Image.Height + Ypad);
 						ctx.Stroke ();
 					}
 				}


### PR DESCRIPTION
Because this is an app-paintable widget it doesn't draw a focus
rectangle as needed. There doesn't seem to be a themable color for
drawing focus rectangles so I'm choosing this style color just
because it seems to look the best.

Fixes VSTS #751980