### PR TITLE
Fixes issue #6730 [8.0p1] C# error squiggles never go away A canceled

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Result.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.AnalysisCore/Result.cs
@@ -27,6 +27,7 @@
 using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using MonoDevelop.Ide.Editor.Extension;
 
 namespace MonoDevelop.AnalysisCore
 {
@@ -67,6 +68,7 @@ namespace MonoDevelop.AnalysisCore
 		public TextSpan Region { get; private set; }
 		
 		public bool Underline { get; private set; }
+		public QuickTask QuickTask { get; internal set; }
 
 		internal bool Equals (Result other, int correctedOffset)
 		{


### PR DESCRIPTION
operation could leave the editor in a half updated state. This should
prevent that from happening.
+ Fixed a bug where the quick task update was broken.