### PR TITLE
[WIP] Support ItemDefinitionGroup

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -744,6 +744,7 @@
     <Compile Include="MonoDevelop.Core.FeatureConfiguration\FeatureSwitchCondition.cs" />
     <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildProcessService.cs" />
     <Compile Include="MonoDevelop.Core.FeatureConfiguration\IFeatureSwitchController.cs" />
+    <Compile Include="MonoDevelop.Projects.MSBuild\MSBuildItemDefinitionGroup.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="BuildVariables.cs.in" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -1267,7 +1267,6 @@ namespace MonoDevelop.Projects.MSBuild
 				var trueCond = conditionIsTrue && (string.IsNullOrEmpty (item.Condition) || SafeParseAndEvaluate (project, context, item.Condition));
 				if (trueCond) {
 					var it = CreateEvaluatedItem (context, project, project.Project, item, string.Empty);
-					((MSBuildPropertyGroupEvaluated)it.Metadata).ItemName = null;
 					project.EvaluatedItemDefinitions.Add (it);
 				}
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -61,6 +61,7 @@ namespace MonoDevelop.Projects.MSBuild
 			public MSBuildProject Project;
 			public List<MSBuildItemEvaluated> EvaluatedItemsIgnoringCondition = new List<MSBuildItemEvaluated> ();
 			public List<MSBuildItemEvaluated> EvaluatedItems = new List<MSBuildItemEvaluated> ();
+			public List<MSBuildItemEvaluated> EvaluatedItemDefinitions = new List<MSBuildItemEvaluated> ();
 			public Dictionary<string,PropertyInfo> Properties = new Dictionary<string, PropertyInfo> (StringComparer.OrdinalIgnoreCase);
 			public Dictionary<MSBuildImport,string> Imports = new Dictionary<MSBuildImport, string> ();
 			public Dictionary<string,string> GlobalProperties = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
@@ -211,6 +212,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			pi.EvaluatedItemsIgnoringCondition.Clear ();
 			pi.EvaluatedItems.Clear ();
+			pi.EvaluatedItemDefinitions.Clear ();
 			pi.Properties.Clear ();
 			pi.Imports.Clear ();
 			pi.Targets.Clear ();
@@ -313,6 +315,8 @@ namespace MonoDevelop.Projects.MSBuild
 						Evaluate (pi, context, (MSBuildItemGroup)ob);
 					else if (ob is MSBuildTarget)
 						Evaluate (pi, context, (MSBuildTarget)ob);
+					else if (ob is MSBuildItemDefinitionGroup)
+						Evaluate (pi, context, (MSBuildItemDefinitionGroup)ob);
 				} else {
 					if (ob is MSBuildPropertyGroup)
 						Evaluate (pi, context, (MSBuildPropertyGroup)ob);
@@ -1076,6 +1080,9 @@ namespace MonoDevelop.Projects.MSBuild
 						it.IsImported = true;
 						project.EvaluatedItemsIgnoringCondition.Add (it);
 					}
+					foreach (var it in p.EvaluatedItemDefinitions) {
+						project.EvaluatedItemDefinitions.Add (it);
+					}
 					foreach (var t in p.Targets) {
 						t.IsImported = true;
 						project.Targets.Add (t);
@@ -1247,6 +1254,23 @@ namespace MonoDevelop.Projects.MSBuild
 			project.TargetsIgnoringCondition.Add (newTarget);
 			if (condIsTrue)
 				project.Targets.Add (newTarget);
+		}
+
+		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItemDefinitionGroup items)
+		{
+			bool conditionIsTrue = true;
+
+			if (!string.IsNullOrEmpty (items.Condition))
+				conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition);
+
+			foreach (var item in items.Items) {
+				var trueCond = conditionIsTrue && (string.IsNullOrEmpty (item.Condition) || SafeParseAndEvaluate (project, context, item.Condition));
+				if (trueCond) {
+					var it = CreateEvaluatedItem (context, project, project.Project, item, string.Empty);
+					((MSBuildPropertyGroupEvaluated)it.Metadata).ItemName = null;
+					project.EvaluatedItemDefinitions.Add (it);
+				}
+			}
 		}
 
 		ImmutableDictionary<string, ConditionExpression> conditionCache = ImmutableDictionary<string, ConditionExpression>.Empty;
@@ -1497,6 +1521,11 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 
 			return false;
+		}
+
+		internal override IEnumerable<object> GetEvaluatedItemDefinitions (object projectInstance)
+		{
+			return ((ProjectInfo)projectInstance).EvaluatedItemDefinitions;
 		}
 
 		#endregion

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngine.cs
@@ -109,6 +109,8 @@ namespace MonoDevelop.Projects.MSBuild
 		public abstract IEnumerable<MSBuildItem> FindGlobItemsIncludingFile  (object projectInstance, string include);
 
 		internal abstract IEnumerable<MSBuildItem> FindUpdateGlobItemsIncludingFile (object projectInstance, string include, MSBuildItem globItem);
+
+		internal abstract IEnumerable<object> GetEvaluatedItemDefinitions (object projectInstance);
 	}
 }
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngineV12.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEngineV12.cs
@@ -200,6 +200,11 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			throw new NotImplementedException ();
 		}
+
+		internal override IEnumerable<object> GetEvaluatedItemDefinitions (object projectInstance)
+		{
+			throw new NotImplementedException ();
+		}
 	}
 
 	#if !WINDOWS

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItem.cs
@@ -289,7 +289,7 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			this.include = include;
 			this.evaluatedInclude = evaluatedInclude;
-			metadata = new MSBuildPropertyGroupEvaluated (parent, name);
+			metadata = new MSBuildPropertyGroupEvaluated (parent);
 			Name = name;
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItem.cs
@@ -289,7 +289,7 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			this.include = include;
 			this.evaluatedInclude = evaluatedInclude;
-			metadata = new MSBuildPropertyGroupEvaluated (parent);
+			metadata = new MSBuildPropertyGroupEvaluated (parent, name);
 			Name = name;
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItemDefinitionGroup.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItemDefinitionGroup.cs
@@ -1,0 +1,53 @@
+//
+// MSBuildItemDefinitionGroup.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoDevelop.Projects.MSBuild
+{
+	public class MSBuildItemDefinitionGroup : MSBuildElement
+	{
+		internal override void ReadChildElement (MSBuildXmlReader reader)
+		{
+			var item = new MSBuildItem ();
+			item.ParentNode = this;
+			item.Read (reader);
+			ChildNodes = ChildNodes.Add (item);
+		}
+
+		internal override string GetElementName ()
+		{
+			return "ItemDefinitionGroup";
+		}
+
+		public IEnumerable<MSBuildItem> Items {
+			get {
+				return ChildNodes.OfType<MSBuildItem> ();
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -729,15 +729,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal IMSBuildPropertyGroupEvaluated GetEvaluatedItemDefinitionProperties (string itemName)
 		{
-			if (itemName == null)
-				return null;
-
-			foreach (var it in mainProjectInstance.EvaluatedItemDefinitions) {
-				if (it.Name == itemName) {
-					return it.Metadata;
-				}
-			}
-			return null;
+			return mainProjectInstance.GetEvaluatedItemDefinitionProperties (itemName);
 		}
 
 		public IEnumerable<IMSBuildItemEvaluated> EvaluatedItems

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -332,6 +332,7 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			MSBuildObject ob = null;
 			switch (reader.LocalName) {
+				case "ItemDefinitionGroup": ob = new MSBuildItemDefinitionGroup (); break;
 				case "ItemGroup": ob = new MSBuildItemGroup (); break;
 				case "PropertyGroup": ob = new MSBuildPropertyGroup (); break;
 				case "ImportGroup": ob = new MSBuildImportGroup (); break;
@@ -860,6 +861,11 @@ namespace MonoDevelop.Projects.MSBuild
 		public IEnumerable<MSBuildItemGroup> ItemGroups
 		{
 			get { return ChildNodes.OfType<MSBuildItemGroup> (); }
+		}
+
+		public IEnumerable<MSBuildItemDefinitionGroup> ItemDefinitionGroups
+		{
+			get { return ChildNodes.OfType<MSBuildItemDefinitionGroup> (); }
 		}
 
 		public IEnumerable<MSBuildImportGroup> ImportGroups

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -727,6 +727,19 @@ namespace MonoDevelop.Projects.MSBuild
 			get { return mainProjectInstance != null ? mainProjectInstance.EvaluatedProperties : (IMSBuildEvaluatedPropertyCollection)GetGlobalPropertyGroup (); }
 		}
 
+		internal IMSBuildPropertyGroupEvaluated GetEvaluatedItemDefinitionProperties (string itemName)
+		{
+			if (itemName == null)
+				return null;
+
+			foreach (var it in mainProjectInstance.EvaluatedItemDefinitions) {
+				if (it.Name == itemName) {
+					return it.Metadata;
+				}
+			}
+			return null;
+		}
+
 		public IEnumerable<IMSBuildItemEvaluated> EvaluatedItems
 		{
 			get { return mainProjectInstance.EvaluatedItems; }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.Projects.MSBuild
 		MSBuildProject msproject;
 		List<IMSBuildItemEvaluated> evaluatedItems = new List<IMSBuildItemEvaluated> ();
 		List<IMSBuildItemEvaluated> evaluatedItemsIgnoringCondition = new List<IMSBuildItemEvaluated> ();
+		List<IMSBuildItemEvaluated> evaluatedItemDefinitions = new List<IMSBuildItemEvaluated> ();
 		MSBuildEvaluatedPropertyCollection evaluatedProperties;
 		MSBuildTarget[] targets = new MSBuildTarget[0];
 		MSBuildTarget[] targetsIgnoringCondition = new MSBuildTarget[0];
@@ -124,9 +125,16 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			evaluatedItemsIgnoringCondition.Clear ();
 			evaluatedItems.Clear ();
+			evaluatedItemDefinitions.Clear ();
 
 			if (!OnlyEvaluateProperties) {
-				
+				foreach (var it in e.GetEvaluatedItemDefinitions (project)) {
+					var xit = it as MSBuildItemEvaluated;
+					if (xit != null) {
+						evaluatedItemDefinitions.Add (xit);
+					}
+				}
+
 				var evalItems = new Dictionary<string,MSBuildItemEvaluated> ();
 				foreach (var it in e.GetEvaluatedItems (project)) {
 					var xit = it as MSBuildItemEvaluated;
@@ -199,6 +207,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public IMSBuildEvaluatedPropertyCollection EvaluatedProperties {
 			get { return evaluatedProperties; }
+		}
+
+		internal IEnumerable<IMSBuildItemEvaluated> EvaluatedItemDefinitions {
+			get { return evaluatedItemDefinitions; }
 		}
 
 		public IEnumerable<IMSBuildItemEvaluated> EvaluatedItems {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProjectInstance.cs
@@ -183,6 +183,7 @@ namespace MonoDevelop.Projects.MSBuild
 							evalItemsNoCond [key] = xit;
 						}
 					}
+					UpdateMetadata (xit);
 					evaluatedItemsIgnoringCondition.Add (xit);
 				}
 
@@ -199,6 +200,21 @@ namespace MonoDevelop.Projects.MSBuild
 			props.SyncCollection (e, project);
 
 			conditionedProperties = engine.GetConditionedProperties (project);
+		}
+
+		void UpdateMetadata (MSBuildItemEvaluated it)
+		{
+			if (evaluatedItemDefinitions == null)
+				return;
+
+			if (!evaluatedItemDefinitions.TryGetValue (it.Name, out MSBuildPropertyGroupEvaluated itemDefProps))
+				return;
+
+			var props = (MSBuildPropertyGroupEvaluated)it.Metadata;
+			foreach (var evaluatedProp in itemDefProps.GetProperties ()) {
+				if (!props.HasProperty (evaluatedProp.Name))
+					props.SetProperty (evaluatedProp.Name, evaluatedProp);
+			}
 		}
 
 		MSBuildItemEvaluated CreateEvaluatedItem (MSBuildEngine e, object it)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
@@ -48,9 +48,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal string ItemName { get; set; }
 
-		internal void Sync (MSBuildEngine engine, object item)
+		internal void Sync (MSBuildEngine engine, object item, bool clearProperties = true)
 		{
-			properties.Clear ();
+			if (clearProperties)
+				properties.Clear ();
 			this.engine = engine;
 			foreach (var propName in engine.GetItemMetadataNames (item)) {
 				var prop = new MSBuildPropertyEvaluated (ParentProject, propName, engine.GetItemMetadata (item, propName), engine.GetEvaluatedItemMetadata (item, propName));

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
@@ -40,14 +40,6 @@ namespace MonoDevelop.Projects.MSBuild
 			ParentProject = parent;
 		}
 
-		internal MSBuildPropertyGroupEvaluated (MSBuildProject parent, string itemName)
-		{
-			ParentProject = parent;
-			ItemName = itemName;
-		}
-
-		internal string ItemName { get; set; }
-
 		internal void Sync (MSBuildEngine engine, object item, bool clearProperties = true)
 		{
 			if (clearProperties)
@@ -67,14 +59,8 @@ namespace MonoDevelop.Projects.MSBuild
 		public IMSBuildPropertyEvaluated GetProperty (string name)
 		{
 			IMSBuildPropertyEvaluated prop;
-			if (properties.TryGetValue (name, out prop))
-				return prop;
-
-			if (ParentProject == null)
-				return null;
-
-			var itemDefinitionProps = ParentProject.GetEvaluatedItemDefinitionProperties (ItemName);
-			return itemDefinitionProps?.GetProperty (name);
+			properties.TryGetValue (name, out prop);
+			return prop;
 		}
 
 		internal void SetProperty (string key, IMSBuildPropertyEvaluated value)
@@ -89,18 +75,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public IEnumerable<IMSBuildPropertyEvaluated> GetProperties ()
 		{
-			foreach (var prop in properties.Values) {
-				yield return prop;
-			}
-
-			var itemDefinitionProps = ParentProject?.GetEvaluatedItemDefinitionProperties (ItemName);
-			if (itemDefinitionProps != null) {
-				foreach (var prop in itemDefinitionProps.GetProperties ()) {
-					if (!properties.ContainsKey (prop.Name)) {
-						yield return prop;
-					}
-				}
-			}
+			return properties.Values;
 		}
 
 		internal bool RemoveProperty (string name)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3850,7 +3850,14 @@ namespace MonoDevelop.Projects
 					item.Write (this, buildItem);
 					PurgeUpdatePropertiesSetInSourceItems (buildItem, item.BackingEvalItem.SourceItems, propertiesAlreadySet);
 				} else {
-					item.Write (this, buildItem);
+					var itemDefinitionProps = msproject.GetEvaluatedItemDefinitionProperties (buildItem.Name);
+					if (itemDefinitionProps != null) {
+						var propertiesAlreadySet = new HashSet<string> (buildItem.Metadata.GetProperties ().Select (p => p.Name));
+						item.Write (this, buildItem);
+						PurgeItemDefinitionProperties (buildItem, itemDefinitionProps, propertiesAlreadySet);
+					} else {
+						item.Write (this, buildItem);
+					}
 					if (buildItem.Include != include)
 						buildItem.Include = include;
 				}
@@ -3897,6 +3904,27 @@ namespace MonoDevelop.Projects
 							propsToRemove.Add (p.Name);
 						}
 						break;
+					}
+				}
+			}
+			if (propsToRemove != null) {
+				foreach (var name in propsToRemove)
+					buildItem.Metadata.RemoveProperty (name);
+			}
+		}
+
+		void PurgeItemDefinitionProperties (MSBuildItem buildItem, IMSBuildPropertyGroupEvaluated itemDefinitionProps, HashSet<string> propertiesAlreadySet)
+		{
+			List<string> propsToRemove = null;
+
+			foreach (var p in buildItem.Metadata.GetProperties ().Where (pr => !propertiesAlreadySet.Contains (pr.Name))) {
+				var prop = itemDefinitionProps.GetProperty (p.Name);
+				if (prop != null) {
+					if (p.ValueType.Equals (p.Value, prop.Value)) {
+						// This item definition defines the same metadata, so that metadata does not need to be set in the MSBuild item
+						if (propsToRemove == null)
+							propsToRemove = new List<string> ();
+						propsToRemove.Add (p.Name);
 					}
 				}
 			}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -557,6 +557,20 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void ItemDefinitionGroup ()
+		{
+			using (var p = LoadAndEvaluate ("project-with-item-def-group", "item-definition-group.csproj")) {
+				var itemDefinitionGroup = p.ItemDefinitionGroups.Single ();
+				Assert.AreEqual (itemDefinitionGroup.Condition, " '$(DefineMyItem)' == 'true' ");
+				MSBuildItem item = itemDefinitionGroup.Items.Single ();
+				Assert.AreEqual ("MyItem", item.Name);
+				Assert.AreEqual ("PreserveNewest", item.Metadata.GetValue ("CopyToOutputDirectory"));
+				Assert.IsTrue (item.Metadata.GetValue<bool> ("BoolProperty"));
+				Assert.AreEqual ("OriginalValue", item.Metadata.GetValue ("OverriddenProperty"));
+			}
+		}
+
+		[Test]
 		public void StartWhitespaceForImportInsertedAsLastImport ()
 		{
 			var p = LoadAndEvaluate ("ConsoleApp-VS2013", "ConsoleApplication.csproj");

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -895,6 +895,22 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task ItemDefinitionGroup_ItemDefinedMultipleTimes ()
+		{
+			string projFile = Util.GetSampleProject ("project-with-item-def-group", "multiple-item-definitions-same-item.csproj");
+			using (var p = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				var projectItem = p.Files.Single (f => f.Include == "Test.myitem");
+
+				Assert.AreEqual ("NewValue", projectItem.Metadata.GetValue ("OverriddenProperty"));
+				Assert.IsTrue (projectItem.Metadata.HasProperty ("BoolProperty"));
+				Assert.IsTrue (projectItem.Metadata.GetValue<bool> ("BoolProperty"));
+				Assert.AreEqual (FileCopyMode.Always, projectItem.CopyToOutputDirectory);
+				Assert.AreEqual ("First", projectItem.Metadata.GetValue ("FirstItemDefinitionProperty"));
+				Assert.AreEqual ("Second", projectItem.Metadata.GetValue ("SecondItemDefinitionProperty"));
+			}
+		}
+
+		[Test]
 		public async Task XamarinIOSProjectReferencesCollectionsImmutableNetStandardAssembly_GetReferencedAssembliesShouldIncludeNetStandard ()
 		{
 			if (!Platform.IsMac) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -881,6 +881,20 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task ItemDefinitionGroup ()
+		{
+			string projFile = Util.GetSampleProject ("project-with-item-def-group", "item-definition-group.csproj");
+			using (var p = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projFile)) {
+				var projectItem = p.Files.Single (f => f.Include == "Test.myitem");
+
+				Assert.AreEqual ("NewValue", projectItem.Metadata.GetValue ("OverriddenProperty"));
+				Assert.IsTrue (projectItem.Metadata.GetValue<bool> ("BoolProperty"));
+				Assert.IsTrue (projectItem.Metadata.HasProperty ("BoolProperty"));
+				Assert.AreEqual (FileCopyMode.PreserveNewest, projectItem.CopyToOutputDirectory);
+			}
+		}
+
+		[Test]
 		public async Task XamarinIOSProjectReferencesCollectionsImmutableNetStandardAssembly_GetReferencedAssembliesShouldIncludeNetStandard ()
 		{
 			if (!Platform.IsMac) {

--- a/main/tests/test-projects/project-with-item-def-group/Class1.cs
+++ b/main/tests/test-projects/project-with-item-def-group/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Lib
+{
+    public class Class1
+    {
+        public static void Run (object s)
+        {
+            
+        }
+    }
+}

--- a/main/tests/test-projects/project-with-item-def-group/item-definition-group.csproj
+++ b/main/tests/test-projects/project-with-item-def-group/item-definition-group.csproj
@@ -35,5 +35,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <ItemGroup>
+    <MyItem Include="Test.myitem">
+      <OverriddenProperty>NewValue</OverriddenProperty>
+    </MyItem>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/test-projects/project-with-item-def-group/item-definition-group.csproj
+++ b/main/tests/test-projects/project-with-item-def-group/item-definition-group.csproj
@@ -1,0 +1,39 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <ItemDefinitionGroup Condition=" '$(DefineMyItem)' == 'true' ">
+    <MyItem>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <BoolProperty>true</BoolProperty>
+      <OverriddenProperty>OriginalValue</OverriddenProperty>
+    </MyItem>
+  </ItemDefinitionGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <DefineMyItem>true</DefineMyItem>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/project-with-item-def-group/multiple-item-definitions-same-item.csproj
+++ b/main/tests/test-projects/project-with-item-def-group/multiple-item-definitions-same-item.csproj
@@ -1,0 +1,51 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <ItemDefinitionGroup Condition=" '$(DefineMyItem)' == 'true' ">
+    <MyItem>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <BoolProperty>true</BoolProperty>
+      <FirstItemDefinitionProperty>First</FirstItemDefinitionProperty>
+      <OverriddenProperty>OriginalValue</OverriddenProperty>
+    </MyItem>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition=" '$(DefineMyItem)' == 'true' ">
+    <MyItem>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SecondItemDefinitionProperty>Second</SecondItemDefinitionProperty>
+      <OverriddenProperty>NewValue</OverriddenProperty>
+    </MyItem>
+  </ItemDefinitionGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleProject</RootNamespace>
+    <AssemblyName>ConsoleProject</AssemblyName>
+    <DefineMyItem>true</DefineMyItem>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <MyItem Include="Test.myitem">
+    </MyItem>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/project-with-item-def-group/netstandard-sdk.csproj
+++ b/main/tests/test-projects/project-with-item-def-group/netstandard-sdk.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <Compile>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TestProperty>Test</TestProperty>
+      <OverriddenProperty>OriginalValue</OverriddenProperty>
+    </Compile>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <Compile Update="Class1.cs">
+      <OverriddenProperty>NewValue</OverriddenProperty>
+    </Compile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
WIP to support [Item definitions](https://docs.microsoft.com/en-us/visualstudio/msbuild/item-definitions).

TODO:

 - [x] Item definition groups elements loaded
 - [x] Item definition item metadata evaluated
 - [x] Handle item defined multiple times
 - [x] Item definition metadata available to project items
    - [x] Classic project
    - [x] Sdk project - Properties window not showing data for Update items
      - Does not work as implemented. Current implementation requires the MSBuildPropertyGroupEvaluated on the MSBuildItem to have access to the root project - which is not always the case.
 - [x] Saving project should not add item definition metadata to project items (currently breaking some tests)
    - [x] Classic project
    - [x] Sdk project - this seems to be OK but there is no code explicitly added to handle this.
 - [ ] Project items need to be able to remove an item definition metadata property (i.e. add an empty element for that property)
 - [ ] Handle new files added to a project that have associated item definition metadata.
    - Currently new files do not necessarily have the item definition metadata so when they are added the Properties window shows the files do not have this data but on reloading the project they will have this data. On saving it seems that the item definition should be checked and empty elements added for properties that are not set. Also for wildcards we have [logic that removes update items and adds an include](https://github.com/mono/monodevelop/blob/3cc0a0901f8c703f26c4e0578c2bdc4cb378f607/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs#L4021-L4028) - which possibly could be handled by adding an empty element for the property instead.
   - [ ] Classic project
   - [ ] Sdk project

Fixes VSTS #731472 - Support ItemDefinitionGroup for generators