### PR TITLE
[release-7.8] Fixes VSTS Bug 752653: A11y_VS for Mac_Find in Files_Screen Reader:

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -245,6 +245,9 @@ namespace MonoDevelop.Ide.FindInFiles
 												"Find",
 												GettextCatalog.GetString ("Enter string to find"));
 			comboboxentryFind.SetAccessibilityLabelRelationship (labelFind);
+			toggleFindInFiles.Accessible.SetLabel (GettextCatalog.GetString ("Find in files toggle button"));
+			toggleReplaceInFiles.Accessible.SetLabel (GettextCatalog.GetString ("Replace in files toggle button"));
+
 		}
 
 		void SetupAccessibilityForReplace ()


### PR DESCRIPTION
Voice Over focus is reading “Find in files” and “Replace in files”
buttons as radio buttons.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/752653

In fact these buttons are radio buttons - but UI wise from user point
of view they aren't.

Backport of #6859.

/cc @mkrueger 