### PR TITLE
[a11] Fixes VoiceOver to announce hexadecimal content

### DIFF
--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
@@ -37,6 +37,7 @@ using Xwt;
 using Mono.MHex.Data;
 using Mono.MHex.Rendering;
 using Xwt.Drawing;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace Mono.MHex
 {
@@ -101,8 +102,12 @@ namespace Mono.MHex
 
 		public bool IsReadOnly { get; set; }
 
+		readonly Gtk.Widget hexWidget;
+
 		public HexEditor ()
 		{
+			hexWidget = (Gtk.Widget)Xwt.Toolkit.CurrentEngine.GetNativeWidget (this);
+
 			BackgroundColor = Color.FromBytes (0, 0, 0);
 			CanGetFocus = true;
 			HexEditorData = new HexEditorData ();
@@ -114,6 +119,7 @@ namespace Mono.MHex
 				if (HexEditorData.Caret.AutoScrollToCaret)
 					ScrollToCaret ();
 				RepaintLine (HexEditorData.Caret.Line);
+				AnnounceCurrentSelection ();
 			};
 			HexEditorData.Caret.OffsetChanged += delegate(object sender, CaretLocationEventArgs e) {
 				if (!HexEditorData.Caret.PreserveSelection)
@@ -518,6 +524,18 @@ namespace Mono.MHex
 			requestResetCaretBlink = true;
 		}
 		
+		void AnnounceCurrentSelection ()
+		{
+			try {
+				var character = HexEditorData.Bytes [HexEditorData.Caret.Offset];
+				var data = Convert.ToString (character, 16);
+				var message = string.Format ("Selected '{0}' char:'{1}'", data[HexEditorData.Caret.SubPosition], (char)character);
+				hexWidget.Accessible.MakeAccessibilityAnnouncement (message);
+			} catch (Exception ex) {
+
+			}
+		}
+
 		public void DrawCaret (Context ctx, Rectangle area)
 		{
 			if (!caretBlink || HexEditorData.IsSomethingSelected) 

--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
@@ -99,6 +99,8 @@ namespace Mono.MHex
 			}
 		}
 
+		public bool IsReadOnly { get; set; }
+
 		public HexEditor ()
 		{
 			BackgroundColor = Color.FromBytes (0, 0, 0);

--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
@@ -38,6 +38,7 @@ using Mono.MHex.Data;
 using Mono.MHex.Rendering;
 using Xwt.Drawing;
 using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
 
 namespace Mono.MHex
 {
@@ -529,10 +530,9 @@ namespace Mono.MHex
 			try {
 				var character = HexEditorData.Bytes [HexEditorData.Caret.Offset];
 				var data = Convert.ToString (character, 16);
-				var message = string.Format ("Selected '{0}' char:'{1}'", data[HexEditorData.Caret.SubPosition], (char)character);
+				var message = GettextCatalog.GetString ("Selected '{0}' char:'{1}'", data [HexEditorData.Caret.SubPosition], (char)character);
 				hexWidget.Accessible.MakeAccessibilityAnnouncement (message);
-			} catch (Exception ex) {
-
+			} catch {
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditorDebugger.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditorDebugger.cs
@@ -80,6 +80,8 @@ namespace Mono.MHex
 			comboBox.Items.Add ("Hex 16");
 			comboBox.SelectedIndex = 0;
 			editor.Options.StringRepresentationType = StringRepresentationTypes.ASCII;
+			editor.Accessible.Label = GettextCatalog.GetString ("Hexadecimal Text Editor");
+
 			comboBox.SelectionChanged += delegate {
 				switch (comboBox.SelectedIndex) {
 				case 0:

--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/SimpleEditMode.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/SimpleEditMode.cs
@@ -184,8 +184,10 @@ namespace Mono.MHex
 				keyBindings [keyCode] (HexEditorData);
 				return;
 			}
-			
-			InsertCharacter (unicodeChar);
+
+			if (!Editor.IsReadOnly) {
+				InsertCharacter (unicodeChar);
+			}
 		}
 		
 		void InsertCharacter (uint unicodeChar)

--- a/main/src/addins/MonoDevelop.HexEditor/MonoDevelop.HexEditor/HexEditorVisualizer.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/MonoDevelop.HexEditor/HexEditorVisualizer.cs
@@ -130,7 +130,7 @@ namespace MonoDevelop.HexEditor
 			}
 
 			hexEditor.HexEditorData.Buffer = buffer;
-			hexEditor.Editor.Sensitive = CanEdit (val);
+			hexEditor.Editor.IsReadOnly = !CanEdit (val);
 
 			var xwtScrollView = new Xwt.ScrollView (hexEditor);
 			var scrollWidget = (Widget) Xwt.Toolkit.CurrentEngine.GetNativeWidget (xwtScrollView);


### PR DESCRIPTION
HexEditor was completely broken because we where setting Sensitive = false, this means all the signals were not working including Focus and Accessibility.

I added a ReadOnly state to the control and included a feature to announce the current character selected.

NOTE: VoiceOver Announcement needs a little delay between calls

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/648994

![hextext-1](https://user-images.githubusercontent.com/1587480/50994814-8b7d7280-151d-11e9-9864-4246838178c8.gif)

Intrucctions to test de issue:
1) Open any console application
2) Set a break point after a declaration of a string variable
3) Inspect this string variable and click in the "pencil icon" to show the "Value Visualizer" panel
4) click on HexEdit button
5) Enable VoiceOver and change the selected item with CAPSLOCK + Arrow keys
6) VoiceOver should set the HexEditor and announce the hexadecimal value selected

