### PR TITLE
[Ide] Fixed InformationPopoverWidget and EventBoxTooltip to allow Markup.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EventBoxTooltip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EventBoxTooltip.cs
@@ -127,7 +127,10 @@ namespace MonoDevelop.Components
 				HideTooltip ();
 				tooltipWindow = TooltipPopoverWindow.Create ();
 				tooltipWindow.ShowArrow = true;
-				tooltipWindow.Text = tip;
+				if (UseMarkup)
+					tooltipWindow.Markup = tip;
+				else
+					tooltipWindow.Text = tip;
 				tooltipWindow.Severity = Severity;
 				var rect = new Gdk.Rectangle (0, 0, eventBox.Allocation.Width, eventBox.Allocation.Height + 5);
 				tooltipWindow.ShowPopup (eventBox, rect, Position);
@@ -157,9 +160,12 @@ namespace MonoDevelop.Components
 			set {
 				tip = value;
 				if (tooltipWindow != null) {
-					if (!string.IsNullOrEmpty (tip))
-						tooltipWindow.Text = value;
-					else
+					if (!string.IsNullOrEmpty (tip)) {
+						if (UseMarkup)
+							tooltipWindow.Markup = value;
+						else
+							tooltipWindow.Text = value;
+					} else
 						HideTooltip ();
 				} else if (!string.IsNullOrEmpty (tip) && mouseOver)
 					ShowTooltip ();
@@ -169,6 +175,7 @@ namespace MonoDevelop.Components
 
 		public TaskSeverity? Severity { get; set; }
 		public PopupPosition Position { get; set; }
+		public bool UseMarkup { get; set; }
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/InformationPopoverWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/InformationPopoverWidget.cs
@@ -35,6 +35,7 @@ namespace MonoDevelop.Components
 		TaskSeverity severity;
 		Xwt.ImageView imageView;
 		string message;
+		bool markup;
 		TooltipPopoverWindow popover;
 		PopupPosition popupPosition = PopupPosition.Top;
 
@@ -69,6 +70,14 @@ namespace MonoDevelop.Components
 				UpdatePopover ();
 
 				this.Accessible.Label = value;
+			}
+		}
+
+		public bool UseMarkup {
+			get { return markup; }
+			set {
+				markup = value;
+				UpdatePopover ();
 			}
 		}
 
@@ -127,7 +136,10 @@ namespace MonoDevelop.Components
 				popover.Destroy ();
 			popover = TooltipPopoverWindow.Create (!WorkaroundNestedDialogFlickering ());
 			popover.ShowArrow = true;
-			popover.Text = message;
+			if (markup)
+				popover.Markup = message;
+			else
+				popover.Text = message;
 			popover.Severity = severity;
 			popover.ShowPopup (this, popupPosition);
 		}


### PR DESCRIPTION
This is needed for Android and iOS addins which expect to be able
to use markup in tooltips.