### PR TITLE
[release-7.8] [Ide] Fix focus problem when tabbing out of the IDE

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SearchBar.cs
@@ -231,17 +231,32 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				var other = (NSWindow)notification.Object;
 
 				if (notification.Object == Window) {
-					if (LostFocus != null)
-						LostFocus (this, null);
+					if (IsFirstResponderOfWindow (Window)) {
+						if (LostFocus != null)
+							LostFocus (this, null);
+					}
 				}
 			}));
 			NSNotificationCenter.DefaultCenter.AddObserver (NSWindow.DidResizeNotification, notification => Runtime.RunInMainThread (() => {
 				var other = (NSWindow)notification.Object;
 				if (notification.Object == Window) {
-					if (LostFocus != null)
-						LostFocus (this, null);
+					if (IsFirstResponderOfWindow (Window)) {
+						if (LostFocus != null)
+							LostFocus (this, null);
+					}
 				}
 			}));
+		}
+
+		bool IsFirstResponderOfWindow (NSWindow window)
+		{
+			if (window.FirstResponder is NSTextView tv) {
+				var field = tv.WeakDelegate;
+				if (field == this)
+					return true;
+			}
+
+			return false;
 		}
 
 		bool SendKeyPressed (Xwt.KeyEventArgs kargs)


### PR DESCRIPTION
The searchbar would indiscriminately trigger FocusOut events every
time the window was focused out. That would cause the focus to move
to the next responder when tabbing out.

Fixes VSTS #754535 - Focusing out/into VisualStudio changes the default focused element on the UI

Backport of #6845.

/cc @Therzok 