### PR TITLE
Adds implementation to remove items in Toolbox Dynamic Providers

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
@@ -36,10 +36,9 @@ using MonoDevelop.Ide.Gui;
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
 	
-	public class CodeTemplateToolboxProvider : IToolboxDynamicProvider
+	public class CodeTemplateToolboxProvider : IToolboxDynamicProvider, IToolboxDynamicProviderDeleteSupport
 	{
 		static string category = MonoDevelop.Core.GettextCatalog.GetString ("Text Snippets");
-
 
 		public System.Collections.Generic.IEnumerable<ItemToolboxNode> GetDynamicItems (IToolboxConsumer consumer)
 		{
@@ -58,7 +57,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				};
 			}
 		}
-		
+
+		public bool DeleteDynamicItem (ItemToolboxNode node) => false;
+
+		public bool CanDeleteDynamicItem (ItemToolboxNode node) => false;
+
 		public event EventHandler ItemsChanged {
 			add { CodeTemplateService.TemplatesChanged += value; }
 			remove { CodeTemplateService.TemplatesChanged -= value; }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
@@ -36,7 +36,7 @@ using MonoDevelop.Ide.Gui;
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
 	
-	public class CodeTemplateToolboxProvider : IToolboxDynamicProvider, IToolboxDynamicProviderDeleteSupport
+	public class CodeTemplateToolboxProvider : IToolboxDynamicProvider
 	{
 		static string category = MonoDevelop.Core.GettextCatalog.GetString ("Text Snippets");
 
@@ -57,10 +57,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				};
 			}
 		}
-
-		public bool DeleteDynamicItem (ItemToolboxNode node) => false;
-
-		public bool CanDeleteDynamicItem (ItemToolboxNode node) => false;
 
 		public event EventHandler ItemsChanged {
 			add { CodeTemplateService.TemplatesChanged += value; }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxProvider.cs
@@ -35,7 +35,13 @@ using System.Collections.Generic;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
-	
+	public interface IToolboxDynamicProviderDeleteSupport
+	{
+		bool DeleteDynamicItem (ItemToolboxNode node);
+
+		bool CanDeleteDynamicItem (ItemToolboxNode node);
+	}
+
 	//Used to fetch or generate the default toolbox items at the beginning of each MD session
 	public interface IToolboxDefaultProvider
 	{
@@ -53,7 +59,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		//This method will be called each time the consumer changes. Return null if not
 		//returning any items for a specific consumer.
 		IEnumerable<ItemToolboxNode> GetDynamicItems (IToolboxConsumer consumer);
-		
+
 		event EventHandler ItemsChanged;
 	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -447,7 +447,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			// Hack manually filter out gtk# widgets & container since they cannot be re added
 			// because they're missing the toolbox attributes.
-			info.Enabled = selectedNode != null
+			info.Enabled = selectedNode != null && toolboxService.CanRemoveUserItem (selectedNode)
 				&& (selectedNode.ItemDomain != GtkWidgetDomain
 					|| (selectedNode.Category != "Widgets" && selectedNode.Category != "Container"));
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxService.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxService.cs
@@ -152,8 +152,16 @@ namespace MonoDevelop.DesignerSupport
 		
 		public void RemoveUserItem (ItemToolboxNode node)
 		{
-			Configuration.ItemList.Remove (node);
-			SaveConfiguration ();
+			if (Configuration.ItemList.Remove (node)) {
+				SaveConfiguration ();
+			} else {
+				//we need check in the dynamic providers
+				foreach (var prov in dynamicProviders) {
+					if (prov is IToolboxDynamicProviderDeleteSupport provDelSupport && provDelSupport.DeleteDynamicItem (node)) {
+						break;
+					}
+				}
+			}
 			OnToolboxContentsChanged ();
 		}
 		
@@ -526,7 +534,22 @@ namespace MonoDevelop.DesignerSupport
 			//we assume permitted, so only return false when blocked by a filter
 			return true;
 		}
-		
+
+		internal bool CanRemoveUserItem (ItemToolboxNode node)
+		{
+			if (Configuration.ItemList.Contains (node)) {
+				return true;
+			} else {
+				//we need check in the dynamic providers
+				foreach (var prov in dynamicProviders) {
+					if (prov is IToolboxDynamicProviderDeleteSupport provDelSupport && provDelSupport.CanDeleteDynamicItem (node)) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
 		//evaluate a filter attribute against a list, and check whether permitted
 		private bool FilterPermitted (ItemToolboxNode node, ToolboxItemFilterAttribute desFa, 
 		    ICollection<ToolboxItemFilterAttribute> filterAgainst, IToolboxConsumer consumer)

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/ToolboxProvider.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/ToolboxProvider.cs
@@ -14,7 +14,7 @@ using MonoDevelop.Components;
 
 namespace MonoDevelop.GtkCore.GuiBuilder
 {
-	public class ToolboxProvider: IToolboxDynamicProvider, IToolboxDefaultProvider
+	public class ToolboxProvider: IToolboxDynamicProvider, IToolboxDefaultProvider, IToolboxDynamicProviderDeleteSupport
 	{
 		internal static ToolboxProvider Instance;
 		
@@ -82,7 +82,11 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 		{
 			yield return typeof(Stetic.Wrapper.Widget).Assembly.Location;
 		}
-		
+
+		public virtual bool DeleteDynamicItem (ItemToolboxNode node) => false;
+
+		public virtual bool CanDeleteDynamicItem (ItemToolboxNode node) => false;
+
 		public event EventHandler ItemsChanged;
 	}
 	

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ClipboardRingService.cs
@@ -31,6 +31,7 @@ using MonoDevelop.Core;
 using MonoDevelop.DesignerSupport.Toolbox;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Gui;
+using System.Linq;
 
 namespace MonoDevelop.SourceEditor
 {
@@ -102,6 +103,8 @@ namespace MonoDevelop.SourceEditor
 			return clipboardRing;
 		}
 
+		internal static bool DeleteItem (ItemToolboxNode node) => clipboardRing.Remove (node as ClipboardToolboxNode);
+		
 		class ClipboardToolboxNode : ItemToolboxNode, ITextToolboxNode, ICustomTooltipToolboxNode
 		{
 			static readonly ToolboxItemFilterAttribute filterAtt = new ToolboxItemFilterAttribute ("text/plain", ToolboxItemFilterType.Allow);

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -66,7 +66,7 @@ using System.Collections.Immutable;
 namespace MonoDevelop.SourceEditor
 {
 	partial class SourceEditorView : ViewContent, IBookmarkBuffer, IClipboardHandler, ITextFile,
-		ICompletionWidget2,  ISplittable, IFoldable, IToolboxDynamicProvider,
+		ICompletionWidget2,  ISplittable, IFoldable, IToolboxDynamicProvider, IToolboxDynamicProviderDeleteSupport,
 		ICustomFilteringToolboxConsumer, IZoomable, ITextEditorResolver, ITextEditorDataProvider,
 		ICodeTemplateHandler, ICodeTemplateContextProvider, IPrintable,
 	ITextEditorImpl, ITextMarkerFactory, IUndoHandler
@@ -3392,6 +3392,10 @@ namespace MonoDevelop.SourceEditor
 		{
 			return TextEditor.GetLineHeight (line);
 		}
+
+		public bool DeleteDynamicItem (ItemToolboxNode node) => ClipboardRingService.DeleteItem (node);
+
+		public bool CanDeleteDynamicItem (ItemToolboxNode node) => ClipboardRingService.GetToolboxItems ().Contains (node);
 
 		public bool HasFocus {
 			get {


### PR DESCRIPTION
This fix fixes the possibility to delete items from external toolbox providers (like for example clipboard copied items). Right now this deletion was doing nothing and was confusing the user.

Fixes VSTS #598533 - Unable to delete entries from Toolbox Clipboard Ring https://devdiv.visualstudio.com/DevDiv/_workitems/edit/598533

![deleteitems](https://user-images.githubusercontent.com/1587480/51052409-d3ac9b80-15d6-11e9-9fe8-8bb0f81f1bb9.gif)

To test the bug:
1) Open a project
2) Select and copy from the clipboard any text from Source Editor
3) A new item should appear in the Toolbox in a new section called Clipboard Ring
4) Click right button and select Remove menu item

Probably this PR will break the current API