### PR TITLE
[DotNetCore] Accessibility - Voice over in .NET Core SDK Location preferences

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
@@ -80,6 +80,10 @@ namespace MonoDevelop.DotNetCore.Gui
 			locationBox.PackStart (locationLabel, false, false);
 
 			locationFileSelector = new CustomFileSelector ();
+			locationFileSelector.TextEntry.SetCommonAccessibilityAttributes (
+				"DotNetCoreSdkLocationWidget.Location",
+				locationLabel.Text,
+				GettextCatalog.GetString ("Enter the .NET Core SDK location"));
 			locationBox.PackStart (locationFileSelector, true, true);
 
 			// .NET Core SDK section.
@@ -187,6 +191,10 @@ namespace MonoDevelop.DotNetCore.Gui
 				browseButton.Clicked += BrowseButtonClicked;
 
 				Content = box;
+			}
+
+			internal TextEntry TextEntry {
+				get { return entry; }
 			}
 
 			public string CurrentFolder {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
@@ -84,6 +84,10 @@ namespace MonoDevelop.DotNetCore.Gui
 				"DotNetCoreSdkLocationWidget.Location",
 				locationLabel.Text,
 				GettextCatalog.GetString ("Enter the .NET Core SDK location"));
+			locationFileSelector.BrowseButton.SetCommonAccessibilityAttributes (
+				"DotNetCoreSdkLocationWidget.Browse",
+				GettextCatalog.GetString ("Browse"),
+				GettextCatalog.GetString ("Select a folder for the .NET Core SDK location"));
 			locationBox.PackStart (locationFileSelector, true, true);
 
 			// .NET Core SDK section.
@@ -175,6 +179,7 @@ namespace MonoDevelop.DotNetCore.Gui
 		class CustomFileSelector : Widget
 		{
 			TextEntry entry;
+			Button browseButton;
 			FileDialog dialog;
 			string currentFolder;
 			string title;
@@ -186,7 +191,7 @@ namespace MonoDevelop.DotNetCore.Gui
 				entry.Changed += EntryChanged;
 				box.PackStart (entry, true);
 
-				var browseButton = new Button ("…");
+				browseButton = new Button ("…");
 				box.PackStart (browseButton);
 				browseButton.Clicked += BrowseButtonClicked;
 
@@ -195,6 +200,10 @@ namespace MonoDevelop.DotNetCore.Gui
 
 			internal TextEntry TextEntry {
 				get { return entry; }
+			}
+
+			internal Button BrowseButton {
+				get { return browseButton; }
 			}
 
 			public string CurrentFolder {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
@@ -156,7 +156,7 @@ namespace MonoDevelop.DotNetCore.Gui
 
 		void UpdateCommandLineIconAccessibility (bool found)
 		{
-			sdkFoundIcon.SetCommonAccessibilityAttributes (
+			commandLineFoundIcon.SetCommonAccessibilityAttributes (
 				"DotNetCoreCommandLineFoundImage",
 				found ? GettextCatalog.GetString ("A Tick") : GettextCatalog.GetString ("A Cross"),
 				found ? GettextCatalog.GetString ("The .NET Core command line was found") : GettextCatalog.GetString ("The .NET Core command line was not found"));


### PR DESCRIPTION
 - Fix voice over not reading SDK location label in preferences

The .NET Core SDK location text box was not linked to its label so the
location was not being read by Voice Over.

 - Add accessibility title for browse button in sdk location

In preferences the button to browse for a .NET Core SDK location
now has an accessibility title and description.

- Fix accessibility image title in .NET Core sdk location

The .NET Core command line tick/cross image did not have an accessible
label or description. The other tick/cross images for sdk and runtimes
did have this available.

Fixes VSTS #752796 - Accessibility: Voice over is not reading the label for
Location field