### PR TITLE
[Ide] Fix accessibility solution text box label in new project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkProjectConfigurationWidget.cs
@@ -87,6 +87,13 @@ namespace MonoDevelop.Ide.Projects
 			projectNameTextBox.Accessible.Description = GettextCatalog.GetString ("Enter the name for the new project");
 			projectNameTextBox.Accessible.SetTitleUIElement (projectNameLabel.Accessible);
 
+			solutionNameLabel.Accessible.Name = "ProjectConfigurationWidget.SolutionNameLabel";
+			solutionNameLabel.Accessible.SetTitleFor (solutionNameTextBox.Accessible);
+
+			solutionNameTextBox.Accessible.Name = "ProjectConfigurationWidget.SolutionNameTextBox";
+			solutionNameTextBox.Accessible.Description = GettextCatalog.GetString ("Enter the name for the new solution");
+			solutionNameTextBox.Accessible.SetTitleUIElement (solutionNameLabel.Accessible);
+
 			locationLabel.Accessible.Name = "ProjectConfigurationWidget.LocationLabel";
 			locationLabel.Accessible.SetTitleFor (locationTextBox.Accessible, browseButton.Accessible);
 


### PR DESCRIPTION
When the Solution Name text box had focus there was no accessibility
label set for the text box so Voice Over would not read the label text.

Fixes VSTS #754349 - Accessibility New Project Dialog: Voice over is
not reading the Label name for “Solution name” in configure app window