### PR TITLE
[Ide] Remove button not keyboard accessible in Edit References dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/SelectReferenceDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/SelectReferenceDialog.cs
@@ -236,7 +236,7 @@ namespace MonoDevelop.Ide.Projects
 			header.Add (w);
 			selectedHeader.Add (header);
 			
-			RemoveReferenceButton.CanFocus = false;
+			RemoveReferenceButton.CanFocus = true;
 			ReferencesTreeView.Selection.Changed += new EventHandler (OnChanged);
 			Child.ShowAll ();
 			OnChanged (null, null);


### PR DESCRIPTION
The Remote button which is used to remove the selected references
could not get keyboard focus. This is now enabled. Note that the Remove
button still does not get focus if it is clicked only if you tab to
it.

Fixes VSTS #750234 - Accessibility: Remove ‘X’ button is not accessible
through keyboard