### PR TITLE
Pressing Enter key when Exception Caught tooltip is shown displays di…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -1105,12 +1105,19 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 	{
 		public override bool KeyPress (KeyDescriptor descriptor)
 		{
-			if (descriptor.SpecialKey == SpecialKey.Escape && DebuggingService.ExceptionCaughtMessage != null &&
+			if (DebuggingService.ExceptionCaughtMessage != null &&
 				!DebuggingService.ExceptionCaughtMessage.IsMinimized &&
 				DebuggingService.ExceptionCaughtMessage.File.CanonicalPath == new FilePath (DocumentContext.Name).CanonicalPath) {
 
-				DebuggingService.ExceptionCaughtMessage.ShowMiniButton ();
-				return true;
+				if (descriptor.SpecialKey == SpecialKey.Escape) {
+					DebuggingService.ExceptionCaughtMessage.ShowMiniButton ();
+					return true;
+				}
+
+				if (descriptor.SpecialKey == SpecialKey.Return) {
+					DebuggingService.ExceptionCaughtMessage.ShowDialog ();
+					return false;
+				}
 			}
 
 			return base.KeyPress (descriptor);


### PR DESCRIPTION
…alog

Note that pressing escape already works to hide tooltip.

Fixes VSTS #646440