### PR TITLE
Gtkrc a11y fixes

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Styles.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Styles.cs
@@ -55,7 +55,7 @@ namespace Mono.TextEditor.PopupWindow
 
 		public static void LoadStyles ()
 		{
-			var bgColor = Platform.IsMac ? Color.FromName ("#5189ed") : Color.FromName ("#cce8ff");
+			var bgColor = Platform.IsMac ? Color.FromName ("#2862d9") : Color.FromName ("#cce8ff");
 			var fgColor = Platform.IsMac ? Color.FromName ("#ffffff") : Color.FromName ("#000000");
 
 			ModeHelpWindowTokenOutlineColor = fgColor;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplatePanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeTemplates/CodeTemplatePanel.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components;
 using MonoDevelop.Ide.Editor;
+using MonoDevelop.Ide.Gui;
 
 namespace MonoDevelop.Ide.CodeTemplates
 {
@@ -177,7 +178,7 @@ namespace MonoDevelop.Ide.CodeTemplates
 					GLib.Markup.EscapeText (GettextCatalog.GetString (template.Description)) + ")";
 			} else {
 				crt.Markup =  GLib.Markup.EscapeText (template.Shortcut) + " <span foreground=\"" + 
-					GetColorString (Style.Text (StateType.Insensitive)) + "\">(" 
+					Styles.SecondaryTextColorHexString + "\">(" 
 					+ GLib.Markup.EscapeText (GettextCatalog.GetString (template.Description)) + ")</span>";
 			}
 		}
@@ -208,11 +209,6 @@ namespace MonoDevelop.Ide.CodeTemplates
 				} while (templateStore.IterNext (ref iter));
 			}
 			return templateStore.AppendValues (null, groupName, "<b>" + groupName + "</b>");
-		}
-		
-		internal static string GetColorString (Gdk.Color color)
-		{
-			return string.Format ("#{0:X02}{1:X02}{2:X02}", color.Red / 256, color.Green / 256, color.Blue / 256);
 		}
 		
 		TreeIter InsertTemplate (CodeTemplate template)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -473,7 +473,7 @@ namespace MonoDevelop.Ide.Gui
 			PrimaryBackgroundColor = BaseBackgroundColor;
 			SecondaryBackgroundDarkerColor = Color.FromName ("#e7eaee");
 			SecondaryBackgroundLighterColor = Color.FromName ("#f9f9fb");
-			SecondaryTextColorHexString = "#888888";
+			SecondaryTextColorHexString = "#767676";
 			SecondaryTextColor = Color.FromName (SecondaryTextColorHexString);
 			SecondarySelectionTextColor = Color.FromName ("#ffffff");
 			PadBackground = Color.FromName ("#fafafa");
@@ -597,7 +597,7 @@ namespace MonoDevelop.Ide.Gui
 			PrimaryBackgroundColor = BaseBackgroundColor;
 			SecondaryBackgroundDarkerColor = Color.FromName ("#484848");
 			SecondaryBackgroundLighterColor = SeparatorColor;
-			SecondaryTextColorHexString = "#777777";
+			SecondaryTextColorHexString = "#ababab";
 			SecondaryTextColor = Color.FromName (SecondaryTextColorHexString);
 			SecondarySelectionTextColor = Color.FromName ("#ffffff");
 			PadBackground = Color.FromName ("#525252");

--- a/main/src/core/MonoDevelop.Ide/gtkrc
+++ b/main/src/core/MonoDevelop.Ide/gtkrc
@@ -1,5 +1,5 @@
 # Xamarin Studio GTK Theme
-# Copyright 2012-2016 Xamarin Inc.
+# Copyright 2012-2019 Xamarin Inc.
 # Authors:
 #   Christian Kellner <christian.kellner@lanedo.com>
 #   Carlos Garnacho <carlos.garnacho@lanedo.com>
@@ -13,6 +13,7 @@ gtk-color-scheme =
 fg_color: #000
 base_color: #fff
 text_color: #000
+dim_color: #767676
 selected_bg_color: #649dd6
 selected_fg_color: #fff
 tooltip_bg_color: #fff9e5
@@ -42,13 +43,13 @@ style "default" {
     fg[NORMAL] = @fg_color
     fg[PRELIGHT] = @fg_color
     fg[SELECTED] = @selected_fg_color
-    fg[INSENSITIVE] = darker (@bg_color)
+    fg[INSENSITIVE] = @dim_color
     fg[ACTIVE] = @fg_color
 
     text[NORMAL] = @fg_color
     text[PRELIGHT] = @fg_color
     text[SELECTED] = @selected_fg_color
-    text[INSENSITIVE] = darker (@bg_color)
+    text[INSENSITIVE] = @dim_color
     text[ACTIVE] = @fg_color
 
     base[NORMAL] = @base_color

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -15,7 +15,7 @@ base_color: #fff
 text_color: #272727
 link_color: #175fde
 dim_color: #767676
-selected_bg_color: #5189ed
+selected_bg_color: #2862d9
 selected_fg_color: #fff
 tooltip_bg_color: #f2f2f2
 tooltip_fg_color: #272727

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -1,5 +1,5 @@
 # Xamarin Studio Light Mac GTK Theme
-# Copyright 2012-2016 Xamarin Inc.
+# Copyright 2012-2019 Xamarin Inc.
 # Authors:
 #   Christian Kellner <christian.kellner@lanedo.com>
 #   Carlos Garnacho <carlos.garnacho@lanedo.com>
@@ -14,6 +14,7 @@ fg_color: #272727
 base_color: #fff
 text_color: #272727
 link_color: #175fde
+dim_color: #767676
 selected_bg_color: #5189ed
 selected_fg_color: #fff
 tooltip_bg_color: #f2f2f2
@@ -49,13 +50,13 @@ style "default" {
     fg[NORMAL] = @fg_color
     fg[PRELIGHT] = @fg_color
     fg[SELECTED] = @selected_fg_color
-    fg[INSENSITIVE] = darker (@bg_color)
+    fg[INSENSITIVE] = @dim_color
     fg[ACTIVE] = @fg_color
 
     text[NORMAL] = @fg_color
     text[PRELIGHT] = @fg_color
     text[SELECTED] = @selected_fg_color
-    text[INSENSITIVE] = darker (@bg_color)
+    text[INSENSITIVE] = @dim_color
     text[ACTIVE] = @fg_color
 
     base[NORMAL] = @base_color

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -15,7 +15,7 @@ base_color: #404040
 text_color: #d7d7d7
 link_color: #ace2ff
 dim_color: #ababab
-selected_bg_color: #5189ed
+selected_bg_color: #2257c9
 selected_fg_color: #fff
 tooltip_bg_color: #5a5a5a
 tooltip_fg_color: #d2d5cd

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -1,5 +1,5 @@
 # Xamarin Studio Dark Mac GTK Theme
-# Copyright 2012-2016 Xamarin Inc.
+# Copyright 2012-2019 Xamarin Inc.
 # Authors:
 #   Christian Kellner <christian.kellner@lanedo.com>
 #   Carlos Garnacho <carlos.garnacho@lanedo.com>
@@ -14,7 +14,7 @@ fg_color: #d7d7d7
 base_color: #404040
 text_color: #d7d7d7
 link_color: #ace2ff
-dim_color: #777777
+dim_color: #ababab
 selected_bg_color: #5189ed
 selected_fg_color: #fff
 tooltip_bg_color: #5a5a5a

--- a/main/src/core/MonoDevelop.Ide/gtkrc.win32
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.win32
@@ -1,5 +1,5 @@
 # Xamarin Studio Light Windows GTK Theme
-# Copyright 2012-2016 Xamarin Inc.
+# Copyright 2012-2019 Xamarin Inc.
 # Authors:
 #   Christian Kellner <christian.kellner@lanedo.com>
 #   Carlos Garnacho <carlos.garnacho@lanedo.com>
@@ -14,6 +14,7 @@ fg_color: #000
 base_color: #fff
 text_color: #000
 link_color: #175fde
+dim_color: #767676
 selected_bg_color: #cce8ff
 selected_fg_color: #000
 tooltip_bg_color: #f2f2f2
@@ -48,13 +49,13 @@ style "default" {
     fg[NORMAL] = @fg_color
     fg[PRELIGHT] = @fg_color
     fg[SELECTED] = @selected_fg_color
-    fg[INSENSITIVE] = darker (@bg_color)
+    fg[INSENSITIVE] = @dim_color
     fg[ACTIVE] = @fg_color
 
     text[NORMAL] = @fg_color
     text[PRELIGHT] = @fg_color
     text[SELECTED] = @selected_fg_color
-    text[INSENSITIVE] = darker (@bg_color)
+    text[INSENSITIVE] = @dim_color
     text[ACTIVE] = @fg_color
 
     base[NORMAL] = @base_color

--- a/main/src/core/MonoDevelop.Ide/gtkrc.win32-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.win32-dark
@@ -1,5 +1,5 @@
 # Xamarin Studio Dark Windows GTK Theme
-# Copyright 2012-2016 Xamarin Inc.
+# Copyright 2012-2019 Xamarin Inc.
 # Authors:
 #   Christian Kellner <christian.kellner@lanedo.com>
 #   Carlos Garnacho <carlos.garnacho@lanedo.com>
@@ -14,7 +14,7 @@ fg_color: #d7d7d7
 base_color: #404040
 text_color: #d7d7d7
 link_color: #ace2ff
-dim_color: #777777
+dim_color: #ababab
 selected_bg_color: #4c5e6e
 selected_fg_color: #bfbfbf
 tooltip_bg_color: #5a5a5a


### PR DESCRIPTION
These two commits fix color accessibility issues in these areas:

- Secondary (gray) text color now matches required 4.5:1.
- New macOS selection background which follows changes in macOS Mojave.

Fixes VSTS #612400
Fixes VSTS #754225