### PR TITLE
[Ide] Fix focus after adding new custom command in project options

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/CustomCommandWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/CustomCommandWidget.cs
@@ -198,10 +198,6 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 				} else
 					cmd.Type = supportedTypes [comboType.Active];
 				UpdateControls ();
-				if (cmd.Type == CustomCommandType.Custom)
-					entryName.GrabFocus ();
-				else
-					entryCommand.GrabFocus ();
 			}
 		}
 


### PR DESCRIPTION
Keyboard focus was moving from the custom command combo box to the
first text entry in the new custom command just created. The keyboard
focus now stays on the combo box after an item is selected from its
list.

Fixes VSTS #753595 - Accessibility: Project Options Custom Commands:
After selecting any option in Select a project Operation drop down focus
is going to command text field. It should stay on the same control