### PR TITLE
[release-7.7] Visual Studio text model tweaks

### DIFF
--- a/main/msbuild/ReferencesVSEditor.props
+++ b/main/msbuild/ReferencesVSEditor.props
@@ -34,7 +34,7 @@
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Implementation">
-      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.2.2-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
+      <HintPath>$(PackagesDirectory)\Microsoft.VisualStudio.Text.Implementation.15.2.3-pre\lib\net46\Microsoft.VisualStudio.Text.Implementation.dll</HintPath>
       <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
   </ItemGroup>

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -2446,6 +2446,8 @@ namespace MonoDevelop.SourceEditor
 				return TextEditor.GetTextEditorData ();
 			if (type.Equals (typeof (IDocumentReloadPresenter)))
 				return widget;
+			if (type.Equals (typeof (Microsoft.VisualStudio.Text.ITextDocument)))
+				return Document.VsTextDocument;
 			return base.OnGetContent (type);
 		}
 

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -246,8 +246,10 @@ namespace Mono.TextEditor
 			this.TextBuffer.ContentTypeChanged -= this.OnTextBufferContentTypeChanged;
 			this.TextBuffer.Properties.RemoveProperty(typeof(ITextDocument));
 			this.VsTextDocument.FileActionOccurred -= this.OnTextDocumentFileActionOccurred;
-			this.VsTextDocument.Dispose ();
 			SyntaxMode = null;
+
+			// Dispose this after SyntaxMode is set, otherwise we'll query the VsTextDocument when setting SyntaxMode.
+			this.VsTextDocument.Dispose ();
 		}
 
 		private void OnTextBufferChangedImmediate (object sender, Microsoft.VisualStudio.Text.TextContentChangedEventArgs args)

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -246,6 +246,7 @@ namespace Mono.TextEditor
 			this.TextBuffer.ContentTypeChanged -= this.OnTextBufferContentTypeChanged;
 			this.TextBuffer.Properties.RemoveProperty(typeof(ITextDocument));
 			this.VsTextDocument.FileActionOccurred -= this.OnTextDocumentFileActionOccurred;
+			this.VsTextDocument.Dispose ();
 			SyntaxMode = null;
 		}
 

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -28,7 +28,7 @@
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Data" version="15.8.519" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.2.2-pre" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Text.Implementation" version="15.2.3-pre" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.Internal" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.8.519" targetFramework="net45" />


### PR DESCRIPTION
This PR adds two tweaks to the current integration with the Visual Studio text model:

- It integrates with the `GetContent<T>` machinery so that an underlying `ITextDocument` instance can be queried from a `TextEditor` instance
- If fixes `ITextDocument` lifecycle when the parent document is disposed so that the corresponding event in `ITextDocumentFactoryService` is fired properly

Ultimately those two changes help us share our integration code between Visual Studio Windows and VSMac.

Backport of #6374.

/cc @garuma 