### PR TITLE
[A11y] Update the bounds of the Tabstrip tabs when one is inserted

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
@@ -136,6 +136,7 @@ namespace MonoDevelop.Components
 				proxies [i] = tab.Accessible;
 				tab.Accessible.Index = i;
 				i++;
+				tab.Allocation = GetBounds (tab);
 			}
 
 			Accessible.SetTabs (proxies);


### PR DESCRIPTION
Inserted tabs may bump previous tabs to the right, so update all the bounds

Fixes VSTS #752791