### PR TITLE
[Packaging] Accessibility - NuGet packaging metadata

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/Gui/MonoDevelop.Packaging.Gui.GtkNuGetPackageMetadataOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/Gui/MonoDevelop.Packaging.Gui.GtkNuGetPackageMetadataOptionsPanelWidget.cs
@@ -48,7 +48,7 @@ namespace MonoDevelop.Packaging.Gui
 
 		private global::Gtk.HBox packageLanguageHBox;
 
-		private global::Gtk.ComboBoxEntry packageLanguageComboBox;
+		private global::Gtk.ComboBox packageLanguageComboBox;
 
 		private global::Gtk.Label packageLanguageLabel;
 
@@ -321,7 +321,7 @@ namespace MonoDevelop.Packaging.Gui
 			this.packageLanguageHBox.Name = "packageLanguageHBox";
 			this.packageLanguageHBox.Spacing = 6;
 			// Container child packageLanguageHBox.Gtk.Box+BoxChild
-			this.packageLanguageComboBox = global::Gtk.ComboBoxEntry.NewText();
+			this.packageLanguageComboBox = global::Gtk.ComboBox.NewText();
 			this.packageLanguageComboBox.Name = "packageLanguageComboBox";
 			this.packageLanguageHBox.Add(this.packageLanguageComboBox);
 			global::Gtk.Box.BoxChild w19 = ((global::Gtk.Box.BoxChild)(this.packageLanguageHBox[this.packageLanguageComboBox]));

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkNuGetPackageMetadataOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkNuGetPackageMetadataOptionsPanelWidget.cs
@@ -60,85 +60,68 @@ namespace MonoDevelop.Packaging.Gui
 			packageReleaseNotesPaddingLabel.Accessible.Role = Atk.Role.Filler;
 
 			packageIdTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.ID",
-			                                                   GettextCatalog.GetString ("ID"),
-			                                                   GettextCatalog.GetString ("Enter the ID of the NuGet package"));
-			packageIdTextBox.SetAccessibilityLabelRelationship (packageIdLabel);
+				packageIdLabel,
+				GettextCatalog.GetString ("Enter the ID of the NuGet package"));
 
 			packageVersionTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Version",
-			                                                        GettextCatalog.GetString ("Version"),
-			                                                        GettextCatalog.GetString ("Enter the version of the NuGet package"));
-			packageVersionTextBox.SetAccessibilityLabelRelationship (packageVersionLabel);
+				packageVersionLabel,
+				GettextCatalog.GetString ("Enter the version of the NuGet package"));
 
 			packageAuthorsTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Authors",
-			                                                        GettextCatalog.GetString ("Authors"),
-			                                                        GettextCatalog.GetString ("Enter the authors of the NuGet package"));
-			packageAuthorsTextBox.SetAccessibilityLabelRelationship (packageAuthorsLabel);
+				packageAuthorsLabel,
+				GettextCatalog.GetString ("Enter the authors of the NuGet package"));
 
 			packageDescriptionTextView.SetCommonAccessibilityAttributes ("NuGetMetadata.Description",
-			                                                             GettextCatalog.GetString ("Description"),
-			                                                             GettextCatalog.GetString ("Enter the description of the NuGet package"));
-			packageDescriptionTextView.SetAccessibilityLabelRelationship (packageDescriptionLabel);
+				packageDescriptionLabel,
+				GettextCatalog.GetString ("Enter the description of the NuGet package"));
 
 			packageOwnersTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Owners",
-			                                                       GettextCatalog.GetString ("Owners"),
-			                                                       GettextCatalog.GetString ("Enter the owners of the NuGet package"));
-			packageOwnersTextBox.SetAccessibilityLabelRelationship (packageOwnersLabel);
+				packageOwnersLabel,
+				GettextCatalog.GetString ("Enter the owners of the NuGet package"));
 
 			packageCopyrightTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Copyright",
-			                                                          GettextCatalog.GetString ("Copyright"),
-			                                                          GettextCatalog.GetString ("Enter the copyright statement for the NuGet package"));
-			packageCopyrightTextBox.SetAccessibilityLabelRelationship (packageCopyrightLabel);
+				packageCopyrightLabel,
+				GettextCatalog.GetString ("Enter the copyright statement for the NuGet package"));
 
 			packageTitleTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Title",
-			                                                      GettextCatalog.GetString ("Title"),
-			                                                      GettextCatalog.GetString ("Enter the title of the NuGet package"));
-			packageTitleTextBox.SetAccessibilityLabelRelationship (packageTitleLabel);
+				packageTitleLabel,
+				GettextCatalog.GetString ("Enter the title of the NuGet package"));
 
 			packageSummaryTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Summary",
-			                                                        GettextCatalog.GetString ("Summary"),
-			                                                        GettextCatalog.GetString ("Enter the summary for the NuGet package"));
-			packageSummaryTextBox.SetAccessibilityLabelRelationship (packageSummaryLabel);
+				packageSummaryLabel,
+				GettextCatalog.GetString ("Enter the summary for the NuGet package"));
 
 			packageProjectUrlTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.URL",
-			                                                           GettextCatalog.GetString ("Project URL"),
-			                                                           GettextCatalog.GetString ("Enter the project URL for the NuGet package"));
-			packageProjectUrlTextBox.SetAccessibilityLabelRelationship (packageProjectUrlLabel);
+				packageProjectUrlLabel,
+				GettextCatalog.GetString ("Enter the project URL for the NuGet package"));
 
 			packageIconUrlTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Icon",
-			                                                        GettextCatalog.GetString ("Icon URL"),
-			                                                        GettextCatalog.GetString ("Enter the URL for the NuGet package's icon"));
-			packageIconUrlTextBox.SetAccessibilityLabelRelationship (packageIconUrlLabel);
+				packageIconUrlLabel,
+				GettextCatalog.GetString ("Enter the URL for the NuGet package's icon"));
 
 			packageLicenseUrlTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.licence",
-			                                                           GettextCatalog.GetString ("License URL"),
-			                                                           GettextCatalog.GetString ("Enter the URL for the NuGet package's license"));
-			packageLicenseUrlTextBox.SetAccessibilityLabelRelationship (packageLicenseUrlLabel);
+				packageLicenseUrlLabel,
+				GettextCatalog.GetString ("Enter the URL for the NuGet package's license"));
 
 			packageRequireLicenseAcceptanceCheckBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Acceptance",
-			                                                                          GettextCatalog.GetString ("Require License Acceptance"),
-			                                                                          GettextCatalog.GetString ("Check to require the user to accept the NuGet package's license"));
-			packageRequireLicenseAcceptanceCheckBox.SetAccessibilityLabelRelationship (packageRequireLicenseAcceptanceLabel);
+				packageRequireLicenseAcceptanceLabel,
+				GettextCatalog.GetString ("Check to require the user to accept the NuGet package's license"));
 
 			packageDevelopmentDependencyCheckBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Development",
-			                                                                       GettextCatalog.GetString ("Development Dependency"),
-			                                                                       GettextCatalog.GetString ("Check to indicate that this is a development dependency"));
-			packageDevelopmentDependencyCheckBox.SetAccessibilityLabelRelationship (packageDevelopmentDependencyLabel);
+				packageDevelopmentDependencyLabel,
+				GettextCatalog.GetString ("Check to indicate that this is a development dependency"));
 
 			packageTagsTextBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Tags",
-			                                                     GettextCatalog.GetString ("Tags"),
-			                                                     GettextCatalog.GetString ("Enter the tags for this NuGet package"));
-			packageTagsTextBox.SetAccessibilityLabelRelationship (packageTagsLabel);
+				packageTagsLabel,
+				GettextCatalog.GetString ("Enter the tags for this NuGet package"));
 
 			packageLanguageComboBox.SetCommonAccessibilityAttributes ("NuGetMetadata.Language",
-			                                                          GettextCatalog.GetString ("Language"),
-			                                                          GettextCatalog.GetString ("Select the language for this NuGet package"));
-			packageLanguageComboBox.SetAccessibilityLabelRelationship (packageLanguageLabel);
+				packageLanguageLabel,
+				GettextCatalog.GetString ("Select the language for this NuGet package"));
 
 			packageReleaseNotesTextView.SetCommonAccessibilityAttributes ("NuGetMetadata.ReleaseNotes",
-			                                                              GettextCatalog.GetString ("Release Notes"),
-			                                                              GettextCatalog.GetString ("Enter the release notes for this NuGet package"));
-			packageReleaseNotesTextView.SetAccessibilityLabelRelationship (packageReleaseNotesLabel);
-
+				packageReleaseNotesLabel,
+				GettextCatalog.GetString ("Enter the release notes for this NuGet package"));
 		}
 
 		internal static System.Action<bool> OnProjectHasMetadataChanged;


### PR DESCRIPTION
**Fix language metadata accessibility in project options**

Tabbing to the language combo box in project options - NuGet Package -
Metadata would not announce the label associated with the combo box
with Voice Over. The problem is that the combo box with an enabled
text entry does not work well with the accessibility library. To
fix this the combo box no longer allows free text entry. If no
language is selected then 'None' is displayed.

Fixes VSTS #753486 - Accessibility: NuGet Package Metadata: Voice
Over is not reading the label of the "Language" combo box.

Fixes VSTS #753489 - Usability: NuGet Package Metadata: Text area
inside the "Language" combo box does not serves any purpose and seems
not to be useful in this scenario.

**Show language display name in project options for metadata**

In project options - NuGet Package - Metadata the language display
name is shown in the language combo box. Previously the language
code (e.g. 'en-GB') was displayed. The display name is more user
friendly and also matches the behaviour of Visual Studio on Windows
when it shows package metadata for .NET Standard projects.

**Fix voice over announcing items twice for package metadata**

In project options - NuGet Package - Metadata tabbing through the
UI controls would result in the label text being announced twice.
This was because an accessibility label was being set twice - once
as plain text, and then when associating the label with the main
UI element via a role.