### PR TITLE
[Packaging] Fix voice over not reading warning label in project options

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkProjectNuGetBuildOptionsPanelWidget.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging.Gui/GtkProjectNuGetBuildOptionsPanelWidget.cs
@@ -44,9 +44,13 @@ namespace MonoDevelop.Packaging.Gui
 			SetupAccessibility ();
 		}
 
-		void SetupAccessibility ()
+		void SetupAccessibility (bool includeMissingMetadataLabelText = false)
 		{
-			packOnBuildButton.SetCommonAccessibilityAttributes ("NugetBuildOptionsPanel.PackOnBuild", "",
+			string accessibilityLabel = packOnBuildButton.Label;
+			if (includeMissingMetadataLabelText) {
+				accessibilityLabel += " " + missingMetadataLabel.Text;
+			}
+			packOnBuildButton.SetCommonAccessibilityAttributes ("NugetBuildOptionsPanel.PackOnBuild", accessibilityLabel,
 			                                                    GettextCatalog.GetString ("Check to create a NuGet package when building"));
 		}
 
@@ -73,10 +77,15 @@ namespace MonoDevelop.Packaging.Gui
 
 		void UpdateMissingMetadataLabelVisibility ()
 		{
-			if (packOnBuildButton.Active) {
-				missingMetadataLabel.Visible = !ProjectHasMetadata;
+			bool visible = packOnBuildButton.Active && !ProjectHasMetadata;
+			missingMetadataLabel.Visible = visible;
+
+			// Refresh accessibility information so missing metadata label text is available to Voice Over
+			// when the check box is selected.
+			if (visible) {
+				SetupAccessibility (includeMissingMetadataLabelText: true);
 			} else {
-				missingMetadataLabel.Visible = false;
+				SetupAccessibility ();
 			}
 		}
 


### PR DESCRIPTION
In project options - NuGet Package - Build the check box to enable creation
of a NuGet package at build time will show a warning label if there is no
associated package metadata defined for the project. This warning label was
not being read by voice over when the check box is selected. Now the
accessibility text is updated and includes the warning text if it is applies
so this is now read by voice over when the check box is selected.

Fixes VSTS #753475 - Accessibility: Voice Over is not reading the alert text
revealed after the "Create a NuGet Package" checkbox is checked.