### PR TITLE
[Ide] Fix accessibility Voice Over problems in Find in Files dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/SearchEntry.cs
@@ -683,6 +683,13 @@ namespace MonoDevelop.Components
 
 		}
 
+		public void SetEntryAccessibilityAttributes (string name, string label, string help)
+		{
+			entry.SetCommonAccessibilityAttributes (name, label, help);
+		}
+
+		public Atk.Object EntryAccessible => entry.Accessible;
+
 		private class FramelessEntry : Entry
 		{
 			private SearchEntry parent;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -242,33 +242,37 @@ namespace MonoDevelop.Ide.FindInFiles
 		void SetupAccessibility ()
 		{
 			comboboxentryFind.SetCommonAccessibilityAttributes ("FindInFilesDialog.comboboxentryFind",
-												"Find",
+												labelFind,
 												GettextCatalog.GetString ("Enter string to find"));
-			comboboxentryFind.SetAccessibilityLabelRelationship (labelFind);
+
+			comboboxScope.SetCommonAccessibilityAttributes ("FindInFilesDialog.comboboxScope",
+				labelScope,
+				GettextCatalog.GetString ("Select where to search"));
 		}
 
 		void SetupAccessibilityForReplace ()
 		{
 			comboboxentryReplace.SetCommonAccessibilityAttributes ("FindInFilesDialog.comboboxentryReplace",
-											"Replace",
+											labelReplace,
 											GettextCatalog.GetString ("Enter string to replace"));
-			comboboxentryReplace.SetAccessibilityLabelRelationship (labelReplace);
 		}
 
 		void SetupAccessibilityForPath ()
 		{
 			comboboxentryPath.SetCommonAccessibilityAttributes ("FindInFilesDialog.comboboxentryPath",
-												"Path",
+												labelPath,
 												GettextCatalog.GetString ("Enter the Path"));
-			comboboxentryPath.SetAccessibilityLabelRelationship (labelPath);
+
+			buttonBrowsePaths.SetCommonAccessibilityAttributes ("FindInFilesDialog.buttonBrowsePaths",
+				GettextCatalog.GetString ("Browse Path"),
+				GettextCatalog.GetString ("Select a folder"));
 		}
 
 		void SetupAccessibilityForSearch ()
 		{
-			searchentryFileMask.SetCommonAccessibilityAttributes ("FindInFilesDialog.searchentryFileMask",
-				"File Mask",
+			searchentryFileMask.SetEntryAccessibilityAttributes ("FindInFilesDialog.searchentryFileMask",
+				labelFileMask.Text,
 				GettextCatalog.GetString ("Enter the file mask"));
-			searchentryFileMask.SetAccessibilityLabelRelationship (labelFileMask);
 		}
 
 		static void TableAddRow (Table table, uint row, Widget column1, Widget column2)
@@ -432,9 +436,7 @@ namespace MonoDevelop.Ide.FindInFiles
 			
 			labelPath.MnemonicWidget = comboboxentryPath;
 
-			SetupAccessibilityForPath ();
-			
-			buttonBrowsePaths = new Button { Label = "..." };
+			buttonBrowsePaths = new Button { Label = "…" };
 			buttonBrowsePaths.Clicked += ButtonBrowsePathsClicked;
 			buttonBrowsePaths.Show ();
 			hboxPath.PackStart (buttonBrowsePaths, false, false, 0);
@@ -454,6 +456,8 @@ namespace MonoDevelop.Ide.FindInFiles
 			checkbuttonRecursively.Show ();
 			
 			TableAddRow (tableFindAndReplace, row, null, checkbuttonRecursively);
+
+			SetupAccessibilityForPath ();
 		}
 		
 		void HideDirectoryPathUI ()


### PR DESCRIPTION
 - Fixed Voice Over reading accessibility text for some UI controls.
 - Fixed Voice Over Look in combo box not reading label text.
 - Fixed ellipsis used in browse button.
 - Fixed Voice Over not describing browse button.
 - Fixed Voice Over saying 'Search' for the File Mask text entry.

Still a problem with the combo box with enabled text entry which is
not fixed here. This may be fixed in AtkCocoa at some point.
Otherwise the dialog would need to be changed to use a MenuButton.

Fixes VSTS #752731 - Accessibility: Voice Over is not reading the
labels for text fields