### PR TITLE
[WIP][NuGet] Attempt to fix accessibility issues in Add Packages dialog

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.UI.cs
@@ -83,11 +83,17 @@ namespace MonoDevelop.PackageManagement
 			packageSourceComboBox = new ComboBox ();
 			packageSourceComboBox.Name = "packageSourceComboBox";
 			packageSourceComboBox.MinWidth = 200;
+			packageSourceComboBox.Accessible.Identifier = packageSourceComboBox.Name;
+			packageSourceComboBox.Accessible.Label = GettextCatalog.GetString ("NuGet package source");
+			packageSourceComboBox.Accessible.Description = GettextCatalog.GetString ("Select NuGet package source");
 			topHBox.PackStart (packageSourceComboBox);
 
 			packageSearchEntry = new SearchTextEntry ();
 			packageSearchEntry.Name = "addPackagesDialogSearchEntry";
 			packageSearchEntry.WidthRequest = 187;
+			packageSearchEntry.Accessible.Identifier = packageSearchEntry.Name;
+			packageSearchEntry.Accessible.Label = GettextCatalog.GetString ("Search");
+			packageSearchEntry.Accessible.Description = GettextCatalog.GetString ("Search for NuGet packages");
 			topHBox.PackEnd (packageSearchEntry);
 
 			this.HeaderContent = topHBox;
@@ -140,7 +146,10 @@ namespace MonoDevelop.PackageManagement
 			loadingSpinnerHBox.PackStart (loadingSpinner);
 
 			loadingSpinnerLabel = new Label ();
-			loadingSpinnerLabel.Text = Catalog.GetString ("Loading package list...");
+			loadingSpinnerLabel.Text = Catalog.GetString ("Loading package list…");
+			loadingSpinner.Accessible.Identifier ="addPackagesDialogLoadingSpinner";
+			loadingSpinner.Accessible.LabelWidget = loadingSpinnerLabel;
+
 			loadingSpinnerHBox.PackEnd (loadingSpinnerLabel);
 
 			loadingSpinnerFrame = new FrameBox ();
@@ -332,6 +341,9 @@ namespace MonoDevelop.PackageManagement
 
 			packageVersionComboBox = new ComboBox ();
 			packageVersionComboBox.Name = "packageVersionComboBox";
+			packageVersionComboBox.Accessible.Identifier = packageVersionComboBox.Name;
+			packageVersionComboBox.Accessible.LabelWidget = packageVersionsLabel;
+			packageVersionComboBox.Accessible.Description = GettextCatalog.GetString ("Select a NuGet package version");
 			packageVersionsHBox.Spacing = 15;
 			packageVersionsHBox.PackStart (packageVersionComboBox, true, true);
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackagesDialog.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.PackageManagement
 		TimeSpan searchDelayTimeSpan = TimeSpan.FromMilliseconds (500);
 		IDisposable searchTimer;
 		SourceRepositoryViewModel dummyPackageSourceRepresentingConfigureSettingsItem =
-			new SourceRepositoryViewModel (Catalog.GetString ("Configure Sources..."));
+			new SourceRepositoryViewModel (Catalog.GetString ("Configure Sources…"));
 		ImageLoader imageLoader = new ImageLoader ();
 		bool loadingMessageVisible;
 		bool ignorePackageVersionChanges;
@@ -174,9 +174,9 @@ namespace MonoDevelop.PackageManagement
 		void UpdateSpinnerLabel ()
 		{
 			if (String.IsNullOrWhiteSpace (packageSearchEntry.Text)) {
-				loadingSpinnerLabel.Text = Catalog.GetString ("Loading package list...");
+				loadingSpinnerLabel.Text = Catalog.GetString ("Loading package list…");
 			} else {
-				loadingSpinnerLabel.Text = Catalog.GetString ("Searching packages...");
+				loadingSpinnerLabel.Text = Catalog.GetString ("Searching packages…");
 			}
 		}
 


### PR DESCRIPTION
Fixed incorrect ellipsis used in label text.
Added accessibility text for the search text box, package sources
combo box and the versions combo box. However voice over does not
read any of this text. Search text area accessibility text is read
when using Voice Over arrow keys but not when tabbing into the
control.

Fixes VSTS #750371 - Accessibility: VoiceOver is not reading the label
for Search text field; Label and title are not provided for the search
text field