### PR TITLE
[Ide] Fix Voice Over reading UI controls multiple times in options

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/PolicyOptionsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/PolicyOptionsPanel.cs
@@ -122,8 +122,9 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			}
 			
 			policyCombo.Changed += HandlePolicyComboChanged;
-			
-			return vbox;
+
+			var widget = new PolicyOptionsWidgetContainer (vbox);
+			return widget;
 		}
 		
 		void LoadPolicy (T policy)
@@ -338,6 +339,22 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 				}
 			} finally {
 				loading = false;
+			}
+		}
+
+		/// <summary>
+		/// Container for the VBox used to  display the options panel information.
+		/// This is needed since using just a VBox causes Voice Over on the Mac to
+		/// read out the UI widgets multiple times with using the arrow keys.
+		/// </summary>
+		class PolicyOptionsWidgetContainer : Bin
+		{
+			public PolicyOptionsWidgetContainer (VBox child)
+			{
+				BinContainer.Attach (this);
+
+				Add (child);
+				ShowAll ();
 			}
 		}
 	}


### PR DESCRIPTION
The standardard header options panel and the .NET naming policy
options panel would cause Voice Over to read the accessibility text
multiple times when using the arrow keys. The parent policy options
class now wraps the Gtk.VBox in a Gtk.Bin which fixes the problem.

Fixes VSTS #752365 - Accessibility: Voice Over is reading few controls
(Warning and the content provided after that icon) twice when user is
navigating using "Control + Option + Right arrow".

Fixes VSTS #753328 - Accessibility: Net Naming Policies: Voice Over is
reading few controls(Warning and the content provided after that icon)
twice when user is navigating using "Control + Option + Right arrow".