### PR TITLE
[Ide] Various memory retention fixes around the project model

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -68,18 +68,11 @@ namespace MonoDevelop.Ide
 		WorkspaceItem currentWorkspaceItem = null;
 		object currentItem;
 		
-		BuildResult lastResult = new BuildResult ();
-		
 		internal ProjectOperations ()
 		{
 			IdeApp.Workspace.WorkspaceItemUnloaded += OnWorkspaceItemUnloaded;
 			IdeApp.Workspace.ItemUnloading += IdeAppWorkspaceItemUnloading;
 			
-		}
-
-		[Obsolete ("This property will be removed.")]
-		public BuildResult LastCompilerResult {
-			get { return lastResult; }
 		}
 		
 		public Project CurrentSelectedProject {
@@ -1806,7 +1799,6 @@ namespace MonoDevelop.Ide
 			tt.Trace ("Begin reporting build result");
 			try {
 				if (result != null) {
-					lastResult = result;
 					monitor.Log.WriteLine ();
 
 					var msg = GettextCatalog.GetString (
@@ -1826,7 +1818,7 @@ namespace MonoDevelop.Ide
 
 					if (monitor.CancellationToken.IsCancellationRequested) {
 						monitor.ReportError (GettextCatalog.GetString ("Build canceled."), null);
-					} else if (result.ErrorCount == 0 && result.WarningCount == 0 && lastResult.FailedBuildCount == 0) {
+					} else if (result.ErrorCount == 0 && result.WarningCount == 0 && result.FailedBuildCount == 0) {
 						monitor.ReportSuccess (GettextCatalog.GetString ("Build successful."));
 					} else if (result.ErrorCount == 0 && result.WarningCount > 0) {
 						monitor.ReportWarning(GettextCatalog.GetString("Build: ") + errorString + ", " + warningString);
@@ -1836,7 +1828,7 @@ namespace MonoDevelop.Ide
 						monitor.ReportError(GettextCatalog.GetString("Build failed."), null);
 					}
 					tt.Trace ("End build event");
-					OnEndBuild (monitor, lastResult.FailedBuildCount == 0, lastResult, entry as SolutionFolderItem);
+					OnEndBuild (monitor, result.FailedBuildCount == 0, result, entry as SolutionFolderItem);
 				} else {
 					tt.Trace ("End build event");
 					OnEndBuild (monitor, false);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1239,10 +1239,7 @@ namespace MonoDevelop.Ide
 				currentBuildOperation = op;
 				currentBuildOperationOwner = entry;
 
-				t.ContinueWith (ta => {
-					ResetCurrentBuildOperation ();
-					return ta.Result;
-				});
+				t.ContinueWith (ta => { ResetCurrentBuildOperation (); });
 				return op;
 			}
 			catch {
@@ -1377,10 +1374,7 @@ namespace MonoDevelop.Ide
 			currentBuildOperation = op;
 			currentBuildOperationOwner = entry;
 
-			t.ContinueWith (ta => {
-				ResetCurrentBuildOperation ();
-				return ta.Result;
-			});
+			t.ContinueWith (ta => { ResetCurrentBuildOperation (); });
 			return op;
 		}
 		
@@ -1679,11 +1673,7 @@ namespace MonoDevelop.Ide
 				currentBuildOperation = op;
 				currentBuildOperationOwner = entry;
 
-				t.ContinueWith (ta => {
-					ResetCurrentBuildOperation ();
-					return ta.Result;
-				});
-
+				t.ContinueWith (ta => { ResetCurrentBuildOperation (); });
 				return op;
 			} catch {
 				tt.End ();


### PR DESCRIPTION
This change allows us to reclaim some memory earlier, rather than relying on the user invalidating the data via a future operation.

Fixes VSTS #773051 - Possible leak of large data via AsyncOperation