### PR TITLE
[release-7.8] Fixes VSTS Bug 770635: NRE in TextEditorData.GetChunks

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/ISyntaxHighlighting.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/ISyntaxHighlighting.cs
@@ -61,6 +61,11 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			TextSegment = textSegment;
 			Segments = segments;
 		}
+
+		public override string ToString ()
+		{
+			return string.Format ("[HighlightedLine: TextSegment={0}, #Segments={1}, IsContinuedBeyondLineEnd={2}]", TextSegment, Segments?.Count, IsContinuedBeyondLineEnd);
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/770635

At least it'll help to find the real cause. Added segment == null
check which is a guess which would expose an issue in the syntax mode
implemention. From where that method is called line is always != null.

Backport of #6922.

/cc @slluis @mkrueger