### PR TITLE
[Debugger] Show main window when debugging app

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
@@ -65,6 +65,10 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation DebugApplication (this ProjectOperations opers, string executableFile, string args, string workingDir, IDictionary<string,string> envVars)
 		{
+			if (!IdeApp.Workbench.RootWindow.Visible) {
+				IdeApp.Workbench.RootWindow.Show ();
+			}
+
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileName (executableFile));
 
 			var oper = DebuggingService.Run (executableFile, args, workingDir, envVars, monitor.Console);
@@ -79,6 +83,10 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation AttachToProcess (this ProjectOperations opers, DebuggerEngine debugger, ProcessInfo proc)
 		{
+			if (!IdeApp.Workbench.RootWindow.Visible) {
+				IdeApp.Workbench.RootWindow.Show ();
+			}
+
 			var oper = DebuggingService.AttachToProcess (debugger, proc);
 
 			opers.AddRunOperation (oper);


### PR DESCRIPTION
Now that we have a separate window (Start Window), we need to make
sure we show the main window if it's not visible for operations that
rely on the main window being shown, like is the case for Run->Debug
Application.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/770996