### PR TITLE
Fixes NRE in case of bind a instance non IComponent

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/EventEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid.Editors/EventEditor.cs
@@ -47,12 +47,18 @@ namespace MonoDevelop.Components.PropertyGrid.PropertyEditors
 		protected override void Initialize ()
 		{
 			IComponent comp = Instance as IComponent;
-			evtBind = (IEventBindingService) comp.Site.GetService (typeof (IEventBindingService));
-			base.Initialize ();
+			if (comp != null) {
+				evtBind = (IEventBindingService)comp.Site.GetService (typeof (IEventBindingService));
+				base.Initialize ();
+			}
 		}
 		
 		protected override IPropertyEditor CreateEditor (Gdk.Rectangle cell_area, Gtk.StateType state)
 		{
+			if (evtBind == null) {
+				return null;
+			}
+
 			//get existing method names
 			ICollection IColl = evtBind.GetCompatibleMethods (evtBind.GetEvent (Property)) ;
 			string[] methods = new string [IColl.Count + 1];


### PR DESCRIPTION
In case of crating an Event editor with a instance that desn't inherit from IComponent this thows a NRE breaking the IDE.

This commit, returns null creating this Editor which is covered by the current implementation