### PR TITLE
Fixes VSTS Bug 752631: Accessibility: Preferences - External Tools:

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/BaseFileEntry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/BaseFileEntry.cs
@@ -154,6 +154,12 @@ namespace MonoDevelop.Components
 			pathEntry.SetCommonAccessibilityAttributes (name, label, help);
 		}
 
+
+		public void SetEntryAccessibleTitleUIElement (Atk.Object accessible)
+		{
+			pathEntry.Accessible.SetTitleUIElement (accessible);
+		}
+
 		public Atk.Object EntryAccessible {
 			get {
 				return pathEntry.Accessible;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ExternalTools/ExternalToolPanel.cs
@@ -153,7 +153,7 @@ namespace MonoDevelop.Ide.ExternalTools
 			                                               GettextCatalog.GetString ("Enter the title for this command"));
 			browseButton.Accessible.SetCommonAttributes ("ExternalTools.Command", null,
 			                                             GettextCatalog.GetString ("Enter or select the path for the external command"));
-			browseButton.Accessible.SetTitleUIElement (commandLabel.Accessible);
+			browseButton.SetEntryAccessibleTitleUIElement (commandLabel.Accessible);
 			argumentTextBox.SetCommonAccessibilityAttributes ("ExternalTools.Arguments", "",
 			                                                  GettextCatalog.GetString ("Enter the arguments for the external command"));
 			argumentTextBox.SetAccessibilityLabelRelationship (argumentLabel);


### PR DESCRIPTION
Voice over is not reading the name of the command text field. It is
just reading as edit text

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/752631