### PR TITLE
[Core] Prevents NullReferenceException

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4528,6 +4528,13 @@ namespace MonoDevelop.Projects
 
 		void OnFileCreatedExternally (FilePath fileName)
 		{
+			if (sourceProject == null) {
+				// sometimes this method is called after disposing this class. 
+				// (i.e. when quitting MD or creating a new project.)
+				LoggingService.LogWarning ("File created externally not processed. {0}", fileName);
+				return;
+			}
+
 			// Check file is inside the project directory. The file globs would exclude the file anyway
 			// if the relative path starts with "..\" but checking here avoids checking the file globs.
 			if (!fileName.IsChildPathOf (BaseDirectory))


### PR DESCRIPTION
BACKGROUND:
- After creating a project, once we create another one or quit MD a NRE is thrown in `OnFileCreatedExternally()`. It looks like that at this point, the class has been `Disposed()` and it's called inside MainUIThread from OnFileRenamed () method.
- [NewProjectDialogController.DisposeExistingNewItems ()](https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs#L685) disposes it.

NOTE: I tried to figure out what's the real problem and looks like that `OnFileCreatedExternally` is called under `Runtime.RunInMainThread` [here](https://github.com/mono/monodevelop/blob/87b8a993ccb3ebb635dcf0ebf3156354cf94b497/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs#L4431) by removing `Runtime.RunInMainThread` looks like that the issue is also fixed (because of the class is disposed after `OnFileCreatedExternally` is called) but I suspect that this could break anything else like when moving a folder externally.

[This commit could be related](https://github.com/mono/monodevelop/commit/8af931e08842ccc7c9f821880ce6bdb1a1b1238f) 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/753629