### PR TITLE
 Fixes calculate of the next focused view in SelectorView

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -124,22 +124,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		internal void OnSizeChanged ()
 		{
-			if (SizeChanged != null) {
-				SizeChanged (this, EventArgs.Empty);
-			}
+			SizeChanged?.Invoke (this, EventArgs.Empty);
 		}
 
-		public override bool BecomeFirstResponder()
-		{
-			if (Window.FirstResponder != RealSelectorView)
-				return Window.MakeFirstResponder(RealSelectorView);
-			return false;
-		}
-
-		public override bool AcceptsFirstResponder()
-		{
-			return Window.FirstResponder != RealSelectorView;
-		}
+		public override bool AcceptsFirstResponder () => false;
 
 		#region PathSelectorView
 		[Register]
@@ -584,29 +572,39 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 				// 0x30 is Tab
 				if (theEvent.KeyCode == (ushort)KeyCodes.Tab) {
-					if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
-						focusedCellIndex--;
-						if (focusedCellIndex < 0) {
-							if (PreviousKeyView != null) {
+
+					if (theEvent.KeyCode == (ushort)KeyCodes.Space) {
+						var item = Cells [focusedCellIndex].Cell;
+						PopupMenuForCell (item);
+						return;
+					}
+
+					// 0x30 is Tab
+					if (theEvent.KeyCode == (ushort)KeyCodes.Tab) {
+						if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
+							if (focusedCellIndex <= 0) {
+								if (PreviousKeyView != null) {
+									SetSelection ();
+									focusedCellIndex = 0;
+									focusedItem = null;
+								}
+							} else {
+								focusedCellIndex--;
 								SetSelection ();
-								focusedCellIndex = 0;
-								focusedItem = null;
+								return;
 							}
 						} else {
-							SetSelection ();
-							return;
-						}
-					} else {
-						focusedCellIndex++;
-						if (focusedCellIndex >= VisibleCellIds.Length) {
-							if (NextKeyView != null) {
+							if (focusedCellIndex >= VisibleCellIds.Length - 1) {
+								if (NextKeyView != null) {
+									SetSelection ();
+									focusedCellIndex = 0;
+									focusedItem = null;
+								}
+							} else {
+								focusedCellIndex++;
 								SetSelection ();
-								focusedCellIndex = 0;
-								focusedItem = null;
+								return;
 							}
-						} else {
-							SetSelection ();
-							return;
 						}
 					}
 				}

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -614,15 +614,20 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			void SetSelection ()
 			{
-				if (focusedItem != null) {
-					focusedItem.HasFocus = false;
-				}
+				//ensures our cells are in the correct enabled state
 				if (focusedCellIndex >= 0 && focusedCellIndex < Cells.Length) {
-					var item = Cells [focusedCellIndex].Cell as NSPathComponentCellFocusable;
-					focusedItem = item;
-					if (item != null)
-						item.HasFocus = true;
+					focusedItem = Cells [focusedCellIndex].Cell as NSPathComponentCellFocusable;
+					if (focusedItem != null)
+						focusedItem.HasFocus = true;
 				}
+
+				//we want ensure our state is correct in other elements
+				for (int i = 0; i < Cells.Length; i++) {
+					if (i != focusedCellIndex && Cells [i].Cell is NSPathComponentCellFocusable focusable) {
+						focusable.HasFocus = false;
+					}
+				}
+
 				SetNeedsDisplay ();
 			}
 

--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -572,39 +572,29 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 				// 0x30 is Tab
 				if (theEvent.KeyCode == (ushort)KeyCodes.Tab) {
-
-					if (theEvent.KeyCode == (ushort)KeyCodes.Space) {
-						var item = Cells [focusedCellIndex].Cell;
-						PopupMenuForCell (item);
-						return;
-					}
-
-					// 0x30 is Tab
-					if (theEvent.KeyCode == (ushort)KeyCodes.Tab) {
-						if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
-							if (focusedCellIndex <= 0) {
-								if (PreviousKeyView != null) {
-									SetSelection ();
-									focusedCellIndex = 0;
-									focusedItem = null;
-								}
-							} else {
-								focusedCellIndex--;
+					if ((theEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
+						if (focusedCellIndex <= 0) {
+							if (PreviousKeyView != null) {
 								SetSelection ();
-								return;
+								focusedCellIndex = 0;
+								focusedItem = null;
 							}
 						} else {
-							if (focusedCellIndex >= VisibleCellIds.Length - 1) {
-								if (NextKeyView != null) {
-									SetSelection ();
-									focusedCellIndex = 0;
-									focusedItem = null;
-								}
-							} else {
-								focusedCellIndex++;
+							focusedCellIndex--;
+							SetSelection ();
+							return;
+						}
+					} else {
+						if (focusedCellIndex >= VisibleCellIds.Length - 1) {
+							if (NextKeyView != null) {
 								SetSelection ();
-								return;
+								focusedCellIndex = 0;
+								focusedItem = null;
 							}
+						} else {
+							focusedCellIndex++;
+							SetSelection ();
+							return;
 						}
 					}
 				}


### PR DESCRIPTION
Fixes VSTS 648190 - Accessibility: Keyboard: MAS2.4.3: Focus order is inappropriate while navigating in reverse order in the toolbar.

https://devdiv.visualstudio.com/DevDiv/_queries/edit/648190/?triage=true

![toolbarfocusfix](https://user-images.githubusercontent.com/1587480/51702991-7fada800-2015-11e9-8f02-b17a748b8269.gif)

To test the issue:
- Open VS4Mac
- Click on the Global Search box
- Press Shift + Tab/Tab to move the focus between the views
- Ensure you can access all buttons in the correct order
