### PR TITLE
[MacPlatform] Ignore hidden items in responder chain

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/SelectorView.cs
@@ -562,6 +562,28 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			int focusedCellIndex = 0;
 			NSPathComponentCellFocusable focusedItem;
 
+			bool UpdatePreviousCellForResponderChain (int fromPosition)
+			{
+				for (focusedCellIndex = fromPosition; focusedCellIndex >= 0; focusedCellIndex--) {
+					var cell = Cells [focusedCellIndex].Cell;
+					if (PathComponentCells.Contains (cell) && cell.Enabled) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			bool UpdateNextCellForResponderChain (int fromPosition)
+			{
+				for (focusedCellIndex = fromPosition; focusedCellIndex < Cells.Length; focusedCellIndex++) {
+					var cell = Cells [focusedCellIndex].Cell;
+					if (PathComponentCells.Contains (cell) && cell.Enabled) {
+						return true;
+					}
+				}
+				return false;
+			}
+
 			public override void KeyDown (NSEvent theEvent)
 			{
 				if (theEvent.KeyCode == (ushort) KeyCodes.Space) {
@@ -580,9 +602,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 								focusedItem = null;
 							}
 						} else {
-							focusedCellIndex--;
-							SetSelection ();
-							return;
+							if (UpdatePreviousCellForResponderChain (focusedCellIndex - 1)) {
+								SetSelection ();
+								return;
+							}
 						}
 					} else {
 						if (focusedCellIndex >= VisibleCellIds.Length - 1) {
@@ -592,9 +615,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 								focusedItem = null;
 							}
 						} else {
-							focusedCellIndex++;
-							SetSelection ();
-							return;
+							if (UpdateNextCellForResponderChain (focusedCellIndex + 1)) {
+								SetSelection ();
+								return;
+							}
 						}
 					}
 				}
@@ -632,9 +656,9 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				if (currentEvent.Type == NSEventType.KeyDown) {
 					if (currentEvent.KeyCode == (ushort) KeyCodes.Tab) {
 						if ((currentEvent.ModifierFlags & NSEventModifierMask.ShiftKeyMask) == NSEventModifierMask.ShiftKeyMask) {
-							focusedCellIndex = Cells.Length - 1;
+							UpdatePreviousCellForResponderChain (Cells.Length - 1);
 						} else {
-							focusedCellIndex = 0;
+							UpdateNextCellForResponderChain (0);
 						}
 					}
 				}


### PR DESCRIPTION
PathSelectorView has 3 "sections", one of them being, for some kind of
projects/setups, hidden, but the code was assuming all of them were
always visible when responding to responder chain events. Now make sure
only visible items are processed so that there is never focus loss.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/753499