### PR TITLE
[release-7.8] Fixes VSTS Bug 763702: [Feedback] Using NUnit, typing inside

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CompletionProvider/DelegateCompletionProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CompletionProvider/DelegateCompletionProvider.cs
@@ -372,7 +372,8 @@ namespace MonoDevelop.CSharp.Completion.Provider
 		{
 			(string beforeText, string afterText, string newMethod) = await GetInsertText (item.Properties);
 			TextChange change;
-			if (newMethod != null && CompletionWindowManager.IsVisible) { // check for completion window manager to prevent the insertion cursor popup when the changes are queried by code diagnostics.
+
+			if (newMethod != null && RoslynCompletionData.RequestInsertText) { // check for completion window manager to prevent the insertion cursor popup when the changes are queried by code diagnostics.
 				change = new TextChange (new TextSpan (item.Span.Start, item.Span.Length), item.Properties [MethodNameKey] + ";");
 				var semanticModel = await doc.GetSemanticModelAsync (cancellationToken);
 				if (!doc.IsOpen () || await doc.IsForkedDocumentWithSyntaxChangesAsync (cancellationToken))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/RoslynCompletionData.cs
@@ -245,6 +245,8 @@ namespace MonoDevelop.Ide.CodeCompletion
 			}
 		}
 
+		public static bool RequestInsertText { get; internal set; }
+
 		public override void InsertCompletionText (CompletionListWindow window, ref KeyActions ka, KeyDescriptor descriptor)
 		{
 			var document = IdeApp.Workbench.ActiveDocument;
@@ -258,7 +260,13 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		internal void InsertCompletionText (TextEditor editor, DocumentContext context, ref KeyActions ka, KeyDescriptor descriptor)
 		{
-			var completionChange = Provider.GetChangeAsync (doc, CompletionItem, null, default (CancellationToken)).WaitAndGetResult (default (CancellationToken));
+			CompletionChange completionChange;
+			try {
+				RequestInsertText = true;
+				completionChange = Provider.GetChangeAsync (doc, CompletionItem, null, default (CancellationToken)).WaitAndGetResult (default (CancellationToken));
+			} finally {
+				RequestInsertText = false;
+			}
 
 			var currentBuffer = editor.GetPlatformTextBuffer ();
 			var textChange = completionChange.TextChange;


### PR DESCRIPTION
Assert.That(tes pops up a Create method dialog that gets in the way

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763702

The old CompletionWindowManager hack doesn't work in this case - so I
introduced a pseudo-parameter (can't change that API or use it in any
sane way). A roslyn refactoring is requesting now the changes and that
happens during completion as well - that's why the insert windows are
popping up. This prevents that from happening.

Backport of #6992.

/cc @mkrueger 