### PR TITLE
Locking hierarchy changes in MonoDevelopWorkspace

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -245,11 +245,16 @@ namespace MonoDevelop.Ide.TypeSystem
 						var projectFile = options.Project.GetProjectFile (options.FileName);
 						if (projectFile != null) {
 							ws.UpdateProjectionEntry (projectFile, result.Projections);
-							foreach (var projection in result.Projections) {
-								var docId = ws.GetDocumentId (projectId, projection.Document.FileName);
-								if (docId != null) {
-									ws.InformDocumentTextChange (docId, new MonoDevelopSourceText (projection.Document));
+							await ws.LoadLock.WaitAsync ();
+							try {
+								foreach (var projection in result.Projections) {
+									var docId = ws.GetDocumentId (projectId, projection.Document.FileName);
+									if (docId != null) {
+										ws.InformDocumentTextChange (docId, new MonoDevelopSourceText (projection.Document));
+									}
 								}
+							} finally {
+								ws.LoadLock.Release ();
 							}
 						}
 					}


### PR DESCRIPTION
We were using a sync lock on async/await transitioning between threads (i.e. marshal to UI thread).

That caused code to cause a hang, because the UI thread was already locking on the data structure and waiting
for the background thread to release.

Introduce a SemaphoreSlim async lock that can be used instead.

Should fix problems like the above stacktrace:
```
"GUI Thread"  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) object.__icall_wrapper_mono_monitor_enter_v4_internal (object,intptr) [0x00008] in <98fac219bd4e453693d76fda7bd96ab0>:0
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace/ProjectDataMap.GetData (Microsoft.CodeAnalysis.ProjectId) [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs:116
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace.GetDocumentId (Microsoft.CodeAnalysis.ProjectId,string) [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.Shims.cs:54
  at MonoDevelop.Ide.TypeSystem.TypeSystemService.GetDocumentId (MonoDevelop.Projects.Project,string) [0x0004a] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs:199
  at MonoDevelop.Ide.Gui.Document.EnsureAnalysisDocumentIsOpen () [0x000d1] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs:900
  at MonoDevelop.Ide.Gui.Document/<StartReparseThreadDelayed>d__128.MoveNext () [0x00067] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs:1060
  at System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Start<MonoDevelop.Ide.Gui.Document/<StartReparseThreadDelayed>d__128> (MonoDevelop.Ide.Gui.Document/<StartReparseThreadDelayed>d__128&) [0x0002c] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:84
  at MonoDevelop.Ide.Gui.Document.StartReparseThreadDelayed (MonoDevelop.Core.FilePath) [0x0002f] in <2f9c58e1ad264da8a6180e1e97f35ef2>:0
  at MonoDevelop.Ide.Gui.Document/<>c__DisplayClass126_0.<StartReparseThread>b__1 () [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs:1036
  at GLib.Timeout/TimeoutProxy.HandlerInternal (intptr) [0x00017] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/gtk-sharp-None/glib/Timeout.cs:38
  at (wrapper native-to-managed) GLib.Timeout/TimeoutProxy.HandlerInternal (intptr) [0x00021] in <bbc097c736e649f0bbe49b81946fd886>:0
  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) Gtk.Application.gtk_main () [0x00008] in <40f46e55eb67454ab904dc9e5644a3a1>:0
  at Gtk.Application.Run () [0x00001] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:145
  at MonoDevelop.Ide.IdeApp.Run () [0x00006] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs:461
  at MonoDevelop.Ide.IdeStartup.Run (MonoDevelop.Ide.MonoDevelopOptions) [0x00a66] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:395
  at MonoDevelop.Ide.IdeStartup.Main (string[],MonoDevelop.Ide.Extensions.IdeCustomizer) [0x000bc] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:843
  at Xamarin.Startup.MainClass.Main (string[]) [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/md-addins/Xamarin.Startup/Main.cs:11
  at (wrapper runtime-invoke) <Module>.runtime_invoke_int_object (object,intptr,intptr,intptr) [0x00057] in <a1aebe77c32b4fa7b6fab4cda40a099e>:0
```

Fixes #768879 - VSM hangs when opening a xaml file