### PR TITLE
Locking hierarchy changes in MonoDevelopWorkspace

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -117,7 +117,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (fileName.IsNullOrEmpty)
 					fileName = new FilePath (p.Name + ".dll");
 
-				var (references, projectReferences) = await metadataHandler.Value.CreateReferences (p, token);
+				var (references, projectReferences) = await metadataHandler.Value.CreateReferences (p, token).ConfigureAwait(false);
 				if (token.IsCancellationRequested)
 					return null;
 
@@ -131,37 +131,45 @@ namespace MonoDevelop.Ide.TypeSystem
 
 				var loader = workspace.Services.GetService<IAnalyzerService> ().GetLoader ();
 
-				lock (workspace.updatingProjectDataLock) {
+				ProjectData projectData, oldProjectData;
+				List<DocumentInfo> mainDocuments, additionalDocuments;
+				try {
+					await workspace.LoadLock.WaitAsync ().ConfigureAwait (false);
 					//when reloading e.g. after a save, preserve document IDs
-					var oldProjectData = projectMap.RemoveData (projectId);
-					var projectData = projectMap.CreateData (projectId, references);
+					oldProjectData = projectMap.RemoveData (projectId);
+					projectData = projectMap.CreateData (projectId, references);
 
-					var documents = CreateDocuments (projectData, p, token, sourceFiles, oldProjectData);
+					var documents = await CreateDocuments (projectData, p, token, sourceFiles, oldProjectData).ConfigureAwait (false);
 					if (documents == null)
 						return null;
 
-					// TODO: Pass in the WorkspaceMetadataFileReferenceResolver
-					var info = ProjectInfo.Create (
-						projectId,
-						VersionStamp.Create (),
-						p.Name,
-						fileName.FileNameWithoutExtension,
-						(p as MonoDevelop.Projects.DotNetProject)?.RoslynLanguageName ?? LanguageNames.CSharp,
-						p.FileName,
-						fileName,
-						cp?.CreateCompilationOptions (),
-						cp?.CreateParseOptions (config),
-						documents.Item1,
-						projectReferences,
-						references.Select (x => x.CurrentSnapshot),
-						analyzerReferences: analyzerFiles.SelectAsArray (x => {
-							var analyzer = new MonoDevelopAnalyzer (x, hostDiagnosticUpdateSource.Value, projectId, workspace, loader, LanguageNames.CSharp);
-							return analyzer.GetReference ();
-						}),
-						additionalDocuments: documents.Item2
-					);
-					return info;
+					mainDocuments = documents.Item1;
+					additionalDocuments = documents.Item2;
+				} finally {
+					workspace.LoadLock.Release ();
 				}
+
+				// TODO: Pass in the WorkspaceMetadataFileReferenceResolver
+				var info = ProjectInfo.Create (
+					projectId,
+					VersionStamp.Create (),
+					p.Name,
+					fileName.FileNameWithoutExtension,
+					(p as MonoDevelop.Projects.DotNetProject)?.RoslynLanguageName ?? LanguageNames.CSharp,
+					p.FileName,
+					fileName,
+					cp?.CreateCompilationOptions (),
+					cp?.CreateParseOptions (config),
+					mainDocuments,
+					projectReferences,
+					references.Select (x => x.CurrentSnapshot),
+					analyzerReferences: analyzerFiles.SelectAsArray (x => {
+						var analyzer = new MonoDevelopAnalyzer (x, hostDiagnosticUpdateSource.Value, projectId, workspace, loader, LanguageNames.CSharp);
+						return analyzer.GetReference ();
+					}),
+					additionalDocuments: additionalDocuments
+				);
+				return info;
 			}
 
 			async Task<ConcurrentBag<ProjectInfo>> CreateProjectInfos (IEnumerable<MonoDevelop.Projects.Project> mdProjects, CancellationToken token)
@@ -298,7 +306,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				return node.Parser.CanGenerateAnalysisDocument (mimeType, f.BuildAction, p.SupportedLanguages);
 			}
 
-			Tuple<List<DocumentInfo>, List<DocumentInfo>> CreateDocuments (ProjectData projectData, MonoDevelop.Projects.Project p, CancellationToken token, MonoDevelop.Projects.ProjectFile [] sourceFiles, ProjectData oldProjectData)
+			async Task<Tuple<List<DocumentInfo>, List<DocumentInfo>>> CreateDocuments (ProjectData projectData, MonoDevelop.Projects.Project p, CancellationToken token, ImmutableArray<MonoDevelop.Projects.ProjectFile> sourceFiles, ProjectData oldProjectData)
 			{
 				var documents = new List<DocumentInfo> ();
 				// We don' add additionalDocuments anymore because they were causing slowdown of compilation generation
@@ -319,7 +327,7 @@ namespace MonoDevelop.Ide.TypeSystem
 							continue;
 						documents.Add (CreateDocumentInfo (solutionData, p.Name, projectData, f));
 					} else {
-						foreach (var projectedDocument in GenerateProjections (f, projectData.DocumentData, p, oldProjectData, null)) {
+						foreach (var projectedDocument in await GenerateProjections (f, projectData.DocumentData, p, token, oldProjectData, null)) {
 							var projectedId = projectData.DocumentData.GetOrCreate (projectedDocument.FilePath, oldProjectData?.DocumentData);
 							if (!duplicates.Add (projectedId))
 								continue;
@@ -337,41 +345,44 @@ namespace MonoDevelop.Ide.TypeSystem
 				return Tuple.Create (documents, additionalDocuments);
 			}
 
-			IEnumerable<DocumentInfo> GenerateProjections (MonoDevelop.Projects.ProjectFile f, DocumentMap documentMap, MonoDevelop.Projects.Project p, ProjectData oldProjectData, HashSet<DocumentId> duplicates)
+			async Task<List<DocumentInfo>> GenerateProjections (MonoDevelop.Projects.ProjectFile f, DocumentMap documentMap, MonoDevelop.Projects.Project p, CancellationToken token, ProjectData oldProjectData, HashSet<DocumentId> duplicates)
 			{
 				var mimeType = DesktopService.GetMimeTypeForUri (f.FilePath);
 				var node = TypeSystemService.GetTypeSystemParserNode (mimeType, f.BuildAction);
 				if (node == null || !node.Parser.CanGenerateProjection (mimeType, f.BuildAction, p.SupportedLanguages))
-					yield break;
+					return new List<DocumentInfo> ();
+
 				var options = new ParseOptions {
 					FileName = f.FilePath,
 					Project = p,
 					Content = TextFileProvider.Instance.GetReadOnlyTextEditorData (f.FilePath),
 				};
-				var generatedProjections = node.Parser.GenerateProjections (options);
+				var generatedProjections = await node.Parser.GenerateProjections (options, token);
 				var list = new List<Projection> ();
 				var entry = new ProjectionEntry {
 					File = f,
 					Projections = list,
 				};
 
-				foreach (var projection in generatedProjections.Result) {
+				var result = new List<DocumentInfo> (generatedProjections.Count);
+				foreach (var projection in generatedProjections) {
 					list.Add (projection);
 					if (duplicates != null && !duplicates.Add (documentMap.GetOrCreate (projection.Document.FileName, oldProjectData?.DocumentData)))
 						continue;
 					var plainName = projection.Document.FileName.FileName;
 					var folders = GetFolders (p.Name, f);
-					yield return DocumentInfo.Create (
+					result.Add(DocumentInfo.Create (
 						documentMap.GetOrCreate (projection.Document.FileName, oldProjectData?.DocumentData),
 						plainName,
 						folders,
 						SourceCodeKind.Regular,
 						TextLoader.From (TextAndVersion.Create (new MonoDevelopSourceText (projection.Document), VersionStamp.Create (), projection.Document.FileName)),
 						projection.Document.FileName,
-						false
+						false)
 					);
 				}
 				projections.AddProjectionEntry (entry);
+				return result;
 			}
 
 			static DocumentInfo CreateDocumentInfo (SolutionData data, string projectName, ProjectData id, MonoDevelop.Projects.ProjectFile f)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -245,11 +245,16 @@ namespace MonoDevelop.Ide.TypeSystem
 						var projectFile = options.Project.GetProjectFile (options.FileName);
 						if (projectFile != null) {
 							ws.UpdateProjectionEntry (projectFile, result.Projections);
-							foreach (var projection in result.Projections) {
-								var docId = ws.GetDocumentId (projectId, projection.Document.FileName);
-								if (docId != null) {
-									ws.InformDocumentTextChange (docId, new MonoDevelopSourceText (projection.Document));
+							await ws.LoadLock.WaitAsync ();
+							try {
+								foreach (var projection in result.Projections) {
+									var docId = ws.GetDocumentId (projectId, projection.Document.FileName);
+									if (docId != null) {
+										ws.InformDocumentTextChange (docId, new MonoDevelopSourceText (projection.Document));
+									}
 								}
+							} finally {
+								ws.LoadLock.Release ();
 							}
 						}
 					}


### PR DESCRIPTION
We were using a sync lock on async/await transitioning between threads (i.e. marshal to UI thread).

That caused code to cause a hang, because the UI thread was already locking on the data structure and waiting
for the background thread to release.

Introduce a SemaphoreSlim async lock that can be used instead.

Should fix problems like the above stacktrace:
```
"GUI Thread"  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) object.__icall_wrapper_mono_monitor_enter_v4_internal (object,intptr) [0x00008] in <98fac219bd4e453693d76fda7bd96ab0>:0
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace/ProjectDataMap.GetData (Microsoft.CodeAnalysis.ProjectId) [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs:116
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace.GetDocumentId (Microsoft.CodeAnalysis.ProjectId,string) [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.Shims.cs:54
  at MonoDevelop.Ide.TypeSystem.TypeSystemService.GetDocumentId (MonoDevelop.Projects.Project,string) [0x0004a] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs:199
  at MonoDevelop.Ide.Gui.Document.EnsureAnalysisDocumentIsOpen () [0x000d1] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs:900
  at MonoDevelop.Ide.Gui.Document/<StartReparseThreadDelayed>d__128.MoveNext () [0x00067] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs:1060
  at System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Start<MonoDevelop.Ide.Gui.Document/<StartReparseThreadDelayed>d__128> (MonoDevelop.Ide.Gui.Document/<StartReparseThreadDelayed>d__128&) [0x0002c] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:84
  at MonoDevelop.Ide.Gui.Document.StartReparseThreadDelayed (MonoDevelop.Core.FilePath) [0x0002f] in <2f9c58e1ad264da8a6180e1e97f35ef2>:0
  at MonoDevelop.Ide.Gui.Document/<>c__DisplayClass126_0.<StartReparseThread>b__1 () [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs:1036
  at GLib.Timeout/TimeoutProxy.HandlerInternal (intptr) [0x00017] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/gtk-sharp-None/glib/Timeout.cs:38
  at (wrapper native-to-managed) GLib.Timeout/TimeoutProxy.HandlerInternal (intptr) [0x00021] in <bbc097c736e649f0bbe49b81946fd886>:0
  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) Gtk.Application.gtk_main () [0x00008] in <40f46e55eb67454ab904dc9e5644a3a1>:0
  at Gtk.Application.Run () [0x00001] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:145
  at MonoDevelop.Ide.IdeApp.Run () [0x00006] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs:461
  at MonoDevelop.Ide.IdeStartup.Run (MonoDevelop.Ide.MonoDevelopOptions) [0x00a66] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:395
  at MonoDevelop.Ide.IdeStartup.Main (string[],MonoDevelop.Ide.Extensions.IdeCustomizer) [0x000bc] in /Users/vsts/agent/2.144.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:843
  at Xamarin.Startup.MainClass.Main (string[]) [0x00000] in /Users/vsts/agent/2.144.0/work/1/s/md-addins/Xamarin.Startup/Main.cs:11
  at (wrapper runtime-invoke) <Module>.runtime_invoke_int_object (object,intptr,intptr,intptr) [0x00057] in <a1aebe77c32b4fa7b6fab4cda40a099e>:0
```

Fixes #768879 - VSM hangs when opening a xaml file