### PR TITLE
[Ide] Add New Folder dialog for adding new folders

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -256,7 +256,7 @@
 			_description = "Adds and existing folder and its contents"
 			_label = "_Add Existing Folder..." />
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.NewFolder"
-			_label = "New _Folder"
+			_label = "New _Folder…"
 			_description = "Create a new folder"
 			icon  = "md-new-folder" />
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.IncludeToProject"

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/NewFolderDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/NewFolderDialog.cs
@@ -1,0 +1,201 @@
+//
+// NewFolderDialog.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui.Pads.ProjectPad;
+using Xwt;
+
+namespace MonoDevelop.Ide.Gui.Dialogs
+{
+	class NewFolderDialog : Dialog
+	{
+		readonly FilePath parentFolder;
+		TextEntry folderNameTextEntry;
+		DialogButton addButton;
+
+		public NewFolderDialog (FilePath parentFolder)
+		{
+			this.parentFolder = parentFolder;
+
+			Build ();
+
+			folderNameTextEntry.Text = GetDefaultFolderName ();
+			folderNameTextEntry.SetFocus ();
+			folderNameTextEntry.Changed += FolderNameTextEntryChanged;
+			addButton.Clicked += AddButtonClicked;
+		}
+
+		public FilePath NewFolderCreated { get; private set; }
+
+		void Build ()
+		{
+			Padding = 0;
+			Resizable = false;
+			Title = GettextCatalog.GetString ("New Folder");
+
+			var mainVBox = new VBox ();
+
+			var folderNameHBox = new HBox ();
+			folderNameHBox.Margin = 20;
+			var folderNameLabel = new Label ();
+			folderNameLabel.Text = GettextCatalog.GetString ("Folder Name:");
+			folderNameHBox.PackStart (folderNameLabel);
+
+			folderNameTextEntry = new TextEntry ();
+			folderNameTextEntry.MinWidth = 200;
+			folderNameHBox.PackStart (folderNameTextEntry, true, true);
+			folderNameTextEntry.SetCommonAccessibilityAttributes (
+				"NewFolderDialog.FolderNameTextEntry",
+				folderNameLabel.Text,
+				GettextCatalog.GetString ("Enter the name for the new folder"));
+
+			mainVBox.PackStart (folderNameHBox);
+
+			var cancelButton = new DialogButton (Command.Cancel);
+			Buttons.Add (cancelButton);
+
+			addButton = new DialogButton (Command.Add);
+			Buttons.Add (addButton);
+
+			DefaultCommand = addButton.Command;
+
+			Content = mainVBox;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (disposing) {
+				folderNameTextEntry.Changed -= FolderNameTextEntryChanged;
+				addButton.Clicked -= AddButtonClicked;
+			}
+		}
+
+		internal static Task<FilePath> Open (FilePath parentFolder)
+		{
+			var result = new TaskCompletionSource<FilePath> ();
+			Toolkit.NativeEngine.Invoke (delegate {
+				using (var dialog = new NewFolderDialog (parentFolder)) {
+					dialog.Run (MessageDialog.RootWindow);
+					result.SetResult (dialog.NewFolderCreated);
+				}
+			});
+			return result.Task;
+		}
+
+		string GetDefaultFolderName ()
+		{
+			string childFolderName = GettextCatalog.GetString ("New Folder");
+			string directoryName = Path.Combine (parentFolder, childFolderName);
+			int index = -1;
+
+			if (Directory.Exists (directoryName)) {
+				while (Directory.Exists (directoryName + (++index + 1))) {
+				}
+			}
+
+			if (index >= 0) {
+				return childFolderName += index + 1;
+			}
+			return childFolderName;
+		}
+
+		void FolderNameTextEntryChanged (object sender, EventArgs e)
+		{
+			addButton.Sensitive = folderNameTextEntry.Text.Length > 0;
+		}
+
+		void AddButtonClicked (object sender, EventArgs e)
+		{
+			try {
+				bool canClose = AddNewFolder ();
+				if (canClose) {
+					Close ();
+				}
+			} catch (Exception ex) {
+				MessageService.ShowError (
+					TransientFor,
+					GettextCatalog.GetString ("An error occurred creating the new folder"),
+					null,
+					ex,
+					logError: true);
+				Present ();
+			}
+		}
+
+		FilePath GetNewFolderPath ()
+		{
+			return parentFolder.Combine (folderNameTextEntry.Text);
+		}
+
+		bool AddNewFolder ()
+		{
+			FilePath directoryPath = GetNewFolderPath ();
+
+			if (!IsValidFolderName (directoryPath, folderNameTextEntry.Text)) {
+				ShowWarning (GettextCatalog.GetString ("The name you have chosen contains illegal characters. Please choose a different name."));
+				return false;
+			}
+
+			if (Directory.Exists (directoryPath)) {
+				ShowWarning (GettextCatalog.GetString ("Folder name is already in use. Please choose a different name."));
+				return false;
+			}
+
+			Directory.CreateDirectory (directoryPath);
+			NewFolderCreated = directoryPath;
+
+			return true;
+		}
+
+		void ShowWarning (string message)
+		{
+			MessageService.ShowWarning (TransientFor, message);
+
+			// Give focus back to dialog.
+			Present ();
+		}
+
+		bool IsValidFolderName (FilePath folderPath, string folderName)
+		{
+			return FileService.IsValidPath (folderPath) &&
+				!ProjectFolderCommandHandler.ContainsDirectorySeparator (folderName);
+		}
+
+		protected override void OnCommandActivated (Command cmd)
+		{
+			if (cmd == Command.Add) {
+				// Prevent dialog closing after Add button is activated since an alert message dialog may have been shown.
+				return;
+			}
+			base.OnCommandActivated (cmd);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4235,6 +4235,7 @@
     <Compile Include="MonoDevelop.Components\Mac\NSLine.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\NewSolutionRunConfigurationDialog.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\HackyWorkspaceFilesCache.cs" />
+    <Compile Include="MonoDevelop.Ide.Gui.Dialogs\NewFolderDialog.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />


### PR DESCRIPTION
Due to various problems with the Solution window when adding a new
folder directly into the tree and then editing the label, instead
a New Folder dialog is used when creating a new folder for a project.

Fixes VSTS #721437 Can't focus on a folder and name it during creation.

Needs a UI review. Is using a separate message alert for errors OK or should an icon + text be in the dialog itself?

![newfolderalertmessage](https://user-images.githubusercontent.com/372361/51974274-8013cc00-2477-11e9-98c6-85f8af713d22.gif)

Also has some voice over problems since the native XWT toolkit is being used - there is a bug open for one problem about not announcing the label for the text box - also seeing odd behaviour with the alert message being in the wrong position and the text is not selected, unlike over alert dialogs.

![newfoldervoiceover](https://user-images.githubusercontent.com/372361/51974359-a8032f80-2477-11e9-99d8-04266e02e6d8.gif)


