### PR TITLE
[SystemAssemblyService] Partially replace Mono.Cecil usage with System.Reflection.Metadata

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpBindingCompilerManager.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpBindingCompilerManager.cs
@@ -167,7 +167,7 @@ namespace MonoDevelop.CSharp
 				}
 			}
 
-			if (alreadyAddedReference.Any (reference => SystemAssemblyService.ContainsReferenceToSystemRuntime (reference))) {
+			if (alreadyAddedReference.Any (reference => SystemAssemblyService.RequiresFacadeAssembliesAsync (reference).WaitAndGetResult (monitor.CancellationToken))) {
 				LoggingService.LogInfo ("Found PCLv2 assembly.");
 				var facades = runtime.FindFacadeAssembliesForPCL (project.TargetFramework);
 				foreach (var facade in facades)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -424,8 +424,7 @@ namespace MonoDevelop.Core.Assemblies
 		public static ImmutableArray<string> GetAssemblyReferences (string fileName)
 		{
 			try {
-				using (var stream = File.OpenRead (fileName))
-				using (var reader = new PEReader (stream, PEStreamOptions.Default)) {
+				using (var reader = new PEReader (File.OpenRead (fileName))) {
 					var mr = reader.GetMetadataReader ();
 					var assemblyReferences = reader.GetMetadataReader ().AssemblyReferences;
 
@@ -449,8 +448,7 @@ namespace MonoDevelop.Core.Assemblies
 				return result;
 
 			try {
-				using (var stream = File.OpenRead (fileName))
-				using (var reader = new PEReader (stream, PEStreamOptions.Default)) {
+				using (var reader = new PEReader (File.OpenRead (fileName))) {
 					var mr = reader.GetMetadataReader ();
 
 					foreach (var assemblyReferenceHandle in mr.AssemblyReferences) {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -35,30 +35,6 @@ namespace MonoDevelop.Core.Assemblies
 	[TestFixture]
 	public class SystemAssemblyServiceTests
 	{
-		[TestCase(true, "System.Collections.Immutable.dll")]
-		[TestCase(false, "MonoDevelop.Core.dll")]
-		public void ImmutableCollectionsContainReferenceToSystemRuntime (bool withSystemRuntime, string relativeDllPath)
-		{
-			var result = SystemAssemblyService.ContainsReferenceToSystemRuntime(relativeDllPath);
-			Assert.That(result, Is.EqualTo(withSystemRuntime));
-		}
-
-		[TestCase(true, "System.Collections.Immutable.dll")]
-		[TestCase(false, "MonoDevelop.Core.dll")]
-		public async Task ImmutableCollectionsContainReferenceToSystemRuntimeAsync (bool withSystemRuntime, string relativeDllPath)
-		{
-			var result = await SystemAssemblyService.ContainsReferenceToSystemRuntimeAsync(relativeDllPath);
-			Assert.That(result, Is.EqualTo(withSystemRuntime));
-		}
-
-		[TestCase (true, "System.Collections.Immutable.dll")]
-		[TestCase (false, "MonoDevelop.Core.dll")]
-		public void RequiresFacadeAssemblies (bool addFacades, string relativeDllPath)
-		{
-			var result = SystemAssemblyService.RequiresFacadeAssemblies (relativeDllPath);
-			Assert.That (result, Is.EqualTo (addFacades));
-		}
-
 		[TestCase (true, "System.Collections.Immutable.dll")]
 		[TestCase (false, "MonoDevelop.Core.dll")]
 		public async Task RequiresFacadeAssembliesAsync (bool addFacades, string relativeDllPath)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -56,5 +56,17 @@ namespace MonoDevelop.Core.Assemblies
 			var references = SystemAssemblyService.GetAssemblyReferences(Path.Combine(Path.GetDirectoryName (GetType().Assembly.Location), "Mono.Cecil.dll"));
 			Assert.That(references, Is.EquivalentTo(names));
 		}
+
+		[Test]
+		public void CheckAssemblyReferences ()
+		{
+			var result = SystemAssemblyService.GetAssemblyReferences ("Mono.Addins.dll");
+
+			Assert.AreEqual (4, result.Length);
+			Assert.That (result, Contains.Item ("mscorlib"));
+			Assert.That (result, Contains.Item ("System"));
+			Assert.That (result, Contains.Item ("System.Core"));
+			Assert.That (result, Contains.Item ("System.Xml"));
+		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.Core.Assemblies
 	{
 		[TestCase (true, "System.Collections.Immutable.dll")]
 		[TestCase (false, "MonoDevelop.Core.dll")]
+		[TestCase (false, "NonExistingDll.dll")]
 		public async Task RequiresFacadeAssembliesAsync (bool addFacades, string relativeDllPath)
 		{
 			var result = await SystemAssemblyService.RequiresFacadeAssembliesAsync (relativeDllPath);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using MonoDevelop.Projects;
 using NUnit.Framework;
@@ -67,6 +68,28 @@ namespace MonoDevelop.Core.Assemblies
 			Assert.That (result, Contains.Item ("System"));
 			Assert.That (result, Contains.Item ("System.Core"));
 			Assert.That (result, Contains.Item ("System.Xml"));
+		}
+
+		[Test]
+		public void GetManifestResources ()
+		{
+			var result = SystemAssemblyService.GetAssemblyManifestResources ("MonoDevelop.Core.dll").ToArray ();
+
+			Assert.That (result.Length, Is.GreaterThanOrEqualTo (1));
+
+			var addinXml = result.SingleOrDefault (x => x.Name == "MonoDevelop.Core.addin.xml");
+			Assert.IsNotNull (addinXml);
+
+			string fromReader, actual;
+
+			using (var streamReader = new StreamReader (addinXml.Open ())) {
+				fromReader = streamReader.ReadToEnd ();
+			}
+			using (var streamReader = new StreamReader (typeof (SystemAssemblyService).Assembly.GetManifestResourceStream ("MonoDevelop.Core.addin.xml"))) {
+				actual = streamReader.ReadToEnd ();
+			}
+
+			Assert.AreEqual (actual, fromReader);
 		}
 	}
 }


### PR DESCRIPTION
Given our methods in SystemAssemblyService are really granular, we're better off using lower-level System.Reflection.Metadata.

Whilst cecil is lazy, it does a lot of decoding out of the box. With System.Reflection.Metadata, it makes use of a reader class which can skip and read just what is needed.

Running the tests did decrease time from an average of 20ms to 2ms on each of the added tests.