### PR TITLE
[Tests] Move restore-netcore-offline test project back to 2.1

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreRestoreTests.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
-		public async Task OfflineRestore_NetCore22Project ()
+		public async Task OfflineRestore_NetCore21Project ()
 		{
 			FilePath solutionFileName = Util.GetSampleProject ("restore-netcore-offline", "dotnetcoreconsole.sln");
 			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);

--- a/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.csproj
+++ b/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
2.1 is the version we ship, as it's the latest stable LTS, and is the one
we provision in CI, so make sure all tests are ran on the officially
supported .NET Core version.