### PR TITLE
[release-7.8] [Tests] Move restore-netcore-offline test project back to 2.1

### DIFF
--- a/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.csproj
+++ b/main/tests/test-projects/restore-netcore-offline/dotnetcoreconsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
2.1 is the version we ship, as it's the latest stable LTS, and is the one
we provision in CI, so make sure all tests are ran on the officially
supported .NET Core version.

Backport of #7005.

/cc @rodrmoya 