### PR TITLE
Rework FileService allowing us to avoid File.Replace bug that closes documents

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring/RefactoringService.cs
@@ -108,7 +108,7 @@ namespace MonoDevelop.Refactoring
 			}
 			public void FileRename (object sender, FileCopyEventArgs e)
 			{
-				foreach (FileCopyEventInfo args in e) {
+				foreach (FileEventInfo args in e) {
 					foreach (Change change in changes) {
 						var replaceChange = change as TextReplaceChange;
 						if (replaceChange == null)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/EventArgsChain.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/EventArgsChain.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.Core
 		void MergeWith (IEventArgsChain args);
 	}
 	
-	public class EventArgsChain<T>: EventArgs, ICollection<T>, IEnumerable<T>, IEventArgsChain
+	public class EventArgsChain<T>: EventArgs, IList<T>, IEventArgsChain
 	{
 		List<T> events = new List<T> ();
 		
@@ -118,6 +118,14 @@ namespace MonoDevelop.Core
 		{
 			return events.GetEnumerator ();
 		}
+
+		public T this [int index] { get => events[index]; set => events[index] = value; }
+
+		public int IndexOf (T item) => events.IndexOf (item);
+
+		public void Insert (int index, T item) => events.Insert (index, item);
+
+		public void RemoveAt (int index) => events.RemoveAt (index);
 		#endregion
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileEventArgs.cs
@@ -39,7 +39,7 @@ namespace MonoDevelop.Core
 		protected FileCopyEventInfo (string sourceFile, string targetFile, bool isDirectory)
 		{
 			SourceFile = sourceFile;
-			TargetFile = TargetFile;
+			TargetFile = targetFile;
 			IsDirectory = isDirectory;
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileEventArgs.cs
@@ -29,22 +29,31 @@ using System.Collections.Generic;
 
 namespace MonoDevelop.Core
 {
-	public class FileEventInfo
+	// For backwards compat.
+	public class FileCopyEventInfo
 	{
 		public FilePath SourceFile { get; }
 		public FilePath TargetFile { get; }
-		public FilePath FileName => TargetFile;
 		public bool IsDirectory { get; }
 
-		public FileEventInfo (string fileName, bool isDirectory) : this (fileName, fileName, isDirectory)
-		{
-		}
-
-		public FileEventInfo (string sourceFile, string targetFile, bool isDirectory)
+		protected FileCopyEventInfo (string sourceFile, string targetFile, bool isDirectory)
 		{
 			SourceFile = sourceFile;
 			TargetFile = TargetFile;
 			IsDirectory = isDirectory;
+		}
+	}
+
+	public class FileEventInfo : FileCopyEventInfo
+	{
+		public FilePath FileName => TargetFile;
+
+		public FileEventInfo (string fileName, bool isDirectory) : base (fileName, fileName, isDirectory)
+		{
+		}
+
+		public FileEventInfo (string sourceFile, string targetFile, bool isDirectory) : base (sourceFile, targetFile, isDirectory)
+		{
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileEventArgs.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileEventArgs.cs
@@ -29,6 +29,25 @@ using System.Collections.Generic;
 
 namespace MonoDevelop.Core
 {
+	public class FileEventInfo
+	{
+		public FilePath SourceFile { get; }
+		public FilePath TargetFile { get; }
+		public FilePath FileName => TargetFile;
+		public bool IsDirectory { get; }
+
+		public FileEventInfo (string fileName, bool isDirectory) : this (fileName, fileName, isDirectory)
+		{
+		}
+
+		public FileEventInfo (string sourceFile, string targetFile, bool isDirectory)
+		{
+			SourceFile = sourceFile;
+			TargetFile = TargetFile;
+			IsDirectory = isDirectory;
+		}
+	}
+
 	public class FileEventArgs : EventArgsChain<FileEventInfo>
 	{
 		public FileEventArgs ()
@@ -45,55 +64,30 @@ namespace MonoDevelop.Core
 			foreach (var f in files)
 				Add (new FileEventInfo (f, isDirectory));
 		}
-	}
-	
-	public class FileEventInfo
-	{
-		public FilePath FileName { get; }
 
-		public bool IsDirectory { get; }
-
-		public FileEventInfo (FilePath fileName, bool isDirectory)
+		public FileEventArgs (IEnumerable<FileEventInfo> args) : base (args)
 		{
-			this.FileName = fileName;
-			this.IsDirectory = isDirectory;
 		}
 	}
 	
-	public class FileCopyEventArgs : EventArgsChain<FileCopyEventInfo>
+	public class FileCopyEventArgs : FileEventArgs
 	{
-		public FileCopyEventArgs (IEnumerable<FileCopyEventInfo> args): base (args)
-		{
-		}
-		
-		public FileCopyEventArgs (FilePath sourceFile, FilePath targetFile, bool isDirectory)
-		{
-			Add (new FileCopyEventInfo (sourceFile, targetFile, isDirectory));
-		}
-		
 		public FileCopyEventArgs ()
 		{
+		}
+
+		public FileCopyEventArgs (IEnumerable<FileEventInfo> args): base (args)
+		{
+		}
+
+		public FileCopyEventArgs (FilePath sourceFile, FilePath targetFile, bool isDirectory)
+		{
+			Add (new FileEventInfo (sourceFile, targetFile, isDirectory));
 		}
 
 		/// <summary>
 		/// Indicates whether or not user made this change in the IDE as opposed to externally.
 		/// </summary>
 		public bool IsExternal { get; set; }
-	}
-	
-	public class FileCopyEventInfo : System.EventArgs
-	{
-		public FilePath SourceFile { get; }
-
-		public FilePath TargetFile { get; }
-
-		public bool IsDirectory { get; }
-
-		public FileCopyEventInfo (FilePath sourceFile, FilePath targetFile, bool isDirectory)
-		{
-			this.SourceFile = sourceFile;
-			this.TargetFile = targetFile;
-			this.IsDirectory = isDirectory;
-		}
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -646,16 +646,21 @@ namespace MonoDevelop.Core
 
 		static void WindowsRename (string sourceFile, string destFile)
 		{
-			//Replace fails if the target file doesn't exist, so in that case try a simple move
-			if (!File.Exists (destFile)) {
-				try {
-					File.Move (sourceFile, destFile);
-					return;
-				} catch {
+			FreezeEvents ();
+			try {
+				//Replace fails if the target file doesn't exist, so in that case try a simple move
+				if (!File.Exists (destFile)) {
+					try {
+						File.Move (sourceFile, destFile);
+						return;
+					} catch {
+					}
 				}
-			}
 
-			File.Replace (sourceFile, destFile, null);
+				File.Replace (sourceFile, destFile, null);
+			} finally {
+				ThawEvents ();
+			}
 		}
 
 		static void UnixRename (string sourceFile, string destFile)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -773,7 +773,7 @@ namespace MonoDevelop.Core
 		{
 			AsyncEvents.OnFileRenamed (args);
 
-			foreach (FileCopyEventInfo fi in args) {
+			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
 					Counters.DirectoriesRenamed++;
 				else

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -927,6 +927,7 @@ namespace MonoDevelop.Core
 				throw new InvalidOperationException ();
 		}
 
+		[DebuggerDisplay("{DebuggerDisplay,nq}")]
 		internal class FileEventData : EventData
 		{
 			public FileService.EventDataKind Kind;
@@ -951,6 +952,18 @@ namespace MonoDevelop.Core
 
 				return shouldMerge;
 			}
+
+			private string DebuggerDisplay => string.Format (
+				"{0}: {1}",
+				Kind.ToString (),
+				string.Join (
+					", ",
+					Args.Select (x => x.SourceFile == x.TargetFile
+						? x.FileName.ToString ()
+						: string.Format ("{0} -> {1}", x.SourceFile.ToString (), x.TargetFile.ToString ())
+					)
+				)
+			);
 		}
 
 		sealed class EmptyEventData : EventData

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -909,6 +909,8 @@ namespace MonoDevelop.Core
 		static void RaiseSync (FileService.EventDataKind kind, FileEventArgs args)
 		{
 			var handler = FileService.GetHandler (kind);
+			if (handler == null)
+				return;
 
 			// Ugly, but it saves us the problem of having to deal with generic event handlers without covariance.
 			if (args is FileCopyEventArgs copyArgs) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -942,7 +942,7 @@ namespace MonoDevelop.Core
 					shouldMerge = true;
 
 					if (next.Args is FileCopyEventArgs nextArgs && Args is FileCopyEventArgs thisArgs)
-						shouldMerge &= nextArgs.IsExternal == thisArgs.IsReadOnly;
+						shouldMerge &= nextArgs.IsExternal == thisArgs.IsExternal;
 
 					if (shouldMerge)
 						next.Args.MergeWith (Args);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -1198,8 +1198,7 @@ namespace MonoDevelop.Core
 
 				switch (targetState) {
 				case FileState.Changed:
-					if (oldState == FileState.Changed || oldState == FileState.Created) {
-						// Created + Changed => Created
+					if (oldState == FileState.Changed) {
 						// Changed + Changed => Changed
 						Discard (args, ref i);
 						return true;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4414,7 +4414,7 @@ namespace MonoDevelop.Projects
 
 		void OnFileRenamed (object sender, FileCopyEventArgs e)
 		{
-			foreach (FileCopyEventInfo info in e) {
+			foreach (FileEventInfo info in e) {
 				OnFileRenamed (info.SourceFile, info.TargetFile);
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
@@ -295,7 +295,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		void OnSystemFileRenamed (object sender, FileCopyEventArgs args)
 		{
-			foreach (FileCopyEventInfo e in args) {
+			foreach (FileEventInfo e in args) {
 				Project project = GetProjectForFile (e.SourceFile);
 				if (project == null) return;
 				

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -738,7 +738,12 @@ namespace MonoDevelop.Ide.Gui
 					foreach (ViewContent content in viewContentCollection) {
 						if (content.ContentName != null &&
 						    content.ContentName == e.SourceFile) {
-							content.ContentName = e.TargetFile;
+
+							// In case of a File.Replace, on Windows, the OS will rename this file to a temporary file.
+							// By the time the thaw is done, the temporary file is gone, so don't bother relocating.
+							if (File.Exists (e.TargetFile)) {
+								content.ContentName = e.TargetFile;
+							}
 							return;
 						}
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -727,7 +727,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		void CheckRenamedFile(object sender, FileCopyEventArgs args)
 		{
-			foreach (FileCopyEventInfo e in args) {
+			foreach (FileEventInfo e in args) {
 				if (e.IsDirectory) {
 					foreach (ViewContent content in viewContentCollection) {
 						if (content.ContentName != null && ((FilePath)content.ContentName).IsChildPathOf (e.SourceFile)) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -314,7 +314,7 @@ namespace MonoDevelop.Ide
 			if (args.IsExternal)
 				return;
 
-			foreach (FileCopyEventInfo e in args) {
+			foreach (FileEventInfo e in args) {
 				if (!e.IsDirectory) {
 					PlatformService.RecentFiles.NotifyFileRenamed (e.SourceFile, e.TargetFile);
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -1239,7 +1239,7 @@ namespace MonoDevelop.Ide
 				return;
 
 			foreach (Solution sol in GetAllSolutions ()) {
-				foreach (FileCopyEventInfo e in args)
+				foreach (FileEventInfo e in args)
 					sol.RootFolder.RenameFileInProjects (e.SourceFile, e.TargetFile);
 			}
 		}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -150,6 +150,8 @@
     <Compile Include="MonoDevelop.Core.Web\LambdaMessageHandler.cs" />
     <Compile Include="MonoDevelop.Core.Web\HttpSourceAuthenticationHandlerTests.cs" />
     <Compile Include="MonoDevelop.Core\SdkResolverTests.cs" />
+    <Compile Include="MonoDevelop.Core\FileServiceEventQueueTests.cs" />
+    <Compile Include="MonoDevelop.Core\FileServiceEventStateMachineTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
@@ -223,17 +223,28 @@ namespace MonoDevelop.Core
 				// Renamed .#Program.cs -> Program.cs
 				// Removed Program.cs~hash.tmp
 				processor.Queue (CreateData (EventDataKind.Renamed, (b, btmp)));
+				processor.Queue (CreateData (EventDataKind.Changed, btmp)); // FileService does this.
 				processor.Queue (CreateData (EventDataKind.Renamed, (a, b)));
+				processor.Queue (CreateData (EventDataKind.Changed, b)); // FileService does this.
 				processor.Queue (CreateData (EventDataKind.Removed, btmp));
+
+				// This should become
+				// Renamed .#Program.cs -> Program.cs
+				// Changed Program.cs
 			});
 
-			Assert.AreEqual (1, events.Length);
+			Assert.AreEqual (2, events.Length);
 
 			var ev = events [0];
 			Assert.AreEqual (EventDataKind.Renamed, ev.Kind);
 			Assert.AreEqual (1, ev.Args.Count);
 			Assert.AreEqual (a, ev.Args [0].SourceFile);
 			Assert.AreEqual (b, ev.Args [0].TargetFile);
+
+			ev = events [1];
+			Assert.AreEqual (EventDataKind.Changed, ev.Kind);
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (b, ev.Args [0].FileName);
 		}
 
 		[Test]

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
@@ -1,0 +1,295 @@
+//
+// FileServiceEventQueueTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using NUnit.Framework;
+using static MonoDevelop.Core.EventQueue;
+using static MonoDevelop.Core.FileService;
+
+namespace MonoDevelop.Core
+{
+	[TestFixture]
+	public class FileServiceEventQueueTests
+	{
+		readonly FilePath a = "a", b = "b", c = "c", d = "d", e = "e", btmp = "b.tmp";
+
+		[Test]
+		public void TestMergeRemovesEmptyChangeSets()
+		{
+			var processor = new Processor ();
+			processor.Queue (CreateData (EventDataKind.Changed, Array.Empty<FilePath> ()));
+			processor.Merge ();
+
+			Assert.AreEqual (0, processor.Events.Count);
+		}
+
+		[Test]
+		public void TestQueueChanged()
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Changed, a, c));
+				processor.Queue (CreateData (EventDataKind.Changed, a, b));
+				processor.Queue (CreateData (EventDataKind.Changed, d));
+				processor.Queue (CreateData (EventDataKind.Changed, c));
+			});
+
+			Assert.AreEqual (1, events.Length);
+
+			var ev = events [0];
+			Assert.AreEqual (4, ev.Args.Count);
+			Assert.AreEqual (d, ev.Args [0].FileName);
+			Assert.AreEqual (b, ev.Args [1].FileName);
+			Assert.AreEqual (a, ev.Args [2].FileName);
+			Assert.AreEqual (c, ev.Args [3].FileName);
+		}
+
+		[Test]
+		public void TestQueueChangedCreatedWithSkip()
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Changed, a));
+				processor.Queue (CreateData (EventDataKind.Created, b));
+				processor.Queue (CreateData (EventDataKind.Created, b));
+				processor.Queue (CreateData (EventDataKind.Changed, a, b));
+			});
+
+			Assert.AreEqual (2, events.Length);
+
+			var ev = events [0];
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (a, ev.Args [0].FileName);
+
+			ev = events [1];
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (b, ev.Args [0].FileName);
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public void FileRemovedAfterCreated(bool withSkip)
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Created, a));
+				if (withSkip)
+					processor.Queue (CreateData (EventDataKind.Changed, b));
+				processor.Queue (CreateData (EventDataKind.Removed, a));
+			});
+
+			if (withSkip) {
+				Assert.AreEqual (1, events.Length);
+
+				var ev = events [0];
+				Assert.AreEqual (EventDataKind.Changed, ev.Kind);
+				Assert.AreEqual (1, ev.Args.Count);
+				Assert.AreEqual (b, ev.Args[0].FileName);
+			} else {
+				Assert.AreEqual (0, events.Length);
+			}
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public void FileCreatedAfterRemoved(bool withSkip)
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Removed, a));
+				if (withSkip)
+					processor.Queue (CreateData (EventDataKind.Changed, b));
+				processor.Queue (CreateData (EventDataKind.Created, a));
+				if (withSkip)
+					processor.Queue (CreateData (EventDataKind.Changed, b));
+				processor.Queue (CreateData (EventDataKind.Removed, c));
+				processor.Queue (CreateData (EventDataKind.Created, c));
+			});
+
+			Assert.AreEqual (1, events.Length);
+			var ev = events [0];
+			Assert.AreEqual (EventDataKind.Changed, ev.Kind);
+			Assert.AreEqual (withSkip ? 3 : 2, ev.Args.Count);
+			Assert.AreEqual (c, ev.Args [0].FileName);
+
+			Assert.AreEqual (a, ev.Args [1].FileName);
+			if (withSkip) {
+				Assert.AreEqual (b, ev.Args [2].FileName);
+			}
+		}
+
+		[TestCase (true)]
+		[TestCase (false)]
+		public void FileRemovedAfterChanged (bool withSkip)
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Changed, a));
+				if (withSkip)
+					processor.Queue (CreateData (EventDataKind.Changed, b));
+				processor.Queue (CreateData (EventDataKind.Removed, a));
+			});
+
+			FileEventData ev;
+			if (withSkip) {
+				Assert.AreEqual (2, events.Length);
+
+				ev = events [0];
+				Assert.AreEqual (EventDataKind.Changed, ev.Kind);
+				Assert.AreEqual (1, ev.Args.Count);
+				Assert.AreEqual (b, ev.Args [0].FileName);
+
+				ev = events [1];
+			} else {
+				Assert.AreEqual (1, events.Length);
+				ev = events [0];
+			}
+
+			Assert.AreEqual (EventDataKind.Removed, ev.Kind);
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (a, ev.Args [0].FileName);
+		}
+
+		[Test]
+		public void DetectFileRenamePatternCopy ()
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Removed, b));
+				processor.Queue (CreateData (EventDataKind.Copied, (a, b)));
+			});
+
+			Assert.AreEqual (1, events.Length);
+
+			var ev = events [0];
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (EventDataKind.Copied, ev.Kind);
+			Assert.AreEqual (a, ev.Args [0].SourceFile);
+			Assert.AreEqual (b, ev.Args [0].TargetFile);
+		}
+
+		[Test]
+		public void DetectFileRenamePatternMove ()
+		{
+			var kinds = new [] {
+				EventDataKind.Moved,
+				EventDataKind.Renamed,
+			};
+
+			foreach (var kind in kinds) {
+				var events = DoRun (processor => {
+					processor.Queue (CreateData (EventDataKind.Removed, b));
+					processor.Queue (CreateData (kind, (a, b)));
+					processor.Queue (CreateData (EventDataKind.Created, a));
+				});
+
+				Assert.AreEqual (2, events.Length);
+
+				var ev = events [0];
+				Assert.AreEqual (1, ev.Args.Count);
+				Assert.AreEqual (kind, ev.Kind);
+				Assert.AreEqual (a, ev.Args [0].SourceFile);
+				Assert.AreEqual (b, ev.Args [0].TargetFile);
+
+				ev = events [1];
+				Assert.AreEqual (1, ev.Args.Count);
+				Assert.AreEqual (EventDataKind.Created, ev.Kind);
+				Assert.AreEqual (a, ev.Args [0].FileName);
+			}
+		}
+
+		[Test]
+		public void NothingToReduce ()
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Changed, a));
+				processor.Queue (CreateData (EventDataKind.Created, b));
+				processor.Queue (CreateData (EventDataKind.Removed, c));
+				processor.Queue (CreateData (EventDataKind.Moved, (c, d)));
+				processor.Queue (CreateData (EventDataKind.Copied, (d, btmp)));
+				processor.Queue (CreateData (EventDataKind.Renamed, (e, e)));
+			});
+
+			Assert.AreEqual (6, events.Length);
+		}
+
+		[Test]
+		public void DirectoryDoesNotAffect ()
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Changed, a));
+				processor.Queue (CreateDirectoryData (EventDataKind.Changed, a));
+			});
+
+			Assert.AreEqual (1, events.Length);
+			Assert.AreEqual (2, events [0].Args.Count);
+		}
+
+		FileEventData [] DoRun(Action<Processor> callback)
+		{
+			var processor = new Processor ();
+			callback (processor);
+			processor.Merge ();
+
+			return processor.Events.OfType<FileEventData> ().ToArray ();
+
+		}
+
+		static FileEventData CreateDirectoryData (EventDataKind kind, params FilePath [] paths)
+			=> CreateData (kind, true, paths);
+
+		static FileEventData CreateData (EventDataKind kind, params FilePath [] paths)
+			=> CreateData (kind, false, paths);
+
+		static FileEventData CreateData (EventDataKind kind, bool isDirectory, params FilePath [] paths)
+		{
+			if (kind != EventDataKind.Created && kind != EventDataKind.Changed && kind != EventDataKind.Removed) {
+				Assert.Fail ("Wrong data kind passed to this method");
+			}
+
+			var args = new FileEventArgs ();
+			foreach (var path in paths) {
+				args.Add (new FileEventInfo (path, isDirectory));
+			}
+
+			return new FileEventData {
+				Kind = kind,
+				Args = args,
+			};
+		}
+
+		static FileEventData CreateData (EventDataKind kind, params (FilePath, FilePath) [] paths)
+		{
+			if (kind != EventDataKind.Moved && kind != EventDataKind.Copied && kind != EventDataKind.Renamed) {
+				Assert.Fail ("Wrong data kind passed to this method");
+			}
+
+			var args = new FileCopyEventArgs ();
+			foreach (var path in paths) {
+				args.Add (new FileEventInfo (path.Item1, path.Item2, false));
+			}
+
+			return new FileEventData {
+				Kind = kind,
+				Args = args,
+			};
+		}
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
@@ -76,13 +76,20 @@ namespace MonoDevelop.Core
 				processor.Queue (CreateData (EventDataKind.Changed, a, b));
 			});
 
-			Assert.AreEqual (2, events.Length);
+			Assert.AreEqual (3, events.Length);
 
 			var ev = events [0];
+			Assert.AreEqual (EventDataKind.Changed, ev.Kind);
 			Assert.AreEqual (1, ev.Args.Count);
 			Assert.AreEqual (a, ev.Args [0].FileName);
 
 			ev = events [1];
+			Assert.AreEqual (EventDataKind.Created, ev.Kind);
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (b, ev.Args [0].FileName);
+
+			ev = events [2];
+			Assert.AreEqual (EventDataKind.Changed, ev.Kind);
 			Assert.AreEqual (1, ev.Args.Count);
 			Assert.AreEqual (b, ev.Args [0].FileName);
 		}
@@ -245,6 +252,18 @@ namespace MonoDevelop.Core
 			Assert.AreEqual (EventDataKind.Changed, ev.Kind);
 			Assert.AreEqual (1, ev.Args.Count);
 			Assert.AreEqual (b, ev.Args [0].FileName);
+		}
+
+		[Test]
+		public void ReduceGoesRecursive()
+		{
+			var events = DoRun (processor => {
+				processor.Queue (CreateData (EventDataKind.Created, b));
+				processor.Queue (CreateData (EventDataKind.Changed, b));
+				processor.Queue (CreateData (EventDataKind.Removed, b));
+			});
+
+			Assert.AreEqual (0, events.Length);
 		}
 
 		[Test]

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventQueueTests.cs
@@ -216,6 +216,27 @@ namespace MonoDevelop.Core
 		}
 
 		[Test]
+		public void DetectAutoSavePatternMove ()
+		{
+			var events = DoRun (processor => {
+				// Renamed Program.cs -> Program.cs~hash.tmp
+				// Renamed .#Program.cs -> Program.cs
+				// Removed Program.cs~hash.tmp
+				processor.Queue (CreateData (EventDataKind.Renamed, (b, btmp)));
+				processor.Queue (CreateData (EventDataKind.Renamed, (a, b)));
+				processor.Queue (CreateData (EventDataKind.Removed, btmp));
+			});
+
+			Assert.AreEqual (1, events.Length);
+
+			var ev = events [0];
+			Assert.AreEqual (EventDataKind.Renamed, ev.Kind);
+			Assert.AreEqual (1, ev.Args.Count);
+			Assert.AreEqual (a, ev.Args [0].SourceFile);
+			Assert.AreEqual (b, ev.Args [0].TargetFile);
+		}
+
+		[Test]
 		public void NothingToReduce ()
 		{
 			var events = DoRun (processor => {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventStateMachineTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FileServiceEventStateMachineTests.cs
@@ -1,0 +1,152 @@
+//
+// FileServiceEventStateMachineTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using NUnit.Framework;
+using static MonoDevelop.Core.EventQueue;
+using static MonoDevelop.Core.EventQueue.Processor;
+using static MonoDevelop.Core.FileService;
+
+namespace MonoDevelop.Core
+{
+	[TestFixture]
+	public class FileServiceEventStateMachineTests
+	{
+		[Test]
+		public void Functionality ()
+		{
+			var fsm = new FileEventStateMachine ();
+
+			FilePath a = "a", b = "b", c = "c";
+			var eventData = new FileEventData {
+				Kind = EventDataKind.Changed,
+				Args = new FileEventArgs (new [] { a, b, c }, false),
+			};
+
+			fsm.Queue (eventData);
+
+			Assert.AreEqual (false, fsm.TryGet (a, out var state));
+
+			fsm.Set (a, 0, 0, false, FileState.Changed);
+			fsm.Set (b, 0, 1, false, FileState.Changed);
+			fsm.Set (c, 0, 2, false, FileState.Changed);
+
+			Assert.AreEqual (true, fsm.TryGet (a, out state));
+			AssertState (state, FileState.Changed, 1, 0, 0);
+
+			Assert.AreEqual (true, fsm.TryGet (b, out state));
+			AssertState (state, FileState.Changed, 1, 0, 1);
+
+			Assert.AreEqual (true, fsm.TryGet (c, out state));
+			AssertState (state, FileState.Changed, 1, 0, 2);
+
+			eventData = new FileEventData {
+				Kind = EventDataKind.Removed,
+				Args = new FileEventArgs (new [] { b, a, c }, false),
+			};
+
+			fsm.Queue (eventData);
+
+			fsm.Set (a, 1, 1, false, FileState.Removed);
+			fsm.Set (b, 1, 0, false, FileState.Removed);
+			fsm.Set (c, 1, 2, false, FileState.Removed);
+
+			Assert.AreEqual (true, fsm.TryGet (a, out state));
+			AssertState (state, FileState.Removed, 2, 1, 1);
+
+			Assert.AreEqual (true, fsm.TryGet (b, out state));
+			AssertState (state, FileState.Removed, 2, 1, 0);
+
+			Assert.AreEqual (true, fsm.TryGet (c, out state));
+			AssertState (state, FileState.Removed, 2, 1, 2);
+
+			fsm.RemoveLastEventData (c);
+
+			Assert.AreEqual (true, fsm.TryGet (a, out state));
+			AssertState (state, FileState.Removed, 2, 1, 1);
+
+			Assert.AreEqual (true, fsm.TryGet (b, out state));
+			AssertState (state, FileState.Removed, 2, 1, 0);
+
+			Assert.AreEqual (true, fsm.TryGet (c, out state));
+			AssertState (state, FileState.Changed, 1, 0, 2);
+
+			fsm.RemoveLastEventData (c);
+
+			Assert.AreEqual (false, fsm.TryGet (c, out state));
+			Assert.IsNull (state);
+
+			void AssertState (FileEventState s, FileState fs, int count, int eventIndex, int fileIndex)
+			{
+				Assert.AreEqual (fs, state.FinalState);
+				Assert.AreEqual (count, state.Indices.Count);
+				if (count == 0)
+					return;
+
+				Assert.AreEqual (eventIndex, state.Indices [count - 1].EventIndex);
+				Assert.AreEqual (fileIndex, state.Indices [count - 1].FileIndex);
+			}
+		}
+
+		[Test]
+		public void AddAndRemove ()
+		{
+			var fsm = new FileEventStateMachine ();
+
+			var eventData = new FileEventData {
+				Kind = EventDataKind.Changed,
+				Args = new FileEventArgs ("a", false),
+			};
+
+			fsm.Queue (eventData);
+
+			fsm.Set ("a", 0, 0, false, FileState.Removed);
+			fsm.RemoveLastEventData ("a");
+
+			Assert.IsFalse (fsm.TryGet ("a", out var state));
+
+			fsm.RemoveLastEventData ("a");
+			Assert.IsFalse (fsm.TryGet ("a", out state));
+		}
+
+		[Test]
+		public void UnsyncedWillThrow()
+		{
+			var fsm = new FileEventStateMachine ();
+
+			Assert.Throws<ArgumentOutOfRangeException> (() => fsm.Set ("a", 0, 0, false, FileState.Removed));
+
+			// Add a busted FileEventData
+			var eventData = new FileEventData {
+				Kind = EventDataKind.Changed,
+				Args = new FileEventArgs (),
+			};
+
+			Assert.Throws<ArgumentOutOfRangeException> (() => fsm.Set ("a", 0, 0, false, FileState.Removed));
+
+		}
+	}
+}


### PR DESCRIPTION
This PR aims to integrate the proposal found [here](https://paper.dropbox.com/doc/FileService-API-breakages-and-optimizations--AWqJFOGJmAqRDNdUa8A6OC7BAg-Lmx4sBpGbT2V0vd2IGD1S) to allow Files not to be closed when the new vs editor backend is used.

Fixes VSTS #718767 - File close when save

TODO List:
* [x] Problem 1 - Simplify EventData
* [x] Problem 2 - Fix handler value bug
* [x] Problem 3 - Merging events is now fixed
* [x] Problem 4 - Event reduction.

