### PR TITLE
[Core] Fix Sdk resolver argument null exception

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProcessService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProcessService.cs
@@ -63,9 +63,19 @@ namespace MonoDevelop.Projects.MSBuild
 			return MSBuildProjectService.GetMSBuildBinPath (Runtime.SystemAssemblyService.CurrentRuntime);
 		}
 
+		static FilePath GetMSBuildBinDirectory (TargetRuntime runtime)
+		{
+			return MSBuildProjectService.GetMSBuildBinPath (runtime);
+		}
+
 		static FilePath GetMSBuildBinPath ()
 		{
-			FilePath binDirectory = GetMSBuildBinDirectory ();
+			return GetMSBuildBinPath (Runtime.SystemAssemblyService.CurrentRuntime);
+		}
+
+		internal static FilePath GetMSBuildBinPath (TargetRuntime runtime)
+		{
+			FilePath binDirectory = GetMSBuildBinDirectory (runtime);
 			FilePath binPath = binDirectory.Combine ("MSBuild.dll");
 			if (File.Exists (binPath)) {
 				return binPath;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
@@ -294,10 +294,6 @@ namespace MonoDevelop.Projects.MSBuild
 
 			public SdkReference Sdk { get; }
 
-			public string Path { get; }
-
-			public string Version { get; }
-
 			public IEnumerable<string> Errors { get; }
 
 			public IEnumerable<string> Warnings { get; }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using Microsoft.Build.Framework;
 using MonoDevelop.Core.Assemblies;
-using MonoDevelop.Core;
 
 namespace MonoDevelop.Projects.MSBuild
 {
@@ -24,6 +24,7 @@ namespace MonoDevelop.Projects.MSBuild
 		readonly object _lockObject = new object ();
 		IList<SdkResolver> _resolvers;
 		TargetRuntime runtime;
+		Version msbuildVersion;
 
 		internal SdkResolution (TargetRuntime runtime)
 		{
@@ -58,7 +59,7 @@ namespace MonoDevelop.Projects.MSBuild
 			try {
 				var buildEngineLogger = new SdkLoggerImpl (logger, buildEventContext);
 				foreach (var sdkResolver in _resolvers) {
-					var context = new SdkResolverContextImpl (buildEngineLogger, projectFile, solutionPath);
+					var context = new SdkResolverContextImpl (buildEngineLogger, projectFile, solutionPath, msbuildVersion);
 					var resultFactory = new SdkResultFactoryImpl (sdk);
 					try {
 						var result = (SdkResultImpl)sdkResolver.Resolve (sdk, context, resultFactory);
@@ -96,8 +97,19 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			lock (_lockObject) {
 				if (_resolvers != null) return;
+				msbuildVersion = GetMSBuildVersion ();
 				_resolvers = LoadResolvers (logger);
 			}
+		}
+
+		Version GetMSBuildVersion ()
+		{
+			var msbuildFileName = MSBuildProcessService.GetMSBuildBinPath (runtime);
+			if (!File.Exists (msbuildFileName))
+				return null;
+
+			var versionInfo = FileVersionInfo.GetVersionInfo (msbuildFileName);
+			return new Version (versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
 		}
 
 		IList<SdkResolver> LoadResolvers (ILoggingService logger)
@@ -313,11 +325,12 @@ namespace MonoDevelop.Projects.MSBuild
 
 		sealed class SdkResolverContextImpl : SdkResolverContext
 		{
-			public SdkResolverContextImpl (SdkLogger logger, string projectFilePath, string solutionPath)
+			public SdkResolverContextImpl (SdkLogger logger, string projectFilePath, string solutionPath, Version msbuildVersion)
 			{
 				Logger = logger;
 				ProjectFilePath = projectFilePath;
 				SolutionFilePath = solutionPath;
+				MSBuildVersion = msbuildVersion;
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs
@@ -303,7 +303,7 @@ namespace MonoDevelop.Projects.MSBuild
 			public IEnumerable<string> Warnings { get; }
 		}
 
-		class SdkResultFactoryImpl : SdkResultFactory
+		internal class SdkResultFactoryImpl : SdkResultFactory
 		{
 			readonly SdkReference _sdkReference;
 

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.MSBuildResolver/Resolver.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.MSBuildResolver/Resolver.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.Projects.MSBuild
 			// Pick the SDK with the highest version
 
 			foreach (var sdk in sdkFetcher ()) {
-				if (sdk.Name == sdkReference.Name) {
+				if (StringComparer.OrdinalIgnoreCase.Equals (sdk.Name, sdkReference.Name)) {
 					if (sdk.Version != null) {
 						// If the sdk has a version, it must satisfy the min version requirement
 						if (minVersion != null && sdk.Version < minVersion)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -55,6 +55,21 @@
     <Reference Include="mscorlib" />
     <Reference Include="System.Memory">
       <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <!-- when building with xbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/xbuild/*/bin`
+    when building with msbuild on Unix, $(MSBuildToolsPath) is like `$prefix/lib/mono/msbuild/*/bin`
+    Prefer referencing msbuild 15.* assemblies over 14.1 . At runtime, we use correct one anyway
+    -->
+    <Reference Include="Microsoft.Build">
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework">
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.Framework.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core">
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -122,6 +137,7 @@
     <Compile Include="MonoDevelop.Core.Instrumentation\BucketTimingsTests.cs" />
     <Compile Include="MonoDevelop.Utilities\RaceCheckerTests.cs" />
     <Compile Include="MonoDevelop.Core\FeatureSwitchServiceTests.cs" />
+    <Compile Include="MonoDevelop.Core\SdkResolverTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/SdkResolverTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/SdkResolverTests.cs
@@ -1,0 +1,104 @@
+//
+// SdkResolverTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using MonoDevelop.Projects.MSBuild;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Core
+{
+	[TestFixture]
+	public class SdkResolverTests : TestBase
+	{
+		/// <summary>
+		/// Tests that the MSBuild version is passed to sdk resolvers. The DotNetMSBuildSdkResolver throws an
+		/// ArgumentNullException if it is not set. Have to use an unknown sdk otherwise other resolvers will
+		/// be used and the DotNetMSBuildSdkResolver will not be used.
+		/// </summary>
+		[Test]
+		public void UnknownSdk_DotNetMSBuildSdkResolverDoesNotFatalReportError ()
+		{
+			var resolution = SdkResolution.GetResolver (Runtime.SystemAssemblyService.CurrentRuntime);
+			// Using a sdk with a version to avoid an ArgumentNullException from the NuGet sdk resolver since
+			// we are not specifying any project or solution paths.
+			var sdkReference = new SdkReference ("MonoDevelop.Unknown.Test.Sdk", "1.2", null);
+			var logger = new TestLoggingService ();
+			var context = new MSBuildContext ();
+			var result = resolution.GetSdkPath (sdkReference, logger, context, null, null);
+
+			var error = logger.FatalBuildErrors.FirstOrDefault ();
+			Assert.AreEqual (0, logger.FatalBuildErrors.Count, "First error: " + error);
+			Assert.IsNull (result);
+		}
+
+		[Test]
+		public void SdkReference_DifferentCase_StillFindsMatchWithMonoDevelopResolver ()
+		{
+			var sdks = new List<SdkInfo> ();
+			var info = new SdkInfo ("MonoDevelop.Test.NET.Sdk", SdkVersion.Parse ("1.2.3"), null);
+			sdks.Add (info);
+
+			var resolver = new Resolver (() => sdks);
+
+			var sdkReference = new SdkReference ("monodevelop.test.net.sdk", null, null);
+			var factory = new SdkResolution.SdkResultFactoryImpl (sdkReference);
+			var result = resolver.Resolve (sdkReference, null, factory);
+
+			Assert.IsTrue (result.Success);
+			Assert.AreEqual (result.Version, info.Version.ToString ());
+		}
+
+		class TestLoggingService : ILoggingService
+		{
+			public List<Exception> FatalBuildErrors = new List<Exception> ();
+
+			public void LogCommentFromText (MSBuildContext buildEventContext, MessageImportance messageImportance, string message)
+			{
+			}
+
+			public void LogErrorFromText (MSBuildContext buildEventContext, object subcategoryResourceName, object errorCode, object helpKeyword, string file, string message)
+			{
+			}
+
+			public void LogFatalBuildError (MSBuildContext buildEventContext, Exception e, string projectFile)
+			{
+				FatalBuildErrors.Add (e);
+			}
+
+			public void LogWarning (string message)
+			{
+			}
+
+			public void LogWarningFromText (MSBuildContext bec, object p1, object p2, object p3, string projectFile, string warning)
+			{
+			}
+		}
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/SdkResolverTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/SdkResolverTests.cs
@@ -46,9 +46,12 @@ namespace MonoDevelop.Core
 		public void UnknownSdk_DotNetMSBuildSdkResolverDoesNotFatalReportError ()
 		{
 			var resolution = SdkResolution.GetResolver (Runtime.SystemAssemblyService.CurrentRuntime);
-			// Using a sdk with a version to avoid an ArgumentNullException from the NuGet sdk resolver since
-			// we are not specifying any project or solution paths.
-			var sdkReference = new SdkReference ("MonoDevelop.Unknown.Test.Sdk", "1.2", null);
+			// Using a sdk with an invalid version to prevent the NuGet sdk resolver causing a test crash.
+			// Invalid version numbers cause the NuGet sdk resolver to not try to resolve the sdk. The crash
+			// only seems to happen with this test - using the IDE does not trigger the crash. There is a
+			// separate NuGet sdk resolver test that runs the resolver. Crash error:
+			// NuGet.Configuration.NuGetPathContext doesn't implement interface NuGet.Common.INuGetPathContext
+			var sdkReference = new SdkReference ("MonoDevelop.Unknown.Test.Sdk", "InvalidVersion", null);
 			var logger = new TestLoggingService ();
 			var context = new MSBuildContext ();
 			var result = resolution.GetSdkPath (sdkReference, logger, context, null, null);


### PR DESCRIPTION
- Pass MSBuild version to sdk resolvers

The DotNetMSBuildSdkResolver needs the MSBuildVersion to be set on
the SdkResolverContext. Without this if an sdk cannot be resolved
by the MonoDevelop sdk resolver or the NuGet sdk resolver then the
DotNetMSBuildSdkResolver will fail with an error:

System.ArgumentNullException: Value cannot be null.
Parameter name: v1
  at System.Version.op_LessThan (System.Version v1, System.Version v2) [0x00003]
  in mono-x64/mcs/class/referencesource/mscorlib/system/version.cs:452
  at Microsoft.DotNet.MSBuildSdkResolver.DotNetMSBuildSdkResolver.Resolve (Microsoft.Build.Framework.SdkReference sdkReference, Microsoft.Build.Framework.SdkResolverContext context, Microsoft.Build.Framework.SdkResultFactory factory) [0x000b7]
  in cli/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs:71
  at MonoDevelop.Projects.MSBuild.SdkResolution.GetSdkPath (Microsoft.Build.Framework.SdkReference sdk, MonoDevelop.Projects.MSBuild.ILoggingService logger, MonoDevelop.Projects.MSBuild.MSBuildContext buildEventContext, System.String projectFile, System.String solutionPath) [0x00055]
 in main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/SdkResolution.cs:64

 - Compare sdk names case insensitively in the sdk resolver

In general the DotNetMSBuildSdkResolver is not used, however if the
Sdk name being resolved differed in case (e.g. Microsoft.Net.Sdk
versus Microsoft.NET.Sdk) then the MonoDevelop sdk resolver would
fail to find a match. The main MSBuild sdk resolvers seem to do
directory/file checks when resolving sdk resolvers which would be
case insensitive if the drive was not case sensitive. To avoid this
problem the sdk names are checked ignoring the case.

Fixes VSTS #706541 - ArgumentNullException in DotNetMSBuildSdkResolver
Resolve