### PR TITLE
Fix NRE exposed by HackyCache

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs
@@ -458,7 +458,7 @@ namespace MonoDevelop.Projects
 
 		public FilePath GetPreferencesDirectory ()
 		{
-			return FileName.ParentDirectory.Combine (".vs", Name, "xs");
+			return FileName.ParentDirectory.Combine (".vs", Name ?? string.Empty, "xs");
 		}
 
 		internal string GetPreferencesFileName ()


### PR DESCRIPTION
It seems that the Name can end up being null, so just shortcircuit it to string.Empty.

It fixes typesystem information not being available in this scenario.

```
System.ArgumentNullException: Value cannot be null.
Parameter name: path1
  at System.IO.Path.Combine (System.String path1, System.String path2) [0x000a0] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/Path.cs:126
  at MonoDevelop.Core.FilePath.Combine (System.String[] paths) [0x00000] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs:232
  at MonoDevelop.Projects.WorkspaceItem.GetPreferencesDirectory () [0x00000] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/WorkspaceItem.cs:461
  at MonoDevelop.Ide.TypeSystem.HackyWorkspaceFilesCache..ctor (MonoDevelop.Projects.Solution solution) [0x00046] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/HackyWorkspaceFilesCache.cs:53
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace+ProjectSystemHandler..ctor (MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace workspace, MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace+ProjectDataMap projectMap, MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace+ProjectionData projections) [0x0004f] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs:64
  at MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace..ctor (MonoDevelop.Projects.Solution solution) [0x000b5] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs:111
  at MonoDevelop.Ide.TypeSystem.TypeSystemService+<CreateWorkspaces>d__75.MoveNext () [0x0012e] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs:138
  at System.Collections.Generic.List`1[T].AddEnumerable (System.Collections.Generic.IEnumerable`1[T] enumerable) [0x00059] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/List.cs:1108
  at System.Collections.Generic.List`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection) [0x00062] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/List.cs:87
  at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x0000e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/ToCollection.cs:30
  at MonoDevelop.Ide.TypeSystem.TypeSystemService.Load (MonoDevelop.Projects.WorkspaceItem item, MonoDevelop.Core.ProgressMonitor progressMonitor, System.Threading.CancellationToken cancellationToken, System.Boolean showStatusIcon) [0x0001e] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs:120
  ```