### PR TITLE
[Toolbox] Fix event ownership, double free and assertion on trying to free a null event

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -89,7 +89,7 @@ namespace MonoDevelop.DesignerSupport
 					// Gtk.Application.CurrentEvent and other copied gdk_events seem to have a problem
 					// when used as they use gdk_event_copy which seems to crash on de-allocating the private slice.
 					IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
-					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent));
+					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent, false));
 
 					// gtk_drag_begin does not store the event, so we're okay
 					GtkWorkarounds.FreeEvent (currentEvent);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/GtkWorkarounds.cs
@@ -1538,7 +1538,11 @@ namespace MonoDevelop.Components
 		[DllImport ("libgdk-win32-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern void gdk_event_free (IntPtr raw);
 
-		public static void FreeEvent (IntPtr raw) => gdk_event_free (raw);
+		public static void FreeEvent (IntPtr raw)
+		{
+			if (raw != IntPtr.Zero)
+				gdk_event_free (raw);
+		}
 	}
 
 	public readonly struct KeyboardShortcut : IEquatable<KeyboardShortcut>


### PR DESCRIPTION
Fixes VSTS #783919 - Unable to Drag and Drop controls to Main.storyboard via search from Tool Box