### PR TITLE
Only prepend CS when a warning code is a number, not when some other …

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
@@ -186,11 +186,10 @@ namespace MonoDevelop.CSharp.Project
 			var items = warnings.Split (new [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries).Distinct ();
 
 			foreach (string warning in items) {
-				if (warning.StartsWith ("CS", StringComparison.OrdinalIgnoreCase)) {
-					yield return warning;
-				} else {
+				if (int.TryParse (warning, out _))
 					yield return "CS" + warning;
-				}
+				else
+					yield return warning;
 			}
 		}
 


### PR DESCRIPTION
…identifier is prefixed

Fixes VSTS #783932 - "NoWarn IDE0051 is not honored"