### PR TITLE
Fix strees test and improvements to memory profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,4 @@ main/po/StripMnemonics.pdb
 main/po/StripMnemonics.exe
 *.binlog
 *.ProjectImports.zip
+main/tests/StressTest/bin

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEnums.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEnums.cs
@@ -66,6 +66,7 @@ namespace Mono.Profiler.Log {
 		RuntimeJitHelper = 1 << 4,
 
 		MetaSynchronizationPoint = 0 << 4,
+		MetaAotId = 1 << 4,
 	}
 
 	// mono/profiler/log.h : TYPE_*
@@ -122,17 +123,18 @@ namespace Mono.Profiler.Log {
 
 	// mono/metadata/profiler.h : MonoProfilerCodeBufferType
 	public enum LogJitHelper {
-		Unknown = 0,
-		Method = 1,
-		MethodTrampoline = 2,
-		UnboxTrampoline = 3,
-		ImtTrampoline = 4,
-		GenericsTrampoline = 5,
-		SpecificTrampoline = 6,
-		Helper = 7,
-		Monitor = 8,
-		DelegateInvoke = 9,
-		ExceptionHandling = 10,
+		Method = 0,
+		[Obsolete ("This value is no longer produced.")]
+		MethodTrampoline = 1,
+		UnboxTrampoline = 2,
+		ImtTrampoline = 3,
+		GenericsTrampoline = 4,
+		SpecificTrampoline = 5,
+		Helper = 6,
+		[Obsolete ("This value is no longer produced.")]
+		Monitor = 7,
+		DelegateInvoke = 8,
+		ExceptionHandling = 9,
 	}
 
 	// mono/metadata/profiler.h : MonoProfilerGCRootType
@@ -168,7 +170,8 @@ namespace Mono.Profiler.Log {
 		Marshal = 11,
 		ThreadPool = 12,
 		Debugger = 13,
-		RuntimeHandle = 14,
+		Handle = 14,
+		Ephemeron = 15,
 	}
 
 	// mono/profiler/log.h : MonoProfilerMonitorEvent

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEventVisitor.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEventVisitor.cs
@@ -189,5 +189,9 @@ namespace Mono.Profiler.Log {
 		public virtual void Visit (SynchronizationPointEvent ev)
 		{
 		}
+
+		public virtual void Visit (AotIdEvent ev)
+		{
+		}
 	}
 }

--- a/main/tests/StressTest/Mono.Profiling.Log/LogEvents.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogEvents.cs
@@ -101,6 +101,8 @@ namespace Mono.Profiler.Log {
 
 		public string Name { get; internal set; }
 
+		public Guid ModuleVersionId { get; internal set; }
+
 		internal override void Accept (LogEventVisitor visitor)
 		{
 			visitor.Visit (this);
@@ -260,6 +262,8 @@ namespace Mono.Profiler.Log {
 
 		public long ObjectSize { get; internal set; }
 
+		public int Generation { get; internal set; }
+
 		public IReadOnlyList<HeapObjectReference> References { get; internal set; }
 
 		internal override void Accept (LogEventVisitor visitor)
@@ -272,7 +276,7 @@ namespace Mono.Profiler.Log {
 
 		public struct HeapRoot {
 
-			public long AddressPointer { get; internal set; }
+			public long SlotPointer { get; internal set; }
 
 			public long ObjectPointer { get; internal set; }
 
@@ -314,7 +318,7 @@ namespace Mono.Profiler.Log {
 
 	public sealed class HeapRootUnregisterEvent : LogEvent {
 
-		public long StartPointer { get; internal set; }
+		public long RootPointer { get; internal set; }
 
 		internal override void Accept (LogEventVisitor visitor)
 		{
@@ -326,7 +330,7 @@ namespace Mono.Profiler.Log {
 
 		public LogGCEvent Type { get; internal set; }
 
-		public byte Generation { get; internal set; }
+		public int Generation { get; internal set; }
 
 		internal override void Accept (LogEventVisitor visitor)
 		{
@@ -554,6 +558,7 @@ namespace Mono.Profiler.Log {
 		}
 	}
 
+	[Obsolete ("This event is no longer produced.")]
 	public sealed class UnmanagedBinaryEvent : LogEvent {
 
 		public long SegmentPointer { get; internal set; }
@@ -587,6 +592,16 @@ namespace Mono.Profiler.Log {
 	public sealed class SynchronizationPointEvent : LogEvent {
 
 		public LogSynchronizationPoint Type { get; internal set; }
+
+		internal override void Accept (LogEventVisitor visitor)
+		{
+			visitor.Visit (this);
+		}
+	}
+
+	public sealed class AotIdEvent : LogEvent {
+
+		public Guid AotId { get; internal set; }
 
 		internal override void Accept (LogEventVisitor visitor)
 		{

--- a/main/tests/StressTest/Mono.Profiling.Log/LogStreamHeader.cs
+++ b/main/tests/StressTest/Mono.Profiling.Log/LogStreamHeader.cs
@@ -9,7 +9,8 @@ namespace Mono.Profiler.Log {
 	public sealed class LogStreamHeader {
 		
 		const int MinVersion = 13;
-		const int MaxVersion = 15;
+
+		const int MaxVersion = 17;
 
 		const int Id = 0x4d505a01;
 
@@ -20,6 +21,8 @@ namespace Mono.Profiler.Log {
 		public byte PointerSize { get; }
 
 		public ulong StartupTime { get; }
+
+		public ulong TimestampStartupTime { get; }
 
 		public int TimerOverhead { get; }
 
@@ -50,6 +53,10 @@ namespace Mono.Profiler.Log {
 			
 			PointerSize = reader.ReadByte ();
 			StartupTime = reader.ReadUInt64 ();
+
+			if (Version.Major >= 3)
+				TimestampStartupTime = reader.ReadUInt64 ();
+
 			TimerOverhead = reader.ReadInt32 ();
 			Flags = reader.ReadInt32 ();
 			ProcessId = reader.ReadInt32 ();

--- a/main/tests/StressTest/MonoDevelop.StressTest/ProfilerProcessor.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/ProfilerProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -166,9 +166,9 @@ namespace MonoDevelop.StressTest
 		{
 			switch (Options.Type) {
 				case StressTestOptions.ProfilerOptions.ProfilerType.HeapOnly:
-					return $"--profile=log:heapshot=ondemand,noalloc,nocalls,maxframes=0,output=\"{Options.MlpdOutputPath}\"";
+					return $"--profile=log:nodefaults,heapshot=ondemand,output=\"{Options.MlpdOutputPath}\"";
 				case StressTestOptions.ProfilerOptions.ProfilerType.All:
-					return $"--profile=log:heapshot=ondemand,alloc,nocalls,maxframes={Options.MaxFrames},output=\"{Options.MlpdOutputPath}\"";
+					return $"--profile=log:nodefaults,heapshot-on-shutdown,heapshot=ondemand,gcalloc,gcmove,gcroot,counter,maxframes={Options.MaxFrames},output=\"{Options.MlpdOutputPath}\"";
 				case StressTestOptions.ProfilerOptions.ProfilerType.Custom:
 					return Options.CustomProfilerArguments;
 				default:

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // StressTestApp.cs
 //
 // Author:
@@ -67,6 +67,8 @@ namespace MonoDevelop.StressTest
 			if (ProfilerOptions.Type != StressTestOptions.ProfilerOptions.ProfilerType.Disabled) {
 				if (ProfilerOptions.MlpdOutputPath == null)
 					ProfilerOptions.MlpdOutputPath = Path.Combine (profilePath, "profiler.mlpd");
+				if (File.Exists (ProfilerOptions.MlpdOutputPath))
+					File.Delete (ProfilerOptions.MlpdOutputPath);
 				profilerProcessor = new ProfilerProcessor (ProfilerOptions);
 				string monoPath = Environment.GetEnvironmentVariable ("PATH")
 											 .Split (Path.PathSeparator)
@@ -83,6 +85,7 @@ namespace MonoDevelop.StressTest
 
 			scenario = TestScenarioProvider.GetTestScenario ();
 
+			ReportMemoryUsage (-1);
 			for (int i = 0; i < Iterations; ++i) {
 				scenario.Run ();
 				ReportMemoryUsage (i);

--- a/main/tests/StressTest/StressTest.csproj
+++ b/main/tests/StressTest/StressTest.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{A1F9B020-6573-4BB2-A887-7F26561A9D18}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>MonoDevelop.StressTest</RootNamespace>
-    <TargetFrameworkVersion>4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -95,6 +95,6 @@
       </ItemGroup>
       <Copy SourceFiles="@(TestProjectFiles)" DestinationFolder="$(OutputPath)\TestProject\%(RecursiveDir)" SkipUnchangedFiles="true" />
       <Copy SourceFiles="@(MonoAddinsFiles)" DestinationFolder="$(OutputPath)\TestProject\mono-addins\Mono.Addins\%(RecursiveDir)" SkipUnchangedFiles="true" />
-      <Copy SourceFiles="$(MonoAddinsDir)\Version.props;$(MonoAddinsDir)\mono-addins.snk" DestinationFolder="$(OutputPath)\TestProject\mono-addins" SkipUnchangedFiles="true" />
+      <Copy SourceFiles="$(MonoAddinsDir)\Version.props;$(MonoAddinsDir)\TargetFrameworks.props;$(MonoAddinsDir)\mono-addins.snk" DestinationFolder="$(OutputPath)\TestProject\mono-addins" SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Changes under `main/tests/StressTest/Mono.Profiling.Log/` are just copied files from mono repo.
Changes in `ProfilerProcessor.cs` are mostly just modernization of arguments.
Change to include TargetFrameworks.props in StressTest.csproj is actual fix actually.
`ReportMemoryUsage (-1);` is to take heapshot/show memory even before 1st iteration.