### PR TITLE
[SourceControl] Switches to Humanizer for version control date formatting

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -36,6 +36,7 @@ using Mono.TextEditor;
 using System.Linq;
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide.Fonts;
+using Humanizer;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -512,21 +513,15 @@ namespace MonoDevelop.VersionControl.Views
 		
 		static void DateFunc (Gtk.TreeViewColumn tree_column, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter)
 		{
-			CellRendererText renderer = (CellRendererText)cell;
-			var rev = (Revision)model.GetValue (iter, 0);
-			string day;
-
+			var renderer = (CellRendererText)cell;
+			var revision = (Revision)model.GetValue (iter, 0);
 			// Grab today's day and the start of tomorrow's day to make Today/Yesterday calculations.
 			var now = DateTime.Now;
-			var age = new DateTime (now.Year, now.Month, now.Day).AddDays(1) - rev.Time;
-			if (age.Days >= 0 && age.Days < 1) { // Check whether it's a commit that's less than a day away. Also discard future commits.
-				day = GettextCatalog.GetString ("Today");
-			} else if (age.Days < 2) { // Check whether it's a commit from yesterday.
-				day = GettextCatalog.GetString ("Yesterday");
-			} else {
-				day = rev.Time.ToShortDateString ();
-			}
-			renderer.Text = string.Format ("{0} {1:HH:mm}", day, rev.Time);
+			var age = new DateTime (now.Year, now.Month, now.Day).AddDays (1) - revision.Time;
+
+			renderer.Text = age.Days >= 2 ?
+				revision.Time.ToShortDateString () :
+				revision.Time.Humanize (dateToCompareAgainst: now);
 		}	
 		
 		static void GraphFunc (Gtk.TreeViewColumn tree_column, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -78,6 +78,7 @@
       <HintPath>..\..\..\..\build\bin\Microsoft.VisualStudio.Text.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <PackageReference Include="Humanizer.Core" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="icons\added-overlay-16.png" />


### PR DESCRIPTION
Uses Humanizer to show better log date info

Fixes VSTS #589734

<img width="726" alt="screen shot 2019-02-04 at 13 43 26" src="https://user-images.githubusercontent.com/1587480/52209242-9b217a00-2883-11e9-867c-03eac3f2eb97.png">




