### PR TITLE
[build] Bump Microsoft.VisualStudio.Threading to 15.8

### DIFF
--- a/main/msbuild/MonoDevelop.BeforeCommon.targets
+++ b/main/msbuild/MonoDevelop.BeforeCommon.targets
@@ -59,4 +59,20 @@
 	<PropertyGroup Condition="$(Configuration.Contains('Gnome'))">
 		<DefineConstants>$(DefineConstants);GNOME;LINUX</DefineConstants>
 	</PropertyGroup>
+
+	<Target Name="RemoveNoisyAnalyzers" BeforeTargets="CoreCompile">
+		<ItemGroup>
+			<!--
+			This analyzer gets pulled in by Microsoft.VisualStudio.Threading, propagates
+			through most of the solution, and produces an overwhelming amount of noise.
+			Disable it for now until someone can go audit all its warnings.
+			-->
+			<Analyzer Remove="@(Analyzer->WithMetadataValue('Filename', 'Microsoft.VisualStudio.Threading.Analyzers.CodeFixes'))" />
+			<Analyzer Remove="@(Analyzer->WithMetadataValue('Filename', 'Microsoft.VisualStudio.Threading.Analyzers'))" />
+			<Analyzer Remove="@(Analyzer->WithMetadataValue('Filename', 'Microsoft.VisualStudio.Threading.Analyzers.resources'))" />
+			<!-- thes analyzers are pulled in by Roslyn but aren't particularly relevant and have some internal errors -->
+			<Analyzer Remove="@(Analyzer->WithMetadataValue('Filename', 'Microsoft.CodeAnalysis.CSharp.Analyzers'))" />
+			<Analyzer Remove="@(Analyzer->WithMetadataValue('Filename', 'Microsoft.CodeAnalysis.Analyzers'))" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -779,7 +779,7 @@
     <Exec Command="&quot;$(Git)&quot; rev-parse HEAD &gt; $(VcRevision)" WorkingDirectory="$(MSBuildProjectDirectory)" IgnoreExitCode="True" />
     <RemoveDir Directories="$(FullBuildInfo)" />
   </Target>
-  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.209\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Import Project="..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets" Condition="Exists('..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" />
   <Import Project="..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
   <Import Project="..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />

--- a/main/src/core/MonoDevelop.Core/packages.config
+++ b/main/src/core/MonoDevelop.Core/packages.config
@@ -35,8 +35,8 @@
   <package id="Microsoft.VisualStudio.Text.Logic" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI" version="15.8.519" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.8.519" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.8.209" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.209" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.32" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0" targetFramework="net471" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -46,8 +46,8 @@
     <Reference Include="Microsoft.VisualStudio.Composition, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Composition.15.6.36\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\packages\Microsoft.VisualStudio.Threading.15.8.209\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Validation.15.3.32\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>

--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -160,7 +160,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-15.6.0.0" newVersion="15.6.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-15.8.0.0" newVersion="15.8.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
This aligns master with a more recent version of the library which allows external extenders to target both VSWin and VSMac using the official latest stable NuGet.