### PR TITLE
[Toolbox] Fixes toolboxService is allways in sync with toolbox selected item

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxWidget.cs
@@ -40,7 +40,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		IEnumerable<ToolboxWidgetCategory> Categories { get; }
 		IEnumerable<ToolboxWidgetItem> AllItems { get; }
 
-		event EventHandler SelectedItemChanged;
 		event EventHandler ActivateSelectedItem;
 
 		void AddCategory (ToolboxWidgetCategory category);

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -62,7 +62,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public event EventHandler<Gtk.TargetEntry []> DragSourceSet;
 		public event EventHandler ContentFocused;
 
-		public ItemToolboxNode selectedNode;
+		public ItemToolboxNode SelectedNode => toolboxWidget.SelectedItem?.Node;
 
 		NativeViews.ToggleButton catToggleButton;
 		NativeViews.ToggleButton compactModeToggleButton;
@@ -180,7 +180,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 			filterEntry.Changed += FilterEntry_Changed;
 
-			toolboxWidget.SelectedItemChanged += ToolboxWidget_SelectedItemChanged;
 			toolboxWidget.DragBegin += ToolboxWidget_DragBegin;
 			toolboxWidget.MouseDownActivated += ToolboxWidget_MouseDownActivated;
 			toolboxWidget.ActivateSelectedItem += ToolboxWidget_ActivateSelectedItem;
@@ -205,15 +204,13 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			Refresh ();
 		}
 
-		void ToolboxWidget_SelectedItemChanged (object sender, EventArgs e)
-		{
-			selectedNode = this.toolboxWidget.SelectedItem != null ? this.toolboxWidget.SelectedItem.Tag as ItemToolboxNode : null;
-			toolboxService.SelectItem (selectedNode);
-		}
-
 		void ToolboxWidget_ActivateSelectedItem (object sender, EventArgs e)
 		{
-			toolboxService.UseSelectedItem ();
+			var selectedNode = SelectedNode;
+			if (selectedNode != null) {
+				DesignerSupport.Service.ToolboxService.SelectItem (selectedNode);
+				toolboxService.UseSelectedItem ();
+			}
 		}
 
 		void FilterEntry_Changed (object sender, EventArgs e)
@@ -438,13 +435,17 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		[CommandHandler (MonoDevelop.Ide.Commands.EditCommands.Delete)]
 		internal void OnDeleteItem ()
 		{
-			if (MessageService.Confirm (GettextCatalog.GetString ("Are you sure you want to remove the selected Item?"), AlertButton.Delete))
-				toolboxService.RemoveUserItem (selectedNode);
+			var selectedNode = SelectedNode;
+			if (selectedNode != null) {
+				if (MessageService.Confirm (GettextCatalog.GetString ("Are you sure you want to remove the selected Item?"), AlertButton.Delete))
+					toolboxService.RemoveUserItem (SelectedNode);
+			}
 		}
 
 		[CommandUpdateHandler (MonoDevelop.Ide.Commands.EditCommands.Delete)]
 		internal void OnUpdateDeleteItem (CommandInfo info)
 		{
+			var selectedNode = SelectedNode;
 			// Hack manually filter out gtk# widgets & container since they cannot be re added
 			// because they're missing the toolbox attributes.
 			info.Enabled = selectedNode != null && toolboxService.CanRemoveUserItem (selectedNode)
@@ -540,7 +541,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				toolboxAddButton.Activated -= ToolboxAddButton_Clicked;
 				toolboxAddButton.Focused -= ToolboxAddButton_Focused;
 
-				toolboxWidget.SelectedItemChanged -= ToolboxWidget_SelectedItemChanged;
 				toolboxWidget.ActivateSelectedItem -= ToolboxWidget_ActivateSelectedItem;
 				toolboxWidget.MenuOpened -= ToolboxWidget_MenuOpened;
 				toolboxWidget.MouseDownActivated -= ToolboxWidget_MouseDownActivated;
@@ -560,12 +560,12 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		
 		object IPropertyPadProvider.GetActiveComponent ()
 		{
-			return selectedNode;
+			return SelectedNode;
 		}
 
 		object IPropertyPadProvider.GetProvider ()
 		{
-			return selectedNode;
+			return SelectedNode;
 		}
 
 		void IPropertyPadProvider.OnEndEditing (object obj)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -56,7 +56,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public event EventHandler Focused;
 		public event EventHandler DragBegin;
 		public event EventHandler<CGPoint> MenuOpened;
-		public event EventHandler SelectedItemChanged;
 		public event EventHandler ActivateSelectedItem;
 		public Action<NSEvent> MouseDownActivated { get; set; }
 
@@ -74,8 +73,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		internal void PerformActivateSelectedItem () => OnActivateSelectedItem (EventArgs.Empty);
 
 		void OnActivateSelectedItem (EventArgs args) => ActivateSelectedItem?.Invoke (this, args);
-	
-		void OnSelectedItemChanged (EventArgs args) => SelectedItemChanged?.Invoke (this, args);
 
 		NSIndexPath selectedIndexPath;
 		public NSIndexPath SelectedIndexPath {
@@ -85,7 +82,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			set {
 				if (selectedIndexPath != value) {
 					selectedIndexPath = value;
-					OnSelectedItemChanged (EventArgs.Empty);
 				}
 			}
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -82,7 +82,10 @@ namespace MonoDevelop.DesignerSupport
 				targets.AddTable (e);
 			};
 			toolbox.DragBegin += (object sender, EventArgs e) => {
-				if (!isDragging) {
+				var selectedNode = toolbox.SelectedNode;
+				if (!isDragging && selectedNode != null) {
+
+					DesignerSupport.Service.ToolboxService.SelectItem (selectedNode);
 
 					Gtk.Drag.SourceUnset (widget);
 


### PR DESCRIPTION
This PR fixes ensure we set the correct selected element in Toolbox to start a drag and drop operation

![selection](https://user-images.githubusercontent.com/1587480/52270188-7ccd8400-2940-11e9-8211-c8e669bc0fc0.gif)

When we were filtering the toolbox was not correctly updating this.

Fixes VSTS #783919 - Unable to Drag and Drop controls to Main.storyboard via search from Tool Box

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/783919

To test the issue:

1) Create iOS single view application and open main.storyboard
2) Drag any control from toolbox (Lets say Button) to storyboard file
3) Then search (Type Label) any other control from Toolbox - search and try to drag to storyboard file


