### PR TITLE
Report and Cancel Project Run if WorkingDirectory doesn't exist

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1916,6 +1916,12 @@ namespace MonoDevelop.Projects
 			bool externalConsole = false, pauseConsole = false;
 
 			var dotNetExecutionCommand = executionCommand as DotNetExecutionCommand;
+
+			if (!Directory.Exists (dotNetExecutionCommand.WorkingDirectory)) {
+				monitor.ReportError (GettextCatalog.GetString ("Can not execute. The run configuration working directory doesn't exist at {0}", dotNetExecutionCommand.WorkingDirectory), null);
+				return;
+			}
+
 			if (dotNetExecutionCommand != null) {
 				dotNetExecutionCommand.UserAssemblyPaths = GetUserAssemblyPaths (configuration);
 				externalConsole = dotNetExecutionCommand.ExternalConsole;


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #3697**

## Description

- Added a check to `OnExecuteCommand` to ensure the run configuration is not set up to a working directory that does not exist.

Previously if one had set their "Run in directory" path in the run configuration to a folder that did not exist, then attempted `Start Debugging` or `Start Without Debugging` MonoDevelop would keep attempting to run without cancelling or alerting the user of the issue.

Now in this situation the run will be cancelled and the user will have an error reported informing them of the path issue in their project run configuration.

Any feedback on the implementation of this or the selected verbiage would be greatly appreciated!

Fixes VSTS #569970