### PR TITLE
Fixes VSTS Bug 786750: Error squiggles are sometimes not up to date

### DIFF
--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpResultsEditorExtensionTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpResultsEditorExtensionTests.cs
@@ -76,12 +76,13 @@ class MyClass
 		[Test]
 		public async Task DiagnosticEnableSourceAnalysisChanged ()
 		{
-			await RunTest (5, OneFromEach, (remainingUpdates, doc) => {
-				if (remainingUpdates == 4) {
+			await RunTest (9, OneFromEach, (remainingUpdates, doc) => {
+
+				if (remainingUpdates == 8) {
 					AssertExpectedDiagnostics (OneFromEachDiagnostics.Take (2), doc);
 				}
 
-				if (remainingUpdates == 1) {
+				if (remainingUpdates == 5) {
 					AssertExpectedDiagnostics (OneFromEachDiagnostics, doc);
 					IdeApp.Preferences.EnableSourceAnalysis.Value = false;
 				}


### PR DESCRIPTION
t's possible that the cancellation finish gets in the way of the new
idle handler. At least it all runs now on the UI thread and the
updaters are all canceled properly on dispose and before the new one
is started.