### PR TITLE
[release-7.8] [A11y] Fix up memory pressure caused by lots of arrays being created

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -343,7 +343,7 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 				return;
 			}
 
-			using (var realTabs = new NSMutableArray ((nuint)tabs.Length)) {
+			using (var realTabs = tabs.ToAccessibilityArray ()) {
 				Messaging.void_objc_msgSend_IntPtr (nsa.Handle, selSetAccessibilityTabs_Handle, realTabs != null ? realTabs.Handle : IntPtr.Zero);
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/Messaging.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/Messaging.cs
@@ -42,6 +42,9 @@ namespace MonoDevelop.Components.Mac
 		public static extern void void_objc_msgSend (IntPtr handle, IntPtr sel);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
+		public static extern void void_objc_msgSend_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
 		public static extern bool bool_objc_msgSend_IntPtr_IntPtr (IntPtr handle, IntPtr sel, IntPtr a1, IntPtr a2);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSendSuper")]


### PR DESCRIPTION
By using native NSMutableArrays we avoid copying a lot of arrays between
native and managed, thus avoid a lot of GC pressure that can happen while
modifying a11y properties.

Backport of #7062.

/cc @Therzok 