### PR TITLE
[VersionControl] Matches scrollarea in authors tab with its source editor

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
@@ -28,6 +28,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Content;
 using Mono.TextEditor;
 using System;
+using System.Linq;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -59,13 +60,9 @@ namespace MonoDevelop.VersionControl.Views
 			info.Start ();
 			BlameWidget blameWidget = Control.GetNativeWidget<BlameWidget> ();
 			blameWidget.Reset ();
-
 			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
 			if (buffer != null) {
-				if (buffer.TextView is MonoTextEditor exEditor) {
-					blameWidget.Editor.SetCaretTo (exEditor.Caret.Line, exEditor.Caret.Column);
-					blameWidget.Editor.VAdjustment.Value = exEditor.VAdjustment.Value;
-				} else {
+				if (!(buffer.TextView is MonoTextEditor)) {
 					//compatibility for other not MonoTextEditor editors
 					var loc = buffer.CaretLocation;
 					int line = loc.Line < 1 ? 1 : loc.Line;
@@ -82,7 +79,8 @@ namespace MonoDevelop.VersionControl.Views
 				var blameWidget = Control.GetNativeWidget<BlameWidget> ();
 
 				if (buffer.TextView is MonoTextEditor exEditor) {
-
+					if (blameWidget.Revision == null)
+						exEditor.Document.UpdateFoldSegments (blameWidget.Editor.Document.FoldSegments.Select (f => new Mono.TextEditor.FoldSegment (f)));
 					exEditor.SetCaretTo (blameWidget.Editor.Caret.Line, blameWidget.Editor.Caret.Column);
 					exEditor.VAdjustment.Value = blameWidget.Editor.VAdjustment.Value;
 				} else {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
@@ -27,6 +27,7 @@ using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Content;
 using Mono.TextEditor;
+using System;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -56,25 +57,39 @@ namespace MonoDevelop.VersionControl.Views
 		protected override void OnSelected ()
 		{
 			info.Start ();
-			BlameWidget widget = Control.GetNativeWidget<BlameWidget> ();
-			widget.Reset ();
+			BlameWidget blameWidget = Control.GetNativeWidget<BlameWidget> ();
+			blameWidget.Reset ();
 
 			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
 			if (buffer != null) {
-				var loc = buffer.CaretLocation;
-				int line = loc.Line < 1 ? 1 : loc.Line;
-				int column = loc.Column < 1 ? 1 : loc.Column;
-				widget.Editor.SetCaretTo (line, column, highlight: false, centerCaret: false);
+				if (buffer.TextView is MonoTextEditor exEditor) {
+					blameWidget.Editor.SetCaretTo (exEditor.Caret.Line, exEditor.Caret.Column);
+					blameWidget.Editor.VAdjustment.Value = exEditor.VAdjustment.Value;
+				} else {
+					//compatibility for other not MonoTextEditor editors
+					var loc = buffer.CaretLocation;
+					int line = loc.Line < 1 ? 1 : loc.Line;
+					int column = loc.Column < 1 ? 1 : loc.Column;
+					blameWidget.Editor.SetCaretTo (line, column, highlight: false, centerCaret: false);
+				}
 			}
 		}
 
 		protected override void OnDeselected ()
 		{
-			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
+			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> () ;
 			if (buffer != null) {
-				BlameWidget widget = Control.GetNativeWidget<BlameWidget> ();
-				buffer.SetCaretLocation (widget.Editor.Caret.Line, widget.Editor.Caret.Column, usePulseAnimation: false, centerCaret: false);
-				buffer.ScrollTo (new Ide.Editor.DocumentLocation (widget.Editor.YToLine (widget.Editor.VAdjustment.Value), 1));
+				var blameWidget = Control.GetNativeWidget<BlameWidget> ();
+
+				if (buffer.TextView is MonoTextEditor exEditor) {
+
+					exEditor.SetCaretTo (blameWidget.Editor.Caret.Line, blameWidget.Editor.Caret.Column);
+					exEditor.VAdjustment.Value = blameWidget.Editor.VAdjustment.Value;
+				} else {
+					//compatibility for other not MonoTextEditor editors
+					buffer.ScrollTo (new Ide.Editor.DocumentLocation (blameWidget.Editor.YToLine (blameWidget.Editor.VAdjustment.Value), 1));
+					buffer.SetCaretLocation (blameWidget.Editor.Caret.Line, blameWidget.Editor.Caret.Column, usePulseAnimation: false, centerCaret: false);
+				}
 			}
 		}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -418,7 +418,7 @@ namespace MonoDevelop.VersionControl.Views
 				if (annotation != null)
 					TooltipText = GetCommitMessage (startLine - 1, true);
 
-				SetHighlight (annotation, startLine, evnt.Y, highlightAnnotation != annotation);
+				SetHighligh (annotation, startLine, evnt.Y, highlightAnnotation != annotation);
 
 				return base.OnMotionNotifyEvent (evnt);
 			}
@@ -787,18 +787,18 @@ namespace MonoDevelop.VersionControl.Views
 				return true;
 			}
 
-			int GetStartLineFromY (double y) => widget.Editor.YToLine (widget.Editor.VAdjustment.Value + y);
+			int YToStartLine (double y) => widget.Editor.YToLine (widget.Editor.VAdjustment.Value + y);
 
 			void GetAnnotationFromY (double y, out Annotation annotation, out int startLine)
 			{
-				startLine = GetStartLineFromY (y);
+				startLine = YToStartLine (y);
 				annotation = GetAnnotationFromLine (startLine);
 			}
 
 			internal Annotation GetAnnotationFromLine (int startLine) =>
-			 startLine > 0 && startLine <= annotations.Count ? annotations [startLine - 1] : null;
+				startLine > 0 && startLine <= annotations.Count ? annotations [startLine - 1] : null;
 
-			internal void SetHighlight (Annotation annotation, int line, double y, bool needsRedraw)
+			internal void SetHighligh (Annotation annotation, int line, double y, bool needsRedraw)
 			{
 				highlightPositon = y;
 				highlightAnnotation = annotation;
@@ -807,11 +807,11 @@ namespace MonoDevelop.VersionControl.Views
 				}
 			}
 
-			internal void Hightlight (int line)
+			internal void Hightligh (int line)
 			{
 				var y = widget.editor.LineToY (line);
 			 	var annotation = GetAnnotationFromLine (line);
-				SetHighlight (annotation, line, y, true);
+				SetHighligh (annotation, line, y, true);
 			}
 		}	
 	}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -412,17 +412,14 @@ namespace MonoDevelop.VersionControl.Views
 					WidthRequest = newWidthRequest;
 					QueueResize ();
 				}
-				int startLine = widget.Editor.YToLine (widget.Editor.VAdjustment.Value + evnt.Y);
-				var ann = startLine > 0 && startLine <= annotations.Count ? annotations[startLine - 1] : null;
-				if (ann != null)
+
+				GetAnnotationFromY (evnt.Y, out var annotation, out var startLine);
+
+				if (annotation != null)
 					TooltipText = GetCommitMessage (startLine - 1, true);
 
-				highlightPositon = evnt.Y;
-				if (highlightAnnotation != ann) {
-					highlightAnnotation = ann;
-					widget.QueueDraw ();
-				}
-				
+				SetHighlight (annotation, startLine, evnt.Y, highlightAnnotation != annotation);
+
 				return base.OnMotionNotifyEvent (evnt);
 			}
 			
@@ -438,8 +435,8 @@ namespace MonoDevelop.VersionControl.Views
 			protected override bool OnButtonPressEvent (EventButton evnt)
 			{
 				if (evnt.TriggersContextMenu ()) {
-					int startLine = widget.Editor.YToLine (widget.Editor.VAdjustment.Value + evnt.Y);
-					menuAnnotation = startLine > 0 && startLine <= annotations.Count ? annotations[startLine - 1] : null;
+
+					GetAnnotationFromY (evnt.Y, out menuAnnotation, out var startLine);
 
 					CommandEntrySet opset = new CommandEntrySet ();
 					opset.AddItem (BlameCommands.ShowDiff);
@@ -789,7 +786,33 @@ namespace MonoDevelop.VersionControl.Views
 				}
 				return true;
 			}
-			
+
+			int GetStartLineFromY (double y) => widget.Editor.YToLine (widget.Editor.VAdjustment.Value + y);
+
+			void GetAnnotationFromY (double y, out Annotation annotation, out int startLine)
+			{
+				startLine = GetStartLineFromY (y);
+				annotation = GetAnnotationFromLine (startLine);
+			}
+
+			internal Annotation GetAnnotationFromLine (int startLine) =>
+			 startLine > 0 && startLine <= annotations.Count ? annotations [startLine - 1] : null;
+
+			internal void SetHighlight (Annotation annotation, int line, double y, bool needsRedraw)
+			{
+				highlightPositon = y;
+				highlightAnnotation = annotation;
+				if (needsRedraw) {
+					widget.QueueDraw ();
+				}
+			}
+
+			internal void Hightlight (int line)
+			{
+				var y = widget.editor.LineToY (line);
+			 	var annotation = GetAnnotationFromLine (line);
+				SetHighlight (annotation, line, y, true);
+			}
 		}	
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -36,6 +36,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Components;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Ide.Fonts;
+using MonoDevelop.Ide.Editor;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -49,6 +50,13 @@ namespace MonoDevelop.VersionControl.Views
 	class BlameWidget : Bin
 	{
 		Revision revision;
+
+		public Revision Revision {
+			get {
+				return revision;
+			}
+		}
+
 		Adjustment vAdjustment;
 		Gtk.VScrollbar vScrollBar;
 		
@@ -131,7 +139,11 @@ namespace MonoDevelop.VersionControl.Views
 				IsReadOnly = true,
 				MimeType = sourceEditor.TextEditor.Document.MimeType,
 			};
-			editor = new MonoTextEditor (doc, sourceEditor.TextEditor.Options);
+			var options = new CustomEditorOptions (DefaultSourceEditorOptions.Instance);
+			options.TabsToSpaces = false;
+
+			editor = new MonoTextEditor (doc, new SourceEditor.StyledSourceEditorOptions (options));
+
 			AddChild (editor);
 			editor.SetScrollAdjustments (hAdjustment, vAdjustment);
 			
@@ -569,6 +581,11 @@ namespace MonoDevelop.VersionControl.Views
 							document.Text = widget.VersionControlItem.Repository.GetTextAtRevision (widget.Document.FileName, widget.revision);
 						} else {
 							document.Text = widget.Document.Editor.Text;
+							if (widget.Document.Editor.TextView is MonoTextEditor exEditor) {
+								document.UpdateFoldSegments (exEditor.Document.FoldSegments.Select (f => new Mono.TextEditor.FoldSegment (f)));
+								widget.Editor.SetCaretTo (exEditor.Caret.Line, exEditor.Caret.Column);
+								widget.Editor.VAdjustment.Value = exEditor.VAdjustment.Value;
+							}
 						}
 						widget.editor.Caret.Location = location;
 						widget.editor.VAdjustment.Value = adj;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -418,7 +418,7 @@ namespace MonoDevelop.VersionControl.Views
 				if (annotation != null)
 					TooltipText = GetCommitMessage (startLine - 1, true);
 
-				SetHighligh (annotation, startLine, evnt.Y, highlightAnnotation != annotation);
+				SetHighlight (annotation, startLine, evnt.Y, highlightAnnotation != annotation);
 
 				return base.OnMotionNotifyEvent (evnt);
 			}
@@ -798,20 +798,13 @@ namespace MonoDevelop.VersionControl.Views
 			internal Annotation GetAnnotationFromLine (int startLine) =>
 				startLine > 0 && startLine <= annotations.Count ? annotations [startLine - 1] : null;
 
-			internal void SetHighligh (Annotation annotation, int line, double y, bool needsRedraw)
+			internal void SetHighlight (Annotation annotation, int line, double y, bool needsRedraw)
 			{
 				highlightPositon = y;
 				highlightAnnotation = annotation;
 				if (needsRedraw) {
 					widget.QueueDraw ();
 				}
-			}
-
-			internal void Hightligh (int line)
-			{
-				var y = widget.editor.LineToY (line);
-			 	var annotation = GetAnnotationFromLine (line);
-				SetHighligh (annotation, line, y, true);
 			}
 		}	
 	}


### PR DESCRIPTION
This issue, allow switch between Source code and Authors tab and respect the current line selected with the same scroll position

Fixes VSTS #596859 - usability: switching to Authors tab should jump to the context line, not to "cached" line state
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/596859

![authors-fix](https://user-images.githubusercontent.com/1587480/52345359-529dc400-2a1d-11e9-97be-3ff20935473e.gif)


