### PR TITLE
Fixes VSTS Bug 749965: Fatal error on copy + paste in

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextArea.cs
@@ -1414,8 +1414,13 @@ namespace Mono.TextEditor
 						return true;
 					}
 				}
-				if (margin != null) 
-					margin.MousePressed (new MarginMouseEventArgs (textEditorData.Parent, e, e.Button, e.X - startPos, e.Y, e.State));
+				if (margin != null) {
+					try {
+						margin.MousePressed (new MarginMouseEventArgs (textEditorData.Parent, e, e.Button, e.X - startPos, e.Y, e.State));
+ 					} catch (Exception ex) {
+						LoggingService.LogInternalError ("Exception while margin mouse press.", ex);
+					}
+				}
 			}
 			return result;
 		}

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/CaretImpl.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/CaretImpl.cs
@@ -39,7 +39,9 @@ namespace Mono.TextEditor
 		bool autoScrollToCaret = true;
 		
 		CaretMode mode;
-		
+
+		ITextSnapshot currentBuffer;
+
 		int line = DocumentLocation.MinLine;
 		public override int Line {
 			get {
@@ -54,7 +56,7 @@ namespace Mono.TextEditor
 					CheckLine ();
 					SetColumn ();
 					UpdateCaretOffset ();
-					OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.Movement));
+					OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.Movement));
 				}
 			}
 		}
@@ -73,7 +75,7 @@ namespace Mono.TextEditor
 					CheckColumn ();
 					SetDesiredColumn ();
 					UpdateCaretOffset ();
-					OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.Movement));
+					OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.Movement));
 				}
 			}
 		}
@@ -93,7 +95,7 @@ namespace Mono.TextEditor
 					CheckColumn ();
 					SetDesiredColumn ();
 					UpdateCaretOffset ();
-					OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.Movement));
+					OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.Movement));
 				}
 			}
 		}
@@ -119,7 +121,7 @@ namespace Mono.TextEditor
 				CheckLine ();
 				CheckColumn ();
 				SetDesiredColumn ();
-				OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.Movement));
+				OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.Movement));
 			}
 		}
 
@@ -270,7 +272,7 @@ namespace Mono.TextEditor
 			}
 
 			UpdateCaretOffset ();
-			OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.Movement));
+			OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.Movement));
 		}
 
 		void SetDesiredColumn ()
@@ -301,7 +303,7 @@ namespace Mono.TextEditor
 			var old = Location;
 			DesiredColumn = desiredColumn;
 			SetColumn ();
-			OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.Movement));
+			OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.Movement));
 		}
 		
 		public override string ToString ()
@@ -330,6 +332,7 @@ namespace Mono.TextEditor
 			TextEditorData.Document.EnsureOffsetIsUnfolded (Offset);
 			base.OnPositionChanged (args);
 			PositionChanged_ITextCaret (args);
+			currentBuffer = TextEditorData.Document.TextBuffer.CurrentSnapshot;
 		}
 		
 		protected virtual void OnModeChanged ()
@@ -385,7 +388,7 @@ namespace Mono.TextEditor
 
 			SetDesiredColumn ();
 			UpdateCaretOffset ();
-			OnPositionChanged (new CaretLocationEventArgs (old, CaretChangeReason.BufferChange));
+			OnPositionChanged (new CaretLocationEventArgs (old, currentBuffer ?? TextEditorData.Document.TextBuffer.CurrentSnapshot, CaretChangeReason.BufferChange));
 		}
 
 		public void SetDocument (TextDocument doc)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Caret.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Caret.cs
@@ -73,10 +73,12 @@ namespace MonoDevelop.Ide.Editor
 
 	public class CaretLocationEventArgs : DocumentLocationEventArgs
 	{
+		public Microsoft.VisualStudio.Text.ITextSnapshot Snapshot { get; }
 		public CaretChangeReason CaretChangeReason { get; } 
 
-		public CaretLocationEventArgs (DocumentLocation location, CaretChangeReason reason) : base (location)
+		public CaretLocationEventArgs (DocumentLocation location, Microsoft.VisualStudio.Text.ITextSnapshot textSnapshot, CaretChangeReason reason) : base (location)
 		{
+			Snapshot = textSnapshot;
 			CaretChangeReason = reason;
 		}
 	}


### PR DESCRIPTION
launchSettings.json

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/749965

PositionChanged_ITextCaret tried to calculate an old caret position
using the current buffer - that may fail on certain buffer changed
events. Now the coordinates are calculated using the snapshot which
was valid to the former caret location.