### PR TITLE
Fixes broken focus chain in "Exception Caught" window

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/TextVisualizer.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/TextVisualizer.cs
@@ -112,7 +112,7 @@ namespace MonoDevelop.Debugger.Visualizer
 
 			if (value.TypeName == "string") {
 				rawString = value.GetRawValue (options) as RawValueString;
-				length = rawString.Length;
+				length = rawString?.Length ?? 0;
 				offset = 0;
 
 				if (length > 0) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -639,7 +639,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 				InnerExceptionTypeLabel.Markup = "<b>" + GLib.Markup.EscapeText (ex.Type) + "</b>";
 				InnerExceptionMessageLabel.Text = ex.Message;
 				if (!string.IsNullOrEmpty (ex.HelpLink)) {
-					InnerExceptionHelpLinkButton.Label = GettextCatalog.GetString ("Read More...");
+					InnerExceptionHelpLinkButton.Label = GettextCatalog.GetString ("Read More…");
 					innerExceptionHelpLink = ex.HelpLink;
 					InnerExceptionHelpLinkButton.Show ();
 				} else {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -180,6 +180,7 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			ExceptionValueTreeView.AllowExpanding = true;
 			ExceptionValueTreeView.AllowPinning = false;
 			ExceptionValueTreeView.AllowEditing = false;
+			ExceptionValueTreeView.CanFocus = true;
 			ExceptionValueTreeView.AllowAdding = false;
 			ExceptionValueTreeView.RulesHint = true;
 			ExceptionValueTreeView.ModifyFont (Pango.FontDescription.FromString (Platform.IsWindows ? "9" : "11"));
@@ -189,6 +190,7 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 
 			var scrolled = new ScrolledWindow {
 				HeightRequest = 180,
+				CanFocus = true,
 				HscrollbarPolicy = PolicyType.Automatic,
 				VscrollbarPolicy = PolicyType.Automatic
 			};
@@ -230,7 +232,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			expander.Child = widget;
 			expander.Spacing = 0;
 			expander.Show ();
-			expander.CanFocus = false;
+			expander.CanFocus = true;
 			expander.UseMarkup = true;
 			expander.Expanded = true;
 			expander.Activated += Expander_Activated;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -60,7 +60,7 @@ namespace MonoDevelop.Debugger
 
 		protected Label ExceptionMessageLabel { get; private set; }
 
-		protected Label ExceptionHelpLinkLabel { get; private set; }
+		protected Button ExceptionHelpLinkButton { get; private set; }
 
 		protected Label ExceptionTypeLabel { get; private set; }
 
@@ -105,8 +105,8 @@ namespace MonoDevelop.Debugger
 
 			ExceptionTypeLabel = new Label { Xalign = 0.0f, Selectable = true, CanFocus = false };
 			ExceptionMessageLabel = new Label { Wrap = true, Xalign = 0.0f, Selectable = true, CanFocus = false };
-			ExceptionHelpLinkLabel = new Label { Wrap = true, Xalign = 0.0f, Selectable = true, CanFocus = false, UseMarkup = true, LineWrapMode = Pango.WrapMode.Char };
-			ExceptionHelpLinkLabel.Name = "exception_help_link_label";
+			ExceptionHelpLinkButton = new Button { HasFocus = true, Xalign = 0, Relief = ReliefStyle.None, BorderWidth = 0 };
+			ExceptionHelpLinkButton.Name = "exception_help_link_label";
 			Gtk.Rc.ParseString (@"style ""exception-help-link-label""
 {
 	GtkWidget::link-color = ""#ffffff""
@@ -114,23 +114,26 @@ namespace MonoDevelop.Debugger
 }
 widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 ");
-
 			var textColor = Styles.ExceptionCaughtDialog.HeaderTextColor.ToGdkColor ();
+			var headerColor = Styles.ExceptionCaughtDialog.HeaderBackgroundColor.ToGdkColor ();
 
-			ExceptionHelpLinkLabel.ModifyBase (StateType.Prelight, Styles.ExceptionCaughtDialog.HeaderBackgroundColor.ToGdkColor ());
-			ExceptionHelpLinkLabel.SetLinkHandler ((str) => DesktopService.ShowUrl (str));
+			ExceptionHelpLinkButton.ModifyBg (StateType.Selected, headerColor);
+
+			ExceptionHelpLinkButton.Clicked += ExceptionHelpLinkLabel_Clicked;
+			ExceptionHelpLinkButton.KeyPressEvent += EventBoxLink_KeyPressEvent;
+
 			ExceptionTypeLabel.ModifyFg (StateType.Normal, textColor);
 			ExceptionMessageLabel.ModifyFg (StateType.Normal, textColor);
-			ExceptionHelpLinkLabel.ModifyFg (StateType.Normal, textColor);
+			ExceptionHelpLinkButton.ModifyFg (StateType.Normal, textColor);
 
 			if (Platform.IsWindows) {
 				ExceptionTypeLabel.ModifyFont (Pango.FontDescription.FromString ("bold 19"));
 				ExceptionMessageLabel.ModifyFont (Pango.FontDescription.FromString ("10"));
-				ExceptionHelpLinkLabel.ModifyFont (Pango.FontDescription.FromString ("10"));
+				ExceptionHelpLinkButton.ModifyFont (Pango.FontDescription.FromString ("10"));
 			} else {
 				ExceptionTypeLabel.ModifyFont (Pango.FontDescription.FromString ("21"));
 				ExceptionMessageLabel.ModifyFont (Pango.FontDescription.FromString ("12"));
-				ExceptionHelpLinkLabel.ModifyFont (Pango.FontDescription.FromString ("12"));
+				ExceptionHelpLinkButton.ModifyFont (Pango.FontDescription.FromString ("12"));
 			}
 
 			//Force rendering of background with EventBox
@@ -141,8 +144,13 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			leftVBox.PackStart (icon, false, false, (uint)(Platform.IsWindows ? 5 : 0)); // as we change frame.BorderWidth below, we need to compensate
 
 			rightVBox.PackStart (ExceptionTypeLabel, false, false, (uint)(Platform.IsWindows ? 0 : 2));
+
+			var exceptionHContainer = new HBox ();
+			exceptionHContainer.PackStart (ExceptionHelpLinkButton, false, false, 0);
+			exceptionHContainer.PackStart (new Fixed (), true, true, 0);
+
 			rightVBox.PackStart (ExceptionMessageLabel, true, true, (uint)(Platform.IsWindows ? 6 : 5));
-			rightVBox.PackStart (ExceptionHelpLinkLabel, false, false, 2);
+			rightVBox.PackStart (exceptionHContainer, false, false, 2);
 
 			hBox.PackStart (leftVBox, false, false, (uint)(Platform.IsWindows ? 5 : 0)); // as we change frame.BorderWidth below, we need to compensate
 			hBox.PackStart (rightVBox, true, true, (uint)(Platform.IsWindows ? 5 : 10));
@@ -155,19 +163,29 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 
 			eventBox.Add (frame);
 			eventBox.ShowAll ();
-			eventBox.ModifyBg (StateType.Normal, Styles.ExceptionCaughtDialog.HeaderBackgroundColor.ToGdkColor ());
+			eventBox.ModifyBg (StateType.Normal, headerColor);
 
 			return eventBox;
 		}
+
+		void ExceptionHelpLinkLabel_Clicked (object sender, EventArgs e) => DesktopService.ShowUrl (exceptionHelpLink);
+
+		void EventBoxLink_KeyPressEvent (object o, KeyPressEventArgs args)
+		{ 
+			if (args.Event.Key == Gdk.Key.KP_Enter || args.Event.Key == Gdk.Key.KP_Space)
+				DesktopService.ShowUrl (exceptionHelpLink);
+		}
+
+		void EventBoxLink_ExceptionHelpLink (object o, ButtonPressEventArgs args) => DesktopService.ShowUrl (exceptionHelpLink);
 
 		protected override void OnSizeAllocated (Gdk.Rectangle allocation)
 		{
 			base.OnSizeAllocated (allocation);
 			ExceptionMessageLabel.WidthRequest = rightVBox.Allocation.Width;
-			ExceptionHelpLinkLabel.WidthRequest = rightVBox.Allocation.Width;
+			//ExceptionHelpLinkButton.WidthRequest = rightVBox.Allocation.Width;
 			if (vboxAroundInnerExceptionMessage != null) {
 				InnerExceptionMessageLabel.WidthRequest = vboxAroundInnerExceptionMessage.Allocation.Width;
-				InnerExceptionHelpLinkLabel.WidthRequest = vboxAroundInnerExceptionMessage.Allocation.Width;
+				InnerExceptionHelpLinkButton.WidthRequest = vboxAroundInnerExceptionMessage.Allocation.Width;
 			}
 		}
 
@@ -401,7 +419,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 
 		Label InnerExceptionTypeLabel;
 		Label InnerExceptionMessageLabel;
-		Label InnerExceptionHelpLinkLabel;
+		Button InnerExceptionHelpLinkButton;
 
 		Widget CreateInnerExceptionMessage ()
 		{
@@ -427,22 +445,37 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			InnerExceptionMessageLabel.Xalign = 0;
 			InnerExceptionMessageLabel.ModifyFont (Pango.FontDescription.FromString (Platform.IsWindows ? "9" : "11"));
 
-			InnerExceptionHelpLinkLabel = new Label ();
-			InnerExceptionHelpLinkLabel.UseMarkup = true;
-			InnerExceptionHelpLinkLabel.Wrap = true;
-			InnerExceptionHelpLinkLabel.LineWrapMode = Pango.WrapMode.Char;
-			InnerExceptionHelpLinkLabel.Selectable = true;
-			InnerExceptionHelpLinkLabel.CanFocus = false;
-			InnerExceptionHelpLinkLabel.Xalign = 0;
-			InnerExceptionHelpLinkLabel.ModifyFont (Pango.FontDescription.FromString (Platform.IsWindows ? "9" : "11"));
-			InnerExceptionHelpLinkLabel.SetLinkHandler ((str) => DesktopService.ShowUrl (str));
+			InnerExceptionHelpLinkButton = new Button {
+				CanFocus = true,
+				BorderWidth = 0,
+				Relief = ReliefStyle.Half,
+				Xalign = 0
+			};
+			InnerExceptionHelpLinkButton.ModifyFont (Pango.FontDescription.FromString (Platform.IsWindows ? "9" : "11"));
+			InnerExceptionHelpLinkButton.KeyPressEvent += InnerExceptionHelpLinkLabel_KeyPressEvent;
+			InnerExceptionHelpLinkButton.Clicked += InnerExceptionHelpLinkLabel_Pressed;
+
+			InnerExceptionHelpLinkButton.ModifyBg (StateType.Selected, Styles.ExceptionCaughtDialog.TreeSelectedBackgroundColor.ToGdkColor ());
 
 			vboxAroundInnerExceptionMessage.PackStart (hbox, false, true, 0);
 			vboxAroundInnerExceptionMessage.PackStart (InnerExceptionMessageLabel, true, true, 10);
-			vboxAroundInnerExceptionMessage.PackStart (InnerExceptionHelpLinkLabel, true, true, 2);
+
+			var innerExceptionHContainer = new HBox ();
+
+			innerExceptionHContainer.PackStart (InnerExceptionHelpLinkButton, false, false, 0);
+			innerExceptionHContainer.PackStart (new Fixed (), true, true, 0);
+
+			vboxAroundInnerExceptionMessage.PackStart (innerExceptionHContainer, true, true, 2);
 			hboxMain.PackStart (vboxAroundInnerExceptionMessage, true, true, 10);
 			hboxMain.ShowAll ();
 			return hboxMain;
+		}
+
+		void InnerExceptionHelpLinkLabel_Pressed (object sender, EventArgs e) => DesktopService.ShowUrl (innerExceptionHelpLink);
+		void InnerExceptionHelpLinkLabel_KeyPressEvent (object o, KeyPressEventArgs args)
+		{
+			if (args.Event.Key == Gdk.Key.KP_Enter || args.Event.Key == Gdk.Key.KP_Space)
+				DesktopService.ShowUrl (innerExceptionHelpLink);
 		}
 
 		TreeStore InnerExceptionsStore;
@@ -608,13 +641,18 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 				InnerExceptionTypeLabel.Markup = "<b>" + GLib.Markup.EscapeText (ex.Type) + "</b>";
 				InnerExceptionMessageLabel.Text = ex.Message;
 				if (!string.IsNullOrEmpty (ex.HelpLink)) {
-					InnerExceptionHelpLinkLabel.Markup = GetHelpLinkMarkup (ex);
-					InnerExceptionHelpLinkLabel.Show ();
+					InnerExceptionHelpLinkButton.Label = ex.HelpLink;
+					innerExceptionHelpLink = ex.HelpLink;
+					InnerExceptionHelpLinkButton.Show ();
 				} else {
-					InnerExceptionHelpLinkLabel.Hide ();
+					innerExceptionHelpLink = string.Empty;
+					InnerExceptionHelpLinkButton.Hide ();
 				}
 			}
 		}
+
+		string innerExceptionHelpLink;
+		string exceptionHelpLink;
 
 		void UpdateDisplay ()
 		{
@@ -624,18 +662,14 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			ExceptionTypeLabel.Text = exception.Type;
 			ExceptionMessageLabel.Text = exception.Message ?? string.Empty;
 			if (!string.IsNullOrEmpty (exception.HelpLink)) {
-				ExceptionHelpLinkLabel.Show ();
-				ExceptionHelpLinkLabel.Markup = GetHelpLinkMarkup (exception);
+				ExceptionHelpLinkButton.Show ();
+				exceptionHelpLink = exception.HelpLink;
+				ExceptionHelpLinkButton.Label = GettextCatalog.GetString ("More information");
 			} else {
-				ExceptionHelpLinkLabel.Hide ();
+				ExceptionHelpLinkButton.Hide ();
 			}
 
 			UpdateSelectedException (exception);
-		}
-
-		internal static string GetHelpLinkMarkup (ExceptionInfo exception)
-		{
-			return $"<a href=\"{System.Security.SecurityElement.Escape (exception.HelpLink)}\">{GettextCatalog.GetString ("More information")}</a>";
 		}
 
 		void ExceptionChanged (object sender, EventArgs e)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -182,10 +182,8 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 		{
 			base.OnSizeAllocated (allocation);
 			ExceptionMessageLabel.WidthRequest = rightVBox.Allocation.Width;
-			//ExceptionHelpLinkButton.WidthRequest = rightVBox.Allocation.Width;
 			if (vboxAroundInnerExceptionMessage != null) {
 				InnerExceptionMessageLabel.WidthRequest = vboxAroundInnerExceptionMessage.Allocation.Width;
-				InnerExceptionHelpLinkButton.WidthRequest = vboxAroundInnerExceptionMessage.Allocation.Width;
 			}
 		}
 
@@ -641,7 +639,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 				InnerExceptionTypeLabel.Markup = "<b>" + GLib.Markup.EscapeText (ex.Type) + "</b>";
 				InnerExceptionMessageLabel.Text = ex.Message;
 				if (!string.IsNullOrEmpty (ex.HelpLink)) {
-					InnerExceptionHelpLinkButton.Label = ex.HelpLink;
+					InnerExceptionHelpLinkButton.Label = GettextCatalog.GetString ("Read More...");
 					innerExceptionHelpLink = ex.HelpLink;
 					InnerExceptionHelpLinkButton.Show ();
 				} else {


### PR DESCRIPTION
Change focus from current selected object was broken in  "Exception Caught" window.

This fix allows navigating between views pressing tab key in both directions and changes link labels to use buttons, which are more accessibility friendly and focusable.  

Fixes VSTS #646443 Accessibility: Keyboard: MAS2.1.1: "Stacktrace, Properties" buttons and the contents under "Stacktrace" button and "More information" link in "Exception Caught" window is not accessible using keyboard.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646443

Fixes VSTS #646442  Accessibility: Keyboard: MAS2.4.3: Focus order is inappropriate in "Exception Caught" window
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646442

![exception](https://user-images.githubusercontent.com/1587480/52391507-bcf64900-2a9d-11e9-9703-8675b43c4d29.gif)

Exception Caught dialog changes depending the exception catched, but a good exception candidate to show all the link cases are thow a CatchInner Exception:

To test the issue:

1) Open a new project a new console project
2) Try to force a CatchInner Exception:
https://docs.microsoft.com/en-us/dotnet/api/system.exception.innerexception?view=netframework-4.7.2
3) Execute the application and you will hit a System.DivideByZeroExcption message
4) Click in Show Details and Exception Caught window will appear
5) Press Tab key and ensure you can navigate between views.