### PR TITLE
Update MonoDevelop.FSharp.fsproj

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -9,7 +9,7 @@
     <RootNamespace>FSharp.MonoDevelop</RootNamespace>
     <AssemblyName>FSharpBinding</AssemblyName>
     <UsePartialTypes>False</UsePartialTypes>
-    <RestorePackages>true</RestorePackages>
+    <RestorePackages>False</RestorePackages>
     <TargetFrameworkVersion>$(MDFrameworkVersion)</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.3.0</TargetFSharpCoreVersion>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
F# doesn't use NuGet for restoring packages and having `<RestorePackages>` set to true means that I can't build F# standalone outside of main.sln