### PR TITLE
[Core] Fix error running project with empty working directory

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1916,7 +1916,7 @@ namespace MonoDevelop.Projects
 			bool externalConsole = false, pauseConsole = false;
 
 			if (executionCommand is ProcessExecutionCommand processExecutionCommand) {
-				if (!Directory.Exists (processExecutionCommand.WorkingDirectory)) {
+				if (!string.IsNullOrEmpty (processExecutionCommand.WorkingDirectory) && !Directory.Exists (processExecutionCommand.WorkingDirectory)) {
 					monitor.ReportError (GettextCatalog.GetString ("Can not execute. The run configuration working directory doesn't exist at {0}", processExecutionCommand.WorkingDirectory), null);
 					return;
 				}


### PR DESCRIPTION
With a project that has a run configuration to run an external
program but did not set the working directory it was not possible
to run the external program. The working directory, which is an
empty string, was being passed to Directory.Exists which returns
false and an error about a missing directory was shown in the
status bar. Now the Directory.Exists check is only made for a
non-empty string.

Fixes VSTS #787952 - Empty working directory prevents project from
running