### PR TITLE
Harden the null checking around unregistering object val in debugger

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -980,6 +980,8 @@ namespace MonoDevelop.Debugger
 
 		void RefreshRow (TreeIter iter, ObjectValue val)
 		{
+			if (val == null)
+				return;
 			UnregisterValue (val);
 			
 			RemoveChildren (iter);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1013,8 +1013,7 @@ namespace MonoDevelop.Debugger
 
 			while (store.IterChildren (out citer, iter)) {
 				var val = (ObjectValue) store.GetValue (citer, ObjectColumn);
-				if (val != null)
-					UnregisterValue (val);
+				UnregisterValue (val);
 				RemoveChildren (citer);
 				store.Remove (ref citer);
 			}
@@ -1030,6 +1029,8 @@ namespace MonoDevelop.Debugger
 
 		void UnregisterValue (ObjectValue val)
 		{
+			if (val == null)
+				return;
 			val.ValueChanged -= OnValueUpdated;
 			nodes.Remove (val);
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -930,7 +930,7 @@ namespace MonoDevelop.Debugger
 					ExpandRow (store.GetPath (it), false);
 				}
 			} else {
-				RefreshRow (it);
+				RefreshRow (it, val);
 			}
 		}
 
@@ -977,10 +977,9 @@ namespace MonoDevelop.Debugger
 				enumerableLoading.Remove (value);
 			}, cancellationTokenSource.Token, TaskContinuationOptions.NotOnCanceled, Xwt.Application.UITaskScheduler);
 		}
-		
-		void RefreshRow (TreeIter iter)
+
+		void RefreshRow (TreeIter iter, ObjectValue val)
 		{
-			var val = (ObjectValue) store.GetValue (iter, ObjectColumn);
 			UnregisterValue (val);
 			
 			RemoveChildren (iter);
@@ -1905,7 +1904,7 @@ namespace MonoDevelop.Debugger
 					var val = (ObjectValue)store.GetValue (it, ObjectColumn);
 					if (DebuggingService.ShowValueVisualizer (val)) {
 						UpdateParentValue (it);
-						RefreshRow (it);
+						RefreshRow (it, val);
 					}
 				} else if (cr == crtExp && !PreviewWindowManager.IsVisible && ValidObjectForPreviewIcon (it)) {
 					var val = (ObjectValue)store.GetValue (it, ObjectColumn);


### PR DESCRIPTION
MERP / DR Watson shows this as one of the most frequent crashes in VSMac

```
    Fault:       Crash
    thread 0:
        IsManaged:   False
        NativeFrames:0
        Managed Frames:
            MonoDevelop.Debugger.dll!ObjectValueTreeView.UnregisterValue+0
            MonoDevelop.Debugger.dll!ObjectValueTreeView.RefreshRow+13
            MonoDevelop.Debugger.dll!ObjectValueTreeView.OnButtonPressEvent+89
            40f46e55-eb67-454a-b904-dc9e5644a3a1!6003ba7+16 (UNKNOWN MVID)
```

Ensure that object value can never be null when calling UnregisterValue. It was
checked from some call sites previously, but not all.