### PR TITLE
Defensive programming in Dock Container

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -1,5 +1,4 @@
 //
-// DockContainer.cs
 //
 // Author:
 //   Lluis Sanchez Gual
@@ -36,6 +35,7 @@ using Gtk;
 using Gdk;
 using System.Linq;
 using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui;
 
 namespace MonoDevelop.Components.Docking
@@ -403,7 +403,11 @@ namespace MonoDevelop.Components.Docking
 		
 		internal bool UpdatePlaceholder (DockItem item, Gdk.Size size, bool allowDocking)
 		{
-			MonoDevelop.Core.Runtime.AssertMainThread ();
+			if (!Runtime.IsMainThread) {
+				var msg = "UpdatePlaceholder called from background thread.";
+				LoggingService.LogInternalError ($"{msg}\n{Environment.StackTrace}", new InvalidOperationException (msg));
+			}
+
 			var placeholderWindow = this.placeholderWindow;
 			var padTitleWindow = this.padTitleWindow;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -403,6 +403,7 @@ namespace MonoDevelop.Components.Docking
 		
 		internal bool UpdatePlaceholder (DockItem item, Gdk.Size size, bool allowDocking)
 		{
+			MonoDevelop.Core.Runtime.AssertMainThread ();
 			var placeholderWindow = this.placeholderWindow;
 			var padTitleWindow = this.padTitleWindow;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -52,8 +52,8 @@ namespace MonoDevelop.Components.Docking
 
 		bool needsRelayout = true;
 
-		PlaceholderWindow placeholderWindow;
-		PadTitleWindow padTitleWindow;
+		volatile PlaceholderWindow placeholderWindow;
+		volatile PadTitleWindow padTitleWindow;
 		
 		public DockContainer (DockFrame frame)
 		{
@@ -403,7 +403,10 @@ namespace MonoDevelop.Components.Docking
 		
 		internal bool UpdatePlaceholder (DockItem item, Gdk.Size size, bool allowDocking)
 		{
-			if (placeholderWindow == null)
+			var placeholderWindow = this.placeholderWindow;
+			var padTitleWindow = this.padTitleWindow;
+
+			if (placeholderWindow == null || padTitleWindow == null)
 				return false;
 			
 			int px, py;


### PR DESCRIPTION
MERP / Dr Watson show this as one of the most frequent crashes in VSMac

```
    Fault:       Crash
    thread 0:
        IsManaged:   False
        NativeFrames:0
        Managed Frames:
            MonoDevelop.Ide.dll!DockContainer.UpdatePlaceholder+20
            MonoDevelop.Ide.dll!DockFrame.UpdatePlaceholder+0
            MonoDevelop.Ide.dll!DockItemTitleTab.OnMotionNotifyEvent+d0
            40f46e55-eb67-454a-b904-dc9e5644a3a1!6003c23+16 (UNKNOWN MVID)
```

which points to `placeholderWindow.AllowDocking = allowDocking;` as the line
that is failing.

It isn't obvious at all how placeholderWindow could ever be null at this point.
(I don't see access to the placeholderWindow field from threads other than the
UI), so I have just made the method more robust.