### PR TITLE
[release-7.8] Add a lock to version control file list status view updates

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -81,7 +81,7 @@ namespace MonoDevelop.VersionControl.Views
 		bool updatingComment;
 		ChangeSet changeSet;
 		bool firstLoad = true;
-		VersionControlItemList fileList;
+		volatile VersionControlItemList fileList;
 
 		const int ColIcon = 0;
 		const int ColStatus = 1;
@@ -432,6 +432,7 @@ namespace MonoDevelop.VersionControl.Views
 				return widget;
 			}
 		}
+		object updateLock = new object ();
 
 		void StartUpdate ()
 		{
@@ -448,25 +449,27 @@ namespace MonoDevelop.VersionControl.Views
 			buttonCommit.Sensitive = false;
 
 			ThreadPool.QueueUserWorkItem (delegate {
-				if (fileList != null) {
-					var group = fileList.GroupBy (v => v.IsDirectory || v.WorkspaceObject is SolutionFolderItem);
-					foreach (var item in group) {
-						// Is directory.
-						if (item.Key) {
-							foreach (var directory in item)
-								changeSet.AddFiles (vc.GetDirectoryVersionInfo (directory.Path, remoteStatus, true));
-						} else
-							changeSet.AddFiles (item.Select (v => v.VersionInfo).ToArray ());
+				lock (updateLock) {
+					if (fileList != null) {
+						var group = fileList.GroupBy (v => v.IsDirectory || v.WorkspaceObject is SolutionFolderItem);
+						foreach (var item in group) {
+							// Is directory.
+							if (item.Key) {
+								foreach (var directory in item)
+									changeSet.AddFiles (vc.GetDirectoryVersionInfo (directory.Path, remoteStatus, true));
+							} else
+								changeSet.AddFiles (item.Select (v => v.VersionInfo).ToArray ());
+						}
+						changeSet.AddFiles (fileList.Where (v => !v.IsDirectory).Select (v => v.VersionInfo).ToArray ());
+						fileList = null;
 					}
-					changeSet.AddFiles (fileList.Where (v => !v.IsDirectory).Select (v => v.VersionInfo).ToArray ());
-					fileList = null;
+					List<VersionInfo> newList = new List<VersionInfo> ();
+					newList.AddRange (vc.GetDirectoryVersionInfo (filepath, remoteStatus, true));
+					Runtime.RunInMainThread (delegate {
+						if (!disposed)
+							LoadStatus (newList);
+					});
 				}
-				List<VersionInfo> newList = new List<VersionInfo> ();
-				newList.AddRange (vc.GetDirectoryVersionInfo (filepath, remoteStatus, true));
-				Runtime.RunInMainThread (delegate {
-					if (!disposed)
-						LoadStatus (newList);
-				});
 			});
 		}
 


### PR DESCRIPTION
MERP / Dr Watson shows this as one of the most frequent crashes seen in VSMac

```
    Fault:       Crash
    thread 0:
        IsManaged:   False
        NativeFrames:0
        Managed Frames:
            System.Core.dll!Enumerable.Where+ffffffff
            MonoDevelop.VersionControl.dll!StatusView.<StartUpdate>b__53_0+f8
            mscorlib.dll!QueueUserWorkItemCallback.WaitCallback_Context+d
            mscorlib.dll!ExecutionContext.RunInternal+71
            mscorlib.dll!ExecutionContext.Run+0
            mscorlib.dll!QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem+21
            mscorlib.dll!ThreadPoolWorkQueue.Dispatch+74
            mscorlib.dll!_ThreadPoolWaitCallback.PerformWaitCallback+0
```

StartUpdate can be called from multiple locations:  StatusView.Init,
StatusView.OnShowRemoteStatusClicked, StatusView.OnRefresh,
StatusView.OnFileStatusChanged, StatusView.BringStatusViewToFront.
and so there is a race condtion where `fileList` can be null.

Backport of #7094.

/cc @nosami 