### PR TITLE
Update TestLogSynchronizationContextThroughWrites to work against both old and new BCL TextWriter implementations

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/ProgressMonitorTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/ProgressMonitorTests.cs
@@ -114,6 +114,8 @@ namespace MonoDevelop.Core
 		public void TestLogSynchronizationContextThroughWrites ()
 		{
 			using (var ctx = new TestSingleThreadSynchronizationContext ()) {
+				int offset;
+
 				using (var mon = new ChainedProgressMonitor (ctx)) {
 					// These call once into Write.
 					mon.Log.Write ("a");
@@ -125,21 +127,31 @@ namespace MonoDevelop.Core
 					mon.Log.Write (new [] { 'a' }, 0, 1);
 					Assert.AreEqual (3, ctx.CallCount);
 
+					offset = 3;
+
+					// This calls twice into Write in newer versions of the BCL,
+					//  and once in older versions.
 					mon.Log.WriteLine ("a");
-					Assert.AreEqual (4, ctx.CallCount);
+					Assert.IsTrue (ctx.CallCount - offset <= 2, "WriteLine should produce 1-2 calls");
+					offset = ctx.CallCount;
 
 					// These 2 call twice into Write.
 					mon.Log.WriteLine ('a');
-					Assert.AreEqual (6, ctx.CallCount);
+					Assert.AreEqual (2, ctx.CallCount - offset);
+					offset = ctx.CallCount;
 
 					mon.Log.WriteLine (new [] { 'a' }, 0, 1);
-					Assert.AreEqual (8, ctx.CallCount);
+					Assert.AreEqual (2, ctx.CallCount - offset);
+					offset = ctx.CallCount;
 
+					// Flush performs one call
 					mon.Log.Flush ();
-					Assert.AreEqual (9, ctx.CallCount);
+					Assert.AreEqual (1, ctx.CallCount - offset);
+					offset = ctx.CallCount;
 				}
+
 				// Once for completed, once for Dispose.
-				Assert.AreEqual (11, ctx.CallCount);
+				Assert.AreEqual (2, ctx.CallCount - offset);
 			}
 		}
 	}


### PR DESCRIPTION
This should make the test able to handle the difference in call counts that is introduced by updating to a newer version of mono. I wasn't able to identify what specific file changed (since we have 8000 different TextWriters in-tree) but the change in call counts matches what I see in the corefx source.

Hard to test locally so MD CI should tell me whether this works against older BCL, and then the other CI I hit the bug on will tell me whether I've fixed the issue...