### PR TITLE
Fixed error opening Dialogs using MessageService

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CheckoutCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CheckoutCommand.cs
@@ -18,7 +18,7 @@ namespace MonoDevelop.VersionControl
 		{
 			SelectRepositoryDialog del = new SelectRepositoryDialog (SelectRepositoryMode.Checkout);
 			try {
-				if (MessageService.RunCustomDialog (del, MessageService.RootWindow ?? IdeApp.Workbench.RootWindow) == (int) Gtk.ResponseType.Ok && del.Repository != null) {
+				if (MessageService.RunCustomDialog (del) == (int) Gtk.ResponseType.Ok && del.Repository != null) {
 					CheckoutWorker w = new CheckoutWorker (del.Repository, del.TargetPath);
 					w.Start ();
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CheckoutCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CheckoutCommand.cs
@@ -18,7 +18,7 @@ namespace MonoDevelop.VersionControl
 		{
 			SelectRepositoryDialog del = new SelectRepositoryDialog (SelectRepositoryMode.Checkout);
 			try {
-				if (MessageService.RunCustomDialog (del) == (int) Gtk.ResponseType.Ok && del.Repository != null) {
+				if (MessageService.RunCustomDialog (del, MessageService.RootWindow ?? IdeApp.Workbench.RootWindow) == (int) Gtk.ResponseType.Ok && del.Repository != null) {
 					CheckoutWorker w = new CheckoutWorker (del.Repository, del.TargetPath);
 					w.Start ();
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -134,7 +134,7 @@ namespace MonoDevelop.Ide
 		static Window defaultRootWindow;
 		public static Window RootWindow {
 			get {
-				if (WelcomePageService.WelcomePageVisible)
+				if (WelcomePageService.WelcomeWindowVisible)
 					return WelcomePageService.WelcomeWindow;
 				return defaultRootWindow;
 			}


### PR DESCRIPTION
Using `MessageService.RunCustomDialog` we got an exception (Null) under certain situations. For example: Trying to open the Checkout dialog without open any solution, etc. The problem is that `RootWindow` in `MessageService` is null.

Fixed by changing validation in WelcomePage that affects the RootWindow search in `MesageService`.

Fixes gh #7108 