### PR TITLE
[VersionControl] Fixed error fetching from Git server

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -364,12 +364,20 @@ namespace MonoDevelop.VersionControl.Git
 
 		protected async void OnButtonFetchClicked (object sender, EventArgs e)
 		{
-			TreeIter it;
-			if (!treeRemotes.Selection.GetSelected (out it))
+			if (!treeRemotes.Selection.GetSelected (out var it))
 				return;
 
-			string remoteName = (string) storeRemotes.GetValue (it, 4);
-			if (remoteName == null)
+			bool toplevel = !storeRemotes.IterParent (out var parent, it);
+
+			string remoteName = string.Empty;
+
+			if (toplevel) {
+				remoteName = (string)storeRemotes.GetValue (it, 4);
+			} else {
+				remoteName = (string)storeRemotes.GetValue (parent, 4);
+			}
+
+			if (string.IsNullOrEmpty(remoteName))
 				return;
 
 			await System.Threading.Tasks.Task.Run (() => repo.Fetch (VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Fetching remote...")), remoteName));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -664,11 +664,13 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			monitor.BeginTask (GettextCatalog.GetString ("Fetching"), 1);
 			monitor.Log.WriteLine (GettextCatalog.GetString ("Fetching from '{0}'", remote));
+
 			int progress = 0;
 			RetryUntilSuccess (monitor, credType => RootRepository.Fetch (remote, new FetchOptions {
 				CredentialsProvider = (url, userFromUrl, types) => GitCredentials.TryGet (url, userFromUrl, types, credType),
 				OnTransferProgress = tp => OnTransferProgress (tp, monitor, ref progress),
 			}));
+
 			monitor.Step (1);
 			monitor.EndTask ();
 		}


### PR DESCRIPTION
We get an error trying to fetch the path to a remote branch. If a branch is selected, we will look for the parent element to obtain the appropriate path.

Fixes gh #7104 