### PR TITLE
[VersionControl] Add validations to Checkout process

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -112,15 +112,14 @@ namespace MonoDevelop.VersionControl.Dialogs
 			}
 		}
 
-		public override void Dispose ()
+		protected override void OnDestroyed ()
 		{
-			base.Dispose ();
-
 			UrlBasedRepositoryEditor edit = currentEditor as UrlBasedRepositoryEditor;
 			if (edit != null) {
 				edit.UrlChanged -= OnEditUrlChanged;
 				edit.PathChanged -= OnPathChanged;
 			}
+			base.Destroy ();
 		}
 
 		protected virtual void OnRepComboChanged(object sender, System.EventArgs e)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -119,7 +119,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 				edit.UrlChanged -= OnEditUrlChanged;
 				edit.PathChanged -= OnPathChanged;
 			}
-			base.Destroy ();
+			base.OnDestroyed ();
 		}
 
 		protected virtual void OnRepComboChanged(object sender, System.EventArgs e)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -69,6 +69,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 				defaultPath = VersionControlDefaultPath;
 				entryFolder.Text = defaultPath;
 				buttonOk.Label = GettextCatalog.GetString ("_Checkout");
+				UpdateCheckoutButton ();
 			} else {
 				labelTargetDir.Visible = false;
 				boxFolder.Visible = false;
@@ -125,11 +126,19 @@ namespace MonoDevelop.VersionControl.Dialogs
 			repoContainer.Add (currentEditor.Widget);
 			currentEditor.Show ();
 			UrlBasedRepositoryEditor edit = currentEditor as UrlBasedRepositoryEditor;
-			if (edit != null)
+			if (edit != null) {
+				edit.UrlChanged += OnEditUrlChanged;
 				edit.PathChanged += OnPathChanged;
+			}
 			UpdateRepoDescription ();
 		}
-		
+
+		protected virtual void OnRepositoryServerEntryChanged (object sender, System.EventArgs e)
+		{
+			if (mode == SelectRepositoryMode.Checkout)
+				buttonOk.Sensitive = this. entryFolder.Text.Length > 0;
+		}
+			
 		public void LoadRepositories ()
 		{
 			store.Clear ();
@@ -346,6 +355,21 @@ namespace MonoDevelop.VersionControl.Dialogs
 					return;
 			}
 			Respond (ResponseType.Ok);
+		}
+
+		protected virtual void OnEditUrlChanged (object sender, EventArgs e)
+		{
+			if (mode == SelectRepositoryMode.Checkout) {
+				UpdateCheckoutButton ();
+			}
+		}
+
+		void UpdateCheckoutButton()
+		{
+			UrlBasedRepositoryEditor edit = currentEditor as UrlBasedRepositoryEditor;
+			if (edit == null)
+				return;
+			buttonOk.Sensitive = edit.RepositoryServer.Length > 0; 
 		}
 
 		protected virtual void OnPathChanged (object sender, EventArgs e)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -112,6 +112,17 @@ namespace MonoDevelop.VersionControl.Dialogs
 			}
 		}
 
+		public override void Dispose ()
+		{
+			base.Dispose ();
+
+			UrlBasedRepositoryEditor edit = currentEditor as UrlBasedRepositoryEditor;
+			if (edit != null) {
+				edit.UrlChanged -= OnEditUrlChanged;
+				edit.PathChanged -= OnPathChanged;
+			}
+		}
+
 		protected virtual void OnRepComboChanged(object sender, System.EventArgs e)
 		{
 			if (repoContainer.Child != null)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -136,7 +136,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 		protected virtual void OnRepositoryServerEntryChanged (object sender, System.EventArgs e)
 		{
 			if (mode == SelectRepositoryMode.Checkout)
-				buttonOk.Sensitive = this. entryFolder.Text.Length > 0;
+				buttonOk.Sensitive = entryFolder.Text.Length > 0;
 		}
 			
 		public void LoadRepositories ()
@@ -369,7 +369,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 			UrlBasedRepositoryEditor edit = currentEditor as UrlBasedRepositoryEditor;
 			if (edit == null)
 				return;
-			buttonOk.Sensitive = edit.RepositoryServer.Length > 0; 
+			buttonOk.Sensitive = !string.IsNullOrWhiteSpace (edit.RepositoryServer);
 		}
 
 		protected virtual void OnPathChanged (object sender, EventArgs e)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/UrlBasedRepositoryEditor.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/UrlBasedRepositoryEditor.cs
@@ -11,6 +11,7 @@ namespace MonoDevelop.VersionControl
 	{
 		UrlBasedRepository repo;
 		public event EventHandler<EventArgs> PathChanged;
+		public event EventHandler<EventArgs> UrlChanged;
 		bool updating;
 		List<string> protocols = new List<string> ();
 
@@ -53,6 +54,10 @@ namespace MonoDevelop.VersionControl
 			get { return repositoryPathEntry.Text; }
 		}
 
+		public string RepositoryServer {
+			get { return repositoryServerEntry.Text; }
+		}
+
 		bool ParseSSHUrl (string url)
 		{
 			if (!url.Contains (':'))
@@ -81,6 +86,7 @@ namespace MonoDevelop.VersionControl
 			comboProtocol.Active = protocols.IndexOf ("ssh");
 			comboProtocol.Sensitive = false;
 			PathChanged?.Invoke (this, EventArgs.Empty);
+			UrlChanged?.Invoke (this, EventArgs.Empty);
 			return true;
 		}
 		
@@ -133,6 +139,7 @@ namespace MonoDevelop.VersionControl
 					repo.Name = repo.Uri.Host;
 			}
 			updating = false;
+			UrlChanged?.Invoke (this, EventArgs.Empty);
 		}
 		
 		void UpdateControls ()


### PR DESCRIPTION
If the Checkout dialog is opened and the button is pressed (without entering an URL), it starts by trying to delete the content of the Target Directory folder. 

Disabled Checkout button without a repository Url.

Fixes gh #7120 