### PR TITLE
Check for disposed TextEditor when retrieving GetContents<T>

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
@@ -32,6 +32,7 @@ using Cairo;
 using Gtk;
 using System.Linq;
 using MonoDevelop.Components.AtkCocoaHelper;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Fonts;
 
@@ -193,7 +194,11 @@ namespace MonoDevelop.Components
 		protected override bool OnButtonPressEvent (Gdk.EventButton evnt)
 		{
 			if (hoverTab != null) {
-				ActiveTab = tabs.IndexOf (hoverTab);
+				try {
+					ActiveTab = tabs.IndexOf (hoverTab);
+				} catch (Exception ex) {
+					LoggingService.LogInternalError (ex);	
+				}
 			}
 			return base.OnButtonPressEvent (evnt);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1256,6 +1256,10 @@ namespace MonoDevelop.Ide.Editor
 		public IEnumerable<object> GetContents (Type type)
 		{
 			var res = Enumerable.Empty<object> ();
+			if (isDisposed) {
+				LoggingService.LogError ($"Error retrieving TextEditor.GetContents({type})\n {Environment.StackTrace}");
+				return res;
+			}
 			if (type.IsInstanceOfType (textEditorImpl))
 				res = res.Concat (textEditorImpl);
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditor.cs
@@ -1236,10 +1236,13 @@ namespace MonoDevelop.Ide.Editor
 			return GetContents<T> ().FirstOrDefault ();
 		}
 
-		public IEnumerable<T> GetContents<T>() where T : class
+		public IEnumerable<T> GetContents<T> () where T : class
 		{
-			T result = textEditorImpl as T;
-			if (result != null)
+			if (isDisposed) {
+				LoggingService.LogError ($"Error retrieving TextEditor.GetContents<{typeof(T)}>\n {Environment.StackTrace}");
+				yield break;
+			}
+			if (textEditorImpl is T result)
 				yield return result;
 			var ext = textEditorImpl.EditorExtension;
 			while (ext != null) {


### PR DESCRIPTION
MERP shows this stacktrace as one of the most frequent crashes in VSMac

```
    Fault:       Crash
    thread 0:
        IsManaged:   False
        NativeFrames:0
        Managed Frames:
            MonoDevelop.SourceEditor.dll!SourceEditorView.MonoDevelop.Ide.Editor.ITextEditorImpl.get_EditorExtension+0
            MonoDevelop.Ide.dll!TextEditor.GetContents+21
            Xamarin.AndroidDesigner.MonoDevelop.dll!LayoutSourceEditorView.OnGetContents+31
            MonoDevelop.Ide.dll!BaseViewContent.GetContents+0
            MonoDevelop.Ide.dll!BaseViewContent.GetContent+0
            Xamarin.AndroidDesigner.MonoDevelop.dll!AndroidDesignerView.OnGetContent+1c
            MonoDevelop.Ide.dll!6005794+1e (UNKNOWN METHOD TOKEN)
            System.Core.dll!Enumerable.TryGetFirst+ffffffff
            System.Core.dll!Enumerable.FirstOrDefault+ffffffff
            MonoDevelop.Ide.dll!BaseViewContent.GetContent+0
            MonoDevelop.Ide.dll!Document.GetContent+ffffffff
            MonoDevelop.Ide.dll!SdiWorkspaceWindow.SetCurrentView+5d
            MonoDevelop.Ide.dll!60057d3+56 (UNKNOWN METHOD TOKEN)
            MonoDevelop.Ide.dll!Tab.OnActivated+a
            MonoDevelop.Ide.dll!Tab.set_Active+f
            MonoDevelop.Ide.dll!Tabstrip.set_ActiveTab+28
            MonoDevelop.Ide.dll!Tabstrip.OnButtonPressEvent+8
            40f46e55-eb67-454a-b904-dc9e5644a3a1!6003ba7+16 (UNKNOWN MVID)
```

Check for a disposed TextEditor and add some logging (@mkrueger's suggestion)