### PR TITLE
Catch errors when setting repository text in the diff view

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Content;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -44,8 +45,15 @@ namespace MonoDevelop.VersionControl.Views
 			get {
 				if (widget == null) {
 					widget = new DiffWidget (info);
-					
-					ComparisonWidget.DiffEditor.Document.Text = info.Item.Repository.GetBaseText (info.Item.Path);
+
+					try {
+						ComparisonWidget.DiffEditor.Document.Text = info.Item.Repository.GetBaseText (info.Item.Path);
+					} catch (Exception ex) {
+						var msg = GettextCatalog.GetString ("Error fetching text from repository");
+						MessageService.ShowError (msg, ex);
+						LoggingService.LogInternalError (ex);
+					}
+
 					ComparisonWidget.SetLocal (ComparisonWidget.OriginalEditor.GetTextEditorData ());
 					widget.ShowAll ();
 					widget.SetToolbar (WorkbenchWindow.GetToolbar (this));


### PR DESCRIPTION
MERP is showing this to be one of the most frequent crashes in VSMac

```
What do    Fault:       Crash
    thread 0:
        IsManaged:   False
        NativeFrames:0
        Managed Frames:
            mscorlib.dll!StreamReader..ctor+7d
            mscorlib.dll!StreamReader..ctor+0
            mscorlib.dll!StreamReader..ctor+0
            mscorlib.dll!0+ffffffff (UNKNOWN METHOD TOKEN)
            mscorlib.dll!File.ReadAllText+0
            2e1bd13d-1d4c-4710-a616-e6c613c698ed!60001e3+ffffffff (UNKNOWN MVID)
            2e1bd13d-1d4c-4710-a616-e6c613c698ed!600004a+ffffffff (UNKNOWN MVID)
            MonoDevelop.VersionControl.dll!DiffView.get_Control+1d
            MonoDevelop.Ide.dll!60057d3+8 (UNKNOWN METHOD TOKEN)
            MonoDevelop.Ide.dll!Tab.OnActivated+a
            MonoDevelop.Ide.dll!Tab.set_Active+f
            MonoDevelop.Ide.dll!Tabstrip.set_ActiveTab+28
            MonoDevelop.Ide.dll!Tabstrip.OnButtonPressEvent+8
            40f46e55-eb67-454a-b904-dc9e5644a3a1!6003ba7+16 (UNKNOWN MVID)
```

DiffView.Control could fail for many different reasons, so add a catch all
exception handler and display a message to the user.