### PR TITLE
[Mac] Allow non-secure http requests when NSUrlSession used

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -296,5 +296,10 @@
 	</array>
 	<key>NSAppleEventsUsageDescription</key>
         <string>@APP_NAME@ needs to control applications through AppleScript</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
When a request was made for a non-secure http url, such as when trying
to use the debugger image visualizer with a Xamarin.Forms UriImageSource,
the image would not be displayed on the Mac when using Xamarin.Mac's
NSUrlSessionHandler with the HttpClient. In the Application Output
you would see an error:

Failed to load image: System.Net.WebException: The resource could not
be loaded because the App Transport Security policy requires the use
of a secure connection.

To allow non-secure http requests the NSAppTransportSecurity property
has been set to NSAllowsArbitraryLoads in the Info.plist file.

Fixes VSTS #776217 - [NSURLSession] Image from Xamarin.Forms.UriImageSource
is not displayed in the debugger’s visualiser window when debugging a
Xamarin.Forms application