### PR TITLE
[UnitTesting] Fix NRE when disposing

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/Services/SolutionFolderTestGroup.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/SolutionFolderTestGroup.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.UnitTesting
 		public override void Dispose ()
 		{
 			folder.NameChanged -= OnCombineRenamed;
-			if (folder.IsRoot) {
+			if (folder.IsRoot && folder.ParentSolution != null) {
 				folder.ParentSolution.SolutionItemAdded -= OnEntryChanged;
 				folder.ParentSolution.SolutionItemRemoved -= OnEntryChanged;
 			}


### PR DESCRIPTION
Fixed problem deleting project folder. If the project uses Version Control (Git), the changes in the Commit view were not reflected.
The problem was disposing the `SolutionFolderTestGroup`. After failing here, the changes in the Commit view were not notified.

Fixes gh #7107