### PR TITLE
[Core] Ensure MSBuild targets are refreshed before re-evaluation

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4216,6 +4216,11 @@ namespace MonoDevelop.Projects
 					try {
 						IsReevaluating = true;
 
+						// Re-evaluating may change MSBuild items and cause the custom tool generator to run. If a
+						// custom MSBuild target is run it may run before the project builder is refreshed so the
+						// target may not available. To avoid this shutdown the project builder before re-evaluating.
+						ShutdownProjectBuilder ();
+
 						// Reevaluate the msbuild project
 						monitorItemsModifiedDuringReevaluation = true;
 						await sourceProject.EvaluateAsync ();


### PR DESCRIPTION
On creating a new Xamarin.Forms project sometimes an error reported
by the custom tool service would be added to the Errors list.

MSB4057: The target "UpdateDesignTimeXaml" does not exist in the project.

The best way to reproduce this seems to be to remove the Xamarin.Forms
NuGet packages from ~/.nuget/packages/xamarin.forms and then restart
the IDE and create a Xamarin.Forms project with iOS, Android and
.NET Standard.

During the NuGet restore the project is re-evaluated. This causes
the .xaml and .xaml.cs files to be removed and then added back to
the project. This is because the files now have different MSBuild
metadata after the Xamarin.Forms MSBuild targets are re-evaluated.
When the files are added back this then causes the custom tool service
to run the UpdateDesignTimeXaml msbuild target. Whilst this seems to
work for App.xaml it sometimes fails for the next file it tries
MainPage.xaml.

To avoid this problem, during the re-evaluation the project builder
is shutdown before the MSBuild items are re-evaluated. This seems
to prevent the generator from failing when running the
UpdateDesignTimeXaml target.

Fixes VSTS #672679 - UpdateDesignTimeXaml does not exist error on
creating new Xamarin.Forms project