### PR TITLE
[Core] Fix version of Xwt that should be expected when running tests

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Assemblies/SystemAssemblyServiceTests.cs
@@ -98,7 +98,7 @@ namespace MonoDevelop.Core.Assemblies
 			var result = new SystemAssemblyService ().GetTargetFrameworkForAssembly (null, "Xwt.dll");
 
 			Assert.AreEqual (TargetFrameworkMoniker.ID_NET_FRAMEWORK, result.Identifier);
-			Assert.AreEqual ("4.0", result.Version);
+			Assert.AreEqual ("4.6.1", result.Version);
 		}
 	}
 }


### PR DESCRIPTION
see https://github.com/xamarin/md-addins/pull/4200

this fixes the expected version of xwt.dll when running tests.