### PR TITLE
 Initial impl for reusable workspaces

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -53,6 +53,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			readonly List<MonoDevelopAnalyzer> analyzersToDispose = new List<MonoDevelopAnalyzer> ();
 			IDisposable persistentStorageLocationServiceRegistration;
 
+			internal bool IsPrimaryWorkspace => persistentStorageLocationServiceRegistration != null;
+
 			bool added;
 			readonly object addLock = new object ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -305,6 +305,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 
 			ClearSolutionData ();
+			MonoDevelopSolution = null;
 
 			var solutionCrawler = Services.GetService<ISolutionCrawlerRegistrationService> ();
 			solutionCrawler.Unregister (this);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -156,8 +156,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			if (MonoDevelopSolution == solution)
 				return;
 
-			MonoDevelopSolution = solution;
 			OnSolutionRemoved ();
+			MonoDevelopSolution = solution;
 
 			// We don't want to do anything else.
 			if (solution == null) {
@@ -172,6 +172,12 @@ namespace MonoDevelop.Ide.TypeSystem
 		// This is called by OnSolutionRemoved.
 		protected override void ClearSolutionData ()
 		{
+			if (MonoDevelopSolution != null) {
+				foreach (var prj in MonoDevelopSolution.GetAllProjects ()) {
+					UnloadMonoProject (prj);
+				}
+			}
+
 			DesktopService.MemoryMonitor.StatusChanged -= OnMemoryStatusChanged;
 			base.ClearSolutionData ();
 		}
@@ -297,11 +303,8 @@ namespace MonoDevelop.Ide.TypeSystem
 			if (IdeApp.Workspace != null) {
 				IdeApp.Workspace.ActiveConfigurationChanged -= HandleActiveConfigurationChanged;
 			}
-			if (MonoDevelopSolution != null) {
-				foreach (var prj in MonoDevelopSolution.GetAllProjects ()) {
-					UnloadMonoProject (prj);
-				}
-			}
+
+			ClearSolutionData ();
 
 			var solutionCrawler = Services.GetService<ISolutionCrawlerRegistrationService> ();
 			solutionCrawler.Unregister (this);

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				var projectInMap = map.GetMonoProject (pid);
 				Assert.AreSame (project, projectInMap);
 
-				map.RemoveProject (project, pid);
+				map.RemoveProject (pid);
 				Assert.IsNull (map.GetId (project));
 			}
 		}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/TypeSystemServiceTests.cs
@@ -299,6 +299,23 @@ namespace MonoDevelop.Ide
 			}
 		}
 
+		[Test]
+		public async Task WorkspaceManagerClearsData ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			using (var sol1 = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var primaryWorkspace = await TypeSystemServiceTestExtensions.LoadSolution (sol1);
+
+				var solution = primaryWorkspace.CurrentSolution;
+
+				TypeSystemServiceTestExtensions.UnloadSolution (sol1);
+
+				Assert.AreNotSame (solution, primaryWorkspace.CurrentSolution);
+				Assert.IsNull (primaryWorkspace.MonoDevelopSolution);
+				Assert.AreEqual (0, primaryWorkspace.CurrentSolution.Projects.Count ());
+			}
+		}
+
 		/// <summary>
 		/// Tests that if the parser takes a long time to return a projection it is ignored instead
 		/// of being used by the type system.


### PR DESCRIPTION
This changes the implementation to use a Primary and Secondary workspaces definitions
to help us with leaking everything.

Currently, every MonoDevelopWorkspace is leaked via roslyn's DiagnosticService, as they
hold onto the workspace for event subscription.

Fixes VSTS #788777 - Change the MonoDevelopWorkspace model to have a primary and secondary workspaces