### PR TITLE
[SourceControl] Creates a Xwt Credentials dialog with key selection

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Gui\MonoDevelop.VersionControl.Git.StashManagerDialog.cs" />
     <Compile Include="Gui\MonoDevelop.VersionControl.Git.UserGitConfigDialog.cs" />
     <Compile Include="Gui\MonoDevelop.VersionControl.Git.UserInfoConflictDialog.cs" />
+    <Compile Include="MonoDevelop.VersionControl.Git\XwtCredentialsDialog.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -150,12 +150,7 @@ namespace MonoDevelop.VersionControl.Git
 				return cred;
 			}
 
-			result = Runtime.RunInMainThread (delegate {
-				using (var credDlg = new CredentialsDialog (url, types, cred))
-					return MessageService.ShowCustomDialog (credDlg) == (int)Gtk.ResponseType.Ok;
-			}).Result;
-
-			if (result) {
+			if (XwtCredentialsDialog.Run (url, types, cred).Result) {
 				if ((types & SupportedCredentialTypes.UsernamePassword) != 0) {
 					var upcred = (UsernamePasswordCredentials)cred;
 					if (!string.IsNullOrEmpty (upcred.Password) && uri != null) {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -139,12 +139,12 @@ namespace MonoDevelop.VersionControl.Git
 
 							var engine = Platform.IsMac ? Xwt.Toolkit.NativeEngine : Xwt.Toolkit.CurrentEngine;
 							engine.Invoke (() => {
-								var xwtDialog = new XwtCredentialsDialog (url, types, cred) {
-									TransientFor = MessageService.RootWindow
-								};
-								xwtDialog.Show ();
-								response = xwtDialog.Run (/*MonoDevelop.Ide.IdeApp.Workbench.RootWindow*/) != Xwt.Command.Ok;
-								xwtDialog.Dispose ();
+								using (var xwtDialog = new XwtCredentialsDialog (url, types, cred)) {
+									xwtDialog.TransientFor = MessageService.RootWindow;
+									xwtDialog.Show ();
+									response = xwtDialog.Run () != Xwt.Command.Ok;
+									xwtDialog.Dispose ();
+								}
 							});
 
 							return response;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -140,10 +140,7 @@ namespace MonoDevelop.VersionControl.Git
 							var engine = Platform.IsMac ? Xwt.Toolkit.NativeEngine : Xwt.Toolkit.CurrentEngine;
 							engine.Invoke (() => {
 								using (var xwtDialog = new XwtCredentialsDialog (url, types, cred)) {
-									xwtDialog.TransientFor = MessageService.RootWindow;
-									xwtDialog.Show ();
-									response = xwtDialog.Run () != Xwt.Command.Ok;
-									xwtDialog.Dispose ();
+									response = xwtDialog.Run (MessageService.RootWindow) != Xwt.Command.Ok;
 								}
 							});
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -140,7 +140,7 @@ namespace MonoDevelop.VersionControl.Git
 							var engine = Platform.IsMac ? Xwt.Toolkit.NativeEngine : Xwt.Toolkit.CurrentEngine;
 							engine.Invoke (() => {
 								using (var xwtDialog = new XwtCredentialsDialog (url, types, cred)) {
-									response = xwtDialog.Run (MessageService.RootWindow) != Xwt.Command.Ok;
+									response = xwtDialog.Run (MessageService.RootWindow) == Xwt.Command.Ok;
 								}
 							});
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -133,21 +133,8 @@ namespace MonoDevelop.VersionControl.Git
 							Passphrase = "",
 						
 						};
-						result = Runtime.RunInMainThread (delegate {
 
-							bool response = false;
-
-							var engine = Platform.IsMac ? Xwt.Toolkit.NativeEngine : Xwt.Toolkit.CurrentEngine;
-							engine.Invoke (() => {
-								using (var xwtDialog = new XwtCredentialsDialog (url, types, cred)) {
-									response = xwtDialog.Run (MessageService.RootWindow) == Xwt.Command.Ok;
-								}
-							});
-
-							return response;
-						}).Result;
-
-						if (result)
+						if (XwtCredentialsDialog.Run (url, types, cred).Result)
 							return cred;
 						throw new VersionControlException (GettextCatalog.GetString ("Invalid credentials were supplied. Aborting operation."));
 					}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -57,6 +57,8 @@ namespace MonoDevelop.VersionControl.Git
 
 	static class GitCredentials
 	{
+		internal static readonly string UserCancelledExceptionMessage = GettextCatalog.GetString("Operation cancelled");
+
 		// Gather keys on initialize.
 		static readonly List<string> Keys = new List<string> ();
 		static readonly List<string> PublicKeys = new List<string> ();
@@ -171,7 +173,7 @@ namespace MonoDevelop.VersionControl.Git
 								state.KeyUsed = keyIndex;
 							return cred;
 						}
-						throw new VersionControlException (GettextCatalog.GetString ("Invalid credentials were supplied. Aborting operation."));
+						throw new UserCancelledException (UserCancelledExceptionMessage);
 					}
 				}
 
@@ -194,7 +196,7 @@ namespace MonoDevelop.VersionControl.Git
 						} else
 							state.KeyUsed = keyIndex;
 					} else
-						throw new VersionControlException (GettextCatalog.GetString ("Invalid credentials were supplied. Aborting operation."));
+						throw new UserCancelledException (UserCancelledExceptionMessage);
 				}
 
 				return cred;
@@ -210,7 +212,7 @@ namespace MonoDevelop.VersionControl.Git
 				return cred;
 			}
 
-			throw new VersionControlException (GettextCatalog.GetString ("Operation cancelled by the user"));
+			throw new UserCancelledException (UserCancelledExceptionMessage);
 		}
 
 		internal static bool KeyHasPassphrase (string key)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -75,6 +75,8 @@ namespace MonoDevelop.VersionControl.Git
 			var defaultKey = FilePath.Null;
 
 			foreach (FilePath privateKey in Directory.EnumerateFiles (keyStorage)) {
+				if (privateKey.Extension == ".pub")
+					continue;
 				string publicKey = privateKey + ".pub";
 				if (File.Exists (publicKey)) {
 					if (privateKey.FileName == "id_rsa")

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -640,6 +640,9 @@ namespace MonoDevelop.VersionControl.Git
 					} catch (LibGit2SharpException e) {
 						GitCredentials.InvalidateCredentials (credType);
 
+						if (e.Message == GettextCatalog.GetString (GitCredentials.UserCancelledExceptionMessage))
+							throw new UserCancelledException (e.Message, e);
+
 						if (credType == GitCredentialsType.Tfs) {
 							retry = true;
 							tfsSession.Dispose ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -634,14 +634,15 @@ namespace MonoDevelop.VersionControl.Git
 						GitCredentials.InvalidateCredentials (credType);
 						monitor?.ReportError (e.Message, null);
 						retry = false;
-					} catch (UserCancelledException) {
+					} catch (UserCancelledException e) {
 						GitCredentials.StoreCredentials (credType);
 						retry = false;
+						throw new VersionControlException (e.Message, e);
 					} catch (LibGit2SharpException e) {
 						GitCredentials.InvalidateCredentials (credType);
 
 						if (e.Message == GettextCatalog.GetString (GitCredentials.UserCancelledExceptionMessage))
-							throw new UserCancelledException (e.Message, e);
+							throw new VersionControlException (e.Message, e);
 
 						if (credType == GitCredentialsType.Tfs) {
 							retry = true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -34,9 +34,7 @@ namespace MonoDevelop.VersionControl.Git
 	public class XwtCredentialsDialog : Xwt.Dialog
 	{
 		const int DefaultlLabelWidth = 100;
-		const int DefaultlErrorLabelWidth = DefaultlLabelWidth + 30;
-		const int KeyLocationContainerHeight = 24;
-		const int KeyLocationContainerTopMargin = 10;
+		const int InputContainerContainerSpacing = 10;
 		readonly SupportedCredentialTypes type;
 		readonly TextEntry privateKeyLocationTextEntry;
 		readonly TextEntry publicKeyLocationTextEntry;
@@ -79,14 +77,18 @@ namespace MonoDevelop.VersionControl.Git
 			mainContainer.PackStart (credentialValue);
 
 			//Private key location
-			var privateKeyLocationContainer = new HBox () { HeightRequest = KeyLocationContainerHeight, MarginTop = KeyLocationContainerTopMargin, VerticalPlacement = WidgetPlacement.Center };
-			mainContainer.PackStart (privateKeyLocationContainer);
+			var inputContainer = new Table () { DefaultRowSpacing = InputContainerContainerSpacing };
+			mainContainer.PackStart (inputContainer, marginTop: InputContainerContainerSpacing);
+			int inputContainerCurrentRow = 0;
 
 			var privateKeyLocationLabel = new Label (GettextCatalog.GetString ("Private Key:")) {
-				WidthRequest = DefaultlLabelWidth,
+				MinWidth = DefaultlLabelWidth,
 				TextAlignment = Alignment.End
 			};
-			privateKeyLocationContainer.PackStart (privateKeyLocationLabel, vpos: WidgetPlacement.Center);
+			inputContainer.Add (privateKeyLocationLabel, 0, inputContainerCurrentRow, hexpand: false, vpos: WidgetPlacement.Center);
+
+			var privateKeyLocationContainer = new HBox ();
+			inputContainer.Add (privateKeyLocationContainer, 1, inputContainerCurrentRow, hexpand: true);
 
 			privateKeyLocationTextEntry = new TextEntry ();
 			privateKeyLocationTextEntry.Accessible.LabelWidget = privateKeyLocationLabel;
@@ -99,16 +101,17 @@ namespace MonoDevelop.VersionControl.Git
 			privateKeyLocationButton.Accessible.LabelWidget = privateKeyLocationLabel;
 			privateKeyLocationButton.Accessible.Title = GettextCatalog.GetString ("Select a key file");
 			privateKeyLocationContainer.PackStart (privateKeyLocationButton);
+			inputContainerCurrentRow++;
 
 			//Public key location
-			var publicKeyLocationContainer = new HBox () { HeightRequest = KeyLocationContainerHeight, MarginTop = KeyLocationContainerTopMargin, VerticalPlacement = WidgetPlacement.Center };
-			mainContainer.PackStart (publicKeyLocationContainer);
-
 			var publicKeyLocationLabel = new Label (GettextCatalog.GetString ("Public Key:")) {
-				WidthRequest = DefaultlLabelWidth,
+				MinWidth = DefaultlLabelWidth,
 				TextAlignment = Alignment.End
 			};
-			publicKeyLocationContainer.PackStart (publicKeyLocationLabel, vpos: WidgetPlacement.Center);
+			inputContainer.Add (publicKeyLocationLabel, 0, inputContainerCurrentRow, hexpand: false, vpos: WidgetPlacement.Center);
+
+			var publicKeyLocationContainer = new HBox ();
+			inputContainer.Add (publicKeyLocationContainer, 1, inputContainerCurrentRow, hexpand: true);
 
 			publicKeyLocationTextEntry = new TextEntry ();
 			publicKeyLocationTextEntry.Accessible.LabelWidget = publicKeyLocationLabel;
@@ -121,37 +124,33 @@ namespace MonoDevelop.VersionControl.Git
 			publicKeyLocationButton.Accessible.LabelWidget = publicKeyLocationLabel;
 			publicKeyLocationButton.Accessible.Title = GettextCatalog.GetString ("Select a key file");
 			publicKeyLocationContainer.PackStart (publicKeyLocationButton);
+			inputContainerCurrentRow++;
 
 			//user container
-			var userContainer = new HBox () { VerticalPlacement = WidgetPlacement.Center };
-			mainContainer.PackStart (userContainer);
-
 			if (type == SupportedCredentialTypes.UsernamePassword) {
 				var userLabel = new Label (GettextCatalog.GetString ("Username:")) {
-					WidthRequest = DefaultlLabelWidth
+					MinWidth = DefaultlLabelWidth
 				};
-				userContainer.PackStart (userLabel);
+				inputContainer.Add (userLabel, 0, inputContainerCurrentRow, hexpand: false, vpos: WidgetPlacement.Center);
 				userLabel.TextAlignment = Alignment.End;
 				userTextEntry = new TextEntry ();
-				userContainer.PackStart (userTextEntry, true);
+				inputContainer.Add (userTextEntry, 1, inputContainerCurrentRow, hexpand: true, vpos: WidgetPlacement.Center, marginRight: Toolkit.CurrentEngine.Type == ToolkitType.XamMac ? 1 : -1);
 
 				userTextEntry.KeyPressed += UserTextEntry_KeyPressed;
+				inputContainerCurrentRow++;
 			}
 
 			//password container
-			var passwordContainer = new HBox () { VerticalPlacement = WidgetPlacement.Center };
-			mainContainer.PackStart (passwordContainer);
-
 			var passwordLabel = new Label () {
 				TextAlignment = Alignment.End,
 				Text = type == SupportedCredentialTypes.Ssh ? GettextCatalog.GetString ("Passphrase:") : GettextCatalog.GetString ("Password:"),
-				WidthRequest = DefaultlLabelWidth
+				MinWidth = DefaultlLabelWidth
 			};
-			passwordContainer.PackStart (passwordLabel, vpos: WidgetPlacement.Center);
+			inputContainer.Add (passwordLabel, 0, inputContainerCurrentRow, hexpand: false, vpos: WidgetPlacement.Center);
 
 			passwordEntry = new PasswordEntry () { MarginTop = 5 };
 			passwordEntry.Accessible.LabelWidget = passwordLabel;
-			passwordContainer.PackStart (passwordEntry, true, vpos: WidgetPlacement.Center);
+			inputContainer.Add (passwordEntry, 1, inputContainerCurrentRow, hexpand: true, vpos: WidgetPlacement.Center, marginRight: Toolkit.CurrentEngine.Type == ToolkitType.XamMac ? 1 : -1);
 			passwordEntry.Changed += PasswordEntry_Changed;
 
 			//Buttons

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -152,7 +152,7 @@ namespace MonoDevelop.VersionControl.Git
 			};
 			Add (userLabel, 0, inputContainerCurrentRow, hexpand: false, vpos: WidgetPlacement.Center);
 			userLabel.TextAlignment = Alignment.End;
-			userTextEntry = new TextEntry { Text = creds?.Username ?? string.Empty };
+			userTextEntry = new TextEntry { Text = Credentials.Username ?? string.Empty };
 			Add (userTextEntry, 1, inputContainerCurrentRow, hexpand: true, vpos: WidgetPlacement.Center, marginRight: Toolkit.CurrentEngine.Type == ToolkitType.XamMac ? 10 : -1);
 
 			userTextEntry.Changed += UserTextEntry_Changed;
@@ -166,7 +166,7 @@ namespace MonoDevelop.VersionControl.Git
 			};
 			Add (passwordLabel, 0, inputContainerCurrentRow, hexpand: false, vpos: WidgetPlacement.Center);
 
-			passwordEntry = new PasswordEntry () { Password = creds?.Password ?? string.Empty, MarginTop = 5 };
+			passwordEntry = new PasswordEntry () { Password = Credentials.Password ?? string.Empty, MarginTop = 5 };
 			passwordEntry.Accessible.LabelWidget = passwordLabel;
 			Add (passwordEntry, 1, inputContainerCurrentRow, hexpand: true, vpos: WidgetPlacement.Center, marginRight: Toolkit.CurrentEngine.Type == ToolkitType.XamMac ? 10 : -1);
 			passwordEntry.Changed += PasswordEntry_Changed;
@@ -230,7 +230,7 @@ namespace MonoDevelop.VersionControl.Git
 			var privateKeyLocationContainer = new HBox ();
 			Add (privateKeyLocationContainer, 1, inputContainerCurrentRow, hexpand: true);
 
-			privateKeyLocationTextEntry = new TextEntry ();
+			privateKeyLocationTextEntry = new TextEntry { Text = Credentials.PrivateKey ?? string.Empty };
 			privateKeyLocationTextEntry.Accessible.LabelWidget = privateKeyLocationLabel;
 			privateKeyLocationTextEntry.Changed += PrivateKeyLocationTextEntry_Changed;
 			privateKeyLocationContainer.PackStart (privateKeyLocationTextEntry, true, vpos: WidgetPlacement.Center);
@@ -253,7 +253,7 @@ namespace MonoDevelop.VersionControl.Git
 			var publicKeyLocationContainer = new HBox ();
 			Add (publicKeyLocationContainer, 1, inputContainerCurrentRow, hexpand: true);
 
-			publicKeyLocationTextEntry = new TextEntry ();
+			publicKeyLocationTextEntry = new TextEntry { Text = Credentials.PublicKey ?? string.Empty };
 			publicKeyLocationTextEntry.Accessible.LabelWidget = publicKeyLocationLabel;
 			publicKeyLocationTextEntry.Changed += PublicKeyLocationTextEntry_Changed;
 			publicKeyLocationContainer.PackStart (publicKeyLocationTextEntry, true, vpos: WidgetPlacement.Center);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -272,15 +272,16 @@ namespace MonoDevelop.VersionControl.Git
 
 		protected override void Dispose (bool disposing)
 		{
-			privateKeyLocationTextEntry.Changed -= PrivateKeyLocationTextEntry_Changed;
-			publicKeyLocationTextEntry.Changed -= PublicKeyLocationTextEntry_Changed;
-			if (userTextEntry != null) {
-				userTextEntry.KeyPressed -= UserTextEntry_KeyPressed;
+			if (disposing && !IsDisposed) {
+				privateKeyLocationTextEntry.Changed -= PrivateKeyLocationTextEntry_Changed;
+				publicKeyLocationTextEntry.Changed -= PublicKeyLocationTextEntry_Changed;
+				if (userTextEntry != null) {
+					userTextEntry.KeyPressed -= UserTextEntry_KeyPressed;
+				}
+				passwordEntry.Changed -= PasswordEntry_Changed;
+				privateKeyLocationButton.Clicked -= PrivateKeyLocationButton_Clicked;
+				publicKeyLocationButton.Clicked -= PublicKeyLocationButton_Clicked;
 			}
-			passwordEntry.Changed -= PasswordEntry_Changed;
-			privateKeyLocationButton.Clicked -= PrivateKeyLocationButton_Clicked;
-			publicKeyLocationButton.Clicked -= PublicKeyLocationButton_Clicked;
-
 			base.Dispose (disposing);
 		}
 	}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.VersionControl.Git
 
 			privateKeyLocationTextEntry = new TextEntry ();
 			privateKeyLocationTextEntry.Accessible.LabelWidget = privateKeyLocationLabel;
-			privateKeyLocationTextEntry.KeyPressed += PrivateKeyLocationTextEntry_Changed;
+			privateKeyLocationTextEntry.Changed += PrivateKeyLocationTextEntry_Changed;
 			privateKeyLocationContainer.PackStart (privateKeyLocationTextEntry, true, vpos: WidgetPlacement.Center);
 
 			warningPrivateKey = new Components.InformationPopoverWidget { Severity = Ide.Tasks.TaskSeverity.Warning };
@@ -115,7 +115,7 @@ namespace MonoDevelop.VersionControl.Git
 
 			publicKeyLocationTextEntry = new TextEntry ();
 			publicKeyLocationTextEntry.Accessible.LabelWidget = publicKeyLocationLabel;
-			publicKeyLocationTextEntry.KeyPressed += PublicKeyLocationTextEntry_KeyPressed;
+			publicKeyLocationTextEntry.Changed += PublicKeyLocationTextEntry_Changed;
 			publicKeyLocationContainer.PackStart (publicKeyLocationTextEntry, true, vpos: WidgetPlacement.Center);
 
 			warningPublicKey = new Components.InformationPopoverWidget { Severity = Ide.Tasks.TaskSeverity.Warning };
@@ -244,7 +244,7 @@ namespace MonoDevelop.VersionControl.Git
 		}
 
 		void PrivateKeyLocationTextEntry_Changed (object sender, EventArgs e) => RefreshPasswordState ();
-		void PublicKeyLocationTextEntry_KeyPressed (object sender, KeyEventArgs e) => RefreshPasswordState ();
+		void PublicKeyLocationTextEntry_Changed (object sender, EventArgs e) => RefreshPasswordState ();
 
 		static bool ValidatePrivateKey (FilePath privateKey)
 		{
@@ -287,8 +287,8 @@ namespace MonoDevelop.VersionControl.Git
 
 		protected override void Dispose (bool disposing)
 		{
-			privateKeyLocationTextEntry.KeyPressed -= PrivateKeyLocationTextEntry_Changed;
-			publicKeyLocationTextEntry.KeyPressed -= PublicKeyLocationTextEntry_KeyPressed;
+			privateKeyLocationTextEntry.Changed -= PrivateKeyLocationTextEntry_Changed;
+			publicKeyLocationTextEntry.Changed -= PublicKeyLocationTextEntry_Changed;
 			if (userTextEntry != null) {
 				userTextEntry.KeyPressed -= UserTextEntry_KeyPressed;
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -238,11 +238,23 @@ namespace MonoDevelop.VersionControl.Git
 		void PrivateKeyLocationTextEntry_Changed (object sender, EventArgs e) => RefreshPasswordState ();
 		void PublicKeyLocationTextEntry_KeyPressed (object sender, KeyEventArgs e) => RefreshPasswordState ();
 
+		static bool ValidatePrivateKey (FilePath privateKey)
+		{
+			if (privateKey.IsNullOrEmpty)
+				return false;
+			var finfo = new System.IO.FileInfo (privateKey);
+			if (!finfo.Exists)
+				return false;
+			if (finfo.Length > 512 * 1024) // let's don't allow anything bigger than 512kb
+				return false;
+			return true;
+		}
+
 		void RefreshPasswordState ()
 		{
 			okButton.Sensitive = false;
 			bool hasPassphrase = false;
-			if (System.IO.File.Exists (privateKeyLocationTextEntry.Text)) {
+			if (ValidatePrivateKey (privateKeyLocationTextEntry.Text)) {
 				hasPassphrase = passwordEntry.Sensitive = GitCredentials.KeyHasPassphrase (privateKeyLocationTextEntry.Text);
 				if (!hasPassphrase) {
 					passwordEntry.Password = "";

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -50,8 +50,8 @@ namespace MonoDevelop.VersionControl.Git
 		TextEntry userTextEntry;
 		const string credentialMarkupFormat = "<b>{0}</b>";
 
-		readonly Components.InformationPopoverWidget warningPublicKey = new Components.InformationPopoverWidget () { Severity = Ide.Tasks.TaskSeverity.Warning };
-		readonly Components.InformationPopoverWidget warningPrivateKey = new Components.InformationPopoverWidget () { Severity = Ide.Tasks.TaskSeverity.Warning };
+		readonly Components.InformationPopoverWidget warningPublicKey;
+		readonly Components.InformationPopoverWidget warningPrivateKey;
 
 		public XwtCredentialsDialog (string uri, SupportedCredentialTypes supportedCredential, Credentials credentials)
 		{
@@ -89,11 +89,15 @@ namespace MonoDevelop.VersionControl.Git
 			privateKeyLocationContainer.PackStart (privateKeyLocationLabel);
 
 			privateKeyLocationTextEntry = new TextEntry ();
+			privateKeyLocationTextEntry.Accessible.LabelWidget = privateKeyLocationLabel;
 			privateKeyLocationTextEntry.KeyPressed += PrivateKeyLocationTextEntry_Changed;
 			privateKeyLocationContainer.PackStart (privateKeyLocationTextEntry, true);
 
+			warningPrivateKey = new Components.InformationPopoverWidget { Severity = Ide.Tasks.TaskSeverity.Warning };
 			privateKeyLocationContainer.PackStart (warningPrivateKey);
 			privateKeyLocationButton = new Button ("…");
+			privateKeyLocationButton.Accessible.LabelWidget = privateKeyLocationLabel;
+			privateKeyLocationButton.Accessible.Title = GettextCatalog.GetString ("Select a key file");
 			privateKeyLocationContainer.PackStart (privateKeyLocationButton);
 
 			//Public key location
@@ -107,11 +111,15 @@ namespace MonoDevelop.VersionControl.Git
 			publicKeyLocationContainer.PackStart (publicKeyLocationLabel);
 
 			publicKeyLocationTextEntry = new TextEntry ();
+			publicKeyLocationTextEntry.Accessible.LabelWidget = publicKeyLocationLabel;
 			publicKeyLocationTextEntry.KeyPressed += PublicKeyLocationTextEntry_KeyPressed;
 			publicKeyLocationContainer.PackStart (publicKeyLocationTextEntry, true);
 
+			warningPublicKey = new Components.InformationPopoverWidget { Severity = Ide.Tasks.TaskSeverity.Warning };
 			publicKeyLocationContainer.PackStart (warningPublicKey);
 			publicKeyLocationButton = new Button ("…");
+			publicKeyLocationButton.Accessible.LabelWidget = publicKeyLocationLabel;
+			publicKeyLocationButton.Accessible.Title = GettextCatalog.GetString ("Select a key file");
 			publicKeyLocationContainer.PackStart (publicKeyLocationButton);
 
 			//user container
@@ -142,6 +150,7 @@ namespace MonoDevelop.VersionControl.Git
 			passwordContainer.PackStart (passwordLabel);
 
 			passwordEntry = new PasswordEntry () { MarginTop = 5 };
+			passwordEntry.Accessible.LabelWidget = passwordLabel;
 			passwordContainer.PackStart (passwordEntry, true);
 			passwordEntry.Changed += PasswordEntry_Changed;
 
@@ -258,6 +267,7 @@ namespace MonoDevelop.VersionControl.Git
 				hasPassphrase = passwordEntry.Sensitive = GitCredentials.KeyHasPassphrase (privateKeyLocationTextEntry.Text);
 				if (!hasPassphrase) {
 					passwordEntry.Password = "";
+					passwordEntry.PlaceholderText = passwordEntry.Accessible.Description = GettextCatalog.GetString ("Private Key is not encrypted");
 					passwordEntry.Sensitive = false;
 				}
 				warningPrivateKey.Hide ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -86,12 +86,12 @@ namespace MonoDevelop.VersionControl.Git
 				WidthRequest = DefaultlLabelWidth,
 				TextAlignment = Alignment.End
 			};
-			privateKeyLocationContainer.PackStart (privateKeyLocationLabel);
+			privateKeyLocationContainer.PackStart (privateKeyLocationLabel, vpos: WidgetPlacement.Center);
 
 			privateKeyLocationTextEntry = new TextEntry ();
 			privateKeyLocationTextEntry.Accessible.LabelWidget = privateKeyLocationLabel;
 			privateKeyLocationTextEntry.KeyPressed += PrivateKeyLocationTextEntry_Changed;
-			privateKeyLocationContainer.PackStart (privateKeyLocationTextEntry, true);
+			privateKeyLocationContainer.PackStart (privateKeyLocationTextEntry, true, vpos: WidgetPlacement.Center);
 
 			warningPrivateKey = new Components.InformationPopoverWidget { Severity = Ide.Tasks.TaskSeverity.Warning };
 			privateKeyLocationContainer.PackStart (warningPrivateKey);
@@ -108,12 +108,12 @@ namespace MonoDevelop.VersionControl.Git
 				WidthRequest = DefaultlLabelWidth,
 				TextAlignment = Alignment.End
 			};
-			publicKeyLocationContainer.PackStart (publicKeyLocationLabel);
+			publicKeyLocationContainer.PackStart (publicKeyLocationLabel, vpos: WidgetPlacement.Center);
 
 			publicKeyLocationTextEntry = new TextEntry ();
 			publicKeyLocationTextEntry.Accessible.LabelWidget = publicKeyLocationLabel;
 			publicKeyLocationTextEntry.KeyPressed += PublicKeyLocationTextEntry_KeyPressed;
-			publicKeyLocationContainer.PackStart (publicKeyLocationTextEntry, true);
+			publicKeyLocationContainer.PackStart (publicKeyLocationTextEntry, true, vpos: WidgetPlacement.Center);
 
 			warningPublicKey = new Components.InformationPopoverWidget { Severity = Ide.Tasks.TaskSeverity.Warning };
 			publicKeyLocationContainer.PackStart (warningPublicKey);
@@ -147,11 +147,11 @@ namespace MonoDevelop.VersionControl.Git
 				Text = type == SupportedCredentialTypes.Ssh ? GettextCatalog.GetString ("Passphrase:") : GettextCatalog.GetString ("Password:"),
 				WidthRequest = DefaultlLabelWidth
 			};
-			passwordContainer.PackStart (passwordLabel);
+			passwordContainer.PackStart (passwordLabel, vpos: WidgetPlacement.Center);
 
 			passwordEntry = new PasswordEntry () { MarginTop = 5 };
 			passwordEntry.Accessible.LabelWidget = passwordLabel;
-			passwordContainer.PackStart (passwordEntry, true);
+			passwordContainer.PackStart (passwordEntry, true, vpos: WidgetPlacement.Center);
 			passwordEntry.Changed += PasswordEntry_Changed;
 
 			//Buttons

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -162,9 +162,9 @@ namespace MonoDevelop.VersionControl.Git
 		void PasswordEntry_Changed (object sender, EventArgs e)
 		{
 			if (cred is UsernamePasswordCredentials usernamePasswordCredentials) {
-				usernamePasswordCredentials.Password = passwordEntry.Password ?? "";
+				usernamePasswordCredentials.Password = passwordEntry.Password ?? string.Empty;
 			} else if (cred is SshUserKeyCredentials userKeyCredentials) {
-				userKeyCredentials.Passphrase = passwordEntry.Password ?? "";
+				userKeyCredentials.Passphrase = passwordEntry.Password ?? string.Empty;
 			}
 			RefreshPasswordState ();
 		}
@@ -178,6 +178,7 @@ namespace MonoDevelop.VersionControl.Git
 				: Environment.GetFolderPath (Environment.SpecialFolder.Personal)
 			};
 			dialog.AddFilter (GettextCatalog.GetString ("Public Key Files (.pub)"), "*.pub");
+			dialog.AddAllFilesFilter ();
 
 			if (dialog.Run ()) {
 				publicKeyLocationTextEntry.Text = dialog.SelectedFile;
@@ -249,7 +250,7 @@ namespace MonoDevelop.VersionControl.Git
 				}
 				warningPrivateKey.Hide ();
 			} else {
-				warningPrivateKey.Message = GettextCatalog.GetString ("No private key file in the selected location");
+				warningPrivateKey.Message = GettextCatalog.GetString ("Please select a valid private key file");
 				warningPrivateKey.Visible = true;
 			}
 
@@ -258,7 +259,7 @@ namespace MonoDevelop.VersionControl.Git
 				warningPublicKey.Hide ();
 			} else {
 				okButton.Sensitive = false;
-				warningPublicKey.Message = GettextCatalog.GetString ("The public key (.pub) is missing in the selected location");
+				warningPublicKey.Message = GettextCatalog.GetString ("Please select a valid public key (.pub) file");
 				warningPublicKey.Show ();
 			}
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -1,0 +1,231 @@
+﻿//
+// XwtCredentialsDialog.cs
+//
+// Author:
+//       Jose Medrano <josmed@nmicrosoft.com>
+//
+// Copyright (c) 2019 Microsoft Corp, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using LibGit2Sharp;
+using MonoDevelop.Core;
+using Xwt;
+
+namespace MonoDevelop.VersionControl.Git
+{
+	public class XwtCredentialsDialog : Xwt.Dialog
+	{
+		const int DefaultTextWidth = 350;
+		const int DefaultlLabelWidth = 100;
+		const int DefaultlErrorLabelWidth = DefaultlLabelWidth + 30;
+
+		readonly SupportedCredentialTypes type;
+		readonly TextEntry keyLocationTextEntry;
+		readonly PasswordEntry passwordEntry;
+		readonly Label errorLabel;
+		readonly Credentials cred;
+		readonly DialogButton okButton;
+		readonly DialogButton cancelButton;
+		readonly Button keyLocationButton;
+
+		TextEntry userTextEntry;
+
+		public XwtCredentialsDialog (string uri, SupportedCredentialTypes supportedCredential, Credentials credentials)
+		{
+			Title = GettextCatalog.GetString ("Git Credential");
+			Width = 500;
+			Resizable = false;
+
+			type = supportedCredential;
+			cred = credentials;
+
+			var mainContainer = new VBox ();
+			Content = mainContainer;
+
+			//Credentials
+			var credentialsLabel = new Label (GettextCatalog.GetString ("Credentials required for the repository:")) {
+				Wrap = WrapMode.Word
+			};
+			mainContainer.PackStart (credentialsLabel);
+
+			var credentialValue = new Label {
+				Markup = string.Format ("<b>{0}</b>", uri),
+				Wrap = WrapMode.Word
+			};
+			mainContainer.PackStart (credentialValue);
+
+			//Key location
+			var keyLocationContainer = new HBox ();
+			mainContainer.PackStart (keyLocationContainer);
+
+			keyLocationContainer.MarginTop = 10;
+
+			var keyLocationLabel = new Label (GettextCatalog.GetString ("Key Location:")) {
+				WidthRequest = DefaultlLabelWidth,
+				TextAlignment = Alignment.End
+			};
+			keyLocationContainer.PackStart (keyLocationLabel);
+
+			keyLocationTextEntry = new TextEntry ();
+			keyLocationTextEntry.KeyPressed += KeyLocationTextEntry_Changed;
+
+			keyLocationContainer.PackStart (keyLocationTextEntry, true);
+
+			keyLocationButton = new Button ("…");
+			keyLocationContainer.PackStart (keyLocationButton);
+
+			errorLabel = new Label {
+				TextColor = Xwt.Drawing.Colors.Red,
+				Visible = false
+			};
+			mainContainer.PackStart (errorLabel);
+			errorLabel.MarginLeft = DefaultlLabelWidth;
+			//user container
+			var userContainer = new HBox ();
+			mainContainer.PackStart (userContainer);
+
+			if (type == SupportedCredentialTypes.UsernamePassword) {
+				var userLabel = new Label (GettextCatalog.GetString ("Username:"));
+				userLabel.WidthRequest = DefaultlLabelWidth;
+				userContainer.PackStart (userLabel);
+				userLabel.TextAlignment = Alignment.End;
+				userTextEntry = new TextEntry ();
+				userContainer.PackStart (userTextEntry, true);
+
+				userTextEntry.KeyPressed += UserTextEntry_KeyPressed;
+			}
+
+			//password container
+			var passwordContainer = new HBox ();
+			mainContainer.PackStart (passwordContainer);
+
+			var passwordLabel = new Label () {
+				TextAlignment = Alignment.End,
+				Text = GettextCatalog.GetString (type == SupportedCredentialTypes.Ssh ? "Passphrase:" : "Password:"),
+				WidthRequest = DefaultlLabelWidth
+			};
+			passwordContainer.PackStart (passwordLabel);
+
+			passwordEntry = new PasswordEntry {
+				WidthRequest = DefaultTextWidth
+			};
+			passwordContainer.PackStart (passwordEntry, true);
+			passwordEntry.KeyPressed += PasswordEntry_KeyPressed;
+
+			//Buttons
+			cancelButton = new Xwt.DialogButton (Command.Cancel);
+			Buttons.Add (cancelButton);
+			cancelButton.Clicked += CancelButton_Clicked;
+
+			okButton = new Xwt.DialogButton (Command.Ok);
+			Buttons.Add (okButton);
+			okButton.Clicked += OkButton_Clicked;
+
+			keyLocationButton.Clicked += KeyLocationButton_Clicked;
+			RefreshPasswordState ();
+		}
+
+		void OkButton_Clicked (object sender, EventArgs e)
+		{
+			if (cred is SshUserKeyCredentials ssh) {
+				ssh.PrivateKey = keyLocationTextEntry.Text;
+				ssh.PublicKey = ssh.PrivateKey + ".pub";
+			}
+			Close ();
+		}
+
+		void CancelButton_Clicked (object sender, EventArgs e) => Close ();
+
+		void KeyLocationButton_Clicked (object sender, EventArgs e)
+		{
+			var dialog = new Components.SelectFileDialog (GettextCatalog.GetString ("Select a private SSH key to use.")) {
+				ShowHidden = true,
+				CurrentFolder = Environment.GetFolderPath (Environment.SpecialFolder.Personal)
+			};
+			if (dialog.Run ()) {
+				keyLocationTextEntry.Text = dialog.SelectedFile;
+				RefreshPasswordState ();
+				if (type == SupportedCredentialTypes.Ssh) {
+					if (passwordEntry.Sensitive == true) {
+						passwordEntry.SetFocus ();
+					}
+				} else {
+					userTextEntry?.SetFocus ();
+				}
+			};
+		}
+
+		void PasswordEntry_KeyPressed (object sender, KeyEventArgs e)
+		{
+			if (cred is UsernamePasswordCredentials usernamePasswordCredentials) {
+				usernamePasswordCredentials.Password = passwordEntry.Password ?? "";
+			} else if (cred is SshUserKeyCredentials userKeyCredentials) {
+				userKeyCredentials.Passphrase = passwordEntry.Password ?? "";
+			}
+			RefreshPasswordState ();
+		}
+
+		void UserTextEntry_KeyPressed (object sender, KeyEventArgs e)
+		{
+			if (cred is UsernamePasswordCredentials usernamePasswordCredentials) {
+				usernamePasswordCredentials.Username = userTextEntry.Text;
+			}
+		}
+
+		void KeyLocationTextEntry_Changed (object sender, EventArgs e) => RefreshPasswordState ();
+
+		void RefreshPasswordState ()
+		{
+			if (System.IO.File.Exists (keyLocationTextEntry.Text)) {
+				var hasPassphrase = passwordEntry.Sensitive = GitCredentials.KeyHasPassphrase (keyLocationTextEntry.Text);
+
+				if (System.IO.File.Exists (keyLocationTextEntry.Text + ".pub")) {
+					errorLabel.Visible = false;
+					okButton.Sensitive = !hasPassphrase || passwordEntry.Password.Length > 0;
+				} else {
+					errorLabel.Text = GettextCatalog.GetString ("The public key (.pub) is missing in the selected location");
+					errorLabel.Visible = true;
+					okButton.Sensitive = false;
+				}
+				return;
+			}
+
+			errorLabel.Text = GettextCatalog.GetString ("No key file in the selected location");
+			errorLabel.Visible = true;
+			okButton.Sensitive = false;
+			passwordEntry.Sensitive = false;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			keyLocationTextEntry.KeyPressed -= KeyLocationTextEntry_Changed;
+			if (userTextEntry != null) {
+				userTextEntry.KeyPressed -= UserTextEntry_KeyPressed;
+			}
+
+			passwordEntry.KeyPressed -= PasswordEntry_KeyPressed;
+			okButton.Clicked -= OkButton_Clicked;
+			cancelButton.Clicked -= CancelButton_Clicked;
+			keyLocationButton.Clicked -= KeyLocationButton_Clicked;
+			base.Dispose (disposing);
+		}
+	}
+}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -140,7 +140,7 @@ namespace MonoDevelop.VersionControl.Git
 
 			var passwordLabel = new Label () {
 				TextAlignment = Alignment.End,
-				Text = GettextCatalog.GetString (type == SupportedCredentialTypes.Ssh ? "Passphrase:" : "Password:"),
+				Text = type == SupportedCredentialTypes.Ssh ? GettextCatalog.GetString ("Passphrase:") : GettextCatalog.GetString ("Password:"),
 				WidthRequest = DefaultlLabelWidth
 			};
 			passwordContainer.PackStart (passwordLabel);
@@ -177,8 +177,9 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			var dialog = new Components.SelectFileDialog (GettextCatalog.GetString ("Select a public SSH key to use.")) {
 				ShowHidden = true,
-				CurrentFolder = System.IO.File.Exists (privateKeyLocationTextEntry.Text) ? 
-				System.IO.Path.GetDirectoryName (privateKeyLocationTextEntry.Text) : Environment.GetFolderPath (Environment.SpecialFolder.Personal)
+				CurrentFolder = System.IO.File.Exists (privateKeyLocationTextEntry.Text) 
+				? System.IO.Path.GetDirectoryName (privateKeyLocationTextEntry.Text) 
+				: Environment.GetFolderPath (Environment.SpecialFolder.Personal)
 			};
 			if (dialog.Run ()) {
 				publicKeyLocationTextEntry.Text = dialog.SelectedFile;
@@ -188,13 +189,7 @@ namespace MonoDevelop.VersionControl.Git
 						passwordEntry.SetFocus ();
 					}
 				} else {
-					if (type == SupportedCredentialTypes.Ssh) {
-						if (passwordEntry.Sensitive == true) {
-							passwordEntry.SetFocus ();
-						}
-					} else {
-						userTextEntry?.SetFocus ();
-					}
+					userTextEntry?.SetFocus ();
 				}
 			};
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/XwtCredentialsDialog.cs
@@ -30,6 +30,7 @@ using LibGit2Sharp;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 using Xwt;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -93,7 +94,7 @@ namespace MonoDevelop.VersionControl.Git
 				var response = false;
 				engine.Invoke (() => {
 					using (var xwtDialog = new XwtCredentialsDialog (url, types, cred)) {
-						response = xwtDialog.Run (parentWindow ?? Ide.MessageService.RootWindow) == Command.Ok;
+						response = xwtDialog.Run (parentWindow ?? DesktopService.GetFocusedTopLevelWindow ()) == Command.Ok;
 					}
 				});
 				return response;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ProgressDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ProgressDialog.cs
@@ -57,7 +57,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			ActionArea.Hide ();
 			DefaultHeight = 5;
 			
-			TransientFor = parent;
+			TransientFor = parent.nativeWidget as Gtk.Window;
 			
 			btnCancel.Visible = allowCancel;
 


### PR DESCRIPTION
When the user connects to a repository using ** git ssh protocol ** and ** does not have an ssh-agent running **, he needs to use an ssh key.

Until now, we were doing 2 steps to authenticate:
Opening a not descriptive FileOpen dialog to select this key file... and before that a second dialog with the user and password fields.

This was not obvious for all the users, and some of them got confused over this step.

To resolve this, we merged both into a single screen in a new XwtCredentialsDialog, which includes additional information error from the key file selected.

What checks do now in this new dialog:

- The key file exists in the path
- if the key has passphrase (is this is true enables the password field)
- if ".pub" file exists with the selected private key file
- Ok button is only enabled in case all the required fields are validated

As @sevoku proposed we revamped native CredentialsDialog in Xwt

Fixes VSTS #675468 - Can't access remote repos over SSH in VS Comm macos
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/675468

New Xwt dialog:
![image](https://user-images.githubusercontent.com/1587480/52857629-0131bb00-3128-11e9-9bea-5bda581b41f8.png)


Old Gtk dialog:

![image](https://user-images.githubusercontent.com/1587480/52829141-df0a4f80-30cb-11e9-8082-a7a1505b8007.png)

Note: I detected after doing some checkouts we get some log errors connecting, probably this issue not related but it would be great to double check