### PR TITLE
[SourceControl] Adds a Native a contextual menu in Log Window

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/Gui/MonoDevelop.VersionControl.Views.LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/Gui/MonoDevelop.VersionControl.Views.LogWidget.cs
@@ -189,7 +189,7 @@ namespace MonoDevelop.VersionControl.Views
 			w1.SetUiManager (UIManager);
 			this.scrolledLoading.Hide ();
 			this.Show ();
-			this.labelRevision.ButtonPressEvent += new global::Gtk.ButtonPressEventHandler (this.OnLabelRevisionButtonPressEvent);
+
 		}
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogView.cs
@@ -125,6 +125,11 @@ namespace MonoDevelop.VersionControl.Views
 				return;
 			}
 
+			CopyToClipboard (data);
+		}
+
+		internal static void CopyToClipboard (string data)
+		{
 			var clipboard = Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
 			clipboard.Text = data;
 			clipboard = Clipboard.Get (Gdk.Atom.Intern ("PRIMARY", false));

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -287,7 +287,7 @@ namespace MonoDevelop.VersionControl.Views
 		[GLib.ConnectBeforeAttribute]
 		void LabelRevision_ButtonPressEvent (object o, ButtonPressEventArgs args)
 		{
-			if (args.Event.Button != 3) {
+			if (args.Event.IsContextMenuButton ()) {
 				if (currentRevisionShortened) {
 					Revision d = SelectedRevision;
 					labelRevision.Text = GettextCatalog.GetString ("Revision: {0}", d.Name);
@@ -312,7 +312,7 @@ namespace MonoDevelop.VersionControl.Views
 
 		void PopulateLabelMenuAndRaisePopup (Label label, ButtonPressEventArgs args)
 		{
-			if (args.Event.Button == 3) {
+			if (args.Event.IsContextMenuButton ()) {
 				var selectedText = GetSelectedTextFromLabel (label);
 				if (string.IsNullOrEmpty (selectedText)) {
 					args.RetVal = true;
@@ -325,7 +325,7 @@ namespace MonoDevelop.VersionControl.Views
 		[GLib.ConnectBeforeAttribute]
 		void TextviewDetails_ButtonPressEvent (object o, ButtonPressEventArgs args)
 		{
-			if (args.Event.Button == 3) {
+			if (args.Event.IsContextMenuButton ()) {
 				var selectedText = GetSelectedTextFromTextView (textviewDetails);
 				if (string.IsNullOrEmpty (selectedText)) {
 					args.RetVal = true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -884,11 +884,7 @@ namespace MonoDevelop.VersionControl.Views
 		static string GetSelectedTextFromTextView (TextView textView)
 		{
 			textView.Buffer.GetSelectionBounds (out var A, out var B);
-			var result = textView.Buffer.GetText (A, B, true);
-			if (!string.IsNullOrEmpty (result)) {
-				return result;
-			}
-			return null;
+			return textView.Buffer.GetText (A, B, true);
 		}
 
 		internal string GetSelectedText ()

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -901,7 +901,7 @@ namespace MonoDevelop.VersionControl.Views
 			if (treeviewLog.HasFocus) {
 				if (treeviewLog.Selection.GetSelected (out var iter)) {
 					if (logstore.GetValue (iter, 0) is Revision revision) {
-						return string.Format ("{0}, {1}, {2}", revision.ShortMessage, revision.Time, revision.Author);
+						return string.Format ("{0}, {1}, {2}, {3}", revision.ShortMessage, revision.Time, revision.Author, revision.Name);
 					}
 				}
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -70,10 +70,6 @@ namespace MonoDevelop.VersionControl.Views
 		
 		bool currentRevisionShortened;
 
-		readonly Xwt.Widget xwtTextviewDetails;
-		readonly Xwt.Widget xwtLabelRevision;
-		readonly Xwt.Widget xwtLabelDate;
-		readonly Xwt.Widget xwtLabelAuthor;
 		readonly Xwt.Menu popupMenu;
 
 		class RevisionGraphCellRenderer : Gtk.CellRenderer
@@ -248,7 +244,6 @@ namespace MonoDevelop.VersionControl.Views
 			textviewDetails.WrapMode = Gtk.WrapMode.Word;
 			textviewDetails.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
 			textviewDetails.ButtonPressEvent += TextviewDetails_ButtonPressEvent;
-			xwtTextviewDetails = Xwt.Toolkit.CurrentEngine.WrapWidget (textviewDetails);
 
 			labelAuthor.Text = "";
 			labelDate.Text = "";
@@ -256,15 +251,12 @@ namespace MonoDevelop.VersionControl.Views
 
 			labelDate.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
 			labelDate.ButtonPressEvent += LabelDate_ButtonPressEvent;
-			xwtLabelDate = Xwt.Toolkit.CurrentEngine.WrapWidget (labelDate);
 
 			labelAuthor.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
 			labelAuthor.ButtonPressEvent += LabelAuthor_ButtonPressEvent;
-			xwtLabelAuthor = Xwt.Toolkit.CurrentEngine.WrapWidget (labelAuthor);
 
 			labelRevision.AddEvents ((int)Gdk.EventMask.ButtonPressMask);
 			labelRevision.ButtonPressEvent += LabelRevision_ButtonPressEvent;
-			xwtLabelRevision = Xwt.Toolkit.CurrentEngine.WrapWidget (labelRevision);
 
 			vbox2.Remove (scrolledwindow1);
 			HeaderBox tb = new HeaderBox ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.VersionControl.Views
 		
 		bool currentRevisionShortened;
 
-		readonly Xwt.Menu popupMenu;
+		Xwt.Menu popupMenu;
 
 		class RevisionGraphCellRenderer : Gtk.CellRenderer
 		{
@@ -269,7 +269,16 @@ namespace MonoDevelop.VersionControl.Views
 			tb.Add (scrolledwindow1);
 			vbox2.PackStart (tb, true, true, 0);
 
-			popupMenu = new Xwt.Menu ();
+			(Platform.IsMac ? Xwt.Toolkit.NativeEngine : Xwt.Toolkit.CurrentEngine).Invoke (() => {
+				popupMenu = new Xwt.Menu ();
+				var copyItem = new Xwt.MenuItem (GettextCatalog.GetString ("Copy"));
+				popupMenu.Items.Add (copyItem);
+				copyItem.Clicked += (sender, e) => {
+					var selectedText = GetSelectedText ();
+					if (!string.IsNullOrEmpty (selectedText))
+						LogView.CopyToClipboard (selectedText);
+				};
+			});
 
 			UpdateStyle ();
 			Ide.Gui.Styles.Changed += HandleStylesChanged;
@@ -328,13 +337,6 @@ namespace MonoDevelop.VersionControl.Views
 
 		void PopulateMenuAndRaisePopup (Gtk.Widget gtkWidget, string selectedText, ButtonPressEventArgs args)
 		{
-			popupMenu.Items.Clear ();
-
-			var copyItem = new Xwt.MenuItem (GettextCatalog.GetString ("Copy"));
-			popupMenu.Items.Add (copyItem);
-			copyItem.Clicked += (sender, e) => {
-				LogView.CopyToClipboard (selectedText);
-			};
 			popupMenu.Popup ();
 			args.RetVal = true;
 		}
@@ -594,6 +596,8 @@ namespace MonoDevelop.VersionControl.Views
 			messageRenderer.Dispose ();
 			textRenderer.Dispose ();
 			treeviewFiles.Dispose ();
+
+			popupMenu.Dispose ();
 
 			base.OnDestroyed ();
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -294,22 +294,22 @@ namespace MonoDevelop.VersionControl.Views
 				}
 				return;
 			}
-			PopulateLabelMenuAndRaisePopup (labelRevision, xwtLabelRevision, args);
+			PopulateLabelMenuAndRaisePopup (labelRevision, args);
 		}
 
 		[GLib.ConnectBeforeAttribute]
 		void LabelAuthor_ButtonPressEvent (object o, ButtonPressEventArgs args)
 		{
-			PopulateLabelMenuAndRaisePopup (labelAuthor, xwtLabelAuthor, args);
+			PopulateLabelMenuAndRaisePopup (labelAuthor, args);
 		}
 
 		[GLib.ConnectBeforeAttribute]
 		void LabelDate_ButtonPressEvent (object o, ButtonPressEventArgs args)
 		{
-			PopulateLabelMenuAndRaisePopup (labelDate, xwtLabelDate, args);
+			PopulateLabelMenuAndRaisePopup (labelDate, args);
 		}
 
-		void PopulateLabelMenuAndRaisePopup (Label label, Xwt.Widget labelWidget, ButtonPressEventArgs args)
+		void PopulateLabelMenuAndRaisePopup (Label label, ButtonPressEventArgs args)
 		{
 			if (args.Event.Button == 3) {
 				var selectedText = GetSelectedTextFromLabel (label);
@@ -317,7 +317,7 @@ namespace MonoDevelop.VersionControl.Views
 					args.RetVal = true;
 					return;
 				}
-				PopulateMenuAndRaisePopup (label, labelWidget, selectedText, args);
+				PopulateMenuAndRaisePopup (label, selectedText, args);
 			}
 		}
 
@@ -330,11 +330,11 @@ namespace MonoDevelop.VersionControl.Views
 					args.RetVal = true;
 					return;
 				}
-				PopulateMenuAndRaisePopup (textviewDetails, xwtTextviewDetails, selectedText, args);
+				PopulateMenuAndRaisePopup (textviewDetails, selectedText, args);
 			}
 		}
 
-		void PopulateMenuAndRaisePopup (Gtk.Widget gtkWidget, Xwt.Widget xwtWidget, string selectedText, ButtonPressEventArgs args)
+		void PopulateMenuAndRaisePopup (Gtk.Widget gtkWidget, string selectedText, ButtonPressEventArgs args)
 		{
 			popupMenu.Items.Clear ();
 


### PR DESCRIPTION
Replaces the current Gtk menu to use a native one.

Fixes VSTS #790405 - [Source Control] Log view: no native context menus
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/790405

![copypaste](https://user-images.githubusercontent.com/1587480/52881619-54762e80-3165-11e9-9558-09523dcdd2b1.gif)