### PR TITLE
[Roslyn] Fixes multiple leaks in the workspace integration

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkNotebookResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkNotebookResult.cs
@@ -73,6 +73,12 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 			return false;
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			noteBook = null;
+			base.Dispose (disposing);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -282,6 +282,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 				base.SetProperty (modelValue, propertyName, value);
 			}
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			ParentWidget = null;
+			TModel = null;
+			base.Dispose (disposing);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -530,6 +530,12 @@ namespace MonoDevelop.Components.AutoTest.Results
 		{
 			base.SetProperty (resultWidget, propertyName, value);
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			resultWidget = null;
+			base.Dispose (disposing);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -366,7 +366,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 			pinfo.SetValue (ResultObject, runtime);
 			return true;
 		}
-#endregion
+		#endregion
+
+		protected override void Dispose (bool disposing)
+		{
+			ResultObject = null;
+			base.Dispose (disposing);
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/ObjectResult.cs
@@ -132,5 +132,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 		{
 			SetProperty (value, propertyName, newValue);
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			value = null;
+			base.Dispose (disposing);
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppQuery.cs
@@ -39,7 +39,7 @@ using AppKit;
 
 namespace MonoDevelop.Components.AutoTest
 {
-	public class AppQuery : MarshalByRefObject
+	public class AppQuery : MarshalByRefObject, IDisposable
 	{
 		AppResult rootNode;
 		List<Operation> operations = new List<Operation> ();
@@ -368,7 +368,13 @@ namespace MonoDevelop.Components.AutoTest
 		{
 			var operationChain = string.Join (".", operations.Select (x => x.ToString ()));
 			return string.Format ("c => c.{0};", operationChain);
-		}		
+		}
+
+		public void Dispose ()
+		{
+			rootNode?.Dispose ();
+			rootNode = null;
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -35,7 +35,7 @@ using MonoDevelop.Core;
 
 namespace MonoDevelop.Components.AutoTest
 {
-	public abstract class AppResult : MarshalByRefObject
+	public abstract class AppResult : MarshalByRefObject, IDisposable
 	{
 		//public Gtk.Widget ResultWidget { get; private set; }
 
@@ -228,6 +228,19 @@ namespace MonoDevelop.Components.AutoTest
 			} else {
 				return haystack != null && (haystack.IndexOf (needle, StringComparison.Ordinal) > -1);
 			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			FirstChild?.Dispose ();
+			NextSibling?.Dispose ();
+
+			FirstChild = NextSibling = ParentNode = PreviousSibling = null;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestClientSession.cs
@@ -122,6 +122,8 @@ namespace MonoDevelop.Components.AutoTest
 			return null;
 		}
 
+		public void DisconnectQueries () => session.DisconnectQueries ();
+
 		public void Stop ()
 		{
 			if (service != null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
@@ -163,9 +163,11 @@ namespace MonoDevelop.Components.AutoTest
 		
 		public void DetachClient (IAutoTestClient client)
 		{
-			if (client == this.client)
+			if (client == this.client) {
 				this.client = null;
-			else
+				currentSession?.Dispose ();
+				currentSession = null;
+			} else
 				throw new InvalidOperationException ("Not connected");
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopPersistentStorageLocationService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopPersistentStorageLocationService.cs
@@ -151,6 +151,11 @@ namespace MonoDevelop.Ide.TypeSystem
 		void DisconnectCurrentStorage ()
 		{
 			lock (_gate) {
+				var workspace = TypeSystemService.GetWorkspace (primaryWorkspace);
+				var solution = workspace.MonoDevelopSolution;
+				if (solution != null)
+					solution.Modified -= OnSolutionModified;
+
 				// We want to make sure everybody synchronously detaches
 				OnWorkingFolderChanging_NoLock (
 					new PersistentStorageLocationChangingEventArgs (

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
@@ -85,17 +85,36 @@ namespace MonoDevelop.Ide.TypeSystem
 				}
 			}
 
-			internal void RemoveProject (MonoDevelop.Projects.Project project, ProjectId id)
+			internal void RemoveProject (MonoDevelop.Projects.Project project)
 			{
+				ProjectId projectId;
+
 				lock (gate) {
-					if (projectIdMap.TryGetValue (project, out ProjectId val))
+					if (projectIdMap.TryGetValue (project, out projectId)) {
 						projectIdMap.Remove (project);
-					projectIdToMdProjectMap = projectIdToMdProjectMap.Remove (val);
+						projectIdToMdProjectMap = projectIdToMdProjectMap.Remove (projectId);
+					}
 				}
 
-				lock (updatingProjectDataLock) {
-					projectDataMap.Remove (id);
+				if (projectId != null) {
+					RemoveData (projectId);
 				}
+			}
+
+			internal MonoDevelop.Projects.Project RemoveProject (ProjectId id)
+			{
+				MonoDevelop.Projects.Project actualProject;
+
+				lock (gate) {
+					if (projectIdToMdProjectMap.TryGetValue (id, out actualProject)) {
+						projectIdMap.Remove (actualProject);
+						projectIdToMdProjectMap = projectIdToMdProjectMap.Remove (id);
+					}
+				}
+
+				RemoveData (id);
+
+				return actualProject;
 			}
 
 			internal MonoDevelop.Projects.Project GetMonoProject (ProjectId projectId)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -81,7 +81,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		ProjectDataMap ProjectMap { get; }
 		ProjectSystemHandler ProjectHandler { get; }
 
-		public MonoDevelop.Projects.Solution MonoDevelopSolution { get; }
+		public MonoDevelop.Projects.Solution MonoDevelopSolution { get; private set; }
 
 		internal MonoDevelopMetadataReferenceManager MetadataReferenceManager => manager.Value;
 		internal static HostServices HostServices => CompositionManager.Instance.HostServices;
@@ -275,6 +275,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				foreach (var prj in MonoDevelopSolution.GetAllProjects ()) {
 					UnloadMonoProject (prj);
 				}
+				MonoDevelopSolution = null;
 			}
 
 			var solutionCrawler = Services.GetService<ISolutionCrawlerRegistrationService> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -303,6 +303,9 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 
 			base.Dispose (finalize);
+
+			// Do this at the end so solution removal from base disposal is done properly.
+			MonoDevelopSolution = null;
 		}
 
 		internal void InformDocumentTextChange (DocumentId id, SourceText text)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1127,13 +1127,6 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			var id = GetProjectId (project);
 			if (id != null) {
-				foreach (var docId in GetOpenDocumentIds (id).ToList ()) {
-					ClearOpenDocument (docId);
-				}
-
-				ProjectMap.RemoveProject (project, id);
-				UnloadMonoProject (project);
-
 				OnProjectRemoved (id);
 			}
 		}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
@@ -49,7 +49,14 @@ namespace MonoDevelop.Ide.TypeSystem
 				var projectInMap = map.GetMonoProject (pid);
 				Assert.AreSame (project, projectInMap);
 
-				map.RemoveProject (project, pid);
+				var projectRemovedFromMap = map.RemoveProject (pid);
+				Assert.AreSame (projectInMap, projectRemovedFromMap);
+
+				Assert.IsNull (map.GetId (project));
+
+				pid = map.GetOrCreateId (project, null);
+				map.RemoveProject (project);
+
 				Assert.IsNull (map.GetId (project));
 			}
 		}

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.StressTest
 		public int Iterations { get; set; } = 1;
 		ProfilerProcessor profilerProcessor;
 
-		const int cleanupIteration = int.MaxValue;
+		const int cleanupIteration = int.MinValue;
 
 		public void Start ()
 		{
@@ -91,6 +91,8 @@ namespace MonoDevelop.StressTest
 			for (int i = 0; i < Iterations; ++i) {
 				scenario.Run ();
 				ReportMemoryUsage (i);
+				// This is to prevent leaking of AppQuery instances.
+				TestService.Session.DisconnectQueries ();
 			}
 
 			UserInterfaceTests.Ide.CloseAll (exit: false);

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
@@ -90,9 +90,11 @@ namespace MonoDevelop.StressTest
 			ReportMemoryUsage (-1);
 			for (int i = 0; i < Iterations; ++i) {
 				scenario.Run ();
-				ReportMemoryUsage (i);
+
 				// This is to prevent leaking of AppQuery instances.
 				TestService.Session.DisconnectQueries ();
+
+				ReportMemoryUsage (i);
 			}
 
 			UserInterfaceTests.Ide.CloseAll (exit: false);

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
@@ -56,6 +56,8 @@ namespace MonoDevelop.StressTest
 		public int Iterations { get; set; } = 1;
 		ProfilerProcessor profilerProcessor;
 
+		const int cleanupIteration = int.MaxValue;
+
 		public void Start ()
 		{
 			ValidateMonoDevelopBinPath ();
@@ -90,6 +92,9 @@ namespace MonoDevelop.StressTest
 				scenario.Run ();
 				ReportMemoryUsage (i);
 			}
+
+			UserInterfaceTests.Ide.CloseAll (exit: false);
+			ReportMemoryUsage (cleanupIteration);
 		}
 
 		public void Stop ()
@@ -165,7 +170,11 @@ namespace MonoDevelop.StressTest
 
 			var memoryStats = TestService.Session.MemoryStats;
 
-			Console.WriteLine ("Run {0}", iteration + 1);
+			if (iteration == cleanupIteration) {
+				Console.WriteLine ("Cleanup");
+			} else {
+				Console.WriteLine ("Run {0}", iteration + 1);
+			}
 
 			Console.WriteLine ("  NonPagedSystemMemory: " + memoryStats.NonPagedSystemMemory);
 			Console.WriteLine ("  PagedMemory: " + memoryStats.PagedMemory);

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
@@ -90,10 +90,6 @@ namespace MonoDevelop.StressTest
 			ReportMemoryUsage (-1);
 			for (int i = 0; i < Iterations; ++i) {
 				scenario.Run ();
-
-				// This is to prevent leaking of AppQuery instances.
-				TestService.Session.DisconnectQueries ();
-
 				ReportMemoryUsage (i);
 			}
 
@@ -167,6 +163,9 @@ namespace MonoDevelop.StressTest
 
 		void ReportMemoryUsage (int iteration)
 		{
+			// This is to prevent leaking of AppQuery instances.
+			TestService.Session.DisconnectQueries ();
+
 			UserInterfaceTests.Ide.WaitForIdeIdle ();//Make sure IDE stops doing what it was doing
 			if (profilerProcessor != null) {
 				profilerProcessor.TakeHeapshotAndMakeReport ().Wait ();

--- a/main/tests/UserInterfaceTests/Ide.cs
+++ b/main/tests/UserInterfaceTests/Ide.cs
@@ -50,11 +50,12 @@ namespace UserInterfaceTests
 			Assert.AreEqual (file, GetActiveDocumentFilename ());
 		}
 
-		public static void CloseAll ()
+		public static void CloseAll (bool exit = true)
 		{
 			Session.ExecuteCommand (FileCommands.SaveAll);
 			Session.ExecuteCommand (FileCommands.CloseWorkspace);
-			Session.ExitApp ();
+			if (exit)
+				Session.ExitApp ();
 		}
 
 		public static FilePath GetActiveDocumentFilename ()


### PR DESCRIPTION
This mitigates the leak that happen at the workspace level by making the leak really small (just the workspace instance with no data in it).

This should help with our current situation where we leak ~everything.

There's still a few leaks here and there, but I'll open a different PR for that, as I have automated the leak retention process using the stress test tool.

Fixes VSTS #788777 - Change the MonoDevelopWorkspace model to have a primary and secondary workspaces

Should supersede https://github.com/mono/monodevelop/pull/7159
