### PR TITLE
[SourceControl] Add a new command to go back  to previous blame

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -560,7 +560,7 @@ namespace MonoDevelop.VersionControl.Views
 			[CommandUpdateHandler (BlameCommands.ShowPreviousBlame)]
 			protected void OnUpdateShowPreviousBlame (CommandInfo cinfo)
 			{
-				cinfo.Enabled = history.Count == 0;
+				cinfo.Enabled = history.Count > 0;
 			}
 
 			protected override bool OnButtonReleaseEvent (EventButton evnt)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -532,12 +532,11 @@ namespace MonoDevelop.VersionControl.Views
 			protected void OnShowBlameBefore ()
 			{
 				var current = menuAnnotation?.Revision;
-				history.Push (current);
-
 				var rev = current?.GetPrevious () ?? widget.info.History.FirstOrDefault ();
 				if (rev == null)
 					return;
-				
+
+				history.Push (current);
 				widget.revision = rev;
 				UpdateAnnotations ();
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.VersionControl.Views
 			get {
 				return revision;
 			}
-			set {
+			private set {
 				revision = value;
 			}
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -44,7 +44,8 @@ namespace MonoDevelop.VersionControl.Views
 		CopyRevision,
 		ShowDiff,
 		ShowLog,
-		ShowBlameBefore
+		ShowBlameBefore,
+		ShowPreviousBlame
 	}
 	
 	class BlameWidget : Bin
@@ -54,6 +55,9 @@ namespace MonoDevelop.VersionControl.Views
 		public Revision Revision {
 			get {
 				return revision;
+			}
+			set {
+				revision = value;
 			}
 		}
 
@@ -364,6 +368,7 @@ namespace MonoDevelop.VersionControl.Views
 			double dragPosition = -1;
 
 			TextDocument document;
+			Stack<Revision> history = new Stack<Revision> ();
 
 			public BlameRenderer (BlameWidget widget)
 			{
@@ -453,6 +458,7 @@ namespace MonoDevelop.VersionControl.Views
 					CommandEntrySet opset = new CommandEntrySet ();
 					opset.AddItem (BlameCommands.ShowDiff);
 					opset.AddItem (BlameCommands.ShowLog);
+					opset.AddItem (BlameCommands.ShowPreviousBlame);
 					opset.AddItem (BlameCommands.ShowBlameBefore);
 					opset.AddItem (Command.Separator);
 					opset.AddItem (BlameCommands.CopyRevision);
@@ -526,7 +532,9 @@ namespace MonoDevelop.VersionControl.Views
 			protected void OnShowBlameBefore ()
 			{
 				var current = menuAnnotation?.Revision;
-				Revision rev = current?.GetPrevious () ?? widget.info.History.FirstOrDefault ();
+				history.Push (current);
+
+				var rev = current?.GetPrevious () ?? widget.info.History.FirstOrDefault ();
 				if (rev == null)
 					return;
 				
@@ -541,7 +549,20 @@ namespace MonoDevelop.VersionControl.Views
 				// If we have a working copy segment or we have a parent commit.
 				cinfo.Enabled = current == null || current.GetPrevious () != null;
 			}
-			
+
+			[CommandHandler (BlameCommands.ShowPreviousBlame)]
+			protected void OnShowPreviousBlame ()
+			{
+				widget.Revision = history.Pop ();
+				UpdateAnnotations ();
+			}
+
+			[CommandUpdateHandler (BlameCommands.ShowPreviousBlame)]
+			protected void OnUpdateShowPreviousBlame (CommandInfo cinfo)
+			{
+				cinfo.Enabled = history.Count == 0;
+			}
+
 			protected override bool OnButtonReleaseEvent (EventButton evnt)
 			{
 				if (dragPosition >= 0) {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
@@ -193,7 +193,9 @@
 		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowLog"
 			_label = "S_how Log"/>
 		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowBlameBefore"
-			_label = "Show _Authors prior to this change"/>
+			_label = "Show _Authors prior to this change"/>			
+		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowPreviousBlame"
+			_label = "Show _Previous Blame"/>
 		</Category>
 	</Extension>
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
@@ -195,7 +195,7 @@
 		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowBlameBefore"
 			_label = "Show _Authors prior to this change"/>			
 		<Command id = "MonoDevelop.VersionControl.Views.BlameCommands.ShowPreviousBlame"
-			_label = "Show _Previous Blame"/>
+			_label = "Back to _Previous view"/>
 		</Category>
 	</Extension>
 


### PR DESCRIPTION
In the Authors tab, there is a history of all the users that modified the file in the right panel.

When we press Show "authors before this change", our context has changed with new information, but there is no way to go back to the author's page.

This PR adds a new command to go back  to previous blame

Fixes VSTS #790407 - Blame view: no way back in history (once you select to show blame before the current, you can’t come back)

https://devdiv.visualstudio.com/DevDiv/_queries/edit/790407/?triage=true

![blame](https://user-images.githubusercontent.com/1587480/52956511-a4383e00-338f-11e9-8cb4-553a8bc96a92.gif)

