### PR TITLE
[SourceControl] Hiddes merge tab in case of no conflicting file

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeView.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using MonoDevelop.Components;
 using MonoDevelop.Core;
+using System.Linq;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -34,7 +35,8 @@ namespace MonoDevelop.VersionControl.Views
 	
 	class MergeView : BaseView, IMergeView
 	{
-		VersionControlDocumentInfo info;
+		readonly VersionControlDocumentInfo info;
+		readonly FileEventInfo fileEventInfo;
 		MergeWidget widget;
 		readonly MergeWidgetContainer widgetContainer;
 		readonly Gtk.Label NoMergeConflictsLabel;
@@ -44,6 +46,7 @@ namespace MonoDevelop.VersionControl.Views
 		public MergeView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Merge"), GettextCatalog.GetString ("Shows the merge view for the current file"))
 		{
 			this.info = info;
+			fileEventInfo = new FileEventInfo (info.Item.Path.FullPath, info.Item.IsDirectory);
 			widgetContainer = new MergeWidgetContainer ();
 			NoMergeConflictsLabel = new Gtk.Label () { Text = GettextCatalog.GetString ("No merge conflicts detected.") };
 			FileService.FileChanged += FileService_FileChanged;
@@ -73,7 +76,13 @@ namespace MonoDevelop.VersionControl.Views
 			if (widgetContainer.Content == null) {
 				return;
 			}
-			//if is shown we refresh we show the content and refresh the editor if was the case
+
+			//continue only if file server detected some change in this file
+			if (e.All (s => s.FileName.CompareTo (fileEventInfo.FileName) < 0)) {
+				return;
+			}
+
+			//if it is shown we refresh we show the content and refresh the editor (probably this nee
 			info.Start ();
 			RefreshContent ();
 			RefreshMergeEditor ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/MergeView.cs
@@ -36,34 +36,103 @@ namespace MonoDevelop.VersionControl.Views
 	{
 		VersionControlDocumentInfo info;
 		MergeWidget widget;
+		readonly MergeWidgetContainer widgetContainer;
+		readonly Gtk.Label NoMergeConflictsLabel;
 
-		public override Control Control { 
-			get {
-				if (widget == null) {
-					widget = new MergeWidget ();
-					widget.Load (info);
-				}
-				
-				return widget;
-			}
-		}
+		public override Control Control => widgetContainer;
 
 		public MergeView (VersionControlDocumentInfo info) : base (GettextCatalog.GetString ("Merge"), GettextCatalog.GetString ("Shows the merge view for the current file"))
 		{
 			this.info = info;
+			widgetContainer = new MergeWidgetContainer ();
+			NoMergeConflictsLabel = new Gtk.Label () { Text = GettextCatalog.GetString ("No merge conflicts detected.") };
+			FileService.FileChanged += FileService_FileChanged;
+		}
+
+		void RefreshContent ()
+		{
+			var isConflicted = info?.Item?.VersionInfo?.Status.HasFlag (VersionStatus.Conflicted) ?? false;
+			if (isConflicted) {
+				if (widget == null) {
+					widget = new MergeWidget ();
+					widget.Load (info);
+				}
+				if (widgetContainer.Content != widget) {
+					widgetContainer.Content = widget;
+				}
+			} else {
+				if (widgetContainer.Content != NoMergeConflictsLabel) {
+					widgetContainer.Content = NoMergeConflictsLabel;
+				}
+			}
+		}
+
+		void FileService_FileChanged (object sender, FileEventArgs e)
+		{
+			//content is null when is deselected
+			if (widgetContainer.Content == null) {
+				return;
+			}
+			//if is shown we refresh we show the content and refresh the editor if was the case
+			info.Start ();
+			RefreshContent ();
+			RefreshMergeEditor ();
 		}
 
 		protected override void OnSelected ()
 		{
-			widget.UpdateLocalText ();
-			widget.info.Start ();
+			info.Start ();
+			RefreshContent ();
+			RefreshMergeEditor ();
+		}
 
-			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
-			if (buffer != null) {
-				var loc = buffer.CaretLocation;
-				int line = loc.Line < 1 ? 1 : loc.Line;
-				int column = loc.Column < 1 ? 1 : loc.Column;
-				widget.MainEditor.SetCaretTo (line, column);
+		void RefreshMergeEditor ()
+		{
+			if (widgetContainer.Content is MergeWidget) {
+				widget.UpdateLocalText ();
+				var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
+				if (buffer != null) {
+					var loc = buffer.CaretLocation;
+					int line = loc.Line < 1 ? 1 : loc.Line;
+					int column = loc.Column < 1 ? 1 : loc.Column;
+					widget.MainEditor.SetCaretTo (line, column);
+				}
+			}
+		}
+
+		void ClearContainer () => widgetContainer.Clear ();
+
+		protected override void OnDeselected () => ClearContainer ();
+
+		public override void Dispose ()
+		{
+			ClearContainer ();
+			FileService.FileChanged -= FileService_FileChanged;
+			base.Dispose ();
+		}
+
+		class MergeWidgetContainer : Gtk.VBox
+		{
+			Gtk.Widget content;
+			public Gtk.Widget Content {
+				get => content;
+				set {
+					if (content == value) {
+						return;
+					}
+					Clear ();
+					content = value;
+					PackStart (value, true, true, 0);
+					ShowAll ();
+				}
+			}
+
+			public void Clear ()
+			{
+				if (content != null) {
+					Remove (content);
+					content = null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hiddes merge tab in case of no conflicting file

Fixes VSTS #790409 - Merge view: should be hidden if there is no merge pending for the current file
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/790409

![conflict](https://user-images.githubusercontent.com/1587480/52971080-639feb00-33b6-11e9-9847-36dbd246e1ca.gif)