### PR TITLE
[VersionControl] Fixes an error publish a project to Git

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -582,21 +582,16 @@ namespace MonoDevelop.VersionControl.Git
 						CredentialsProvider = (url, userFromUrl, types) => GitCredentials.TryGet (url, userFromUrl, types, credType)
 					});
 				} catch(VersionControlException vcex) {
+					RootRepository.Dispose ();
+					RootRepository = null;
+					if (RootPath.Combine (".git").IsDirectory)
+						Directory.Delete (RootPath.Combine (".git"), true);
 					LoggingService.LogError ("Failed to publish to the repository", vcex);
-					DeleteGitFolder ();
 					throw;
 				}
 			});
 
 			return this;
-		}
-
-		void DeleteGitFolder()
-		{
-			RootRepository.Dispose ();
-			RootRepository = null;
-			if (RootPath.Combine (".git").IsDirectory)
-				Directory.Delete (RootPath.Combine (".git"), true);
 		}
 
 		protected override void OnUpdate (FilePath[] localPaths, bool recurse, ProgressMonitor monitor)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -519,7 +519,7 @@ namespace MonoDevelop.VersionControl
 		// repository directory (must use absolute local paths).
 		public Repository Publish (string serverPath, FilePath localPath, FilePath[] files, string message, ProgressMonitor monitor)
 		{
-			var metadata = new PublishMetadata (VersionControlSystem) { PathsCount = files.Length, SubFolder = localPath.IsChildPathOf (RootPath) };
+			var metadata = new PublishMetadata (VersionControlSystem) { PathsCount = files.Length, SubFolder = localPath.IsChildPathOf(RootPath) };
 			using (var tracker = Instrumentation.PublishCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
 					var res = OnPublish (serverPath, localPath, files, message, monitor);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -519,7 +519,7 @@ namespace MonoDevelop.VersionControl
 		// repository directory (must use absolute local paths).
 		public Repository Publish (string serverPath, FilePath localPath, FilePath[] files, string message, ProgressMonitor monitor)
 		{
-			var metadata = new PublishMetadata (VersionControlSystem) { PathsCount = files.Length, SubFolder = localPath.IsChildPathOf(RootPath) };
+			var metadata = new PublishMetadata (VersionControlSystem) { PathsCount = files.Length, SubFolder = !RootPath.IsNullOrEmpty && localPath.IsChildPathOf(RootPath) };
 			using (var tracker = Instrumentation.PublishCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
 					var res = OnPublish (serverPath, localPath, files, message, monitor);


### PR DESCRIPTION
Fixes and error validation paths publishing a project to a Git repository. 
Fixes also another issue trying to publish a project and canceling the process. In these cases the folder .git was created and MD manage the project as if it were under VCS.

Fixes gh #7175 
Fixes gh #7163