### PR TITLE
[Core] Add a counter for installed user addins

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -123,7 +123,6 @@ namespace MonoDevelop.Core
 					AddinManager.Registry.Update (null);
 				setupService = new AddinSetupService (AddinManager.Registry);
 				Counters.RuntimeInitialization.Trace ("Initialized Addin Manager");
-				ReportUserAddins ();
 				
 				PropertyService.Initialize ();
 
@@ -154,25 +153,6 @@ namespace MonoDevelop.Core
 			} finally {
 				Counters.RuntimeInitialization.EndTiming ();
 			}
-		}
-
-		static void ReportUserAddins ()
-		{
-			Counters.UserAddins.Inc (1, null, GetUserAddinsMetadata ());
-		}
-
-		static IDictionary<string, object> GetUserAddinsMetadata ()
-		{
-			var metadata = new Dictionary<string, object> ();
-
-			foreach (Addin addin in AddinManager.Registry.GetModules (AddinSearchFlags.IncludeAddins | AddinSearchFlags.LatestVersionsOnly)) {
-				if (addin.IsUserAddin && addin.Enabled) {
-					string id = Addin.GetFullId (addin.Namespace, addin.LocalId, null);
-					metadata [id] = addin.Version;
-				}
-			}
-
-			return metadata;
 		}
 
 		static void RegisterAddinRepositories ()
@@ -565,7 +545,6 @@ namespace MonoDevelop.Core
 		public static TimerCounter PropertyServiceInitialization = InstrumentationService.CreateTimerCounter ("Property Service initialization", "Runtime");
 		
 		public static Counter AddinsLoaded = InstrumentationService.CreateCounter ("Add-ins loaded", "Add-in Engine", true, id:"Core.AddinsLoaded");
-		public static Counter UserAddins = InstrumentationService.CreateCounter ("User Add-ins", "Add-in Engine", id:"Core.UserAddins");
 
 		public static Counter ProcessesStarted = InstrumentationService.CreateCounter ("Processes started", "Process Service");
 		public static Counter ExternalObjects = InstrumentationService.CreateCounter ("External objects", "Process Service");

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs
@@ -123,6 +123,7 @@ namespace MonoDevelop.Core
 					AddinManager.Registry.Update (null);
 				setupService = new AddinSetupService (AddinManager.Registry);
 				Counters.RuntimeInitialization.Trace ("Initialized Addin Manager");
+				ReportUserAddins ();
 				
 				PropertyService.Initialize ();
 
@@ -154,7 +155,26 @@ namespace MonoDevelop.Core
 				Counters.RuntimeInitialization.EndTiming ();
 			}
 		}
-		
+
+		static void ReportUserAddins ()
+		{
+			Counters.UserAddins.Inc (1, null, GetUserAddinsMetadata ());
+		}
+
+		static IDictionary<string, object> GetUserAddinsMetadata ()
+		{
+			var metadata = new Dictionary<string, object> ();
+
+			foreach (Addin addin in AddinManager.Registry.GetModules (AddinSearchFlags.IncludeAddins | AddinSearchFlags.LatestVersionsOnly)) {
+				if (addin.IsUserAddin && addin.Enabled) {
+					string id = Addin.GetFullId (addin.Namespace, addin.LocalId, null);
+					metadata [id] = addin.Version;
+				}
+			}
+
+			return metadata;
+		}
+
 		static void RegisterAddinRepositories ()
 		{
 			var validUrls = Enum.GetValues (typeof(UpdateLevel)).Cast<UpdateLevel> ().Select (v => setupService.GetMainRepositoryUrl (v)).ToList ();
@@ -545,7 +565,8 @@ namespace MonoDevelop.Core
 		public static TimerCounter PropertyServiceInitialization = InstrumentationService.CreateTimerCounter ("Property Service initialization", "Runtime");
 		
 		public static Counter AddinsLoaded = InstrumentationService.CreateCounter ("Add-ins loaded", "Add-in Engine", true, id:"Core.AddinsLoaded");
-		
+		public static Counter UserAddins = InstrumentationService.CreateCounter ("User Add-ins", "Add-in Engine", id:"Core.UserAddins");
+
 		public static Counter ProcessesStarted = InstrumentationService.CreateCounter ("Processes started", "Process Service");
 		public static Counter ExternalObjects = InstrumentationService.CreateCounter ("External objects", "Process Service");
 		public static Counter ExternalHostProcesses = InstrumentationService.CreateCounter ("External processes hosting objects", "Process Service");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -51,6 +51,7 @@ using MonoDevelop.Ide.Templates;
 using System.Threading.Tasks;
 using MonoDevelop.Ide.RoslynServices.Options;
 using MonoDevelop.Ide.RoslynServices;
+using MonoDevelop.Ide.Updater;
 
 namespace MonoDevelop.Ide
 {
@@ -376,7 +377,7 @@ namespace MonoDevelop.Ide
 					}
 				} else if (file.FileName.HasExtension ("mpack")) {
 					var service = new SetupService (AddinManager.Registry);
-					AddinManagerWindow.RunToInstallFile (Workbench.RootWindow,
+					AddinsUpdateHandler.RunToInstallFile (Workbench.RootWindow,
 					                                     service,
 					                                     file.FileName.FullPath);
 				} else {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -58,6 +58,7 @@ using MonoDevelop.Components.Extensions;
 using MonoDevelop.Ide.Desktop;
 using System.Threading.Tasks;
 using MonoDevelop.Components;
+using MonoDevelop.Ide.Updater;
 
 namespace MonoDevelop.Ide
 {
@@ -391,6 +392,7 @@ namespace MonoDevelop.Ide
 			IdeApp.Workbench.DocumentOpened += CompleteFileTimeToCode;
 
 			CreateStartupMetadata (startupInfo, sectionTimings);
+			AddinsUpdateHandler.ReportUserAddins ();
 
 			GLib.Idle.Add (OnIdle);
 			IdeApp.Run ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -70,6 +70,7 @@ namespace MonoDevelop.Ide
 		internal static TimerCounter<BuildAndDeployMetadata> BuildAndDeploy = InstrumentationService.CreateTimerCounter<BuildAndDeployMetadata> ("Build and Deploy", "IDE", id: "Ide.BuildAndDeploy");
 		internal static Counter<PlatformMemoryMetadata> MemoryPressure = InstrumentationService.CreateCounter<PlatformMemoryMetadata> ("Memory Pressure", "IDE", id: "Ide.MemoryPressure");
 		internal static Counter<PlatformThermalMetadata> ThermalNotification = InstrumentationService.CreateCounter<PlatformThermalMetadata> ("Thermal Notification", "IDE", id: "Ide.ThermalNotification");
+		internal static Counter UserAddins = InstrumentationService.CreateCounter ("User Add-ins", "IDE", id:"Ide.UserAddins");
 
 		internal static Counter<UnhandledExceptionMetadata> UnhandledExceptions = InstrumentationService.CreateCounter<UnhandledExceptionMetadata> ("Unhandled Exceptions", "IDE", id: "Ide.UnhandledExceptions");
 		internal static class ParserService {


### PR DESCRIPTION
Reports the addin id and version for all installed and enabled user
addins.

Fixes VSTS #712478 - Add Telemetry to identify extensions installed

Currently this does not handle addins being disabled/enabled or installed/uninstalled.

The AddinManager.AddinUnloaded event can be used for disabling and uninstalling.

However AddinManager.AddinLoaded fires on startup or when an addin is lazily loaded. So it does not necessarily indicate an addin is being installed or enabled. It seems like we would need the AddinEngine's ActivateAddin to fire an event. That seems to be called by the AddinDatabase on installing a new addin.

Another possibility would be to cache the list of user installed addins and every time the AddinLoaded event is fired the AddinManager's Registry is checked to see if there is a difference. Although this would mean using memory just for a counter that might not be used during an IDE session.

Or not as good, we could send an event on shutdown listing the installed addins at the end of the IDE session.