### PR TITLE
Use bound configuration properties for OnTheFlyFormatting options

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormattingPanel.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormattingPanel.cs
@@ -68,31 +68,34 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			readonly CheckBox formatOnCloseBraceCheckBox;
 			readonly CheckBox formatOnReturnCheckBox;
 			readonly CheckBox formatOnPasteCheckBox;
+			readonly Ide.RoslynServices.Options.RoslynPreferences.PerLanguagePreferences preferences;
 
 			public OnTheFlyFormattingPanelWidget ()
 			{
+				preferences = Ide.IdeApp.Preferences.Roslyn.CSharp;
+
 				OptionService = TypeSystemService.Workspace.Services.GetService<IOptionService> ();
 				formatOnTypeCheckBox = new CheckBox (GettextCatalog.GetString ("Automatically format when typing"));
-				formatOnTypeCheckBox.Active = OptionService.GetOption (FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp);
+				formatOnTypeCheckBox.Active = preferences.AutoFormattingOnTyping;
 				formatOnTypeCheckBox.Toggled += FormatOnTypeCheckBox_Toggled;
 				PackStart (formatOnTypeCheckBox);
 
 				formatOnSemicolonCheckBox = new CheckBox (GettextCatalog.GetString ("Automatically format statement on ;"));
-				formatOnSemicolonCheckBox.Active = OptionService.GetOption (FeatureOnOffOptions.AutoFormattingOnSemicolon, LanguageNames.CSharp);
+				formatOnSemicolonCheckBox.Active = preferences.AutoFormattingOnSemicolon;
 				formatOnSemicolonCheckBox.MarginLeft = 18;
 				PackStart (formatOnSemicolonCheckBox);
 
 				formatOnCloseBraceCheckBox = new CheckBox (GettextCatalog.GetString ("Automatically format block on }"));
-				formatOnCloseBraceCheckBox.Active = OptionService.GetOption (FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp);
+				formatOnCloseBraceCheckBox.Active = preferences.AutoFormattingOnCloseBrace;
 				formatOnCloseBraceCheckBox.MarginLeft = 18;
 				PackStart (formatOnCloseBraceCheckBox);
 
 				formatOnReturnCheckBox = new CheckBox (GettextCatalog.GetString ("Automatically format on return"));
-				formatOnReturnCheckBox.Active = OptionService.GetOption (FeatureOnOffOptions.AutoFormattingOnReturn, LanguageNames.CSharp);
+				formatOnReturnCheckBox.Active = preferences.AutoFormattingOnReturn;
 				PackStart (formatOnReturnCheckBox);
 
 				formatOnPasteCheckBox = new CheckBox (GettextCatalog.GetString ("Automatically format on paste"));
-				formatOnPasteCheckBox.Active = OptionService.GetOption (FeatureOnOffOptions.FormatOnPaste, LanguageNames.CSharp);
+				formatOnPasteCheckBox.Active = preferences.FormatOnPaste;
 				PackStart (formatOnPasteCheckBox);
 				FormatOnTypeCheckBox_Toggled (this, EventArgs.Empty);
 			}
@@ -105,14 +108,11 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 
 			public void ApplyChanges ()
 			{
-				var optionSet = this.OptionService.GetOptions ();
-				var changedOptions = optionSet
-					.WithChangedOption (FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp, formatOnTypeCheckBox.Active)
-					.WithChangedOption (FeatureOnOffOptions.AutoFormattingOnSemicolon, LanguageNames.CSharp, formatOnSemicolonCheckBox.Active)
-					.WithChangedOption (FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp, formatOnCloseBraceCheckBox.Active)
-					.WithChangedOption (FeatureOnOffOptions.AutoFormattingOnReturn, LanguageNames.CSharp, formatOnReturnCheckBox.Active)
-					.WithChangedOption (FeatureOnOffOptions.FormatOnPaste, LanguageNames.CSharp, formatOnPasteCheckBox.Active);
-				this.OptionService.SetOptions (changedOptions);
+				preferences.AutoFormattingOnTyping.Value = formatOnTypeCheckBox.Active;
+				preferences.AutoFormattingOnSemicolon.Value = formatOnSemicolonCheckBox.Active;
+				preferences.AutoFormattingOnCloseBrace.Value = formatOnCloseBraceCheckBox.Active;
+				preferences.AutoFormattingOnReturn.Value = formatOnReturnCheckBox.Active;
+				preferences.FormatOnPaste.Value = formatOnPasteCheckBox.Active;
 				PropertyService.SaveProperties ();
 
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.Properties.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.Properties.cs
@@ -168,8 +168,7 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			protected sealed override T OnGetValue () => deserializer (underlying.Value);
 			protected sealed override bool OnSetValue (T value)
 			{
-				underlying.Value = serializer (value);
-				return true;
+				return underlying.Set (serializer (value));
 			}
 
 			internal void SetSerializedValue (string value)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Options;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Implementation.TodoComments;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
@@ -63,6 +64,11 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			readonly string language;
 			readonly RoslynPreferences roslynPreferences;
 
+			public readonly ConfigurationProperty<bool> AutoFormattingOnCloseBrace;
+			public readonly ConfigurationProperty<bool> AutoFormattingOnReturn;
+			public readonly ConfigurationProperty<bool> AutoFormattingOnSemicolon;
+			public readonly ConfigurationProperty<bool> AutoFormattingOnTyping;
+			public readonly ConfigurationProperty<bool> FormatOnPaste;
 			public readonly ConfigurationProperty<bool> PlaceSystemNamespaceFirst;
 			public readonly ConfigurationProperty<bool> SeparateImportDirectiveGroups;
 			public readonly ConfigurationProperty<bool> SuggestForTypesInNuGetPackages;
@@ -72,6 +78,30 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			{
 				this.language = language;
 				roslynPreferences = preferences;
+
+				AutoFormattingOnCloseBrace = preferences.Wrap<bool> (
+					new OptionKey (FeatureOnOffOptions.AutoFormattingOnCloseBrace, language),
+					language + ".AutoFormattingOnCloseBrace"
+				);
+
+				AutoFormattingOnReturn = preferences.Wrap<bool> (
+					new OptionKey (FeatureOnOffOptions.AutoFormattingOnReturn, language),
+					language + ".AutoFormattingOnReturn"
+				);
+
+				AutoFormattingOnSemicolon = preferences.Wrap<bool> (
+					new OptionKey (FeatureOnOffOptions.AutoFormattingOnSemicolon, language),
+					language + ".AutoFormattingOnSemicolon"
+				);
+				AutoFormattingOnTyping = preferences.Wrap<bool> (
+					new OptionKey (FeatureOnOffOptions.AutoFormattingOnTyping, language),
+					language + ".AutoFormattingOnTyping"
+				);
+
+				FormatOnPaste = preferences.Wrap<bool> (
+					new OptionKey (FeatureOnOffOptions.FormatOnPaste, language),
+					language + ".FormatOnPaste"
+				);
 
 				PlaceSystemNamespaceFirst = preferences.Wrap<bool> (
 					new OptionKey (Microsoft.CodeAnalysis.Editing.GenerationOptions.PlaceSystemNamespaceFirst, language),


### PR DESCRIPTION
Fixes VSTS #795488 - Serialization error on enabling paste on format for
editor