### PR TITLE
[Version Control] If the Repository has no remotes, disable remote commands and show publish command

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Commands.cs
@@ -127,7 +127,16 @@ namespace MonoDevelop.VersionControl
 		{
 			return true;
 		}
-	}	
+	}
+
+	class PublishCommandHandler : SolutionVersionControlCommandHandler
+	{
+		protected override bool RunCommand (VersionControlItemList items, bool test)
+		{
+			VersionControlItem it = items [0];
+			return PublishCommand.Publish (items, it.WorkspaceObject, it.Path, test);
+		}
+	}
 
 	class UpdateCommandHandler: SolutionVersionControlCommandHandler
 	{

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/PublishCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/PublishCommand.cs
@@ -10,10 +10,16 @@ namespace MonoDevelop.VersionControl
 {
 	internal class PublishCommand 
 	{
-		public static bool Publish (WorkspaceObject entry, FilePath localPath, bool test)
+		public static bool Publish (VersionControlItemList items, WorkspaceObject entry, FilePath localPath, bool test)
 		{
-			if (test)
+			if (test) {
+				var canUpdate = !items.Any (it => it.VersionInfo.CanUpdate);
+
+				if (canUpdate)
+					return true;
+
 				return VersionControlService.CheckVersionControlInstalled () && VersionControlService.GetRepository (entry) == null;
+			}
 
 			List<FilePath> files = new List<FilePath> ();
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
@@ -465,7 +465,7 @@ namespace MonoDevelop.VersionControl
 				case Commands.Publish:
 					VersionControlItem it = items [0];
 					if (items.Count == 1 && it.IsDirectory && it.WorkspaceObject != null)
-						res = PublishCommand.Publish (it.WorkspaceObject, it.Path, test);
+					res = PublishCommand.Publish (items, it.WorkspaceObject, it.Path, test);
 					break;
 				case Commands.Annotate:
 					res = await BlameCommand.Show (items, test);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
@@ -152,6 +152,7 @@
 		<Command id = "MonoDevelop.VersionControl.Commands.Publish"
 			_label = "_Publish in Version Control..."
 			icon = "vc-push"
+			defaultHandler="MonoDevelop.VersionControl.PublishCommandHandler"
 			description = "Publish actual project into repository."/>
 		<Command id = "MonoDevelop.VersionControl.Commands.Checkout"
 			defaultHandler = "MonoDevelop.VersionControl.CheckoutCommand"


### PR DESCRIPTION
If the Repository has no remotes, we already disabled options like push, etc.
With this changes we add the option to publish visible without any remotes.

Fixes gh #7176