### PR TITLE
[VersionControl] Error creating branches 

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditBranchDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditBranchDialog.cs
@@ -37,6 +37,8 @@ namespace MonoDevelop.VersionControl.Git
 {
 	partial class EditBranchDialog : Gtk.Dialog
 	{
+		const int GitRefnameMax = 1024;
+
 		readonly ListStore comboStore;
 		readonly string currentTracking;
 		readonly string oldName;
@@ -80,6 +82,8 @@ namespace MonoDevelop.VersionControl.Git
 			checkTrack.Active = !string.IsNullOrEmpty (tracking);
 
 			UpdateStatus ();
+
+			WidthRequest = 400;
 		}
 
 		void AddValues (string name, Xwt.Drawing.Image icon, string prefix)
@@ -127,6 +131,10 @@ namespace MonoDevelop.VersionControl.Git
 				labelError.Markup = "<span color='" + Ide.Gui.Styles.ErrorForegroundColor.ToHexString (false) + "'>" + GettextCatalog.GetString (@"A branch name can not:
 Start with '.' or end with '/' or '.lock'
 Contain a ' ', '..', '~', '^', ':', '\', '?', '['") + "</span>";
+				labelError.Show ();
+				buttonOk.Sensitive = false;
+			} else if (entryName.Text.Length > GitRefnameMax) {
+				labelError.Markup = "<span color='" + Ide.Gui.Styles.ErrorForegroundColor.ToHexString (false) + "'>" + GettextCatalog.GetString ("Branch name too long") + "</span>";
 				labelError.Show ();
 				buttonOk.Sensitive = false;
 			} else

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -170,10 +170,12 @@ namespace MonoDevelop.VersionControl.Git
 		{
 			var dlg = new EditBranchDialog (repo);
 			try {
-				if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
+				if (MessageService.RunCustomDialog (dlg) == (int)ResponseType.Ok) {
 					repo.CreateBranch (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
 					FillBranches ();
 				}
+			} catch (Exception ex) {
+				MessageService.ShowError (GettextCatalog.GetString ("The branch could not be created"), ex);
 			} finally {
 				dlg.Destroy ();
 				dlg.Dispose ();


### PR DESCRIPTION
The first thing I considered is to add validations in the name of branches. Libgit2 has a method for it: https://libgit2.org/libgit2/#HEAD/group/reference/git_reference_is_valid_name
But we are using it: http://source.monodevelop.com/#MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/EditBranchDialog.cs,126

With this changes, show an error message to notify the user that there has been a problem creating the branch.

Fixes gh #7106 