### PR TITLE
[Roslyn] Fix NRE of solution when cancelling load

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
@@ -158,10 +158,10 @@ namespace MonoDevelop.Ide.Tasks
 			UpdateWorkspaceOptions (ws);
 		}
 
-		static async void OnWorkspaceItemClosed (object sender, WorkspaceItemEventArgs args)
+		static void OnWorkspaceItemClosed (object sender, WorkspaceItemEventArgs args)
 		{
 			if (args.Item is MonoDevelop.Projects.Solution sol) {
-				var ws = await TypeSystemService.GetWorkspaceAsync (sol);
+				var ws = TypeSystemService.GetWorkspace (sol);
 
 				lock (lockObject) {
 					if (cachedUntilViewCreated == null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -266,6 +266,9 @@ namespace MonoDevelop.Ide.TypeSystem
 							return await CreateSolutionInfoInternal (solution, token).ConfigureAwait (false);
 						}
 
+						if (token.IsCancellationRequested)
+							return null;
+
 						var solutionId = GetSolutionId (solution);
 						var solutionInfo = SolutionInfo.Create (solutionId, VersionStamp.Create (), solution.FileName, projectInfos);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -248,13 +248,13 @@ namespace MonoDevelop.Ide.TypeSystem
 				}
 			}
 
-			internal Task<SolutionInfo> CreateSolutionInfo (MonoDevelop.Projects.Solution sol, CancellationToken ct)
+			internal Task<(MonoDevelop.Projects.Solution, SolutionInfo)> CreateSolutionInfo (MonoDevelop.Projects.Solution sol, CancellationToken ct)
 			{
 				return Task.Run (delegate {
 					return CreateSolutionInfoInternal (sol, ct);
 				});
 
-				async Task<SolutionInfo> CreateSolutionInfoInternal (MonoDevelop.Projects.Solution solution, CancellationToken token)
+				async Task<(MonoDevelop.Projects.Solution, SolutionInfo)> CreateSolutionInfoInternal (MonoDevelop.Projects.Solution solution, CancellationToken token)
 				{
 					using (var timer = Counters.AnalysisTimer.BeginTiming ()) {
 						projections.ClearOldProjectionList ();
@@ -267,7 +267,7 @@ namespace MonoDevelop.Ide.TypeSystem
 						}
 
 						if (token.IsCancellationRequested)
-							return null;
+							return (solution, null);
 
 						var solutionId = GetSolutionId (solution);
 						var solutionInfo = SolutionInfo.Create (solutionId, VersionStamp.Create (), solution.FileName, projectInfos);
@@ -291,7 +291,7 @@ namespace MonoDevelop.Ide.TypeSystem
 						// ensures the type system does not have missing references that may have been added by
 						// the restore.
 						ReloadModifiedProjects ();
-						return solutionInfo;
+						return (solution, solutionInfo);
 					}
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -343,7 +343,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			var token = src.Token;
 
 			try {
-				var si = await ProjectHandler.CreateSolutionInfo (MonoDevelopSolution, token).ConfigureAwait (false);
+				var (solution, si) = await ProjectHandler.CreateSolutionInfo (MonoDevelopSolution, token).ConfigureAwait (false);
 				if (si != null)
 					OnSolutionReloaded (si);
 			} catch (OperationCanceledException) {
@@ -361,7 +361,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			ProjectHandler.ReloadModifiedProject (project);
 		}
 
-		internal Task<SolutionInfo> TryLoadSolution (CancellationToken cancellationToken = default(CancellationToken))
+		internal Task<(MonoDevelop.Projects.Solution, SolutionInfo)> TryLoadSolution (CancellationToken cancellationToken = default(CancellationToken))
 		{
 			return ProjectHandler.CreateSolutionInfo (MonoDevelopSolution, CancellationTokenSource.CreateLinkedTokenSource (cancellationToken, src.Token).Token);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -275,6 +275,8 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			disposed = true;
 
+			CancelLoad ();
+
 			var cacheService = Services.GetService<IWorkspaceCacheService> ();
 			if (cacheService != null)
 				cacheService.CacheFlushRequested -= OnCacheFlushRequested;
@@ -289,7 +291,6 @@ namespace MonoDevelop.Ide.TypeSystem
 			IdeApp.Preferences.Roslyn.FullSolutionAnalysisRuntimeEnabledChanged -= OnEnableFullSourceAnalysisChanged;
 			DesktopService.MemoryMonitor.StatusChanged -= OnMemoryStatusChanged;
 
-			CancelLoad ();
 			if (IdeApp.Workspace != null) {
 				IdeApp.Workspace.ActiveConfigurationChanged -= HandleActiveConfigurationChanged;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -184,6 +184,11 @@ namespace MonoDevelop.Ide.TypeSystem
 					if (result != emptyWorkspace) {
 						lock (workspaceLock)
 							workspaces = workspaces.Remove (result);
+
+						if (workspaceRequests.TryGetValue (solution, out var request)) {
+							request.TrySetCanceled ();
+						}
+
 						result.Dispose ();
 					}
 					solution.SolutionItemAdded -= OnSolutionItemAdded;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -150,9 +150,9 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (showStatusIcon)
 					workspace.ShowStatusIcon ();
 
-				var solutionInfo = await workspace.TryLoadSolution (cancellationToken).ConfigureAwait (false);
+				var (solution, solutionInfo) = await workspace.TryLoadSolution (cancellationToken).ConfigureAwait (false);
 
-				if (workspaceRequests.TryGetValue (workspace.MonoDevelopSolution, out var request)) {
+				if (workspaceRequests.TryGetValue (solution, out var request)) {
 					if (solutionInfo == null) {
 						// Check for solutionInfo == null rather than cancellation was requested, as cancellation does not happen
 						// after all project infos are loaded.


### PR DESCRIPTION
If a Workspace is disposed before load is finished, we would have a NRE on trying to add to the ConcurrentDictionary. Prevent that from happening.

Fixes VSTS 797986 - Unloading a solution while it's being loaded by the roslyn workspace can lead to NRE