### PR TITLE
[NuGet] Fix possible NullReferenceException

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
@@ -483,5 +483,20 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (expectedCacheFilePath, cacheFilePath);
 		}
+
+		[Test]
+		public void CanCreate_MSBuildProjectIsNull_DoesNotThrowNullReferenceException ()
+		{
+			var dotNetCoreProject = CreateDotNetCoreProject ();
+			dotNetCoreProject.Dispose ();
+
+			bool result = false;
+			Assert.DoesNotThrow (() => {
+				result = DotNetCoreNuGetProject.CanCreate (dotNetCoreProject);
+			});
+
+			Assert.IsNull (dotNetCoreProject.MSBuildProject);
+			Assert.IsFalse (result);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -108,7 +108,11 @@ namespace MonoDevelop.PackageManagement
 
 		public static bool CanCreate (DotNetProject project)
 		{
-			return project.MSBuildProject.GetReferencedSDKs ().Any ();
+			var msbuildProject = project.MSBuildProject;
+			if (msbuildProject == null)
+				return false;
+
+			return msbuildProject.GetReferencedSDKs ().Any ();
 		}
 
 		public static NuGetProject Create (DotNetProject project)


### PR DESCRIPTION
Handle a project being disposed when checking to see if it supports
NuGet. A disposed project will have a null MSBuildProject property.

Fixes VSTS #797960 - Null reference in DotNetCoreNuGetProject