### PR TITLE
[NuGet] Do not log errors for canceled tasks

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -382,6 +382,7 @@
     <Compile Include="NuGet.Commands\MSBuildUtility.cs" />
     <Compile Include="MonoDevelop.PackageManagement\MonoDevelopDependencyGraphRestoreUtility.cs" />
     <Compile Include="MonoDevelop.PackageManagement\DependencyGraphContextExtensions.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\ExceptionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForNuGetPackageUpdatesTaskRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/CheckForNuGetPackageUpdatesTaskRunner.cs
@@ -175,7 +175,8 @@ namespace MonoDevelop.PackageManagement
 
 		protected virtual void LogError (string message, Exception ex)
 		{
-			LoggingService.LogError (message, ex);
+			if (!ex.IsOperationCanceledException ())
+				LoggingService.LogError (message, ex);
 		}
 
 		protected virtual void GuiBackgroundDispatch (Action action)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ExceptionExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ExceptionExtensions.cs
@@ -1,0 +1,48 @@
+//
+// ExceptionExtensions.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NuGet.Protocol.Core.Types;
+
+namespace MonoDevelop.PackageManagement
+{
+	static class ExceptionExtensions
+	{
+		public static bool IsOperationCanceledException (this Exception ex)
+		{
+			var baseEx = ex.GetBaseException ();
+			if (baseEx is OperationCanceledException)
+				return true;
+
+			if (baseEx is NuGetProtocolException) {
+				// NuGet has the TaskCanceledException as an InnerException.
+				return baseEx.InnerException is OperationCanceledException;
+			}
+
+			return false;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementEventsMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementEventsMonitor.cs
@@ -141,7 +141,9 @@ namespace MonoDevelop.PackageManagement
 
 		public void ReportError (ProgressMonitorStatusMessage progressMessage, Exception ex, bool showPackageConsole = true)
 		{
-			LoggingService.LogError (progressMessage.Error, ex);
+			if (!ex.IsOperationCanceledException ())
+				LoggingService.LogError (progressMessage.Error, ex);
+
 			progressMonitor.Log.WriteLine (GetErrorMessageForPackageConsole (ex));
 			progressMonitor.ReportError (progressMessage.Error, null);
 			if (showPackageConsole)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesProvider.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdatedNuGetPackagesProvider.cs
@@ -146,7 +146,8 @@ namespace MonoDevelop.PackageManagement
 
 		void LogError (Task<PackageIdentity> task)
 		{
-			logError ("Check for updates error.", task.Exception.GetBaseException ());
+			if (!task.Exception.IsOperationCanceledException ())
+				logError ("Check for updates error.", task.Exception.GetBaseException ());
 		}
 
 		bool IsPackageVersionAllowed (IPackageSearchMetadata package, PackageReference packageReference)


### PR DESCRIPTION
Check the exception is not an OperationCanceledException when logging
failures on NuGet restore and check for updates.

Fixes VSTS #797961 - Task canceled error logged when checking for
updates