### PR TITLE
Fixes unexpected overlaps in pads with native contents in a DockGroup

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -335,7 +335,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		#endregion
 
-		internal void KeyReleased (object o, Gtk.KeyReleaseEventArgs ev)
+		internal void OnKeyReleased (object o, Gtk.KeyReleaseEventArgs ev)
 		{
 			ev.RetVal = true;
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.addin.xml
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.addin.xml
@@ -37,15 +37,28 @@
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Ide/Pads">
-		<Pad id = "MonoDevelop.DesignerSupport.ToolboxPad"
-			class = "MonoDevelop.DesignerSupport.ToolboxPad"
-			_label="Toolbox"
-			icon = "md-toolbox-pad"
-			group = "Designer"
-			defaultLayout="*"
-			defaultPlacement="Right"
-			defaultStatus="AutoHide"
-			/>
+		<Condition id="Platform" value="!mac">
+			<Pad id = "MonoDevelop.DesignerSupport.ToolboxPad"
+			        class = "MonoDevelop.DesignerSupport.ToolboxPad"
+			        _label="Toolbox"
+			        icon = "md-toolbox-pad"
+			        group = "Designer"
+			        defaultLayout="*"
+			        defaultPlacement="Right"
+			        defaultStatus="AutoHide"
+			        />
+		</Condition>
+		<Condition id="Platform" value="mac">
+			<Pad id = "MonoDevelop.DesignerSupport.ToolboxPad"
+		            class = "MonoDevelop.DesignerSupport.MacToolboxPad"
+		            _label="Toolbox"
+		            icon = "md-toolbox-pad"
+		            group = "Designer"
+		            defaultLayout="*"
+		            defaultPlacement="Right"
+		            defaultStatus="AutoHide"
+		            />
+		</Condition>
 		<Pad id = "MonoDevelop.DesignerSupport.PropertyPad"
 			class = "MonoDevelop.DesignerSupport.PropertyPad"
 			_label="Properties"

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -149,6 +149,7 @@
     <Compile Include="MonoDevelop.DesignerSupport.Toolbox\MacToolboxWidgetFlowLayoutDelegate.cs" />
     <Compile Include="MonoDevelop.DesignerSupport.Toolbox\Styles.cs" />
     <Compile Include="MonoDevelop.DesignerSupport.Toolbox\Toolbox.cs" />
+    <Compile Include="MonoDevelop.DesignerSupport\MacToolboxPad.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.DesignerSupport.addin.xml" />

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacToolboxPad.cs
@@ -1,0 +1,146 @@
+﻿//
+// ToolboxPad.cs: The pad that hold the MD toolbox.
+//
+// Authors:
+//   Michael Hutchinson <m.j.hutchinson@gmail.com>
+//
+// Copyright (C) 2006 Michael Hutchinson
+//
+//
+// This source code is licenced under The MIT License:
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+#if MAC
+using System;
+using MonoDevelop.Ide.Gui;
+using MonoDevelop.Components;
+using Gtk;
+
+namespace MonoDevelop.DesignerSupport
+{
+	public class MacToolboxPad : NativePadContent
+	{
+		Widget widget;
+
+		Toolbox.MacToolbox toolbox;
+
+		protected override void OnContentInitialized (Widget widget)
+		{
+			this.widget = widget;
+
+			widget.KeyPressEvent += toolbox.OnKeyPressed;
+			widget.KeyReleaseEvent += toolbox.OnKeyReleased;
+
+			widget.DragBegin += Widget_DragBegin;
+			widget.DragEnd += Widget_DragEnd; 
+			widget.Focused += Widget_Focused;
+		}
+
+		void Widget_Focused (object o, FocusedArgs args)
+		{
+			toolbox.FocusSelectedView ();
+		}
+
+		void Widget_DragEnd (object o, DragEndArgs args)
+		{
+			isDragging = false;
+		}
+
+		void Widget_DragBegin (object o, DragBeginArgs args)
+		{
+			if (!isDragging) {
+				DesignerSupport.Service.ToolboxService.DragSelectedItem (widget, args.Context);
+				isDragging = true;
+			}
+		}
+
+		protected override AppKit.NSView GetNativeContentView (IPadWindow window)
+		{
+			toolbox = new Toolbox.MacToolbox (DesignerSupport.Service.ToolboxService, window);
+			toolbox.ContentFocused += Toolbox_ContentFocused;
+			toolbox.DragSourceSet += Toolbox_DragSourceSet;
+			toolbox.DragBegin += Toolbox_DragBegin;
+
+			return toolbox;
+		}
+
+		void Toolbox_DragBegin (object sender, EventArgs e)
+		{
+			var selectedNode = toolbox.SelectedNode;
+			if (!isDragging && selectedNode != null) {
+
+				DesignerSupport.Service.ToolboxService.SelectItem (selectedNode);
+
+				Drag.SourceUnset (widget);
+
+				// Gtk.Application.CurrentEvent and other copied gdk_events seem to have a problem
+				// when used as they use gdk_event_copy which seems to crash on de-allocating the private slice.
+				var currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
+				Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent, false));
+
+				// gtk_drag_begin does not store the event, so we're okay
+				GtkWorkarounds.FreeEvent (currentEvent);
+
+			}
+		}
+
+		void Toolbox_DragSourceSet (object sender, TargetEntry [] e)
+		{
+			targets = new TargetList ();
+			targets.AddTable (e);
+		}
+
+		void Toolbox_ContentFocused (object sender, EventArgs e)
+		{
+			if (!widget.HasFocus) {
+				widget.HasFocus = true;
+				toolbox.FocusSelectedView ();
+			}
+		}
+
+		TargetList targets = new TargetList ();
+		bool isDragging;
+
+		public override void Dispose ()
+		{
+			if (widget != null) {
+				widget.KeyPressEvent -= toolbox.OnKeyPressed;
+				widget.KeyReleaseEvent -= toolbox.OnKeyReleased;
+				widget.DragBegin -= Widget_DragBegin;
+				widget.DragEnd -= Widget_DragEnd;
+				widget.Focused -= Widget_Focused;
+				//the base class disposes the object
+				widget = null;
+			}
+
+			if (toolbox != null) {
+				toolbox.ContentFocused -= Toolbox_ContentFocused;
+				toolbox.DragSourceSet -= Toolbox_DragSourceSet;
+				toolbox.DragBegin -= Toolbox_DragBegin;
+				toolbox.Dispose ();
+				toolbox = null;
+			}
+			base.Dispose ();
+		}
+
+	}
+}
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/NativePadContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/NativePadContent.cs
@@ -1,0 +1,107 @@
+﻿// NarivePadContent.cs
+//
+// Author:
+//   Jose Medrano (josmed@microsoft.com)
+//
+// Copyright (c) Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+
+#if MAC
+using AppKit;
+using MonoDevelop.Components;
+using MonoDevelop.Components.Mac;
+
+namespace MonoDevelop.Ide.Gui
+{
+	public abstract class NativePadContent : PadContent
+	{
+		NSView container;
+		Gtk.Widget widget;
+
+		public override Control Control => widget;
+
+		protected NativePadContent ()
+		{
+		}
+
+		protected NativePadContent (string title, string icon = null) : base (title, icon)
+		{
+		}
+
+		IPadWindow window;
+		protected override void Initialize (IPadWindow window)
+		{
+			this.window = window;
+			this.window.PadContentShown += OnPadContentShown;
+			this.window.PadContentHidden += OnPadContentHidden;
+
+			container = GetNativeContentView (window);
+			if (container == null) {
+				throw new System.Exception ($"GetContentView cannot be null in a NativePadContent ({this.GetType ()})");
+			}
+			widget = GtkMacInterop.NSViewToGtkWidget (container);
+			widget.CanFocus = true;
+			widget.Sensitive = true;
+
+			OnContentInitialized (widget);
+
+			widget.ShowAll ();
+		}
+
+		protected virtual void OnContentInitialized (Gtk.Widget widget)
+		{
+			//to implement
+		}
+
+		void OnPadContentHidden (object sender, System.EventArgs e)
+		{
+			container.Hidden = true;
+		}
+
+		void OnPadContentShown (object sender, System.EventArgs e)
+		{
+			container.Hidden = false;
+		}
+
+		internal void ShowAll () => widget.ShowAll ();
+
+		protected abstract NSView GetNativeContentView (IPadWindow window);
+
+		public override void Dispose ()
+		{
+			if (widget != null) {
+			
+				widget.Destroy ();
+				widget.Dispose ();
+				widget = null;
+			}
+
+			if (window != null) {
+				window.PadContentShown -= OnPadContentShown;
+				window.PadContentHidden -= OnPadContentHidden;
+				window = null;
+			}
+			base.Dispose ();
+		}
+	}
+}
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4237,6 +4237,7 @@
     <Compile Include="MonoDevelop.Ide.Projects\NewSolutionRunConfigurationDialog.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\HackyWorkspaceFilesCache.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.Dialogs\NewFolderDialog.cs" />
+    <Compile Include="MonoDevelop.Ide.Gui\NativePadContent.cs" />
   </ItemGroup>
   <ItemGroup>
     <Data Include="options\DefaultEditingLayout.xml" />


### PR DESCRIPTION
When we attach some Pad which contains a native view to a DockGroup, we are not handling how this native view acts when the content is shown or hidden.

To try to normalize this I created a NativePadContent which encapsulates all this logic to reuse in other cases, right now implemented in the Toolbox.

![clipissue](https://user-images.githubusercontent.com/1587480/53270761-e5f91980-36ec-11e9-90ee-3c6863123dbd.gif)

Fixes VSTS #790903 - Toolbox and Document Outline overlap each other
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/790903
