### PR TITLE
[Ide] Don't show NPD in its "constructor"

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -316,8 +316,6 @@ namespace MonoDevelop.Ide.Projects
 				Child.ShowAll ();
 			}
 
-			Show ();
-
 			templatesTreeView.HasFocus = true;
 			Resizable = false;
 		}


### PR DESCRIPTION
Doing so means the dialog is visible before actually running it via
MessageService, which tries to retrieve the current focused window,
which would be the NPD dialog itself, completely breaking the
child window positioning code.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/796030