### PR TITLE
Fix Add/Remove Element to Title selector

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -311,6 +311,7 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		}
 
 		static readonly IntPtr selSetAccessibilityServesAsTitleForUIElements_Handle = Selector.GetHandle ("setAccessibilityServesAsTitleForUIElements:");
+		static readonly IntPtr selAccessibilityServesAsTitleForUIElements_Handle = Selector.GetHandle ("accessibilityServesAsTitleForUIElements:");
 		public static void SetTitleFor (this Atk.Object o, params Atk.Object [] objects)
 		{
 			var nsa = GetNSAccessibilityElement (o);
@@ -348,7 +349,6 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			}
 		}
 
-		static readonly IntPtr selAccessibilityServesAsTitleForUIElements_Handle = Selector.GetHandle ("setAccessibilityServesAsTitleForUIElements:");
 		public static void AddElementToTitle (this Atk.Object title, Atk.Object o)
 		{
 			var titleNsa = GetNSAccessibilityElement (title);


### PR DESCRIPTION
```
  =================================================================
  	Managed Stacktrace:
  =================================================================
  	  at <unknown> <0xffffffff>
  	  at MonoDevelop.Components.Mac.Messaging:IntPtr_objc_msgSend <0x00064>
  	  at MonoDevelop.Components.AtkCocoaHelper.AtkCocoaMacExtensions:AddElementToTitle <0x000ba>
  	  at MonoDevelop.Ide.WelcomePage.WelcomePageSection:SetTitledWidget <0x000ca>
  	  at MonoDevelop.Ide.WelcomePage.WelcomePageRecentProjectsList:RecentFilesChanged <0x0033a>
  	  at MonoDevelop.Ide.WelcomePage.WelcomePageRecentProjectsList:.ctor <0x0022a>
  	  at MonoDevelop.Ide.WelcomePage.DefaultWelcomePage:BuildContent <0x006ea>
  	  at MonoDevelop.Ide.WelcomePage.WelcomePageWidget:.ctor <0x001f9>
  	  at MonoDevelop.Ide.WelcomePage.DefaultWelcomePage:.ctor <0x0001a>
  	  at MonoDevelop.Ide.WelcomePage.WelcomePageService:ShowWelcomePage <0x000ea>
  	  at MonoDevelop.Ide.IdeStartup:OnIdle <0x00082>
  	  at IdleProxy:Invoke <0x00019>
  	  at GLib.SourceProxy:HandlerInternal <0x00083>
  	  at GLib.SourceProxy:HandlerInternal <0x00062>
  	  at <unknown> <0xffffffff>
  	  at Gtk.Application:gtk_main <0x00056>
  	  at Gtk.Application:Run <0x00012>
  	  at MonoDevelop.Ide.IdeApp:Run <0x00022>
  	  at MonoDevelop.Ide.IdeStartup:Run <0x03402>
  	  at MonoDevelop.Ide.IdeStartup:Main <0x003d2>
  	  at MonoDevelop.Startup.MonoDevelopMain:Main <0x0001a>
  	  at <Module>:runtime_invoke_int_object <0x0010c>
  =================================================================
```

Fixes VSTS #802435 - Wrong selector being used in AtkCocoaExtensions