### PR TITLE
[Roslyn] Add more information about signing when applicable

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
@@ -144,6 +144,7 @@ namespace MonoDevelop.CSharp.Project
 				cryptoKeyFile: ParentConfiguration.SignAssembly ? ParentConfiguration.AssemblyKeyFile : null,
 				cryptoPublicKey: ImmutableArray<byte>.Empty,
 				platform: GetPlatform (),
+				delaySign: ParentConfiguration.DelaySign,
 				generalDiagnosticOption: TreatWarningsAsErrors ? ReportDiagnostic.Error : ReportDiagnostic.Default,
 				warningLevel: WarningLevel,
 				specificDiagnosticOptions: GetSpecificDiagnosticOptions (),

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
@@ -144,6 +144,7 @@ namespace MonoDevelop.CSharp.Project
 				cryptoKeyFile: ParentConfiguration.SignAssembly ? ParentConfiguration.AssemblyKeyFile : null,
 				cryptoPublicKey: ImmutableArray<byte>.Empty,
 				platform: GetPlatform (),
+				publicSign: ParentConfiguration.PublicSign,
 				delaySign: ParentConfiguration.DelaySign,
 				generalDiagnosticOption: TreatWarningsAsErrors ? ReportDiagnostic.Error : ReportDiagnostic.Default,
 				warningLevel: WarningLevel,

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.Projects
 			assembly = pset.GetValue ("AssemblyName");
 			signAssembly = pset.GetValue<bool> ("SignAssembly");
 			delaySign = pset.GetValue<bool> ("DelaySign");
-			PublicSign = pset.GetValue<bool> ("PublicSign");
+			PublicSign = pset.GetValue<bool> (nameof(PublicSign));
 			assemblyKeyFile = pset.GetPathValue ("AssemblyOriginatorKeyFile", FilePath.Empty);
 			if (string.IsNullOrEmpty (assemblyKeyFile))
 				assemblyKeyFile = pset.GetPathValue ("AssemblyKeyFile", FilePath.Empty);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProjectConfiguration.cs
@@ -63,6 +63,7 @@ namespace MonoDevelop.Projects
 			assembly = pset.GetValue ("AssemblyName");
 			signAssembly = pset.GetValue<bool> ("SignAssembly");
 			delaySign = pset.GetValue<bool> ("DelaySign");
+			PublicSign = pset.GetValue<bool> ("PublicSign");
 			assemblyKeyFile = pset.GetPathValue ("AssemblyOriginatorKeyFile", FilePath.Empty);
 			if (string.IsNullOrEmpty (assemblyKeyFile))
 				assemblyKeyFile = pset.GetPathValue ("AssemblyKeyFile", FilePath.Empty);
@@ -76,6 +77,7 @@ namespace MonoDevelop.Projects
 			pset.SetValue ("AssemblyName", assembly, mergeToMainGroup: true);
 			pset.SetValue ("SignAssembly", signAssembly, defaultValue:false, mergeToMainGroup: true);
 			pset.SetValue ("DelaySign", delaySign, defaultValue:false, mergeToMainGroup:true);
+			pset.SetValue (nameof(PublicSign), PublicSign, defaultValue: false, mergeToMainGroup: true);
 			pset.SetValue ("AssemblyOriginatorKeyFile", assemblyKeyFile, defaultValue:FilePath.Empty, mergeToMainGroup:true);
 			if (compilationParameters != null)
 				compilationParameters.Write (pset);
@@ -92,6 +94,8 @@ namespace MonoDevelop.Projects
 			get { return delaySign; }
 			set { delaySign = value; }
 		}
+
+		public bool PublicSign { get; set; }
 
 		internal string OldAssemblyKeyFile {
 			set { assemblyKeyFile = value; }


### PR DESCRIPTION
This PR introduces DelaySign and PublicSign properties being
passed to Roslyn, as they might be necessary inside the
Compilation itself.

Fixes VSTS #798087 - CSharpCompilationOptions is missing some information