### PR TITLE
Fixes Open current TextQuestionDialog using centralized RunCustomDialog

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -970,7 +970,7 @@ namespace MonoDevelop.MacIntegration
 
 		public override Window GetParentForModalWindow ()
 		{
-			return NSApplication.SharedApplication.KeyWindow ?? NSApplication.SharedApplication.MainWindow;
+			return NSApplication.SharedApplication.ModalWindow ?? NSApplication.SharedApplication.KeyWindow ?? NSApplication.SharedApplication.MainWindow;
 		}
 
 		public override Window GetFocusedTopLevelWindow ()


### PR DESCRIPTION
This PR fixes NRE trying to show the TextQuestionDialog because expects a Gtk window but it's getting an NSWindow.  

Just fixed GetParentForModalWindow to also check NSApplication.SharedApplication.ModalWindow and RunCustomDialog now calls CenterWindow.

Probably with this change is also **fixed focus the parent view in natives modal views**, because the parent was not well calculated.

Fixes Bug #802168 - Android app archive and publishing is broken - fails at MessageService.GetPassword.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/802168

![curioso](https://user-images.githubusercontent.com/1587480/53534689-3bc02e00-3b00-11e9-8fc3-f04da0b46c31.gif)
