### PR TITLE
[release-8.0-integration] [Core] Handle missing language on saving shared assets project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -107,8 +107,16 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 			base.OnReadProject (monitor, msproject);
 
 			var import = msproject.Imports.FirstOrDefault (im => im.Label == "Shared");
-			if (import == null)
+			if (import == null) {
+				// Sanity check.
+				if (!StringComparer.OrdinalIgnoreCase.Equals (msproject.FileName.Extension, FileName.Extension)) {
+					// ProjectTypeGuid mismatch in solution file.
+					throw new InvalidOperationException (GettextCatalog.GetString (
+						"Project {0} is being loaded as a Shared Assets project but has a different file extension. Please check the project type GUID in the solution file is correct.",
+						Name));
+				}
 				return;
+			}
 
 			// TODO: load the type from msbuild
 			foreach (var item in msproject.Imports) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.SharedAssetsProjects/SharedAssetsProject.cs
@@ -183,7 +183,7 @@ namespace MonoDevelop.Projects.SharedAssetsProjects
 				msproject.AddNewImport (@"$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props");
 				import = msproject.AddNewImport (MSBuildProjectService.ToMSBuildPath (FileName.ParentDirectory, projItemsPath));
 				import.Label = "Shared";
-				if (LanguageName.Equals("C#", StringComparison.OrdinalIgnoreCase)) {
+				if (LanguageName == null || LanguageName.Equals("C#", StringComparison.OrdinalIgnoreCase)) {
 					msproject.AddNewImport (CSharptargets);
 				}
 				else if (LanguageName.Equals("F#", StringComparison.OrdinalIgnoreCase)) {

--- a/main/tests/test-projects/SharedProjectMissingImport/Shared.shproj
+++ b/main/tests/test-projects/SharedProjectMissingImport/Shared.shproj
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{551C9391-1E8F-47D3-9C80-6AE04DE1AEE3}</ProjectGuid>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/SharedProjectTypeGuidMismatch/Library.csproj
+++ b/main/tests/test-projects/SharedProjectTypeGuidMismatch/Library.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{551C9391-1E8F-47D3-9C80-6AE04DE1AEE3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/SharedProjectTypeGuidMismatch/SharedProjectTypeGuidMismatch.sln
+++ b/main/tests/test-projects/SharedProjectTypeGuidMismatch/SharedProjectTypeGuidMismatch.sln
@@ -1,0 +1,15 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Library", "Library.csproj", "{551C9391-1E8F-47D3-9C80-6AE04DE1AEE3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
If a shared assets project was missing the import for its projItems
then this could result in a null reference exception when the project
was saved.

    <Import Project="Shared.projitems" Label="Shared" />

This was because the language is not set if the above import is
missing.

Handle a shared assets project type guid used for C# project

If the solution file is edited by hand and a shared assets project
entry was converted to a C# project file but the shared assets
project type guid is kept then the project would be loaded as a
shared assets project. To avoid this a check is made to see if the
project file extension is correct on reading the project file. If
not then an exception is thrown indicating there is a problem with
the project type guid. This avoids the project being treated as a
shared assets project incorrectly.

Fixes VSTS #802484 Unable to save Xamarin.Android-Tests.sln after adding
an existing shared project

Backport of #7262.

/cc @slluis @mrward