### PR TITLE
Fixes remove minimize and maximize from SelectRepositoryDialog + allways on top

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -37,6 +37,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 		{
 			Build ();
 			
+			GtkWorkarounds.DisableMinimizeMaximizeButtons (this);
 			foreach (VersionControlSystem vcs in VersionControlService.GetVersionControlSystems ()) {
 				if (vcs.IsInstalled) {
 					repCombo.AppendText (vcs.Name);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/SelectRepositoryDialog.cs
@@ -38,6 +38,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 			Build ();
 			
 			GtkWorkarounds.DisableMinimizeMaximizeButtons (this);
+			Modal = true;
 			foreach (VersionControlSystem vcs in VersionControlService.GetVersionControlSystems ()) {
 				if (vcs.IsInstalled) {
 					repCombo.AppendText (vcs.Name);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -348,15 +348,16 @@ namespace MonoDevelop.Ide
 			Runtime.RunInMainThread (() => {
 				// If there is a native NSWindow model window running, we need
 				// to show the new dialog over that window.
-				if (NSApplication.SharedApplication.ModalWindow != null) {
+				if (NSApplication.SharedApplication.ModalWindow != null || (parent.nativeWidget is NSWindow && dialog.Modal)) {
 					EventHandler shownHandler = null;
 					shownHandler = (s,e) => {
 						ShowCustomModalDialog (dialog, parent);
 						dialog.Shown -= shownHandler;
 					};
 					dialog.Shown += shownHandler;
-				} else
+				} else {
 					PlaceDialog (dialog, parent);
+				}
 			}).Wait ();
 			#endif
 


### PR DESCRIPTION
When we were opening the SelectRepositoryDialog (Checkout menu), this window was appearing always on top of all other system windows, this was because we were not set correctly the Parent in this GTK.Dialog when the parent window was native because this parent was null.

Included the case in our RunCustomDialog from MessageService, to handle this in all dialogs with the same problem.

Also Removed Minimize and Maximize button from the window toolbar 

![dialog](https://user-images.githubusercontent.com/1587480/53628753-27695780-3c0c-11e9-8301-d9fdec3d8c35.gif)

Fixes VSTS #801733 - [x] When cloning a git repo starting from GTC, SCC dialogs appear on top of other apps.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/801733

Fixes VSTS #801737 - - [x] Select Repository doesn't re-appear after being hidden and reactivated (staring with GTC)
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/801737
