### PR TITLE
[release-7.8] Retrieve editor markup on the UI thread. Fixes F# tooltips.

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -375,10 +375,15 @@ module Highlight =
         |> Async.AwaitTask 
         |> Async.RunSynchronously
 
-    let syntaxHighlight s =
-        Runtime.RunInMainThread(fun() -> editor.Text <- s) |> Async.AwaitTask |> Async.RunSynchronously
+    let getHighlightedMarkup s =
+        editor.Text <- s
         let data = editor.GetContent<ITextEditorDataProvider>().GetTextEditorData()
         data.GetMarkup(0, s.Length, false, true, false, true)
+
+    let syntaxHighlight s =
+        Runtime.RunInMainThread (fun () -> getHighlightedMarkup s)
+        |> Async.AwaitTask
+        |> Async.RunSynchronously
 
     let asUnderline = sprintf "_STARTUNDERLINE_%s_ENDUNDERLINE_" // we replace with real markup after highlighting
 


### PR DESCRIPTION
Fixes VSTS #802684 (#7254)

Backport of #7282.

/cc @nosami 