### PR TITLE
Add more missing files for `make dist` to be valid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,13 @@ Thumbs.db
 /main/tests/MonoDevelop.Core.Tests/Makefile
 /main/tests/WindowsPlatform.Tests/Makefile
 /main/tests/IdeUnitTests/Makefile
+/main/tests/performance/Makefile
+/main/tests/performance/MonoDevelop.Ide.PerfTests/Makefile
+/main/tests/performance/MonoDevelop.PerformanceTesting/Makefile
+/main/tests/performance/PerfTool/Makefile
+/main/tests/ui/Makefile
+/main/tests/ui/MonoDevelop.UserInterfaceTesting/Makefile
+
 
 # extras configure junk
 /extras/MonoDevelop.Database/INSTALL

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -387,6 +387,12 @@ tests/MonoDevelop.Core.Tests.Addin/Makefile
 tests/MonoDevelop.CSharpBinding.Tests/Makefile
 tests/MonoDevelop.Refactoring.Tests/Makefile
 tests/WindowsPlatform.Tests/Makefile
+tests/performance/Makefile
+tests/performance/PerfTool/Makefile
+tests/performance/MonoDevelop.Ide.PerfTests/Makefile
+tests/performance/MonoDevelop.PerformanceTesting/Makefile
+tests/ui/Makefile
+tests/ui/MonoDevelop.UserInterfaceTesting/Makefile
 Makefile
 monodevelop
 mdtool

--- a/main/src/addins/MonoDevelop.AspNetCore/Makefile.am
+++ b/main/src/addins/MonoDevelop.AspNetCore/Makefile.am
@@ -1,4 +1,5 @@
 include $(top_srcdir)/xbuild.include
 
 EXTRA_DIST += \
-	$(wildcard Templates/*.cshtml)
+	$(wildcard Templates/*.cshtml) \
+	$(wildcard Templates/*.json)

--- a/main/tests/Makefile.am
+++ b/main/tests/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/xbuild.include
 
-SUBDIRS=UnitTests IdeUnitTests MacPlatform.Tests UserInterfaceTests TestRunner Ide.Tests MonoDevelop.CSharpBinding.Tests WindowsPlatform.Tests MonoDevelop.Core.Tests MonoDevelop.Core.Tests.Addin MonoDevelop.Refactoring.Tests
+SUBDIRS=UnitTests IdeUnitTests MacPlatform.Tests UserInterfaceTests TestRunner Ide.Tests MonoDevelop.CSharpBinding.Tests WindowsPlatform.Tests MonoDevelop.Core.Tests MonoDevelop.Core.Tests.Addin MonoDevelop.Refactoring.Tests performance ui
 
 MONO=mono$(SGEN_SUFFIX)
 RUN_TEST=$(MDTOOL_RUN) run-md-tests

--- a/main/tests/performance/Makefile.am
+++ b/main/tests/performance/Makefile.am
@@ -1,0 +1,6 @@
+include $(top_srcdir)/xbuild.include
+
+SUBDIRS = \
+	MonoDevelop.Ide.PerfTests \
+	MonoDevelop.PerformanceTesting \
+	PerfTool

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/Makefile.am
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/Makefile.am
@@ -1,0 +1,4 @@
+include $(top_srcdir)/xbuild.include
+
+EXTRA_DIST += \
+	$(wildcard TestSolutions/*.zip)

--- a/main/tests/performance/MonoDevelop.PerformanceTesting/Makefile.am
+++ b/main/tests/performance/MonoDevelop.PerformanceTesting/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include

--- a/main/tests/performance/PerfTool/Makefile.am
+++ b/main/tests/performance/PerfTool/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include

--- a/main/tests/ui/Makefile.am
+++ b/main/tests/ui/Makefile.am
@@ -1,0 +1,4 @@
+include $(top_srcdir)/xbuild.include
+
+SUBDIRS = \
+	MonoDevelop.UserInterfaceTesting

--- a/main/tests/ui/MonoDevelop.UserInterfaceTesting/Makefile.am
+++ b/main/tests/ui/MonoDevelop.UserInterfaceTesting/Makefile.am
@@ -1,0 +1,1 @@
+include $(top_srcdir)/xbuild.include


### PR DESCRIPTION
It looks like my 7.7 changes from #6695 were never merged, so I rewrote them again from scratch when I ran into the same issues in 7.8 :man_shrugging: 