### PR TITLE
When firing async events, clone the event to avoid a collection modification exception

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -757,7 +757,7 @@ namespace MonoDevelop.Core
 		public static event EventHandler<FileEventArgs> FileCreated;
 		static void OnFileCreated (FileEventArgs args)
 		{
-			AsyncEvents.OnFileCreated (Clone (args));
+			AsyncEvents.OnFileCreated (args);
 
 			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
@@ -784,7 +784,7 @@ namespace MonoDevelop.Core
 		public static event EventHandler<FileCopyEventArgs> FileRenamed;
 		static void OnFileRenamed (FileCopyEventArgs args)
 		{
-			AsyncEvents.OnFileRenamed (Clone (args));
+			AsyncEvents.OnFileRenamed (args);
 
 			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
@@ -799,7 +799,7 @@ namespace MonoDevelop.Core
 		public static event EventHandler<FileEventArgs> FileRemoved;
 		static void OnFileRemoved (FileEventArgs args)
 		{
-			AsyncEvents.OnFileRemoved (Clone (args));
+			AsyncEvents.OnFileRemoved (args);
 
 			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
@@ -905,13 +905,6 @@ namespace MonoDevelop.Core
 		/// File watcher events - these are not fired on the UI thread.
 		/// </summary>
 		public static AsyncEvents AsyncEvents { get; } = new AsyncEvents ();
-
-		static T Clone<T> (T args) where T : FileEventArgs, new()
-		{
-			var result = new T ();
-			result.AddRange (args);
-			return result;
-		}
 	}
 
 	class EventQueue
@@ -1352,17 +1345,24 @@ namespace MonoDevelop.Core
 
 		internal void OnFileCreated (FileEventArgs args)
 		{
-			FileCreated?.Invoke (this, args);
+			FileCreated?.Invoke (this, Clone (args));
 		}
 
 		internal void OnFileRemoved (FileEventArgs args)
 		{
-			FileRemoved?.Invoke (this, args);
+			FileRemoved?.Invoke (this, Clone (args));
 		}
 
 		internal void OnFileRenamed (FileCopyEventArgs args)
 		{
-			FileRenamed?.Invoke (this, args);
+			FileRenamed?.Invoke (this, Clone (args));
+		}
+
+		static T Clone<T> (T args) where T : FileEventArgs, new()
+		{
+			var result = new T ();
+			result.AddRange (args);
+			return result;
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -757,7 +757,7 @@ namespace MonoDevelop.Core
 		public static event EventHandler<FileEventArgs> FileCreated;
 		static void OnFileCreated (FileEventArgs args)
 		{
-			AsyncEvents.OnFileCreated (args);
+			AsyncEvents.OnFileCreated (Clone (args));
 
 			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
@@ -784,7 +784,7 @@ namespace MonoDevelop.Core
 		public static event EventHandler<FileCopyEventArgs> FileRenamed;
 		static void OnFileRenamed (FileCopyEventArgs args)
 		{
-			AsyncEvents.OnFileRenamed (args);
+			AsyncEvents.OnFileRenamed (Clone (args));
 
 			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
@@ -799,7 +799,7 @@ namespace MonoDevelop.Core
 		public static event EventHandler<FileEventArgs> FileRemoved;
 		static void OnFileRemoved (FileEventArgs args)
 		{
-			AsyncEvents.OnFileRemoved (args);
+			AsyncEvents.OnFileRemoved (Clone (args));
 
 			foreach (FileEventInfo fi in args) {
 				if (fi.IsDirectory)
@@ -905,6 +905,13 @@ namespace MonoDevelop.Core
 		/// File watcher events - these are not fired on the UI thread.
 		/// </summary>
 		public static AsyncEvents AsyncEvents { get; } = new AsyncEvents ();
+
+		static T Clone<T> (T args) where T : FileEventArgs, new()
+		{
+			var result = new T ();
+			result.AddRange (args);
+			return result;
+		}
 	}
 
 	class EventQueue


### PR DESCRIPTION
```
ERROR [2019-02-28 23:20:50Z]: An unhandled exception has occurred. Terminating Visual Studio? False
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
  at System.Collections.Generic.List`1+Enumerator[T].MoveNextRare () [0x00013] in <3c73e0665b1b47bb9d553430a97aa942>:0
  at System.Collections.Generic.List`1+Enumerator[T].MoveNext () [0x0004a] in <3c73e0665b1b47bb9d553430a97aa942>:0
  at MonoDevelop.Projects.Project+<>c__DisplayClass349_0.<OnFileDeleted>b__0 () [0x00031] in <500e8d32b687408f897daf1edbb52aa9>:0
  at MonoDevelop.Core.Runtime+<>c.<RunInMainThread>b__40_0 (System.Object state) [0x00015]
```

Instead of doing the clone conditionally, do it unconditionally. Doing it conditionally, can race
and re-introduce the exception

Fixes VSTS #806669 - FileService event reduction can cause exceptions in async events