### PR TITLE
[release-8.0-integration] [VersionControl] Fixes error in PasswordService; refuses to (re)store Git Credentials

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -3,9 +3,11 @@
 //
 // Authors: Michael Hutchinson <mhutchinson@novell.com>
 //          Jeffrey Stedfast <jeff@xamarin.com>
+//			Javier Suárez <jsuarez@microsoft.com>
 //
 // Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
 // Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)
+// Copyright (c) 2019 Microsoft Corporation (http://www.microsoft.com)
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,624 +28,272 @@
 // THE SOFTWARE.
 
 using System;
-using System.Text;
-using System.Runtime.InteropServices;
 using Security;
+using Foundation;
 
 namespace MonoDevelop.MacInterop
 {
 	public static class Keychain
 	{
-		const string CoreFoundationLib = ObjCRuntime.Constants.CoreFoundationLibrary;
-		const string SecurityLib = ObjCRuntime.Constants.SecurityLibrary;
+		static readonly string Service = "MonoDevelop";
 
-		internal static IntPtr CurrentKeychain = IntPtr.Zero;
-
-		[DllImport (CoreFoundationLib, EntryPoint="CFRelease")]
-		static extern void CFReleaseInternal (IntPtr cfRef);
-
-		static void CFRelease (IntPtr cfRef)
+		public static void AddInternetPassword (Uri uri, string password)
 		{
-			if (cfRef != IntPtr.Zero)
-				CFReleaseInternal (cfRef);
-		}
+			var serverInfo = new ServerInfo (uri);
+			var passwd = NSData.FromString (password);
 
-		#region Managing Keychains
+			// See if there is already a password there for this uri
+			var record = SecKeychainFindInternetPassword (uri, out SecRecord searchRecord);
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainCreate (byte[] pathName, uint passwordLength, byte[] password,
-		                                          bool promptUser,  IntPtr initialAccess, out IntPtr keychain);
+			if (record == null) {
+				record = new SecRecord (SecKind.InternetPassword) {
+					AuthenticationType = serverInfo.AuthenticationType,
+					Description = serverInfo.Description,
+					Service = Service,
+					Server = serverInfo.Host,
+					Path = serverInfo.Path,
+					Port = serverInfo.Port,
+					Protocol = serverInfo.Protocol,
+					ValueData = passwd
+				};
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainDelete (IntPtr keychain);
+				SecStatusCode result = SecKeyChain.Add (record);
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainOpen (byte[] pathName, out IntPtr keychain);
+				if (result != SecStatusCode.Success && result != SecStatusCode.DuplicateItem)
+					throw new Exception ("Could not add internet password to keychain: " + result.GetStatusDescription ());
 
-		internal static IntPtr CreateKeychain (string path, string password)
-		{
-			var passwd = Encoding.UTF8.GetBytes (password);
-
-			var status = SecKeychainCreate (path.ToNullTerminatedUtf8 (), (uint) passwd.Length, passwd, false, IntPtr.Zero, out IntPtr result);
-			if (status != SecStatusCode.Success)
-				throw new Exception (status.GetStatusDescription ());
-
-			return result;
-		}
-
-		internal static bool TryDeleteKeychain (string path)
-		{
-			var result = SecKeychainOpen (path.ToNullTerminatedUtf8 (), out IntPtr ptr);
-			try {
-				if (result == SecStatusCode.Success) {
-					DeleteKeychain (ptr);
-					return true;
-				}
-			} catch {
-				// If we call 'SecKeychainOpen' on a keychain path that does not exist,
-				// we get a return value of 'success' and we also get a non-null handle.
-				// As such there's no way for the test suite to safely check if a keychain
-				// exists so it can delete a pre-existing one before exceuting. Work around
-				// this by wrapping in a try/catch. The 'DeleteKeyChain (IntPtr)' method 
-				// will throw a 'key chain does not exist' error if there is no pre-existing
-				// keychain
-			} finally {
-				CFRelease (ptr);
+				return;
 			}
-			return false;
+
+			record.ValueData = NSData.FromString (password);
+
+			// If there is, replace it with the new one
+			SecKeyChain.Update (searchRecord, record);
 		}
 
-		internal static void DeleteKeychain (IntPtr keychain)
+		public static void AddInternetPassword (Uri uri, string username, string password)
 		{
-			var status = SecKeychainDelete (keychain);
-			if (status != SecStatusCode.Success)
-				throw new Exception (status.GetStatusDescription ());
-		}
+			var serverInfo = new ServerInfo (uri);
+			string account = username;
+			var passwd = NSData.FromString (password);
 
-		#endregion
+			// See if there is already a password there for this uri
+			var record = SecKeychainFindInternetPassword (uri, out SecRecord searchRecord);
 
-		#region Storing and Retrieving Passwords
+			if (record == null) {
+				record = new SecRecord (SecKind.InternetPassword) {
+					Account = account,
+					AuthenticationType = serverInfo.AuthenticationType,
+					Service = Service,
+					Server = serverInfo.Host,
+					Path = serverInfo.Path,
+					Port = serverInfo.Port,
+					Protocol = serverInfo.Protocol,
+					ValueData = passwd
+				};
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainAddInternetPassword (IntPtr keychain, uint serverNameLength, byte[] serverName, uint securityDomainLength,
-		                                                       byte[] securityDomain, uint accountNameLength, byte[] accountName, uint pathLength,
-		                                                       byte[] path, ushort port, SecProtocolType protocol, SecAuthenticationType authType,
-		                                                       uint passwordLength, byte[] passwordData, ref IntPtr itemRef);
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainFindInternetPassword (IntPtr keychain, uint serverNameLength, byte[] serverName, uint securityDomainLength,
-		                                                        byte[] securityDomain, uint accountNameLength, byte[] accountName, uint pathLength,
-		                                                        byte[] path, ushort port, SecProtocolType protocol, SecAuthenticationType authType,
-		                                                        out uint passwordLength, out IntPtr passwordData, ref IntPtr itemRef);
+				SecStatusCode result = SecKeyChain.Add (record);
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainFindInternetPassword (IntPtr keychain, uint serverNameLength, byte[] serverName, uint securityDomainLength,
-		                                                        byte[] securityDomain, uint accountNameLength, byte[] accountName, uint pathLength,
-		                                                        byte[] path, ushort port, SecProtocolType protocol, SecAuthenticationType authType,
-		                                                        IntPtr passwordLengthRef, IntPtr passwordDataRef, ref IntPtr itemRef);
+				if (result != SecStatusCode.Success && result != SecStatusCode.DuplicateItem)
+					throw new Exception ("Could not add internet password to keychain: " + result.GetStatusDescription ());
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainAddGenericPassword (IntPtr keychain, uint serviceNameLength, byte[] serviceName,
-		                                                      uint accountNameLength, byte[] accountName, uint passwordLength,
-		                                                      byte[] passwordData, ref IntPtr itemRef);
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainFindGenericPassword (IntPtr keychain, uint serviceNameLength, byte[] serviceName,
-		                                                       uint accountNameLength, byte[] accountName, out uint passwordLength,
-		                                                       out IntPtr passwordData, ref IntPtr itemRef);
-
-		#endregion
-
-		#region Creating and Deleting Keychain Items
-
-		[StructLayout (LayoutKind.Sequential)]
-		struct SecKeychainAttributeList
-		{
-			public int Count;
-			public IntPtr Attrs;
-
-			public SecKeychainAttributeList (int count, IntPtr attrs)
-			{
-				Count = count;
-				Attrs = attrs;
+				return;
 			}
+
+			record.ValueData = NSData.FromString (password);
+
+			// If there is, replace it with the new one
+			SecKeyChain.Update (searchRecord, record);
 		}
 
-		[StructLayout (LayoutKind.Sequential)]
-		struct SecKeychainAttribute
+		public static string FindInternetPassword (Uri url)
 		{
-			public SecItemAttr Tag;
-			public uint Length;
-			public IntPtr Data;
+			// See if there is already a password there for this uri
+			var record = SecKeychainFindInternetPassword (url, out _);
 
-			public SecKeychainAttribute (SecItemAttr tag, uint length, IntPtr data)
-			{
-				Tag = tag;
-				Length = length;
-				Data = data;
+			if (record == null) {
+				return string.Empty;
+			}
+
+			return NSString.FromData (record.ValueData, NSStringEncoding.UTF8);
+		}
+
+		public static unsafe Tuple<string, string> FindInternetUserNameAndPassword (Uri uri)
+		{
+			var serverInfo = new ServerInfo (uri);
+			var protocol = serverInfo.Protocol;
+			return FindInternetUserNameAndPassword (uri, protocol);
+		}
+
+		public static Tuple<string, string> FindInternetUserNameAndPassword (Uri url, SecProtocol protocol)
+		{
+			var record = SecKeychainFindInternetPassword (url, protocol, out _);
+
+			if (record == null) {
+				return null;
+			}
+
+			string username = NSString.FromData (record.Account, NSStringEncoding.UTF8);
+			string password = NSString.FromData (record.ValueData, NSStringEncoding.UTF8);
+
+			return Tuple.Create (username, password);
+		}
+
+		public static void RemoveInternetPassword (Uri url)
+		{
+			var record = SecKeychainFindInternetPassword (url, out _);
+
+			if (record != null) {
+				var result = SecKeyChain.Remove (record);
+
+				if (result != SecStatusCode.Success)
+					throw new Exception ("Could not delete internet password from keychain: " + result.GetStatusDescription ());
 			}
 		}
 
-		[DllImport (SecurityLib)]
-		static extern unsafe SecStatusCode SecKeychainItemCreateFromContent (SecItemClass itemClass, SecKeychainAttributeList *attrList,
-		                                                                uint passwordLength, byte[] password, IntPtr keychain,
-		                                                                IntPtr initialAccess, IntPtr itemRef);
-
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainItemDelete (IntPtr itemRef);
-
-		#endregion
-
-		#region Managing Keychain Items
-
-		[StructLayout (LayoutKind.Sequential)]
-		unsafe struct SecKeychainAttributeInfo
+		public static void RemoveInternetUserNameAndPassword (Uri url)
 		{
-			public uint Count;
-			public int* Tag;
-			public int* Format;
+			var record = SecKeychainFindInternetPassword (url, out _);
+
+			if (record != null) {
+				SecStatusCode result = SecKeyChain.Remove (record);
+
+				if (result == SecStatusCode.Success)
+					throw new Exception ("Could not delete internet password from keychain: " + result.GetStatusDescription ());
+			}
 		}
 
-		[DllImport (SecurityLib)]
-		static extern unsafe SecStatusCode SecKeychainItemFreeAttributesAndData (SecKeychainAttributeList* list, IntPtr data);
+		static SecRecord SecKeychainFindInternetPassword (Uri uri, out SecRecord searchRecord)
+		{
+			var serverInfo = new ServerInfo (uri);
+			return SecKeychainFindInternetPassword (uri, serverInfo.Protocol, out searchRecord);
+		}
 
-		[DllImport (SecurityLib)]
-		static extern unsafe SecStatusCode SecKeychainItemCopyAttributesAndData (IntPtr itemRef, SecKeychainAttributeInfo* info, ref SecItemClass itemClass,
-		                                                                         SecKeychainAttributeList** attrList, IntPtr lengthRef, IntPtr outDataRef);
+		static SecRecord SecKeychainFindInternetPassword (Uri uri, SecProtocol protocol, out SecRecord searchRecord)
+		{
+			var serverInfo = new ServerInfo (uri);
 
-		[DllImport (SecurityLib)]
-		static extern unsafe SecStatusCode SecKeychainItemModifyAttributesAndData (IntPtr itemRef, SecKeychainAttributeList *attrList, uint length, byte [] data);
+			// Look for an internet password for the given protocol and auth mechanism
+			searchRecord = new SecRecord (SecKind.InternetPassword) {
+				Account = serverInfo.Account,
+				AuthenticationType = serverInfo.AuthenticationType,
+				Description = serverInfo.Description,
+				Service = Service,
+				Server = serverInfo.Host,
+				Path = serverInfo.Path,
+				Port = serverInfo.Port,
+				Protocol = protocol
+			};
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainItemCopyContent (IntPtr itemRef, ref SecItemClass itemClass, IntPtr attrList, ref uint length, ref IntPtr data);
+			var data = SecKeyChain.QueryAsRecord (searchRecord, out SecStatusCode code);
 
-		[DllImport (SecurityLib)]
-		static extern SecStatusCode SecKeychainItemFreeContent (IntPtr attrList, IntPtr data);
+			if (code == SecStatusCode.ItemNotFound) {
+				// Fall back to looking for a password without use SecProtocol && SecAuthenticationType
+				searchRecord = new SecRecord (SecKind.InternetPassword) {
+					Service = Service,
+					Server = serverInfo.Host,
+					Path = serverInfo.Path
+				};
 
-		#endregion
+				data = SecKeyChain.QueryAsRecord (searchRecord, out code);
+			}
+
+			if (code != SecStatusCode.Success)
+				return null;
+
+			return data;
+		}
+	}
+
+	public class ServerInfo
+	{
+		static readonly string WebFormPassword = "Web form password";
+
+		public ServerInfo (Uri uri)
+		{
+			Account = Uri.UnescapeDataString (uri.UserInfo);
+			AuthenticationType = GetSecAuthenticationType (uri.Query);
+			Host = uri.Host;
+			Path = string.Join (string.Empty, uri.Segments);
+			Port = uri.Port;
+			Protocol = GetSecProtocolType (uri.Scheme);
+
+			Description = string.Empty;
+			if (AuthenticationType == SecAuthenticationType.HtmlForm)
+				Description = WebFormPassword;
+		}
+
+		public string Account { get; set; }
+		public SecAuthenticationType AuthenticationType { get; set; }
+		public string Host { get; set; }
+		public string Path { get; set; }
+		public int Port { get; set; }
+		public SecProtocol Protocol { get; set; }
+		public string Description { get; set; }
+
+		static SecProtocol GetSecProtocolType (string protocol)
+		{
+			switch (protocol.ToLowerInvariant ()) {
+			case "ftp": return SecProtocol.Ftp;
+			case "ftpaccount": return SecProtocol.FtpAccount;
+			case "http": return SecProtocol.Http;
+			case "https": return SecProtocol.Https;
+			case "irc": return SecProtocol.Irc;
+			case "nntp": return SecProtocol.Nntp;
+			case "pop3": return SecProtocol.Pop3;
+			case "pop3s": return SecProtocol.Pop3s;
+			case "smtp": return SecProtocol.Smtp;
+			case "socks": return SecProtocol.Socks;
+			case "imap": return SecProtocol.Imap;
+			case "imaps": return SecProtocol.Imaps;
+			case "ldap": return SecProtocol.Ldap;
+			case "ldaps": return SecProtocol.Ldaps;
+			case "appletalk": return SecProtocol.AppleTalk;
+			case "afp": return SecProtocol.Afp;
+			case "telnet": return SecProtocol.Telnet;
+			case "ssh": return SecProtocol.Ssh;
+			case "ftps": return SecProtocol.Ftps;
+			case "httpproxy": return SecProtocol.HttpProxy;
+			case "httpsproxy": return SecProtocol.HttpProxy;
+			case "ftpproxy": return SecProtocol.FtpProxy;
+			case "smb": return SecProtocol.Smb;
+			case "rtsp": return SecProtocol.Rtsp;
+			case "rtspproxy": return SecProtocol.RtspProxy;
+			case "daap": return SecProtocol.Daap;
+			case "eppc": return SecProtocol.Eppc;
+			case "ipp": return SecProtocol.Ipp;
+			case "nntps": return SecProtocol.Nntps;
+			case "telnets": return SecProtocol.Telnets;
+			case "ircs": return SecProtocol.Ircs;
+			default: return SecProtocol.Http;
+			}
+		}
 
 		static SecAuthenticationType GetSecAuthenticationType (string query)
 		{
 			if (string.IsNullOrEmpty (query))
-				return SecAuthenticationType.Any;
+				return SecAuthenticationType.Default;
 
 			string auth = "default";
-			foreach (var pair in query.Substring (1).Split (new char[] { '&' })) {
-				var kvp = pair.Split (new char[] { '=' });
-				if (string.Equals (kvp[0], "auth", StringComparison.InvariantCultureIgnoreCase) && kvp.Length == 2) {
-					auth = kvp[1].ToLowerInvariant ();
+			foreach (var pair in query.Substring (1).Split (new char [] { '&' })) {
+				var kvp = pair.Split (new char [] { '=' });
+				if (string.Equals (kvp [0], "auth", StringComparison.InvariantCultureIgnoreCase) && kvp.Length == 2) {
+					auth = kvp [1].ToLowerInvariant ();
 					break;
 				}
 			}
 
 			switch (auth) {
-			case "ntlm": return SecAuthenticationType.NTLM;
-			case "msn": return SecAuthenticationType.MSN;
-			case "dpa": return SecAuthenticationType.DPA;
-			case "rpa": return SecAuthenticationType.RPA;
-			case "httpbasic": case "basic": return SecAuthenticationType.HTTPBasic;
-			case "httpdigest": case "digest": return SecAuthenticationType.HTTPDigest;
-			case "htmlform": case "form": return SecAuthenticationType.HTMLForm;
+			case "ntlm": return SecAuthenticationType.Ntlm;
+			case "msn": return SecAuthenticationType.Msn;
+			case "dpa": return SecAuthenticationType.Dpa;
+			case "rpa": return SecAuthenticationType.Rpa;
+			case "httpbasic": case "basic": return SecAuthenticationType.HttpBasic;
+			case "httpdigest": case "digest": return SecAuthenticationType.HttpDigest;
+			case "htmlform": case "form": return SecAuthenticationType.HtmlForm;
 			case "default": return SecAuthenticationType.Default;
-			default: return SecAuthenticationType.Any;
+			default: return SecAuthenticationType.Default;
 			}
 		}
-
-		static SecProtocolType GetSecProtocolType (string protocol)
-		{
-			switch (protocol.ToLowerInvariant ()) {
-			case "ftp": return SecProtocolType.FTP;
-			case "ftpaccount": return SecProtocolType.FTPAccount;
-			case "http": return SecProtocolType.HTTP;
-			case "irc": return SecProtocolType.IRC;
-			case "nntp": return SecProtocolType.NNTP;
-			case "pop3": return SecProtocolType.POP3;
-			case "smtp": return SecProtocolType.SMTP;
-			case "socks": return SecProtocolType.SOCKS;
-			case "imap": return SecProtocolType.IMAP;
-			case "ldap": return SecProtocolType.LDAP;
-			case "appletalk": return SecProtocolType.AppleTalk;
-			case "afp": return SecProtocolType.AFP;
-			case "telnet": return SecProtocolType.Telnet;
-			case "ssh": return SecProtocolType.SSH;
-			case "ftps": return SecProtocolType.FTPS;
-			case "httpproxy": return SecProtocolType.HTTPProxy;
-			case "httpsproxy": return SecProtocolType.HTTPSProxy;
-			case "ftpproxy": return SecProtocolType.FTPProxy;
-			case "cifs": return SecProtocolType.CIFS;
-			case "smb": return SecProtocolType.SMB;
-			case "rtsp": return SecProtocolType.RTSP;
-			case "rtspproxy": return SecProtocolType.RTSPProxy;
-			case "daap": return SecProtocolType.DAAP;
-			case "eppc": return SecProtocolType.EPPC;
-			case "ipp": return SecProtocolType.IPP;
-			case "nntps": return SecProtocolType.NNTPS;
-			case "ldaps": return SecProtocolType.LDAPS;
-			case "telnets": return SecProtocolType.TelnetS;
-			case "imaps": return SecProtocolType.IMAPS;
-			case "ircs": return SecProtocolType.IRCS;
-			case "pop3s": return SecProtocolType.POP3S;
-			case "cvspserver": return SecProtocolType.CVSpserver;
-			case "svn": return SecProtocolType.SVN;
-			default: return SecProtocolType.Any;
-			}
-		}
-
-		static unsafe SecStatusCode ReplaceInternetPassword (IntPtr item, byte[] desc, byte[] passwd)
-		{
-			fixed (byte* descPtr = desc) {
-				SecKeychainAttribute* attrs = stackalloc SecKeychainAttribute [1];
-				int n = 0;
-
-				if (desc != null)
-					attrs[n++] = new SecKeychainAttribute (SecItemAttr.Description, (uint) desc.Length, (IntPtr) descPtr);
-
-				SecKeychainAttributeList attrList = new SecKeychainAttributeList (n, (IntPtr) attrs);
-
-				return SecKeychainItemModifyAttributesAndData (item, &attrList, (uint) passwd.Length, passwd);
-			}
-		}
-
-		static unsafe SecStatusCode AddInternetPassword (byte[] label, byte[] desc, SecAuthenticationType auth, byte[] user, byte[] passwd, SecProtocolType protocol, byte[] host, int port, byte[] path)
-		{
-			// Note: the following code does more-or-less the same as:
-			//SecKeychainAddInternetPassword (CurrentKeychain, (uint) host.Length, host, 0, null,
-			//                                (uint) user.Length, user, (uint) path.Length, path, (ushort) port,
-			//                                protocol, auth, (uint) passwd.Length, passwd, ref item);
-
-			fixed (byte* labelPtr = label, descPtr = desc, userPtr = user, hostPtr = host, pathPtr = path) {
-				SecKeychainAttribute* attrs = stackalloc SecKeychainAttribute [8];
-				int* protoPtr = (int*) &protocol;
-				int* authPtr = (int*) &auth;
-				int* portPtr = &port;
-				int n = 0;
-
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Label,    (uint) label.Length, (IntPtr) labelPtr);
-				if (desc != null)
-					attrs[n++] = new SecKeychainAttribute (SecItemAttr.Description, (uint) desc.Length, (IntPtr) descPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Account,  (uint) user.Length,  (IntPtr) userPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Protocol, (uint) 4,            (IntPtr) protoPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.AuthType, (uint) 4,            (IntPtr) authPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Server,   (uint) host.Length,  (IntPtr) hostPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Port,     (uint) 4,            (IntPtr) portPtr);
-				attrs[n++] = new SecKeychainAttribute (SecItemAttr.Path,     (uint) Math.Max (path.Length - 1, 0),  (IntPtr) pathPtr);
-
-				SecKeychainAttributeList attrList = new SecKeychainAttributeList (n, (IntPtr) attrs);
-
-				var result = SecKeychainItemCreateFromContent (SecItemClass.InternetPassword, &attrList, (uint) passwd.Length, passwd, CurrentKeychain, IntPtr.Zero, IntPtr.Zero);
-
-				return result;
-			}
-		}
-
-		public static unsafe void AddInternetPassword (Uri uri, string username, string password)
-		{
-			byte[] path = uri.ToPathBytes ();
-			byte[] passwd = Encoding.UTF8.GetBytes (password);
-			byte[] host = Encoding.UTF8.GetBytes (uri.Host);
-			byte[] user = Encoding.UTF8.GetBytes (username);
-			var auth = GetSecAuthenticationType (uri.Query);
-			var protocol = GetSecProtocolType (uri.Scheme);
-			IntPtr item = IntPtr.Zero;
-			int port = uri.Port;
-			byte[] desc = null;
-
-			if (auth == SecAuthenticationType.HTMLForm)
-				desc = WebFormPassword;
-
-			// See if there is already a password there for this uri
-			var result = SecKeychainFindInternetPassword (CurrentKeychain, (uint)host.Length, host, 0, null,
-											  (uint)user.Length, user, (uint)path.Length, path, (ushort)port,
-											  protocol, auth, IntPtr.Zero, IntPtr.Zero, ref item);
-
-			try {
-				if (result == SecStatusCode.Success) {
-					// If there is, replace it with the new one
-					result = ReplaceInternetPassword (item, desc, passwd);
-				} else {
-					var label = Encoding.UTF8.GetBytes (string.Format ("{0} ({1})", uri.Host, username));
-
-					result = AddInternetPassword (label, desc, auth, user, passwd, protocol, host, port, path);
-				}
-			} finally {
-				CFRelease (item);
-			}
-
-			if (result != SecStatusCode.Success && result != SecStatusCode.DuplicateItem)
-				throw new Exception ("Could not add internet password to keychain: " + result.GetStatusDescription ());
-		}
-
-		static readonly byte[] WebFormPassword = Encoding.UTF8.GetBytes ("Web form password");
-
-		public static unsafe void AddInternetPassword (Uri uri, string password) =>
-			AddInternetPassword (uri, Uri.UnescapeDataString (uri.UserInfo), password);
-
-		static unsafe string GetUsernameFromKeychainItemRef (IntPtr itemRef)
-		{
-			int[] formatConstants = { (int) CssmDbAttributeFormat.String };
-			int[] attributeTags = { (int) SecItemAttr.Account };
-
-			fixed (int* tags = attributeTags, formats = formatConstants) {
-				var attributeInfo = new SecKeychainAttributeInfo {
-					Count = 1,
-					Tag = tags,
-					Format = formats
-				};
-				SecKeychainAttributeList* attributeList = null;
-				SecItemClass itemClass = 0;
-
-				try {
-					SecStatusCode status = SecKeychainItemCopyAttributesAndData (itemRef, &attributeInfo, ref itemClass, &attributeList, IntPtr.Zero, IntPtr.Zero);
-
-					if (status == SecStatusCode.ItemNotFound)
-						throw new Exception ("Could not add internet password to keychain: " + status.GetStatusDescription ());
-
-					if (status != SecStatusCode.Success)
-						throw new Exception ("Could not find internet username and password: " + status.GetStatusDescription ());
-
-					var userNameAttr = (SecKeychainAttribute*)attributeList->Attrs;
-
-					if (userNameAttr->Length == 0)
-						return null;
-
-					return Marshal.PtrToStringAuto (userNameAttr->Data, (int)userNameAttr->Length);
-				} finally {
-					SecKeychainItemFreeAttributesAndData (attributeList, IntPtr.Zero);
-				}
-			}
-		}
-
-		public static unsafe Tuple<string, string> FindInternetUserNameAndPassword (Uri uri)
-		{
-			var protocol = GetSecProtocolType (uri.Scheme);
-			return FindInternetUserNameAndPassword (uri, protocol);
-		}
-
-		public static unsafe Tuple<string, string> FindInternetUserNameAndPassword (Uri uri, SecProtocolType protocol)
-		{
-			byte[] path = uri.ToPathBytes ();
-			byte[] host = Encoding.UTF8.GetBytes (uri.Host);
-			var auth = GetSecAuthenticationType (uri.Query);
-			IntPtr passwordData;
-			IntPtr item = IntPtr.Zero;
-			uint passwordLength = 0;
-
-			var result = SecKeychainFindInternetPassword (
-				CurrentKeychain, (uint) host.Length, host, 0, null,
-				0, null, (uint) path.Length, path, (ushort) uri.Port,
-				protocol, auth, out passwordLength, out passwordData, ref item);
-
-			try {
-				if (result != SecStatusCode.Success)
-					return null;
-
-				var username = GetUsernameFromKeychainItemRef (item);
-				return Tuple.Create (username, Marshal.PtrToStringAuto (passwordData, (int) passwordLength));
-			} finally {
-				SecKeychainItemFreeContent (IntPtr.Zero, passwordData);
-				CFRelease (item);
-			}
-		}
-
-		public static string FindInternetPassword (Uri uri)
-		{
-			byte[] path = uri.ToPathBytes ();
-			byte[] user = Encoding.UTF8.GetBytes (Uri.UnescapeDataString (uri.UserInfo));
-			byte[] host = Encoding.UTF8.GetBytes (uri.Host);
-			var auth = GetSecAuthenticationType (uri.Query);
-			var protocol = GetSecProtocolType (uri.Scheme);
-			IntPtr passwordData = IntPtr.Zero;
-			IntPtr item = IntPtr.Zero;
-			uint passwordLength = 0;
-
-			try {
-				// Look for an internet password for the given protocol and auth mechanism
-				var result = SecKeychainFindInternetPassword (CurrentKeychain, (uint)host.Length, host, 0, null,
-															  (uint)user.Length, user, (uint)path.Length, path, (ushort)uri.Port,
-															  protocol, auth, out passwordLength, out passwordData, ref item);
-
-				// Fall back to looking for a password for SecProtocolType.Any && SecAuthenticationType.Any
-				if (result == SecStatusCode.ItemNotFound && protocol != SecProtocolType.Any)
-					result = SecKeychainFindInternetPassword (CurrentKeychain, (uint)host.Length, host, 0, null,
-															  (uint)user.Length, user, (uint)path.Length, path, (ushort)uri.Port,
-															  0, auth, out passwordLength, out passwordData, ref item);
-
-				if (result != SecStatusCode.Success)
-					return null;
-
-				return Marshal.PtrToStringAuto (passwordData, (int)passwordLength);
-			} finally {
-				CFRelease (item);
-
-				SecKeychainItemFreeContent (IntPtr.Zero, passwordData);
-			}
-		}
-
-		public static void RemoveInternetPassword (Uri uri)
-		{
-			byte[] path = uri.ToPathBytes ();
-			byte[] user = Encoding.UTF8.GetBytes (Uri.UnescapeDataString (uri.UserInfo));
-			byte[] host = Encoding.UTF8.GetBytes (uri.Host);
-			var auth = GetSecAuthenticationType (uri.Query);
-			var protocol = GetSecProtocolType (uri.Scheme);
-			IntPtr item = IntPtr.Zero;
-
-			// Look for an internet password for the given protocol and auth mechanism
-			var result = SecKeychainFindInternetPassword (CurrentKeychain, (uint) host.Length, host, 0, null,
-				(uint) user.Length, user, (uint) path.Length, path, (ushort) uri.Port,
-				protocol, auth, IntPtr.Zero, IntPtr.Zero, ref item);
-
-			// Fall back to looking for a password for SecProtocolType.Any && SecAuthenticationType.Any
-			if (result == SecStatusCode.ItemNotFound && protocol != SecProtocolType.Any)
-				result = SecKeychainFindInternetPassword (CurrentKeychain, (uint) host.Length, host, 0, null,
-					(uint) user.Length, user, (uint) path.Length, path, (ushort) uri.Port,
-					0, auth, IntPtr.Zero, IntPtr.Zero, ref item);
-
-			try {
-				if (result != SecStatusCode.Success)
-					return;
-
-				SecKeychainItemDelete (item);
-			} finally {
-				CFRelease (item);
-			}
-		}
-
-		public static void RemoveInternetUserNameAndPassword (Uri uri)
-		{
-			byte[] path = uri.ToPathBytes ();
-			byte[] host = Encoding.UTF8.GetBytes (uri.Host);
-			var auth = GetSecAuthenticationType (uri.Query);
-			IntPtr item = IntPtr.Zero;
-
-			var result = SecKeychainFindInternetPassword (
-				CurrentKeychain, (uint) host.Length, host, 0, null,
-				0, null, (uint) path.Length, path, (ushort) uri.Port,
-				GetSecProtocolType (uri.Scheme), auth, IntPtr.Zero, IntPtr.Zero, ref item);
-
-			try {
-				if (result != SecStatusCode.Success)
-					return;
-
-				result = SecKeychainItemDelete (item);
-			} finally {
-				CFRelease (item);
-			}
-		}
-
-		static byte [] ToPathBytes (this Uri uri)
-		{
-			var pathStr = string.Join (string.Empty, uri.Segments);
-			byte[] path = pathStr.Length > 0 ? pathStr.ToNullTerminatedUtf8 (1) : Array.Empty<byte> (); // don't include the leading '/'
-			return path;
-		}
-
-		// It seems that keychain APIs require null terminated native strings.
-		internal static byte [] ToNullTerminatedUtf8 (this string str, int offset = 0)
-		{
-			unsafe {
-				fixed (char* p = str) {
-					return ToNullTerminatedUtf8 (p + offset, str.Length - offset);
-				}
-			}
-		}
-
-		static unsafe byte [] ToNullTerminatedUtf8 (char* p, int len)
-		{
-			if (len == 0)
-				return Array.Empty<byte> ();
-
-			var byteCount = Encoding.UTF8.GetByteCount (p, len);
-			var bytes = new byte [byteCount + 1];
-			fixed (byte* b = bytes) {
-				Encoding.UTF8.GetBytes (p, len, b, byteCount);
-			}
-			return bytes;
-		}
-	}
-
-	enum SecItemClass : uint
-	{
-		InternetPassword     = 1768842612, // 'inet'
-		GenericPassword      = 1734700656, // 'genp'
-		AppleSharePassword   = 1634953328, // 'ashp'
-		Certificate          = 0x80000000 + 0x1000,
-		PublicKey            = 0x0000000A + 5,
-		PrivateKey           = 0x0000000A + 6,
-		SymmetricKey         = 0x0000000A + 7
-	}
-
-	enum SecItemAttr : int
-	{
-		CreationDate         = 1667522932,
-		ModDate              = 1835295092,
-		Description          = 1684370275,
-		Comment              = 1768123764,
-		Creator              = 1668445298,
-		Type                 = 1954115685,
-		ScriptCode           = 1935897200,
-		Label                = 1818321516,
-		Invisible            = 1768846953,
-		Negative             = 1852139361,
-		CustomIcon           = 1668641641,
-		Account              = 1633903476,
-		Service              = 1937138533,
-		Generic              = 1734700641,
-		SecurityDomain       = 1935961454,
-		Server               = 1936881266,
-		AuthType             = 1635023216,
-		Port                 = 1886351988,
-		Path                 = 1885434984,
-		Volume               = 1986817381,
-		Address              = 1633969266,
-		Signature            = 1936943463,
-		Protocol             = 1886675820,
-		CertificateType      = 1668577648,
-		CertificateEncoding  = 1667591779,
-		CrlType              = 1668445296,
-		CrlEncoding          = 1668443747,
-		Alias                = 1634494835,
-	}
-
-	enum SecAuthenticationType : int
-	{
-		NTLM                 = 1835824238,
-		MSN                  = 1634628461,
-		DPA                  = 1633775716,
-		RPA                  = 1633775730,
-		HTTPBasic            = 1886680168,
-		HTTPDigest           = 1685353576,
-		HTMLForm             = 1836216166,
-		Default              = 1953261156,
-		Any                  = 0
-	}
-
-	public enum SecProtocolType : int
-	{
-		FTP                  = 1718906912,
-		FTPAccount           = 1718906977,
-		HTTP                 = 1752462448,
-		IRC                  = 1769104160,
-		NNTP                 = 1852732528,
-		POP3                 = 1886351411,
-		SMTP                 = 1936553072,
-		SOCKS                = 1936685088,
-		IMAP                 = 1768776048,
-		LDAP                 = 1818517872,
-		AppleTalk            = 1635019883,
-		AFP                  = 1634103328,
-		Telnet               = 1952803950,
-		SSH                  = 1936943136,
-		FTPS                 = 1718906995,
-		HTTPProxy            = 1752461432,
-		HTTPSProxy           = 1752462200,
-		FTPProxy             = 1718907000,
-		CIFS                 = 1667851891,
-		SMB                  = 1936548384,
-		RTSP                 = 1920234352,
-		RTSPProxy            = 1920234360,
-		DAAP                 = 1684103536,
-		EPPC                 = 1701867619,
-		IPP                  = 1768976416,
-		NNTPS                = 1853124723,
-		LDAPS                = 1818521715,
-		TelnetS              = 1952803955,
-		IMAPS                = 1768779891,
-		IRCS                 = 1769104243,
-		POP3S                = 1886351475,
-		CVSpserver           = 1668707184,
-		SVN                  = 1937141280,
-		Any                  = 0
-	}
-
-	enum CssmDbAttributeFormat : int
-	{
-		String               = 0,
-		Int32                = 1,
-		UInt32               = 2,
-		BigNum               = 3,
-		Real                 = 4,
-		DateTime             = 5,
-		Blob                 = 6,
-		MultiUInt32          = 7,
-		Complex              = 8
 	}
 }

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -151,12 +151,8 @@ namespace MonoDevelop.MacInterop
 
 			if (code == SecStatusCode.ItemNotFound) {
 				// Fall back to looking for a password without use SecProtocol && SecAuthenticationType
-				searchRecord = new SecRecord (SecKind.InternetPassword) {
-					Service = searchRecord.Service,
-					Server = searchRecord.Server,
-					Path = searchRecord.Path,
-					Port = searchRecord.Port,
-				};
+				searchRecord.Protocol = SecProtocol.Http; // Http is the default used by SecKeyChain internally
+				searchRecord.AuthenticationType = SecAuthenticationType.Default;
 
 				data = SecKeyChain.QueryAsRecord (searchRecord, out code);
 			}

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -35,8 +35,6 @@ namespace MonoDevelop.MacInterop
 {
 	public static class Keychain
 	{
-		static readonly string Service = "MonoDevelop";
-
 		public static void AddInternetPassword (Uri uri, string password)
 		{
 			// See if there is already a password there for this uri
@@ -168,7 +166,6 @@ namespace MonoDevelop.MacInterop
 		static SecRecord ToSecRecord (this Uri uri, string username = null, string password = null)
 		{
 			var record = new SecRecord (SecKind.InternetPassword) {
-				Service = Service,
 				Server = uri.Host,
 				Path = string.Join (string.Empty, uri.Segments),
 				Port = uri.Port,

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -130,7 +130,7 @@ namespace MonoDevelop.MacInterop
 			if (record != null) {
 				SecStatusCode result = SecKeyChain.Remove (record);
 
-				if (result == SecStatusCode.Success)
+				if (result != SecStatusCode.Success)
 					throw new Exception ("Could not delete internet password from keychain: " + result.GetStatusDescription ());
 			}
 		}

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -111,11 +111,10 @@ namespace MonoDevelop.MacInterop
 			// See if there is already a password there for this uri
 			var record = SecKeychainFindInternetPassword (url, out _);
 
-			if (record == null) {
-				return string.Empty;
-			}
+			if (record != null)
+				return NSString.FromData (record.ValueData, NSStringEncoding.UTF8);
 
-			return NSString.FromData (record.ValueData, NSStringEncoding.UTF8);
+			return null;
 		}
 
 		public static unsafe Tuple<string, string> FindInternetUserNameAndPassword (Uri uri)
@@ -129,14 +128,14 @@ namespace MonoDevelop.MacInterop
 		{
 			var record = SecKeychainFindInternetPassword (url, protocol, out _);
 
-			if (record == null) {
-				return null;
+			if (record != null) {
+
+				string username = record.Account != null ? NSString.FromData (record.Account, NSStringEncoding.UTF8) : null;
+				string password = record.ValueData != null ? NSString.FromData (record.ValueData, NSStringEncoding.UTF8) : null;
+
+				return Tuple.Create (username, password);
 			}
-
-			string username = NSString.FromData (record.Account, NSStringEncoding.UTF8);
-			string password = NSString.FromData (record.ValueData, NSStringEncoding.UTF8);
-
-			return Tuple.Create (username, password);
+			return null;
 		}
 
 		public static void RemoveInternetPassword (Uri url)

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -73,10 +73,9 @@ namespace MonoDevelop.MacInterop
 				return;
 			}
 
-			record.ValueData = NSData.FromString (password);
-
 			// If there is, replace it with the new one
-			SecKeyChain.Update (searchRecord, record);
+			var update = uri.ToSecRecord (username, password);
+			SecKeyChain.Update (record, update);
 		}
 
 		public static string FindInternetPassword (Uri url)

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -56,6 +56,9 @@ namespace MonoDevelop.MacInterop
 					Protocol = serverInfo.Protocol,
 					ValueData = passwd
 				};
+				// set account from Uri
+				if (!string.IsNullOrEmpty (serverInfo.Account))
+					record.Account = serverInfo.Account;
 
 				SecStatusCode result = SecKeyChain.Add (record);
 

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -186,9 +186,12 @@ namespace MonoDevelop.MacInterop
 
 			record.Description = record.AuthenticationType == SecAuthenticationType.HtmlForm ? WebFormPassword : string.Empty;
 
-			username = username ?? Uri.UnescapeDataString (uri.UserInfo);
-			if (!string.IsNullOrEmpty (username))
-				record.Account = username;
+			var account = Uri.UnescapeDataString (uri.UserInfo);
+			if (string.IsNullOrEmpty (account)) // account from Uri has always priority
+				account = username;
+
+			if (!string.IsNullOrEmpty (account))
+				record.Account = account;
 
 			if (password != null)
 				record.ValueData = NSData.FromString (password);

--- a/main/src/addins/MacPlatform/MacInterop/Keychain.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Keychain.cs
@@ -184,7 +184,8 @@ namespace MonoDevelop.MacInterop
 			if (authType != SecAuthenticationType.Default)
 				record.AuthenticationType = authType;
 
-			record.Description = record.AuthenticationType == SecAuthenticationType.HtmlForm ? WebFormPassword : string.Empty;
+			if (record.AuthenticationType == SecAuthenticationType.HtmlForm)
+				record.Description = WebFormPassword;
 
 			var account = Uri.UnescapeDataString (uri.UserInfo);
 			if (string.IsNullOrEmpty (account)) // account from Uri has always priority

--- a/main/src/addins/MacPlatform/MacProxyCredentialProvider.cs
+++ b/main/src/addins/MacPlatform/MacProxyCredentialProvider.cs
@@ -34,6 +34,7 @@ using AppKit;
 using CoreGraphics;
 using Foundation;
 using MonoDevelop.MacInterop;
+using Security;
 
 namespace MonoDevelop.MacIntegration
 {
@@ -65,11 +66,11 @@ namespace MonoDevelop.MacIntegration
 
 		static ICredentials GetSystemProxyCredentials (Uri uri)
 		{
-			var kind = SecProtocolType.Any;
+			var kind = SecProtocol.Http;
 			if (uri.Scheme == "http")
-				kind = SecProtocolType.HTTPProxy;
+				kind = SecProtocol.HttpProxy;
 			else if (uri.Scheme == "https")
-				kind = SecProtocolType.HTTPSProxy;
+				kind = SecProtocol.HttpsProxy;
 
 			//TODO: get username from SystemConfiguration APIs so we don't trigger a double auth prompt
 			var existing = Keychain.FindInternetUserNameAndPassword (uri, kind);

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\TypeSystemServiceTests.cs" />
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopFrameworkAssemblyPathResolverFactoryTests.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\MonoDevelopWorkspaceTests.cs" />
+    <Compile Include="MonoDevelop.Ide\BaseCredentialsProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/BaseCredentialsProviderTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/BaseCredentialsProviderTests.cs
@@ -26,11 +26,13 @@
 using System;
 using NUnit.Framework;
 using System.IO;
+using UnitTests;
+using MonoDevelop.Core;
 
-namespace MonoDevelop.Core
+namespace MonoDevelop.Ide
 {
 	[TestFixture]
-	public abstract class BaseCredentialsProviderTests
+	public abstract class BaseCredentialsProviderTests : IdeTestBase
 	{
 		static readonly string mockUser = "md_test_" + Guid.NewGuid ();
 		static readonly Uri mockUrl = new Uri ("ftp://" + Path.GetRandomFileName () + ".randomdomain");

--- a/main/tests/MacPlatform.Tests/CredentialsProviderTests.cs
+++ b/main/tests/MacPlatform.Tests/CredentialsProviderTests.cs
@@ -24,12 +24,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using AppKit;
 using NUnit.Framework;
 
 namespace MacPlatform.Tests
 {
 	[TestFixture]
-	public class CredentialsProviderTests : MonoDevelop.Core.BaseCredentialsProviderTests
+	public class CredentialsProviderTests : MonoDevelop.Ide.BaseCredentialsProviderTests
 	{
 		protected override MonoDevelop.Core.IPasswordProvider GetPasswordProvider ()
 		{

--- a/main/tests/MacPlatform.Tests/CredentialsProviderTests.cs
+++ b/main/tests/MacPlatform.Tests/CredentialsProviderTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // CredentialsProviderTests.cs
 //
 // Author:
@@ -23,8 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
-using MonoDevelop.MacInterop;
+
 using NUnit.Framework;
 
 namespace MacPlatform.Tests
@@ -32,22 +31,6 @@ namespace MacPlatform.Tests
 	[TestFixture]
 	public class CredentialsProviderTests : MonoDevelop.Core.BaseCredentialsProviderTests
 	{
-		static string TestKeyChain = "ThisIsMonoDevelopsPrivateKeyChainForTests";
-
-		[TestFixtureSetUp]
-		public void FixtureSetup ()
-		{
-			Keychain.TryDeleteKeychain (TestKeyChain);
-			Keychain.CurrentKeychain = Keychain.CreateKeychain (TestKeyChain, "mypassword");
-		}
-
-		[TestFixtureTearDown]
-		public void FixtureTeardown ()
-		{
-			Keychain.DeleteKeychain (Keychain.CurrentKeychain);
-			Keychain.CurrentKeychain = IntPtr.Zero;
-		}
-
 		protected override MonoDevelop.Core.IPasswordProvider GetPasswordProvider ()
 		{
 			return new MonoDevelop.MacIntegration.MacKeychainPasswordProvider ();

--- a/main/tests/MacPlatform.Tests/KeychainTests.cs
+++ b/main/tests/MacPlatform.Tests/KeychainTests.cs
@@ -25,13 +25,14 @@
 // THE SOFTWARE.
 
 using System;
+using MonoDevelop.Ide;
 using MonoDevelop.MacInterop;
 using NUnit.Framework;
 
 namespace MacPlatform.Tests
 {
 	[TestFixture]
-	public class KeychainTests
+	public class KeychainTests : IdeTestBase
 	{
 		const string password = "pa55word";
 

--- a/main/tests/MacPlatform.Tests/KeychainTests.cs
+++ b/main/tests/MacPlatform.Tests/KeychainTests.cs
@@ -36,8 +36,9 @@ namespace MacPlatform.Tests
 	{
 		const string password = "pa55word";
 
-		const string site = "http://google.com";
-		const string siteWithUser = "http://user@google.com";
+		const string testDomain = "test-monodevelop-mac-keychain.com";
+		const string site = "http://" + testDomain;
+		const string siteWithUser = "http://user@" + testDomain;
 		const string siteWithPath = site + "/path";
 		const string siteWithUserAndPath = siteWithUser + "/path";
 
@@ -86,10 +87,10 @@ namespace MacPlatform.Tests
 		{
 			string passwordNoUser = password + "nouser";
 
-			var uriBase = new Uri ("http://google.com");
-			var uri1 = new Uri ("http://user1@google.com");
-			var uri2 = new Uri ("http://user2@google.com");
-			var uri3 = new Uri ("http://google.com/path");
+			var uriBase = new Uri ("http://" + testDomain);
+			var uri1 = new Uri ("http://user1@" + testDomain);
+			var uri2 = new Uri ("http://user2@" + testDomain);
+			var uri3 = new Uri ("http://" + testDomain + "/path");
 
 			try {
 				Keychain.AddInternetPassword (uriBase, passwordNoUser);

--- a/main/tests/MacPlatform.Tests/KeychainTests.cs
+++ b/main/tests/MacPlatform.Tests/KeychainTests.cs
@@ -82,6 +82,58 @@ namespace MacPlatform.Tests
 			}
 		}
 
+		[TestCase (site, "", "path2")]
+		[TestCase (site, "path1", "path2")]
+		[TestCase (siteWithUser, "path1", "path2")]
+		public void InternetPassword_SameHostDifferentPath (string url, string path1, string path2)
+		{
+			var uri1 = new Uri (url + "/" + path1);
+			var uri2 = new Uri (url + "/" + path2);
+			var user1 = !string.IsNullOrEmpty (uri1.UserInfo) ? uri1.UserInfo : "user1";
+			var user2 = !string.IsNullOrEmpty (uri2.UserInfo) ? uri2.UserInfo : "user2";
+			var password1 = password + "1";
+			var password2 = password + "2";
+
+			if (!string.IsNullOrEmpty (uri1.UserInfo))
+				Keychain.AddInternetPassword (uri1, password1);
+			else
+				Keychain.AddInternetPassword (uri1, user1, password1);
+
+			if (!string.IsNullOrEmpty (uri2.UserInfo))
+				Keychain.AddInternetPassword (uri2, password2);
+			else
+				Keychain.AddInternetPassword (uri2, user2, password2);
+
+			try {
+				var foundPassword1 = Keychain.FindInternetPassword (uri1);
+				var foundPasswordAndUser1 = Keychain.FindInternetUserNameAndPassword (uri1);
+				var foundPassword2 = Keychain.FindInternetPassword (uri2);
+				var foundPasswordAndUser2 = Keychain.FindInternetUserNameAndPassword (uri2);
+
+				Assert.AreEqual (password1, foundPassword1);
+				Assert.AreEqual (user1, foundPasswordAndUser1.Item1);
+				Assert.AreEqual (password1, foundPasswordAndUser1.Item2);
+				Assert.AreEqual (password2, foundPassword2);
+				Assert.AreEqual (user2, foundPasswordAndUser2.Item1);
+				Assert.AreEqual (password2, foundPasswordAndUser2.Item2);
+			} finally {
+				Keychain.RemoveInternetPassword (uri1);
+				Keychain.RemoveInternetPassword (uri2);
+				if (!string.IsNullOrEmpty (uri1.UserInfo)) {
+					Keychain.RemoveInternetUserNameAndPassword (uri1);
+				}
+				if (!string.IsNullOrEmpty (uri2.UserInfo)) {
+					Keychain.RemoveInternetUserNameAndPassword (uri2);
+				}
+
+				Assert.IsNull (Keychain.FindInternetPassword (uri1));
+				Assert.IsNull (Keychain.FindInternetUserNameAndPassword (uri1));
+
+				Assert.IsNull (Keychain.FindInternetPassword (uri2));
+				Assert.IsNull (Keychain.FindInternetUserNameAndPassword (uri2));
+			}
+		}
+
 		[Test]
 		public void InternetPassword_Remove ()
 		{

--- a/main/tests/MacPlatform.Tests/KeychainTests.cs
+++ b/main/tests/MacPlatform.Tests/KeychainTests.cs
@@ -27,30 +27,13 @@
 using System;
 using MonoDevelop.MacInterop;
 using NUnit.Framework;
-using System.IO;
-using System.Text;
 
 namespace MacPlatform.Tests
 {
 	[TestFixture]
 	public class KeychainTests
 	{
-		const string TestKeyChain = "ThisIsMonoDevelopsPrivateKeyChainForTests";
 		const string password = "pa55word";
-
-		[SetUp]
-		public void Setup ()
-		{
-			Keychain.TryDeleteKeychain (TestKeyChain);
-			Keychain.CurrentKeychain = Keychain.CreateKeychain (TestKeyChain, "mypassword");
-		}
-
-		[TearDown]
-		public void Teardown ()
-		{
-			Keychain.DeleteKeychain (Keychain.CurrentKeychain);
-			Keychain.CurrentKeychain = IntPtr.Zero;
-		}
 
 		const string site = "http://google.com";
 		const string siteWithUser = "http://user@google.com";
@@ -157,25 +140,5 @@ namespace MacPlatform.Tests
 				Assert.AreEqual (expectedPassword, foundPassword);
 			}
 		}
-
-		[Test]
-		public void ToNullTerminatedUtf8IsNullTerminated ()
-		{
-			var str = "This is a test string";
-
-			var bytes = Encoding.UTF8.GetBytes (str);
-			var bytesWithNullTerm = str.ToNullTerminatedUtf8 ();
-
-			Assert.AreEqual (bytes.Length + 1, bytesWithNullTerm.Length);
-			Assert.AreEqual (0, bytesWithNullTerm [bytesWithNullTerm.Length - 1]);
-
-			// UTF8Encoding does not handle null terminated strings, so do the check like this.
-			Assert.AreEqual (str + char.MinValue, Encoding.UTF8.GetString (bytesWithNullTerm));
-
-			const int offset = 2;
-			var bytesWithNullTermOffset = str.ToNullTerminatedUtf8 (offset);
-			Assert.AreEqual (str.Substring (offset) + char.MinValue, Encoding.UTF8.GetString (bytesWithNullTermOffset));
-		}
 	}
 }
-

--- a/main/tests/MacPlatform.Tests/KeychainTests.cs
+++ b/main/tests/MacPlatform.Tests/KeychainTests.cs
@@ -82,6 +82,59 @@ namespace MacPlatform.Tests
 			}
 		}
 
+		[TestCase (site, null, null, null, Description = "No User, Password Only")]
+		[TestCase (site, "user", "user", "user", Description = "User unchanged, Password Only")]
+		[TestCase (site, null, "user2", "user2", Description = "Add User")]
+		[TestCase (site, "user", "user2", "user2", Description = "Update User and Password")]
+		[TestCase (siteWithPath, null, null, null, Description = "With Path, No User, Password Only")]
+		[TestCase (siteWithPath, "user", "user", "user", Description = "With Path, User unchanged, Password Only")]
+		[TestCase (siteWithPath, null, "user2", "user2", Description = "Add User")]
+		[TestCase (siteWithPath, "user", "user2", "user2", Description = "With Path, Update User and Password")]
+		[TestCase (siteWithUser, null, null, "user", Description = "Fixed User, Password Only")]
+		[TestCase (siteWithUser, "user", "user2", "user", Description = "Fixed User, User and Password")]
+		public void InternetPassword_AddUpdateRemove (string url, string user, string updateUser, string expectedUsername)
+		{
+			var uri = new Uri (url);
+			var updatePassword = password + "Update";
+
+			if (user != null) {
+				Keychain.AddInternetPassword (uri, user, password);
+			} else {
+				Keychain.AddInternetPassword (uri, password);
+			}
+
+			try {
+				var foundPassword = Keychain.FindInternetPassword (uri);
+				var passAndUser = Keychain.FindInternetUserNameAndPassword (uri);
+
+				Assert.AreEqual (password, foundPassword);
+				if (user != null)
+					Assert.AreEqual (user, passAndUser.Item1);
+				Assert.AreEqual (password, passAndUser.Item2);
+
+				if (updateUser != null) {
+					Keychain.AddInternetPassword (uri, updateUser, updatePassword);
+				} else {
+					Keychain.AddInternetPassword (uri, updatePassword);
+				}
+
+				foundPassword = Keychain.FindInternetPassword (uri);
+				passAndUser = Keychain.FindInternetUserNameAndPassword (uri);
+
+				Assert.AreEqual (updatePassword, foundPassword);
+				Assert.AreEqual (expectedUsername, passAndUser.Item1);
+				Assert.AreEqual (updatePassword, passAndUser.Item2);
+			} finally {
+				Keychain.RemoveInternetPassword (uri);
+				if (!string.IsNullOrEmpty (uri.UserInfo)) {
+					Keychain.RemoveInternetUserNameAndPassword (uri);
+				}
+
+				Assert.IsNull (Keychain.FindInternetPassword (uri));
+				Assert.IsNull (Keychain.FindInternetUserNameAndPassword (uri));
+			}
+		}
+
 		[TestCase (site, "", "path2")]
 		[TestCase (site, "path1", "path2")]
 		[TestCase (siteWithUser, "path1", "path2")]

--- a/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
+++ b/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
@@ -65,6 +65,11 @@
       <Name>IdeUnitTests</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\Ide.Tests\MonoDevelop.Ide.Tests.csproj">
+      <Project>{73D4CC8B-BAB9-4A29-841B-F25C6311F067}</Project>
+      <Name>MonoDevelop.Ide.Tests</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -83,7 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoDevelop.Core\BacktrackingStringMatcherTests.cs" />
-    <Compile Include="MonoDevelop.Core\BaseCredentialsProviderTests.cs" />
     <Compile Include="MonoDevelop.Core\CoreExtensionsTests.cs" />
     <Compile Include="MonoDevelop.Core\FilePathTests.cs" />
     <Compile Include="MonoDevelop.Core\FileServiceTests.cs" />

--- a/main/tests/WindowsPlatform.Tests/CredentialsProviderTests.cs
+++ b/main/tests/WindowsPlatform.Tests/CredentialsProviderTests.cs
@@ -30,7 +30,7 @@ using System.IO;
 namespace WindowsPlatform.Tests
 {
 	[TestFixture]
-	public class CredentialsProviderTests : MonoDevelop.Core.BaseCredentialsProviderTests
+	public class CredentialsProviderTests : MonoDevelop.Ide.BaseCredentialsProviderTests
 	{
 		protected override MonoDevelop.Core.IPasswordProvider GetPasswordProvider ()
 		{

--- a/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
+++ b/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
@@ -28,10 +28,6 @@
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
       <Name>GuiUnit_NET_4_5</Name>
     </ProjectReference>
-    <ProjectReference Include="..\MonoDevelop.Core.Tests\MonoDevelop.Core.Tests.csproj">
-      <Project>{fda43caa-1c2a-4593-8601-3e2ee06d9e03}</Project>
-      <Name>MonoDevelop.Core.Tests</Name>
-    </ProjectReference>
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
@@ -39,6 +35,11 @@
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
       <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
       <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Ide.Tests\MonoDevelop.Ide.Tests.csproj">
+      <Project>{73D4CC8B-BAB9-4A29-841B-F25C6311F067}</Project>
+      <Name>MonoDevelop.Ide.Tests</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Actually, the keychain implementation (macOS) has several issues:
- Missing protocols (especially "https" for Git and Azure DevOps)
- The URL Path part is not stored correctly

Due to these issues, we can not update an existing keychain item sometimes, and generate new ones on each query, the service always returns the first entry for a service. 

We have changed the implementation of KeyChain to use the security APIs of Xamarin.Mac directly.

Fixes #795844

Backport of #7278.

/cc @sevoku @jsuarezruiz