### PR TITLE
[Ide] Fix progress dialog in front of confirmation dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
@@ -57,10 +57,16 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 		{
 		}
 		
-		public MessageDialogProgressMonitor (bool showProgress, bool allowCancel, bool showDetails, bool hideWhenDone): base (Runtime.MainSynchronizationContext)
+		public MessageDialogProgressMonitor (bool showProgress, bool allowCancel, bool showDetails, bool hideWhenDone)
+			: this (showProgress, allowCancel, showDetails, hideWhenDone, null)
+		{
+		}
+
+		public MessageDialogProgressMonitor (bool showProgress, bool allowCancel, bool showDetails, bool hideWhenDone, Components.Window parent)
+			: base (Runtime.MainSynchronizationContext)
 		{
 			if (showProgress) {
-				var parentWindow = DesktopService.GetFocusedTopLevelWindow ();
+				var parentWindow = parent ?? DesktopService.GetFocusedTopLevelWindow ();
 				dialog = new ProgressDialog (parentWindow, allowCancel, showDetails);
 				dialog.Message = "";
 				MessageService.PlaceDialog (dialog, parentWindow);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -1979,7 +1979,7 @@ namespace MonoDevelop.Ide
 			ProgressMonitor monitor = null;
 			
 			if (files.Length > 10) {
-				monitor = new MessageDialogProgressMonitor (true);
+				monitor = new MessageDialogProgressMonitor (true, true, true, true, MessageService.RootWindow);
 				monitor.BeginTask (GettextCatalog.GetString("Adding files..."), files.Length);
 			}
 			


### PR DESCRIPTION
Adding an existing folder, that does not exist inside the project and
has more than 10 files, was opening a progress monitor dialog in front
of the confirmation dialog asking how to copy the files into the
project. A change to the MessageDialogProgressMonitor affected its
parent causing it to appear above the confirmation dialog. To fix this
the MessageDialogProgressMonitor now has a constructor that takes the
parent window.

Fixes VSTS #807518 - New ASP.NET Core Empty > .NET Core 2.x project,
add Existing Folder "bootstrap-4.3.1-dist", "Adding files..." dialog
in the front.