### PR TITLE
[VersionControl] Ask to stash changes before update a solution.

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -875,7 +875,7 @@ namespace MonoDevelop.VersionControl.Git
 			var oldHead = RootRepository.Head.Tip;
 
 			if (!CommonPreMergeRebase (GitUpdateOptions.None, monitor, out stashIndex))
-				throw new UserCancelledException();
+				throw new UserCancelledException ();
 
 			if (RootRepository.Head.IsTracking) {
 				try {
@@ -888,7 +888,7 @@ namespace MonoDevelop.VersionControl.Git
 						Merge (RootRepository.Head.TrackedBranch.FriendlyName, options, monitor);
 
 					monitor.Step (1);
-				} catch(UserCancelledException) {
+				} catch (UserCancelledException) {
 					CommonPostMergeRebase (stashIndex, GitUpdateOptions.SaveLocalChanges, monitor, oldHead);
 				}
 			}


### PR DESCRIPTION
Now, before fetch and discarding local changes, we ask if want to make a stash of the pending changes.
If the user cancel the fetch operation, we retrieve the changes from the stash and remove it.

Fixes VSTS #735838 