### PR TITLE
[VersionControl] Fix problem detecting sln and csproj changes

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -1001,7 +1001,7 @@ namespace MonoDevelop.VersionControl.Views
 			VersionInfo newInfo;
 			try {
 				// Reuse remote status from old version info
-				newInfo = vc.GetVersionInfo (args.FilePath);
+				newInfo = vc.GetVersionInfo (args.FilePath, VersionInfoQueryFlags.IgnoreCache);
 				if (found && newInfo != null) {
 					VersionInfo oldInfo = statuses [oldStatusIndex];
 					if (oldInfo != null) {
@@ -1034,9 +1034,11 @@ namespace MonoDevelop.VersionControl.Views
 			}
 			else {
 				if (FileVisible (newInfo)) {
-					statuses.Add (newInfo);
-					changeSet.AddFile (newInfo);
-					AppendFileInfo (newInfo, wasExpanded);
+					if (!statuses.Any(s => s.LocalPath == newInfo.LocalPath)) {
+						statuses.Add (newInfo);
+						changeSet.AddFile (newInfo);
+						AppendFileInfo (newInfo, wasExpanded);
+					}
 				}
 			}
 			return true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -997,6 +997,7 @@ namespace MonoDevelop.VersionControl.Views
 			}
 
 			VersionInfo newInfo;
+
 			try {
 				// Reuse remote status from old version info
 				newInfo = vc.GetVersionInfo (args.FilePath, VersionInfoQueryFlags.IgnoreCache);
@@ -1034,11 +1035,16 @@ namespace MonoDevelop.VersionControl.Views
 			}
 			else {
 				if (FileVisible (newInfo)) {
-					if (!statuses.Any (s => s.LocalPath.Equals (newInfo.LocalPath))) {
+					if (!statuses.Any (s => s.LocalPath == newInfo.LocalPath)) {
 						statuses.Add (newInfo);
-						changeSet.AddFile (newInfo);
 						AppendFileInfo (newInfo, wasExpanded);
 					}
+
+					if (changeSet.GetFileItem (args.FilePath) != null) {
+						changeSet.RemoveFile (args.FilePath);
+					}
+
+					changeSet.AddFile (newInfo);
 				}
 			}
 			return true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -1034,21 +1034,9 @@ namespace MonoDevelop.VersionControl.Views
 					changeSet.AddFile (newInfo);
 					statuses.Add (newInfo);
 					AppendFileInfo (newInfo, wasExpanded);
-				} else {
-					InalidateChangeSet (newInfo.LocalPath);
 				}
 			}
 			return true;
-		}
-
-		void InalidateChangeSet(FilePath path)
-		{
-			if (!changeSet.ContainsFile (path)) {
-				var newInfo = vc.GetVersionInfo (path, VersionInfoQueryFlags.IgnoreCache);
-				if (FileVisible (newInfo)) {
-					changeSet.AddFile (newInfo);
-				}
-			}
 		}
 
 		void InvalidateDiffData (FilePath path, bool remote, VersionInfo info)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs
@@ -4,16 +4,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Mono.Addins;
-
 using Gtk;
-
 using MonoDevelop.Core;
 using MonoDevelop.Components;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Projects;
 using MonoDevelop.Ide;
-using Mono.TextEditor;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -1017,10 +1015,12 @@ namespace MonoDevelop.VersionControl.Views
 
 			if (found) {
 				if (!FileVisible (newInfo)) {
-					// Just remove the file from the change set
-					changeSet.RemoveFile (args.FilePath);
-					statuses.RemoveAt (oldStatusIndex);
-					filestore.Remove (ref oldStatusIter);
+					if (changeSet.GetFileItem (args.FilePath) != null) {
+						// Just remove the file from the change set
+						changeSet.RemoveFile (args.FilePath);
+						statuses.RemoveAt (oldStatusIndex);
+						filestore.Remove (ref oldStatusIter);
+					}
 					return true;
 				}
 
@@ -1034,7 +1034,7 @@ namespace MonoDevelop.VersionControl.Views
 			}
 			else {
 				if (FileVisible (newInfo)) {
-					if (!statuses.Any(s => s.LocalPath == newInfo.LocalPath)) {
+					if (!statuses.Any (s => s.LocalPath.Equals (newInfo.LocalPath))) {
 						statuses.Add (newInfo);
 						changeSet.AddFile (newInfo);
 						AppendFileInfo (newInfo, wasExpanded);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -225,7 +225,7 @@ namespace MonoDevelop.VersionControl
 				return infos [0];
 			}*/
 		}
-		
+
 		/// <summary>
 		/// Returns the versioning status of a set of files or directories
 		/// </summary>
@@ -258,11 +258,11 @@ namespace MonoDevelop.VersionControl
 				else {
 					// If there is no cached status, query it asynchronously
 					vi = new VersionInfo (p, "", Directory.Exists (p), VersionStatus.Versioned, null, VersionStatus.Versioned, null);
-					infoCache.SetStatus (vi, false);
+					infoCache.SetStatus (vi, true);
 					result.Add (vi);
 					pathsToQuery.Add (p);
 				}
-//				Console.WriteLine ("GetVersionInfo " + string.Join (", ", paths.Select (p => p.FullPath)));
+				// Console.WriteLine ("GetVersionInfo " + string.Join (", ", paths.Select (p => p.FullPath)));
 			}
 			if (pathsToQuery.Count > 0)
 				AddQuery (new VersionInfoQuery () { Paths = pathsToQuery, QueryFlags = queryFlags });
@@ -429,8 +429,9 @@ namespace MonoDevelop.VersionControl
 						if (IsDisposed)
 							break;
 						var status = OnGetVersionInfo (group.SelectMany (q => q.Paths), group.Key).ToList ();
-						foreach (var vi in status)
+						foreach (var vi in status) 
 							if (!vi.IsInitialized) vi.Init (this);
+					
 						infoCache.SetStatus (status);
 					}
 
@@ -652,8 +653,8 @@ namespace MonoDevelop.VersionControl
 			var metadata = new RevertMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Recursive = recurse, OperationType = RevertMetadata.RevertType.LocalChanges };
 			using (var tracker = Instrumentation.RevertCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					ClearCachedVersionInfo (localPaths);
 					OnRevert (localPaths, recurse, monitor);
+					ClearCachedVersionInfo (localPaths);
 				} catch {
 					metadata.SetFailure ();
 					throw;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.VersionControl
 				return;
 			}
 
-			fileStatus.AddOrUpdate (versionInfo.LocalPath, versionInfo, (f, v) => versionInfo);
+			fileStatus [versionInfo.LocalPath] = versionInfo;
 
 			if (notify)
 				VersionControlService.NotifyFileStatusChanged (new FileUpdateEventArgs (repo, versionInfo.LocalPath, versionInfo.IsDirectory));
@@ -111,7 +111,7 @@ namespace MonoDevelop.VersionControl
 					continue;
 				}
 
-				fileStatus.AddOrUpdate (versionInfo.LocalPath, versionInfo, (f, v) => versionInfo);
+				fileStatus [versionInfo.LocalPath] = versionInfo;
 
 				var a = new FileUpdateEventArgs (repo, versionInfo.LocalPath, versionInfo.IsDirectory);
 				if (args == null)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
@@ -23,91 +23,76 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using MonoDevelop.Core;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System;
+using System.Collections.Concurrent;
 
 namespace MonoDevelop.VersionControl
 {
 	class VersionInfoCache : IDisposable
 	{
-		ReaderWriterLockSlim fileLock = new ReaderWriterLockSlim();
-		Dictionary<FilePath,VersionInfo> fileStatus = new Dictionary<FilePath, VersionInfo> ();
-		ReaderWriterLockSlim directoryLock = new ReaderWriterLockSlim ();
-		Dictionary<FilePath,DirectoryStatus> directoryStatus = new Dictionary<FilePath, DirectoryStatus> ();
+		static readonly ConcurrentDictionary<FilePath, VersionInfo> fileStatus = new ConcurrentDictionary<FilePath, VersionInfo> ();
+		static readonly ConcurrentDictionary<FilePath, DirectoryStatus> directoryStatus = new ConcurrentDictionary<FilePath, DirectoryStatus> ();
 		Repository repo;
 
 		public VersionInfoCache (Repository repo)
 		{
 			this.repo = repo;
 		}
-
+					
 		public void ClearCachedVersionInfo (FilePath rootPath)
 		{
+			FileUpdateEventArgs args = null;
 			var canonicalPath = rootPath.CanonicalPath;
 
-			try {
-				fileLock.EnterWriteLock ();
-				foreach (var p in fileStatus.Where (e => e.Key.IsChildPathOf (rootPath) || e.Key == canonicalPath))
-					p.Value.RequiresRefresh = true;
-			} finally {
-				fileLock.ExitWriteLock ();
+			foreach (var p in fileStatus.Where (e => e.Key.IsChildPathOf (rootPath) || e.Key == canonicalPath)) {
+				p.Value.RequiresRefresh = true;
+
+				var a = new FileUpdateEventArgs (repo, p.Value.LocalPath, p.Value.IsDirectory);
+				if (args == null)
+					args = a;
+				else
+					args.MergeWith (a);
 			}
 
-			try {
-				directoryLock.EnterWriteLock ();
-				foreach (var p in directoryStatus.Where (e => e.Key.IsChildPathOf (rootPath) || e.Key == canonicalPath))
-					p.Value.RequiresRefresh = true;
-			} finally {
-				directoryLock.ExitWriteLock ();
+			foreach (var p in directoryStatus.Where (e => e.Key.IsChildPathOf (rootPath) || e.Key == canonicalPath)) {
+				p.Value.RequiresRefresh = true;
+			}
+
+			if (args != null) {
+				//	Console.WriteLine ("Notifying Status " + string.Join (", ", args.Select (p => p.FilePath.FullPath)));
+				VersionControlService.NotifyFileStatusChanged (args);
 			}
 		}
 
 		public VersionInfo GetStatus (FilePath localPath)
 		{
-			try {
-				fileLock.EnterReadLock ();
+			fileStatus.TryGetValue (localPath, out var vi);
 
-				VersionInfo vi;
-				fileStatus.TryGetValue (localPath, out vi);
-				return vi;
-			} finally {
-				fileLock.ExitReadLock ();
-			}
+			return vi;
 		}
 
 		public DirectoryStatus GetDirectoryStatus (FilePath localPath)
 		{
-			try {
-				directoryLock.EnterReadLock ();
-
-				DirectoryStatus vis;
-				if (directoryStatus.TryGetValue (localPath.CanonicalPath, out vis))
-					return vis;
-				return null;
-			} finally {
-				directoryLock.ExitReadLock ();
-			}
+			if (directoryStatus.TryGetValue (localPath.CanonicalPath, out var vis))
+				return vis;
+			return null;
 		}
 
 		public void SetStatus (VersionInfo versionInfo, bool notify = true)
 		{
-			try {
-				fileLock.EnterWriteLock ();
+			if (!versionInfo.IsInitialized)
+				versionInfo.Init (repo);
 
-				if (!versionInfo.IsInitialized)
-					versionInfo.Init (repo);
-				VersionInfo vi;
-				if (fileStatus.TryGetValue (versionInfo.LocalPath, out vi) && vi.Equals (versionInfo)) {
-					vi.RequiresRefresh = false;
-					return;
-				}
-				fileStatus [versionInfo.LocalPath] = versionInfo;
-			} finally {
-				fileLock.ExitWriteLock ();
+			if (fileStatus.TryGetValue (versionInfo.LocalPath, out var vi) && vi.Equals (versionInfo)) {
+				vi.RequiresRefresh = false;
+				return;
 			}
+
+			fileStatus.AddOrUpdate (versionInfo.LocalPath, versionInfo, (f, v) => versionInfo);
 
 			if (notify)
 				VersionControlService.NotifyFileStatusChanged (new FileUpdateEventArgs (repo, versionInfo.LocalPath, versionInfo.IsDirectory));
@@ -117,77 +102,58 @@ namespace MonoDevelop.VersionControl
 		{
 			FileUpdateEventArgs args = null;
 
-			try {
-				fileLock.EnterWriteLock ();
-				foreach (var versionInfo in versionInfos) {
-					if (!versionInfo.IsInitialized)
-						versionInfo.Init (repo);
-					VersionInfo vi;
-					if (fileStatus.TryGetValue (versionInfo.LocalPath, out vi) && vi.Equals (versionInfo)) {
-						vi.RequiresRefresh = false;
-						continue;
-					}
-					fileStatus [versionInfo.LocalPath] = versionInfo;
-					var a = new FileUpdateEventArgs (repo, versionInfo.LocalPath, versionInfo.IsDirectory);
-					if (args == null)
-						args = a;
-					else
-						args.MergeWith (a);
+			foreach (var versionInfo in versionInfos) {
+				if (!versionInfo.IsInitialized)
+					versionInfo.Init (repo);
+
+				if (fileStatus.TryGetValue (versionInfo.LocalPath, out var vi) && vi.Equals (versionInfo)) {
+					vi.RequiresRefresh = false;
+					continue;
 				}
-			} finally {
-				fileLock.ExitWriteLock ();
+
+				fileStatus.AddOrUpdate (versionInfo.LocalPath, versionInfo, (f, v) => versionInfo);
+
+				var a = new FileUpdateEventArgs (repo, versionInfo.LocalPath, versionInfo.IsDirectory);
+				if (args == null)
+					args = a;
+				else
+					args.MergeWith (a);
 			}
+
 			if (args != null) {
-			//	Console.WriteLine ("Notifying Status " + string.Join (", ", args.Select (p => p.FilePath.FullPath)));
+				//	Console.WriteLine ("Notifying Status " + string.Join (", ", args.Select (p => p.FilePath.FullPath)));
 				VersionControlService.NotifyFileStatusChanged (args);
 			}
 		}
 
-		public void SetDirectoryStatus (FilePath localDirectory, VersionInfo[] versionInfos, bool hasRemoteStatus)
+		public void SetDirectoryStatus (FilePath localDirectory, VersionInfo [] versionInfos, bool hasRemoteStatus)
 		{
-			try {
-				directoryLock.EnterWriteLock ();
-
-				DirectoryStatus vis;
-				if (directoryStatus.TryGetValue (localDirectory.CanonicalPath, out vis)) {
-					if (versionInfos.Length == vis.FileInfo.Length && (hasRemoteStatus == vis.HasRemoteStatus)) {
-						bool allEqual = true;
-						for (int n = 0; n < versionInfos.Length; n++) {
-							if (!versionInfos [n].Equals (vis.FileInfo [n])) {
-								allEqual = false;
-								break;
-							}
-						}
-						if (allEqual) {
-							vis.RequiresRefresh = false;
-							return;
+			if (directoryStatus.TryGetValue (localDirectory.CanonicalPath, out var vis)) {
+				if (versionInfos.Length == vis.FileInfo.Length && (hasRemoteStatus == vis.HasRemoteStatus)) {
+					bool allEqual = true;
+					for (int n = 0; n < versionInfos.Length; n++) {
+						if (!versionInfos [n].Equals (vis.FileInfo [n])) {
+							allEqual = false;
+							break;
 						}
 					}
+					if (allEqual) {
+						vis.RequiresRefresh = false;
+						return;
+					}
 				}
-				directoryStatus [localDirectory.CanonicalPath] = new DirectoryStatus { FileInfo = versionInfos, HasRemoteStatus = hasRemoteStatus };
-				SetStatus (versionInfos);
-			} finally {
-				directoryLock.ExitWriteLock ();
 			}
+			directoryStatus [localDirectory.CanonicalPath] = new DirectoryStatus { FileInfo = versionInfos, HasRemoteStatus = hasRemoteStatus };
+			SetStatus (versionInfos);
 		}
 
 		public void Dispose ()
 		{
-			if (fileLock != null) {
-				fileLock.Dispose ();
-				fileLock = null;
-			}
-			if (directoryLock != null) {
-				directoryLock.Dispose ();
-				directoryLock = null;
-			}
 			if (fileStatus != null) {
 				fileStatus.Clear ();
-				fileStatus = null;
 			}
 			if (directoryStatus != null) {
 				directoryStatus.Clear ();
-				directoryStatus = null;
 			}
 			repo = null;
 		}
@@ -195,9 +161,8 @@ namespace MonoDevelop.VersionControl
 
 	class DirectoryStatus
 	{
-		public VersionInfo[] FileInfo { get; set; }
+		public VersionInfo [] FileInfo { get; set; }
 		public bool HasRemoteStatus { get; set; }
 		public bool RequiresRefresh { get; set; }
 	}
 }
-


### PR DESCRIPTION
In the StatusView, obtaining the status of files using `GetVersionInfo`, we obtain an incorrect value (without local changes). It seems to be a cache problem. For this reason, sometimes trying to add the change to the changeset we do not do it and we do not update the UI correctly.
Added validation where we verify the status of the file ignoring the cache (in necessary case).

Fixes VSTS #675483
Fixes VSTS #672672