### PR TITLE
[release-8.0-integration] [Version Control] Manage multiple VCS in the same path

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -118,7 +118,10 @@ namespace MonoDevelop.VersionControl
 
 				if (search < 0)
 					handlers.Insert (~search, vcs);
-
+				else {
+					LoggingService.LogError ("Error trying to add an existing version control system.");
+					return;
+				}
 				try {
 					// Include the repository type in the serialization context, so repositories
 					// of this type can be deserialized from the configuration file.

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -113,7 +113,7 @@ namespace MonoDevelop.VersionControl
 
 			if (args.Change == ExtensionChange.Add) {
 				IComparer<VersionControlSystem> compare = new CompareVersionControlSystem ();
-				handlers.Sort (compare.Compare);
+		
 				int search = handlers.BinarySearch (vcs, compare);
 
 				if (search < 0)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -127,6 +127,8 @@ namespace MonoDevelop.VersionControl
 			else {
 				handlers.Remove (vcs);
 			}
+
+			handlers = handlers.OrderBy (h => h.Name).ToList();
 		}
 		
 		public static Xwt.Drawing.Image LoadOverlayIconForStatus(VersionStatus status)
@@ -663,7 +665,7 @@ namespace MonoDevelop.VersionControl
 		
 		static public IEnumerable<VersionControlSystem> GetVersionControlSystems ()
 		{
-			foreach (VersionControlSystem vs in handlers.OrderBy(h => h.Name))
+			foreach (VersionControlSystem vs in handlers)
 				if (vs.IsInstalled)
 					yield return vs;
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -119,7 +119,7 @@ namespace MonoDevelop.VersionControl
 				if (search < 0)
 					handlers.Insert (~search, vcs);
 				else {
-					LoggingService.LogError ("Error trying to add an existing version control system.");
+					LoggingService.LogError ("Adding new version control system {0} failed, the name {1} is already reserved.", vcs.GetType ().Name, vcs.Name);
 					return;
 				}
 				try {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -105,14 +105,20 @@ namespace MonoDevelop.VersionControl
 			VersionControlSystem vcs;
 
 			try {
-				vcs = (VersionControlSystem) args.ExtensionObject;
+				vcs = (VersionControlSystem)args.ExtensionObject;
 			} catch (Exception e) {
 				LoggingService.LogError ("Failed to initialize VersionControlSystem type.", e);
 				return;
 			}
 
 			if (args.Change == ExtensionChange.Add) {
-				handlers.Add (vcs);
+				IComparer<VersionControlSystem> compare = new CompareVersionControlSystem ();
+				handlers.Sort (compare.Compare);
+				int search = handlers.BinarySearch (vcs, compare);
+
+				if (search < 0)
+					handlers.Insert (~search, vcs);
+
 				try {
 					// Include the repository type in the serialization context, so repositories
 					// of this type can be deserialized from the configuration file.
@@ -123,12 +129,9 @@ namespace MonoDevelop.VersionControl
 				} catch (Exception e) {
 					LoggingService.LogError ("Error while adding version control system.", e);
 				}
-			}
-			else {
+			} else {
 				handlers.Remove (vcs);
 			}
-
-			handlers = handlers.OrderBy (h => h.Name).ToList();
 		}
 		
 		public static Xwt.Drawing.Image LoadOverlayIconForStatus(VersionStatus status)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -663,7 +663,7 @@ namespace MonoDevelop.VersionControl
 		
 		static public IEnumerable<VersionControlSystem> GetVersionControlSystems ()
 		{
-			foreach (VersionControlSystem vs in handlers)
+			foreach (VersionControlSystem vs in handlers.OrderBy(h => h.Name))
 				if (vs.IsInstalled)
 					yield return vs;
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlSystem.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.VersionControl
@@ -29,9 +30,9 @@ namespace MonoDevelop.VersionControl
 		/// The default implementation returns the full name of the class.
 		/// </remarks>
 		public virtual string Id {
-			get { return GetType().ToString(); }
+			get { return GetType ().ToString (); }
 		}
-		
+
 		/// <summary>
 		/// Display name of the version control system
 		/// </summary>
@@ -55,12 +56,12 @@ namespace MonoDevelop.VersionControl
 		public virtual bool IsInstalled {
 			get { return false; }
 		}
-		
+
 		/// <summary>
 		/// Creates an instance of a repository for this version control system
 		/// </summary>
 		protected abstract Repository OnCreateRepositoryInstance ();
-		
+
 		/// <summary>
 		/// Creates an editor object for a repository.
 		/// </summary>
@@ -121,6 +122,43 @@ namespace MonoDevelop.VersionControl
 		public virtual string GetRelativeCheckoutPathForRemote (string remoteRelativePath)
 		{
 			return remoteRelativePath.Replace ('/', System.IO.Path.DirectorySeparatorChar);
+		}
+	}
+
+	public class CompareVersionControlSystem : IComparer<VersionControlSystem>
+	{
+		public int Compare (VersionControlSystem vcs1, VersionControlSystem vcs2)
+		{
+			int result;
+
+			if (ReferenceEquals (vcs1, vcs2)) {
+				result = 0;
+			} else {
+				if (vcs1 == null) {
+					result = 1;
+				} else if (vcs2 == null) {
+					result = -1;
+				} else {
+					result = StringCompare (vcs1.Name, vcs2.Name);
+				}
+			}
+
+			return result;
+		}
+
+		int StringCompare (string strFirstString, string secondString)
+		{
+			int result;
+			if (strFirstString == null) {
+				if (secondString == null) {
+					result = 0;
+				} else {
+					result = 1;
+				}
+			} else {
+				result = string.Compare(strFirstString, secondString, StringComparison.InvariantCultureIgnoreCase);
+			}
+			return result;
 		}
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlSystem.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlSystem.cs
@@ -134,30 +134,15 @@ namespace MonoDevelop.VersionControl
 			if (ReferenceEquals (vcs1, vcs2)) {
 				result = 0;
 			} else {
-				if (vcs1 == null) {
+				if (vcs1 is null) {
 					result = 1;
-				} else if (vcs2 == null) {
+				} else if (vcs2 is null) {
 					result = -1;
 				} else {
-					result = StringCompare (vcs1.Name, vcs2.Name);
+					result = string.Compare(vcs1.Name, vcs2.Name, StringComparison.InvariantCultureIgnoreCase);
 				}
 			}
 
-			return result;
-		}
-
-		int StringCompare (string strFirstString, string secondString)
-		{
-			int result;
-			if (strFirstString == null) {
-				if (secondString == null) {
-					result = 0;
-				} else {
-					result = 1;
-				}
-			} else {
-				result = string.Compare(strFirstString, secondString, StringComparison.InvariantCultureIgnoreCase);
-			}
 			return result;
 		}
 	}


### PR DESCRIPTION
In case of use Git and Tfvc VCS in the same folder, order the VCS by name alphabetically. By doing this, we prioritize the use of Git in these cases. 
We should analyze how to improve this situation in future versions. Show some type of selector or maybe include a new parameter in the Version Control configuration.

Fixes VSTS #801910 

Backport of #7286.

/cc @slluis @jsuarezruiz