### PR TITLE
[SourceEditor] Takes line length as column when cursor is set at the …

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -1487,8 +1487,9 @@ namespace MonoDevelop.SourceEditor
 			} else if (args.Button == 1) {
 				if (!string.IsNullOrEmpty (Document.FileName)) {
 					if (args.LineSegment != null) {
-						int column = TextEditor.Caret.Line == args.LineNumber ? TextEditor.Caret.Column : 1;
-
+						int column = TextEditor.Caret.Line == args.LineNumber ? 
+												Math.Min (TextEditor.Caret.Column, args.LineSegment.Length) : 1;
+							
 						lock (breakpoints)
 							breakpoints.Toggle (Document.FileName, args.LineNumber, column);
 					}


### PR DESCRIPTION
…end of the caret.

- When the cursor is at the end of the line, the caret Column is higher than line length so that after adding a new breakpoint, this is set at the line after. With this commit, we prevent it.
- Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/792482