### PR TITLE
[release-8.0-integration] [Core] Fix stack overflow when using AsyncCriticalSection

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="MonoDevelop.Core\SdkResolverTests.cs" />
     <Compile Include="MonoDevelop.Core\FileServiceEventQueueTests.cs" />
     <Compile Include="MonoDevelop.Core\FileServiceEventStateMachineTests.cs" />
+    <Compile Include="MonoDevelop.Projects\AsyncCriticalSectionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/AsyncCriticalSectionTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/AsyncCriticalSectionTests.cs
@@ -1,0 +1,78 @@
+//
+// AsyncCriticalSectionTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace MonoDevelop.Projects
+{
+	[TestFixture]
+	public class AsyncCriticalSectionTests
+	{
+		AsyncCriticalSection referenceCacheLock;
+		ManualResetEvent unlockEvent;
+		ManualResetEvent doneEvent;
+		const int maxLoadProjectCalls = 10000;
+
+		[Test]
+		public void StackOverflowTest ()
+		{
+			referenceCacheLock = new AsyncCriticalSection ();
+			unlockEvent = new ManualResetEvent (false);
+			doneEvent = new ManualResetEvent (false);
+
+			for (int i = 0; i < maxLoadProjectCalls; ++i) {
+				Run (i);
+			}
+
+			Thread.Sleep (500);
+
+			unlockEvent.Set ();
+			bool result = doneEvent.WaitOne (5000);
+			if (!result)
+				Assert.Fail ("Done event not fired.");
+		}
+
+		void Run (int i)
+		{
+			Task.Run (async () => {
+				await LoadProject (i);
+			});
+		}
+
+		async Task LoadProject (int i)
+		{
+			using (await referenceCacheLock.EnterAsync ().ConfigureAwait (false)) {
+				unlockEvent.WaitOne ();
+
+				if (i == maxLoadProjectCalls - 1)
+					doneEvent.Set ();
+			}
+		}
+	}
+}


### PR DESCRIPTION
If many tasks call DotNetProject.RunResolveAssemblyReferencesTarget
then they can all be queued with an AsyncCriticalSection. When the
AsyncCriticalSection is disposed it calls TaskCompletionSource's
TrySetResult. If there are many queued items this can result in a
stackoverflow if the continuations are run synchronously. To prevent
this the TaskCompletionSource is created with the TaskCreationOptions
set to RunContinuationsAsynchronously.

https://stackoverflow.com/questions/28321457/taskcontinuationoptions-runcontinuationsasynchronously-and-stack-dives

```
System.StackOverflowException: The requested operation caused a stack overflow.
  at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction (System.Action action, System.Boolean allowInlining, System.Threading.Tasks.Task& currentTask) [0x00022]
  in mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs:684
  at System.Threading.Tasks.Task.FinishContinuations () [0x00052]
  in mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:3198
  at System.Threading.Tasks.Task.FinishStageThree () [0x0003c]
  in mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2247
  at System.Threading.Tasks.Task`1[TResult].TrySetResult (TResult result) [0x0004f]
  in mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs:433
  at System.Threading.Tasks.TaskCompletionSource`1[TResult].TrySetResult (TResult result) [0x00000]
  in mono-x64/external/corefx/src/Common/src/CoreLib/System/Threading/Tasks/TaskCompletionSource.cs:274
  at System.Threading.Tasks.TaskCompletionSource`1[TResult].SetResult (TResult result) [0x00000]
  in mono-x64/external/corefx/src/Common/src/CoreLib/System/Threading/Tasks/TaskCompletionSource.cs:297
  at MonoDevelop.Projects.AsyncCriticalSection.Exit () [0x00042]
  in main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AsyncCriticalSection.cs:86
  at MonoDevelop.Projects.AsyncCriticalSection+CriticalSectionDisposer.Dispose () [0x00000]
  in main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AsyncCriticalSection.cs:45
  at MonoDevelop.Projects.DotNetProject.RunResolveAssemblyReferencesTarget (MonoDevelop.Projects.ConfigurationSelector configuration) [0x00237]
  in main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs:1079
```

Fixes VSTS #814631 - Instant crashes

Backport of #7324.

/cc @Therzok @mrward