### PR TITLE
[release-8.0-integration] [Packaging] Fix copyright metadata not being saved.

### DIFF
--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/NuGetPackageMetadata.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/NuGetPackageMetadata.cs
@@ -70,6 +70,7 @@ namespace MonoDevelop.Packaging
 			Id = GetProperty (propertyGroup, PackageIdPropertyName);
 			Version = GetProperty (propertyGroup, "PackageVersion");
 			Authors = GetProperty (propertyGroup, "Authors");
+			Copyright = GetProperty (propertyGroup, "Copyright");
 			DevelopmentDependency = GetProperty (propertyGroup, "DevelopmentDependency", false);
 			IconUrl = GetProperty (propertyGroup, "PackageIconUrl");
 			Language = GetProperty (propertyGroup, "NeutralLanguage");
@@ -107,6 +108,7 @@ namespace MonoDevelop.Packaging
 			SetProperty (propertyGroup, PackageIdPropertyName, Id);
 			SetProperty (propertyGroup, "PackageVersion", Version);
 			SetProperty (propertyGroup, "Authors", Authors);
+			SetProperty (propertyGroup, "Copyright", Copyright);
 			SetProperty (propertyGroup, "DevelopmentDependency", DevelopmentDependency);
 			SetProperty (propertyGroup, "PackageIconUrl", IconUrl);
 			SetProperty (propertyGroup, "NeutralLanguage", Language);


### PR DESCRIPTION
The Copyright NuGet package metadata in project options - NuGet
Package - Metadata was not being read nor written.

Fixes VSTS #807733 - NuGet Copyright metadata not saved

Backport of #7333.

/cc @slluis @mrward