### PR TITLE
Added Missing IDE Unit Tests Reference

### DIFF
--- a/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
+++ b/main/tests/WindowsPlatform.Tests/WindowsPlatform.Tests.csproj
@@ -28,6 +28,10 @@
       <Project>{D12F0F7B-8DE3-43EC-BA49-41052D065A9B}</Project>
       <Name>GuiUnit_NET_4_5</Name>
     </ProjectReference>
+    <ProjectReference Include="..\IdeUnitTests\IdeUnitTests.csproj">
+      <Project>{F7B2B155-7CF4-42C4-B5AF-63C0667D2E4F}</Project>
+      <Name>IdeUnitTests</Name>
+	  </ProjectReference>
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>


### PR DESCRIPTION
 It appears [this](https://github.com/mono/monodevelop/commit/86db65afabcef60c749427abef7ff99b4b4260cb) commit missed the reference for IdeUnitTests. This has broken the ability to run winbuild.bat

 **Currently on Windows, running winbuild.bat will result in the following message:**
>    "C:\temp\monodevelop\main\Main.sln" (default target) (1:2) ->
>        "C:\temp\monodevelop\main\tests\WindowsPlatform.Tests\WindowsPlatform.Tests.csproj" (default target) (84:6) ->
>        (CoreCompile target) ->
>          CredentialsProviderTests.cs(32,3): error CS0012: The type 'IdeTestBase' is defined in an assembly that is not
>        referenced. You must add a reference to assembly 'IdeUnitTests, Version=0.0.0.0, Culture=neutral, PublicKeyToken
>        =3ead7498f347467b'. [C:\temp\monodevelop\main\tests\WindowsPlatform.Tests\WindowsPlatform.Tests.csproj]
>          CredentialsProviderTests.cs(33,42): error CS0012: The type 'IdeTestBase' is defined in an assembly that is not
>         referenced. You must add a reference to assembly 'IdeUnitTests, Version=0.0.0.0, Culture=neutral, PublicKeyToke
>        n=3ead7498f347467b'. [C:\temp\monodevelop\main\tests\WindowsPlatform.Tests\WindowsPlatform.Tests.csproj]
>          CredentialsProviderTests.cs(35,22): error CS0012: The type 'IdeTestBase' is defined in an assembly that is not
>         referenced. You must add a reference to assembly 'IdeUnitTests, Version=0.0.0.0, Culture=neutral, PublicKeyToke
>        n=3ead7498f347467b'. [C:\temp\monodevelop\main\tests\WindowsPlatform.Tests\WindowsPlatform.Tests.csproj]
> 
>     245 Warning(s)
>     3 Error(s)