### PR TITLE
[release-8.0-integration] [VersionControl] Added support to auth using PAT in Azure DevOps

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Gui\MonoDevelop.VersionControl.Git.StashManagerDialog.cs" />
     <Compile Include="Gui\MonoDevelop.VersionControl.Git.UserGitConfigDialog.cs" />
     <Compile Include="Gui\MonoDevelop.VersionControl.Git.UserInfoConflictDialog.cs" />
+    <Compile Include="MonoDevelop.VersionControl.Git\IGitCredentialsProvider.cs" />
     <Compile Include="MonoDevelop.VersionControl.Git\XwtCredentialsDialog.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCredentials.cs
@@ -271,6 +271,10 @@ namespace MonoDevelop.VersionControl.Git
 		static bool TryGetUsernamePassword (Uri uri, out string username, out string password)
 		{
 			var cred = PasswordService.GetWebUserNameAndPassword (uri);
+			// if the Uri has a path, fallback to base Uri if available
+			if (cred == null && !string.IsNullOrEmpty (uri.PathAndQuery) && Uri.TryCreate (uri.GetLeftPart (UriPartial.Authority), UriKind.Absolute, out var baseUri)) {
+				cred = PasswordService.GetWebUserNameAndPassword (baseUri);
+			}
 			if (cred != null) {
 				username = cred.Item1;
 				password = cred.Item2;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/IGitCredentialsProvider.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/IGitCredentialsProvider.cs
@@ -33,7 +33,14 @@ namespace MonoDevelop.VersionControl.Git
 	public interface IGitCredentialsProvider
 	{
 		bool SupportsUrl (string url);
-		Task<(bool exists, GitCredential credentials)> TryGetCredentialsAsync (string url);
+		Task<(GitCredentialsProviderResult result, GitCredential credentials)> TryGetCredentialsAsync (string url);
+	}
+
+	public enum GitCredentialsProviderResult
+	{
+		Found,
+		NotFound,
+		Cancelled,
 	}
 
 	public class GitCredential

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/IGitCredentialsProvider.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/IGitCredentialsProvider.cs
@@ -1,0 +1,50 @@
+//
+// IGitCredentialsProvider.cs
+//
+// Author:
+//       Javier Suárez Ruiz <jsuarez@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Threading.Tasks;
+using Mono.Addins;
+
+namespace MonoDevelop.VersionControl.Git
+{
+	[TypeExtensionPoint]
+	public interface IGitCredentialsProvider
+	{
+		bool SupportsUrl (string url);
+		Task<(bool exists, GitCredential credentials)> TryGetCredentialsAsync (string url);
+	}
+
+	public class GitCredential
+	{
+		public GitCredential (string username, string password)
+		{
+			Username = username;
+			Password = password;
+		}
+
+		public string Username { get; }
+		public string Password { get; }
+	}
+}


### PR DESCRIPTION
To support Git repositories hosted on Azure DevOps we need to support auth using (without use basic auth with username and password) a PAT (Personal Access Token).

<img width="732" alt="screenshot 2019-02-07 at 09 36 10" src="https://user-images.githubusercontent.com/6755973/52412136-2eee8280-2ade-11e9-89d8-54440aa9cb6e.png">

Fixes VSTS #706903

Backport of #7079.

/cc @sevoku @jsuarezruiz