### PR TITLE
[Version Control] Fixes error adding new files to the Solution Items under Version Control

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFileNodeBuilder.cs
@@ -176,7 +176,19 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 						}
 						else {
 							Solution sol = node.GetParentDataItem (typeof(Solution), true) as Solution;
-							sol.RootFolder.Files.Add (file.Path);
+
+							var solutionFolder = sol.RootFolder;
+
+							if (solutionFolder != null) {
+								if (solutionFolder.IsRoot) {
+									// Don't allow adding files to the root folder. VS doesn't allow it
+									// If there is no existing folder, create one
+									solutionFolder = solutionFolder.ParentSolution.DefaultSolutionFolder;
+								}
+
+								solutionFolder.Files.Add (file.Path);
+							}
+
 							projects.Add (sol);
 						}
 					}


### PR DESCRIPTION
We have some changes here. The first one was adding the file in the solution. If there is no "Solution Items" folder, we create it.
On the other hand, trying to add the file to the repository (Add command) a validation was made taking into account the ActiveDocument that we will only have if the document is open (it is not always the case, or can even deal with a file that is not text). Validation changed.

Fixes VSTS #715157