### PR TITLE
[Version Control] Revision shown in "Unified-Diff" incorrect

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/ComparisonWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/ComparisonWidget.cs
@@ -56,6 +56,18 @@ namespace MonoDevelop.VersionControl.Views
 			}
 		}
 
+		public DropDownBox OriginalCombo {
+			get {
+				return originalComboBox;
+			}
+		}
+
+		public DropDownBox DiffCombo {
+			get {
+				return diffComboBox;
+			}
+		}
+
 		internal override MonoTextEditor MainEditor {
 			get {
 				return editors[1];

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -101,7 +101,6 @@ namespace MonoDevelop.VersionControl.Views
 		protected override void OnSelected ()
 		{
 			info.Start ();
-			ComparisonWidget.UpdateLocalText ();
 			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
 			if (buffer != null) {
 				var loc = buffer.CaretLocation;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -101,6 +101,8 @@ namespace MonoDevelop.VersionControl.Views
 		protected override void OnSelected ()
 		{
 			info.Start ();
+			if (ComparisonWidget.originalComboBox.Text == GettextCatalog.GetString ("Local"))
+				ComparisonWidget.UpdateLocalText ();
 			var buffer = info.Document.GetContent<MonoDevelop.Ide.Editor.TextEditor> ();
 			if (buffer != null) {
 				var loc = buffer.CaretLocation;


### PR DESCRIPTION
Entering to the DiffView we avoid reloading the local changes with the current version. We keep the option selected in the local version selector.

Fixes VSTS #801631