### PR TITLE
[Version Control] Fix problem notifying VCS changes

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -29,7 +29,9 @@ namespace MonoDevelop.VersionControl
 			get;
 			protected set;
 		}
-		
+
+		internal FilePath RepositoryPath { get; set; }
+
 		public event EventHandler NameChanged;
 		
 		protected Repository ()
@@ -102,6 +104,8 @@ namespace MonoDevelop.VersionControl
 					recursiveDirectoryQueryQueue.Clear ();
 				}
 			}
+
+			VersionControlService.repositoryCache.TryRemove (RepositoryPath.CanonicalPath, out _);
 
 			infoCache?.Dispose ();
 			infoCache = null;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -258,7 +258,7 @@ namespace MonoDevelop.VersionControl
 				else {
 					// If there is no cached status, query it asynchronously
 					vi = new VersionInfo (p, "", Directory.Exists (p), VersionStatus.Versioned, null, VersionStatus.Versioned, null);
-					infoCache.SetStatus (vi, false);
+					infoCache.SetStatus (vi, true);
 					result.Add (vi);
 					pathsToQuery.Add (p);
 				}
@@ -652,8 +652,8 @@ namespace MonoDevelop.VersionControl
 			var metadata = new RevertMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Recursive = recurse, OperationType = RevertMetadata.RevertType.LocalChanges };
 			using (var tracker = Instrumentation.RevertCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					ClearCachedVersionInfo (localPaths);
 					OnRevert (localPaths, recurse, monitor);
+					ClearCachedVersionInfo (localPaths);
 				} catch {
 					metadata.SetFailure ();
 					throw;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -262,7 +262,7 @@ namespace MonoDevelop.VersionControl
 				else {
 					// If there is no cached status, query it asynchronously
 					vi = new VersionInfo (p, "", Directory.Exists (p), VersionStatus.Versioned, null, VersionStatus.Versioned, null);
-					infoCache.SetStatus (vi, true);
+					infoCache.SetStatus (vi, false);
 					result.Add (vi);
 					pathsToQuery.Add (p);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlService.cs
@@ -261,6 +261,7 @@ namespace MonoDevelop.VersionControl
 					var result = detectedVCS?.GetRepositoryReference (p, id);
 					if (result != null) {
 						Instrumentation.Repositories.Inc (new RepositoryMetadata (detectedVCS));
+						result.RepositoryPath = p.CanonicalPath;
 						return result;
 					}
 					// never add null values
@@ -834,7 +835,6 @@ namespace MonoDevelop.VersionControl
 		public void Dispose ()
 		{
 			VersionControlService.referenceCache.TryRemove (repo, out _);
-			VersionControlService.repositoryCache.TryRemove (repo.RootPath.CanonicalPath, out _);
 			repo.Unref ();
 		}
 	}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
@@ -34,8 +34,8 @@ namespace MonoDevelop.VersionControl
 {
 	class VersionInfoCache : IDisposable
 	{
-		static readonly ConcurrentDictionary<FilePath, VersionInfo> fileStatus = new ConcurrentDictionary<FilePath, VersionInfo> ();
-		static readonly ConcurrentDictionary<FilePath, DirectoryStatus> directoryStatus = new ConcurrentDictionary<FilePath, DirectoryStatus> ();
+		readonly ConcurrentDictionary<FilePath, VersionInfo> fileStatus = new ConcurrentDictionary<FilePath, VersionInfo> ();
+		readonly ConcurrentDictionary<FilePath, DirectoryStatus> directoryStatus = new ConcurrentDictionary<FilePath, DirectoryStatus> ();
 		Repository repo;
 
 		public VersionInfoCache (Repository repo)


### PR DESCRIPTION
Updated `VersionInfoCache` to avoid cache problems.
Call `NotifyFileStatusChanged` deleting files and directories in the `Repository` class.

Fixes GH #7119 
Fixes VSTS #675483
Fixes VSTS #672672