### PR TITLE
[release-8.0-integration] [IDE] Track whether a file load was initiated by the File Manager better

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -57,6 +57,7 @@ using Xwt.Mac;
 using MonoDevelop.Components.Mac;
 using System.Reflection;
 using MacPlatform;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.MacIntegration
 {
@@ -582,6 +583,14 @@ namespace MonoDevelop.MacIntegration
 //			Gtk.Rc.ParseString (gtkrc);
 		}
 
+		static TimeToCodeMetadata.DocumentType GetDocumentTypeFromFilename (string filename)
+		{
+			if (Projects.Services.ProjectService.IsWorkspaceItemFile (filename) || Projects.Services.ProjectService.IsSolutionItemFile (filename)) {
+				return TimeToCodeMetadata.DocumentType.Solution;
+			}
+			return TimeToCodeMetadata.DocumentType.File;
+		}
+
 		void GlobalSetup ()
 		{
 			//FIXME: should we remove these when finalizing?
@@ -628,21 +637,30 @@ namespace MonoDevelop.MacIntegration
 				};
 
 				ApplicationEvents.OpenDocuments += delegate (object sender, ApplicationDocumentEventArgs e) {
-					//OpenFiles may pump the mainloop, but can't do that from an AppleEvent, so use a brief timeout
-					GLib.Timeout.Add (0, delegate {
+					//OpenFiles may pump the mainloop, but can't do that from an AppleEvent
+					GLib.Idle.Add (delegate {
 						Ide.WelcomePage.WelcomePageService.HideWelcomePageOrWindow ();
-						IdeApp.ReportTimeToCode = true;
+						var trackTTC = IdeApp.StartTimeToCodeLoadTimer ();
 						IdeApp.OpenFiles (e.Documents.Select (
-							doc => new FileOpenInformation (doc.Key, null, doc.Value, 1, OpenDocumentOptions.DefaultInternal))
-						);
+							doc => new FileOpenInformation (doc.Key, null, doc.Value, 1, OpenDocumentOptions.DefaultInternal)),
+							null
+						).ContinueWith ((result) => {
+							if (!trackTTC) {
+								return;
+							}
+
+							var firstFile = e.Documents.First ().Key;
+
+							IdeApp.TrackTimeToCode (GetDocumentTypeFromFilename (firstFile));
+						});
 						return false;
 					});
 					e.Handled = true;
 				};
 
 				ApplicationEvents.OpenUrls += delegate (object sender, ApplicationUrlEventArgs e) {
-					GLib.Timeout.Add (0, delegate {
-						IdeApp.ReportTimeToCode = true;
+					GLib.Idle.Add (delegate {
+						var trackTTC = IdeApp.StartTimeToCodeLoadTimer ();
 						// Open files via the monodevelop:// URI scheme, compatible with the
 						// common TextMate scheme: http://blog.macromates.com/2007/the-textmate-url-scheme/
 						IdeApp.OpenFiles (e.Urls.Select (url => {
@@ -666,7 +684,14 @@ namespace MonoDevelop.MacIntegration
 								LoggingService.LogError ("Invalid TextMate URI: " + url, ex);
 								return null;
 							}
-						}).Where (foi => foi != null));
+						}).Where (foi => foi != null), null).ContinueWith ((result) => {
+							if (!trackTTC) {
+								return;
+							}
+							var firstFile = e.Urls.First ();
+
+							IdeApp.TrackTimeToCode (GetDocumentTypeFromFilename (firstFile));
+						});
 						return false;
 					});
 				};

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -161,7 +161,8 @@ namespace MonoDevelop.Ide
 	{
 		public enum DocumentType {
 			Solution,
-			File
+			File,
+			Unknown
 		};
 
 		public long CorrectedDuration {


### PR DESCRIPTION
Instead of using a timer that isn't very accurate, track whether or not a
file load was initiated by the FileManager by passing a boolean to the events

Fixes VSTS #806672 https://devdiv.visualstudio.com/DevDiv/_workitems/edit/806672

Backport of #7320.

/cc @slluis @iainx