### PR TITLE
[Core] Do not log project unload error if builder has been shutdown

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngine.cs
@@ -171,7 +171,8 @@ namespace MonoDevelop.Projects.MSBuild
 			try {
 				await connection.SendMessage (new UnloadProjectRequest { ProjectId = projectId }).ConfigureAwait (false);
 			} catch (Exception ex) {
-				LoggingService.LogError ("Project unloading failed", ex);
+				if (alive)
+					LoggingService.LogError ("Project unloading failed", ex);
 				if (!await CheckDisconnected ())
 					throw;
 			}


### PR DESCRIPTION
Creating a new Xamarin.Forms solution would sometimes log an error
about project unloading failing due to a connection closed error.
On opening a solution the NuGet restore runs. If a project is a
.NET Standard project then the project will be re-evaluated after
the restore. The re-evaluation will shutdown the project builders.
This shutdown will call RemoteBuildEngineManager.UnloadSolution
which will shutdown project builders and shutdown the remote
builder process. Shutting down the project builder can result
in an unload project request being sent to the remote builder host.
Shutting down the remote builder process will result in a stop
process message sent to the remote builder host which will abort
any messages that have not been processed. Both the project builder
shutdown and the remote builder host shutdown run in parallel on
background threads, since they are run by using ContinueWith. This
can result in both these actions happening at the same time causing
the unload project request to be aborted and an error message
returned from the remote builder host. Now a check is made to see
if the remote builder host is alive and if it is not the error
is not logged.

Fixes VSTS #818682 - Project unloading failed - System.Exception:
Connection closed

Another idea:
 - Remove the logging completely. The CheckDisconnected also checks the alive flag. If the exception is re-thrown then it should be logged.