### PR TITLE
[Ide] Close open documents if parent directory is removed externally

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DefaultWorkbench.cs
@@ -696,35 +696,42 @@ namespace MonoDevelop.Ide.Gui
 		{
 			foreach (var e in args) {
 				if (e.IsDirectory) {
-					var views = new ViewContent [viewContentCollection.Count];
-					viewContentCollection.CopyTo (views, 0);
-					foreach (var content in views) {
-						if (content.ContentName.StartsWith (e.FileName, StringComparison.CurrentCulture)) {
-							if (content.IsDirty) {
-								content.UntitledName = content.ContentName;
-								content.ContentName = null;
-							} else {
-								((SdiWorkspaceWindow)content.WorkbenchWindow).CloseWindow (true, true).Ignore();
-							}
-						}
-					}
+					CheckRemovedDirectory (e.FileName);
 				} else {
 					foreach (var content in viewContentCollection) {
 						if (content.ContentName != null &&
 							content.ContentName == e.FileName) {
-							if (content.IsDirty) {
-								content.UntitledName = content.ContentName;
-								content.ContentName = null;
-							} else {
-								((SdiWorkspaceWindow)content.WorkbenchWindow).CloseWindow (true, true).Ignore();
-							}
+							CloseViewForRemovedFile (content);
 							return;
 						}
 					}
+					CheckRemovedDirectory (e.FileName);
 				}
 			}
 		}
-		
+
+		void CheckRemovedDirectory (FilePath fileName)
+		{
+			var views = new ViewContent [viewContentCollection.Count];
+			viewContentCollection.CopyTo (views, 0);
+			foreach (var content in views) {
+				if (content.ContentName != null &&
+					((FilePath)content.ContentName).IsChildPathOf (fileName)) {
+					CloseViewForRemovedFile (content);
+				}
+			}
+		}
+
+		static void CloseViewForRemovedFile (ViewContent content)
+		{
+			if (content.IsDirty) {
+				content.UntitledName = content.ContentName;
+				content.ContentName = null;
+			} else {
+				((SdiWorkspaceWindow)content.WorkbenchWindow).CloseWindow (true, true).Ignore ();
+			}
+		}
+
 		void CheckRenamedFile(object sender, FileCopyEventArgs args)
 		{
 			foreach (FileEventInfo e in args) {


### PR DESCRIPTION
Deleting a directory outside the IDE would not close documents that
were open in the IDE. Deleting individual files outside the IDE
that corresponded to open documents were closed correctly. The problem
was that the file service events for a directory being deleted do
not indicate a directory was removed so the existing logic was being
bypassed. To handle this, when a deletion event is processed, if no
exact filename match is found, then a check is made to see if the
deleted item matches a parent directory for any open view. If there
is a match then the document is closed.

Fixes VSTS #823237 Document not closed when parent directory removed