### PR TITLE
[Ide] Prevent InvalidOperationException when calling GetCodeAnalysisProjectAsync with a token

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -283,14 +283,16 @@ namespace MonoDevelop.Ide.TypeSystem
 			//We assume that since we have projectId and project is not found in solution
 			//project is being loaded(waiting MSBuild to return list of source files)
 			var taskSource = new TaskCompletionSource<Microsoft.CodeAnalysis.Project> ();
+			var registration = cancellationToken.Register (() => taskSource.TrySetCanceled ());
 			EventHandler<WorkspaceChangeEventArgs> del = (s, e) => {
 				if (e.Kind == WorkspaceChangeKind.SolutionAdded || e.Kind == WorkspaceChangeKind.SolutionReloaded) {
 					proj = workspace.CurrentSolution.GetProject (projectId);
-					if (proj != null)
-						taskSource.SetResult (proj);
+					if (proj != null) {
+						registration.Dispose ();
+						taskSource.TrySetResult (proj);
+					}
 				}
 			};
-			cancellationToken.Register (taskSource.SetCanceled);
 			workspace.WorkspaceChanged += del;
 			try {
 				proj = await taskSource.Task;


### PR DESCRIPTION
The way cancellation was previously registered in the method would easily lead to InvalidOperationException being thrown since the registration on the cancellation token was kept indefinitely. As such disposing the token source after the taskSource has long been completed would throw.

With this patch we keep and dispose the cancellation token registration as soon as possible and switch every TaskCompletionSource access to the `Try` pattern to avoid spurious failures.