### PR TITLE
[msbuild] Update to work with ToolsVersion=`Current`

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
@@ -561,7 +561,7 @@ namespace MonoDevelop.Projects.MSBuild
 				ConfigFileUtilities.SetOrAppendSubelementAttributeValue (runtimeElement, "AppContextSwitchOverrides", "value", "Switch.System.IO.UseLegacyPathHandling=false");
 			}
 
-			foreach (var toolset in doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")) {
+			foreach (var toolset in doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset") ?? Enumerable.Empty<XElement> ()) {
 
 				// This is required for MSBuild to properly load the searchPaths element (@radical knows why)
 				SetMSBuildConfigProperty (toolset, "MSBuildBinPath", binDir, append: false, insertBefore: true);
@@ -595,7 +595,7 @@ namespace MonoDevelop.Projects.MSBuild
 						SetMSBuildConfigProperty (toolset, path.Property, path.Path);
 				}
 
-				var projectImportSearchPaths = doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")?.FirstOrDefault ()?.Element ("projectImportSearchPaths");
+				var projectImportSearchPaths = toolset.Element ("projectImportSearchPaths");
 				if (projectImportSearchPaths != null) {
 					var os = Platform.IsMac ? "osx" : Platform.IsWindows ? "windows" : "unix";
 					XElement searchPaths = projectImportSearchPaths.Elements ("searchPaths").FirstOrDefault (sp => sp.Attribute ("os")?.Value == os);
@@ -607,8 +607,9 @@ namespace MonoDevelop.Projects.MSBuild
 					foreach (var path in MSBuildProjectService.GetProjectImportSearchPaths (runtime, false))
 						SetMSBuildConfigProperty (searchPaths, path.Property, path.Path, append: true, insertBefore: false);
 				}
-				doc.Save (destinationConfigFile);
 			}
+
+			doc.Save (destinationConfigFile);
 
 			// Update the sdk list for the MD resolver
 			SdkInfo.SaveConfig (mdResolverConfig, MSBuildProjectService.FindRegisteredSdks ());

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
@@ -561,8 +561,7 @@ namespace MonoDevelop.Projects.MSBuild
 				ConfigFileUtilities.SetOrAppendSubelementAttributeValue (runtimeElement, "AppContextSwitchOverrides", "value", "Switch.System.IO.UseLegacyPathHandling=false");
 			}
 
-			var toolset = doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")?.FirstOrDefault ();
-			if (toolset != null) {
+			foreach (var toolset in doc.Root.Elements ("msbuildToolsets").FirstOrDefault ()?.Elements ("toolset")) {
 
 				// This is required for MSBuild to properly load the searchPaths element (@radical knows why)
 				SetMSBuildConfigProperty (toolset, "MSBuildBinPath", binDir, append: false, insertBefore: true);

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.config
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/app.config
@@ -47,6 +47,22 @@
 				</searchPaths>
 			</projectImportSearchPaths>
 		</toolset>
+		<toolset toolsVersion="Current">
+			<property name="MSBuildRuntimeVersion" value="4.0.30319" />
+			<property name="MSBuildToolsPath" value="$(MSBuildBinPath)" />
+			<property name="MSBuildToolsPath32" value="$(MSBuildBinPath)" />
+			<property name="MSBuildToolsPath64" value="$(MSBuildBinPath)" />
+			<property name="RoslynTargetsPath" value="$(MSBuildToolsPath)\Roslyn" />
+			<property name="TargetFrameworkRootPathSearchPathsOSX" value="/Library/Frameworks/Mono.framework/External/xbuild-frameworks/" />
+			<property name="VisualStudioVersion" value="16.0" />
+			<projectImportSearchPaths>
+				<searchPaths os="osx">
+					<property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+					<property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+					<property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+				</searchPaths>
+			</projectImportSearchPaths>
+		</toolset>
 	</msbuildToolsets>
 
 </configuration>


### PR DESCRIPTION
- the recent msbuild update changed the toolsVersion from `15.0` to
`Current`.
- we add a second toolset `Current` to the app.config for the remote
builder.
- VSMac still tries to pick `15.0`
	- with older mono, msbuild will use the 15.0 toolset
	- with newer mono, vsmac asks for 15.0 but msbuild picks
	`current` instead.

- VSMac needs to pick `Current` for newer mono, which will be fixed in a
follow up PR.

Fixes VS bug #831219 - 6.x Mono MSBuild support is broken 