### PR TITLE
Workaround for .NET Core debugger

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -318,7 +318,9 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 						break;
 					case StoppedEvent.ReasonValue.Exception:
 						var match = VsdbgExceptionNameRegex.Match (body.Text);
-						if (match.Success && match.Groups.Count == 2 && !breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (e => e.Enabled && match.Groups[1].Value == e.ExceptionName))
+						if (match.Success && match.Groups.Count == 2 && !breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (e =>
+							e.Enabled &&
+							(match.Groups[1].Value == e.ExceptionName) || (e.IncludeSubclasses && e.ExceptionName == "System.Exception")))
 						{
 							OnContinue ();
 							return;

--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -333,9 +333,11 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 						break;
 					case StoppedEvent.ReasonValue.Exception:
 						var match = VsdbgExceptionNameRegex.Match (body.Text);
+						stackFrame = (VsCodeStackFrame)this.GetThreadBacktrace (body.ThreadId ?? -1).GetFrame (0);
 						if (match.Success && match.Groups.Count == 2 && !breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (e =>
 							e.Enabled &&
-							(match.Groups[1].Value == e.ExceptionName) || (e.IncludeSubclasses && e.ExceptionName == "System.Exception")))
+							(match.Groups[1].Value == e.ExceptionName || e.IncludeSubclasses && e.ExceptionName == "System.Exception") &&
+							(string.IsNullOrWhiteSpace(e.ConditionExpression) || EvaluateCondition (stackFrame.frameId, e.ConditionExpression) != false)))
 						{
 							OnContinue ();
 							return;

--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -324,11 +324,27 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 						break;
 					case StoppedEvent.ReasonValue.Exception:
 						stackFrame = (VsCodeStackFrame)this.GetThreadBacktrace (body.ThreadId ?? -1).GetFrame (0);
-						if (!breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (e =>
-							e.Enabled &&
-							(e.ExceptionName.Contains ("::") ? e.ExceptionName : $"global::{e.ExceptionName}") is var qualifiedExceptionType && // global:: is necessary if the exception type is contained in current namespace, and it also contains a class with the same name as the namespace itself. Example: "Tests.Tests" and "Tests.TestException"
-							(e.IncludeSubclasses && EvaluateCondition(stackFrame.frameId, $"$exception is {qualifiedExceptionType}") != false || !e.IncludeSubclasses && EvaluateCondition(stackFrame.frameId, $"$exception.GetType() == typeof({qualifiedExceptionType})") != false) &&
-							(string.IsNullOrWhiteSpace(e.ConditionExpression) || EvaluateCondition (stackFrame.frameId, e.ConditionExpression) != false)))
+
+						bool ShouldStopOnExceptionCatchpoint(Catchpoint e)
+						{
+							if (!e.Enabled)
+								return false;
+							var qualifiedExceptionType = e.ExceptionName.Contains ("::") ? e.ExceptionName : $"global::{e.ExceptionName}";
+							// global:: is necessary if the exception type is contained in current namespace,
+							// and it also contains a class with the same name as the namespace itself.
+							// Example: "Tests.Tests" and "Tests.TestException"
+							if (e.IncludeSubclasses) {
+								if (EvaluateCondition (stackFrame.frameId, $"$exception is {qualifiedExceptionType}") == false)
+									return false;
+							}
+							else {
+								if (EvaluateCondition (stackFrame.frameId, $"$exception.GetType() == typeof({qualifiedExceptionType})") == false)
+									return false;
+							}
+							return string.IsNullOrWhiteSpace (e.ConditionExpression) || EvaluateCondition (stackFrame.frameId, e.ConditionExpression) != false;
+						}
+
+						if (!breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (ShouldStopOnExceptionCatchpoint))
 						{
 							OnContinue ();
 							return;

--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -39,6 +39,7 @@ using MonoDevelop.Core;
 using MonoDevelop.Core.Execution;
 using MonoFunctionBreakpoint = Mono.Debugging.Client.FunctionBreakpoint;
 using VsCodeFunctionBreakpoint = Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages.FunctionBreakpoint;
+using System.Text.RegularExpressions;
 
 namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 {
@@ -277,6 +278,8 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 			return sb.ToString();
 		}
 
+		private static readonly Regex VsdbgExceptionNameRegex = new Regex ("Exception thrown: '(.*)' in .*");
+
 		protected void HandleEvent (object sender, EventReceivedEventArgs obj)
 		{
 			Task.Run (() => {
@@ -314,6 +317,12 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 						args = new TargetEventArgs (TargetEventType.TargetStopped);
 						break;
 					case StoppedEvent.ReasonValue.Exception:
+						var match = VsdbgExceptionNameRegex.Match (body.Text);
+						if (match.Success && match.Groups.Count == 2 && !breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (e => e.Enabled && match.Groups[1].Value == e.ExceptionName))
+						{
+							OnContinue ();
+							return;
+						}
 						args = new TargetEventArgs (TargetEventType.ExceptionThrown);
 						break;
 					default:


### PR DESCRIPTION
Fixes issue #6793 until `vsdbg` supports filtering by exception type. Now it offers only "all" and "user-unhandled" exception filters.