### PR TITLE
Removed using Compile items directly from the project [WIP]

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -531,15 +531,11 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		protected virtual async Task<ImmutableArray<ProjectFile>> OnGetSourceFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
-			// pre-load the results with the current list of files in the project
-			var evaluatedItems = await GetEvaluatedSourceFiles (configuration);
-
 			// add in any compile items that we discover from running the CoreCompile dependencies
 			var coreCompileResult = await compileEvaluator.GetItemsFromCoreCompileDependenciesAsync (this, monitor, configuration);
 			var evaluatedCompileItems = coreCompileResult.SourceFiles;
 
-			var results = new HashSet<ProjectFile> (evaluatedItems, ProjectFileFilePathComparer.Instance);
-			results.UnionWith (evaluatedCompileItems);
+			var results = new HashSet<ProjectFile> (evaluatedCompileItems, ProjectFileFilePathComparer.Instance);
 
 			return results.ToImmutableArray ();
 		}


### PR DESCRIPTION
If your project uses Conditions on `Compile` items, or runs a target before CoreCompile to dynamically add/remove items you will get IntelliSense errors. This is because monodevelop is including ALL `Compile` files in the csproj even if they are not really used. 

I think we really only need the results of `GetItemsFromCoreCompileDependenciesAsync` which will only include the bits the compiler will actually get. This seems to be how Visual Studio works. The attached sample project does not have any IntelliSense errors in it in VS 2019, however you will see errors in the IDE about the `EmptyClass.Config` property being declared already. The project will build perfectly fine however. 

[CompileRemoveTest.zip](https://github.com/mono/monodevelop/files/3131444/CompileRemoveTest.zip)