### PR TITLE
Bump minimum Mono version

### DIFF
--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -326,7 +326,7 @@ int main (int argc, char **argv)
 	run_md_bundle_if_needed(appDir, argc, argv);
 
 	// can be overridden with plist string MonoMinVersion
-	NSString *req_mono_version = @"5.18.0.244";
+	NSString *req_mono_version = @"5.18.1.24";
 
 	// can be overridden with either plist bool MonoUseSGen or MONODEVELOP_USE_SGEN env
 	bool use_sgen = YES;


### PR DESCRIPTION
This is needed because of the MSBuild/NuGet bumps done in Mono to support
the latest 2.1, 2.2 and 3.0 SDKs, which are MSBuild16/NuGet5-based. With
old Mono versions, even basic builds will fail with all sort of packaging,
missing targets, etc issues.