### PR TITLE
Fix several toolbox issues

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
@@ -29,26 +29,40 @@
 using System;
 using MonoDevelop.Ide.CodeTemplates;
 using MonoDevelop.Ide;
-using MonoDevelop.Ide.Gui.Content;
-using MonoDevelop.Ide.Editor;
-using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Gui.Documents;
+using System.Collections.Generic;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
-	
+
 	public class CodeTemplateToolboxProvider : IToolboxDynamicProvider
 	{
-		static string category = MonoDevelop.Core.GettextCatalog.GetString ("Text Snippets");
+		static string category = GettextCatalog.GetString ("Text Snippets");
 
-		public System.Collections.Generic.IEnumerable<ItemToolboxNode> GetDynamicItems (IToolboxConsumer consumer)
+		readonly FilePath filePath;
+
+		public CodeTemplateToolboxProvider ()
 		{
-			// TOTEST
-			if (!(consumer is FileDocumentController content) || !consumer.IsTextView ()) {
-				yield break;
+		}
+
+		public CodeTemplateToolboxProvider (FilePath filePath)
+		{
+			this.filePath = filePath;
+		}
+
+		public IEnumerable<ItemToolboxNode> GetDynamicItems (IToolboxConsumer consumer)
+		{
+			var file = filePath;
+
+			if (file.IsNullOrEmpty) {
+				if (!(consumer is FileDocumentController content) || !consumer.IsTextView ()) {
+					yield break;
+				}
+				file = content.FilePath;
 			}
 
-			foreach (CodeTemplate ct in CodeTemplateService.GetCodeTemplatesForFile (content.FilePath)) {
+			foreach (CodeTemplate ct in CodeTemplateService.GetCodeTemplatesForFile (file)) {
 				if (ct.CodeTemplateContext != CodeTemplateContext.Standard)
 					continue;
 				yield return new TemplateToolboxNode (ct) {

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxService.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxService.cs
@@ -414,7 +414,7 @@ namespace MonoDevelop.DesignerSupport
 		Document oldActiveDoc =  null;
 		SolutionFolderItem oldProject = null;
 		bool configChanged;
-		IToolboxDynamicProvider viewProvider = null;
+		List<IToolboxDynamicProvider> viewProviders = new List<IToolboxDynamicProvider> ();
 		
 		void onActiveDocChanged (object o, EventArgs e)
 		{
@@ -436,28 +436,29 @@ namespace MonoDevelop.DesignerSupport
 		
 		void OnContentChanged (object sender, EventArgs args)
 		{
-			if (viewProvider != null) {
+			foreach (var viewProvider in viewProviders) {
 				this.dynamicProviders.Remove (viewProvider);
 				viewProvider.ItemsChanged -= OnProviderItemsChanged;
 			}
-			
+			viewProviders.Clear ();
+
 			//only treat active ViewContent as a Toolbox consumer if it implements IToolboxConsumer
 			if (IdeApp.Workbench.ActiveDocument != null) {
 				CurrentConsumer = IdeApp.Workbench.ActiveDocument.GetContent<IToolboxConsumer> (true);
-				viewProvider    = IdeApp.Workbench.ActiveDocument.GetContent<IToolboxDynamicProvider> (true);
-				customizer = IdeApp.Workbench.ActiveDocument.GetContent<IToolboxCustomizer> (true);
-				if (viewProvider != null)  {
-					this.dynamicProviders.Add (viewProvider);
+				foreach (var viewProvider in IdeApp.Workbench.ActiveDocument.GetContents<IToolboxDynamicProvider> (true)) {
+					viewProviders.Add (viewProvider);
+					dynamicProviders.Add (viewProvider);
 					viewProvider.ItemsChanged += OnProviderItemsChanged;
-					OnToolboxContentsChanged ();
 				}
+				customizer = IdeApp.Workbench.ActiveDocument.GetContent<IToolboxCustomizer> (true);
+				if (viewProviders.Count > 0)
+					OnToolboxContentsChanged ();
 			} else {
 				CurrentConsumer = null;
-				viewProvider = null;
 				customizer = null;
 			}
 		}
-		
+
 		//changing project settings could cause the toolbox contents to change
 		void onProjectConfigChanged (object sender, EventArgs args)
 		{

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -87,6 +87,7 @@ namespace MonoDevelop.SourceEditor
 		bool writeAccessChecked;
 		TaskService taskService;
 		TextEditorService textEditorService;
+		CodeTemplateToolboxProvider codeTemplateToolboxProvider;
 
 		internal BreakpointStore Breakpoints => breakpoints;
 
@@ -343,6 +344,7 @@ namespace MonoDevelop.SourceEditor
 		{
 			Document.FileName = ContentName;
 			UpdateMimeType (Document.FileName);
+			codeTemplateToolboxProvider = new CodeTemplateToolboxProvider (contentName);
 			ContentNameChanged?.Invoke (this, EventArgs.Empty);
 		}
 
@@ -2417,6 +2419,8 @@ namespace MonoDevelop.SourceEditor
 			var c = GetContent (type);
 			if (c != null)
 				yield return c;
+			if (typeof (IToolboxDynamicProvider).IsAssignableFrom (type) && codeTemplateToolboxProvider != null)
+				yield return codeTemplateToolboxProvider;
 		}
 
 		#region widget command handlers

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -371,6 +371,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 				LoggingService.LogInternalError (ex);
 			}
 			SourceController?.NotifyFocused ();
+			SetActive ();
 		}
 
 		private void ShellContentView_LostFocus (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerSplit.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerSplit.cs
@@ -79,13 +79,7 @@ namespace MonoDevelop.Ide.Gui.Shell
 			}
 		}
 
-		public GtkShellDocumentViewItem ActiveView {
-			get {
-				return (GtkShellDocumentViewItem)Children.FirstOrDefault ();
-			}
-			set {
-			}
-		}
+		public GtkShellDocumentViewItem ActiveView { get; set; }
 
 		public event EventHandler ActiveViewChanged;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -134,6 +134,18 @@ namespace MonoDevelop.Ide.Gui
 			return GetContent<T> (false);
 		}
 
+		public IEnumerable<T> GetContents<T> (bool forActiveView) where T : class
+		{
+			if (forActiveView)
+				return view.GetActiveControllerHierarchy ().Select (controller => controller.GetContents<T> ()).SelectMany (c => c);
+			return GetControllersForContentCheck ().Select (controller => controller.GetContents<T> ()).SelectMany (c => c);
+		}
+
+		public IEnumerable<T> GetContents<T> () where T : class
+		{
+			return GetContents<T> (false);
+		}
+
 		object GetContent (bool forActiveView, Type type)
 		{
 			if (forActiveView)
@@ -143,12 +155,12 @@ namespace MonoDevelop.Ide.Gui
 
 		object GetContentIncludingAllViews (Type type)
 		{
-			return GetControllersForContentCheck ().Select (controller => controller.GetContent (type)).FirstOrDefault (c => c != null);
+			return GetControllersForContentCheck ().Select (controller => controller.GetContent (type)).FirstOrDefault (content => content != null);
 		}
 
 		object GetContentForActiveView (Type type)
 		{
-			return view.GetActiveControllerHierarchy ()?.FirstOrDefault ()?.GetContent (type);
+			return view.GetActiveControllerHierarchy ().Select (controller => controller.GetContent (type)).FirstOrDefault (content => content != null);
 		}
 
 		ContentCallbackRegistry contentCallbackRegistry;
@@ -213,11 +225,6 @@ namespace MonoDevelop.Ide.Gui
 			get {
 				return controller.DocumentTitle;
 			}
-		}
-
-		public IEnumerable<T> GetContents<T> () where T : class
-		{
-			return GetControllersForContentCheck ().Select (controller => controller.GetContent (typeof (T)) as T).Where (c => c != null);
 		}
 
 		internal Document (DocumentManager documentManager, IShell shell, DocumentController controller, DocumentControllerDescription controllerDescription)

--- a/main/tests/IdeUnitTests/MockShellDocumentViewContent.cs
+++ b/main/tests/IdeUnitTests/MockShellDocumentViewContent.cs
@@ -48,6 +48,7 @@ namespace IdeUnitTests
 		{
 			await base.Show ();
 			control = await contentLoader (CancellationToken.None);
+			ContentInserted?.Invoke (this, EventArgs.Empty);
 		}
 
 		IShellDocumentToolbar IShellDocumentViewContent.GetToolbar (DocumentToolbarKind kind)


### PR DESCRIPTION
Fix several toolbox issues:

* SourceEditorView.cs, CodeTemplateToolboxProvider.cs: In the old editor, use a private
  toolbox provider for snippets. The global provider tries to get the
  editor from the consumer, and that's not possible anymore.

* ToolboxService.cs: Support views that provide several
  IToolboxDynamicProvider instances.

* Document.cs, DocumentController.cs: Added GetContent() method to
  DocumentController to get the content for the active view hierarchy.
  Removed some duplicated code in Document.

* DocumentView.cs, DocumentViewContainer.cs: When a view gets the focus, make sure it
  is set as active. This is important when in Split mode, since now
  clicking in the different views of the split will set it as active.

Also fixed some focus issues with tab views. When switching between tabs, ensure the activated tab gets the focus. Also fixed issue in Shown event, that was not properly invoked for
view containers. Added unit tests.

