### PR TITLE
Add property to signal xamarin.mac analyzer

### DIFF
--- a/main/msbuild/MonoDevelop.AfterCommon.props
+++ b/main/msbuild/MonoDevelop.AfterCommon.props
@@ -58,6 +58,7 @@
 	</ItemGroup>
 
 	<PropertyGroup>
+		<XamarinMacAnalyzerMinimumOSVersion>10.11</XamarinMacAnalyzerMinimumOSVersion>
 		<MonoDevelopDevAnalyzer>$(PackagesDirectory)\MonoDevelopDev.Analyzers.$(NugetVersionMonoDevelopAnalyzers)\analyzers\dotnet\cs\MonoDevelop.Analyzers.dll</MonoDevelopDevAnalyzer>
 	</PropertyGroup>
 


### PR DESCRIPTION
This new property is supported now in the macios API analyzer, and is used to detect
when we don't have a PList in the project.

Fixes VSTS #833279 - Run MacCoreApiIssue Analyzer for MonoDevelop and Addins