### PR TITLE
[8.1][Debugger] Keep variable values synchronized across all debugger pads

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/ValueVisualizerDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Visualizer/ValueVisualizerDialog.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // ValueViewerDialog.cs
 //  
 // Author:
@@ -116,8 +116,14 @@ namespace MonoDevelop.Debugger.Viewers
 
 		protected virtual void OnSaveClicked (object sender, EventArgs e)
 		{
-			if (currentVisualizer == null || currentVisualizer.StoreValue (value))
+			bool saved = false;
+
+			if (currentVisualizer == null || (saved = currentVisualizer.StoreValue (value))) {
 				Respond (Gtk.ResponseType.Ok);
+
+				if (saved)
+					DebuggingService.NotifyVariableChanged ();
+			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -87,6 +87,7 @@ namespace MonoDevelop.Debugger
 		static public event EventHandler CallStackChanged;
 		static public event EventHandler CurrentFrameChanged;
 		static public event EventHandler ExecutionLocationChanged;
+		static public event EventHandler VariableChanged;
 		static public event EventHandler DisassemblyRequested;
 		static public event EventHandler<DocumentEventArgs> DisableConditionalCompilation;
 
@@ -1052,22 +1053,26 @@ namespace MonoDevelop.Debugger
 		static void NotifyLocationChanged ()
 		{
 			Runtime.AssertMainThread ();
-			if (ExecutionLocationChanged != null)
-				ExecutionLocationChanged (null, EventArgs.Empty);
+
+			ExecutionLocationChanged?.Invoke (null, EventArgs.Empty);
 		}
 
 		static void NotifyCurrentFrameChanged ()
 		{
 			if (currentBacktrace != null)
 				pinnedWatches.InvalidateAll ();
-			if (CurrentFrameChanged != null)
-				CurrentFrameChanged (null, EventArgs.Empty);
+
+			CurrentFrameChanged?.Invoke (null, EventArgs.Empty);
 		}
 
 		static void NotifyCallStackChanged ()
 		{
-			if (CallStackChanged != null)
-				CallStackChanged (null, EventArgs.Empty);
+			CallStackChanged?.Invoke (null, EventArgs.Empty);
+		}
+
+		internal static void NotifyVariableChanged ()
+		{
+			VariableChanged?.Invoke (null, EventArgs.Empty);
 		}
 
 		public static void Stop ()

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ImmediatePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ImmediatePad.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // ImmediatePad.cs
 //  
 // Authors: Lluis Sanchez Gual <lluis@novell.com>
@@ -78,9 +78,11 @@ namespace MonoDevelop.Debugger
 				var val = frame.GetExpressionValue (expression, ops);
 				if (val.IsEvaluating) {
 					WaitForCompleted (val, frame.DebuggerSession);
+					DebuggingService.NotifyVariableChanged ();
 					return;
 				}
 
+				DebuggingService.NotifyVariableChanged ();
 				PrintValue (val);
 			}
 		}	

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
@@ -25,9 +25,6 @@
 //
 //
 
-using System;
-using Mono.Debugging.Client;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace MonoDevelop.Debugger
@@ -40,17 +37,27 @@ namespace MonoDevelop.Debugger
 			tree.AllowAdding = false;
 		}
 
-		public override void OnUpdateList ()
+		void ReloadValues ()
 		{
-			base.OnUpdateList ();
-
 			var frame = DebuggingService.CurrentFrame;
-			
+
 			if (frame == null)
 				return;
 
 			tree.ClearValues ();
 			tree.AddValues (frame.GetAllLocals ().Where (l => !string.IsNullOrWhiteSpace (l.Name) && l.Name != "?").ToArray ());
+		}
+
+		public override void OnUpdateFrame ()
+		{
+			base.OnUpdateFrame ();
+			ReloadValues ();
+		}
+
+		public override void OnUpdateValues ()
+		{
+			base.OnUpdateValues ();
+			ReloadValues ();
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1509,14 +1509,14 @@ namespace MonoDevelop.Debugger
 
 			try {
 				string newVal = args.NewText;
-/*				if (newVal == null) {
-					MessageService.ShowError (GettextCatalog.GetString ("Unregognized escape sequence."));
+
+				if (val.Value == newVal)
 					return;
-				}
-*/				if (val.Value != newVal)
-					val.Value = newVal;
+
+				val.Value = newVal;
 			} catch (Exception ex) {
 				LoggingService.LogError ("Could not set value for object '" + val.Name + "'", ex);
+				return;
 			}
 
 			store.SetValue (it, ValueColumn, val.DisplayValue);
@@ -1535,6 +1535,8 @@ namespace MonoDevelop.Debugger
 			store.SetValue (it, NameColorColumn, newColor);
 			store.SetValue (it, ValueColorColumn, newColor);
 			UpdateParentValue (it);
+
+			DebuggingService.NotifyVariableChanged ();
 		}
 
 		private void UpdateParentValue (TreeIter it)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/WatchPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/WatchPad.cs
@@ -70,9 +70,15 @@ namespace MonoDevelop.Debugger
 		{
 			tree.AddExpression (expression);
 		}
-		
+
+		public override void OnUpdateValues ()
+		{
+			base.OnUpdateValues ();
+			tree.Update ();
+		}
+
 		#region IMementoCapable implementation 
-		
+
 		public ICustomXmlSerializer Memento {
 			get {
 				return this;


### PR DESCRIPTION
When a user changes the value of a variable in 1 debugger pad
(Immediate, Watch, or Locals), make sure the value change(s) are
reflected in the other pads as well.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/806732/