### PR TITLE
Fixes VSTS Bug 705785: [Feedback] Search result tab has temporary files

### DIFF
--- a/main/src/addins/MonoDevelop.Autotools/MakefileData.cs
+++ b/main/src/addins/MonoDevelop.Autotools/MakefileData.cs
@@ -1426,7 +1426,7 @@ namespace MonoDevelop.Autotools
 
 			List<string> files = new List<string> ();
 			foreach (ProjectFile pf in OwnerProject.Files) {
-				if (pf.Subtype != Subtype.Code)
+				if (pf.Subtype != Subtype.Code && pf.Subtype != Subtype.Designer)
 					continue;
 				if (IsFileExcluded (pf.FilePath))
 					continue;

--- a/main/src/addins/MonoDevelop.Autotools/SimpleProjectMakefileHandler.cs
+++ b/main/src/addins/MonoDevelop.Autotools/SimpleProjectMakefileHandler.cs
@@ -152,7 +152,7 @@ namespace MonoDevelop.Autotools
 					{
 						case BuildAction.Compile:
 							
-							if ( projectFile.Subtype != Subtype.Code ) continue;
+							if (projectFile.Subtype != Subtype.Code && projectFile.Subtype != Subtype.Designer) continue;
 							files.AppendFormat ( "\\\n\t{0} ", MakefileData.ToMakefilePath (pfpath));
 							break;
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -729,13 +729,19 @@ namespace MonoDevelop.Projects
 			{
 				var analyzerList = new List<FilePath> ();
 				var sourceFilesList = new List<ProjectFile> ();
-
 				foreach (var item in items) {
 					var msbuildPath = MSBuildProjectService.FromMSBuildPath (project.sourceProject.BaseDirectory, item.Include);
 
-					if (item.Name == "Compile")
-						sourceFilesList.Add (new ProjectFile (msbuildPath, item.Name) { Project = project });
-					else if (item.Name == "Analyzer")
+					if (item.Name == "Compile") {
+						var projectFile = new ProjectFile (msbuildPath, item.Name) { Project = project };
+						const string subtype = "SubType";
+						if (item.Metadata.HasProperty (subtype)) {
+							var property = item.Metadata.GetProperty (subtype);
+							if (property.Value == "Designer")
+								projectFile.Subtype = Subtype.Designer;
+						}
+						sourceFilesList.Add (projectFile);
+					} else if (item.Name == "Analyzer")
 						analyzerList.Add (msbuildPath);
 				}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -733,13 +733,16 @@ namespace MonoDevelop.Projects
 					var msbuildPath = MSBuildProjectService.FromMSBuildPath (project.sourceProject.BaseDirectory, item.Include);
 
 					if (item.Name == "Compile") {
-						var projectFile = new ProjectFile (msbuildPath, item.Name) { Project = project };
-						const string subtype = "SubType";
-						if (item.Metadata.HasProperty (subtype)) {
-							var property = item.Metadata.GetProperty (subtype);
+						var subtype = Subtype.Code;
+
+						const string subtypeKey = "SubType";
+						if (item.Metadata.HasProperty (subtypeKey)) {
+							var property = item.Metadata.GetProperty (subtypeKey);
 							if (property.Value == "Designer")
-								projectFile.Subtype = Subtype.Designer;
+								subtype = Subtype.Designer;
 						}
+
+						var projectFile = new ProjectFile (msbuildPath, item.Name, subtype) { Project = project };
 						sourceFilesList.Add (projectFile);
 					} else if (item.Name == "Analyzer")
 						analyzerList.Add (msbuildPath);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -46,6 +46,7 @@ namespace MonoDevelop.Projects
 	public enum Subtype
 	{
 		Code,
+		Designer,
 		Directory
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -59,14 +59,18 @@ namespace MonoDevelop.Projects
 		{
 		}
 
-		public ProjectFile (string filename): this (filename, MonoDevelop.Projects.BuildAction.Compile)
+		public ProjectFile (string filename) : this (filename, MonoDevelop.Projects.BuildAction.Compile)
 		{
 		}
 
-		public ProjectFile (string filename, string buildAction)
+		public ProjectFile (string filename, string buildAction) : this (filename, buildAction, Subtype.Code)
+		{
+		}
+
+		public ProjectFile (string filename, string buildAction, Subtype subtype)
 		{
 			this.filename = FileService.GetFullPath (filename);
-			subtype = Subtype.Code;
+			this.subtype = subtype;
 			BuildAction = buildAction;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FilterOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FilterOptions.cs
@@ -67,7 +67,12 @@ namespace MonoDevelop.Ide.FindInFiles
 			get;
 			set;
 		}
-		
+
+		public bool IncludeCodeBehind {
+			get;
+			set;
+		}
+
 		public bool NameMatches (string name)
 		{
 			if (string.IsNullOrEmpty (FileMask) || FileMask == "*" || split_file_masks == null)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -173,8 +173,12 @@ namespace MonoDevelop.Ide.FindInFiles
 							  (project, loop, providers) => {
 								  var conf = project.DefaultConfiguration?.Selector;
 
-								  foreach (ProjectFile file in project.GetSourceFilesAsync (conf).Result.Where (f => filterOptions.NameMatches (f.Name) && File.Exists (f.Name))) {
+								  foreach (ProjectFile file in project.GetSourceFilesAsync (conf).Result) {
 									  if ((file.Flags & ProjectItemFlags.Hidden) == ProjectItemFlags.Hidden)
+										  continue;
+									  if (!filterOptions.IncludeCodeBehind && file.Subtype == Subtype.Designer)
+										  continue;
+									  if (!filterOptions.NameMatches (file.Name))
 										  continue;
 									  if (!IdeServices.DesktopService.GetFileIsText (file.FilePath))
 										  continue;
@@ -229,8 +233,12 @@ namespace MonoDevelop.Ide.FindInFiles
 				monitor.Log.WriteLine (GettextCatalog.GetString ("Looking in project '{0}'", project.Name));
 				var alreadyVisited = new HashSet<string> ();
 				var conf = project.DefaultConfiguration?.Selector;
-				foreach (ProjectFile file in project.GetSourceFilesAsync (conf).Result.Where (f => filterOptions.NameMatches (f.Name) && File.Exists (f.Name))) {
+				foreach (ProjectFile file in project.GetSourceFilesAsync (conf).Result) {
 					if ((file.Flags & ProjectItemFlags.Hidden) == ProjectItemFlags.Hidden)
+						continue;
+					if (!filterOptions.IncludeCodeBehind && file.Subtype == Subtype.Designer)
+						continue;
+					if (!filterOptions.NameMatches (file.Name))
 						continue;
 					if (!IdeServices.DesktopService.GetFileIsText (file.Name))
 						continue;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetSourceFilesAsyncTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetSourceFilesAsyncTests.cs
@@ -213,6 +213,25 @@ namespace MonoDevelop.Projects
 
 			project.Dispose ();
 		}
+
+		/// <summary>
+		/// Bug 705785: [Feedback] Search result tab has temporary files
+		/// </summary>
+		[Test ()]
+		public async Task GetSourceFilesFromProjectWithDesignerfiles_VSTS705785 ()
+		{
+			string projectFile = Util.GetSampleProject ("project-with-corecompiledepends", "project-with-design-files.csproj");
+			using (var project = (Project)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile)) {
+
+				var sourceFiles = await project.GetSourceFilesAsync (project.Configurations [0].Selector);
+				var activityFile = sourceFiles.FirstOrDefault (f => f.Name.EndsWith("MainActivity.cs", StringComparison.Ordinal));
+				Assert.AreEqual (Subtype.Code, activityFile.Subtype);
+
+				var file2 = sourceFiles.FirstOrDefault (f => f.Name.EndsWith("GeneratedFile.g.cs", StringComparison.Ordinal));
+				Assert.AreEqual (Subtype.Designer, file2.Subtype);
+			}
+		}
+
 		/// <summary>
 		/// Ensures GetSourceFilesAsync does not include the old filename.
 		/// </summary>

--- a/main/tests/test-projects/project-with-corecompiledepends/project-with-design-files.csproj
+++ b/main/tests/test-projects/project-with-corecompiledepends/project-with-design-files.csproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{A93D8DA8-0BAA-4A23-ACD0-92206A4E2747}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ConsoleME</RootNamespace>
+    <AssemblyName>ConsoleME</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainActivity.cs" />
+  </ItemGroup>
+
+  <Target Name="UpdateGeneratedFiles">
+    <ItemGroup>
+      <Compile Include="GeneratedFile.g.cs">
+        <SubType>Designer</SubType>
+      </Compile>
+    </ItemGroup>
+  </Target>
+
+	<PropertyGroup>
+  		<CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/705785

The user is right that search in whole solution shouldn't include
generated files. However it's a slight behavior change to old
versions. If users want to search in generated files for some reason
they should switch to 'search in directory' instead.