### PR TITLE
[NuGet] Support partial installs into multi-target projects

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetCoreNuGetProjectTests.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using MonoDevelop.Core;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using MonoDevelop.Projects;
 using NuGet.Frameworks;
@@ -84,10 +85,15 @@ namespace MonoDevelop.PackageManagement.Tests
 
 		Task<bool> InstallPackageAsync (string packageId, string version)
 		{
+			var installationContext = CreateInstallationContext ();
+			return InstallPackageAsync (packageId, version, installationContext);
+		}
+
+		Task<bool> InstallPackageAsync (string packageId, string version, BuildIntegratedInstallationContext installationContext)
+		{
 			var packageIdentity = new PackageIdentity (packageId, NuGetVersion.Parse (version));
 			var versionRange = new VersionRange (packageIdentity.Version);
 
-			var installationContext = CreateInstallationContext ();
 			return project.InstallPackageAsync (packageId, versionRange, context, installationContext, CancellationToken.None);
 		}
 
@@ -589,6 +595,223 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.IsNull (dotNetCoreProject.MSBuildProject);
 			Assert.IsFalse (result);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_MultiTargetPartialInstall_PackageReferenceAddedWithCondition ()
+		{
+			CreateNuGetProject ();
+			FilePath projectDirectory = Util.CreateTmpDir ("MultiTargetInstallTest");
+			dotNetProject.FileName = projectDirectory.Combine ("MultiTargetTest.csproj");
+			project.CallBaseSaveProject = true;
+
+			var successfulFrameworks = new NuGetFramework[] {
+				NuGetFramework.Parse ("net472"),
+			};
+
+			var unsuccessfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("netstandard1.5")
+			};
+
+			var originalFrameworks = new Dictionary<NuGetFramework, string> ();
+
+			var installationContext = new BuildIntegratedInstallationContext (
+				successfulFrameworks,
+				unsuccessfulFrameworks,
+				originalFrameworks);
+
+			bool result = await InstallPackageAsync ("TestPackage", "2.6.1", installationContext);
+
+			var packageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.SingleOrDefault (item => item.Include == "TestPackage");
+
+			Assert.AreEqual ("'$(TargetFramework)' == 'net472'", packageReference.ParentGroup.Condition);
+			Assert.AreEqual ("2.6.1", packageReference.Metadata.GetValue ("Version"));
+			Assert.IsFalse (packageReference.Metadata.HasProperty ("IncludeAssets"));
+			Assert.IsFalse (packageReference.Metadata.HasProperty ("PrivateAssets"));
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_MultiTargetPartialInstallNonStandardOriginalFramework_OriginalFrameworkUsedInCondition ()
+		{
+			CreateNuGetProject ();
+			FilePath projectDirectory = Util.CreateTmpDir ("MultiTargetInstallTest");
+			dotNetProject.FileName = projectDirectory.Combine ("MultiTargetTest.csproj");
+			project.CallBaseSaveProject = true;
+
+			var net472Framework = NuGetFramework.Parse ("net472");
+
+			var successfulFrameworks = new NuGetFramework [] {
+				net472Framework
+			};
+
+			var unsuccessfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("netstandard1.5")
+			};
+
+			var originalFrameworks = new Dictionary<NuGetFramework, string> ();
+			originalFrameworks [net472Framework] = ".NETFramework4.7.2";
+
+			var installationContext = new BuildIntegratedInstallationContext (
+				successfulFrameworks,
+				unsuccessfulFrameworks,
+				originalFrameworks);
+
+			bool result = await InstallPackageAsync ("TestPackage", "2.6.1", installationContext);
+
+			var packageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.SingleOrDefault (item => item.Include == "TestPackage");
+
+			Assert.AreEqual ("'$(TargetFramework)' == '.NETFramework4.7.2'", packageReference.ParentGroup.Condition);
+			Assert.AreEqual (packageReference.Metadata.GetValue ("Version"), "2.6.1");
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_MultiTargetPartialInstallPrivateAndIncludeAssets_PackageReferenceHasAssetInfo ()
+		{
+			CreateNuGetProject ();
+			FilePath projectDirectory = Util.CreateTmpDir ("MultiTargetInstallTest");
+			dotNetProject.FileName = projectDirectory.Combine ("MultiTargetTest.csproj");
+			project.CallBaseSaveProject = true;
+
+			var successfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("net472"),
+			};
+
+			var unsuccessfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("netstandard1.5")
+			};
+
+			var originalFrameworks = new Dictionary<NuGetFramework, string> ();
+
+			var installationContext = new BuildIntegratedInstallationContext (
+				successfulFrameworks,
+				unsuccessfulFrameworks,
+				originalFrameworks);
+
+			installationContext.IncludeType = LibraryIncludeFlags.Runtime |
+				LibraryIncludeFlags.Build |
+				LibraryIncludeFlags.Native |
+				LibraryIncludeFlags.ContentFiles |
+				LibraryIncludeFlags.Analyzers;
+
+			installationContext.SuppressParent = LibraryIncludeFlags.All;
+
+			bool result = await InstallPackageAsync ("TestPackage", "2.6.1", installationContext);
+
+			var packageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.SingleOrDefault (item => item.Include == "TestPackage");
+
+			Assert.AreEqual ("'$(TargetFramework)' == 'net472'", packageReference.ParentGroup.Condition);
+			Assert.AreEqual ("2.6.1", packageReference.Metadata.GetValue ("Version"));
+			Assert.AreEqual ("runtime; build; native; contentfiles; analyzers", packageReference.Metadata.GetValue ("IncludeAssets"));
+			Assert.AreEqual ("all", packageReference.Metadata.GetValue ("PrivateAssets"));
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_MultiTargetPartialInstallTwice_PackageReferenceAddedToSameItemGroup ()
+		{
+			CreateNuGetProject ();
+			FilePath projectDirectory = Util.CreateTmpDir ("MultiTargetInstallTest");
+			dotNetProject.FileName = projectDirectory.Combine ("MultiTargetTest.csproj");
+			project.CallBaseSaveProject = true;
+
+			var successfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("net472"),
+			};
+
+			var unsuccessfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("netstandard1.5")
+			};
+
+			var originalFrameworks = new Dictionary<NuGetFramework, string> ();
+
+			var installationContext = new BuildIntegratedInstallationContext (
+				successfulFrameworks,
+				unsuccessfulFrameworks,
+				originalFrameworks);
+
+			bool firstInstallResult = await InstallPackageAsync ("TestPackage", "2.6.1", installationContext);
+			var packageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.SingleOrDefault (item => item.Include == "TestPackage");
+
+			// Update.
+			bool result = await InstallPackageAsync ("AnotherTestPackage", "3.0.1", installationContext);
+
+			var secondPackageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.FirstOrDefault (item => item.Include == "AnotherTestPackage");
+
+			Assert.AreEqual ("'$(TargetFramework)' == 'net472'", packageReference.ParentGroup.Condition);
+			Assert.AreEqual ("2.6.1", packageReference.Metadata.GetValue ("Version"));
+			Assert.IsTrue (firstInstallResult);
+			Assert.AreEqual ("'$(TargetFramework)' == 'net472'", secondPackageReference.ParentGroup.Condition);
+			Assert.AreEqual ("3.0.1", secondPackageReference.Metadata.GetValue ("Version"));
+			Assert.AreEqual (packageReference.ParentGroup, secondPackageReference.ParentGroup);
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
+		}
+
+		[Test]
+		public async Task InstallPackageAsync_MultiTargetPartialUpdate_PackageReferenceUpdated ()
+		{
+			CreateNuGetProject ();
+			FilePath projectDirectory = Util.CreateTmpDir ("MultiTargetInstallTest");
+			dotNetProject.FileName = projectDirectory.Combine ("MultiTargetTest.csproj");
+			project.CallBaseSaveProject = true;
+
+			var successfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("net472"),
+			};
+
+			var unsuccessfulFrameworks = new NuGetFramework [] {
+				NuGetFramework.Parse ("netstandard1.5")
+			};
+
+			var originalFrameworks = new Dictionary<NuGetFramework, string> ();
+
+			var installationContext = new BuildIntegratedInstallationContext (
+				successfulFrameworks,
+				unsuccessfulFrameworks,
+				originalFrameworks);
+
+			bool firstInstallResult = await InstallPackageAsync ("TestPackage", "2.6.1", installationContext);
+
+			var packageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.SingleOrDefault (item => item.Include == "TestPackage");
+			Assert.AreEqual ("2.6.1", packageReference.Metadata.GetValue ("Version"));
+
+			bool result = await InstallPackageAsync ("TestPackage", "3.0.1", installationContext);
+
+			var updatedPackageReference = dotNetProject
+				.MSBuildProject
+				.GetAllItems ()
+				.FirstOrDefault (item => item.Include == "TestPackage");
+
+			Assert.AreEqual ("'$(TargetFramework)' == 'net472'", packageReference.ParentGroup.Condition);
+			Assert.AreEqual ("3.0.1", packageReference.Metadata.GetValue ("Version"));
+			Assert.IsTrue (firstInstallResult);
+			Assert.AreEqual ("'$(TargetFramework)' == 'net472'", updatedPackageReference.ParentGroup.Condition);
+			Assert.AreEqual ("3.0.1", updatedPackageReference.Metadata.GetValue ("Version"));
+			Assert.IsTrue (result);
+			Assert.IsTrue (project.IsSaved);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -341,6 +341,8 @@
     <Compile Include="MonoDevelop.PackageManagement\ExceptionExtensions.cs" />
     <Compile Include="MonoDevelop.PackageManagement\DependencyGraphSpecExtensions.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageSpecExtensions.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\ConditionalPackageReferenceHandler.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\IPropertySetExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ConditionalPackageReferenceHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ConditionalPackageReferenceHandler.cs
@@ -1,0 +1,126 @@
+//
+// ConditionalPackageReferenceHandler.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Linq;
+using MonoDevelop.Projects.MSBuild;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+
+namespace MonoDevelop.PackageManagement
+{
+	class ConditionalPackageReferenceHandler : IDisposable
+	{
+		PackageIdentity packageIdentity;
+		INuGetProjectContext context;
+		BuildIntegratedInstallationContext installationContext;
+
+		public ConditionalPackageReferenceHandler ()
+		{
+			PackageManagementMSBuildExtension.ConditionalPackageReferenceHandler = this;
+		}
+
+		public void Dispose ()
+		{
+			PackageManagementMSBuildExtension.ConditionalPackageReferenceHandler = null;
+		}
+
+		public void AddConditionalPackageReference (
+			PackageIdentity packageIdentity,
+			INuGetProjectContext context,
+			BuildIntegratedInstallationContext installationContext)
+		{
+			this.packageIdentity = packageIdentity;
+			this.context = context;
+			this.installationContext = installationContext;
+		}
+
+		public void UpdateProject (MSBuildProject project)
+		{
+			foreach (NuGetFramework framework in installationContext.SuccessfulFrameworks) {
+
+				MSBuildItem packageReference = AddPackageReference (project, framework);
+
+				if (installationContext.IncludeType != LibraryIncludeFlags.All &&
+					installationContext.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent) {
+					packageReference.Metadata.SetMetadataValue (ProjectItemProperties.IncludeAssets, installationContext.IncludeType);
+					packageReference.Metadata.SetMetadataValue (ProjectItemProperties.PrivateAssets, installationContext.SuppressParent);
+				}
+			}
+		}
+
+		MSBuildItem AddPackageReference (MSBuildProject project, NuGetFramework framework)
+		{
+			string originalFramework;
+			if (!installationContext.OriginalFrameworks.TryGetValue (framework, out originalFramework)) {
+				originalFramework = framework.GetShortFolderName ();
+			}
+
+			MSBuildItemGroup itemGroup = GetOrAddItemGroup (project, originalFramework);
+			MSBuildItem packageReference = GetOrAddPackageReference (itemGroup);
+
+			packageReference.Metadata.SetValue ("Version", packageIdentity.Version.ToNormalizedString ());
+
+			return packageReference;
+		}
+
+		static MSBuildItemGroup GetOrAddItemGroup (MSBuildProject project, string originalFramework)
+		{
+			string condition = string.Format ("'$(TargetFramework)' == '{0}'", originalFramework);
+
+			MSBuildItemGroup itemGroup = project
+				.ItemGroups
+				.FirstOrDefault (item => StringComparer.OrdinalIgnoreCase.Equals (item.Condition, condition));
+
+			if (itemGroup == null) {
+				itemGroup = project.AddNewItemGroup ();
+				itemGroup.Condition = condition;
+			}
+
+			return itemGroup;
+		}
+
+		MSBuildItem GetOrAddPackageReference (MSBuildItemGroup itemGroup)
+		{
+			MSBuildItem packageReference = itemGroup
+				.Items
+				.FirstOrDefault (item => IsPackageReferenceMatch (item));
+
+			if (packageReference == null)
+				packageReference = itemGroup.AddNewItem ("PackageReference", packageIdentity.Id);
+
+			return packageReference;
+		}
+
+		bool IsPackageReferenceMatch (MSBuildItem item)
+		{
+			return item.Name == "PackageReference" &&
+				StringComparer.OrdinalIgnoreCase.Equals (item.Include, packageIdentity.Id);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetCoreNuGetProject.cs
@@ -161,6 +161,10 @@ namespace MonoDevelop.PackageManagement
 		{
 			var packageIdentity = new PackageIdentity (packageId, range.MinVersion);
 
+			if (installationContext.SuccessfulFrameworks.Any () && installationContext.UnsuccessfulFrameworks.Any ()) {
+				return await AddConditionalPackageReference (packageIdentity, nuGetProjectContext, installationContext);
+			}
+
 			bool added = await Runtime.RunInMainThread (() => {
 				return AddPackageReference (packageIdentity, nuGetProjectContext, installationContext);
 			});
@@ -170,6 +174,18 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			return added;
+		}
+
+		async Task<bool> AddConditionalPackageReference (
+			PackageIdentity packageIdentity,
+			INuGetProjectContext context,
+			BuildIntegratedInstallationContext installationContext)
+		{
+			using (var handler = new ConditionalPackageReferenceHandler ()) {
+				handler.AddConditionalPackageReference (packageIdentity, context, installationContext);
+				await SaveProject ();
+			}
+			return true;
 		}
 
 		bool AddPackageReference (PackageIdentity packageIdentity, INuGetProjectContext context, BuildIntegratedInstallationContext installationContext)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPropertySetExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IPropertySetExtensions.cs
@@ -1,10 +1,10 @@
-﻿//
-// TestableDotNetCoreNuGetProject.cs
+//
+// IPropertySetExtensions.cs
 //
 // Author:
-//       Matt Ward <matt.ward@xamarin.com>
+//       Matt Ward <matt.ward@microsoft.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2019 Microsoft
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,40 +24,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System.Threading.Tasks;
 using MonoDevelop.Projects;
+using NuGet.Common;
+using NuGet.LibraryModel;
 
-namespace MonoDevelop.PackageManagement.Tests.Helpers
+namespace MonoDevelop.PackageManagement
 {
-	class TestableDotNetCoreNuGetProject : DotNetCoreNuGetProject
+	static class IPropertySetExtensions
 	{
-		public TestableDotNetCoreNuGetProject (DotNetProject project)
-			: base (project, new [] { "netcoreapp1.0" }, ConfigurationSelector.Default)
+		internal static void SetMetadataValue (this IPropertySet propertySet, string name, LibraryIncludeFlags flags)
 		{
-			BuildIntegratedRestorer = new FakeMonoDevelopBuildIntegratedRestorer ();
-		}
-
-		public bool IsSaved { get; set; }
-
-		public bool CallBaseSaveProject { get; set; }
-
-		public override Task SaveProject ()
-		{
-			IsSaved = true;
-
-			if (CallBaseSaveProject)
-				return base.SaveProject ();
-
-			return Task.FromResult (0);
-		}
-
-		public FakeMonoDevelopBuildIntegratedRestorer BuildIntegratedRestorer;
-		public Solution SolutionUsedToCreateBuildIntegratedRestorer;
-
-		protected override IMonoDevelopBuildIntegratedRestorer CreateBuildIntegratedRestorer (Solution solution)
-		{
-			SolutionUsedToCreateBuildIntegratedRestorer = solution;
-			return BuildIntegratedRestorer;
+			string value = MSBuildStringUtility.Convert (LibraryIncludeFlagUtils.GetFlagString (flags));
+			propertySet.SetValue (name, value);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementMSBuildExtension.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementMSBuildExtension.cs
@@ -38,6 +38,7 @@ namespace MonoDevelop.PackageManagement
 		public static EnsureNuGetPackageBuildImportsTargetUpdater Updater;
 		public static NuGetPackageNewImportsHandler NewImportsHandler;
 		public static NuGetPackageForcedImportsRemover ForcedImportsRemover;
+		public static ConditionalPackageReferenceHandler ConditionalPackageReferenceHandler;
 		public static Task PackageRestoreTask;
 
 		protected override void OnWriteProject (ProgressMonitor monitor, MSBuildProject msproject)
@@ -61,6 +62,11 @@ namespace MonoDevelop.PackageManagement
 			NuGetPackageNewImportsHandler importsHandler = NewImportsHandler;
 			if (importsHandler != null) {
 				importsHandler.UpdateProject (msproject);
+			}
+
+			ConditionalPackageReferenceHandler packageReferenceHandler = ConditionalPackageReferenceHandler;
+			if (packageReferenceHandler != null) {
+				packageReferenceHandler.UpdateProject (msproject);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectPackageReference.cs
@@ -157,8 +157,7 @@ namespace MonoDevelop.PackageManagement
 
 		internal void SetMetadataValue (string name, LibraryIncludeFlags flags)
 		{
-			string value = MSBuildStringUtility.Convert (LibraryIncludeFlagUtils.GetFlagString (flags));
-			Metadata.SetValue (name, value);
+			Metadata.SetMetadataValue (name, flags);
 		}
 	}
 }


### PR DESCRIPTION
A NuGet package being installed into a multi-target framework project
may not support all frameworks. When this happens the PackageReference
will now be added with a condition so the NuGet package is not used
for frameworks that are not supported.

```
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFrameworks>net472;netstandard1.2</TargetFrameworks>
  </PropertyGroup>

  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
    <PackageReference Include="EntityFramework" Version="6.2.0" />
  </ItemGroup>
</Project>
```

Note that NuGet does not support updating a NuGet package with a
condition. Visual Studio on Windows also shows an error about the NuGet
package being incompatible on updating it if it only supports certain
frameworks.

Fixes VSTS #572317 - Make adding PackageReferences to multi-framework
projects robust