### PR TITLE
[release-8.1] [DotNetCore] Supports unknowns SDK

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -134,9 +134,7 @@ namespace MonoDevelop.DotNetCore
 			if (Exist) {
 				IsUnsupportedSdkVersion = !CheckIsSupportedSdkVersion (SdksParentDirectory);
 				Exist = !IsUnsupportedSdkVersion;
-			} else {
-				IsUnsupportedSdkVersion = true;
-			}
+			} 
 		}
 
 		public bool IsUnsupportedSdkVersion { get; private set; }


### PR DESCRIPTION
Although multi targeting is still not supported, by supporting unknowns SDKs -like MSBuild.Sdk.Extras- allows that projects to be built and ran and removes error message.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849421

Backport of #7460.

/cc @rodrmoya @jtorres