### PR TITLE
Avoid unnecessary editor extension chain reinitializaiton

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/RoslynDocumentExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/RoslynDocumentExtension.cs
@@ -685,7 +685,8 @@ namespace MonoDevelop.Ide.Gui
 					StartReparseThread ();
 			};
 
-			Editor.InitializeExtensionChain (this);
+			if (Editor.DocumentContext != this)
+				Editor.InitializeExtensionChain (this);
 			UpdateTextBufferRegistration ();
 		}
 


### PR DESCRIPTION
Fixes VSTS #888272 - InitializeExtensionChain() called twice on editor start