### PR TITLE
[Ide] Refresh build action when adding existing files to project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -2075,6 +2075,10 @@ namespace MonoDevelop.Ide
 							bool? result = MoveCopyFile (file, targetPath, action == AddAction.Move, confirmReplaceFileMessage);
 							if (result == true) {
 								if (vfile == null) {
+									// Build action may depend on file location if globs are used so check again after moving the file.
+									if (string.IsNullOrEmpty (buildAction))
+										fileBuildAction = project.GetDefaultBuildAction (targetPath);
+
 									var pf = new ProjectFile (targetPath, fileBuildAction);
 									vpathsInProject [pf.ProjectVirtualPath] = pf;
 									filesInProject [pf.FilePath] = pf;


### PR DESCRIPTION
If an existing file is copied or moved into a project then the
default build action from the project may be incorrect if the file
uses file globs. DefaultMSBuildEngine's FindGlobItemsIncludingFile
will not find a match if the file does not exist at the target
location. To fix this, if no build action was explicitly set when
adding an existing file to the project, the build action is
refreshed after the file has been copied or moved to the target
location.

This allows an existing .xaml file to be added to a Xamarin.Forms
.NET Standard project and for it to be added as an EmbeddedResource
instead of a None item.

Fixes VSTS 813456 - XAML files added are not actually added