### PR TITLE
[release-8.1] Fix several builder creation issues

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteBuildEngineManager.cs
@@ -166,12 +166,12 @@ namespace MonoDevelop.Projects.MSBuild
 			try {
 				builder = await engine.GetOrCreateRemoteProjectBuilder (projectFile);
 			} catch {
-				ReleaseProjectBuilderNoLock (engine).Ignore ();
+				ReleaseProjectBuilder (engine).Ignore ();
 				throw;
 			}
 
 			if (builder == null) {
-				ReleaseProjectBuilderNoLock (engine).Ignore ();
+				ReleaseProjectBuilder (engine).Ignore ();
 				if (engine.IsShuttingDown) {
 					// The engine was shut down. Try again, using a new engine.
 					return await GetRemoteProjectBuilder (projectFile, solutionFile, runtime, minToolsVersion, buildSessionId, setBusy, allowBusy);
@@ -373,7 +373,7 @@ namespace MonoDevelop.Projects.MSBuild
 				if (b != null)
 					result.Add (b);
 				else
-					ReleaseProjectBuilderNoLock (engine).Ignore ();
+					ReleaseProjectBuilder (engine).Ignore ();
 			}
 			return result;
 		}


### PR DESCRIPTION
To get a project builder RemoteBuildEngineManager first gets a build
engine and then it gets the project builder from it. The process of
getting the project builder was done inside the engine lock and that
was causing a lot of thread contention that lead to a collapse of
builder creation. To avoid this problem builders are now created
outside of the engine lock. With this change there is now the
possibility of the engine being shutdown before the builder can be
obtained from it. If that happens a recursive call is made to get a
new builder from a new engine.

This patch also improves the handling of engine shutdown. The project
builder creation logic now ensures that builders have a reference
count of 1 when they are created and registerd in the builders list.
This was done before in three steps: create -> register builder -> add
reference. In some cases this lead to the engine to be disposed before
the reference was added.

Fixes VSTS #841060 - Hang when opening a file and lots of background threads

Backport of #7449.

/cc @slluis 