### PR TITLE
Fix welcome window initialization

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -401,10 +401,16 @@ namespace MonoDevelop.MacIntegration
 			return map;
 		}
 
+		string currentCommandMenuPath, currentAppMenuPath;
+
 		public override bool SetGlobalMenu (CommandManager commandManager, string commandMenuAddinPath, string appMenuAddinPath)
 		{
 			if (setupFail)
 				return false;
+
+			// avoid reinitialization of the same menu structure
+			if (initedApp == true && currentCommandMenuPath == commandMenuAddinPath && currentAppMenuPath == appMenuAddinPath)
+				return true;
 
 			try {
 				InitApp (commandManager);
@@ -431,6 +437,9 @@ namespace MonoDevelop.MacIntegration
 				// Assign the main menu after loading the items. Otherwise a weird application menu appears.
 				if (NSApplication.SharedApplication.MainMenu == null)
 					NSApplication.SharedApplication.MainMenu = rootMenu;
+
+				currentCommandMenuPath = commandMenuAddinPath;
+				currentAppMenuPath = appMenuAddinPath;
 			} catch (Exception ex) {
 				try {
 					var m = NSApplication.SharedApplication.MainMenu;

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // MacPlatformService.cs
 //
 // Author:
@@ -482,16 +482,18 @@ namespace MonoDevelop.MacIntegration
 
 			initedApp = true;
 
-			IdeApp.Workbench.RootWindow.DeleteEvent += HandleDeleteEvent;
+			IdeApp.Initialized += (s, e) => {
+				IdeApp.Workbench.RootWindow.DeleteEvent += HandleDeleteEvent;
 
-			if (MacSystemInformation.OsVersion >= MacSystemInformation.Lion) {
-				IdeApp.Workbench.RootWindow.Realized += (sender, args) => {
-					var win = GtkQuartz.GetWindow ((Gtk.Window) sender);
-					win.CollectionBehavior |= NSWindowCollectionBehavior.FullScreenPrimary;
-					if (MacSystemInformation.OsVersion >= MacSystemInformation.Sierra)
-						win.TabbingMode = NSWindowTabbingMode.Disallowed;
-				};
-			}
+				if (MacSystemInformation.OsVersion >= MacSystemInformation.Lion) {
+					IdeApp.Workbench.RootWindow.Realized += (sender, args) => {
+						var win = GtkQuartz.GetWindow ((Gtk.Window)sender);
+						win.CollectionBehavior |= NSWindowCollectionBehavior.FullScreenPrimary;
+						if (MacSystemInformation.OsVersion >= MacSystemInformation.Sierra)
+							win.TabbingMode = NSWindowTabbingMode.Disallowed;
+					};
+				}
+			};
 
 			PatchGtkTheme ();
 			NSNotificationCenter.DefaultCenter.AddObserver (NSCell.ControlTintChangedNotification, notif => Core.Runtime.RunInMainThread (

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1038,7 +1038,7 @@ namespace MonoDevelop.MacIntegration
 		public override Window GetFocusedTopLevelWindow ()
 		{
 			if (NSApplication.SharedApplication.KeyWindow != null) {
-				if (IdeApp.Workbench.RootWindow.Visible) {
+				if (IdeApp.Workbench?.RootWindow?.Visible == true) {
 					//if is a docking window then return the current root window
 					if (HasAnyDockWindowFocused ()) {
 						return MessageService.RootWindow;

--- a/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/ProjectHasNuGetMetadataCondition.cs
+++ b/main/src/addins/MonoDevelop.Packaging/MonoDevelop.Packaging/ProjectHasNuGetMetadataCondition.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using Mono.Addins;
+using MonoDevelop.Core;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 
@@ -34,12 +35,12 @@ namespace MonoDevelop.Packaging
 	{
 		public ProjectHasNuGetMetadataCondition ()
 		{
-			IdeApp.ProjectOperations.CurrentProjectChanged += delegate { NotifyChanged (); };
+			Runtime.ServiceProvider.WhenServiceInitialized<ProjectOperations> ((s) => s.CurrentProjectChanged += delegate { NotifyChanged (); });
 		}
 
 		public override bool Evaluate (NodeElement conditionNode)
 		{
-			var project = IdeApp.ProjectOperations.CurrentSelectedProject as DotNetProject;
+			var project = Runtime.ServiceProvider.PeekService<ProjectOperations> ()?.CurrentSelectedProject as DotNetProject;
 			if (project is PackagingProject) {
 				return true;
 			} else if (project != null) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BasicServiceProvider.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BasicServiceProvider.cs
@@ -88,7 +88,7 @@ namespace MonoDevelop.Core
 
 			lock (servicesByType) {
 				// Fast path, try to get a service for this specific type
-				if (servicesByType.TryGetValue (typeof (T), out var service))
+				if (servicesByType.TryGetValue (typeof (T), out var service) && !initializationTasks.ContainsKey (service))
 					return (T)service;
 				return null;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -46,7 +46,7 @@ using System.Threading;
 
 namespace MonoDevelop.Components.Commands
 {
-	[DefaultServiceImplementation]
+	[DefaultServiceImplementation (typeof (IdeCommandManager))]
 	public class CommandManager: Service, IDisposable
 	{
 		// Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -1733,7 +1733,8 @@ namespace MonoDevelop.Components.Commands
 					if (cui != null) {
 						if (cmd.CommandArray) {
 							info.ArrayInfo = new CommandArrayInfo (info);
-							cui.Run (cmdTarget, info.ArrayInfo);
+							if (IsEnabled)
+								cui.Run (cmdTarget, info.ArrayInfo);
 							if (!info.ArrayInfo.Bypass) {
 								if (info.DisableOnShellLock && guiLock > 0)
 									info.Enabled = false;
@@ -1742,7 +1743,8 @@ namespace MonoDevelop.Components.Commands
 						}
 						else {
 							info.Bypass = false;
-							cui.Run (cmdTarget, info);
+							if (IsEnabled)
+								cui.Run (cmdTarget, info);
 							if (!info.Bypass) {
 								if (info.DisableOnShellLock && guiLock > 0)
 									info.Enabled = false;
@@ -1814,10 +1816,12 @@ namespace MonoDevelop.Components.Commands
 			}
 			if (cmd.CommandArray) {
 				info.ArrayInfo = new CommandArrayInfo (info);
-				cmd.DefaultHandler.InternalUpdate (info.ArrayInfo);
+				if (IsEnabled)
+					cmd.DefaultHandler.InternalUpdate (info.ArrayInfo);
 			}
-			else
+			else if (IsEnabled)
 				cmd.DefaultHandler.InternalUpdate (info);
+			info.Enabled &= IsEnabled;
 		}
 		
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/IdeCommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/IdeCommandManager.cs
@@ -1,0 +1,75 @@
+﻿//
+// IdeCommandManager.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Core.Instrumentation;
+using MonoDevelop.Ide;
+
+namespace MonoDevelop.Components.Commands
+{
+	class IdeCommandManager : CommandManager
+	{
+		public IdeCommandManager ()
+		{
+		}
+
+		protected override Task OnInitialize (ServiceProvider serviceProvider)
+		{
+			CommandTargetScanStarted += CommandServiceCommandTargetScanStarted;
+			CommandTargetScanFinished += CommandServiceCommandTargetScanFinished;
+			base.KeyBindingFailed += OnKeyBindingFailed;
+
+			KeyBindingService.LoadBindingsFromExtensionPath ("/MonoDevelop/Ide/KeyBindingSchemes");
+			KeyBindingService.LoadCurrentBindings ("MD2");
+
+			CommandError += delegate (object sender, CommandErrorArgs args) {
+				LoggingService.LogInternalError (args.ErrorMessage, args.Exception);
+			};
+			Counters.Initialization.Trace ("Loading Commands");
+			LoadCommands ("/MonoDevelop/Ide/Commands");
+
+			return base.OnInitialize (serviceProvider);
+		}
+
+		static void OnKeyBindingFailed (object sender, KeyBindingFailedEventArgs e)
+		{
+			IdeApp.Workbench.StatusBar.ShowWarning (e.Message);
+		}
+
+		static ITimeTracker commandTimeCounter;
+
+		static void CommandServiceCommandTargetScanStarted (object sender, EventArgs e)
+		{
+			commandTimeCounter = Counters.CommandTargetScanTime.BeginTiming ();
+		}
+
+		static void CommandServiceCommandTargetScanFinished (object sender, EventArgs e)
+		{
+			commandTimeCounter?.End ();
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -243,7 +243,7 @@ namespace MonoDevelop.Components.Mac
 				if (icon == null)
 					icon = Ide.IdeServices.DesktopService.GetIconForFile (fileName, Gtk.IconSize.Menu);
 				if (icon != null) {
-					var scale = GtkWorkarounds.GetScaleFactor (Ide.IdeApp.Workbench.RootWindow);
+					var scale = NSApplication.SharedApplication.MainWindow?.Screen?.BackingScaleFactor ?? NSScreen.MainScreen.BackingScaleFactor;
 
 					if (NSUserDefaults.StandardUserDefaults.StringForKey ("AppleInterfaceStyle") == "Dark")
 						icon = icon.WithStyles ("dark");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // WelcomePageService.cs
 //
 // Author:
@@ -53,26 +53,28 @@ namespace MonoDevelop.Ide.WelcomePage
 
 		internal static void Initialize ()
 		{
-			IdeApp.Workbench.RootWindow.Hidden += (sender, e) => {
-				if (!IdeApp.IsExiting && HasWindowImplementation) {
-					ShowWelcomeWindow (new WelcomeWindowShowOptions (true));
-				}
-			};
-			IdeApp.Workspace.FirstWorkspaceItemOpened += delegate {
-				HideWelcomePageOrWindow ();
-			};
-			IdeApp.Workspace.LastWorkspaceItemClosed += delegate {
-				if (!IdeApp.IsExiting && !IdeApp.Workspace.WorkspaceItemIsOpening) {
-					ShowWelcomePageOrWindow ();
-				}
-			};
-			IdeApp.Workbench.DocumentOpened += delegate {
-				HideWelcomePageOrWindow ();
-			};
-			IdeApp.Workbench.DocumentClosed += delegate {
-				if (!IdeApp.IsExiting && IdeApp.Workbench.Documents.Count == 0 && !IdeApp.Workspace.IsOpen && !HasWindowImplementation) {
-					ShowWelcomePage ();
-				}
+			IdeApp.Initialized += (s, args) => {
+				IdeApp.Workbench.RootWindow.Hidden += (sender, e) => {
+					if (!IdeApp.IsExiting && HasWindowImplementation) {
+						ShowWelcomeWindow (new WelcomeWindowShowOptions (true));
+					}
+				};
+				IdeApp.Workspace.FirstWorkspaceItemOpened += delegate {
+					HideWelcomePageOrWindow ();
+				};
+				IdeApp.Workspace.LastWorkspaceItemClosed += delegate {
+					if (!IdeApp.IsExiting && !IdeApp.Workspace.WorkspaceItemIsOpening) {
+						ShowWelcomePageOrWindow ();
+					}
+				};
+				IdeApp.Workbench.DocumentOpened += delegate {
+					HideWelcomePageOrWindow ();
+				};
+				IdeApp.Workbench.DocumentClosed += delegate {
+					if (!IdeApp.IsExiting && IdeApp.Workbench.Documents.Count == 0 && !IdeApp.Workspace.IsOpen && !HasWindowImplementation) {
+						ShowWelcomePage ();
+					}
+				};
 			};
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4245,6 +4245,7 @@
     <Compile Include="MonoDevelop.Components.AutoTest\AppQueryRunner.Cocoa.Webview.cs" />
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopExtensionManager.cs" />
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopErrorLoggerService.cs" />
+    <Compile Include="MonoDevelop.Components.Commands\IdeCommandManager.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // IdeApp.cs
 //
 // Author:
@@ -249,6 +249,15 @@ namespace MonoDevelop.Ide
 			commandService.LoadCommands ("/MonoDevelop/Ide/Commands");
 			monitor.Step (1);
 
+			Counters.Initialization.Trace ("Initializing WelcomePage service");
+			WelcomePage.WelcomePageService.Initialize ();
+			if (WelcomePage.WelcomePageService.HasWindowImplementation) {
+				await WelcomePage.WelcomePageService.ShowWelcomeWindow (new WelcomePage.WelcomeWindowShowOptions (false));
+				// load the global menu for the welcome window to avoid unresponsive menus on Mac
+				IdeServices.DesktopService.SetGlobalMenu (commandService, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
+			}
+			monitor.Step (1);
+
 			// Before startup commands.
 			Counters.Initialization.Trace ("Running Pre-Startup Commands");
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/PreStartupHandlers", OnExtensionChanged);
@@ -256,10 +265,6 @@ namespace MonoDevelop.Ide
 
 			Counters.Initialization.Trace ("Initializing Workbench");
 			await workbench.Initialize (monitor);
-			monitor.Step (1);
-
-			Counters.Initialization.Trace ("Initializing WelcomePage service");
-			MonoDevelop.Ide.WelcomePage.WelcomePageService.Initialize ();
 			monitor.Step (1);
 
 			Counters.Initialization.Trace ("Realizing Workbench Window");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -204,6 +204,9 @@ namespace MonoDevelop.Ide
 				PropertyService.SaveProperties ();
 			}
 
+			Counters.Initialization.Trace ("Initializing WelcomePage service");
+			WelcomePage.WelcomePageService.Initialize ().Ignore ();
+
 			Counters.Initialization.Trace ("Creating Services");
 
 			var serviceInitialization = Task.WhenAll (
@@ -220,9 +223,6 @@ namespace MonoDevelop.Ide
 			);
 
 			commandService = await Runtime.GetService<CommandManager> ();
-
-			Counters.Initialization.Trace ("Initializing WelcomePage service");
-			WelcomePage.WelcomePageService.Initialize ().Ignore ();
 
 			await serviceInitialization;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -221,6 +221,9 @@ namespace MonoDevelop.Ide
 
 			commandService = await Runtime.GetService<CommandManager> ();
 
+			Counters.Initialization.Trace ("Initializing WelcomePage service");
+			WelcomePage.WelcomePageService.Initialize ().Ignore ();
+
 			await serviceInitialization;
 
 			Counters.Initialization.Trace ("Creating Workbench");
@@ -232,16 +235,7 @@ namespace MonoDevelop.Ide
 			
 			FileService.ErrorHandler = FileServiceErrorHandler;
 
-			monitor.BeginTask (GettextCatalog.GetString("Loading Workbench"), 4);
-
-			Counters.Initialization.Trace ("Initializing WelcomePage service");
-			WelcomePage.WelcomePageService.Initialize ();
-			if (WelcomePage.WelcomePageService.HasWindowImplementation) {
-				await WelcomePage.WelcomePageService.ShowWelcomeWindow (new WelcomePage.WelcomeWindowShowOptions (false));
-				// load the global menu for the welcome window to avoid unresponsive menus on Mac
-				IdeServices.DesktopService.SetGlobalMenu (commandService, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
-			}
-			monitor.Step (1);
+			monitor.BeginTask (GettextCatalog.GetString("Loading Workbench"), 3);
 
 			// Before startup commands.
 			Counters.Initialization.Trace ("Running Pre-Startup Commands");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // IdeStartup.cs
 //
 // Author:
@@ -367,6 +367,7 @@ namespace MonoDevelop.Ide
 		void RegisterServices ()
 		{
 			Runtime.RegisterServiceType<ProgressMonitorManager, IdeProgressMonitorManager> ();
+			Runtime.RegisterServiceType<CommandManager, IdeCommandManager> ();
 			Runtime.RegisterServiceType<IShell, DefaultWorkbench> ();
 		}
 


### PR DESCRIPTION
With the latest changes to the initialization process (new service model) the welcome window initialization has been removed from the MD initialization process (the welcome page service implementation had to take care of showing the window). This resulted in some unexpected welcome window behaviour if it was shown too early before the command manager and the global menu were initialized.

This PR reduces command dependencies on the workbench and allows to initialize the global menu and the welcome window early enough to avoid noticable startup delays (before the workbench initialization starts), but not too early so the command system has enough information to build the global menu. At the same time MD gets back the control over when and how to show the welcome window.

Fixes VSTS #850578
Fixes VSTS #857394

Depends on https://github.com/xamarin/md-addins/pull/4518