### PR TITLE
[release-8.1] [Core] Fix build with .NET Core 3.0 preview5 installed

### DIFF
--- a/main/msbuild/MonoDevelop.BeforeCommon.targets
+++ b/main/msbuild/MonoDevelop.BeforeCommon.targets
@@ -87,6 +87,7 @@
 	<ItemGroup Condition="$(MSBuildProjectName) != 'MonoDevelop.Core'">
 		<Reference Include="$(NuGetPackageRoot)microsoft.visualstudio.composition/$(NuGetVersionVSComposition)/lib/net45/Microsoft.VisualStudio.Composition.dll">
 			<Private>false</Private>
+			<NuGetPackageId>Microsoft.VisualStudio.Composition</NuGetPackageId>
 		</Reference>
 	</ItemGroup>
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -92,6 +92,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(NuGetVersionVSComposition)" ExcludeAssets="all" />
     <!-- Need the net45 version, see https://github.com/mono/mono/issues/12461 -->
     <Reference Include="$(NuGetPackageRoot)microsoft.visualstudio.composition/$(NuGetVersionVSComposition)/lib/net45/Microsoft.VisualStudio.Composition.dll">
+      <NuGetPackageId>Microsoft.VisualStudio.Composition</NuGetPackageId>
       <Private>true</Private>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionCecil)" PrivateAssets="runtime" />


### PR DESCRIPTION
.NET Core NuGet resolver expects a NuGetPackageId set for every
reference from a NuGet package, so cheat it by adding it.

See https://github.com/dotnet/core-sdk/issues/1904

Backport of #7473.

/cc @rodrmoya 