### PR TITLE
Fix NRE when switching documents

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -1292,7 +1292,7 @@ namespace MonoDevelop.Ide.Gui.Components
 
 		static bool TryHandlePaste (TreeNodeNavigator node, object[] copyObjects, DragOperation currentTransferOperation, bool simulatePaste, bool parentDrop)
 		{
-			if (node == null || copyObjects?.Length <= 0)
+			if (node == null || copyObjects == null || copyObjects.Length == 0)
 				return false;
 			var pos = node.CurrentPosition;
 			foreach (var b in node.NodeBuilderChain) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
@@ -203,7 +203,7 @@ namespace MonoDevelop.Ide.Gui.Shell
 			});
 		}
 
-		public bool ContentVisible => TabControl.CurrentTab.Content == this;
+		public bool ContentVisible => TabControl.CurrentTab?.Content == this;
 
 		public bool CanMoveToNextNotebook ()
 		{


### PR DESCRIPTION
Fixes VSTS #889280 - Cannot move between xaml files
Fixes VSTS #889281 - IDE crashes when clicking on a document tab to swap
documents