### PR TITLE
[NuGet] Fix format exception in Add Packages dialog

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/MultiSourcePackageFeed.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/MultiSourcePackageFeed.cs
@@ -239,18 +239,29 @@ namespace NuGet.PackageManagement.UI
 			if (_logger == null)
 			{
 				// observe the task exception when no UI logger provided.
-				Trace.WriteLine(ExceptionUtilities.DisplayMessage(task.Exception));
+				Trace.WriteLine(DisplayMessage(task.Exception));
 				return;
 			}
 
 			// UI logger only can be engaged from the main thread
 			MonoDevelop.Core.Runtime.RunInMainThread(() =>
 			{
-				var errorMessage = ExceptionUtilities.DisplayMessage(task.Exception);
+				var errorMessage = DisplayMessage(task.Exception);
 				_logger.Log(
 					ProjectManagement.MessageLevel.Error,
 					$"[{state.ToString()}] {errorMessage}");
-			});
+			}).Ignore();
+		}
+
+		static string DisplayMessage(Exception ex)
+		{
+			string errorMessage = ExceptionUtilities.DisplayMessage(ex);
+
+			// NSUrlSessionHandler exceptions contain curly braces {} in the UserInfo part of the message so
+			// to avoid a FormatException we need to escape these.
+			return errorMessage
+				.Replace("{", "{{")
+				.Replace("}", "}}");
 		}
 	}
 }


### PR DESCRIPTION
Exceptions from the NSUrlSessionHandler contain curly braces in the
error messages, such as:

```
[nuget.org] The Internet connection appears to be offline.
  Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." UserInfo={NSUnderlyingError=0x7fce42892a80 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 "(null)" UserInfo={_kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, NSErrorFailingURLStringKey=https://api-v2v3search-1.nuget.org/query?q=&skip=0&take=26&prerelease=false&supportedFramework=Xamarin.iOS,Version=v1.0&semVerLevel=2.0.0, NSErrorFailingURLKey=https://api-v2v3search-1.nuget.org/query?q=&skip=0&take=26&prerelease=false&supportedFramework=Xamarin.iOS,Version=v1.0&semVerLevel=2.0.0, _kCFStreamErrorDomainKey=1, _kCFStreamErrorCodeKey=50, NSLocalizedDescription=The Internet connection appears to be offline.}
```

This text was then being passed to string.Format in the Add Packages
dialog and would cause a FormatException. The error would then not be
displayed in the Add Packages dialog. The text now has the curly braces
escaped to prevent the FormatException.

Fixes VSTS #889359 - NuGet Add Packages - FormatException when offline