### PR TITLE
[8.1] Implement custom infobar handler for analyzer errors

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopErrorLoggerService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopErrorLoggerService.cs
@@ -1,0 +1,48 @@
+//
+// MonoDevelopErrorLoggerService.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.ErrorLogger;
+using Microsoft.CodeAnalysis.Host.Mef;
+using MonoDevelop.Core;
+using static Microsoft.CodeAnalysis.RoslynAssemblyHelper;
+
+namespace MonoDevelop.Ide.RoslynServices
+{
+	[ExportWorkspaceService (typeof (IErrorLoggerService), ServiceLayer.Host), Export (typeof (IErrorLoggerService)), Shared]
+	class MonoDevelopErrorLoggerService : IErrorLoggerService
+	{
+		public void LogException (object source, Exception exception)
+		{
+			if (ShouldReportCrashDumps (source)) {
+				var name = source.GetType ().Name;
+				LoggingService.LogInternalError (name, exception);
+			}
+		}
+
+		 static bool ShouldReportCrashDumps (object source) => HasRoslynPublicKey (source);
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopExtensionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopExtensionManager.cs
@@ -1,0 +1,88 @@
+//
+// MonoDevelopExtensionManager.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.ErrorLogger;
+using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.Text;
+
+namespace MonoDevelop.Ide.RoslynServices
+{
+	[ExportWorkspaceServiceFactory (typeof (IExtensionManager), ServiceLayer.Host), Shared]
+	class MonoDevelopExtensionManager : IWorkspaceServiceFactory
+	{
+		private readonly List<IExtensionErrorHandler> _errorHandlers;
+
+		[ImportingConstructor]
+		public MonoDevelopExtensionManager(
+			[ImportMany]IEnumerable<IExtensionErrorHandler> errorHandlers)
+		{
+			_errorHandlers = errorHandlers.ToList();
+		}
+
+		public IWorkspaceService CreateService (HostWorkspaceServices workspaceServices)
+		{
+			var optionService = workspaceServices.GetService<IOptionService> ();
+			var errorReportingService = workspaceServices.GetService<IErrorReportingService> ();
+			var errorLoggerService = workspaceServices.GetService<IErrorLoggerService> ();
+			return new ExtensionManager (optionService, errorReportingService, errorLoggerService, _errorHandlers);
+		}
+
+		internal class ExtensionManager : Microsoft.CodeAnalysis.Editor.EditorLayerExtensionManager.ExtensionManager
+		{
+			readonly IErrorLoggerService errorLoggerService;
+
+			public ExtensionManager (
+				IOptionService optionsService,
+				IErrorReportingService errorReportingService,
+				IErrorLoggerService errorLoggerService,
+				List<IExtensionErrorHandler> errorHandlers) : base(optionsService, errorReportingService, errorLoggerService, errorHandlers)
+			{
+				this.errorLoggerService = errorLoggerService;
+			}
+
+			public override void HandleException (object provider, Exception exception)
+			{
+#if !DEBUG
+				// Disable info bar for crashing analyzers in release builds.
+				if (provider is CodeFixProvider || provider is FixAllProvider || provider is CodeRefactoringProvider) {
+					errorLoggerService?.LogException (provider, exception);
+					return;
+				}
+#endif
+				base.HandleException (provider, exception);
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4241,6 +4241,8 @@
     <Compile Include="MonoDevelop.Components.AutoTest\AppQueryRunner.Cocoa.cs" />
     <Compile Include="MonoDevelop.Ide\IdeStartupTracker.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.Documents\ContentCallbackRegistry.cs" />
+    <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopExtensionManager.cs" />
+    <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopErrorLoggerService.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />


### PR DESCRIPTION
Fixes VSTS #842187 - Only show analyzer infobar for debug builds
Fixes VSTS #824924 - [Feedback] CSharpAddImportCodeFixProvider error