### PR TITLE
Fix scope of GetContent() for several views

### DIFF
--- a/main/src/addins/AspNet/WebForms/WebFormsToolboxNode.cs
+++ b/main/src/addins/AspNet/WebForms/WebFormsToolboxNode.cs
@@ -129,7 +129,7 @@ namespace MonoDevelop.AspNet.WebForms
 			if (cls == null)
 				return tag;
 
-			var ed = document.GetContent<WebFormsEditorExtension> ();
+			var ed = document.GetContent<WebFormsEditorExtension> (true);
 			if (ed == null)
 				return tag;
 

--- a/main/src/addins/ChangeLogAddIn/ChangeLogAddIn.cs
+++ b/main/src/addins/ChangeLogAddIn/ChangeLogAddIn.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.ChangeLogAddIn
 		
 		static void InsertEntry(Document document)
 		{
-			var textBuffer = document.GetContent<TextEditor>();					
+			var textBuffer = document.GetContent<TextEditor>(true);					
 			if (textBuffer == null) return;
 
 			string changeLogFileName = document.FileName;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
@@ -336,7 +336,7 @@ namespace MonoDevelop.Debugger
 			var breakpoints = DebuggingService.Breakpoints;
 			Breakpoint bp;
 
-			var textView = IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ();
+			var textView = IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true);
 			var (caretLine, caretColumn) = textView.MDCaretLineAndColumn ();
 			var point = textView.Caret.Position.BufferPosition;
 
@@ -354,7 +354,7 @@ namespace MonoDevelop.Debugger
 		{
 			info.Visible = DebuggingService.IsFeatureSupported (DebuggerFeatures.Breakpoints);
 			info.Enabled = IdeApp.Workbench.ActiveDocument != null &&
-					IdeApp.Workbench.ActiveDocument.GetContent<ITextView> () != null &&
+					IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true) != null &&
 					IdeApp.Workbench.ActiveDocument.FileName != FilePath.Null &&
 					!DebuggingService.Breakpoints.IsReadOnly;
 		}
@@ -367,7 +367,7 @@ namespace MonoDevelop.Debugger
 			var breakpoints = DebuggingService.Breakpoints;
 
 			lock (breakpoints) {
-				foreach (var bp in breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ().MDCaretLine ()))
+				foreach (var bp in breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true).MDCaretLine ()))
 					bp.Enabled = !bp.Enabled;
 			}
 		}
@@ -378,11 +378,11 @@ namespace MonoDevelop.Debugger
 
 			info.Visible = DebuggingService.IsFeatureSupported (DebuggerFeatures.Breakpoints);
 			if (IdeApp.Workbench.ActiveDocument != null && 
-			    IdeApp.Workbench.ActiveDocument.GetContent<ITextView> () != null &&
+			    IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true) != null &&
 			    IdeApp.Workbench.ActiveDocument.FileName != FilePath.Null &&
 			    !breakpoints.IsReadOnly) {
 				lock (breakpoints) {
-					var bpInLine = breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ().MDCaretLine());
+					var bpInLine = breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true).MDCaretLine());
 					info.Enabled = bpInLine.Count > 0;
 					info.Text = GettextCatalog.GetString ("Disable Breakpoint");
 					foreach (var bp in bpInLine) {
@@ -463,7 +463,7 @@ namespace MonoDevelop.Debugger
 			lock (breakpoints) {
 				IEnumerable<Breakpoint> brs = breakpoints.GetBreakpointsAtFileLine (
 					IdeApp.Workbench.ActiveDocument.FileName,
-					IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ().MDCaretLine ());
+					IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true).MDCaretLine ());
 
 				List<Breakpoint> list = new List<Breakpoint> (brs);
 				foreach (Breakpoint bp in list)
@@ -477,11 +477,11 @@ namespace MonoDevelop.Debugger
 
 			info.Visible = DebuggingService.IsFeatureSupported (DebuggerFeatures.Breakpoints);
 			if (IdeApp.Workbench.ActiveDocument != null && 
-			    IdeApp.Workbench.ActiveDocument.GetContent<ITextView> () != null &&
+			    IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true) != null &&
 			    IdeApp.Workbench.ActiveDocument.FileName != FilePath.Null &&
 			    !breakpoints.IsReadOnly) {
 				lock (breakpoints)
-					info.Enabled = breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ().MDCaretLine ()).Count > 0;
+					info.Enabled = breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true).MDCaretLine ()).Count > 0;
 			} else {
 				info.Enabled = false;
 			}
@@ -572,7 +572,7 @@ namespace MonoDevelop.Debugger
 		protected override void Run ()
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
-			var textView = doc.GetContent<ITextView> ();
+			var textView = doc.GetContent<ITextView> (true);
 			var (caretLine, caretColumn) = textView.MDCaretLineAndColumn ();
 			if (DebuggingService.IsPaused) {
 				DebuggingService.RunToCursor (doc.FileName, caretLine, caretColumn);
@@ -599,7 +599,7 @@ namespace MonoDevelop.Debugger
 
 			var doc = IdeApp.Workbench.ActiveDocument;
 
-			if (doc?.GetContent<ITextView> () != null && doc.FileName != FilePath.Null) {
+			if (doc?.GetContent<ITextView> (true) != null && doc.FileName != FilePath.Null) {
 				var target = DebugHandler.GetRunTarget ();
 				if (target != null && IdeApp.ProjectOperations.CanDebug (target)) {
 					info.Enabled = true;
@@ -620,7 +620,7 @@ namespace MonoDevelop.Debugger
 			lock (breakpoints) {
 				brs = breakpoints.GetBreakpointsAtFileLine (
 					IdeApp.Workbench.ActiveDocument.FileName,
-					IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ().MDCaretLine ());
+					IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true).MDCaretLine ());
 			}
 
 			if (brs.Count > 0) {
@@ -635,11 +635,11 @@ namespace MonoDevelop.Debugger
 
 			info.Visible = DebuggingService.IsFeatureSupported (DebuggerFeatures.Breakpoints);
 			if (IdeApp.Workbench.ActiveDocument != null && 
-			    IdeApp.Workbench.ActiveDocument.GetContent<ITextView> () != null &&
+			    IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true) != null &&
 			    IdeApp.Workbench.ActiveDocument.FileName != FilePath.Null &&
 			    !breakpoints.IsReadOnly) {
 				lock (breakpoints)
-					info.Enabled = breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ().MDCaretLine ()).Count > 0;
+					info.Enabled = breakpoints.GetBreakpointsAtFileLine (IdeApp.Workbench.ActiveDocument.FileName, IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true).MDCaretLine ()).Count > 0;
 			} else {
 				info.Enabled = false;
 			}
@@ -650,7 +650,7 @@ namespace MonoDevelop.Debugger
 	{
 		protected override void Run ()
 		{
-			var textView = IdeApp.Workbench.ActiveDocument.GetContent<ITextView> ();
+			var textView = IdeApp.Workbench.ActiveDocument.GetContent<ITextView> (true);
 			if (textView != null) {
 				var viewPrimitives = MonoDevelop.Ide.Composition.CompositionManager.GetExport<IEditorPrimitivesFactoryService> ().Value.GetViewPrimitives (textView);
 				var selectedText = viewPrimitives.Selection.GetText ();
@@ -711,7 +711,7 @@ namespace MonoDevelop.Debugger
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
 
-			if (doc != null && doc.FileName != FilePath.Null && doc.GetContent<ITextView> () != null && DebuggingService.IsDebuggingSupported) {
+			if (doc != null && doc.FileName != FilePath.Null && doc.GetContent<ITextView> (true) != null && DebuggingService.IsDebuggingSupported) {
 				info.Enabled = DebuggingService.IsPaused && DebuggingService.DebuggerSession.CanSetNextStatement;
 				info.Visible = DebuggingService.IsPaused;
 			} else {
@@ -725,7 +725,7 @@ namespace MonoDevelop.Debugger
 			var doc = IdeApp.Workbench.ActiveDocument;
 
 			try {
-				var (caretLine, caretColumn) = doc.GetContent<ITextView> ().MDCaretLineAndColumn ();
+				var (caretLine, caretColumn) = doc.GetContent<ITextView> (true).MDCaretLineAndColumn ();
 				DebuggingService.SetNextStatement (doc.FileName, caretLine, caretColumn);
 			} catch (Exception e) {
 				if (e is NotSupportedException || e.InnerException is NotSupportedException) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -1375,7 +1375,7 @@ namespace MonoDevelop.Debugger
 
 		static Microsoft.CodeAnalysis.ISymbol GetLanguageItem (MonoDevelop.Ide.Gui.Document document, SourceLocation sourceLocation, string identifier)
 		{
-			var textBuffer = document.GetContent<ITextBuffer> ();
+			var textBuffer = document.GetContent<ITextBuffer> (true);
 			if (textBuffer == null)
 				return null;
 
@@ -1417,7 +1417,7 @@ namespace MonoDevelop.Debugger
 			Document doc = IdeApp.Workbench.GetDocument (location.FileName);
 			if (doc != null) {
 				Microsoft.CodeAnalysis.ISymbol rr = null;
-				if (doc.GetContent<ITextEditorResolver> () is ITextEditorResolver textEditorResolver) {
+				if (doc.GetContent<ITextEditorResolver> (true) is ITextEditorResolver textEditorResolver) {
 					rr = textEditorResolver.GetLanguageItem (doc.Editor.LocationToOffset (location.Line, 1), identifier);
 				} else {
 					rr = GetLanguageItem (doc, location, identifier);
@@ -1459,7 +1459,7 @@ namespace MonoDevelop.Debugger
 			Document doc = IdeApp.Workbench.GetDocument (frame.SourceLocation.FileName);
 			if (doc == null)
 				return null;
-			var completionProvider = doc.GetContent<IDebuggerCompletionProvider> ();
+			var completionProvider = doc.GetContent<IDebuggerCompletionProvider> (true);
 			if (completionProvider == null)
 				return null;
 			return completionProvider.GetExpressionCompletionData (exp, frame, token);

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxService.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxService.cs
@@ -445,7 +445,7 @@ namespace MonoDevelop.DesignerSupport
 			//only treat active ViewContent as a Toolbox consumer if it implements IToolboxConsumer
 			if (IdeApp.Workbench.ActiveDocument != null) {
 				CurrentConsumer = IdeApp.Workbench.ActiveDocument.GetContent<IToolboxConsumer> (true);
-				foreach (var viewProvider in IdeApp.Workbench.ActiveDocument.GetContents<IToolboxDynamicProvider> (true)) {
+				foreach (var viewProvider in IdeApp.Workbench.ActiveDocument.GetContents<IToolboxDynamicProvider> ()) {
 					viewProviders.Add (viewProvider);
 					dynamicProviders.Add (viewProvider);
 					viewProvider.ItemsChanged += OnProviderItemsChanged;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -724,7 +724,7 @@ namespace MonoDevelop.Components.MainToolbar
 			if (pattern.Pattern == null && pattern.LineNumber > 0) {
 				DestroyPopup ();
 				var doc = IdeApp.Workbench.ActiveDocument;
-				if (doc?.GetContent<ITextView> () is ITextView view) {
+				if (doc?.GetContent<ITextView> (true) is ITextView view) {
 					doc.Select ();
 					var snapshot = view.TextBuffer.CurrentSnapshot;
 					var line = snapshot.GetLineFromLineNumber (pattern.LineNumber - 1);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/CustomStringTagProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/CustomStringTagProvider.cs
@@ -86,7 +86,7 @@ namespace MonoDevelop.Ide.Commands
 					return null;
 					
 				case "CURLINE": {
-					if (wb.ActiveDocument?.GetContent<ITextView> () is ITextView view) {
+					if (wb.ActiveDocument?.GetContent<ITextView> (true) is ITextView view) {
 						var pos = view.Caret.Position.BufferPosition;
 						return pos.Snapshot.GetLineNumberFromPosition (pos.Position) + 1;
 					}
@@ -94,7 +94,7 @@ namespace MonoDevelop.Ide.Commands
 				}
 					
 				case "CURCOLUMN": {
-					if (wb.ActiveDocument?.GetContent<ITextView> () is ITextView view) {
+					if (wb.ActiveDocument?.GetContent<ITextView> (true) is ITextView view) {
 						var pos = view.Caret.Position.BufferPosition;
 						var line = pos.Snapshot.GetLineFromPosition (pos.Position);
 						return pos.Position - line.Start.Position + 1;
@@ -103,21 +103,21 @@ namespace MonoDevelop.Ide.Commands
 				}
 					
 				case "CUROFFSET": {
-					if (wb.ActiveDocument?.GetContent<ITextView> () is ITextView view) {
+					if (wb.ActiveDocument?.GetContent<ITextView> (true) is ITextView view) {
 						return view.Caret.Position.BufferPosition.Position;
 					}
 					return null;
 				}
 					
 				case "CURTEXT": {
-					if (wb.ActiveDocument?.GetContent<ITextView> () is ITextView view) {
+					if (wb.ActiveDocument?.GetContent<ITextView> (true) is ITextView view) {
 						return view.Selection.IsEmpty? "" : view.Selection.SelectedSpans[0].GetText ();
 					}
 					return null;
 				}
 					
 				case "EDITORTEXT": {
-					if (wb.ActiveDocument?.GetContent<ITextView> () is ITextView view) {
+					if (wb.ActiveDocument?.GetContent<ITextView> (true) is ITextView view) {
 						return view.TextBuffer.CurrentSnapshot.GetText ();
 					}
 					return null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/EditCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/EditCommands.cs
@@ -358,13 +358,13 @@ namespace MonoDevelop.Ide.Commands
 		{
 			Document doc = IdeApp.Workbench.ActiveDocument;
 			string header = MonoDevelop.Ide.StandardHeader.StandardHeaderService.GetHeader (doc.Owner as SolutionFolderItem, doc.Name, false);
-			doc.GetContent<ITextView> ().TextBuffer.Insert (0, header + "\n");
+			doc.GetContent<ITextView> (true).TextBuffer.Insert (0, header + "\n");
 		}
 		
 		protected override void Update (CommandInfo info)
 		{
 			Document doc = IdeApp.Workbench.ActiveDocument;
-			if (doc?.GetContent<ITextView> () is ITextView) {
+			if (doc?.GetContent<ITextView> (true) != null) {
 				info.Enabled = doc.CommentTags != null;
 			} else
 				info.Enabled = false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
@@ -212,7 +212,7 @@ namespace MonoDevelop.Ide.Commands
 	{
 		protected override void Run ()
 		{
-			IdeApp.Workbench.ActiveDocument.GetContent<IPrintable> ().PrintDocument (PrintingSettings.Instance);
+			IdeApp.Workbench.ActiveDocument.GetContent<IPrintable> (true).PrintDocument (PrintingSettings.Instance);
 		}
 
 		protected override void Update (CommandInfo info)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
@@ -282,14 +282,14 @@ namespace MonoDevelop.Ide.Commands
 			if (IdeApp.Workbench.ActiveDocument == null)
 				info.Enabled = false;
 			else {
-				IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> ();
+				IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> (true);
 				info.Enabled = zoom != null && zoom.EnableZoomIn;
 			}
 		}
 
 		protected override void Run ()
 		{
-			IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> ();
+			IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> (true);
 			zoom.ZoomIn ();
 		}
 	}
@@ -301,14 +301,14 @@ namespace MonoDevelop.Ide.Commands
 			if (IdeApp.Workbench.ActiveDocument == null)
 				info.Enabled = false;
 			else {
-				IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> ();
+				IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> (true);
 				info.Enabled = zoom != null && zoom.EnableZoomOut;
 			}
 		}
 
 		protected override void Run ()
 		{
-			IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> ();
+			IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> (true);
 			zoom.ZoomOut ();
 		}
 	}
@@ -320,14 +320,14 @@ namespace MonoDevelop.Ide.Commands
 			if (IdeApp.Workbench.ActiveDocument == null)
 				info.Enabled = false;
 			else {
-				IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> ();
+				IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> (true);
 				info.Enabled = zoom != null && zoom.EnableZoomReset;
 			}
 		}
 
 		protected override void Run ()
 		{
-			IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> ();
+			IZoomable zoom = IdeApp.Workbench.ActiveDocument.GetContent<IZoomable> (true);
 			zoom.ZoomReset ();
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
@@ -283,7 +283,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			if (IdeApp.Workbench.ActiveDocument != null) {
-				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 				if (splitt != null) {
 					info.Enabled = splitt.EnableSplitHorizontally;
 				} else 
@@ -294,7 +294,7 @@ namespace MonoDevelop.Ide.Commands
 
 		protected override void Run ()
 		{
-			ISplittable splittVertically = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+			ISplittable splittVertically = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 			if (splittVertically != null)
 				splittVertically.SplitHorizontally ();
 		}
@@ -305,7 +305,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			if (IdeApp.Workbench.ActiveDocument != null) {
-				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 				if (splitt != null) {
 					info.Enabled = splitt.EnableSplitVertically;
 				} else 
@@ -316,7 +316,7 @@ namespace MonoDevelop.Ide.Commands
 
 		protected override void Run ()
 		{
-			ISplittable splittHorizontally = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+			ISplittable splittHorizontally = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 			if (splittHorizontally != null)
 				splittHorizontally.SplitVertically ();
 		}
@@ -327,7 +327,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			if (IdeApp.Workbench.ActiveDocument != null) {
-				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 				if (splitt != null) {
 					info.Enabled = splitt.EnableUnsplit;
 				} else 
@@ -338,7 +338,7 @@ namespace MonoDevelop.Ide.Commands
 
 		protected override void Run ()
 		{
-			ISplittable splittUnsplitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+			ISplittable splittUnsplitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 			if (splittUnsplitt != null)
 				splittUnsplitt.Unsplit ();
 		}
@@ -349,7 +349,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Update (CommandInfo info)
 		{
 			if (IdeApp.Workbench.ActiveDocument != null) {
-				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+				ISplittable splitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 				if (splitt != null) {
 					info.Enabled = splitt.EnableUnsplit;
 				} else 
@@ -360,7 +360,7 @@ namespace MonoDevelop.Ide.Commands
 
 		protected override void Run ()
 		{
-			ISplittable splittUnsplitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> ();
+			ISplittable splittUnsplitt = IdeApp.Workbench.ActiveDocument.GetContent<ISplittable> (true);
 			if (splittUnsplitt != null)
 				splittUnsplitt.SwitchWindow ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/FindInFilesDialog.cs
@@ -207,7 +207,7 @@ namespace MonoDevelop.Ide.FindInFiles
 				toggleFindInFiles.Toggle ();
 
 			if (IdeApp.Workbench.ActiveDocument != null) {
-				var view = IdeApp.Workbench.ActiveDocument.GetContent<ITextView>();
+				var view = IdeApp.Workbench.ActiveDocument.GetContent<ITextView>(true);
 				if (view != null) {
 					string selectedText = FormatPatternToSelectionOption (view.Selection.SelectedSpans.FirstOrDefault ().GetText(), properties.Get ("RegexSearch", false));
 					if (!string.IsNullOrEmpty (selectedText)) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -107,7 +107,7 @@ namespace MonoDevelop.Ide.FindInFiles
 		public override IEnumerable<FileProvider> GetFiles (ProgressMonitor monitor, FilterOptions filterOptions)
 		{
 			var doc = IdeApp.Workbench.ActiveDocument;
-			var textView = doc.GetContent<ITextView> ();
+			var textView = doc.GetContent<ITextView> (true);
 			if (textView != null) {
 				var selection = textView.Selection.SelectedSpans.FirstOrDefault ();
 				yield return new OpenFileProvider (textView.TextBuffer, doc.Owner as Project, doc.FileName, selection.Start, selection.End);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/NavigationHistoryService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/NavigationHistoryService.cs
@@ -192,7 +192,7 @@ namespace MonoDevelop.Ide.Navigation
 
 			NavigationPoint point = null;
 
-			INavigable navigable = doc.GetContent<INavigable> ();
+			INavigable navigable = doc.GetContent<INavigable> (true);
 			if (navigable != null) {
 				point = navigable.BuildNavigationPoint ();
 				if (point != null)


### PR DESCRIPTION
Reviewed calls to GetContent and changed several calls to limit the scope
to the current active view.

For ToolboxService, changed the scope to look for provider in all document.

Fixes VSTS #866686 - Xamarin.Forms previewer does not show toolbox content