### PR TITLE
[release-8.1] Fixes 866554: Enable Snippets within Toolbox

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/CodeTemplateToolboxProvider.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			var file = filePath;
 
 			if (file.IsNullOrEmpty) {
-				if (!(consumer is FileDocumentController content) || !consumer.IsTextView ()) {
+				if (!(consumer is FileDocumentController content) || !consumer.IsTextEditor (out var _)) {
 					yield break;
 				}
 				file = content.FilePath;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -256,13 +256,16 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		public override void MouseDown (NSEvent theEvent)
 		{
+			// MouseDownActivated needs to be called before logic activating toolbox item
+			// because MacToolbox uses this event to focus GTK widget that hosts MacToolboxWidget
+			// resulting into stealing focus from toolbox consumer that gains focus when toolbox item is activated
+			MouseDownActivated?.Invoke (theEvent);
+
 			collectionViewDelegate.IsLastSelectionFromMouseDown = true;
 			base.MouseDown (theEvent);
 			if (SelectedItem != null && theEvent.ClickCount > 1) {
 				OnActivateSelectedItem (EventArgs.Empty);
 			}
-
-			MouseDownActivated?.Invoke (theEvent);
 		}
 
 		public void RedrawItems (bool invalidates, bool reloads)

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
@@ -273,7 +273,10 @@ namespace MonoDevelop.TextEditor
 		static string category = GettextCatalog.GetString ("Text Snippets");
 		public IEnumerable<ItemToolboxNode> GetDynamicItems (IToolboxConsumer consumer)
 		{
-			foreach (var template in Imports.ExpansionManager.EnumerateExpansions (TextView.TextBuffer.ContentType, false, null, true, false)) {
+			var contentType = TextView?.TextBuffer?.ContentType;
+			if (contentType == null)
+				yield break;
+			foreach (var template in Imports.ExpansionManager.EnumerateExpansions (contentType, false, null, true, false)) {
 				yield return new SnippetToolboxNode (template) {
 					Category = category,
 					Icon = ImageService.GetIcon ("md-template", Gtk.IconSize.Menu)

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
@@ -20,25 +20,21 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
-
 using AppKit;
-using ObjCRuntime;
-
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
-
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.Core.FeatureConfiguration;
-using MonoDevelop.Ide.Commands;
-using MonoDevelop.Projects;
-using MonoDevelop.Ide.Gui.Documents;
 using MonoDevelop.DesignerSupport.Toolbox;
-using System.Collections.Generic;
 using MonoDevelop.Ide;
+using MonoDevelop.Ide.Commands;
+using MonoDevelop.Ide.Gui.Documents;
+using ObjCRuntime;
 
 namespace MonoDevelop.TextEditor
 {
@@ -72,7 +68,8 @@ namespace MonoDevelop.TextEditor
 		}
 	}
 
-	class CocoaTextViewContent : TextViewContent<ICocoaTextView, CocoaTextViewImports>,
+	class CocoaTextViewContent :
+		TextViewContent<ICocoaTextView, CocoaTextViewImports>,
 		IToolboxDynamicProvider
 	{
 		ICocoaTextViewHost textViewHost;
@@ -81,6 +78,8 @@ namespace MonoDevelop.TextEditor
 
 		static readonly Lazy<bool> useLegacyGtkNSViewHost = new Lazy<bool> (
 			() => FeatureSwitchService.IsFeatureEnabled ("LegacyGtkNSViewHost").GetValueOrDefault ());
+
+		public event EventHandler ItemsChanged;
 
 		abstract class GtkNSViewHostControl : Control
 		{
@@ -271,7 +270,6 @@ namespace MonoDevelop.TextEditor
 			}
 		}
 
-		public event EventHandler ItemsChanged;
 		static string category = GettextCatalog.GetString ("Text Snippets");
 		public IEnumerable<ItemToolboxNode> GetDynamicItems (IToolboxConsumer consumer)
 		{

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewImports.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewImports.cs
@@ -21,6 +21,7 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Expansion;
 
 namespace MonoDevelop.TextEditor
 {
@@ -29,5 +30,8 @@ namespace MonoDevelop.TextEditor
 	{
 		[Import]
 		public ICocoaTextEditorFactoryService TextEditorFactoryService { get; set; }
+
+		[Import]
+		public IExpansionManager ExpansionManager { get; set; }
 	}
 }

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/MonoDevelop.TextEditor.Cocoa.csproj
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/MonoDevelop.TextEditor.Cocoa.csproj
@@ -64,6 +64,10 @@
     <ProjectReference Include="$(VSEditorCoreDirectory)src\Editor\Text\Impl\GlyphMargin\GlyphMarginImpl.csproj" Private="True" />
     <ProjectReference Include="$(VSEditorCoreDirectory)src\Editor\Text\Impl\Structure\StructureImpl.csproj" Private="true" />
     <ProjectReference Include="$(VSEditorCoreDirectory)src\Editor\Text\Impl\UrlTagger\UrlTagger.csproj" Private="true" />
+    <Reference Include="MonoDevelop.DesignerSupport">
+      <HintPath>..\..\..\..\build\AddIns\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.EditorFeatures.Cocoa.dll" />

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/SnippetsInToolbox/SnippetToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/SnippetsInToolbox/SnippetToolboxNode.cs
@@ -1,0 +1,75 @@
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Editor.Expansion;
+using MonoDevelop.Core;
+using MonoDevelop.DesignerSupport.Toolbox;
+using MonoDevelop.Ide.CodeTemplates;
+using MonoDevelop.Ide.Composition;
+using MonoDevelop.Ide.Gui;
+
+namespace MonoDevelop.TextEditor
+{
+	[Serializable]
+	public class SnippetToolboxNode : ItemToolboxNode, ITextToolboxNode
+	{
+		static IExpansionServiceProvider expansionServiceProvider = CompositionManager.Instance.GetExportedValue<IExpansionServiceProvider> ();
+		static IEditorCommandHandlerServiceFactory commandDispatchFactory = CompositionManager.Instance.GetExportedValue<IEditorCommandHandlerServiceFactory> ();
+
+		public override string Name {
+			get {
+				return Template.Snippet.Shortcut;
+			}
+			set {
+				Template.Snippet.Shortcut = value;
+			}
+		}
+
+		public override string Description {
+			get {
+				return Template.Snippet.Description;
+			}
+			set {
+				Template.Snippet.Description = value;
+			}
+		}
+
+		public string Code {
+			get { return Template.Snippet.Code; }
+			set { Template.Snippet.Code = value; }
+		}
+
+		public ExpansionTemplate Template { get; set; }
+
+		public string GetDragPreview (Document document)
+		{
+			return Template.Snippet.Shortcut;
+		}
+
+		public bool IsCompatibleWith (Document document)
+		{
+			return true;
+		}
+
+		public void InsertAtCaret (Document document)
+		{
+			var textView = document.GetContent<ITextView> ();
+			textView.Properties.AddProperty (typeof (ExpansionTemplate), Template);
+			try {
+				commandDispatchFactory.GetService (textView).Execute ((t, b) => new InsertSnippetCommandArgs (t, b), null);
+			} finally {
+				textView.Properties.RemoveProperty (typeof (ExpansionTemplate));
+			}
+			((ICocoaTextView) textView).VisualElement.Window?.MakeKeyWindow ();
+		}
+
+		public SnippetToolboxNode (ExpansionTemplate template)
+		{
+			this.Template = template;
+			ItemFilters.Add (new ToolboxItemFilterAttribute ("text/plain", ToolboxItemFilterType.Allow));
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Toolbox.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Toolbox.cs
@@ -13,7 +13,7 @@ namespace MonoDevelop.TextEditor
 	{
 		TargetEntry [] IToolboxConsumer.DragTargets { get; } = new TargetEntry [0];
 
-		ToolboxItemFilterAttribute [] IToolboxConsumer.ToolboxFilterAttributes { get; } = new System.ComponentModel.ToolboxItemFilterAttribute [0];
+		ToolboxItemFilterAttribute [] IToolboxConsumer.ToolboxFilterAttributes { get; } = new ToolboxItemFilterAttribute [0];
 
 		string IToolboxConsumer.DefaultItemDomain => "Text";
 

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Toolbox.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Toolbox.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Gdk;
+using Gtk;
+using Microsoft.VisualStudio.Text.Editor;
+using MonoDevelop.DesignerSupport.Toolbox;
+
+namespace MonoDevelop.TextEditor
+{
+	partial class TextViewContent<TView, TImports> :
+		IToolboxConsumer
+	{
+		TargetEntry [] IToolboxConsumer.DragTargets { get; } = new TargetEntry [0];
+
+		ToolboxItemFilterAttribute [] IToolboxConsumer.ToolboxFilterAttributes { get; } = new System.ComponentModel.ToolboxItemFilterAttribute [0];
+
+		string IToolboxConsumer.DefaultItemDomain => "Text";
+
+		void IToolboxConsumer.ConsumeItem (ItemToolboxNode item)
+		{
+			if (item is ITextToolboxNode tn) {
+				tn.InsertAtCaret (this.Document);
+				((ITextView3)TextView).Focus ();
+			}
+		}
+
+		bool IToolboxConsumer.CustomFilterSupports (ItemToolboxNode item)
+		{
+			return false;
+		}
+
+		void IToolboxConsumer.DragItem (ItemToolboxNode item, Widget source, DragContext ctx)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Changed logic in CodeTemplateToolboxProvider to not execute for new editor since code expects `document.Editor` to not be `null`
Main change is in TextViewContent.Toolbox which now makes new editor ViewContent aware of `IToolboxConsumer` and in `CocoaTextViewContent` which actually converts templates that `IExpansionManager` returns to Toolbox items



Backport of #7470.

/cc @sandyarmstrong @DavidKarlas