### PR TITLE
[GTC] Fixes current window child hierarchy (parents) using RunCustomDialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/Gui/MonoDevelop.Debugger.DebugApplicationDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/Gui/MonoDevelop.Debugger.DebugApplicationDialog.cs
@@ -176,7 +176,6 @@ namespace MonoDevelop.Debugger
 			}
 			this.DefaultWidth = 656;
 			this.DefaultHeight = 300;
-			this.Show ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
@@ -80,6 +80,17 @@ namespace MonoDevelop.Components.Mac
 		//	}
 		//}
 
+		public static NSWindow GetNSWindow (Window window)
+		{
+			if (window.nativeWidget is NSWindow nSWindow) {
+				return nSWindow;
+			}
+			if (window.nativeWidget is Gtk.Window gtkWindow) {
+				return GetNSWindow ((Gtk.Window)gtkWindow);
+			}
+			return null;
+		}
+
 		public static NSWindow GetNSWindow (Gtk.Window window)
 		{
 			var ptr = gdk_quartz_window_get_nswindow (window.GdkWindow.Handle);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
@@ -80,17 +80,6 @@ namespace MonoDevelop.Components.Mac
 		//	}
 		//}
 
-		public static NSWindow GetNSWindow (Window window)
-		{
-			if (window.nativeWidget is NSWindow nSWindow) {
-				return nSWindow;
-			}
-			if (window.nativeWidget is Gtk.Window gtkWindow) {
-				return GetNSWindow ((Gtk.Window)gtkWindow);
-			}
-			return null;
-		}
-
 		public static NSWindow GetNSWindow (Gtk.Window window)
 		{
 			var ptr = gdk_quartz_window_get_nswindow (window.GdkWindow.Handle);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -148,7 +148,7 @@ namespace MonoDevelop.Ide.Commands
 				if (!sol.MultiStartupRunConfigurations.Any ()) {
 					Xwt.Toolkit.NativeEngine.Invoke (() => {
 						using (var dlg = new NewSolutionRunConfigurationDialog ()) {
-							if (dlg.Run (DesktopService.GetFocusedTopLevelWindow ()).Id == "create") {
+							if (dlg.Run (IdeServices.DesktopService.GetFocusedTopLevelWindow ()).Id == "create") {
 								config = new MultiItemSolutionRunConfiguration (dlg.RunConfigurationName, dlg.RunConfigurationName);
 								sol.MultiStartupRunConfigurations.Add (config);
 								sol.StartupConfiguration = config;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -148,7 +148,7 @@ namespace MonoDevelop.Ide.Commands
 				if (!sol.MultiStartupRunConfigurations.Any ()) {
 					Xwt.Toolkit.NativeEngine.Invoke (() => {
 						using (var dlg = new NewSolutionRunConfigurationDialog ()) {
-							if (dlg.Run ().Id == "create") {
+							if (dlg.Run (DesktopService.GetFocusedTopLevelWindow ()).Id == "create") {
 								config = new MultiItemSolutionRunConfiguration (dlg.RunConfigurationName, dlg.RunConfigurationName);
 								sol.MultiStartupRunConfigurations.Add (config);
 								sol.StartupConfiguration = config;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/ExecutionModeCommandService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/ExecutionModeCommandService.cs
@@ -519,7 +519,7 @@ namespace MonoDevelop.Ide.Execution
 				}
 				else if ((string)data == "custom") {
 					using (var dlg = new RunWithCustomParametersDialog ((Project)item)) {
-						var cmd = dlg.Run ();
+						var cmd = dlg.Run (IdeServices.DesktopService.GetFocusedTopLevelWindow ());
 						if (cmd?.Id == "run") {
 							// Run the configuration
 							IdeApp.ProjectOperations.Execute (item, dlg.SelectedExecutionMode.ExecutionHandler, IdeApp.Workspace.ActiveConfiguration, dlg.SelectedConfiguration);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -395,12 +395,14 @@ namespace MonoDevelop.Ide
 			try {
 				var nativeParent = (NSWindow)parent;
 				nativeParent.AddChildWindow (nsdialog, NSWindowOrderingMode.Above);
+				var s = NSApplication.SharedApplication.BeginModalSession (nsdialog);
 
 				EventHandler unrealizer = null;
 				unrealizer = delegate {
 					if (nativeParent != null) {
 						nativeParent.RemoveChildWindow (nsdialog);
 					}
+					NSApplication.SharedApplication.EndModalSession (s);
 					dialog.Unrealized -= unrealizer;
 				};
 				dialog.Unrealized += unrealizer;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -392,8 +392,8 @@ namespace MonoDevelop.Ide
 			var nsdialog = GtkMacInterop.GetNSWindow (dialog);
 			// Make the GTK window modal WRT the current modal NSWindow
 
-			var nativeParent = GtkMacInterop.GetNSWindow (parent);
-			if (nativeParent != null) {
+			try {
+				var nativeParent = (NSWindow)parent;
 				nativeParent.AddChildWindow (nsdialog, NSWindowOrderingMode.Above);
 
 				EventHandler unrealizer = null;
@@ -404,7 +404,7 @@ namespace MonoDevelop.Ide
 					dialog.Unrealized -= unrealizer;
 				};
 				dialog.Unrealized += unrealizer;
-			} else {
+			} catch {
 				var s = NSApplication.SharedApplication.BeginModalSession (nsdialog);
 				EventHandler unrealizer = null;
 				unrealizer = delegate {


### PR DESCRIPTION
This fixes the way of we show dialogs in our Messaging.Service, seems BeginModalSession is not parenting correctly the child windows and provokes unexpected results like odd flashes when changing desktops (CMD + LEFT/RIGHT ARROW).

Also now like a child window is attached to it's parent and it moves accordingly with it

Fixes VSTS #823695 - About info flashes briefly if left open while switching desktops
Fixes VSTS #844450 - Run/RunWith/CustomParameters window flashes briefly if left open while switching desktops
Fixes VSTS #844452 - Project/Set Startup project flashes briefly if left open while switching desktops
Fixes VSTS #899539
