### PR TITLE
Fix focus notification issue with the old editor

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/MonoTextEditor.ITextView.cs
@@ -405,8 +405,7 @@ namespace Mono.TextEditor
 		/// </remarks>
 		private void SubscribeToEvents ()
 		{
-			if (IdeApp.IsInitialized)
-				IdeApp.Workbench.ActiveDocumentChanged += Workbench_ActiveDocumentChanged;
+			IdeServices.DocumentManager.ActiveDocumentChanged += Workbench_ActiveDocumentChanged;
 		}
 
 		void Workbench_ActiveDocumentChanged (object sender, EventArgs e)
@@ -416,8 +415,7 @@ namespace Mono.TextEditor
 
 		private void UnsubscribeFromEvents ()
 		{
-			if (IdeApp.IsInitialized)
-				IdeApp.Workbench.ActiveDocumentChanged -= Workbench_ActiveDocumentChanged;
+			IdeServices.DocumentManager.ActiveDocumentChanged -= Workbench_ActiveDocumentChanged;
 		}
 
 		static readonly string[] allowedTextViewCreationListeners = {
@@ -498,7 +496,7 @@ namespace Mono.TextEditor
 #endif
 
 			if (!isClosed) {
-				bool newHasAggregateFocus = ((IdeApp.Workbench.ActiveDocument?.Editor?.Implementation as MonoDevelop.SourceEditor.SourceEditorView)?.TextEditor == this);
+				bool newHasAggregateFocus = ((IdeServices.DocumentManager.ActiveDocument?.Editor?.Implementation as MonoDevelop.SourceEditor.SourceEditorView)?.TextEditor == this);
 				if (newHasAggregateFocus != hasAggregateFocus) {
 					hasAggregateFocus = newHasAggregateFocus;
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -864,6 +864,9 @@ namespace MonoDevelop.SourceEditor
 				RunFirstTimeFoldUpdate (text);
 				*/
 			Document.InformLoadComplete ();
+
+			// Now that the editor has been completely loaded, ask ITextView to update the aggregated focus status
+			widget.TextEditor.QueueAggregateFocusCheck ();
 		}
 
 		protected virtual string ProcessLoadText (string text)


### PR DESCRIPTION
The ITextView implementation relied on the ActiveDocumentChanged
event to be raised after the editor is fully initialized. The handler of that
event would call QueueAggregateFocusCheck() to update the focus
status of the text view.

Since views are now loaded asynchronously, ActiveDocumentChanged is now raised
before the editor is loaded, so QueueAggregateFocusCheck is not called.
To fix this issue, QueueAggregateFocusCheck is now explicitly called once
the editor is initialized.

Fixes VSTS #807522 - [WebToolsE2E][VSforMac]Type keyword in cshtml file, there
is no intellisense.