### PR TITLE
[release-8.1] [Mac] Run Preferred32bit applications in x64

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/AssemblyUtilities.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/AssemblyUtilities.cs
@@ -90,7 +90,12 @@ namespace MonoDevelop.Core.Assemblies
 				throw new ArgumentNullException (nameof (assemblyPath));
 
 			if (TryReadPEHeaders (assemblyPath, out var peKind, out var machine)) {
-				if ((peKind & (PortableExecutableKinds.Preferred32Bit | PortableExecutableKinds.Required32Bit)) != 0)
+				if ((peKind & PortableExecutableKinds.Preferred32Bit) != 0) {
+					// macOS has deprecated 32bit applications, so maintain running in 32bit for non-Mac platforms.
+					return Platform.IsMac ? ProcessExecutionArchitecture.X64 : ProcessExecutionArchitecture.X86;
+				}
+
+				if ((peKind & PortableExecutableKinds.Required32Bit) != 0)
 					return ProcessExecutionArchitecture.X86;
 
 				if ((peKind & PortableExecutableKinds.PE32Plus) != 0 || Is64BitPE (machine))


### PR DESCRIPTION
macOS has deprecated 32bit applications, thus Preferred32bit should
run applications in 64bit, as it has no impact on the assembly, like
Required32Bit - we should check how to handle that when 32bit is completely
deprecated.

Fixes VSTS #890092 - NUnit tests are executed in a 32-bit process
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/749922

Backport of #7516.

/cc @Therzok 