### PR TITLE
[Version Control] Mismatches actual files commited vs selected when using git 

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1256,17 +1256,56 @@ namespace MonoDevelop.VersionControl.Git
 				return;
 
 			var repo = (GitRepository)changeSet.Repository;
-			RunBlockingOperation (() => {
-				LibGit2Sharp.Commands.Stage (RootRepository, changeSet.Items.Select (i => i.LocalPath).ToPathStrings ());
+			var addedFiles = GetAddedLocalPathItems (changeSet);
 
-				if (changeSet.ExtendedProperties.Contains ("Git.AuthorName"))
-					RootRepository.Commit (message, new Signature (
-						(string)changeSet.ExtendedProperties ["Git.AuthorName"],
-						(string)changeSet.ExtendedProperties ["Git.AuthorEmail"],
-						DateTimeOffset.Now), sig);
-				else
-					RootRepository.Commit (message, sig, sig);
+			RunBlockingOperation (() => {
+				try {
+					// Unstage added files not included in the changeSet
+					if (addedFiles.Any ())
+						LibGit2Sharp.Commands.Unstage (RootRepository, addedFiles.ToPathStrings ());
+				} catch (Exception ex) {
+					LoggingService.LogInternalError ("Failed to commit.", ex);
+					return;
+				}
+				try {
+					// Commit
+					LibGit2Sharp.Commands.Stage (RootRepository, changeSet.Items.Select (i => i.LocalPath).ToPathStrings ());
+
+					if (changeSet.ExtendedProperties.Contains ("Git.AuthorName"))
+						RootRepository.Commit (message, new Signature (
+							(string)changeSet.ExtendedProperties ["Git.AuthorName"],
+							(string)changeSet.ExtendedProperties ["Git.AuthorEmail"],
+							DateTimeOffset.Now), sig);
+					else
+						RootRepository.Commit (message, sig, sig);
+				} catch (Exception ex) {
+					LoggingService.LogInternalError ("Failed to commit.", ex);
+				} finally {
+					// Always at the end, stage again the unstage added files not included in the changeSet
+					if (addedFiles.Any ())
+						LibGit2Sharp.Commands.Stage (RootRepository, addedFiles.ToPathStrings ());
+				}
 			});
+		}
+
+		HashSet<FilePath> GetAddedLocalPathItems (ChangeSet changeSet)
+		{
+			return readingOperationFactory.StartNew (() => {
+				var addedLocalPathItems = new HashSet<FilePath> ();
+				try {
+					var directoryVersionInfo = GetDirectoryVersionInfo (changeSet.BaseLocalPath, null, false, true);
+					const VersionStatus addedStatus = VersionStatus.Versioned | VersionStatus.ScheduledAdd;
+					var directoryVersionInfoItems = directoryVersionInfo.Where (vi => vi.Status == addedStatus);
+
+					foreach (var item in directoryVersionInfoItems)
+						foreach (var changeSetItem in changeSet.Items)
+							if (item.LocalPath != changeSetItem.LocalPath)
+								addedLocalPathItems.Add (item.LocalPath);
+				} catch (Exception ex) {
+					LoggingService.LogInternalError ("Could not get added VersionInfo items.", ex);
+				}
+				return addedLocalPathItems;
+			}).RunWaitAndCapture ();
 		}
 
 		public bool IsUserInfoDefault ()


### PR DESCRIPTION
Two (or more) files are created from outside of VS4Mac, then, using VS4Mac are added to Version Control and try to Commit with only one of the files selected.

The expected result is that we only Commit the selected file, however we commit everything.

The problem is that, when doing the Add of a file in Version Control, internally we do a Stage (we add the path of the file to the git index). At the end it is the same as what we do in a Commit. So, although in the Commit only select one of the files, every added files are included (they are in the index).

Added some changes to Unstage the unselected changes and re-stage at the end of the Commit (whether done or in case of an error).

Fixes VSTS #825343