### PR TITLE
Added support to native dialogs (Cocoa) in the CommandManager

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
@@ -37,6 +37,30 @@ namespace MonoDevelop.Components
 		{
 		}
 
+		public bool IsRealized {
+			get {
+				if (nativeWidget is Gtk.Window)
+					return ((Gtk.Window)nativeWidget).IsRealized;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow)
+					return ((AppKit.NSWindow)nativeWidget).IsVisible;
+#endif
+				return false;
+			}
+		}
+
+		public override bool HasFocus {
+			get {
+				if (nativeWidget is Gtk.Window)
+					return ((Gtk.Window)nativeWidget).HasToplevelFocus;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow)
+					return nativeWidget == AppKit.NSApplication.SharedApplication.KeyWindow;
+#endif
+				return false;
+			}
+		}
+
 		public static implicit operator Gtk.Window (Window d)
 		{
 			if (d is XwtWindowControl)


### PR DESCRIPTION
Added support to native dialogs (Cocoa) in the CommandManager. Added to be able to manage commands from native Windows (Example: GTC).

Fixes VSTS #796177
Fixes VSTS #801677