### PR TITLE
[release-8.1] Improve UI responsiveness at startup

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -696,7 +696,7 @@ namespace MonoDevelop.MacIntegration
 					GLib.Idle.Add (delegate {
 						Ide.WelcomePage.WelcomePageService.HideWelcomePageOrWindow ();
 						var trackTTC = IdeStartupTracker.StartupTracker.StartTimeToCodeLoadTimer ();
-						IdeApp.OpenFiles (e.Documents.Select (
+						IdeApp.OpenFilesAsync (e.Documents.Select (
 							doc => new FileOpenInformation (doc.Key, null, doc.Value, 1, OpenDocumentOptions.DefaultInternal)),
 							null
 						).ContinueWith ((result) => {
@@ -718,7 +718,7 @@ namespace MonoDevelop.MacIntegration
 						var trackTTC = IdeStartupTracker.StartupTracker.StartTimeToCodeLoadTimer ();
 						// Open files via the monodevelop:// URI scheme, compatible with the
 						// common TextMate scheme: http://blog.macromates.com/2007/the-textmate-url-scheme/
-						IdeApp.OpenFiles (e.Urls.Select (url => {
+						IdeApp.OpenFilesAsync (e.Urls.Select (url => {
 							try {
 								var uri = new Uri (url);
 								if (uri.Host != "open")

--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -473,7 +473,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 	}
 
 	[Register]
-	class StatusBar : NSFocusButton, MonoDevelop.Ide.StatusBar
+	class StatusBar : NSFocusButton, MonoDevelop.Ide.ITestableStatusBar
 	{
 		public enum MessageType
 		{
@@ -725,6 +725,10 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 			}
 		}
 
+		// Used by AutoTest.
+		string [] ITestableStatusBar.CurrentIcons => statusIcons.Select (x => x.ToolTip).ToArray ();
+		string ITestableStatusBar.CurrentText => text;
+
 		readonly List<StatusIcon> statusIcons = new List<StatusIcon> ();
 
 		// Xamarin.Mac has a bug where NSView.NextKeyView cannot be set to null
@@ -741,9 +745,6 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 			void_objc_msgSend_IntPtr (parent.Handle, setNextKeyViewSelector, nextKeyView != null ? nextKeyView.Handle : IntPtr.Zero);
 		}
-
-		// Used by AutoTest.
-		internal string[] StatusIcons => statusIcons.Select(x => x.ToolTip).ToArray ();
 
 		internal void RemoveStatusIcon (StatusIcon icon)
 		{

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
@@ -552,8 +552,8 @@ namespace MonoDevelop.Debugger
 	{
 		protected override void Run ()
 		{
-			if (!IdeApp.Workbench.RootWindow.Visible) {
-				IdeApp.Workbench.RootWindow.Show ();
+			if (!IdeApp.Workbench.Visible) {
+				IdeApp.Workbench.Show ();
 			}
 			var breakpointsPad = IdeApp.Workbench.Pads.FirstOrDefault (p => p.Id == "MonoDevelop.Debugger.BreakpointPad");
 			if (breakpointsPad != null) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
@@ -65,8 +65,8 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation DebugApplication (this ProjectOperations opers, string executableFile, string args, string workingDir, IDictionary<string,string> envVars)
 		{
-			if (!IdeApp.Workbench.RootWindow.Visible) {
-				IdeApp.Workbench.RootWindow.Show ();
+			if (!IdeApp.Workbench.Visible) {
+				IdeApp.Workbench.Show ();
 			}
 
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileName (executableFile));
@@ -83,8 +83,8 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation AttachToProcess (this ProjectOperations opers, DebuggerEngine debugger, ProcessInfo proc)
 		{
-			if (!IdeApp.Workbench.RootWindow.Visible) {
-				IdeApp.Workbench.RootWindow.Show ();
+			if (!IdeApp.Workbench.Visible) {
+				IdeApp.Workbench.Show ();
 			}
 
 			var oper = DebuggingService.AttachToProcess (debugger, proc);

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestService.cs
@@ -50,6 +50,7 @@ namespace MonoDevelop.UnitTesting
 	{
 		static ArrayList providers = new ArrayList ();
 		static UnitTest[] rootTests = Array.Empty<UnitTest> ();
+		static bool packageEventsInitialized;
 
 		static UnitTestService ()
 		{
@@ -61,11 +62,16 @@ namespace MonoDevelop.UnitTesting
 			IdeApp.Workspace.ItemRemovedFromSolution += OnItemsChangedInSolution;
 			IdeApp.Workspace.ReferenceAddedToProject += OnReferenceChangedInProject;
 			IdeApp.Workspace.ReferenceRemovedFromProject += OnReferenceChangedInProject;
-
-			PackageManagementServices.ProjectOperations.PackageReferenceAdded += ProjectOperations_PackageReferencesModified;
-			PackageManagementServices.ProjectOperations.PackageReferenceRemoved += ProjectOperations_PackageReferencesModified;
-			PackageManagementServices.ProjectOperations.PackagesRestored += ProjectOperations_PackageReferencesModified;
-
+			
+			IdeApp.Workspace.FirstWorkspaceItemOpened += (s,a) => {
+				if (!packageEventsInitialized) {
+					packageEventsInitialized = true;
+					PackageManagementServices.ProjectOperations.PackageReferenceAdded += ProjectOperations_PackageReferencesModified;
+					PackageManagementServices.ProjectOperations.PackageReferenceRemoved += ProjectOperations_PackageReferencesModified;
+					PackageManagementServices.ProjectOperations.PackagesRestored += ProjectOperations_PackageReferencesModified;
+				}
+			};
+			
 			Mono.Addins.AddinManager.AddExtensionNodeHandler ("/MonoDevelop/UnitTesting/TestProviders", OnExtensionChange);
 
 			RebuildTests ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
@@ -65,6 +65,7 @@ namespace MonoDevelop.Components.AutoTest
 				BinaryFormatter bf = new BinaryFormatter ();
 				IAutoTestClient client = (IAutoTestClient) bf.Deserialize (ms);
 				client.Connect (manager.AttachClient (client));
+				Runtime.Preferences.EnableUpdaterForCurrentSession = false;
 			}
 			if (publishServer && !manager.IsClientConnected) {
 				MonoDevelop.Core.Execution.RemotingService.RegisterRemotingChannel ();
@@ -74,6 +75,7 @@ namespace MonoDevelop.Components.AutoTest
 				bf.Serialize (ms, oref);
 				sref = Convert.ToBase64String (ms.ToArray ());
 				File.WriteAllText (SessionReferenceFile, sref);
+				Runtime.Preferences.EnableUpdaterForCurrentSession = false;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestService.cs
@@ -64,8 +64,12 @@ namespace MonoDevelop.Components.AutoTest
 				MemoryStream ms = new MemoryStream (data);
 				BinaryFormatter bf = new BinaryFormatter ();
 				IAutoTestClient client = (IAutoTestClient) bf.Deserialize (ms);
-				client.Connect (manager.AttachClient (client));
+
+				// Initialize as much as we can before connecting back to the client
+				Ide.IdeApp.Workbench.EnsureLayout ();
 				Runtime.Preferences.EnableUpdaterForCurrentSession = false;
+
+				client.Connect (manager.AttachClient (client));
 			}
 			if (publishServer && !manager.IsClientConnected) {
 				MonoDevelop.Core.Execution.RemotingService.RegisterRemotingChannel ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -162,7 +162,7 @@ namespace MonoDevelop.Components.AutoTest
 					syncEvent.Set ();
 				}
 			});
-			if (!syncEvent.WaitOne (20000))
+			if (!syncEvent.WaitOne (30000))
 				throw new TimeoutException ("Timeout while executing synchronized call");
 			if (error != null)
 				throw error;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs
@@ -52,7 +52,6 @@ namespace MonoDevelop.Components.AutoTest
 		[System.Runtime.InteropServices.DllImport("/System/Library/Frameworks/ApplicationServices.framework/Versions/Current/ApplicationServices", EntryPoint="CGMainDisplayID")]
 		internal static extern int MainDisplayID();
 
-		readonly ManualResetEvent syncEvent = new ManualResetEvent (false);
 		public readonly AutoTestSessionDebug SessionDebug = new AutoTestSessionDebug ();
 		public IAutoTestSessionDebug<MarshalByRefObject> DebugObject { 
 			get { return SessionDebug.DebugObject; }
@@ -153,7 +152,7 @@ namespace MonoDevelop.Components.AutoTest
 				return safe ? SafeObject (res) : res;
 			}
 
-			syncEvent.Reset ();
+			var syncEvent = new ManualResetEvent (false);
 			Gtk.Application.Invoke ((o, args) => {
 				try {
 					res = del ();
@@ -391,7 +390,7 @@ namespace MonoDevelop.Components.AutoTest
 				return;
 			}
 				
-			syncEvent.Reset ();
+			var syncEvent = new ManualResetEvent (false);
 			GLib.Idle.Add (() => {
 				idleFunc ();
 				syncEvent.Set ();
@@ -433,7 +432,7 @@ namespace MonoDevelop.Components.AutoTest
 		public AppResult[] WaitForElement (AppQuery query, int timeout)
 		{
 			const int pollTime = 200;
-			syncEvent.Reset ();
+			var syncEvent = new ManualResetEvent (false);
 			AppResult[] resultSet = null;
 
 			GLib.Timeout.Add ((uint)pollTime, () => {
@@ -458,7 +457,7 @@ namespace MonoDevelop.Components.AutoTest
 		public void WaitForNoElement (AppQuery query, int timeout)
 		{
 			const int pollTime = 100;
-			syncEvent.Reset ();
+			var syncEvent = new ManualResetEvent (false);
 			AppResult[] resultSet = null;
 
 			GLib.Timeout.Add ((uint)pollTime, () => {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarCommandHandlers.cs
@@ -30,6 +30,11 @@ namespace MonoDevelop.Components.MainToolbar
 {
 	class NavigateToHandler : CommandHandler
 	{
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = Ide.IdeApp.Workbench.Visible;
+		}
+
 		protected override void Run ()
 		{
 			Ide.IdeApp.Workbench.Toolbar.FocusSearchBar ();
@@ -38,6 +43,11 @@ namespace MonoDevelop.Components.MainToolbar
 
 	class GotoTypeHandler : CommandHandler
 	{
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = Ide.IdeApp.Workbench.Visible;
+		}
+
 		protected override void Run ()
 		{
 			Ide.IdeApp.Workbench.Toolbar.SetSearchCategory ("type");
@@ -46,6 +56,11 @@ namespace MonoDevelop.Components.MainToolbar
 
 	class GotoFileHandler : CommandHandler
 	{
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = Ide.IdeApp.Workbench.Visible;
+		}
+
 		protected override void Run ()
 		{
 			Ide.IdeApp.Workbench.Toolbar.SetSearchCategory ("file");
@@ -54,6 +69,11 @@ namespace MonoDevelop.Components.MainToolbar
 
 	class RunCommandHandler : CommandHandler
 	{
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = Ide.IdeApp.Workbench.Visible;
+		}
+
 		protected override void Run ()
 		{
 			Ide.IdeApp.Workbench.Toolbar.SetSearchCategory ("command");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/StatusArea.cs
@@ -39,10 +39,11 @@ using StockIcons = MonoDevelop.Ide.Gui.Stock;
 using Xwt.Motion;
 using MonoDevelop.Ide.Fonts;
 using System.Threading;
+using System.Linq;
 
 namespace MonoDevelop.Components.MainToolbar
 {
-	class StatusArea : EventBox, StatusBar, Xwt.Motion.IAnimatable
+	class StatusArea : EventBox, ITestableStatusBar, Xwt.Motion.IAnimatable
 	{
 		struct Message
 		{
@@ -412,17 +413,21 @@ namespace MonoDevelop.Components.MainToolbar
 
 		#region StatusBar implementation
 
+		List<StatusIcon> icons = new List<StatusIcon> ();
+
 		public StatusBarIcon ShowStatusIcon (Xwt.Drawing.Image pixbuf)
 		{
 			Runtime.AssertMainThread ();
 			StatusIcon icon = new StatusIcon (this, pixbuf);
 			statusIconBox.PackEnd (icon.box);
 			statusIconBox.ShowAll ();
+			icons.Add (icon);
 			return icon;
 		}
 
 		void HideStatusIcon (StatusIcon icon)
 		{
+			icons.Remove (icon);
 			statusIconBox.Remove (icon.EventBox);
 			if (statusIconBox.Children.Length == 0)
 				statusIconBox.Hide ();
@@ -887,6 +892,9 @@ namespace MonoDevelop.Components.MainToolbar
 		{
 		}
 		#endregion
+
+		string ITestableStatusBar.CurrentText => messageQueue.Count > 0 ? "" : renderArg.CurrentText;
+		string [] ITestableStatusBar.CurrentIcons => icons.Select (x => x.ToolTip).ToArray ();
 	}
 
 	class StatusAreaSeparator: HBox

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
@@ -172,6 +172,11 @@ namespace MonoDevelop.Ide.Commands
 	// MonoDevelop.Ide.Commands.ViewCommands.NewLayout
 	public class NewLayoutHandler : CommandHandler
 	{
+		protected override void Update (CommandInfo info)
+		{
+			info.Visible = IdeApp.Workbench.Visible;
+		}
+
 		protected override void Run ()
 		{
 			string newLayoutName = null;
@@ -193,6 +198,10 @@ namespace MonoDevelop.Ide.Commands
 	{
 		protected override void Update (CommandInfo info)
 		{
+			if (!IdeApp.Workbench.Visible) {
+				info.Visible = false;
+				return;
+			}
 			info.Enabled = !String.Equals ("Solution", IdeApp.Workbench.CurrentLayout, StringComparison.OrdinalIgnoreCase);
 			string itemName;
 			if (!LayoutListHandler.NameMapping.TryGetValue (IdeApp.Workbench.CurrentLayout, out itemName))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -208,15 +208,16 @@ namespace MonoDevelop.Ide.Gui.Documents
 		/// <value>The owner.</value>
 		public WorkspaceObject Owner {
 			get {
-				CheckInitialized ();
 				return owner;
 			}
 			set {
 				if (value != owner) {
 					owner = value;
 
-					NotifyOwnerChanged ();
-					RefreshExtensions ().Ignore ();
+					if (initialized) {
+						NotifyOwnerChanged ();
+						RefreshExtensions ().Ignore ();
+					}
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -638,26 +638,28 @@ namespace MonoDevelop.Ide.Gui
 		public void Close()
 		{
 			BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
-			PropertyService.Set ("SharpDevelop.Workbench.WorkbenchMemento", this.Memento);
 
-			//don't allow the "full view" layouts to persist - they are always derived from the "normal" layout
-			foreach (var fv in dock.Layouts)
-				if (fv.EndsWith (fullViewModeTag))
-					dock.DeleteLayout (fv);
-			try {
-				dock.SaveLayouts (configFile);
-			} catch (Exception ex) {
-				LoggingService.LogError ("Error while saving layout.", ex);
+			if (rootWidget != null) {
+				PropertyService.Set ("SharpDevelop.Workbench.WorkbenchMemento", this.Memento);
+				//don't allow the "full view" layouts to persist - they are always derived from the "normal" layout
+				foreach (var fv in dock.Layouts)
+					if (fv.EndsWith (fullViewModeTag))
+						dock.DeleteLayout (fv);
+				try {
+					dock.SaveLayouts (configFile);
+				} catch (Exception ex) {
+					LoggingService.LogError ("Error while saving layout.", ex);
+				}
+				UninstallMenuBar ();
+				Remove (rootWidget);
+
+				foreach (PadCodon content in PadContentCollection) {
+					if (content.Initialized)
+						content.PadContent.Dispose ();
+				}
+
+				rootWidget.Destroy ();
 			}
-			UninstallMenuBar ();
-			Remove (rootWidget);
-
-			foreach (PadCodon content in PadContentCollection) {
-				if (content.Initialized)
-					content.PadContent.Dispose ();
-			}
-
-			rootWidget.Destroy ();
 			Destroy ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -80,6 +80,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		IWorkbenchWindow lastActive;
 
+		bool initialized;
 		bool closeAll;
 		bool? fullScreenState = null;
 
@@ -639,7 +640,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			BrandingService.ApplicationNameChanged -= ApplicationNameChanged;
 
-			if (rootWidget != null) {
+			if (initialized) {
 				PropertyService.Set ("SharpDevelop.Workbench.WorkbenchMemento", this.Memento);
 				//don't allow the "full view" layouts to persist - they are always derived from the "normal" layout
 				foreach (var fv in dock.Layouts)
@@ -773,6 +774,7 @@ namespace MonoDevelop.Ide.Gui
 			initializing = true;
 			AddinManager.AddExtensionNodeHandler (viewContentPath, OnExtensionChanged);
 			initializing = false;
+			initialized = true;
 		}
 
 		Task layoutChangedTask;
@@ -1084,6 +1086,9 @@ namespace MonoDevelop.Ide.Gui
 		bool haveFocusedToolbar = false;
 		protected override bool OnFocused (DirectionType direction)
 		{
+			if (!initialized)
+				return base.OnFocused (direction);
+
 			// If the toolbar is not focused, focus it, and focus the next child once it loses focus
 			switch (direction) {
 			case DirectionType.TabForward:

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -58,8 +58,8 @@ namespace MonoDevelop.Ide.Gui
 	/// </summary>
 	internal partial class DefaultWorkbench : WorkbenchWindow, ICommandRouter, IInfoBarHost, IShell, IService
 	{
-		readonly static string mainMenuPath    = "/MonoDevelop/Ide/MainMenu";
-		readonly static string appMenuPath    = "/MonoDevelop/Ide/AppMenu";
+		internal readonly static string MainMenuPath    = "/MonoDevelop/Ide/MainMenu";
+		internal readonly static string AppMenuPath    = "/MonoDevelop/Ide/AppMenu";
 		readonly static string viewContentPath = "/MonoDevelop/Ide/Pads";
 //		readonly static string toolbarsPath    = "/MonoDevelop/Ide/Toolbar";
 		readonly static string stockLayoutsPath    = "/MonoDevelop/Ide/WorkbenchLayouts";
@@ -285,7 +285,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			IdeApp.ProjectOperations.CurrentProjectChanged += (s,a) => SetWorkbenchTitle ();
 
-			if (!IdeServices.DesktopService.SetGlobalMenu (IdeApp.CommandService, mainMenuPath, appMenuPath)) {
+			if (!IdeServices.DesktopService.SetGlobalMenu (IdeApp.CommandService, MainMenuPath, AppMenuPath)) {
 				CreateMenuBar ();
 			}
 			
@@ -297,8 +297,8 @@ namespace MonoDevelop.Ide.Gui
 		
 		void OnExtensionChanged (object s, ExtensionEventArgs args)
 		{
-			if (args.PathChanged (mainMenuPath) || args.PathChanged (appMenuPath)) {
-				if (IdeServices.DesktopService.SetGlobalMenu (IdeApp.CommandService, mainMenuPath, appMenuPath))
+			if (args.PathChanged (MainMenuPath) || args.PathChanged (AppMenuPath)) {
+				if (IdeServices.DesktopService.SetGlobalMenu (IdeApp.CommandService, MainMenuPath, AppMenuPath))
 					return;
 				
 				UninstallMenuBar ();
@@ -309,8 +309,8 @@ namespace MonoDevelop.Ide.Gui
 
 		void CreateMenuBar ()
 		{
-			topMenu = IdeApp.CommandService.CreateMenuBar (mainMenuPath);
-			var appMenu = IdeApp.CommandService.CreateMenu (appMenuPath);
+			topMenu = IdeApp.CommandService.CreateMenuBar (MainMenuPath);
+			var appMenu = IdeApp.CommandService.CreateMenu (AppMenuPath);
 			if (appMenu != null && appMenu.Children.Length > 0) {
 				var item = new MenuItem (BrandingService.ApplicationName);
 				item.Submenu = appMenu;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusBar.cs
@@ -76,5 +76,10 @@ namespace MonoDevelop.Ide
 		/// <value>The cancellation token.</value>
 		void SetCancellationTokenSource (CancellationTokenSource source);
 	}
-	
+
+	internal interface ITestableStatusBar : StatusBar
+	{
+		string CurrentText { get; }
+		string [] CurrentIcons { get; }
+	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -73,6 +73,7 @@ namespace MonoDevelop.Ide.Gui
 	{
 		IdeProgressMonitorManager monitors;
 		DocumentManager documentManager;
+		WorkbenchStatusBar statusBar = new WorkbenchStatusBar ();
 
 		ImmutableList<Document> documents = ImmutableList<Document>.Empty;
 		DefaultWorkbench workbench;
@@ -101,14 +102,6 @@ namespace MonoDevelop.Ide.Gui
 
 				Counters.Initialization.Trace ("Creating DefaultWorkbench");
 				workbench = (DefaultWorkbench) await Runtime.GetService<IShell> ();
-				monitor.Step (1);
-				
-				Counters.Initialization.Trace ("Initializing Workspace");
-				workbench.InitializeWorkspace();
-				monitor.Step (1);
-				
-				Counters.Initialization.Trace ("Initializing Layout");
-				workbench.InitializeLayout ();
 				monitor.Step (1);
 				
 				((Gtk.Window)workbench).Visible = false;
@@ -158,6 +151,11 @@ namespace MonoDevelop.Ide.Gui
 		void EnsureLayout ()
 		{
 			if (!hasEverBeenShown) {
+
+				workbench.InitializeWorkspace ();
+				workbench.InitializeLayout ();
+				statusBar.Attach (workbench.StatusBar);
+
 				workbench.CurrentLayout = "Solution";
 
 				// now we have an layout set notify it
@@ -373,7 +371,7 @@ namespace MonoDevelop.Ide.Gui
 		
 		public StatusBar StatusBar {
 			get {
-				return workbench.StatusBar.MainContext;
+				return statusBar.MainContext;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -148,7 +148,7 @@ namespace MonoDevelop.Ide.Gui
 			Present ();
 		}
 
-		void EnsureLayout ()
+		internal void EnsureLayout ()
 		{
 			if (!hasEverBeenShown) {
 
@@ -353,6 +353,7 @@ namespace MonoDevelop.Ide.Gui
 		public string CurrentLayout {
 			get { return workbench.CurrentLayout; }
 			set {
+				EnsureLayout ();
 				if (value != workbench.CurrentLayout) {
 					workbench.CurrentLayout = value;
 					if (LayoutChanged != null)
@@ -492,12 +493,14 @@ namespace MonoDevelop.Ide.Gui
 
 		internal Pad ShowPad (PadCodon content)
 		{
+			EnsureLayout ();
 			workbench.ShowPad (content);
 			return WrapPad (content);
 		}
 
 		internal Pad AddPad (PadCodon content)
 		{
+			EnsureLayout ();
 			workbench.AddPad (content);
 			return WrapPad (content);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -347,7 +347,10 @@ namespace MonoDevelop.Ide.Gui
 
 		public void GrabDesktopFocus ()
 		{
-			IdeServices.DesktopService.GrabDesktopFocus (RootWindow);
+			if (!Visible)
+				Show ();
+			else
+				IdeServices.DesktopService.GrabDesktopFocus (RootWindow);
 		}
 				
 		public bool FullScreen {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -129,7 +129,7 @@ namespace MonoDevelop.Ide.Gui
 			}
 		}
 
-		internal void Realize ()
+		void Realize ()
 		{
 			Counters.Initialization.Trace ("Realizing Root Window");
 			RootWindow.Realize ();
@@ -152,6 +152,7 @@ namespace MonoDevelop.Ide.Gui
 		{
 			if (!hasEverBeenShown) {
 
+				Realize ();
 				workbench.InitializeWorkspace ();
 				workbench.InitializeLayout ();
 				statusBar.Attach (workbench.StatusBar);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -318,6 +318,10 @@ namespace MonoDevelop.Ide.Gui
 				return dock != null && dock.DockParent == RootWindow;
 			}
 		}
+
+		public bool Visible {
+			get { return RootWindow.Visible; }
+		}
 		
 		public void Present ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchStatusBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchStatusBar.cs
@@ -1,0 +1,350 @@
+//
+// WorkbenchStatusBar.cs
+//
+// Author:
+//       Lluis Sanchez <llsan@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using MonoDevelop.Components.MainToolbar;
+using MonoDevelop.Core;
+using Xwt.Drawing;
+
+namespace MonoDevelop.Ide.Gui
+{
+	class WorkbenchStatusBar : StatusBar
+	{
+		StatusBar delegatedStatusBar;
+		bool autoPulse;
+		string progressMessage;
+		IconId progressImage;
+		bool inProgress;
+		StatusBarContextHandler ctxHandler;
+		CancellationTokenSource cancellationTokenSource;
+		Pad messageSourcePad;
+		double? progressFraction;
+		string message;
+		MessageType messageType;
+		bool messageIsMarkup;
+		IconId messageIcon;
+
+		enum MessageType { None, Error, Warning, Message, Ready }
+
+		List<StatusBarIconWrapper> icons = new List<StatusBarIconWrapper> ();
+
+		public WorkbenchStatusBar ()
+		{
+			ctxHandler = new StatusBarContextHandler (this);
+		}
+
+		public void Attach (StatusBar statusBar)
+		{
+			delegatedStatusBar = statusBar;
+			if (autoPulse)
+				statusBar.AutoPulse = true;
+			if (inProgress) {
+				if (progressImage != IconId.Null)
+					statusBar.BeginProgress (progressMessage, progressImage);
+				else
+					statusBar.BeginProgress (progressMessage);
+			}
+			if (cancellationTokenSource != null)
+				statusBar.SetCancellationTokenSource (cancellationTokenSource);
+			if (messageSourcePad != null)
+				statusBar.SetMessageSourcePad (messageSourcePad);
+			if (progressFraction != null)
+				statusBar.SetProgressFraction (progressFraction.Value);
+			if (messageType != MessageType.None) {
+				switch (messageType) {
+				case MessageType.Error:
+					statusBar.ShowError (message);
+					break;
+				case MessageType.Warning:
+					statusBar.ShowWarning (message);
+					break;
+				case MessageType.Ready:
+					statusBar.ShowReady ();
+					break;
+				default:
+					statusBar.ShowMessage (messageIcon, message, messageIsMarkup);
+					break;
+				}
+			}
+			foreach (var icon in icons)
+				icon.Attach (statusBar);
+
+			cancellationTokenSource = null;
+			messageSourcePad = null;
+			icons.Clear ();
+		}
+
+		public StatusBar MainContext => delegatedStatusBar?.MainContext ?? this;
+
+		public bool AutoPulse {
+			get {
+				return delegatedStatusBar != null ? delegatedStatusBar.AutoPulse : autoPulse;
+			}
+			set {
+				if (delegatedStatusBar != null)
+					delegatedStatusBar.AutoPulse = value;
+				else
+					autoPulse = value;
+			}
+		}
+
+		public void BeginProgress (string name)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.BeginProgress (name);
+			else {
+				inProgress = true;
+				progressMessage = name;
+			}
+		}
+
+		public void BeginProgress (IconId image, string name)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.BeginProgress (image, name);
+			else {
+				inProgress = true;
+				progressMessage = name;
+				progressImage = image;
+			}
+		}
+
+		public StatusBarContext CreateContext ()
+		{
+			return ctxHandler.CreateContext ();
+		}
+
+		public void Dispose ()
+		{
+			delegatedStatusBar?.Dispose ();
+		}
+
+		public void EndProgress ()
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.EndProgress ();
+			else {
+				inProgress = false;
+				progressMessage = null;
+				progressImage = IconId.Null;
+			}
+		}
+
+		public void Pulse ()
+		{
+			delegatedStatusBar?.Pulse ();
+		}
+
+		public void SetCancellationTokenSource (CancellationTokenSource source)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.SetCancellationTokenSource (source);
+			else
+				cancellationTokenSource = source;
+		}
+
+		public void SetMessageSourcePad (Pad pad)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.SetMessageSourcePad (pad);
+			else
+				messageSourcePad = pad;
+		}
+
+		public void SetProgressFraction (double work)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.SetProgressFraction (work);
+			else
+				progressFraction = work;
+		}
+
+		public void ShowError (string error)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowError (error);
+			else
+				StoreMessage (MessageType.Error, message);
+		}
+
+		public void ShowMessage (string message)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowMessage (message);
+			else
+				StoreMessage (MessageType.Message, message);
+		}
+
+		public void ShowMessage (string message, bool isMarkup)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowMessage (message, isMarkup);
+			else
+				StoreMessage (MessageType.Message, message, isMarkup:isMarkup);
+		}
+
+		public void ShowMessage (IconId image, string message)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowMessage (image, message);
+			else
+				StoreMessage (MessageType.Message, message, image);
+		}
+
+		public void ShowMessage (IconId image, string message, bool isMarkup)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowMessage (image, message, isMarkup);
+			else
+				StoreMessage (MessageType.Message, message, image, isMarkup);
+		}
+
+		public void ShowReady ()
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowReady ();
+			else
+				StoreMessage (MessageType.Ready, null);
+		}
+
+		public void ShowWarning (string warning)
+		{
+			if (delegatedStatusBar != null)
+				delegatedStatusBar.ShowWarning (warning);
+			else
+				StoreMessage (MessageType.Warning, message);
+		}
+
+		void StoreMessage (MessageType messageType, string message, IconId image = default(IconId), bool isMarkup = false)
+		{
+			this.messageType = messageType;
+			this.message = message;
+			messageIsMarkup = isMarkup;
+			messageIcon = image;
+		}
+
+		public StatusBarIcon ShowStatusIcon (Image pixbuf)
+		{
+			if (delegatedStatusBar != null)
+				return delegatedStatusBar.ShowStatusIcon (pixbuf);
+
+			var icon = new StatusBarIconWrapper (this, pixbuf);
+			icons.Add (icon);
+			return icon;
+		}
+
+		class StatusBarIconWrapper : StatusBarIcon
+		{
+			WorkbenchStatusBar parent;
+			StatusBarIcon wrapped;
+			Image pixbuf;
+			string title;
+			string tooltip;
+			string help;
+
+			public StatusBarIconWrapper (WorkbenchStatusBar parent, Image pixbuf)
+			{
+				this.parent = parent;
+				this.pixbuf = pixbuf;
+			}
+
+			public void Attach (StatusBar delegatedStatusBar)
+			{
+				wrapped = delegatedStatusBar.ShowStatusIcon (pixbuf);
+				wrapped.Clicked += Wrapped_Clicked;
+				if (title != null)
+					wrapped.Title = title;
+				if (tooltip != null)
+					wrapped.ToolTip = tooltip;
+				if (help != null)
+					wrapped.Help = help;
+			}
+
+			private void Wrapped_Clicked (object sender, StatusBarIconClickedEventArgs e)
+			{
+				Clicked?.Invoke (this, e);
+			}
+
+			public string Title {
+				get { return wrapped != null ? wrapped.Title : title; }
+				set {
+					if (wrapped != null)
+						wrapped.Title = value;
+					else
+						title = value;
+				}
+			}
+
+			public string ToolTip {
+				get { return wrapped != null ? wrapped.ToolTip : tooltip; }
+				set {
+					if (wrapped != null)
+						wrapped.ToolTip = value;
+					else
+						tooltip = value;
+				}
+			}
+
+			public string Help {
+				get { return wrapped != null ? wrapped.Help : help; }
+				set {
+					if (wrapped != null)
+						wrapped.Help = value;
+					else
+						help = value;
+				}
+			}
+			public Image Image {
+				get { return wrapped != null ? wrapped.Image : pixbuf; }
+				set {
+					if (wrapped != null)
+						wrapped.Image = value;
+					else
+						pixbuf = value;
+				}
+			}
+
+			public event EventHandler<StatusBarIconClickedEventArgs> Clicked;
+
+			public void Dispose ()
+			{
+				if (wrapped != null) {
+					wrapped.Clicked -= Wrapped_Clicked;
+					wrapped.Dispose ();
+				} else
+					parent.icons.Remove (this);
+			}
+
+			public void SetAlertMode (int seconds)
+			{
+				if (wrapped != null)
+					wrapped.SetAlertMode (seconds);
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchStatusBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchStatusBar.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using MonoDevelop.Components.MainToolbar;
 using MonoDevelop.Core;
@@ -33,7 +34,7 @@ using Xwt.Drawing;
 
 namespace MonoDevelop.Ide.Gui
 {
-	class WorkbenchStatusBar : StatusBar
+	class WorkbenchStatusBar : ITestableStatusBar
 	{
 		StatusBar delegatedStatusBar;
 		bool autoPulse;
@@ -110,6 +111,22 @@ namespace MonoDevelop.Ide.Gui
 					delegatedStatusBar.AutoPulse = value;
 				else
 					autoPulse = value;
+			}
+		}
+
+		public string CurrentText {
+			get {
+				if (delegatedStatusBar is ITestableStatusBar ideStatusBar)
+					return ideStatusBar.CurrentText;
+				return message;
+			}
+		}
+
+		public string[] CurrentIcons {
+			get {
+				if (delegatedStatusBar is ITestableStatusBar ideStatusBar)
+					return ideStatusBar.CurrentIcons;
+				return icons.Select (x => x.ToolTip).ToArray ();
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -82,8 +82,6 @@ namespace MonoDevelop.Ide.WelcomePage
 				await Runtime.GetService<DesktopService> ();
 				var commandManager = await Runtime.GetService<CommandManager> ();
 				await ShowWelcomeWindow (new WelcomeWindowShowOptions (false));
-				// load the global menu for the welcome window to avoid unresponsive menus on Mac
-				IdeServices.DesktopService.SetGlobalMenu (commandManager, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // WelcomePageService.cs
 //
 // Author:
@@ -81,11 +81,9 @@ namespace MonoDevelop.Ide.WelcomePage
 			if (HasWindowImplementation) {
 				await Runtime.GetService<DesktopService> ();
 				var commandManager = await Runtime.GetService<CommandManager> ();
-				Runtime.RunInMainThread (async () => {
-					await ShowWelcomeWindow (new WelcomeWindowShowOptions (false));
-					// load the global menu for the welcome window to avoid unresponsive menus on Mac
-					IdeServices.DesktopService.SetGlobalMenu (commandManager, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
-				}).Ignore ();
+				await ShowWelcomeWindow (new WelcomeWindowShowOptions (false));
+				// load the global menu for the welcome window to avoid unresponsive menus on Mac
+				IdeServices.DesktopService.SetGlobalMenu (commandManager, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4244,6 +4244,7 @@
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopExtensionManager.cs" />
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopErrorLoggerService.cs" />
     <Compile Include="MonoDevelop.Components.Commands\IdeCommandManager.cs" />
+    <Compile Include="MonoDevelop.Ide.Gui\WorkbenchStatusBar.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -251,10 +251,6 @@ namespace MonoDevelop.Ide
 			await workbench.Initialize (monitor);
 			monitor.Step (1);
 
-			Counters.Initialization.Trace ("Realizing Workbench Window");
-			workbench.Realize ();
-			monitor.Step (1);
-
 			MessageService.RootWindow = workbench.RootWindow;
 			Xwt.MessageDialog.RootWindow = Xwt.Toolkit.CurrentEngine.WrapWindow (workbench.RootWindow);
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -307,13 +307,19 @@ namespace MonoDevelop.Ide
 		}
 
 		//this method is MIT/X11, 2009, Michael Hutchinson / (c) Novell
-		public static Task<bool> OpenFiles (IEnumerable<FileOpenInformation> files)
+
+		public static void OpenFiles (IEnumerable<FileOpenInformation> files)
 		{
-			return OpenFiles (files, null);
+			OpenFilesAsync (files, null).Ignore ();
+		}
+
+		public static Task<bool> OpenFilesAsync (IEnumerable<FileOpenInformation> files)
+		{
+			return OpenFilesAsync (files, null);
 		}
 
 		//this method is MIT/X11, 2009, Michael Hutchinson / (c) Novell
-		internal static async Task<bool> OpenFiles (IEnumerable<FileOpenInformation> files, OpenWorkspaceItemMetadata metadata)
+		internal static async Task<bool> OpenFilesAsync (IEnumerable<FileOpenInformation> files, OpenWorkspaceItemMetadata metadata)
 		{
 			if (!files.Any ())
 				return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -209,7 +209,10 @@ namespace MonoDevelop.Ide
 
 			IdeApp.IsRunning = true;
 
+			// Load the main menu before running the main loop
 			var commandService = Runtime.GetService<CommandManager> ().Result;
+			var desktopService = Runtime.GetService<DesktopService> ().Result;
+			desktopService.SetGlobalMenu (commandService, DefaultWorkbench.MainMenuPath, DefaultWorkbench.AppMenuPath);
 
 			// Run the main loop
 			Gtk.Application.Invoke ((s, e) => {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -209,6 +209,8 @@ namespace MonoDevelop.Ide
 
 			IdeApp.IsRunning = true;
 
+			var commandService = Runtime.GetService<CommandManager> ().Result;
+
 			// Run the main loop
 			Gtk.Application.Invoke ((s, e) => {
 				MainLoop (options, startupInfo).Ignore ();
@@ -236,12 +238,17 @@ namespace MonoDevelop.Ide
 		async Task<int> MainLoop (MonoDevelopOptions options, StartupInfo startupInfo)
 		{
 			ProgressMonitor monitor = new MonoDevelop.Core.ProgressMonitoring.ConsoleProgressMonitor ();
-			
+
 			monitor.BeginTask (GettextCatalog.GetString ("Starting {0}", BrandingService.ApplicationName), 2);
 
 			//make sure that the platform service is initialised so that the Mac platform can subscribe to open-document events
 			Counters.Initialization.Trace ("Initializing Platform Service");
-			await Runtime.GetService<DesktopService> ();
+
+			var desktopService = await Runtime.GetService<DesktopService> ();
+			var commandService = await Runtime.GetService<CommandManager> ();
+
+			// load the global menu for the welcome window to avoid unresponsive menus on Mac
+			desktopService.SetGlobalMenu (commandService, DefaultWorkbench.MainMenuPath, DefaultWorkbench.AppMenuPath);
 
 			IdeStartupTracker.StartupTracker.MarkSection ("PlatformInitialization");
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -293,12 +293,12 @@ namespace MonoDevelop.Ide
 					openedProject = IdeServices.DesktopService.RecentFiles.MostRecentlyUsedProject;
 					if (openedProject != null) {
 						var metadata = GetOpenWorkspaceOnStartupMetadata ();
-						IdeApp.Workspace.OpenWorkspaceItem (openedProject.FileName, true, true, metadata).ContinueWith (t => IdeApp.OpenFiles (startupInfo.RequestedFileList, metadata), TaskScheduler.FromCurrentSynchronizationContext ()).Ignore();
+						IdeApp.Workspace.OpenWorkspaceItem (openedProject.FileName, true, true, metadata).ContinueWith (t => IdeApp.OpenFilesAsync (startupInfo.RequestedFileList, metadata), TaskScheduler.FromCurrentSynchronizationContext ()).Ignore();
 						startupInfo.OpenedRecentProject = true;
 					}
 				}
 				if (openedProject == null) {
-					IdeApp.OpenFiles (startupInfo.RequestedFileList, GetOpenWorkspaceOnStartupMetadata ());
+					IdeApp.OpenFilesAsync (startupInfo.RequestedFileList, GetOpenWorkspaceOnStartupMetadata ()).Ignore ();
 					startupInfo.OpenedFiles = startupInfo.HasFiles;
 				}
 				

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -708,6 +708,7 @@ namespace MonoDevelop.Ide
 			if (!await IdeApp.Workbench.SaveAllDirtyFiles ())
 				return false;
 
+			IdeApp.Workbench.EnsureLayout ();
 			var newProjectDialog = new NewProjectDialogController ();
 			newProjectDialog.OpenSolution = true;
 			newProjectDialog.SelectedTemplateId = defaultTemplate;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -623,6 +623,9 @@ namespace MonoDevelop.Ide
 
 		internal async Task<bool> OpenWorkspaceItem (FilePath file, bool closeCurrent, bool loadPreferences, OpenWorkspaceItemMetadata metadata)
 		{
+			if (IdeApp.IsInitialized)
+				IdeApp.Workbench.Show ();
+
 			lock (loadLock) {
 				if (++loadOperationsCount == 1)
 					currentWorkspaceLoadTask = new TaskCompletionSource<bool> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -661,7 +661,7 @@ namespace MonoDevelop.Ide
 		internal async Task<bool> OpenWorkspaceItemInternal (FilePath file, bool closeCurrent, bool loadPreferences, OpenWorkspaceItemMetadata metadata, ProgressMonitor loadMonitor)
 		{
 			if (IdeApp.IsInitialized)
-				IdeApp.Workbench.RootWindow.Show ();
+				IdeApp.Workbench.Show ();
 			var item = GetAllItems<WorkspaceItem> ().FirstOrDefault (w => w.FileName == file.FullPath);
 			if (item != null) {
 				CurrentSelectedWorkspaceItem = item;

--- a/main/tests/StressTest/MonoDevelop.StressTest/Program.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/Program.cs
@@ -25,6 +25,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.IO;
+using System.Reflection;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.StressTest
@@ -66,6 +68,10 @@ namespace MonoDevelop.StressTest
 				app.Start ();
 			} catch {
 				success = false;
+
+				var thisDirectory = Path.GetDirectoryName (Assembly.GetEntryAssembly ().Location);
+				var screenshotFile = Path.Combine (thisDirectory, "screenshot-failure.png");
+				UserInterfaceTests.TestService.Session.TakeScreenshot (screenshotFile);
 				throw;
 			} finally {
 				app.Stop (success);

--- a/main/tests/StressTest/MonoDevelop.StressTest/Program.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/Program.cs
@@ -25,8 +25,7 @@
 // THE SOFTWARE.
 
 using System;
-using System.IO;
-using System.Reflection;
+using System.Diagnostics;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.StressTest
@@ -69,9 +68,10 @@ namespace MonoDevelop.StressTest
 			} catch {
 				success = false;
 
-				var thisDirectory = Path.GetDirectoryName (Assembly.GetEntryAssembly ().Location);
-				var screenshotFile = Path.Combine (thisDirectory, "screenshot-failure.png");
-				UserInterfaceTests.TestService.Session.TakeScreenshot (screenshotFile);
+				using (var p = Process.Start ("/usr/sbin/screencapture", "screenshot-failure.png")) {
+					Console.WriteLine ("Taking screenshot at point of failure");
+					p.WaitForExit ();
+				}
 				throw;
 			} finally {
 				app.Stop (success);

--- a/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
+++ b/main/tests/StressTest/MonoDevelop.StressTest/StressTestApp.cs
@@ -77,7 +77,7 @@ namespace MonoDevelop.StressTest
 
 			TestService.Session.DebugObject = new UITestDebug ();
 
-			TestService.Session.WaitForElement (IdeQuery.DefaultWorkbench);
+			TestService.Session.WaitForElement (IdeQuery.DefaultWorkbench, 10000);
 
 			leakProcessor = new LeakProcessor (scenario, ProfilerOptions);
 

--- a/main/tests/StressTest/ResultParser/Program.cs
+++ b/main/tests/StressTest/ResultParser/Program.cs
@@ -12,7 +12,7 @@ namespace ResultParser
 		{
 			bool hasLeaks = false;
 
-			foreach (var png in Directory.EnumerableFiles(".", "*.png")) {
+			foreach (var png in Directory.EnumerateFiles(".", "*.png")) {
 				var url = AzureBlobStorage.DefaultInstance.UploadFile (png, "image/png").ToString ();
 				Console.WriteLine ("Failure screenshot: {0}", url);
 				hasLeaks = true;

--- a/main/tests/StressTest/ResultParser/Program.cs
+++ b/main/tests/StressTest/ResultParser/Program.cs
@@ -10,6 +10,12 @@ namespace ResultParser
 	{
 		public static int Main (string[] args)
 		{
+			if (File.Exists ("screenshot-failure.png")) {
+				var url = AzureBlobStorage.DefaultInstance.UploadFile ("screenshot-failure.png", "image/png").ToString ();
+				Console.WriteLine ("Failure screenshot: {0}", url);
+				return 1;
+			}
+
 			bool hasLeaks = false;
 			foreach (var file in Directory.EnumerateFiles(".", "*.json")) {
 				var serializer = new JsonSerializer {

--- a/main/tests/StressTest/ResultParser/Program.cs
+++ b/main/tests/StressTest/ResultParser/Program.cs
@@ -10,13 +10,14 @@ namespace ResultParser
 	{
 		public static int Main (string[] args)
 		{
-			if (File.Exists ("screenshot-failure.png")) {
-				var url = AzureBlobStorage.DefaultInstance.UploadFile ("screenshot-failure.png", "image/png").ToString ();
+			bool hasLeaks = false;
+
+			foreach (var png in Directory.EnumerableFiles(".", "*.png")) {
+				var url = AzureBlobStorage.DefaultInstance.UploadFile (png, "image/png").ToString ();
 				Console.WriteLine ("Failure screenshot: {0}", url);
-				return 1;
+				hasLeaks = true;
 			}
 
-			bool hasLeaks = false;
 			foreach (var file in Directory.EnumerateFiles(".", "*.json")) {
 				var serializer = new JsonSerializer {
 					NullValueHandling = NullValueHandling.Ignore,

--- a/main/tests/UserInterfaceTests/Workbench.cs
+++ b/main/tests/UserInterfaceTests/Workbench.cs
@@ -44,26 +44,15 @@ namespace UserInterfaceTests
 
 		public static string GetStatusMessage (int timeout = 20000, bool waitForNonEmpty = true)
 		{
-			if (Platform.IsMac) {
-				const string macStatusTextField = "MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.text";
-				if (waitForNonEmpty) {
-					Ide.WaitUntil (
-						() => Session.GetGlobalValue<string> (macStatusTextField) != string.Empty,
-						timeout
-					);
-				}
-				return (string)Session.GetGlobalValue (macStatusTextField);
-			}
-
 			if (waitForNonEmpty) {
-				const string gtkStatusMessageCount = "MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.messageQueue.Count";
+				string text = null;
 				Ide.WaitUntil (
-					() => Session.GetGlobalValue<int> (gtkStatusMessageCount) == 0,
-					timeout,
-					timeoutMessage: ()=> "MessageQueue.Count=" + Session.GetGlobalValue<int> (gtkStatusMessageCount)
+					() => (text = Session.GetGlobalValue<string> ("MonoDevelop.Ide.IdeApp.Workbench.statusBar.CurrentText")) != string.Empty,
+					timeout
 				);
+				return text;
 			}
-			return (string) Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.renderArg.CurrentText");
+			return (string)Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.statusBar.CurrentText");
 		}
 
 		public static void WaitForStatusIcon(int timeout = 20000, string text = "", bool waitForExisting = true)
@@ -72,7 +61,7 @@ namespace UserInterfaceTests
 			{
 				Ide.WaitUntil(
 					() => {
-						var icons = Session.GetGlobalValue<string[]>("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.StatusIcons");
+						var icons = Session.GetGlobalValue<string[]>("MonoDevelop.Ide.IdeApp.Workbench.statusBar.CurrentIcons");
 						bool found = false;
 						foreach (string icon in icons) {
 							if (icon == text) {

--- a/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting/Workbench.cs
+++ b/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting/Workbench.cs
@@ -44,24 +44,15 @@ namespace MonoDevelop.UserInterfaceTesting
 
 		public static string GetStatusMessage (int timeout = 20000, bool waitForNonEmpty = true)
 		{
-			if (Platform.IsMac) {
-				if (waitForNonEmpty) {
-					Ide.WaitUntil (
-						() => Session.GetGlobalValue<string> ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.text") != string.Empty,
-						timeout
-					);
-				}
-				return (string)Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.text");
-			}
-
 			if (waitForNonEmpty) {
+				string text = null;
 				Ide.WaitUntil (
-					() => Session.GetGlobalValue<int> ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.messageQueue.Count") == 0,
-					timeout,
-					timeoutMessage: ()=> "MessageQueue.Count="+Session.GetGlobalValue<int> ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.messageQueue.Count")
+					() => (text = Session.GetGlobalValue<string> ("MonoDevelop.Ide.IdeApp.Workbench.statusBar.CurrentText")) != string.Empty,
+					timeout
 				);
+				return text;
 			}
-			return (string) Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.renderArg.CurrentText");
+			return (string)Session.GetGlobalValue ("MonoDevelop.Ide.IdeApp.Workbench.statusBar.CurrentText");
 		}
 
 		public static void WaitForStatusIcon(int timeout = 20000, string text = "", bool waitForExisting = true)
@@ -70,7 +61,7 @@ namespace MonoDevelop.UserInterfaceTesting
 			{
 				Ide.WaitUntil(
 					() => {
-						var icons = Session.GetGlobalValue<string[]>("MonoDevelop.Ide.IdeApp.Workbench.RootWindow.StatusBar.StatusIcons");
+						var icons = Session.GetGlobalValue<string[]>("MonoDevelop.Ide.IdeApp.Workbench.statusBar.CurrentIcons");
 						bool found = false;
 						foreach (string icon in icons) {
 							if (icon == text) {


### PR DESCRIPTION
Don't initialize DefaultWorkbench until it is shown for the first time. One problem is that the status bar is used before the workbench is shown, so added a wrapper class that will work as a dummy status bar until the real one is shown. Improve UI responsiveness when running startup handlers. Delay initialization of package service until the first solution is opened.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/889788
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/888567
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/888564

Backport of #7525.

/cc @slluis 