### PR TITLE
[release-8.1] Fix document focus issues

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -239,7 +239,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		static WeakReference<DocumentView> lastFocusGrabRequest = new WeakReference<DocumentView> (null);
 
-		public void GrabFocus ()
+		public async void GrabFocus ()
 		{
 			// If the view already has the focus, don't do anything
 			//	if (hasFocus) this is disabled because native views don't always correctly report that they have the focus
@@ -251,6 +251,14 @@ namespace MonoDevelop.Ide.Gui.Documents
 				lastFocusGrabRequest.SetTarget (this);
 				return;
 			}
+
+			// Grab the focus in the next UI iteration. 
+			// If GrabFocus is being called in an event handler, the focus may be lost again after executing
+			// the rest of the handler. Real case: if the focus is being grabbed in the double-click handler
+			// of a list, the focus will be lost since the default click handler will return the focus to
+			// the list.
+
+			await Task.Yield ();
 
 			if (SourceController != null)
 				SourceController.GrabFocusForView (this);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -350,6 +350,7 @@ namespace MonoDevelop.Ide.Gui
 		public void Select ()
 		{
 			window?.SelectWindow ();
+			view.GrabFocus ();
 		}
 
 		public TextEditor Editor {


### PR DESCRIPTION
Fixes VSTS #832026 - Double click in Search Results for XAML file does not
set focus to the edit window

Backport of #7529.

/cc @slluis 