### PR TITLE
[Dock] Don't disable hover when hiding a dock item

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBar.cs
@@ -124,17 +124,22 @@ namespace MonoDevelop.Components.Docking
 			box.PackStart (it, false, false, 0);
 			it.ShowAll ();
 			UpdateVisibility ();
-			it.Shown += OnItemVisibilityChanged;
-			it.Hidden += OnItemVisibilityChanged;
+			it.Shown += OnItemVisibilityShown;
+			it.Hidden += OnItemVisibilityHidden;
 			return it;
 		}
 		
-		void OnItemVisibilityChanged (object o, EventArgs args)
+		void OnItemVisibilityShown (object o, EventArgs args)
 		{
 			DisableHoverActivation ();
 			UpdateVisibility ();
 		}
-		
+
+		void OnItemVisibilityHidden (object o, EventArgs args)
+		{
+			UpdateVisibility ();
+		}
+
 		internal void OnCompactLevelChanged ()
 		{
 			UpdateVisibility ();
@@ -161,8 +166,8 @@ namespace MonoDevelop.Components.Docking
 		{
 			DisableHoverActivation ();
 			box.Remove (it);
-			it.Shown -= OnItemVisibilityChanged;
-			it.Hidden -= OnItemVisibilityChanged;
+			it.Shown -= OnItemVisibilityShown;
+			it.Hidden -= OnItemVisibilityHidden;
 			UpdateVisibility ();
 		}
 


### PR DESCRIPTION
Hiding and showing a dock item causes any hovers within the next 1.5seconds to be ignored.
It's possible to move into the dockbar to try to show a new pad within that 1.5 seconds, causing the pad to not appear.

Fix this by only disable the hover when showing the pad, not hiding.

Fixes VSTS #851588