### PR TITLE
Include Entitlements.plist in the app bundle

### DIFF
--- a/main/build/MacOSX/Entitlements.plist
+++ b/main/build/MacOSX/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -89,6 +89,7 @@ app: monostub monostub-test
 	cp ../../COPYING $(MAC_APP_DIR)/Contents/MacOS/share/monodevelop/COPYING.LGPL2.1
 
 	sed -e "s/@BUNDLE_VERSION@/$(BUNDLE_VERSION)/" -e "s/@APP_NAME@/$(APP_NAME)/" -e "s/@APP_DISPLAY_NAME@/$(APP_DISPLAY_NAME)/" -e "s|@RELEASE_ID@|$(PACKAGE_UPDATE_ID)|" Info.plist.in > $(MAC_APP_DIR)/Contents/Info.plist
+	cp Entitlements.plist $(MAC_APP_DIR)/Contents/Entitlements.plist
 	cp ../../theme-icons/Mac/*.icns $(MAC_APP_DIR)/Contents/Resources/
 
 # Native launch scripts

--- a/main/build/MacOSX/render.cs
+++ b/main/build/MacOSX/render.cs
@@ -7,7 +7,7 @@ class X {
 	{
 		var background = new Bitmap ("dmg-bg.png");
 		var ctx = Graphics.FromImage (background);
-		
+
 		//system.drawing doesn't allow setting the actual font weight
 		//so we can't get it as heavy as we need :/
 		var font = new Font ("Helvetica", 12, FontStyle.Bold);

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=fd1df9efb41e9c091ea2de0816130db0c1b78b4f
+DEP_NEEDED_VERSION[0]=376acc9ef1ce356085c0f79efee0c8302c40dfb3
 DEP_BRANCH_AND_REMOTE[0]="cadsit-sign-all-binaries origin/cadsit-sign-all-binaries"
 
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=376acc9ef1ce356085c0f79efee0c8302c40dfb3
+DEP_NEEDED_VERSION[0]=12230a19fca4ec6630f6dd40a446cd5bc738de15
 DEP_BRANCH_AND_REMOTE[0]="cadsit-sign-all-binaries origin/cadsit-sign-all-binaries"
 
 # heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=6d88dff2b7efea0b8ccea84c34e451c83e930527
-DEP_BRANCH_AND_REMOTE[0]="master origin/master"
+DEP_NEEDED_VERSION[0]=5323e3c721f4a657d3391bf77949554c4576f375
+DEP_BRANCH_AND_REMOTE[0]="cadsit-sign-all-binaries origin/cadsit-sign-all-binaries"
 
 # heap-shot
 DEP[1]=heap-shot

--- a/version-checks
+++ b/version-checks
@@ -17,7 +17,7 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=5323e3c721f4a657d3391bf77949554c4576f375
+DEP_NEEDED_VERSION[0]=fd1df9efb41e9c091ea2de0816130db0c1b78b4f
 DEP_BRANCH_AND_REMOTE[0]="cadsit-sign-all-binaries origin/cadsit-sign-all-binaries"
 
 # heap-shot


### PR DESCRIPTION
This PR puts an `Entitlements.plist` file in preparation for VSMac being sent for Apple App Notarization.

We have more details on that here: https://devblogs.microsoft.com/xamarin/macos-hardened-runtime-notary/

https://github.com/xamarin/md-addins/pull/4578 will enable the hardened runtime flag for the binaries in the app bundle.

If we run with a Mono that has this https://github.com/mono/mono/pull/14395 included, then no changes should be needed in `monostub.m`.
