### PR TITLE
[release-8.1] [Shell] Fix wrong initial position of some Dialogs

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1044,12 +1044,25 @@ namespace MonoDevelop.MacIntegration
 			return false;
 		}
 
+		bool CheckIfTopWindowIsWorkbench ()
+		{
+			foreach (var window in Gtk.Window.ListToplevels ()) {
+				if (!window.HasToplevelFocus) {
+					continue;
+				}
+				if (window is DefaultWorkbench) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		public override Window GetFocusedTopLevelWindow ()
 		{
 			if (NSApplication.SharedApplication.KeyWindow != null) {
 				if (IdeApp.Workbench?.RootWindow?.Visible == true) {
 					//if is a docking window then return the current root window
-					if (HasAnyDockWindowFocused ()) {
+					if (CheckIfTopWindowIsWorkbench () || HasAnyDockWindowFocused ()) {
 						return MessageService.RootWindow;
 					}
 				}


### PR DESCRIPTION
Some Version Control dialogs appeared in the top left corner of the screen (like create Stash or manage Stashes).
Fixed passing the Parent.

Fixes VSTS #825038

Backport of #7519.

/cc @slluis @jsuarezruiz