### PR TITLE
[release-8.1] Fixes VSTS Bug 860954: Go To Definition causes a lengthy UI hang

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
@@ -194,17 +194,6 @@ namespace MonoDevelop.AssemblyBrowser
 				foreach (var project in Ide.IdeApp.ProjectOperations.CurrentSelectedSolution.GetAllProjects ()) {
 					try {
 						Widget.AddProject (project, false);
-						var netProject = project as DotNetProject;
-						if (netProject == null)
-							continue;
-						foreach (var file in await netProject.GetReferencedAssemblies (ConfigurationSelector.Default, false)) {
-							if (!System.IO.File.Exists (file.FilePath))
-								continue;
-							if (!alreadyAdded.Add (file.FilePath))
-								continue;
-							var loader = Widget.AddReferenceByFileName (file.FilePath);
-							allTasks.Add (loader.LoadingTask);
-						}
 					} catch (Exception e) {
 						LoggingService.LogError ("Error while adding project " + project.Name + " to the tree.", e);
 					}

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
@@ -64,6 +64,9 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			DocumentTitle = GettextCatalog.GetString ("Assembly Browser");
 			widget = new AssemblyBrowserWidget ();
+			widget.Destroyed += delegate {
+				StopProgress ();
+			}; 
 			IsDisposed = false;
 			FillWidget ();
 		}
@@ -112,6 +115,7 @@ namespace MonoDevelop.AssemblyBrowser
 		protected override void OnDispose ()
 		{
 			IsDisposed = true;
+			StopProgress ();
 			if (currentWs != null) 
 				currentWs.WorkspaceLoaded -= Handle_WorkspaceLoaded;
 
@@ -179,6 +183,8 @@ namespace MonoDevelop.AssemblyBrowser
 		}
 
 		Ide.TypeSystem.MonoDevelopWorkspace currentWs;
+		ProgressMonitor monitor;
+
 		public async void FillWidget ()
 		{
 			if (Ide.IdeApp.ProjectOperations.CurrentSelectedSolution == null) {
@@ -191,19 +197,46 @@ namespace MonoDevelop.AssemblyBrowser
 				if (currentWs != null)
 					currentWs.WorkspaceLoaded += Handle_WorkspaceLoaded;
 				var allTasks = new List<Task> ();
+				monitor = IdeApp.Workbench.ProgressMonitors.GetLoadProgressMonitor (false);
+				monitor.BeginTask (GettextCatalog.GetString ("Loading assemblies…"), 1);
 				foreach (var project in Ide.IdeApp.ProjectOperations.CurrentSelectedSolution.GetAllProjects ()) {
 					try {
 						Widget.AddProject (project, false);
+
+						var netProject = project as DotNetProject;
+						if (netProject == null)
+							continue;
+						foreach (var file in await netProject.GetReferencedAssemblies (ConfigurationSelector.Default, false)) {
+							if (!System.IO.File.Exists (file.FilePath))
+								continue;
+							if (!alreadyAdded.Add (file.FilePath))
+								continue;
+							var loader = Widget.AddReferenceByFileName (file.FilePath);
+							allTasks.Add (loader.LoadingTask);
+						}
+
 					} catch (Exception e) {
 						LoggingService.LogError ("Error while adding project " + project.Name + " to the tree.", e);
 					}
 				}
 				await Task.WhenAll (allTasks).ContinueWith (delegate {
 					Runtime.RunInMainThread (delegate {
+						if (IsDisposed)
+							return;
+						StopProgress ();
 						widget.StartSearch ();
 					});
 				});
 			}
+		}
+
+		void StopProgress ()
+		{
+			if (monitor == null)
+				return;
+			monitor.EndTask ();
+			monitor.Dispose ();
+			monitor = null;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
@@ -907,14 +907,11 @@ namespace MonoDevelop.AssemblyBrowser
 			oldSize2 = size;
 			this.hpaned1.Position = Math.Min (350, this.Allocation.Width * 2 / 3);
 		}
-		bool IsDestroyed => TreeView == null;
-
+		
 		internal void Open (string url, AssemblyLoader currentAssembly = null, bool expandNode = true)
 		{
 			Task.WhenAll (this.definitions.Select (d => d.LoadingTask)).ContinueWith (d => {
 				Application.Invoke ((o, args) => {
-					if (IsDestroyed)
-						return;
 					suspendNavigation = false;
 					ITreeNavigator nav = SearchMember (url, expandNode);
 					if (definitions.Count == 0) // we've been disposed
@@ -1012,8 +1009,6 @@ namespace MonoDevelop.AssemblyBrowser
 				if (definitions.Count == 0) // disposed
 					return;
 				Application.Invoke ((o, args) => {
-					if (IsDestroyed)
-						return;
 					var nav = SearchMember (url);
 					if (nav == null) {
 						LoggingService.LogError ("Assembly browser: Can't find: " + url + ".");

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
@@ -907,11 +907,14 @@ namespace MonoDevelop.AssemblyBrowser
 			oldSize2 = size;
 			this.hpaned1.Position = Math.Min (350, this.Allocation.Width * 2 / 3);
 		}
-		
+		bool IsDestroyed => TreeView == null;
+
 		internal void Open (string url, AssemblyLoader currentAssembly = null, bool expandNode = true)
 		{
 			Task.WhenAll (this.definitions.Select (d => d.LoadingTask)).ContinueWith (d => {
 				Application.Invoke ((o, args) => {
+					if (IsDestroyed)
+						return;
 					suspendNavigation = false;
 					ITreeNavigator nav = SearchMember (url, expandNode);
 					if (definitions.Count == 0) // we've been disposed
@@ -1009,6 +1012,8 @@ namespace MonoDevelop.AssemblyBrowser
 				if (definitions.Count == 0) // disposed
 					return;
 				Application.Invoke ((o, args) => {
+					if (IsDestroyed)
+						return;
 					var nav = SearchMember (url);
 					if (nav == null) {
 						LoggingService.LogError ("Assembly browser: Can't find: " + url + ".");

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyLoader.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyLoader.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 using ICSharpCode.Decompiler.Metadata;
 using System.Reflection.Metadata;
 using System.Linq;
-
+using ICSharpCode.Decompiler.TypeSystem.Implementation;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -84,13 +84,14 @@ namespace MonoDevelop.AssemblyBrowser
 		DecompilerTypeSystem decompilerTypeSystem;
 		public DecompilerTypeSystem DecompilerTypeSystem { 
 			get {
+				LoadTypeSystem (Assembly);
 				return decompilerTypeSystem;
 			}
 		}
 
 		void LoadTypeSystem (PEFile peFile)
 		{
-			decompilerTypeSystem = new DecompilerTypeSystem (peFile, new AssemblyResolver (widget));
+			decompilerTypeSystem = new DecompilerTypeSystem (peFile, new AssemblyResolver (Assembly, widget));
 		}
 
 		public Error Error { get; internal set; }
@@ -113,7 +114,6 @@ namespace MonoDevelop.AssemblyBrowser
 			assemblyLoaderTask = Task.Run (() => {
 				try {
 					var peFile = new PEFile (FileName, System.Reflection.PortableExecutable.PEStreamOptions.PrefetchEntireImage);
-					LoadTypeSystem (peFile);
 					assemblyDefinitionTaskSource.SetResult (peFile);
 					return peFile;
 				} catch (Exception e) {
@@ -125,24 +125,53 @@ namespace MonoDevelop.AssemblyBrowser
 			});
 		}
 
+		ICompilation typeSystem;
+
+		public ICompilation GetMinimalTypeSystem ()
+		{
+			if (typeSystem != null)
+				return typeSystem;
+			var assembly = Assembly;
+			if (assembly == null)
+				return null;
+			return typeSystem = new SimpleCompilation (assembly.WithOptions (TypeSystemOptions.Default | TypeSystemOptions.Uncached | TypeSystemOptions.KeepModifiers), MinimalCorlib.Instance);
+		}
+
+		class MyUniversalAssemblyResolver : UniversalAssemblyResolver
+		{
+			public MyUniversalAssemblyResolver (string mainAssemblyFileName, bool throwOnError, string targetFramework) : base (mainAssemblyFileName, throwOnError, targetFramework)
+			{
+			}
+		}
 		class AssemblyResolver : IAssemblyResolver
 		{
+			readonly PEFile assembly;
 			readonly AssemblyBrowserWidget widget;
-			public AssemblyResolver (AssemblyBrowserWidget widget)
+
+			public AssemblyResolver (PEFile assembly, AssemblyBrowserWidget widget)
 			{
+				this.assembly = assembly;
 				this.widget = widget;
 			}
 
 			public PEFile Resolve (IAssemblyReference reference)
 			{
-				var loader = widget.AddReferenceByAssemblyName (reference.FullName);
-				return loader != null ? loader.Assembly : null;
+				try {
+					var targetFramework = assembly.Reader.DetectTargetFrameworkId () ?? "";
+					var resolver = new MyUniversalAssemblyResolver (assembly.FileName, false, targetFramework);
+					var fileName = resolver.FindAssemblyFile (reference);
+					if (fileName != null && File.Exists (fileName))
+						return widget.AddReferenceByFileName (fileName)?.Assembly;
+				} catch (Exception e) {
+					LoggingService.LogInternalError ($"Error while resolving assembly {reference.FullName} for {assembly.FileName}.", e);
+				}
+
+				return widget.AddReferenceByAssemblyName (reference.FullName)?.Assembly;
 			}
 
 			public PEFile ResolveModule (PEFile mainModule, string moduleName)
 			{
-				var loader = widget.AddReferenceByFileName (mainModule.FileName);
-				return loader != null ? loader.Assembly : null;
+				return widget.AddReferenceByFileName (mainModule.FileName)?.Assembly;
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyLoader.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyLoader.cs
@@ -83,15 +83,19 @@ namespace MonoDevelop.AssemblyBrowser
 
 		DecompilerTypeSystem decompilerTypeSystem;
 		public DecompilerTypeSystem DecompilerTypeSystem { 
-			get { 
-				if (decompilerTypeSystem == null) {
-					decompilerTypeSystem = new DecompilerTypeSystem (Assembly, new AssemblyResolver (widget));
-				}
-				return decompilerTypeSystem; 
+			get {
+				return decompilerTypeSystem;
 			}
 		}
 
+		void LoadTypeSystem (PEFile peFile)
+		{
+			decompilerTypeSystem = new DecompilerTypeSystem (peFile, new AssemblyResolver (widget));
+		}
+
 		public Error Error { get; internal set; }
+
+		public bool IsLoaded { get; private set; }
 
 		public AssemblyLoader (AssemblyBrowserWidget widget, string fileName)
 		{
@@ -109,6 +113,7 @@ namespace MonoDevelop.AssemblyBrowser
 			assemblyLoaderTask = Task.Run (() => {
 				try {
 					var peFile = new PEFile (FileName, System.Reflection.PortableExecutable.PEStreamOptions.PrefetchEntireImage);
+					LoadTypeSystem (peFile);
 					assemblyDefinitionTaskSource.SetResult (peFile);
 					return peFile;
 				} catch (Exception e) {
@@ -116,7 +121,7 @@ namespace MonoDevelop.AssemblyBrowser
 					Error = new Error(e.Message);
 					assemblyDefinitionTaskSource.SetResult (null);
 					return null;
-				}
+				} finally { IsLoaded = true; }
 			});
 		}
 

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyReferenceFolder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyReferenceFolder.cs
@@ -48,8 +48,6 @@ namespace MonoDevelop.AssemblyBrowser
 			}
 		}
 
-		// Ass
-		
 		public IEnumerable<IModule> ModuleReferences {
 			get {
 				// TODO:

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyReferenceFolder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyReferenceFolder.cs
@@ -48,6 +48,8 @@ namespace MonoDevelop.AssemblyBrowser
 			}
 		}
 
+		// Ass
+		
 		public IEnumerable<IModule> ModuleReferences {
 			get {
 				// TODO:

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/IAssemblyBrowserNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/IAssemblyBrowserNodeBuilder.cs
@@ -31,13 +31,14 @@ using MonoDevelop.Ide.Gui.Pads;
 using MonoDevelop.Ide.Gui.Components;
 using System.Collections.Generic;
 using MonoDevelop.Ide.Editor;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
 	interface IAssemblyBrowserNodeBuilder
 	{
-		List<ReferenceSegment> Disassemble (TextEditor data, ITreeNavigator navigator);
-		List<ReferenceSegment> Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags);
+		Task<List<ReferenceSegment>> DisassembleAsync (TextEditor data, ITreeNavigator navigator);
+		Task<List<ReferenceSegment>> DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags);
 	}
 
 	class DecompileFlags

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyBrowserTypeNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/AssemblyBrowserTypeNodeBuilder.cs
@@ -32,6 +32,8 @@ using MonoDevelop.Core;
 using MonoDevelop.Projects;
 using MonoDevelop.Ide.TypeSystem;
 using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -42,6 +44,7 @@ namespace MonoDevelop.AssemblyBrowser
 			private set; 
 		}
 		readonly static CSharpAmbience ambience = new CSharpAmbience ();
+		public static readonly Task<List<ReferenceSegment>> EmptyReferenceSegmentTask = Task.FromResult (new List<ReferenceSegment> ());
 
 		protected CSharpAmbience Ambience {
 			get {

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/AssemblyNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/AssemblyNodeBuilder.cs
@@ -38,6 +38,7 @@ using System.IO;
 using MonoDevelop.Ide.Editor;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.Decompiler.Metadata;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -162,22 +163,22 @@ namespace MonoDevelop.AssemblyBrowser
 			result.AppendLine ();
 		}
 		
-		public List<ReferenceSegment> Disassemble (TextEditor data, ITreeNavigator navigator)
+		public Task<List<ReferenceSegment>> DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 			var assemblyLoader = (AssemblyLoader)navigator.DataItem;
 			var compilationUnit = assemblyLoader.Assembly;
 			if (compilationUnit == null) {
 				LoggingService.LogError ("Can't get cecil object for assembly:" + assemblyLoader.Assembly.FullName);
-				return new List<ReferenceSegment> ();
+				return Task.FromResult (new List<ReferenceSegment> ());
 			}
-			return MethodDefinitionNodeBuilder.Disassemble (data, rd => rd.WriteAssemblyHeader (compilationUnit));
+			return MethodDefinitionNodeBuilder.DisassembleAsync (data, rd => rd.WriteAssemblyHeader (compilationUnit));
 		}
 		
 		
-		public List<ReferenceSegment> Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+		public Task<List<ReferenceSegment>> DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
 			var assemblyLoader = (AssemblyLoader)navigator.DataItem;
-			return MethodDefinitionNodeBuilder.Decompile (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => 
+			return MethodDefinitionNodeBuilder.DecompileAsync (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => 
 				b.DecompileModuleAndAssemblyAttributes(), flags: flags);
 		}
 

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/AssemblyNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/AssemblyNodeBuilder.cs
@@ -85,25 +85,25 @@ namespace MonoDevelop.AssemblyBrowser
 
 		public override void BuildChildNodes (ITreeBuilder treeBuilder, object dataObject)
 		{
-			var compilationUnit = (AssemblyLoader)dataObject;
-			if (compilationUnit.Error != null) {
-				treeBuilder.AddChild (compilationUnit.Error);
+			var assemblyLoader = (AssemblyLoader)dataObject;
+			if (assemblyLoader.Error != null) {
+				treeBuilder.AddChild (assemblyLoader.Error);
 				return;
 			}
-			if (compilationUnit.Assembly == null)
+			if (assemblyLoader.Assembly == null)
 				return;
-			var references = new AssemblyReferenceFolder (compilationUnit.Assembly);
+			var references = new AssemblyReferenceFolder (assemblyLoader.Assembly);
 			if (references.AssemblyReferences.Any () || references.ModuleReferences.Any ())
 				treeBuilder.AddChild (references);
 
-			var resources = new AssemblyResourceFolder (compilationUnit.Assembly);
+			var resources = new AssemblyResourceFolder (assemblyLoader.Assembly);
 			if (resources.Resources.Any ())
 				treeBuilder.AddChild (resources);
 			
 			var namespaces = new Dictionary<string, NamespaceData> ();
 			bool publicOnly = Widget.PublicApiOnly;
-			
-			foreach (var type in compilationUnit.DecompilerTypeSystem.MainModule.TypeDefinitions) {
+
+			foreach (var type in assemblyLoader.GetMinimalTypeSystem ().MainModule.TopLevelTypeDefinitions) {
 				string namespaceName = string.IsNullOrEmpty (type.Namespace) ? "" : type.Namespace;
 				if (!namespaces.ContainsKey (namespaceName))
 					namespaces [namespaceName] = new NamespaceData (namespaceName);
@@ -125,7 +125,7 @@ namespace MonoDevelop.AssemblyBrowser
 		public override bool HasChildNodes (ITreeBuilder builder, object dataObject)
 		{
 			var compilationUnit = (AssemblyLoader)dataObject;
-			return compilationUnit.DecompilerTypeSystem?.MainModule.TypeDefinitions.Any () == true || compilationUnit.Error != null;
+			return compilationUnit.Assembly.Metadata.TypeDefinitions.Count > 0 || compilationUnit.Error != null;
 		}
 		
 		public override int CompareObjects (ITreeNavigator thisNode, ITreeNavigator otherNode)

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/EventDefinitionNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/EventDefinitionNodeBuilder.cs
@@ -39,6 +39,7 @@ using ICSharpCode.Decompiler.TypeSystem;
 using MonoDevelop.Ide.Editor;
 using ICSharpCode.Decompiler.CSharp;
 using MonoDevelop.Core;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -91,24 +92,24 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			return false;
 		}
-		
+
 		#region IAssemblyBrowserNodeBuilder
-		List<ReferenceSegment> IAssemblyBrowserNodeBuilder.Disassemble (TextEditor data, ITreeNavigator navigator)
+		Task<List<ReferenceSegment>> IAssemblyBrowserNodeBuilder.DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var evt = (IEvent)navigator.DataItem;
-			return MethodDefinitionNodeBuilder.Disassemble (data, rd => rd.DisassembleEvent (evt.ParentModule.PEFile, (System.Reflection.Metadata.EventDefinitionHandle)evt.MetadataToken));
+			return MethodDefinitionNodeBuilder.DisassembleAsync (data, rd => rd.DisassembleEvent (evt.ParentModule.PEFile, (System.Reflection.Metadata.EventDefinitionHandle)evt.MetadataToken));
 		}
-		
-		List<ReferenceSegment> IAssemblyBrowserNodeBuilder.Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+
+		Task<List<ReferenceSegment>> IAssemblyBrowserNodeBuilder.DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var evt = navigator.DataItem as IEvent;
 			if (evt == null)
-				return null;
-			return MethodDefinitionNodeBuilder.Decompile (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => b.Decompile (evt.MetadataToken), flags: flags);
+				return EmptyReferenceSegmentTask;
+			return MethodDefinitionNodeBuilder.DecompileAsync (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => b.Decompile (evt.MetadataToken), flags: flags);
 		}
 
 		#endregion

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/FieldDefinitionNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/FieldDefinitionNodeBuilder.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ICSharpCode.Decompiler.TypeSystem;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor;
@@ -72,24 +73,25 @@ namespace MonoDevelop.AssemblyBrowser
 
 		#region IAssemblyBrowserNodeBuilder
 
-		List<ReferenceSegment> IAssemblyBrowserNodeBuilder.Disassemble (TextEditor data, ITreeNavigator navigator)
+
+		Task<List<ReferenceSegment>> IAssemblyBrowserNodeBuilder.DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var field = (IField)navigator.DataItem;
 			if (field == null)
-				return null;
-			return MethodDefinitionNodeBuilder.Disassemble (data, rd => rd.DisassembleField (field.ParentModule.PEFile, (System.Reflection.Metadata.FieldDefinitionHandle)field.MetadataToken));
+				return EmptyReferenceSegmentTask;
+			return MethodDefinitionNodeBuilder.DisassembleAsync (data, rd => rd.DisassembleField (field.ParentModule.PEFile, (System.Reflection.Metadata.FieldDefinitionHandle)field.MetadataToken));
 		}
-		
-		List<ReferenceSegment> IAssemblyBrowserNodeBuilder.Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+
+		Task<List<ReferenceSegment>> IAssemblyBrowserNodeBuilder.DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var field = (IField)navigator.DataItem;
 			if (field == null)
-				return null;
-			return MethodDefinitionNodeBuilder.Decompile (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => b.Decompile (field.MetadataToken), flags: flags);
+				return EmptyReferenceSegmentTask;
+			return MethodDefinitionNodeBuilder.DecompileAsync (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => b.Decompile (field.MetadataToken), flags: flags);
 		}
 
 		#endregion

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/MethodDefinitionNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/MethodDefinitionNodeBuilder.cs
@@ -150,7 +150,9 @@ namespace MonoDevelop.AssemblyBrowser
 						return output.ReferencedSegments;
 					});
 				} catch (Exception e) {
-					data.InsertText (data.Length, "/* decompilation failed: \n" + e + " */");
+					await Runtime.RunInMainThread (delegate {
+						data.InsertText (data.Length, "/* decompilation failed: \n" + e + " */");
+					});
 				}
 				return new List<ReferenceSegment> ();
 			});

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/PropertyDefinitionNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/PropertyDefinitionNodeBuilder.cs
@@ -39,6 +39,7 @@ using ICSharpCode.Decompiler.TypeSystem;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Ide.Editor;
 using MonoDevelop.Core;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -87,25 +88,25 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			return false;
 		}
-		
-		
+
+
 		#region IAssemblyBrowserNodeBuilder
 
-		List<ReferenceSegment> IAssemblyBrowserNodeBuilder.Disassemble (TextEditor data, ITreeNavigator navigator)
+		Task<List<ReferenceSegment>> IAssemblyBrowserNodeBuilder.DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var property = (IProperty)navigator.DataItem;
-			return MethodDefinitionNodeBuilder.Disassemble (data, rd => rd.DisassembleProperty (property.ParentModule.PEFile, (System.Reflection.Metadata.PropertyDefinitionHandle)property.MetadataToken));
+			return MethodDefinitionNodeBuilder.DisassembleAsync (data, rd => rd.DisassembleProperty (property.ParentModule.PEFile, (System.Reflection.Metadata.PropertyDefinitionHandle)property.MetadataToken));
 		}
 
-		List<ReferenceSegment> IAssemblyBrowserNodeBuilder.Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+		Task<List<ReferenceSegment>> IAssemblyBrowserNodeBuilder.DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			if (!(navigator.DataItem is IProperty property))
-				return null;
-			return MethodDefinitionNodeBuilder.Decompile (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => b.Decompile (property.MetadataToken), flags: flags);
+				return EmptyReferenceSegmentTask;
+			return MethodDefinitionNodeBuilder.DecompileAsync (data, MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), b => b.Decompile (property.MetadataToken), flags: flags);
 		}
 		#endregion
 

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/TypeDefinitionNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Cecil/TypeDefinitionNodeBuilder.cs
@@ -44,6 +44,7 @@ using ICSharpCode.Decompiler.CSharp.OutputVisitor;
 using System.Security;
 using ICSharpCode.Decompiler.CSharp.Syntax;
 using ICSharpCode.Decompiler.CSharp;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -166,15 +167,15 @@ namespace MonoDevelop.AssemblyBrowser
 			return "";
 		}
 		
-		public List<ReferenceSegment> Disassemble (TextEditor data, ITreeNavigator navigator)
+		public Task<List<ReferenceSegment>> DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var type = (ITypeDefinition)navigator.DataItem;
 			if (type == null)
-				return null;
+				return EmptyReferenceSegmentTask;
 
-			return MethodDefinitionNodeBuilder.Disassemble (data, rd => rd.DisassembleType (type.ParentModule.PEFile, (System.Reflection.Metadata.TypeDefinitionHandle)type.MetadataToken));
+			return MethodDefinitionNodeBuilder.DisassembleAsync (data, rd => rd.DisassembleType (type.ParentModule.PEFile, (System.Reflection.Metadata.TypeDefinitionHandle)type.MetadataToken));
 		}
 
 		internal static DecompilerSettings CreateDecompilerSettings (bool publicOnly, MonoDevelop.CSharp.Formatting.CSharpFormattingPolicy codePolicy)
@@ -193,16 +194,16 @@ namespace MonoDevelop.AssemblyBrowser
 			};
 		}
 
-		public List<ReferenceSegment> Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+		public Task<List<ReferenceSegment>> DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
 			if (MethodDefinitionNodeBuilder.HandleSourceCodeEntity (navigator, data)) 
-				return null;
+				return EmptyReferenceSegmentTask;
 			var type = (ITypeDefinition)navigator.DataItem;
 			if (type == null)
-				return null;
+				return EmptyReferenceSegmentTask;
 			var settings = MethodDefinitionNodeBuilder.GetDecompilerSettings (data, flags.PublicOnly);
 			// CSharpLanguage.Instance.DecompileType (type, output, settings);
-			return MethodDefinitionNodeBuilder.Decompile (
+			return MethodDefinitionNodeBuilder.DecompileAsync (
 				data, 
 				MethodDefinitionNodeBuilder.GetAssemblyLoader (navigator), 
 				builder => builder.Decompile (type.MetadataToken), flags: flags);

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/NamespaceBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/NamespaceBuilder.cs
@@ -34,6 +34,7 @@ using MonoDevelop.Ide.Gui.Components;
 using System.Collections.Generic;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Editor;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -101,18 +102,18 @@ namespace MonoDevelop.AssemblyBrowser
 		
 		#region IAssemblyBrowserNodeBuilder
 
-		public List<ReferenceSegment> Disassemble (TextEditor data, ITreeNavigator navigator)
+		public Task<List<ReferenceSegment>> DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 		//	bool publicOnly = Widget.PublicApiOnly;
 			NamespaceData ns = (NamespaceData)navigator.DataItem;
 			
 			data.Text = "// " + ns.Name;
-			return null;
+			return EmptyReferenceSegmentTask;
 		}
 		
-		public List<ReferenceSegment> Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+		public Task<List<ReferenceSegment>> DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
-			return Disassemble (data, navigator);
+			return DisassembleAsync (data, navigator);
 		}
 		#endregion
 	}

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Roslyn/RoslynMemberNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/TreeNodes/Roslyn/RoslynMemberNodeBuilder.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Ide.Gui.Components;
 using MonoDevelop.Ide.Gui.Pads;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Core;
+using System.Threading.Tasks;
 
 namespace MonoDevelop.AssemblyBrowser
 {
@@ -79,20 +80,18 @@ namespace MonoDevelop.AssemblyBrowser
 			return 4;
 		}
 
-		public List<ReferenceSegment> Decompile (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
+		public Task<List<ReferenceSegment>> DecompileAsync (TextEditor data, ITreeNavigator navigator, DecompileFlags flags)
 		{
-			return Disassemble (data, navigator);
+			return DisassembleAsync (data, navigator);
 		}
 
-		static readonly List<ReferenceSegment> emptyReferences = new List<ReferenceSegment> ();
-
-		public List<ReferenceSegment> Disassemble (TextEditor data, ITreeNavigator navigator)
+		public Task<List<ReferenceSegment>> DisassembleAsync (TextEditor data, ITreeNavigator navigator)
 		{
 			var symbol = navigator.DataItem as ISymbol;
 			if (symbol == null) {
 				data.Text = "// DataItem is no symbol " + navigator.DataItem; // should never happen
 				LoggingService.LogError ("DataItem is no symbol " + navigator.DataItem);
-				return emptyReferences;
+				return AssemblyBrowserTypeNodeBuilder.EmptyReferenceSegmentTask;
 			}
 			var location = symbol.Locations [0];
 			if (location.IsInSource) {
@@ -107,7 +106,7 @@ namespace MonoDevelop.AssemblyBrowser
 				data.Text = "// Error: Symbol " + symbol.MetadataName + " is not in source."; // should never happen
 				LoggingService.LogError ("Symbol " + symbol.MetadataName + " is not in source.");
 			}
-			return emptyReferences;
+			return AssemblyBrowserTypeNodeBuilder.EmptyReferenceSegmentTask;
 		}
 
 


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/860954

Loading type system in background and removing the lock fixes the
issue. Locking is not needed because immutable data structures are
used now.
When opening a "blank" assembly browser the list of referenced
assemblies can be very long -esp. for .NET core projects it's better
not loading the referenced assemblies of all projects. It's a bit
unrelated but loadung such many assemblies can cause a very long load
time as well.
Even if it's not a hang it's basically "assembly browser does not do
anything" experience.

Backport of #7491.

/cc @slluis @mkrueger