### PR TITLE
Fix 861086: [Feedback] Debug tooltip stays up even after debugger has…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -66,6 +66,11 @@
       <Name>Mono.Debugging</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\MacPlatform\MacPlatform.csproj" Condition="$(HaveXamarinMac) == 'true'">
+      <Project>{50D6768C-C072-4E79-AFC5-C1C40767EF45}</Project>
+      <Name>MacPlatform</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />


### PR DESCRIPTION
… closed

I couldn't reproduce bug where debug tooltip wouldn't disappear if debugee crashed, I tried using `kill $pid` of debugee but debugger correctly called `DebuggingService.StoppedEvent` and editor correctly closed debug tooltip window when that happened. This sounds more like problem with debugger or specific runtime since we debugger didn't get socket disconnected which would cause `DebuggingService.StoppedEvent` to be called. I added closing of tooltip if user switches to another file because I thought thats what bug is about at first.
I also added logic to close on focus lost, but since I'm not sure what UX should be I wrapped that code into `#if CLOSE_ON_FOCUS_LOST` for now