### PR TITLE
TextViewContent: Clean up CanHandleCommand

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
@@ -190,9 +190,10 @@ namespace MonoDevelop.TextEditor
 
 		bool CanHandleCommand (object commandId)
 		{
-			var findPresenter = Imports.FindPresenterFactory?.TryGetFindPresenter (TextView);
-			if (findPresenter != null && findPresenter.IsFocused)
-				return commandsSupportedWhenFindPresenterIsFocused.Contains (commandId);
+			if (commandsSupportedWhenFindPresenterIsFocused.Contains (commandId)) {
+				var findPresenter = Imports.FindPresenterFactory?.TryGetFindPresenter (TextView);
+				return findPresenter != null && findPresenter.IsFocused;
+			}
 
 			return true;
 		}


### PR DESCRIPTION
Only look for a find presenter when querying about find
commands.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/890051