### PR TITLE
[Ide] GLib logging now uses loginternalerror so we can track glib exc…

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -272,16 +272,10 @@ namespace MonoDevelop.MacIntegration
 		[DllImport (FoundationLib)]
 		static extern NSUncaughtExceptionHandler NSGetUncaughtExceptionHandler ();
 
-		internal static void RegisterUncaughtExceptionHandler ()
+		static void RegisterUncaughtExceptionHandler ()
 		{
 			oldHandler = NSGetUncaughtExceptionHandler ();
 			NSSetUncaughtExceptionHandler (uncaughtHandler);
-		}
-
-		internal static void UnregisterUncaughtExceptionHandler ()
-		{
-			NSSetUncaughtExceptionHandler (oldHandler);
-			oldHandler = null;
 		}
 
 		public override Xwt.Toolkit LoadNativeToolkit ()

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -235,6 +235,55 @@ namespace MonoDevelop.MacIntegration
 			}
 		}
 
+		const string FoundationLib = "/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation";
+
+		delegate void NSUncaughtExceptionHandler (IntPtr exception);
+
+		static readonly NSUncaughtExceptionHandler uncaughtHandler = HandleUncaughtException;
+		static NSUncaughtExceptionHandler oldHandler;
+
+		static void HandleUncaughtException(IntPtr exceptionPtr)
+		{
+			// It's non-null guaranteed by objc.
+			Debug.Assert (exceptionPtr != IntPtr.Zero);
+
+			var nsException = ObjCRuntime.Runtime.GetNSObject<NSException> (exceptionPtr);
+			var exception = new MarshalledObjCException (nsException, new StackTrace(true).ToString ());
+			LoggingService.LogInternalError (exception.Message, exception);
+
+			oldHandler?.Invoke (exceptionPtr);
+		}
+
+		class MarshalledObjCException : ObjCException
+		{
+			readonly string stacktrace;
+
+			public MarshalledObjCException (NSException exception, string stacktrace) : base (exception)
+			{
+				this.stacktrace = stacktrace;
+			}
+
+			public override string StackTrace => stacktrace;
+		}
+
+		[DllImport (FoundationLib)]
+		static extern void NSSetUncaughtExceptionHandler (NSUncaughtExceptionHandler handler);
+
+		[DllImport (FoundationLib)]
+		static extern NSUncaughtExceptionHandler NSGetUncaughtExceptionHandler ();
+
+		internal static void RegisterUncaughtExceptionHandler ()
+		{
+			oldHandler = NSGetUncaughtExceptionHandler ();
+			NSSetUncaughtExceptionHandler (uncaughtHandler);
+		}
+
+		internal static void UnregisterUncaughtExceptionHandler ()
+		{
+			NSSetUncaughtExceptionHandler (oldHandler);
+			oldHandler = null;
+		}
+
 		public override Xwt.Toolkit LoadNativeToolkit ()
 		{
 			var path = Path.GetDirectoryName (GetType ().Assembly.Location);
@@ -247,6 +296,7 @@ namespace MonoDevelop.MacIntegration
 			loaded.RegisterBackend<Xwt.Backends.IWindowBackend, ThemedMacWindowBackend> ();
 			loaded.RegisterBackend<Xwt.Backends.IAlertDialogBackend, ThemedMacAlertDialogBackend> ();
 
+			RegisterUncaughtExceptionHandler ();
 
 			// We require Xwt.Mac to initialize MonoMac before we can execute any code using MonoMac
 			timer.Trace ("Installing App Event Handlers");

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -249,7 +249,7 @@ namespace MonoDevelop.MacIntegration
 
 			var nsException = ObjCRuntime.Runtime.GetNSObject<NSException> (exceptionPtr);
 			var exception = new MarshalledObjCException (nsException, new StackTrace(true).ToString ());
-			LoggingService.LogInternalError (exception.Message, exception);
+			LoggingService.LogInternalError ("Unhandled ObjC exception", exception);
 
 			oldHandler?.Invoke (exceptionPtr);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs
@@ -270,7 +270,11 @@ namespace MonoDevelop.Ide.Gui
 			case LogLevelFlags.Error:
 			case LogLevelFlags.Critical:
 			default:
-				LoggingService.LogInternalError (new CriticalGtkException (message, stackTraceString));
+				var exception = new CriticalGtkException (message, stackTraceString);
+				if (logLevel.HasFlag (LogLevelFlags.FlagFatal))
+					LoggingService.LogFatalError ("Fatal GLib error", exception);
+				else
+					LoggingService.LogInternalError ("Critical GLib error", exception);
 				break;
 			}
 			

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs
@@ -239,7 +239,8 @@ namespace MonoDevelop.Ide.Gui
 				return;
 
 			string logDomain = GLib.Marshaller.Utf8PtrToString (logDomainPtr);
-			string message, extra = string.Empty;
+			string message;
+
 			try {
 				// Marshal message manually, because the text can contain invalid UTF-8.
 				// Specifically, with zh_CN, pango fails to render some characters and
@@ -249,11 +250,12 @@ namespace MonoDevelop.Ide.Gui
 				message = GLib.Marshaller.Utf8PtrToString (messagePtr);
 			} catch (Exception e) {
 				message = "Failed to convert message";
-				extra = "\n" + e.ToString ();
+				LoggingService.LogError (message, e);
 			}
-			System.Diagnostics.StackTrace trace = new System.Diagnostics.StackTrace (2, true);
-			string msg = string.Format ("{0}-{1}: {2}\nStack trace: \n{3}{4}", 
-			    logDomain, logLevel, message, trace.ToString (), extra);
+
+			var stackTraceString = new System.Diagnostics.StackTrace (2, true).ToString ();
+
+			string msg = string.Format ("{0}-{1}: {2}", logDomain, logLevel, message);
 
 			switch (logLevel) {
 			case LogLevelFlags.Debug:
@@ -268,13 +270,28 @@ namespace MonoDevelop.Ide.Gui
 			case LogLevelFlags.Error:
 			case LogLevelFlags.Critical:
 			default:
-				LoggingService.LogError (msg);
+				LoggingService.LogInternalError (new CriticalGtkException (message, stackTraceString));
 				break;
 			}
 			
 			RemainingBytes -= msg.Length;
 			if (RemainingBytes < 0)
 				LoggingService.LogError ("Disabling glib logging for the rest of the session");
+		}
+
+		class CriticalGtkException : Exception
+		{
+			readonly string message;
+			readonly string stacktrace;
+
+			public CriticalGtkException(string message, string stacktrace)
+			{
+				this.message = message;
+				this.stacktrace = stacktrace;
+			}
+
+			public override string Message => message;
+			public override string StackTrace => stacktrace;
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
@@ -1,0 +1,69 @@
+//
+// GLibLoggingTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using MonoDevelop.Core;
+using MonoDevelop.Core.LogReporting;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.Gui
+{
+	[TestFixture]
+	public class GLibLoggingTests
+	{
+		[Test]
+		public void ValidateCrashIsSentForGLibExceptions()
+		{
+			var old = GLibLogging.Enabled;
+			var crashReporter = new CapturingCrashReporter ();
+
+			try {
+				GLibLogging.Enabled = true;
+
+				LoggingService.RegisterCrashReporter (crashReporter);
+
+				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Warning, "{0}", "should not be captured");
+				Assert.IsNull (crashReporter.LastException);
+
+				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Critical, "{0}", "critical should be captured");
+				Assert.That (crashReporter.LastException.Message, Contains.Substring ("critical should be captured"));
+			} finally {
+				LoggingService.UnregisterCrashReporter (crashReporter);
+				GLibLogging.Enabled = old;
+			}
+		}
+
+		class CapturingCrashReporter : CrashReporter
+		{
+			public Exception LastException { get; private set; }
+
+			public override void ReportCrash (Exception ex, bool willShutDown, IEnumerable<string> tags)
+			{
+				LastException = ex;
+			}
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
@@ -51,6 +51,8 @@ namespace MonoDevelop.Ide.Gui
 
 				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Critical, "{0}", "critical should be captured");
 				Assert.That (crashReporter.LastException.Message, Contains.Substring ("critical should be captured"));
+
+				// Error will cause the application to exit, so we can't test for that, but it follows the same code as Critical.
 			} finally {
 				LoggingService.UnregisterCrashReporter (crashReporter);
 				GLibLogging.Enabled = old;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="MonoDevelop.Ide.TypeSystem\WorkspaceFilesCacheTests.cs" />
     <Compile Include="MonoDevelop.Ide.FindInFiles\PatternMatcherTests.cs" />
     <Compile Include="MonoDevelop.Ide.Composition\CompositionManagerTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Gui\GLibLoggingTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/UnitTests/CapturingCrashReporter.cs
+++ b/main/tests/UnitTests/CapturingCrashReporter.cs
@@ -1,5 +1,5 @@
 //
-// GLibLoggingTests.cs
+// CapturingCrashReporter.cs
 //
 // Author:
 //       Marius Ungureanu <maungu@microsoft.com>
@@ -25,36 +25,17 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
-using MonoDevelop.Core;
 using MonoDevelop.Core.LogReporting;
-using NUnit.Framework;
-using UnitTests;
 
-namespace MonoDevelop.Ide.Gui
+namespace UnitTests
 {
-	[TestFixture]
-	public class GLibLoggingTests
+	public class CapturingCrashReporter : CrashReporter
 	{
-		[Test]
-		public void ValidateCrashIsSentForGLibExceptions()
+		public Exception LastException { get; private set; }
+
+		public override void ReportCrash (Exception ex, bool willShutDown, IEnumerable<string> tags)
 		{
-			var old = GLibLogging.Enabled;
-			var crashReporter = new CapturingCrashReporter ();
-
-			try {
-				GLibLogging.Enabled = true;
-
-				LoggingService.RegisterCrashReporter (crashReporter);
-
-				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Warning, "{0}", "should not be captured");
-				Assert.IsNull (crashReporter.LastException);
-
-				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Critical, "{0}", "critical should be captured");
-				Assert.That (crashReporter.LastException.Message, Contains.Substring ("critical should be captured"));
-			} finally {
-				LoggingService.UnregisterCrashReporter (crashReporter);
-				GLibLogging.Enabled = old;
-			}
+			LastException = ex;
 		}
 	}
 }

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="TestSingleThreadSynchronizationContext.cs" />
     <Compile Include="ObjectReference.cs" />
     <Compile Include="RequireServiceAttribute.cs" />
+    <Compile Include="CapturingCrashReporter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">


### PR DESCRIPTION
…eptions

Fixes VSTS #890423 - [Telemetry] VS for Mac should log GTK fatal errors to telemetry
Fixes VSTS #867387 - [Telemetry] Objective-C based crashes should log exception information to telemetry

cc @leculver 