### PR TITLE
Cleanup monostub launcher code

### DIFF
--- a/main/build/MacOSX/Info.plist.in
+++ b/main/build/MacOSX/Info.plist.in
@@ -277,8 +277,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>Mono64Bit</key>
-	<true/>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>cs</string>

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -9,9 +9,7 @@ EXTRAS=$(top_srcdir)/../extras
 ARTIFACTS=$(top_srcdir)/../../artifacts
 MD_CONFIGURE=$(top_srcdir)/../scripts/configure.sh
 EXTERNAL=../../external
-MONOSTUB_DEFINES=-DXM_REGISTRAR
 MONOSTUB_STATIC_LINK=$(EXTERNAL)/Xamarin.Mac.registrar.full.a
-EXTERN_C_XM_REGISTRAR_DEFINE=$(shell ./check-xm-extern.sh)
 
 if !RELEASE_BUILDS
 HYBRID_SUSPEND_ABORT=-DHYBRID_SUSPEND_ABORT
@@ -37,10 +35,10 @@ dmg: render.exe app
 	./make-dmg-bundle.sh
 
 monostub.o: monostub.mm $(MONOSTUB_EXTRA_SOURCEFILES)
-	g++ -g $(EXTERN_C_XM_REGISTRAR_DEFINE) $(MONOSTUB_DEFINES) $(HYBRID_SUSPEND_ABORT) -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
+	g++ -g $(HYBRID_SUSPEND_ABORT) -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub-nogui.o: monostub.mm $(MONOSTUB_EXTRA_SOURCEFILES)
-	g++ -g $(EXTERN_C_XM_REGISTRAR_DEFINE) $(MONOSTUB_DEFINES) $(HYBRID_SUSPEND_ABORT) -DNOGUI -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
+	g++ -g $(HYBRID_SUSPEND_ABORT) -DNOGUI -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub: monostub.o $(MONOSTUB_STATIC_LINK)
 	clang++ -g -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -25,6 +25,7 @@ CLEANFILES = render.exe monostub monostub-test
 EXTRA_DIST = dmg-bg.png DS_Store Info.plist.in make-dmg-bundle.sh render.cs
 
 MONOSTUB_EXTRA_SOURCEFILES = monostub-utils.h
+MIN_MACOS_VERSION=10.11
 
 all: monostub monostub-nogui monostub-test
 
@@ -35,23 +36,23 @@ dmg: render.exe app
 	./make-dmg-bundle.sh
 
 monostub.o: monostub.mm $(MONOSTUB_EXTRA_SOURCEFILES)
-	g++ -g $(HYBRID_SUSPEND_ABORT) -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
+	g++ -g $(HYBRID_SUSPEND_ABORT) -c -Wall -mmacosx-version-min=$(MIN_MACOS_VERSION) -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub-nogui.o: monostub.mm $(MONOSTUB_EXTRA_SOURCEFILES)
-	g++ -g $(HYBRID_SUSPEND_ABORT) -DNOGUI -c -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub.mm
+	g++ -g $(HYBRID_SUSPEND_ABORT) -DNOGUI -c -Wall -mmacosx-version-min=$(MIN_MACOS_VERSION) -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub: monostub.o $(MONOSTUB_STATIC_LINK)
-	clang++ -g -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup
+	clang++ -g -Wall -mmacosx-version-min=$(MIN_MACOS_VERSION) -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup
 	mkdir -p ../bin
 	cp $@ ../bin/MonoDevelop
 
 monostub-nogui: monostub-nogui.o $(MONOSTUB_STATIC_LINK)
-	clang++ -g -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup
+	clang++ -g -Wall -mmacosx-version-min=$(MIN_MACOS_VERSION) -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup
 	mkdir -p ../bin
 	cp $@ ../bin/mdtool
 
 monostub-test: monostub-test.m $(MONOSTUB_EXTRA_SOURCEFILES)
-	gcc -g -Wall -mmacosx-version-min=10.10 -m$(MONOSTUB_ARCH) -o $@ monostub-test.m -framework AppKit
+	gcc -g -Wall -mmacosx-version-min=$(MIN_MACOS_VERSION) -m$(MONOSTUB_ARCH) -o $@ monostub-test.m -framework AppKit
 	./monostub-test
 
 clean-local:

--- a/main/build/MacOSX/check-xm-extern.sh
+++ b/main/build/MacOSX/check-xm-extern.sh
@@ -1,6 +1,0 @@
-#/usr/bin/env bash
-
-# If we find a symbol that matches `_xamarin_create_classes_Xamarin_Mac` it means we found a non-mangled version of the
-# symbol. The space before the underscore is mandatory, because that's the delimiter that's used by nm between symbol
-# offset and the function name.
-(nm ../../external/Xamarin.Mac.registrar.full.a | grep " _xamarin_create_classes_Xamarin_Mac" >/dev/null) && echo "-DEXTERN_C"

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -11,7 +11,7 @@ void fail(void)
 void check_string_equal(const char *expected, const char *actual)
 {
 	if (strcmp(expected, actual)) {
-		printf("Expected '%s'\nActual   '%s'\n", expected, actual);
+		NSLog(@"Expected '%s'\nActual   '%s'\n", expected, actual);
 		fail();
 	}
 }
@@ -19,17 +19,9 @@ void check_string_equal(const char *expected, const char *actual)
 void check_bool_equal(int expected, int actual)
 {
 	if (expected != actual) {
-		printf("Expected '%d'\nActual   '%d'\n", expected, actual);
+		NSLog(@"Expected '%d'\nActual   '%d'\n", expected, actual);
 		fail();
 	}
-}
-
-void test_mono_lib_path(void)
-{
-	char *expected = "/Library/Frameworks/Mono.framework/Libraries/test";
-	char *actual = MONO_LIB_PATH("test");
-
-	check_string_equal(expected, actual);
 }
 
 void test_check_mono_version(void)
@@ -121,7 +113,7 @@ void check_path_has_components(char *path, const char **components, int count)
 		}
 
 		if (!found) {
-			printf("Expected '%s'\nIn       '%s'", components[i], tofree);
+			NSLog(@"Expected '%s'\nIn       '%s'", components[i], tofree);
 			fail();
 		}
 		free(tofree);
@@ -130,24 +122,28 @@ void check_path_has_components(char *path, const char **components, int count)
 
 void test_update_environment(void)
 {
+	NSString *exeDir = [[[NSBundle mainBundle] executablePath] stringByDeletingLastPathComponent];
+	NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
+
 	const char *path_components[] = {
 		"/Library/Frameworks/Mono.framework/Commands",
-		"./Resources",
-		"./MacOS",
+		[resourcePath UTF8String],
+		[exeDir UTF8String],
 	};
+
 	const char *dyld_components[] = {
+		[exeDir UTF8String],
 		"/usr/local/lib",
 		"/usr/lib",
 		"/Library/Frameworks/Mono.framework/Libraries",
-		"./Resources/lib/monodevelop/bin",
-		"./Resources/lib",
+		[[resourcePath stringByAppendingPathComponent:@"lib/monodevelop/bin"] UTF8String],
 	};
 	const char *pkg_components[] = {
-		"./Resources/lib/pkgconfig",
+		[[resourcePath stringByAppendingPathComponent:@"lib/pkgconfig"] UTF8String],
 		"/Library/Frameworks/Mono.framework/External/pkgconfig",
 	};
 	const char *gac_components[] = {
-		"./Resources",
+		[resourcePath UTF8String],
 	};
 	const char *safe_components[] = {
 		"yes",
@@ -170,7 +166,6 @@ void test_update_environment(void)
 }
 
 void (*tests[])(void) = {
-	test_mono_lib_path,
 	test_check_mono_version,
 	test_push_env,
 	test_update_environment,

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -132,11 +132,11 @@ void test_update_environment(void)
 	};
 
 	const char *dyld_components[] = {
-		[exeDir UTF8String],
 		"/usr/local/lib",
 		"/usr/lib",
 		"/Library/Frameworks/Mono.framework/Libraries",
-		[[resourcePath stringByAppendingPathComponent:@"lib/monodevelop/bin"] UTF8String],
+		[[resourcePath stringByAppendingPathComponent:@"lib"] UTF8String],
+		"."
 	};
 	const char *pkg_components[] = {
 		[[resourcePath stringByAppendingPathComponent:@"lib/pkgconfig"] UTF8String],

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -78,39 +78,6 @@ void test_str_append(void)
 	check_string_equal("asdfasdf", conc);
 }
 
-void test_env2bool(void)
-{
-	typedef struct {
-		bool expected, defaultValue;
-		const char *var, *value;
-	} bool_check;
-
-	bool_check bools[] = {
-		// If variable does not exist, return default.
-		{ TRUE, TRUE, "WILL_NOT_EXIST", NULL },
-		{ FALSE, FALSE, "WILL_NOT_EXIST", NULL },
-
-		// Check that truth-y values are true.
-		{ TRUE, FALSE, "WILL_EXIST", "TRUE" },
-		{ TRUE, FALSE, "WILL_EXIST", "YES" },
-		{ TRUE, FALSE, "WILL_EXIST", "1" },
-
-		// Check that false-y values are false.
-		{ FALSE, TRUE, "WILL_EXIST", "BOGUS" },
-		{ FALSE, TRUE, "WILL_EXIST", "0" },
-	};
-
-	bool_check *current;
-	int i;
-	for (i = 0; i < sizeof(bools) / sizeof(bool_check); ++i) {
-		current = &bools[i];
-		if (current->value)
-			setenv(current->var, current->value, 1);
-
-		check_bool_equal(current->expected, env2bool(current->var, current->defaultValue));
-	}
-}
-
 void test_push_env(void)
 {
 	typedef struct {
@@ -215,7 +182,6 @@ void (*tests[])(void) = {
 	test_mono_lib_path,
 	test_check_mono_version,
 	test_str_append,
-	test_env2bool,
 	test_push_env,
 	test_update_environment,
 };

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -199,8 +199,8 @@ void test_update_environment(void)
 	};
 
 	// Check that we only get updates one time, that's how monostub works.
-	check_bool_equal(TRUE, update_environment(".", true));
-	check_bool_equal(FALSE, update_environment(".", true));
+	check_bool_equal(TRUE, update_environment("."));
+	check_bool_equal(FALSE, update_environment("."));
 
 
 	check_path_has_components(getenv("DYLD_FALLBACK_LIBRARY_PATH"), dyld_components, sizeof(dyld_components) / sizeof(char *));

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -146,7 +146,6 @@ void test_update_environment(void)
 	const char *dyld_components[] = {
 		"/usr/local/lib",
 		"/usr/lib",
-		"/lib",
 		"/Library/Frameworks/Mono.framework/Libraries",
 		"./Resources/lib/monodevelop/bin",
 		"./Resources/lib",
@@ -166,8 +165,8 @@ void test_update_environment(void)
 	};
 
 	// Check that we only get updates one time, that's how monostub works.
-	check_bool_equal(TRUE, update_environment("."));
-	check_bool_equal(FALSE, update_environment("."));
+	check_bool_equal(TRUE, update_environment(@"."));
+	check_bool_equal(FALSE, update_environment(@"."));
 
 
 	check_path_has_components(getenv("DYLD_FALLBACK_LIBRARY_PATH"), dyld_components, sizeof(dyld_components) / sizeof(char *));

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -136,7 +136,7 @@ void test_update_environment(void)
 		"/usr/lib",
 		"/Library/Frameworks/Mono.framework/Libraries",
 		[[resourcePath stringByAppendingPathComponent:@"lib"] UTF8String],
-		"."
+		[exeDir UTF8String],
 	};
 	const char *pkg_components[] = {
 		[[resourcePath stringByAppendingPathComponent:@"lib/pkgconfig"] UTF8String],
@@ -153,8 +153,8 @@ void test_update_environment(void)
 	};
 
 	// Check that we only get updates one time, that's how monostub works.
-	check_bool_equal(TRUE, update_environment(@"."));
-	check_bool_equal(FALSE, update_environment(@"."));
+	check_bool_equal(TRUE, update_environment(exeDir));
+	check_bool_equal(FALSE, update_environment(exeDir));
 
 
 	check_path_has_components(getenv("DYLD_FALLBACK_LIBRARY_PATH"), dyld_components, sizeof(dyld_components) / sizeof(char *));

--- a/main/build/MacOSX/monostub-test.m
+++ b/main/build/MacOSX/monostub-test.m
@@ -70,14 +70,6 @@ void test_check_mono_version(void)
 	}
 }
 
-void test_str_append(void)
-{
-	char *str = "asdf";
-	char *conc = str_append(str, str);
-
-	check_string_equal("asdfasdf", conc);
-}
-
 void test_push_env(void)
 {
 	typedef struct {
@@ -180,7 +172,6 @@ void test_update_environment(void)
 void (*tests[])(void) = {
 	test_mono_lib_path,
 	test_check_mono_version,
-	test_str_append,
 	test_push_env,
 	test_update_environment,
 };

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -215,7 +215,7 @@ replace_env (const char *variable, const char *value)
 }
 
 static bool
-update_environment (const char *contentsDir, bool need64Bit)
+update_environment (const char *contentsDir)
 {
 	bool updated = NO;
 	char *value;
@@ -274,11 +274,8 @@ update_environment (const char *contentsDir, bool need64Bit)
 	if (push_env_to_end ("PATH", "~/.dotnet/tools"))
 		updated = YES;
 
-	if (need64Bit) {
-		if (push_env_to_start ("MONODEVELOP_64BIT_SAFE", "yes")) {
-			updated = YES;
-		}
-	}
+	if (push_env_to_start ("MONODEVELOP_64BIT_SAFE", "yes"))
+		updated = YES;
 
 	if (replace_env ("LC_NUMERIC", "C"))
 		updated = YES;

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -47,7 +47,7 @@ xcode_get_dev_path ()
 	];
 
 	return xcode_link ? xcode_link : @"/Applications/Xcode.app/Contents/Developer";
-}
+return xcode_link ?: @"/Applications/Xcode.app/Contents/Developer"
 
 static NSArray<NSString *> *
 generate_fallback_paths (NSString *binDir)

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -52,12 +52,12 @@ xcode_get_dev_path ()
 static NSArray<NSString *> *
 generate_fallback_paths (NSString *binDir)
 {
-	NSString *resource_path = [[NSBundle mainBundle] resourcePath];
+	NSString *lib_path = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"lib"];
 
 	return @[
-		[[[NSBundle mainBundle] executablePath] stringByDeletingLastPathComponent],
-		/* Inject our Resources/lib dir */
-		[resource_path stringByAppendingPathComponent:@"lib/monodevelop/bin"],
+		/* Inject our Resources/lib and bin dirs dir */
+		binDir,
+		lib_path,
 		/* Add Xcode's CommandLineTools dev lib dir before Xcode's Developer dir */
 		@"/Library/Developer/CommandLineTools/usr/lib",
 		/* Add Xcode's dev lib dir into the DYLD_FALLBACK_LIBRARY_PATH */

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -46,8 +46,8 @@ xcode_get_dev_path ()
 		error:nil
 	];
 
-	return xcode_link ? xcode_link : @"/Applications/Xcode.app/Contents/Developer";
-return xcode_link ?: @"/Applications/Xcode.app/Contents/Developer"
+	return xcode_link ?: @"/Applications/Xcode.app/Contents/Developer";
+}
 
 static NSArray<NSString *> *
 generate_fallback_paths (NSString *binDir)

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -15,7 +15,7 @@ check_mono_version (const char *version, const char *req_version)
 	while (*req_version && *version) {
 		req_val = strtol (req_version, &req_end, 10);
 		if (req_version == req_end || (*req_end && *req_end != '.')) {
-			fprintf (stderr, "Bad version requirement string '%s'\n", req_end);
+			NSLog (@"Bad version requirement string '%s'", req_end);
 			return FALSE;
 		}
 

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -115,34 +115,6 @@ generate_fallback_path (const char *contentsDir)
 }
 
 static bool
-env2bool (const char *env, bool defaultValue)
-{
-	const char *value;
-	bool nz = NO;
-	int i;
-	
-	if (!(value = getenv (env)))
-		return defaultValue;
-	
-	if (!strcasecmp (value, "true"))
-		return YES;
-	
-	if (!strcasecmp (value, "yes"))
-		return YES;
-	
-	/* check to see if the value is numeric. All numeric values evaluate to true *except* zero */
-	for (i = 0; value[i]; i++) {
-		if (!isdigit ((int) ((unsigned char) value[i])))
-			return NO;
-		
-		if (value[i] != '0')
-			nz = YES;
-	}
-	
-	return nz;
-}
-
-static bool
 push_env (const char *variable, const char *value, BOOL push_to_end)
 {
 	const char *current;

--- a/main/build/MacOSX/monostub-utils.h
+++ b/main/build/MacOSX/monostub-utils.h
@@ -246,7 +246,7 @@ update_environment (const char *contentsDir)
 	if (push_env_to_end ("PATH", "~/.dotnet/tools"))
 		updated = YES;
 
-	if (push_env_to_start ("MONODEVELOP_64BIT_SAFE", "yes"))
+	if (replace_env ("MONODEVELOP_64BIT_SAFE", "yes"))
 		updated = YES;
 
 	if (replace_env ("LC_NUMERIC", "C"))

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -38,14 +38,6 @@ extern
 void xamarin_create_classes ();
 #endif
 
-void *libmono;
-#if defined(XM_REGISTRAR) || defined(STATIC_REGISTRAR)
-void *libxammac;
-#if STATIC_REGISTRAR
-void *libvsmregistrar;
-#endif
-#endif
-
 #if NOGUI
 static void
 show_alert (NSString *msg, NSString *appName, NSString *mono_download_url)
@@ -359,12 +351,10 @@ int main (int argc, char **argv)
   NSString *exePath;
   char **extra_argv;
   int extra_argc;
-#if USE_SIMPLE_PATH
-  exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: SIMPLE_PATH];
-#else
   NSString *exeName;
 	const char *basename;
 	struct rlimit limit;
+	void *libmono;
 
 	if (!(basename = strrchr (argv[0], '/')))
 		basename = argv[0];
@@ -388,7 +378,6 @@ int main (int argc, char **argv)
 
 	exeName = [NSString stringWithFormat:@"%s.exe", basename];
 	exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: exeName];
-#endif
 
 	// allow the MONODEVELOP_USE_SGEN environment variable to override the plist value
 	use_sgen = env2bool ("MONODEVELOP_USE_SGEN", use_sgen);
@@ -402,7 +391,7 @@ int main (int argc, char **argv)
 	}
 
 #if defined(XM_REGISTRAR) || defined(STATIC_REGISTRAR)
-	libxammac = dlopen ("@loader_path/libxammac.dylib", RTLD_LAZY);
+	void *libxammac = dlopen ("@loader_path/libxammac.dylib", RTLD_LAZY);
 	if (!libxammac) {
 		libxammac = dlopen ("@loader_path/../Resources/lib/monodevelop/bin/libxammac.dylib", RTLD_LAZY);
 		if (!libxammac) {
@@ -415,7 +404,7 @@ int main (int argc, char **argv)
 #if STATIC_REGISTRAR
 	char *registrar_toggle = getenv("MD_DISABLE_STATIC_REGISTRAR");
 	if (!registrar_toggle) {
-		libvsmregistrar = dlopen ("@loader_path/libvsmregistrar.dylib", RTLD_LAZY);
+		void *libvsmregistrar = dlopen ("@loader_path/libvsmregistrar.dylib", RTLD_LAZY);
 		if (!libvsmregistrar) {
 			libvsmregistrar = dlopen ("@loader_path/../Resources/lib/monodevelop/bin/libvsmregistrar.dylib", RTLD_LAZY);
 		}

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -53,10 +53,7 @@ show_alert (NSString *msg, NSString *appName, NSString *mono_download_url)
 	[alert release];
 
 	if (answer == NSAlertFirstButtonReturn) {
-		NSString *mono_download_url = @"https://go.microsoft.com/fwlink/?linkid=835346";
-		CFURLRef url = CFURLCreateWithString (NULL, (CFStringRef) mono_download_url, NULL);
-		LSOpenCFURLRef (url, NULL);
-		CFRelease (url);
+		[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:mono_download_url]];
 	}
 }
 #endif
@@ -64,13 +61,10 @@ show_alert (NSString *msg, NSString *appName, NSString *mono_download_url)
 static void
 exit_with_message (NSString *reason, NSString *entryExecutableName)
 {
-	NSString *appName = nil;
+	NSString *appName = entryExecutableName;
 	NSDictionary *plist = [[NSBundle mainBundle] infoDictionary];
 	if (plist) {
 		appName = (NSString *) [plist objectForKey:(NSString *)kCFBundleNameKey];
-	}
-	if (!appName) {
-		appName = entryExecutableName;
 	}
 
 	NSString *fmt = @"%@\n\nPlease download and install the latest version of Mono.";

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -129,7 +129,8 @@ run_md_bundle (NSString *bundleId, NSArray<NSString *> *arguments)
 	}
 
 	NSError *error = nil;
-	mdApp = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:bundleURL options:NSWorkspaceLaunchAsync configuration:[NSDictionary dictionaryWithObject:arguments forKey:NSWorkspaceLaunchConfigurationArguments] error:&error];
+	NSDictionary<NSWorkspaceLaunchConfigurationKey, id> *configuration = [NSDictionary dictionaryWithObject:arguments forKey:NSWorkspaceLaunchConfigurationArguments];
+	mdApp = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:bundleURL options:NSWorkspaceLaunchAsync configuration: configuration error:&error];
 
 	if (mdApp == nil)
 	{
@@ -182,7 +183,7 @@ run_md_bundle_if_needed(int argc, char **argv)
 	// if we are running inside an app bundle and --start-app-bundle has been passed
 	// run the actual bundle and exit.
 	if (bundleId && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
-		NSArray<NSString *> *arguments = [NSArray<NSString *> array];
+		NSArray<NSString *> *arguments = [NSArray array];
 		if (argc > 2) {
 			int new_argc = argc - 2;
 			NSMutableArray<NSString *> *array = [NSMutableArray arrayWithCapacity:new_argc];

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -219,12 +219,12 @@ should_load_xammac_registrar(const char *app_name)
 
 #if XM_FULL_STATIC_REGISTRAR
 	char *registrar_toggle = getenv("MD_DISABLE_STATIC_REGISTRAR");
-	void *libvsmregistrar = nil;
+	void *libvsmregistrar = NULL;
 	if (!registrar_toggle) {
 		LOAD_DYLIB(libvsmregistrar);
 	}
 
-	return libvsmregistrar != nil;
+	return libvsmregistrar != NULL;
 #else
 	return true;
 #endif

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -228,10 +228,9 @@ should_load_xammac_registrar(NSString *app_name)
 #endif
 }
 
-int main (int argc, char **argv)
+int monodevelop_main (int argc, char **argv)
 {
 	//clock_t start = clock();
-	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	NSString *binDir = [[NSString alloc] initWithUTF8String: "Contents/Resources/lib/monodevelop/bin"];
 
 	// Check if we are running inside an actual app bundle. If we are not, then assume we're being run
@@ -269,7 +268,6 @@ int main (int argc, char **argv)
 
 	if (update_environment ([[appDir stringByAppendingPathComponent:@"Contents"] UTF8String])) {
 		//printf ("Updated the environment.\n");
-		[pool drain];
 
 		return execv (argv[0], argv);
 	}
@@ -331,11 +329,17 @@ int main (int argc, char **argv)
 	for (int i = 1; i < argc; i++)
 		new_argv[n++] = argv[i];
 
-	[pool drain];
 
 	//clock_t end = clock();
 	//printf("%f seconds to start\n", (float)(end - start) / CLOCKS_PER_SEC);
 
 	return _mono_main (new_argc, new_argv);
+}
+
+int main (int argc, char **argv)
+{
+	@autoreleasepool {
+		return monodevelop_main (argc, argv);
+	}
 }
 

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -268,7 +268,7 @@ main (int argc, char **argv)
 		setenv ("MONO_THREADS_SUSPEND", "preemptive", 0);
 
 
-		if (update_environment ([[appDir stringByAppendingPathComponent:@"Contents"] UTF8String])) {
+		if (update_environment ([appDir stringByAppendingPathComponent:@"Contents"])) {
 			//printf ("Updated the environment.\n");
 
 			return execv (argv[0], argv);

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -22,19 +22,16 @@ typedef void (* gobject_tracker_init) (void *libmono);
 
 #include "monostub-utils.h"
 
-#if XM_REGISTRAR
-# define XAMARIN_CREATE_CLASSES xamarin_create_classes_Xamarin_Mac
-#elif STATIC_REGISTRAR
+#if STATIC_REGISTRAR
+// We have full static registrar enabled.
+# define XM_FULL_STATIC_REGISTRAR
 # define XAMARIN_CREATE_CLASSES xamarin_create_classes
-#endif
-
-#if EXTERN_C
-# define EXTERNAL_API extern "C"
 #else
-# define EXTERNAL_API extern
+// This means we only have xammac's framework registrar
+# define XAMARIN_CREATE_CLASSES xamarin_create_classes_Xamarin_Mac
 #endif
 
-EXTERNAL_API void XAMARIN_CREATE_CLASSES ();
+extern "C" void XAMARIN_CREATE_CLASSES ();
 
 #if NOGUI
 static void

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -218,7 +218,6 @@ load_xammac()
 	}
 
 	if (should_load_xammac_registrar()) {
-		NSLog (@"loading vsmregistrar");
 		XAMARIN_CREATE_CLASSES ();
 	}
 }

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -171,7 +171,7 @@ try_load_gobject_tracker (void *libmono)
 		return;
 
 	_gobject_tracker_init (libmono);
-	printf ("Loaded gobject tracker\n");
+	NSLog (@"Loaded gobject tracker\n");
 }
 
 static void
@@ -233,12 +233,13 @@ main (int argc, char **argv)
 		//clock_t start = clock();
 		// Check if we are running inside an actual app bundle. If we are not, then assume we're being run
 		// as part of `make run` and then binDir should be '.'
-		NSString *entryExecutable = [NSString stringWithUTF8String: argv[0]];
-		appName = [entryExecutable lastPathComponent];
-		NSString *binDirFullPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"lib/monodevelop/bin"];
+		appName = [[NSProcessInfo processInfo] processName];
+
+		NSBundle *mainBundle = [NSBundle mainBundle];
+		NSString *binDirFullPath = [[mainBundle resourcePath] stringByAppendingPathComponent:@"lib/monodevelop/bin"];
 		BOOL isDir = NO;
 		if (![[NSFileManager defaultManager] fileExistsAtPath: binDirFullPath isDirectory: &isDir] || !isDir)
-			binDirFullPath = [entryExecutable stringByDeletingLastPathComponent];
+			binDirFullPath = [[mainBundle executablePath] stringByDeletingLastPathComponent];
 
 		run_md_bundle_if_needed(argc, argv);
 
@@ -260,7 +261,7 @@ main (int argc, char **argv)
 		// can be overridden with plist string MonoMinVersion
 		NSString *req_mono_version = @"5.18.1.24";
 
-		NSDictionary *plist = [[NSBundle mainBundle] infoDictionary];
+		NSDictionary *plist = [mainBundle infoDictionary];
 		if (plist) {
 			NSString *version_obj = [plist objectForKey:@"MonoMinVersion"];
 			if (version_obj && [version_obj length] > 0)

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -24,7 +24,7 @@ typedef void (* gobject_tracker_init) (void *libmono);
 
 #if STATIC_REGISTRAR
 // We have full static registrar enabled.
-# define XM_FULL_STATIC_REGISTRAR
+# define XM_FULL_STATIC_REGISTRAR 1
 # define XAMARIN_CREATE_CLASSES xamarin_create_classes
 #else
 // This means we only have xammac's framework registrar

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -105,13 +105,13 @@ get_mono_env_options (int *ref_argc, char **ref_argv [], void *libmono)
 }
 
 static void
-run_md_bundle (NSString *bundleId, NSArray *arguments)
+run_md_bundle (NSString *bundleId, NSArray<NSString *> *arguments)
 {
 	NSURL *bundleURL = [[NSBundle mainBundle] bundleURL];
 	int myPID = [[NSProcessInfo processInfo] processIdentifier];
 	NSRunningApplication *mdApp = nil;
 
-	NSArray *runningApplications = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
+	NSArray<NSRunningApplication *> *runningApplications = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
 	for (NSRunningApplication *app in runningApplications) {
 		if ([[[app bundleURL] path] isEqual:[bundleURL path]] && myPID != [app processIdentifier])
 		{
@@ -182,10 +182,10 @@ run_md_bundle_if_needed(int argc, char **argv)
 	// if we are running inside an app bundle and --start-app-bundle has been passed
 	// run the actual bundle and exit.
 	if (bundleId && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
-		NSArray *arguments = [NSArray array];
+		NSArray<NSString *> *arguments = [NSArray<NSString *> array];
 		if (argc > 2) {
 			int new_argc = argc - 2;
-			NSMutableArray *array = [NSMutableArray arrayWithCapacity:new_argc];
+			NSMutableArray<NSString *> *array = [NSMutableArray arrayWithCapacity:new_argc];
 			for (int i = 2; i < new_argc; i++)
 				[array addObject:[NSString stringWithUTF8String:argv[i]]];
 			arguments = array;

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -38,16 +38,16 @@ extern "C" void XAMARIN_CREATE_CLASSES ();
 
 #if NOGUI
 static void
-show_alert (NSString *msg, NSString *bundle_name, NSString *mono_download_url)
+show_alert (NSString *msg, NSString *mono_download_url)
 {
-	NSLog (@"Could not launch: %@\n%@\n%@", bundle_name, msg, mono_download_url);
+	NSLog (@"Could not launch: %@\n%@\n%@", appName, msg, mono_download_url);
 }
 #else
 static void
-show_alert (NSString *msg, NSString *bundle_name, NSString *mono_download_url)
+show_alert (NSString *msg, NSString *mono_download_url)
 {
 	NSAlert *alert = [[NSAlert alloc] init];
-	[alert setMessageText:[NSString stringWithFormat:@"Could not launch %@", bundle_name]];
+	[alert setMessageText:[NSString stringWithFormat:@"Could not launch %@", appName]];
 	[alert setInformativeText:msg];
 	[alert addButtonWithTitle:@"Download Mono Framework"];
 	[alert addButtonWithTitle:@"Cancel"];
@@ -63,17 +63,16 @@ show_alert (NSString *msg, NSString *bundle_name, NSString *mono_download_url)
 static void
 exit_with_message (NSString *reason)
 {
-	NSString *entryExecutableName = appName;
 	NSDictionary *plist = [[NSBundle mainBundle] infoDictionary];
 	if (plist) {
-		entryExecutableName = (NSString *) [plist objectForKey:(NSString *)kCFBundleNameKey];
+		appName = (NSString *) [plist objectForKey:(NSString *)kCFBundleNameKey];
 	}
 
 	NSString *fmt = @"%@\n\nPlease download and install the latest version of Mono.";
 	NSString *msg = [NSString stringWithFormat:fmt, reason];
 	NSString *mono_download_url = @"https://go.microsoft.com/fwlink/?linkid=835346";
 
-	show_alert(msg, entryExecutableName, mono_download_url);
+	show_alert(msg, mono_download_url);
 	exit (1);
 }
 

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -105,13 +105,13 @@ get_mono_env_options (int *ref_argc, char **ref_argv [], void *libmono)
 }
 
 static void
-run_md_bundle (NSArray *arguments)
+run_md_bundle (NSString *bundleId, NSArray *arguments)
 {
 	NSURL *bundleURL = [[NSBundle mainBundle] bundleURL];
 	int myPID = [[NSProcessInfo processInfo] processIdentifier];
 	NSRunningApplication *mdApp = nil;
 
-	NSArray *runningApplications = [[NSWorkspace sharedWorkspace] runningApplications];
+	NSArray *runningApplications = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleId];
 	for (NSRunningApplication *app in runningApplications) {
 		if ([[[app bundleURL] path] isEqual:[bundleURL path]] && myPID != [app processIdentifier])
 		{
@@ -177,11 +177,11 @@ try_load_gobject_tracker (void *libmono)
 static void
 run_md_bundle_if_needed(int argc, char **argv)
 {
-	NSString *appDir = [[NSBundle mainBundle] bundlePath];
+	NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
 
 	// if we are running inside an app bundle and --start-app-bundle has been passed
 	// run the actual bundle and exit.
-	if (![appDir isEqualToString:@"."] && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
+	if (bundleId && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
 		NSArray *arguments = [NSArray array];
 		if (argc > 2) {
 			int new_argc = argc - 2;
@@ -190,7 +190,7 @@ run_md_bundle_if_needed(int argc, char **argv)
 				[array addObject:[NSString stringWithUTF8String:argv[i]]];
 			arguments = array;
 		}
-		run_md_bundle (arguments);
+		run_md_bundle (bundleId, arguments);
 	}
 }
 

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -382,10 +382,10 @@ int main (int argc, char **argv)
 	// To be removed: https://github.com/mono/monodevelop/issues/6326
 	setenv ("MONO_THREADS_SUSPEND", "preemptive", 0);
 
-  NSString *exePath;
-  char **extra_argv;
-  int extra_argc;
-  NSString *exeName;
+	NSString *exePath;
+	char **extra_argv;
+	int extra_argc;
+	NSString *exeName;
 	const char *basename;
 	struct rlimit limit;
 	void *libmono;

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -316,11 +316,11 @@ int monodevelop_main (int argc, char **argv)
 	get_mono_env_options (&mono_argc, &mono_argv, libmono, entryExecutableName);
 
 	// append original arguments
-	int new_argc = mono_argc + argc;
+	int new_argc = mono_argc + argc + 1;
 	char **new_argv = (char **) malloc (sizeof (char *) * new_argc);
 	int n = 0;
 
-	new_argv[0] = argv[0];
+	new_argv[n++] = argv[0];
 	for (int i = 0; i < mono_argc; i++)
 		new_argv[n++] = mono_argv[i];
 

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -234,7 +234,6 @@ main (int argc, char **argv)
 {
 	int new_argc;
 	char **new_argv;
-	void *libmono;
 	mono_main _mono_main;
 
 	@autoreleasepool {
@@ -292,7 +291,7 @@ main (int argc, char **argv)
 		NSString *exeName = [NSString stringWithFormat:@"%@.exe", entryExecutableName];
 		NSString *exePath = [[appDir stringByAppendingPathComponent: binDir] stringByAppendingPathComponent: exeName];
 
-		libmono = dlopen (MONO_LIB_PATH ("libmonosgen-2.0.dylib"), RTLD_LAZY);
+		void *libmono = dlopen (MONO_LIB_PATH ("libmonosgen-2.0.dylib"), RTLD_LAZY);
 
 		if (libmono == NULL) {
 			NSLog (@"Failed to load libmonosgen-2.0.dylib: %s", dlerror ());

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -171,14 +171,15 @@ try_load_gobject_tracker (void *libmono, NSString *entryExecutable)
 	NSString *binDir = [entryExecutable stringByDeletingLastPathComponent];
 	NSString *libgobjectPath = [binDir stringByAppendingPathComponent: @"libgobject-tracker.dylib"];
 	gobject_tracker = dlopen ((char *)[libgobjectPath UTF8String], RTLD_GLOBAL);
-	if (gobject_tracker) {
-		gobject_tracker_init _gobject_tracker_init = (gobject_tracker_init) dlsym (gobject_tracker, "gobject_tracker_init");
-		if (_gobject_tracker_init) {
-			_gobject_tracker_init (libmono);
-			printf ("Loaded gobject tracker\n");
-			return;
-		}
-	}
+	if (!gobject_tracker)
+		return;
+
+	gobject_tracker_init _gobject_tracker_init = (gobject_tracker_init) dlsym (gobject_tracker, "gobject_tracker_init");
+	if (!_gobject_tracker_init)
+		return;
+
+	_gobject_tracker_init (libmono);
+	printf ("Loaded gobject tracker\n");
 }
 
 static void
@@ -189,10 +190,11 @@ run_md_bundle_if_needed(NSString *appDir, int argc, char **argv)
 	if (![appDir isEqualToString:@"."] && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
 		NSArray *arguments = [NSArray array];
 		if (argc > 2) {
-			NSString *strings[argc-2];
-			for (int i = 0; i < argc-2; i++)
+			int new_argc = argc - 2;
+			NSString *strings[new_argc];
+			for (int i = 0; i < new_argc; i++)
 				strings [i] = [NSString stringWithUTF8String:argv[i+2]];
-			arguments = [NSArray arrayWithObjects:strings count:argc-2];
+			arguments = [NSArray arrayWithObjects:strings count:new_argc];
 		}
 		run_md_bundle (appDir, arguments);
 	}

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -40,6 +40,7 @@ EXTERNAL_API void XAMARIN_CREATE_CLASSES ();
 static void
 show_alert (NSString *msg, NSString *appName, NSString *mono_download_url)
 {
+	fprintf(stderr, "Could not launch: %s\n", [appName UTF8String]);
 	fprintf(stderr, "%s\n", [msg UTF8String]);
 	fprintf(stderr, "%s\n", [mono_download_url UTF8String]);
 }

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -184,18 +184,18 @@ try_load_gobject_tracker (void *libmono, NSString *entryExecutable)
 static void
 run_md_bundle_if_needed(NSString *appDir, int argc, char **argv)
 {
-    // if we are running inside an app bundle and --start-app-bundle has been passed
-    // run the actual bundle and exit.
-    if (![appDir isEqualToString:@"."] && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
-        NSArray *arguments = [NSArray array];
-        if (argc > 2) {
-            NSString *strings[argc-2];
-            for (int i = 0; i < argc-2; i++)
-                strings [i] = [NSString stringWithUTF8String:argv[i+2]];
-            arguments = [NSArray arrayWithObjects:strings count:argc-2];
-        }
-        run_md_bundle (appDir, arguments);
-    }
+	// if we are running inside an app bundle and --start-app-bundle has been passed
+	// run the actual bundle and exit.
+	if (![appDir isEqualToString:@"."] && argc > 1 && !strcmp(argv[1], "--start-app-bundle")) {
+		NSArray *arguments = [NSArray array];
+		if (argc > 2) {
+			NSString *strings[argc-2];
+			for (int i = 0; i < argc-2; i++)
+				strings [i] = [NSString stringWithUTF8String:argv[i+2]];
+			arguments = [NSArray arrayWithObjects:strings count:argc-2];
+		}
+		run_md_bundle (appDir, arguments);
+	}
 }
 
 #define LOAD_DYLIB(name) \

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -237,11 +237,10 @@ main (int argc, char **argv)
 		// as part of `make run` and then binDir should be '.'
 		NSString *entryExecutable = [NSString stringWithUTF8String: argv[0]];
 		appName = [entryExecutable lastPathComponent];
-		NSString *entryExecutableDir = [entryExecutable stringByDeletingLastPathComponent];
 		NSString *binDirFullPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"lib/monodevelop/bin"];
 		BOOL isDir = NO;
 		if (![[NSFileManager defaultManager] fileExistsAtPath: binDirFullPath isDirectory: &isDir] || !isDir)
-			binDirFullPath = entryExecutableDir;
+			binDirFullPath = [entryExecutable stringByDeletingLastPathComponent];
 
 		run_md_bundle_if_needed(argc, argv);
 

--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -37,9 +37,7 @@ extern "C" void XAMARIN_CREATE_CLASSES ();
 static void
 show_alert (NSString *msg, NSString *appName, NSString *mono_download_url)
 {
-	fprintf(stderr, "Could not launch: %s\n", [appName UTF8String]);
-	fprintf(stderr, "%s\n", [msg UTF8String]);
-	fprintf(stderr, "%s\n", [mono_download_url UTF8String]);
+	NSLog (@"Could not launch: %@\n%@\n%@", appName, msg, mono_download_url);
 }
 #else
 static void
@@ -87,7 +85,7 @@ load_symbol(const char *symbol_type, void *lib, const char *framework_name, NSSt
 {
 	void *symbol = dlsym (lib, symbol_type);
 	if (!symbol) {
-		fprintf (stderr, "Could not load %s(): %s\n", symbol_type, dlerror ());
+		NSLog (@"Could not load %s(): %s", symbol_type, dlerror ());
 		NSString *msg = [NSString stringWithFormat:@"Failed to load the %s framework.", framework_name];
 		exit_with_message (msg, app_name);
 	}
@@ -105,8 +103,9 @@ get_mono_env_options (int *ref_argc, char **ref_argv [], void *libmono, NSString
 	mono_parse_options_from _mono_parse_options_from = LOAD_MONO_SYMBOL(mono_parse_options_from, libmono, app_name);
 
 	char *ret = _mono_parse_options_from (env, ref_argc, ref_argv);
-	if (ret)
-		fprintf(stderr, "%s", ret);
+	if (ret) {
+		exit_with_message ([NSString stringWithUTF8String:ret], app_name);
+	}
 }
 
 static void
@@ -211,7 +210,7 @@ should_load_xammac_registrar(NSString *app_name)
 
 	LOAD_DYLIB(libxammac);
 	if (!libxammac) {
-		fprintf (stderr, "Failed to load libxammac.dylib: %s\n", dlerror ());
+		NSLog (@"Failed to load libxammac.dylib: %s", dlerror ());
 		NSString *msg = @"This application requires Xamarin.Mac native library side-by-side.";
 		exit_with_message (msg, app_name);
 	}
@@ -295,7 +294,7 @@ main (int argc, char **argv)
 		libmono = dlopen (MONO_LIB_PATH ("libmonosgen-2.0.dylib"), RTLD_LAZY);
 
 		if (libmono == NULL) {
-			fprintf (stderr, "Failed to load libmonosgen-2.0.dylib: %s\n", dlerror ());
+			NSLog (@"Failed to load libmonosgen-2.0.dylib: %s", dlerror ());
 			NSString *msg = [NSString stringWithFormat:@"This application requires Mono %@ or newer.", req_mono_version];
 			exit_with_message (msg, entryExecutableName);
 		}


### PR DESCRIPTION
* Removes a lot of `char *` <-> `NSString` conversions
* Reduces code duplication
* Removes unused defines
* Removes code which could simply invoke mono API