### PR TITLE
[Ide] Handle NuGet restore cancelled whilst type system frozen

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -183,7 +183,7 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			async Task<ProjectCacheInfo> LoadProjectCacheInfo (MonoDevelop.Projects.Project p, DotNetProjectConfiguration config, CancellationToken token)
 			{
-				await TypeSystemService.FreezeLoad ().ConfigureAwait (false);
+				await TypeSystemService.SafeFreezeLoad ().ConfigureAwait (false);
 				if (token.IsCancellationRequested)
 					return null;
 
@@ -191,12 +191,12 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (token.IsCancellationRequested)
 					return null;
 
-				await TypeSystemService.FreezeLoad ().ConfigureAwait (false);
+				await TypeSystemService.SafeFreezeLoad ().ConfigureAwait (false);
 				var sourceFiles = await p.GetSourceFilesAsync (config?.Selector).ConfigureAwait (false);
 				if (token.IsCancellationRequested)
 					return null;
 
-				await TypeSystemService.FreezeLoad ().ConfigureAwait (false);
+				await TypeSystemService.SafeFreezeLoad ().ConfigureAwait (false);
 				var analyzerFiles = await p.GetAnalyzerFilesAsync (config?.Selector).ConfigureAwait (false);
 
 				return new ProjectCacheInfo {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -433,7 +433,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 
 			// No cache.
-			await TypeSystemService.FreezeLoad ().ConfigureAwait (false);
+			await TypeSystemService.SafeFreezeLoad ().ConfigureAwait (false);
 			if (cancellationToken.IsCancellationRequested)
 				return (solution, null);
 
@@ -445,7 +445,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			try {
 				var cts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken, src.Token);
 
-				await TypeSystemService.FreezeLoad ().ConfigureAwait (false);
+				await TypeSystemService.SafeFreezeLoad ().ConfigureAwait (false);
 				if (cancellationToken.IsCancellationRequested)
 					return;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -774,6 +774,17 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		public static Func<Task> FreezeLoad = () => Task.CompletedTask;
 
+		internal static async Task SafeFreezeLoad ()
+		{
+			try {
+				await FreezeLoad ();
+			} catch (Exception) {
+				// Ignore exceptions, such as the task being cancelled. We want to freeze the load
+				// whilst the NuGet restore is being run and continue after it has finished, cancelled,
+				// or thrown an exception.
+			}
+		}
+
 		public Task ProcessPendingLoadOperations ()
 		{
 			lock (workspaceLoadLock) {


### PR DESCRIPTION
If a NuGet restore is cancelled then the type system may stop
processing if it is frozen waiting for the restore to finish since a
TaskCanceledException would be thrown.

To avoid this the TypeSystemService.FreezeTask is used inside a
try/catch so any exceptions can be ignored. Whether the NuGet restore
is cancelled or fails should not stop the type system from getting
project information.

Fixes VSTS #891329 - Handle cancelling NuGet restore whilst type
system is waiting for restore