### PR TITLE
[Ide] Generate valid project name from app name

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectConfiguration.cs
@@ -72,12 +72,12 @@ namespace MonoDevelop.Ide.Projects
 
 		public string GetValidProjectName ()
 		{
-			return GetValidDir (ProjectName);
+			return GenerateValidProjectName (ProjectName);
 		}
 
 		public string GetValidSolutionName ()
 		{
-			return GetValidDir (SolutionName);
+			return GenerateValidProjectName (SolutionName);
 		}
 
 		public bool CreateProjectDirectoryInsideSolutionDirectory { get; set; }
@@ -115,7 +115,7 @@ namespace MonoDevelop.Ide.Projects
 			}
 		}
 
-		static string GetValidDir (string name)
+		static string GetValidDir (string name, Func<char, bool> include = null)
 		{
 			name = name.Trim ();
 			var sb = new StringBuilder ();
@@ -124,6 +124,8 @@ namespace MonoDevelop.Ide.Projects
 				if (Array.IndexOf (FilePath.GetInvalidPathChars (), c) != -1)
 					continue;
 				if (c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar || c == Path.VolumeSeparatorChar)
+					continue;
+				if (include != null && !include (c))
 					continue;
 				sb.Append (c);
 			}
@@ -178,8 +180,7 @@ namespace MonoDevelop.Ide.Projects
 
 		public static bool IsValidProjectName (string name)
 		{
-			return IsValidSolutionName (name) &&
-				name.IndexOf (' ') < 0;
+			return IsValidSolutionName (name);
 		}
 
 		public static bool IsValidSolutionName (string name)
@@ -218,8 +219,7 @@ namespace MonoDevelop.Ide.Projects
 
 		public static string GenerateValidProjectName (string name)
 		{
-			string validName = GetValidDir (name);
-			return validName.Replace (" ", String.Empty);
+			return GetValidDir (name, IsValidProjectNameCharacter);
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Templates/FinalProjectConfigurationTests.cs
@@ -353,6 +353,27 @@ namespace MonoDevelop.Ide.Templates
 			AssertPathsAreEqual (@"d:\projects\MySolution\MyProject", config.ProjectLocation);
 			AssertPathsAreEqual (@"d:\projects\MySolution", config.SolutionLocation);
 		}
+
+		[TestCase ("A", "A")]
+		[TestCase ("A B", "AB")]
+		[TestCase ("A/B", "AB")]
+		[TestCase ("A.B", "A.B")]
+		[TestCase ("A-B", "A-B")]
+		[TestCase ("A_B", "A_B")]
+		[TestCase ("A1", "A1")]
+		[TestCase ("A,B", "AB")]
+		public void GenerateValidNames (string name, string generatedName)
+		{
+			CreateProjectConfig (@"d:\projects\MySolution");
+			config.ProjectName = name;
+			config.SolutionName = name;
+			config.CreateProjectDirectoryInsideSolutionDirectory = true;
+			config.CreateSolution = true;
+
+			Assert.AreEqual (generatedName, NewProjectConfiguration.GenerateValidProjectName (name));
+			Assert.AreEqual (generatedName, config.GetValidProjectName ());
+			Assert.AreEqual (generatedName, config.GetValidSolutionName ());
+		}
 	}
 }
 


### PR DESCRIPTION
The New Project dialog has extra rules for the project name and
solution name on the final page of the dialog, such as not allowing
spaces. The generation of a valid project and solution name from the
app name specified in a project template wizard used different logic
so the names shown on the final page may still be considered invalid
on the final page. For example AppName='Hello, Mac' in the Cocoa App
project templates generates a project and solution name of 'Hello,Mac'
which the New Project dialog considers invalid.

To prevent this the same logic is now used when generating a valid
project and solution name from the project template wizard's app name.

Fixes VSTS #825164 - VS4M partially renames the project but it's still
invalid