### PR TITLE
Add better telemetry for failing to start a process

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/RemoteProcessConnection.cs
@@ -1,4 +1,4 @@
-﻿//#define DEBUG_MESSAGES
+//#define DEBUG_MESSAGES
 
 using System;
 using System.Threading;
@@ -13,6 +13,9 @@ namespace MonoDevelop.Core.Execution
 {
 	public class RemoteProcessConnection: IDisposable
 	{
+		const string DisposedMessage = "{0}: Could not start process";
+		const string StreamNullMessage = "{0}: Connection stream unexpectedly null.";
+
 		bool initializationDone;
 		TaskCompletionSource<bool> processConnectedEvent = new TaskCompletionSource<bool> ();
 		ProcessAsyncOperation process;
@@ -231,6 +234,14 @@ namespace MonoDevelop.Core.Execution
 			}
 		}
 
+		string GetCleanExeName()
+		{
+			if (string.IsNullOrWhiteSpace (exePath))
+				return "(null)";
+
+			return Path.GetFileName (exePath);
+		}
+
 		async Task InitializeRemoteProcessAsync (CancellationToken token)
 		{
 			try {
@@ -239,8 +250,8 @@ namespace MonoDevelop.Core.Execution
 				token.ThrowIfCancellationRequested ();
 
 				if (disposed)
-					throw new Exception ("Could not start process");
-				
+					throw new ObjectDisposedException (string.Format (DisposedMessage, GetCleanExeName ()));
+
 				var timeout = Task.Delay (ProcessInitializationTimeout, token).ContinueWith (t => {
 					if (t.IsCanceled)
 						return;
@@ -249,16 +260,19 @@ namespace MonoDevelop.Core.Execution
 
 				await Task.WhenAny (timeout, processConnectedEvent.Task).ConfigureAwait (false);
 
-				if (connectionStream == null || disposed)
-					throw new Exception ("Process failed to start");
+				if (disposed)
+					throw new ObjectDisposedException (string.Format (DisposedMessage, GetCleanExeName ()));
 
-/*				var msg = new BinaryMessage ("Initialize", "Process").AddArgument ("MessageWaitTimeout", PingPeriod * 2);
-				msg.BypassConnection = true;
-				var cs = new TaskCompletionSource<BinaryMessage> ();
-				PostMessage (msg, cs, false);
-				token.ThrowIfCancellationRequested ();
-				await cs.Task;
-*/
+				if (connectionStream == null)
+					throw new InvalidOperationException (string.Format (StreamNullMessage, GetCleanExeName ()));
+
+				/*				var msg = new BinaryMessage ("Initialize", "Process").AddArgument ("MessageWaitTimeout", PingPeriod * 2);
+								msg.BypassConnection = true;
+								var cs = new TaskCompletionSource<BinaryMessage> ();
+								PostMessage (msg, cs, false);
+								token.ThrowIfCancellationRequested ();
+								await cs.Task;
+				*/
 				token.ThrowIfCancellationRequested ();
 
 				SetStatus (ConnectionStatus.Connected, "Connected");


### PR DESCRIPTION
This is a telemetry only change.

We see a few messages in telemetry of:

      ExceptionType: System.Exception
      Message: Could not start process
      StackTrace: (empty)

It would be good to log the reason we fail here (disposed vs unexpected null stream) along with what executable we couldn't start. Note that even though this changes the exception types thrown, these exceptions are immediately caught by the catch (Exception ex) block in DoConnect.