### PR TITLE
[NuGet] Prevent Add Package Source dialog displayed behind preferences

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageSourcesOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageSourcesOptionsPanel.cs
@@ -43,7 +43,14 @@ namespace MonoDevelop.PackageManagement.Gui
 	{
 		RegisteredPackageSourcesViewModel viewModel;
 		PackageSourcesWidget packageSourcesWidget;
+		OptionsDialog parentDialog;
 		bool loadError;
+
+		public override void Initialize (OptionsDialog dialog, object dataObject)
+		{
+			base.Initialize (dialog, dataObject);
+			parentDialog = dialog;
+		}
 
 		public override Control CreatePanelWidget()
 		{
@@ -68,7 +75,7 @@ namespace MonoDevelop.PackageManagement.Gui
 			viewModel = new RegisteredPackageSourcesViewModel (repositoryProvider);
 			viewModel.Load ();
 			
-			packageSourcesWidget = new PackageSourcesWidget (viewModel);
+			packageSourcesWidget = new PackageSourcesWidget (viewModel, parentDialog);
 			return packageSourcesWidget;
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageSourcesWidget.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageSourcesWidget.cs
@@ -16,15 +16,17 @@ namespace MonoDevelop.PackageManagement
 	internal partial class PackageSourcesWidget : Gtk.Bin
 	{
 		RegisteredPackageSourcesViewModel viewModel;
+		Gtk.Dialog parentDialog;
 		ListStore packageSourcesStore;
 		const int IsEnabledCheckBoxColumn = 1;
 		const int PackageSourceIconColumn = 2;
 		const int PackageSourceViewModelColumn = 3;
 		
-		public PackageSourcesWidget (RegisteredPackageSourcesViewModel viewModel)
+		public PackageSourcesWidget (RegisteredPackageSourcesViewModel viewModel, Gtk.Dialog parentDialog)
 		{
 			this.Build ();
 			this.viewModel = viewModel;
+			this.parentDialog = parentDialog;
 			this.InitializeTreeView ();
 			this.LoadPackageSources ();
 			AddEventHandlers ();
@@ -237,7 +239,7 @@ namespace MonoDevelop.PackageManagement
 
 		Xwt.Command ShowDialogWithParent (AddPackageSourceDialog dialog)
 		{
-			Xwt.WindowFrame parent = Xwt.Toolkit.CurrentEngine.WrapWindow (Toplevel);
+			Xwt.WindowFrame parent = Xwt.Toolkit.CurrentEngine.WrapWindow (parentDialog);
 			return dialog.Run (parent);
 		}
 


### PR DESCRIPTION
Ensure Add Package Source dialog is in front of the preferences dialog.

Fixes VSTS #890133 - VS for Mac hangs on add package source