### PR TITLE
[release-8.1] [DotNetCore] Hide FrameworkReference items in Solution window.

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.csproj
@@ -96,6 +96,7 @@
     <Compile Include="MonoDevelop.DotNetCore\MonoRuntimeInfoExtensions.cs" />
     <Compile Include="MonoDevelop.DotNetCore.NodeBuilders\PackageDependencyInfo.cs" />
     <Compile Include="MonoDevelop.DotNetCore\DotNetCliWatch.cs" />
+    <Compile Include="MonoDevelop.DotNetCore\FrameworkReference.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\mono-addins\Mono.Addins\Mono.Addins.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/FrameworkReference.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/FrameworkReference.cs
@@ -1,0 +1,40 @@
+//
+// FrameworkReference.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.DotNetCore
+{
+	/// <summary>
+	/// FrameworkReference is a set of known framework assemblies that are versioned
+	/// with the project's TargetFramework. Introduced with .NET Core 3.0
+	/// https://github.com/dotnet/designs/pull/50
+	/// </summary>
+	[ExportProjectItemType ("FrameworkReference")]
+	class FrameworkReference : ProjectItem
+	{
+	}
+}


### PR DESCRIPTION
.NET Core 3.0 introduces a FrameworkReference MSBuild item which
represents a set of assemblies that version with the project's
target framework. Adding a new ProjectItem for the FrameworkReference
ensures it is not shown in red as an UnknownProjectItem.

Fixes VSTS #887910 - Create ASP.NET Core xUnit Test ~ 3.0 Project, run
workaround, the color of Microsoft.AspNetCore.App color file is red.

Backport of #7571.

/cc @mrward 