### PR TITLE
[release-8.1] [Ide] Fix native macOS menu not used

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -84,7 +84,7 @@ namespace MonoDevelop.Ide.WelcomePage
 				Runtime.RunInMainThread (async () => {
 					await ShowWelcomeWindow (new WelcomeWindowShowOptions (false));
 					// load the global menu for the welcome window to avoid unresponsive menus on Mac
-					IdeServices.DesktopService.SetGlobalMenu (IdeApp.CommandService, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
+					IdeServices.DesktopService.SetGlobalMenu (commandManager, "/MonoDevelop/Ide/MainMenu", "/MonoDevelop/Ide/AppMenu");
 				}).Ignore ();
 			}
 		}


### PR DESCRIPTION
The WelcomePageService's Initialize method and the DefaultWorkbench's
InitializeWorkspace both attempt to configure the global main menu
asynchronously. If the WelcomePageService configured the main menu
before the command service was initialized in IdeApp the native Mac
menu was not available. A null reference exception was logged:

```
Could not install global menu
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.MacIntegration.MacPlatformService.InitApp (MonoDevelop.Components.Commands.CommandManager commandManager) [0x00009] in /Users/vsts/agent/2.150.3/work/1/s/monodevelop/main/src/addins/MacPlatform/MacPlatform.cs:483
  at MonoDevelop.MacIntegration.MacPlatformService.SetGlobalMenu (MonoDevelop.Components.Commands.CommandManager commandManager, System.String commandMenuAddinPath, System.String appMenuAddinPath) [0x00031] in /Users/vsts/agent/2.150.3/work/1/s/monodevelop/main/src/addins/MacPlatform/MacPlatform.cs:416
```

The problem was that the WelcomePageService was using IdeApp's
CommandService to configure the global main menu instead of using
the CommandManager it had obtained from Runtime.Services.

Fixes VSTS #893198 - Menu bar appears in main VSMac window instead of
native macOS menu bar

Backport of #7574.

/cc @mrward 