### PR TITLE
Fixes VSTS Bug 893674: [Feedback] Goto line jumps to wrong line or

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -727,10 +727,12 @@ namespace MonoDevelop.Components.MainToolbar
 				if (doc?.GetContent<ITextView> (true) is ITextView view) {
 					doc.Select ();
 					var snapshot = view.TextBuffer.CurrentSnapshot;
-					var line = snapshot.GetLineFromLineNumber (pattern.LineNumber - 1);
+					int lineNumber = Math.Min (Math.Max (1, pattern.LineNumber), snapshot.LineCount);
+					var line = snapshot.GetLineFromLineNumber (lineNumber - 1);
 					if (line != null) {
-						view.Caret.MoveTo (new SnapshotPoint (snapshot, line.Start + Math.Min (pattern.Column - 1, line.Length)));
+						view.Caret.MoveTo (new SnapshotPoint (snapshot, line.Start + Math.Max (0, Math.Min (pattern.Column - 1, line.Length))));
 						IdeApp.CommandService.DispatchCommand (ViewCommands.CenterAndFocusCurrentDocument);
+						ToolbarView.SearchText = "";
 					}
 				}
 				return;


### PR DESCRIPTION
crashes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/893674

Bug got introduced by the new editor changes. Pattern.Column == 0 was
the problem so the SnapshotPoint got negative and that explains the
line -1 problem as well.