### PR TITLE
[Core] Fix empty ReferenceSourceTarget added for new project reference

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1199,7 +1199,7 @@ namespace MonoDevelop.Projects
 			SetProperty (metadata, "Project", reference.ProjectGuid);
 			SetProperty (metadata, "MSBuildSourceProjectFile", GetProjectFileName (reference));
 			SetProperty (metadata, "ReferenceOutputAssembly", reference.ReferenceOutputAssembly.ToString ());
-			SetProperty (metadata, "ReferenceSourceTarget", "ProjectReference");
+			SetProperty (metadata, "ReferenceSourceTarget", reference.ReferenceSourceTarget);
 
 			return new AssemblyReference (path, metadata);
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -286,6 +286,8 @@ namespace MonoDevelop.Projects
 			string name = buildItem.Metadata.GetValue ("Name", Path.GetFileNameWithoutExtension (path));
 			string projectGuid = buildItem.Metadata.GetValue ("Project");
 			Init (ReferenceType.Project, name, null, projectGuid);
+
+			ReferenceSourceTarget = buildItem.Metadata.GetValue ("ReferenceSourceTarget");
 		}
 
 		internal protected override void Write (Project project, MSBuildItem buildItem)
@@ -326,6 +328,7 @@ namespace MonoDevelop.Projects
 					buildItem.Metadata.SetValue ("Project", refProj.ItemId, preserveExistingCase:true);
 					buildItem.Metadata.SetValue ("Name", refProj.Name);
 					buildItem.Metadata.SetValue ("ReferenceOutputAssembly", ReferenceOutputAssembly, true);
+					buildItem.Metadata.SetValue ("ReferenceSourceTarget", ReferenceSourceTarget);
 				}
 			}
 
@@ -464,6 +467,8 @@ namespace MonoDevelop.Projects
 					ownerProject.NotifyModified ("References");
 			}
 		}
+
+		internal string ReferenceSourceTarget { get; set; } = "ProjectReference";
 
 		public bool IsValid {
 			get { return string.IsNullOrEmpty (ValidationErrorMessage); }

--- a/main/tests/test-projects/ref-source-target/console-project.sln
+++ b/main/tests/test-projects/ref-source-target/console-project.sln
@@ -1,0 +1,33 @@
+
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "console-project", "console-project\console-project.csproj", "{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "library1", "library1\library1.csproj", "{7F63CBE6-2FE7-47A7-8930-EA078DA05062}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "library2", "library2\library2.csproj", "{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = console-with-libs\console-with-libs.csproj
+		name = console-with-libs
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ref-source-target/console-project/console-project.csproj
+++ b/main/tests/test-projects/ref-source-target/console-project/console-project.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>console-project</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\library1\library1.csproj">
+      <Project>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</Project>
+      <Name>library1</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ref-source-target/console-project/console-project.csproj-saved
+++ b/main/tests/test-projects/ref-source-target/console-project/console-project.csproj-saved
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EAB80A13-FC3E-4E53-8950-E6B9F19E4C90}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>console-project</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\library1\library1.csproj">
+      <Project>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</Project>
+      <Name>library1</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\library2\library2.csproj">
+      <Project>{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}</Project>
+      <Name>library2</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ref-source-target/library1/library1.csproj
+++ b/main/tests/test-projects/ref-source-target/library1/library1.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ref-source-target/library2/library2.csproj
+++ b/main/tests/test-projects/ref-source-target/library2/library2.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{42A9AAF1-DCB8-4F3F-9B20-5F17D4EAAD20}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Adding a reference to another project would result in an empty
ReferenceSourceTarget being added to the project file.

    <ProjectReference Include="..\lib\lib.csproj">
      <Project>{7A11FE57-9070-408C-A100-F1C720FFED6C}</Project>
      <Name>lib</Name>
      <ReferenceSourceTarget></ReferenceSourceTarget>
    </ProjectReference>

Support for ItemDefinitionGroups was added recently and one exists for
ProjectReference which defines the ReferenceSourceTarget to be
'ProjectReference'. Since the ProjectReference item added to the project
in the IDE did not have the ReferenceSourceTarget set an empty value
was being used on saving the project. Now the ReferenceSourceTarget
is set for new project references to be ProjectReference which will
result in the ReferenceSourceTarget not being added to the project file.

Fixes VSTS #893190 - Empty ReferenceSourceTarget added to project