### PR TITLE
[NuGet] Fix multiple NuGet restores run on target framework changed

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -263,8 +263,6 @@ namespace MonoDevelop.DotNetCore
 			if (!IdeApp.IsInitialized)
 				return;
 
-			PackageManagementServices.ProjectTargetFrameworkMonitor.ProjectTargetFrameworkChanged += ProjectTargetFrameworkChanged;
-
 			if (HasSdk && !IsDotNetCoreSdkInstalled ()) {
 				ShowDotNetCoreNotInstalledDialog (sdkPaths.IsUnsupportedSdkVersion);
 			}
@@ -314,26 +312,7 @@ namespace MonoDevelop.DotNetCore
 		{
 			FileService.FileChanged -= FileService_FileChanged;
 
-			if (IdeApp.IsInitialized)
-				PackageManagementServices.ProjectTargetFrameworkMonitor.ProjectTargetFrameworkChanged -= ProjectTargetFrameworkChanged;
-
 			base.Dispose ();
-		}
-
-		/// <summary>
-		/// This event is fired after the project is saved. Runs a restore if the project was
-		/// not reloaded.
-		/// </summary>
-		void ProjectTargetFrameworkChanged (object sender, ProjectTargetFrameworkChangedEventArgs e)
-		{
-			if (e.IsReload || e.Project.Name != this.Project.Name) {
-				// Ignore. A restore will occur on reload elsewhere.
-				return;
-			}
-
-			// Need to re-evaluate before restoring to ensure the implicit package references are correct after
-			// the target framework has changed.
-			DetectSDK (true);
 		}
 
 		protected override Task<BuildResult> OnClean (ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext operationContext)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeProject.cs
@@ -40,6 +40,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public FilePath BaseIntermediateOutputPath { get; set; }
 		public ISolution ParentSolution { get; set; }
 		public IDictionary ExtendedProperties { get; set; }
+		public bool IsReevaluating { get; set; }
 
 		List<string> flavorGuids;
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectTargetFrameworkMonitorTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectTargetFrameworkMonitorTests.cs
@@ -398,6 +398,20 @@ namespace MonoDevelop.PackageManagement.Tests
 
 			Assert.AreEqual (0, eventArgs.Count);
 		}
+
+		[Test]
+		public void ProjectTargetFrameworkChanged_ProjectIsReevaluating_EventDoesNotFire ()
+		{
+			CreateProjectTargetFrameworkMonitor ();
+			FakeDotNetProject project = LoadSolutionWithOneProject ();
+			CaptureProjectTargetFrameworkChangedEvents ();
+
+			project.IsReevaluating = true;
+			project.RaiseModifiedEvent (project, targetFrameworkPropertyName);
+			project.RaiseSavedEvent ();
+
+			Assert.AreEqual (0, eventArgs.Count);
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IProject.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/IProject.cs
@@ -42,6 +42,7 @@ namespace MonoDevelop.PackageManagement
 		IDictionary ExtendedProperties { get; }
 		IEnumerable<string> FlavorGuids { get; }
 		IMSBuildEvaluatedPropertyCollection EvaluatedProperties { get; }
+		bool IsReevaluating { get; }
 
 		Task SaveAsync ();
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectProxy.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectProxy.cs
@@ -74,6 +74,10 @@ namespace MonoDevelop.PackageManagement
 			get { return project.MSBuildProject?.EvaluatedProperties; }
 		}
 
+		public bool IsReevaluating {
+			get { return project.IsReevaluating; }
+		}
+
 		public async Task SaveAsync ()
 		{
 			using (var monitor = new ProgressMonitor ()) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectTargetFrameworkMonitor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectTargetFrameworkMonitor.cs
@@ -108,6 +108,16 @@ namespace MonoDevelop.PackageManagement
 
 		void ProjectModified (object sender, ProjectModifiedEventArgs e)
 		{
+			if (e.Project.IsReevaluating) {
+				// Ignore target framework changes if the project is re-evaluating. We are only
+				// interested in target framework changes made by the user in project options
+				// or when editing the project file.
+				// Sdk style Xamarin.Mac projects sometimes switch the target framework from
+				// .NET to Xamarin.Mac during re-evaluation. The XamMac2ProjectFlavor may change
+				// the target framework when the project file is reloaded during re-evaluation.
+				return;
+			}
+
 			if (e.IsTargetFramework ()) {
 				e.Project.Saved += ProjectSaved;
 			}


### PR DESCRIPTION
[NuGet] Restore only projects affected when target framework changed

When the target framework changed in a .NET Core project all .NET
Core projects in the soluton were restored. Now only the project and
any of its transitive project references are restored.

Fixes VSTS #895149 - Target Framework change in one project restores
all .NET Core projects

[NuGet] Fix adding non-sdk style project triggering NuGet restore

Adding a new non-sdk style project to md-addins would cause a NuGet
restore to run multiple times. The problem was that the Xamarin.Mac
SDK style projects change their target framework on re-evaluation from
.NET to Xamarin.Mac. This was causing the .NET Core project extension
to run a restore for all sdk style projects in the solution, multiple
times. To avoid this the target framework changes during re-evaluation
are ignored. We are only interested in changes due to the user making
changes to the target framework.

Fixes VSTS #893871 - Adding a non-sdk style project to a solution can
trigger a NuGet restore