### PR TITLE
[Ide] Add proper handling of gtk/objc exceptions

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
@@ -118,6 +118,7 @@
     <ProjectReference Include="..\MonoDevelop.FSharpBinding\MonoDevelop.FSharp.fsproj">
       <Project>{4C10F8F9-3816-4647-BA6E-85F5DE39883A}</Project>
       <Name>MonoDevelop.FSharp</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\addins\MonoDevelop.UnitTesting\MonoDevelop.UnitTesting.csproj">
       <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
@@ -51,6 +51,8 @@ namespace MonoDevelop.Ide.Gui
 
 				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Critical, "{0}", "critical should be captured");
 				Assert.That (crashReporter.LastException.Message, Contains.Substring ("critical should be captured"));
+				Assert.That (crashReporter.LastException.StackTrace, Is.Not.Null);
+				Assert.That (crashReporter.LastException.Source, Is.Not.Null);
 
 				// Error will cause the application to exit, so we can't test for that, but it follows the same code as Critical.
 			} finally {

--- a/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
+++ b/main/tests/MacPlatform.Tests/MacPlatform.Tests.csproj
@@ -15,6 +15,7 @@
     <Reference Include="System" />
     <Reference Include="Xamarin.Mac">
       <HintPath>..\..\external\Xamarin.Mac.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/main/tests/MacPlatform.Tests/MacPlatformTest.cs
+++ b/main/tests/MacPlatform.Tests/MacPlatformTest.cs
@@ -166,6 +166,8 @@ namespace MacPlatform.Tests
 				Assert.Throws<ObjCException> (() => void_objc_msgSend (x.Handle, selector));
 
 				Assert.That (crashReporter.LastException.Message, Contains.Substring ("should be captured"));
+				Assert.That (crashReporter.LastException.StackTrace, Is.Not.Null);
+				Assert.That (crashReporter.LastException.Source, Is.Not.Null);
 			} finally {
 				LoggingService.UnregisterCrashReporter (crashReporter);
 			}


### PR DESCRIPTION
We need to throw the exceptions, otherwise nothing processes stacktrace information properly, which is only set by the runtime

Fixes VSTS #890423 - [Telemetry] VS for Mac should log GTK fatal errors to telemetry