### PR TITLE
[release-8.1] [Core] Prevents \u0022Surrounds with...\u0022 command to be enabled ...

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/CompletionTextEditorExtension.cs
@@ -1,4 +1,4 @@
-// CompletionTextEditorExtension.cs
+﻿// CompletionTextEditorExtension.cs
 //
 // Author:
 //   Lluis Sanchez Gual
@@ -537,11 +537,10 @@ namespace MonoDevelop.Ide.Editor.Extension
 		[CommandUpdateHandler (TextEditorCommands.ShowCodeSurroundingsWindow)]
 		internal void OnUpdateSelectionSurroundWith (CommandInfo info)
 		{
-			info.Enabled = Editor.IsSomethingSelected;
+			info.Enabled = Editor.IsSomethingSelected && !string.IsNullOrWhiteSpace (Editor.SelectedText);
 			info.Bypass = !IsActiveExtension () || !info.Enabled;
 			if (info.Enabled) {
-				int cpos, wlen;
-				if (!GetCompletionCommandOffset (out cpos, out wlen)) {
+				if (!GetCompletionCommandOffset (out var cpos, out var wlen)) {
 					cpos = Editor.CaretOffset;
 					wlen = 0;
 				}


### PR DESCRIPTION
… if the selected text is white spaces or empty.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/843214

Backport of #7580.

/cc @rodrmoya @jtorres