### PR TITLE
Fixes VSTS Bug 860976: [Watson] System.NullReferenceException in

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Wrappers/TooltipProviderWrapper.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.Wrappers/TooltipProviderWrapper.cs
@@ -56,11 +56,11 @@ namespace MonoDevelop.SourceEditor.Wrappers
 		static MonoDevelop.Ide.Editor.TextEditor WrapEditor (MonoTextEditor editor)
 		{
 			foreach (var doc in IdeApp.Workbench.Documents) {
-				var textEditor = doc.Editor;
-				if (textEditor == null)
-					continue;
-				if (textEditor.FileName == editor.FileName)
-					return textEditor;
+				if (doc.FileName == editor.FileName) {
+					var textEditor = doc.Editor;
+					if (textEditor != null)
+    					return textEditor;
+				}
 			}
 			return null;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Document.cs
 //
 // Author:
@@ -355,7 +355,12 @@ namespace MonoDevelop.Ide.Gui
 
 		public TextEditor Editor {
 			get {
-				return GetContent <TextEditor> ();
+				try {
+					return GetContent<TextEditor> ();
+				} catch (Exception e) {
+					LoggingService.LogInternalError ("Exception while GetContent<TextEditor>", e);
+					return null;
+				}
 			}
 		}
 


### PR DESCRIPTION
MonoDevelop.Ide.dll!MonoDevelop.Ide.Gui.Document.GetContent
(MonoDevelop.Ide.dll)

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/860976