### PR TITLE
Fix exception in DocumentController.GetContent()

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -2422,7 +2422,7 @@ namespace MonoDevelop.SourceEditor
 			var c = GetContent (type);
 			if (c != null)
 				yield return c;
-			if (typeof (IToolboxDynamicProvider).IsAssignableFrom (type) && codeTemplateToolboxProvider != null)
+			if (type == typeof (IToolboxDynamicProvider) && codeTemplateToolboxProvider != null)
 				yield return codeTemplateToolboxProvider;
 		}
 

--- a/main/src/core/MonoDevelop.Core/CoreExtensions.cs
+++ b/main/src/core/MonoDevelop.Core/CoreExtensions.cs
@@ -262,6 +262,47 @@ namespace System
 					LoggingService.LogError ("Async operation failed", t.Exception);
 			});
 		}
+
+		/// <summary>
+		/// Invokes a callback catching and reporting exceptions thrown by handlers
+		/// </summary>
+		/// <typeparam name="T">Type of the event arguments</typeparam>
+		/// <param name="event">Event to invoke</param>
+		/// <param name="sender">Sender of the event</param>
+		/// <param name="args">Arguments of the event</param>
+		public static void SafeInvoke<T> (this EventHandler<T> @event, object sender, T args)
+		{
+			var events = @event;
+			if (events == null)
+				return;
+			foreach (var ev in events.GetInvocationList ()) {
+				try {
+					((EventHandler < T > )ev) (sender, args);
+				} catch (Exception ex) {
+					LoggingService.LogInternalError (ex);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Invokes a callback catching and reporting exceptions thrown by handlers
+		/// </summary>
+		/// <param name="event">Event to invoke</param>
+		/// <param name="sender">Sender of the event</param>
+		/// <param name="args">Arguments of the event</param>
+		public static void SafeInvoke (this EventHandler @event, object sender, EventArgs args)
+		{
+			var events = @event;
+			if (events == null)
+				return;
+			foreach (var ev in events.GetInvocationList ()) {
+				try {
+					((EventHandler)ev) (sender, args);
+				} catch (Exception ex) {
+					LoggingService.LogInternalError (ex);
+				}
+			}
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -550,18 +550,25 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 			CheckInitialized ();
 			foreach (var c in OnGetContents (type))
-				yield return c;
+				yield return AssertValid (c, type);
 
 			if (extensionChain != null) {
 				foreach (var ext in extensionChain.GetAllExtensions ().OfType<DocumentControllerExtension> ()) {
 					foreach (var c in ext.GetContents (type))
-						yield return c;
+						yield return AssertValid (c, type);
 				}
 			}
 			if (linkedController != null) {
 				foreach (var c in linkedController.GetContents (type))
-					yield return c;
+					yield return AssertValid (c, type);
 			}
+		}
+
+		object AssertValid (object ob, Type type)
+		{
+			if (!type.IsInstanceOfType (ob))
+				throw new InvalidOperationException ($"Invalid content type. Expected: '{type}', Actual: '{ob?.GetType ()}'");
+			return ob;
 		}
 
 		ContentCallbackRegistry contentCallbackRegistry;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -723,7 +723,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 		void OnDocumentOpened (DocumentEventArgs e)
 		{
 			try {
-				DocumentOpened?.Invoke (this, e);
+				DocumentOpened?.SafeInvoke (this, e);
 			} catch (Exception ex) {
 				LoggingService.LogError ("Exception while opening documents", ex);
 			}
@@ -733,7 +733,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			try {
 				var e = new DocumentEventArgs (doc);
-				DocumentClosed?.Invoke (this, e);
+				DocumentClosed?.SafeInvoke (this, e);
 			} catch (Exception ex) {
 				LoggingService.LogError ("Exception while closing documents", ex);
 			}
@@ -764,7 +764,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 			foreach (var doc in documents)
 				doc.UpdateContentVisibility ();
 
-			ActiveDocumentChanged?.Invoke (s, new DocumentEventArgs (activeDocument));
+			ActiveDocumentChanged?.SafeInvoke (s, new DocumentEventArgs (activeDocument));
 
 			if (activeDocument != null) {
 				activeDocument.LastTimeActive = DateTime.Now;


### PR DESCRIPTION
The text editor was doing an incorrect type check in the GetContent implementation.
The document changed event is now raised in a more safe way, so that an exception
in the handler won't crash the IDE, and will ensure that all handlers are
invoked no matter if there is an exception.

Fixes VSTS #891457 - FATAL ERROR: An unhandled exception has occurred.