### PR TITLE
[release-8.1] [TextEditor] Don\u0027t manually dispose the TextDocument instance.

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -310,7 +310,6 @@ namespace MonoDevelop.TextEditor
 				AutoSave.RemoveAutoSaveFile (FilePath);
 
 			UnsubscribeFromEvents ();
-			TextDocument?.Dispose ();
 
 			if (policyContainer != null)
 				policyContainer.PolicyChanged -= PolicyChanged;


### PR DESCRIPTION
Instead the task of disposing it should be left to the document model registry. In case where said instance is shared, the manual dispose would corrupt the version still stored inside the registry causing all sorts of failures when reopening documents.

Backport of #7608.

/cc @slluis @garuma