### PR TITLE
Fix casing error

### DIFF
--- a/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
+++ b/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutDir>bin</OutDir>


### PR DESCRIPTION
`/home/directhex/Projects/monodevelop/main/msbuild/MDBuildTasks/MDBuildTasks.csproj : error : /usr/share/dotnet/sdk/2.2.204/Sdks/Microsoft.Net.Sdk/Sdk not found. Check that a recent enough .NET Core SDK is installed and/or increase the version specified in global.json.`