### PR TITLE
[master] Fix Find commands availability.

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
@@ -190,9 +190,12 @@ namespace MonoDevelop.TextEditor
 
 		bool CanHandleCommand (object commandId)
 		{
-			if (commandsSupportedWhenFindPresenterIsFocused.Contains (commandId)) {
-				var findPresenter = Imports.FindPresenterFactory?.TryGetFindPresenter (TextView);
-				return findPresenter != null && findPresenter.IsFocused;
+			// check TextView for null because of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/890051
+			if (TextView is ITextView textView) {
+				var findPresenter = Imports.FindPresenterFactory?.TryGetFindPresenter (textView);
+				if (findPresenter != null && findPresenter.IsFocused) {
+					return commandsSupportedWhenFindPresenterIsFocused.Contains (commandId);
+				}
 			}
 
 			return true;


### PR DESCRIPTION
The previous fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/890051 was subtly incorrect. It prevented the control flow for find commands from falling through. Turns out when Find is not focused the control flow needs to fall through to the default.

A different way to fix it is to check TextView for null to avoid the NullReferenceException from 890051.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/893794 - Unable to search in text editor with inline search

Backport of #7610.

/cc @abock @KirillOsenkov