### PR TITLE
[release-8.1] TextEditor: Map and menu for multi-caret commands

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
@@ -52,7 +52,40 @@
 		<Assembly file="MonoDevelop.TextEditor.dll"/>
 	</Extension>
 
+	<Extension path="/MonoDevelop/Ide/Commands">
+		<Command id="MonoDevelop.Ide.Commands.TextEditorCommands.InsertNextMatchingCaret"
+		         _label="Insert next matching caret"
+				 shortcut="Shift+Alt+."
+				 macShortcut="Shift+Alt+."/>
+		<Command id="MonoDevelop.Ide.Commands.TextEditorCommands.InsertAllMatchingCarets"
+		         _label="Insert carets at all matching"
+				 shortcut="Shift+Alt+;"
+				 macShortcut="Shift+Alt+;"/>
+		<Command id="MonoDevelop.Ide.Commands.TextEditorCommands.RemoveLastSecondaryCaret"
+		         _label="Remove last caret"
+				 shortcut="Shift+Alt+,"
+				 macShortcut="Shift+Alt+,"/>
+		<Command id="MonoDevelop.Ide.Commands.TextEditorCommands.MoveLastCaretDown"
+		         _label="Move last caret down"
+				 shortcut="Shift+Alt+/"
+				 macShortcut="Shift+Alt+/"/>
+		<Command id="MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretNext"
+		         _label="Rotate primary caret down"
+				 shortcut=""
+				 macShortcut=""/>
+		<Command id="MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretPrevious"
+		         _label="Rotate primary caret up"
+				 shortcut=""
+				 macShortcut=""/>
+	</Extension>
+
 	<Extension path = "/MonoDevelop/TextEditor/CommandMapping">
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.InsertAllMatchingCarets" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InsertAllMatchingCaretsCommandArgs"/>
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.InsertNextMatchingCaret" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InsertNextMatchingCaretCommandArgs"/>
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.RemoveLastSecondaryCaret" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.RemoveLastSecondaryCaretCommandArgs"/>
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.MoveLastCaretDown" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.MoveLastCaretDownCommandArgs"/>
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretNext" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.RotatePrimaryCaretNextCommandArgs"/>
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretPrevious" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.RotatePrimaryCaretPreviousCommandArgs"/>
 		<Map id="MonoDevelop.Ide.Commands.EditCommands.Copy" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.CopyCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.EditCommands.Cut" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.CutCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.EditCommands.Paste" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.PasteCommandArgs" />

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -65,6 +65,14 @@
 
 		<SeparatorItem id = "Separator2" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.EditCommands.SelectAll" />
+		<ItemSet id="MultipleCarets" _label="_Multiple Carets">
+			<CommandItem id="MonoDevelop.Ide.Commands.TextEditorCommands.InsertNextMatchingCaret"/>
+			<CommandItem id="MonoDevelop.Ide.Commands.TextEditorCommands.InsertAllMatchingCarets"/>
+			<CommandItem id="MonoDevelop.Ide.Commands.TextEditorCommands.RemoveLastSecondaryCaret"/>
+			<CommandItem id="MonoDevelop.Ide.Commands.TextEditorCommands.MoveLastCaretDown"/>
+			<CommandItem id="MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretNext"/>
+			<CommandItem id="MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretPrevious"/>
+		</ItemSet>
 		<CommandItem id = "MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeSurroundingsWindow" />
 		
 		<SeparatorItem id = "Separator4" />


### PR DESCRIPTION
Verbiage and default shortcuts taken from Windows.

Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/801922

Backport of #7585.

/cc @abock @sandyarmstrong