### PR TITLE
[release-8.1] [NuGet] Fix being unable to add or update NuGet package sources

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSourceViewModelTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageSourceViewModelTests.cs
@@ -152,6 +152,24 @@ namespace MonoDevelop.PackageManagement.Tests
 			PackageSource updatedPackageSource = viewModel.GetPackageSource ();
 			Assert.IsTrue (updatedPackageSource.IsEnabled);
 		}
+
+		/// <summary>
+		/// This ensures that credentials can be saved to the NuGet.Config file with NuGet 5. Originally
+		/// the url was used which was then used as the element name in the packageSourceCredentials section.
+		/// </summary>
+		[Test]
+		public void Credentials_UserNameAndPasswordSet_CredentialsSourceUsesPackageSourceNameNotUrl ()
+		{
+			packageSource = new PackageSource ("https://nuget.org", "PackageSourceName");
+			CreateViewModel (packageSource);
+			viewModel.UserName = "UserName";
+			viewModel.Password = "Password";
+
+			PackageSource updatedPackageSource = viewModel.GetPackageSource ();
+
+			Assert.AreEqual ("PackageSourceName", updatedPackageSource.Credentials.Source);
+			Assert.AreEqual ("UserName", updatedPackageSource.Credentials.Username);
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSourceViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageSourceViewModel.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.PackageManagement
 		{
 			if (HasUserName () || HasPassword ()) {
 				return PackageSourceCredential.FromUserInput (
-					Source,
+					Name,
 					UserName ?? string.Empty,
 					Password ?? string.Empty,
 					storePasswordInClearText: false,


### PR DESCRIPTION
After updating to NuGet 5 it was not possible to add, remove or update
package sources in Preferences if a package source had a username and
password associated with it. The problem was that the package source
url was being used when saving the username and password information
in the packageSourceCredentials section in the NuGet.Config file. This
resulted in an invalid xml element name so the save would fail. In
NuGet 4.8 the PackageSourceCredential.Source was not used when saving
the NuGet.Config file. With NuGet 4.9 and later it is being used.
However it is not the source url but the source name.

Fixes VSTS #857001 - Unable to update NuGet package sources

Backport of #7624.

/cc @mrward 