### PR TITLE
[Shell] Show an alert in StatusMonitor if the Workbench is not visible

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Gtk;
-
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.VersionControl
 {
@@ -70,7 +68,8 @@ namespace MonoDevelop.VersionControl
 		public void Wakeup() {
 			try {
 				tracker.EndTask();
-				tracker.Dispose ();
+				if(IdeApp.Workbench.RootWindow?.Visible == true)
+					tracker.Dispose ();
 			} finally {
 				Finished();
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -52,13 +52,14 @@ namespace MonoDevelop.VersionControl
 					if (exception is DllNotFoundException) {
 						var msg = GettextCatalog.GetString ("The operation could not be completed because a shared library is missing: ");
 						tracker.ReportError (msg + exception.Message, null);
+						MessageService.ShowError (exception.Message);
 						LoggingService.LogError ("Version Control command failed: ", exception);
 					} else if (exception is VersionControlException) {
 						var msg = GettextCatalog.GetString ("Version control operation failed: ");
-						tracker.ReportError (msg + exception.Message, exception);
+						ReportError (msg + exception.Message, exception);
 					} else {
 						var msg = GettextCatalog.GetString ("Version control operation failed: ");
-						tracker.ReportError (msg, exception);
+						ReportError (msg + exception.Message, exception);
 					}
 				}
 				Wakeup ();
@@ -68,8 +69,7 @@ namespace MonoDevelop.VersionControl
 		public void Wakeup() {
 			try {
 				tracker.EndTask();
-				if(IdeApp.Workbench.RootWindow?.Visible == true)
-					tracker.Dispose ();
+				tracker.Dispose ();
 			} finally {
 				Finished();
 			}
@@ -81,6 +81,13 @@ namespace MonoDevelop.VersionControl
 		
 		protected void Warn(string logtext) {
 			tracker.ReportWarning(logtext);
+		}
+
+		void ReportError (string message, Exception exception)
+		{
+			tracker.ReportError (message, exception);
+			if (IdeApp.Workbench.RootWindow?.Visible == false && exception != null)
+				MessageService.ShowError (exception.Message);
 		}
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlTask.cs
@@ -52,14 +52,11 @@ namespace MonoDevelop.VersionControl
 					if (exception is DllNotFoundException) {
 						var msg = GettextCatalog.GetString ("The operation could not be completed because a shared library is missing: ");
 						tracker.ReportError (msg + exception.Message, null);
-						MessageService.ShowError (exception.Message);
 						LoggingService.LogError ("Version Control command failed: ", exception);
 					} else if (exception is VersionControlException) {
-						var msg = GettextCatalog.GetString ("Version control operation failed: ");
-						ReportError (msg + exception.Message, exception);
+						ReportError (exception.Message, exception);
 					} else {
-						var msg = GettextCatalog.GetString ("Version control operation failed: ");
-						ReportError (msg + exception.Message, exception);
+						ReportError (exception.Message, exception);
 					}
 				}
 				Wakeup ();
@@ -85,9 +82,10 @@ namespace MonoDevelop.VersionControl
 
 		void ReportError (string message, Exception exception)
 		{
-			tracker.ReportError (message, exception);
-			if (IdeApp.Workbench.RootWindow?.Visible == false && exception != null)
-				MessageService.ShowError (exception.Message);
+			string msg = GettextCatalog.GetString ("Version control operation failed");
+			tracker.ReportError ($"{msg}: {message}", exception);
+			if (IdeApp.Workbench.RootWindow?.Visible == false)
+				MessageService.ShowError (msg, message, exception);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
@@ -34,7 +34,7 @@ using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Gui
 {
-	internal class StatusProgressMonitor: ProgressMonitor
+	internal class StatusProgressMonitor : ProgressMonitor
 	{
 		string icon;
 		bool showErrorDialogs;
@@ -44,8 +44,8 @@ namespace MonoDevelop.Ide.Gui
 		string title;
 		StatusBarContext statusBar;
 		Pad statusSourcePad;
-		
-		public StatusProgressMonitor (string title, string iconName, bool showErrorDialogs, bool showTaskTitles, bool lockGui, Pad statusSourcePad, bool showCancelButton): base (Runtime.MainSynchronizationContext)
+
+		public StatusProgressMonitor (string title, string iconName, bool showErrorDialogs, bool showTaskTitles, bool lockGui, Pad statusSourcePad, bool showCancelButton) : base (Runtime.MainSynchronizationContext)
 		{
 
 			this.lockGui = lockGui;
@@ -63,7 +63,7 @@ namespace MonoDevelop.Ide.Gui
 			if (lockGui)
 				IdeApp.Workbench.LockGui ();
 		}
-		
+
 		protected override void OnProgressChanged ()
 		{
 			if (showTaskTitles)
@@ -74,7 +74,7 @@ namespace MonoDevelop.Ide.Gui
 			} else
 				IdeServices.DesktopService.ShowGlobalProgressIndeterminate ();
 		}
-		
+
 		public void UpdateStatusBar ()
 		{
 			if (showTaskTitles)
@@ -86,7 +86,7 @@ namespace MonoDevelop.Ide.Gui
 			else
 				statusBar.SetProgressFraction (0);
 		}
-		
+
 		protected override void OnCompleted ()
 		{
 			if (lockGui)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/StatusProgressMonitor.cs
@@ -34,7 +34,7 @@ using MonoDevelop.Core;
 
 namespace MonoDevelop.Ide.Gui
 {
-	internal class StatusProgressMonitor : ProgressMonitor
+	internal class StatusProgressMonitor: ProgressMonitor
 	{
 		string icon;
 		bool showErrorDialogs;
@@ -44,8 +44,8 @@ namespace MonoDevelop.Ide.Gui
 		string title;
 		StatusBarContext statusBar;
 		Pad statusSourcePad;
-
-		public StatusProgressMonitor (string title, string iconName, bool showErrorDialogs, bool showTaskTitles, bool lockGui, Pad statusSourcePad, bool showCancelButton) : base (Runtime.MainSynchronizationContext)
+		
+		public StatusProgressMonitor (string title, string iconName, bool showErrorDialogs, bool showTaskTitles, bool lockGui, Pad statusSourcePad, bool showCancelButton): base (Runtime.MainSynchronizationContext)
 		{
 
 			this.lockGui = lockGui;
@@ -63,7 +63,7 @@ namespace MonoDevelop.Ide.Gui
 			if (lockGui)
 				IdeApp.Workbench.LockGui ();
 		}
-
+		
 		protected override void OnProgressChanged ()
 		{
 			if (showTaskTitles)
@@ -74,7 +74,7 @@ namespace MonoDevelop.Ide.Gui
 			} else
 				IdeServices.DesktopService.ShowGlobalProgressIndeterminate ();
 		}
-
+		
 		public void UpdateStatusBar ()
 		{
 			if (showTaskTitles)
@@ -86,7 +86,7 @@ namespace MonoDevelop.Ide.Gui
 			else
 				statusBar.SetProgressFraction (0);
 		}
-
+		
 		protected override void OnCompleted ()
 		{
 			if (lockGui)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.ProgressMonitoring/MessageDialogProgressMonitor.cs
@@ -122,7 +122,7 @@ namespace MonoDevelop.Ide.ProgressMonitoring
 		protected override void OnErrorReported (string message, Exception exception)
 		{
 			if (dialog != null) {
-				dialog.WriteText (GettextCatalog.GetString ("ERROR: ") + Errors [Errors.Length - 1] + "\n");
+				dialog.WriteText (GettextCatalog.GetString ("ERROR: ") + Errors [Errors.Length - 1].DisplayMessage + "\n");
 				DispatchService.RunPendingEvents ();
 			}
 			base.OnErrorReported (message, exception);


### PR DESCRIPTION
Having the Get To Code Dialog and not having the Workbench visible, can not see the StatusView monitor feedback.
Added changes to use an alert instead of using the monitor if the workbench is not visible.

Fixes VSTS #896537