### PR TITLE
[Debugger] Fix completion list window behind breakpoint dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -289,7 +289,8 @@ namespace MonoDevelop.Debugger
 		public static bool ShowBreakpointProperties (ref BreakEvent bp, BreakpointType breakpointType = BreakpointType.Location)
 		{
 			using (var dlg = new BreakpointPropertiesDialog (bp, breakpointType)) {
-				Xwt.Command response = dlg.Run ();
+				Xwt.WindowFrame parentWindow = Xwt.Toolkit.CurrentEngine.WrapWindow (IdeApp.Workbench.RootWindow);
+				Xwt.Command response = dlg.Run (parentWindow);
 				if (bp == null)
 					bp = dlg.GetBreakEvent ();
 				return response == Xwt.Command.Ok;


### PR DESCRIPTION
Opening the breakpoint dialog to create an exception catchpoint or a
function breakpoint the completion list window for exception types
would appear behind the dialog.

Making the breakpoint dialog's parent window to be the main IDE window
fixes this problem.

Fixes issue #7628 - Exception class completion popup is hidden under
the window