### PR TITLE
[release-8.1] Update the VS Editor NuGets to 16.1 when building on Windows.

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -20,6 +20,6 @@
     <NuGetVersionRoslyn>3.1.0-beta4-19261-04</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
-    <NuGetVersionVSEditor>16.0.379-g4a55b0e4f2</NuGetVersionVSEditor>
+    <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>
   </PropertyGroup>
 </Project>

--- a/main/msbuild/ReferencesVSEditor.Windows.props
+++ b/main/msbuild/ReferencesVSEditor.Windows.props
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(NuGetVersionVSEditor)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="$(NuGetVersionRoslyn)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(NuGetVersionVSEditor)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
+    <PackageReference Include="Microsoft.VisualStudio.InteractiveWindow" Version="2.0.0-rc3-61304-01" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost" Version="3.1.0-beta3-19222-02" ExcludeAssets="all" />
   </ItemGroup>
 
   <!-- The consolidated package is authored in a way to avoid adding it to the C# compiler (ref\net46 is empty).
@@ -22,6 +24,9 @@
   <ItemGroup>
     <Reference Include="$(NuGetPackageRoot)Microsoft.VisualStudio.Platform.VSEditor\$(NuGetVersionVSEditor)\lib\net472\Microsoft.VisualStudio.Platform.VSEditor.dll">
       <Private>false</Private>
+    </Reference>
+    <Reference Include="$(NuGetPackageRoot)Microsoft.CodeAnalysis.InteractiveHost\3.1.0-beta3-19222-02\Microsoft.CodeAnalysis.InteractiveHost.dll">
+      <Private>$(ReferencesVSEditorCopyToOutput)</Private>
     </Reference>
   </ItemGroup>
 

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Wpf/MonoDevelop.TextEditor.Wpf.csproj
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Wpf/MonoDevelop.TextEditor.Wpf.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <IncludeCopyLocal Include="DiagnosticMargin.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Text.Extras.dll" />
+    <IncludeCopyLocal Include="Microsoft.VisualStudio.InteractiveWindow.dll" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="**\*.xaml">

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Wpf/Properties/MonoDevelop.TextEditor.Wpf.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Wpf/Properties/MonoDevelop.TextEditor.Wpf.addin.xml
@@ -1,6 +1,7 @@
 <ExtensionModel>
 	<Runtime>
 		<Import assembly="MonoDevelop.TextEditor.Wpf.dll"/>
+		<Import assembly="../../../bin/Microsoft.VisualStudio.InteractiveWindow.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Language.NavigateTo.Interfaces.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.Internal.dll" />
 		<Import assembly="Microsoft.VisualStudio.Text.Extras.dll" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -123,6 +123,7 @@
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Elfie.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.ExternalAccess.MonoDevelop.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Features.dll" />
+    <IncludeCopyLocal Include="Microsoft.CodeAnalysis.InteractiveHost.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Scripting.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.VisualBasic.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" />
@@ -131,7 +132,6 @@
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.Workspaces.dll" />
     <IncludeCopyLocal Include="Microsoft.DiaSymReader.dll" />
     <IncludeCopyLocal Include="Microsoft.Extensions.ObjectPool.dll" />
-    <IncludeCopyLocal Include="Microsoft.Microsoft.CodeAnalysis.Workspaces.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.CodingConventions.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Composition.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" />
@@ -139,6 +139,7 @@
     <IncludeCopyLocal Include="Microsoft.VisualStudio.ImageCatalog.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Imaging.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll" />
+    <IncludeCopyLocal Include="Microsoft.VisualStudio.InteractiveWindow.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Language.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Language.Intellisense.dll" />
     <IncludeCopyLocal Include="Microsoft.VisualStudio.Language.NavigateTo.Interfaces.dll" />


### PR DESCRIPTION
This matches what Roslyn 3.1 is using. We need this for ToggleLineCommentCommandArgs that was added in 16.1.

Note that NuGetVersionVSEditor is not used by the build on Mac. Also having an IncludeCopyLocal item that doesn't exist is fine, as evidenced by the removal of Microsoft.Microsoft.CodeAnalysis.Workspace.dll item. All other edited files are Windows specific.