### PR TITLE
[PropertyGrid] Fixes NRE on a second call to EndEditing and currentEditor is null

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGridTable.cs
@@ -906,12 +906,13 @@ namespace MonoDevelop.Components.PropertyGrid
 		internal void EndEditing ()
 		{
 			if (editSession != null) {
-				Remove (currentEditor);
-				currentEditor.Destroy ();
-				currentEditor = null;
+				if (currentEditor != null) {
+					Remove (currentEditor);
+					currentEditor.Destroy ();
+					currentEditor = null;
+				}
 				editSession.Dispose ();
 				editSession = null;
-
 				parentGrid.Populate (saveEditSession: false);
 			}
 			QueueDraw ();


### PR DESCRIPTION
This issue was detected by Watson, and probably could be related call EndEditing 2 times and we don't check for null the currentEditor.

I'm not completely sure about the fix, because at the end we refresh 2 times the grid, maybe we could don't allow call EndEditing 2 times?

Fixes VSTS #861004 - [Watson] System.NullReferenceException in MonoDevelop.Components.PropertyGrid.PropertyGridTable::EndEditing (System.NullReferenceException_MonoDevelop.Ide.dll)