### PR TITLE
[release-8.2] [Version Control] Changing between branches we stopped seeing the list of available branches

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -122,7 +122,7 @@ namespace MonoDevelop.VersionControl.Git
 	{
 		protected override void Run ()
 		{
-			GitService.ShowConfigurationDialog (Repository);
+			GitService.ShowConfigurationDialog (Repository.VersionControlSystem, Repository.RootPath, Repository.Url);
 		}
 	}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -37,15 +37,15 @@ namespace MonoDevelop.VersionControl.Git
 {
 	partial class GitConfigurationDialog : Gtk.Dialog
 	{
-		readonly GitRepository repo;
+		GitRepository repo;
 		readonly ListStore storeBranches;
 		readonly ListStore storeTags;
 		readonly TreeStore storeRemotes;
 
-		public GitConfigurationDialog (GitRepository repo)
+		public GitConfigurationDialog (VersionControlSystem vcs, string repoPath, string repoUrl)
 		{
 			this.Build ();
-			this.repo = repo;
+			this.repo = new GitRepository (vcs, repoPath, repoUrl, false);
 			this.HasSeparator = false;
 
 			this.UseNativeContextMenus ();
@@ -69,7 +69,8 @@ namespace MonoDevelop.VersionControl.Git
 					buttonRemoveBranch.Sensitive = buttonEditBranch.Sensitive = buttonSetDefaultBranch.Sensitive = listBranches.Selection.GetSelected (out it);
 				if (!anythingSelected)
 						return;
-
+				if (repo == null || repo.IsDisposed)
+					return;
 				string currentBranch = repo.GetCurrentBranch ();
 				var b = (Branch) storeBranches.GetValue (it, 0);
 				buttonRemoveBranch.Sensitive = b.FriendlyName != currentBranch;
@@ -163,6 +164,15 @@ namespace MonoDevelop.VersionControl.Git
 			storeTags.Clear ();
 			foreach (string tag in repo.GetTags ()) {
 				storeTags.AppendValues (tag);
+			}
+		}
+
+		protected override void OnDestroyed ()
+		{
+			base.OnDestroyed ();
+			if (this.repo != null) {
+				this.repo.Dispose ();
+				this.repo = null;
 			}
 		}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -67,8 +67,9 @@ namespace MonoDevelop.VersionControl.Git
 
 				rootRepository = value;
 
-				InitScheduler ();
-				InitFileWatcher (false);
+				InitScheduler (); 
+                if (this.watchGitLockfiles)
+					InitFileWatcher (false);
 			}
 		}
 
@@ -79,19 +80,27 @@ namespace MonoDevelop.VersionControl.Git
 		ConcurrentExclusiveSchedulerPair scheduler;
 		TaskFactory blockingOperationFactory;
 		TaskFactory readingOperationFactory;
+		readonly bool watchGitLockfiles;
 
 		public GitRepository ()
 		{
 			Url = "git://";
 		}
 
-		public GitRepository (VersionControlSystem vcs, FilePath path, string url) : base (vcs)
+		internal GitRepository (VersionControlSystem vcs, FilePath path, string url, bool watchGitLockfiles) : base (vcs)
 		{
 			RootRepository = new LibGit2Sharp.Repository (path);
 			RootPath = RootRepository.Info.WorkingDirectory;
 			Url = url;
+			this.watchGitLockfiles = watchGitLockfiles;
 
-			InitFileWatcher ();
+			if (this.watchGitLockfiles && watcher == null)
+				InitFileWatcher ();
+		}
+
+		public GitRepository (VersionControlSystem vcs, FilePath path, string url) : this (vcs, path, url, true)
+		{
+
 		}
 
 		void InitScheduler ()

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -78,9 +78,9 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		public static void ShowConfigurationDialog (GitRepository repo)
+		public static void ShowConfigurationDialog (VersionControlSystem vcs, string repoPath, string repoUrl)
 		{
-			using (var dlg = new GitConfigurationDialog (repo))
+			using (var dlg = new GitConfigurationDialog (vcs, repoPath, repoUrl))
 				MessageService.ShowCustomDialog (dlg);
 		}
 


### PR DESCRIPTION
The problem is that when changing branches we unload and load the solution. When doing unload we dispose the repository. Depending on the solution and its size (and therefore, the time to load) we sometimes try to access the repository (for example, obtain remote branches) before re-instantiating the repository. We obtain:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'GitRepository'.
  at MonoDevelop.VersionControl.Git.GitRepository.EnsureInitialized () [0x0000b] in /Users/jsuarez/Documents/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs:442 
  at MonoDevelop.VersionControl.Git.GitRepository.RunSafeOperation[T] (System.Func`1[TResult] action) [0x00001] in /Users/jsuarez/Documents/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs:456 
  at MonoDevelop.VersionControl.Git.GitRepository.GetCurrentBranch () [0x00001] in /Users/jsuarez/Documents/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs:1782 
  at MonoDevelop.VersionControl.Git.GitConfigurationDialog.FillBranches () [0x00021] in /Users/jsuarez/Documents/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs:136 
  at MonoDevelop.VersionControl.Git.GitConfigurationDialog.OnButtonSetDefaultBranchClicked (System.Object sender, System.EventArgs e) [0x000dd] in /Users/jsuarez/Documents/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs:236 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__6_0 (System.Object state) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/AsyncMethodBuilder.cs:1023 
  at MonoDevelop.Ide.DispatchService+GtkSynchronizationContext+TimeoutProxy.HandlerInternal (System.IntPtr data) [0x00016] in /Users/jsuarez/Documents/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DispatchService.cs:77 
Added changes to get the repository in case of being disposed when trying to obtain information (remote branches).
```

Fixes VSTS #857099

Backport of #7523.

/cc @sevoku @jsuarezruiz