### PR TITLE
Fixes issue #7561 Find in files - open files - returns no results on

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.FindInFiles/Scope.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // Scope.cs
 //  
 // Author:
@@ -270,9 +270,14 @@ namespace MonoDevelop.Ide.FindInFiles
 		{
 			foreach (Document document in IdeApp.Workbench.Documents) {
 				monitor.Log.WriteLine (GettextCatalog.GetString ("Looking in '{0}'", document.FileName));
+				if (!filterOptions.NameMatches (document.FileName))
+					continue;
 				var textBuffer = document.GetContent<ITextBuffer> ();
-				if (textBuffer != null && filterOptions.NameMatches (document.FileName))
+				if (textBuffer != null) {
 					yield return new OpenFileProvider (textBuffer, document.Owner as Project, document.FileName);
+				} else {
+					yield return new FileProvider (document.FileName, document.Owner as Project);
+				}
 			}
 		}
 


### PR DESCRIPTION
re-opening solution This is better than forcing the load, if many
files are open forcing to load all at once without need is worse than
the possibility to load a file twice.