### PR TITLE
[A11y] Check the functions have been set correctly before calling

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -138,18 +138,7 @@ namespace Mono.TextEditor
 
 			public TextViewMarginAccessibilityProxy ()
 			{
-				Accessible = AccessibilityElementProxy.TextElementProxy ();
-				Accessible.Contents = GetContents;
-				Accessible.InsertionPointLineNumber = GetInsertionPointLineNumber;
-				Accessible.NumberOfCharacters = GetNumberOfCharacters;
-				Accessible.FrameForRange = GetFrameForRange;
-				Accessible.LineForIndex = GetLineForIndex;
-				Accessible.RangeForLine = GetRangeForLine;
-				Accessible.StringForRange = GetStringForRange;
-				Accessible.RangeForIndex = GetRangeForIndex;
-				Accessible.StyleRangeForIndex = GetStyleRangeForIndex;
-				Accessible.RangeForPosition = GetRangeForPosition;
-				Accessible.GetVisibleCharacterRange = GetVisibleCharacterRange;
+				Accessible = AccessibilityElementProxy.TextElementProxy (GetContents, GetNumberOfCharacters, GetInsertionPointLineNumber, GetFrameForRange, GetLineForIndex, GetRangeForLine, GetStringForRange, GetRangeForIndex, GetStyleRangeForIndex, GetRangeForPosition, GetVisibleCharacterRange);
 			}
 
 			public void Dispose ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -638,17 +638,17 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 																  Func<AtkCocoa.Range> visibleCharacterRange)
 		{
 			return new AccessibilityElementProxy (new RealAccessibilityElementNavigableStaticTextProxy () {
-				Contents = contents,
-				NumberOfCharacters = numberOfCharacters,
-				InsertionPointLineNumber = insertionPointLineNumber,
-				GetFrameForRange = frameForRange,
-				GetLineForIndex = lineForIndex,
-				GetRangeForLine = rangeForLine,
-				GetStringForRange = stringForRange,
-				GetRangeForIndex = rangeForIndex,
-				GetStyleRangeForIndex = styleRangeForIndex,
-				GetRangeForPosition = rangeForPosition,
-				GetVisibleCharacterRange = visibleCharacterRange
+				Contents = contents ?? throw new ArgumentNullException (nameof (contents)),
+				NumberOfCharacters = numberOfCharacters ?? throw new ArgumentNullException (nameof (numberOfCharacters)),
+				InsertionPointLineNumber = insertionPointLineNumber ?? throw new ArgumentNullException (nameof (insertionPointLineNumber)),
+				GetFrameForRange = frameForRange ?? throw new ArgumentNullException (nameof (frameForRange)),
+				GetLineForIndex = lineForIndex ?? throw new ArgumentNullException (nameof (lineForIndex)),
+				GetRangeForLine = rangeForLine ?? throw new ArgumentNullException (nameof (rangeForLine)),
+				GetStringForRange = stringForRange ?? throw new ArgumentNullException (nameof (stringForRange)),
+				GetRangeForIndex = rangeForIndex ?? throw new ArgumentNullException (nameof (rangeForIndex)),
+				GetStyleRangeForIndex = styleRangeForIndex ?? throw new ArgumentNullException (nameof (styleRangeForIndex)),
+				GetRangeForPosition = rangeForPosition ?? throw new ArgumentNullException (nameof (rangeForPosition)),
+				GetVisibleCharacterRange = visibleCharacterRange ?? throw new ArgumentNullException (nameof (visibleCharacterRange))
 			});
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -38,6 +38,7 @@ using Gdk;
 using ObjCRuntime;
 using MetalPerformanceShaders;
 using MonoDevelop.Components.Mac;
+using LoggingService = MonoDevelop.Core.LoggingService;
 
 namespace MonoDevelop.Components.AtkCocoaHelper
 {
@@ -1522,18 +1523,30 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 
 		public override nint AccessibilityInsertionPointLineNumber {
 			get {
+				if (InsertionPointLineNumber == null) {
+					LoggingService.LogError ("Missing InsertionPointLineNumber");
+					return -1;
+				}
 				return InsertionPointLineNumber ();
 			}
 		}
 
 		public override nint AccessibilityNumberOfCharacters {
 			get {
+				if (NumberOfCharacters != null) {
+					LoggingService.LogError ("Missing NumberOfCharacters");
+					return -1;
+				}
 				return NumberOfCharacters ();
 			}
 		}
 
 		public override NSRange AccessibilityVisibleCharacterRange {
 			get {
+				if (GetVisibleCharacterRange == null) {
+					LoggingService.LogError ("Missing GetVisibleCharacterRange");
+					return default;
+				}
 				var realRange = GetVisibleCharacterRange ();
 				return new NSRange (realRange.Location, realRange.Length);
 			}
@@ -1555,6 +1568,11 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityFrameForRange:")]
 		CGRect AccessibilityFrameForRange (NSRange range)
 		{
+			if (GetFrameForRange == null) {
+				LoggingService.LogError ("Missing GetFrameForRange");
+				return CGRect.Empty;
+			}
+
 			parentRef.TryGetTarget (out var parent);
 			if (parent == null) {
 				return CGRect.Empty;
@@ -1582,12 +1600,21 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityLineForIndex:")]
 		nint AccessibilityLineForIndex (nint index)
 		{
+			if (GetLineForIndex == null) {
+				LoggingService.LogError ("Missing GetLineForIndex");
+				return -1;
+			}
 			return GetLineForIndex ((int)index);
 		}
 
 		[Export ("accessibilityRangeForLine:")]
 		NSRange AccessibilityRangeForLine (nint line)
 		{
+			if (GetRangeForLine == null) {
+				LoggingService.LogError ("Missing GetRangeForLine");
+				return default;
+			}
+
 			var range = GetRangeForLine ((int)line + 1);
 			return new NSRange (range.Location, range.Length);
 		}
@@ -1595,6 +1622,11 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityStringForRange:")]
 		string AccessibilityStringForRange (NSRange range)
 		{
+			if (GetStringForRange == null) {
+				LoggingService.LogError ("Missing GetStringForRange");
+				return null;
+			}
+
 			var realRange = new AtkCocoa.Range { Location = (int)range.Location, Length = (int)range.Length };
 			return GetStringForRange (realRange);
 		}
@@ -1602,6 +1634,11 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityRangeForIndex:")]
 		NSRange AccessibilityRangeForIndex (nint index)
 		{
+			if (GetRangeForIndex == null) {
+				LoggingService.LogError ("Missing GetRangeForIndex");
+				return default;
+			}
+
 			var realRange = GetRangeForIndex ((int)index);
 			return new NSRange (realRange.Location, realRange.Length);
 		}
@@ -1609,6 +1646,11 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityStyleRangeForIndex:")]
 		NSRange AccessibililtyStyleRangeForIndex (nint index)
 		{
+			if (GetStyleRangeForIndex == null) {
+				LoggingService.LogError ("Missing GetStyleRangeForIndex");
+				return default;
+			}
+
 			var realRange = GetStyleRangeForIndex ((int)index);
 			return new NSRange (realRange.Location, realRange.Length);
 		}
@@ -1616,6 +1658,11 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityRangeForPosition:")]
 		NSRange AccessibilityRangeForPosition (CGPoint position)
 		{
+			if (GetRangeForPosition == null) {
+				LoggingService.LogError ("Missing GetRangeForPosition");
+				return default;
+			}
+
 			var point = new Point ((int)position.X, (int)position.Y);
 			var realRange = GetRangeForPosition (point);
 			return new NSRange (realRange.Location, realRange.Length);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -1523,32 +1523,35 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 
 		public override nint AccessibilityInsertionPointLineNumber {
 			get {
-				if (InsertionPointLineNumber == null) {
-					LoggingService.LogError ("Missing InsertionPointLineNumber");
+				try {
+					return InsertionPointLineNumber ();
+				} catch (Exception e) {
+					LoggingService.LogInternalError (e);
 					return -1;
 				}
-				return InsertionPointLineNumber ();
 			}
 		}
 
 		public override nint AccessibilityNumberOfCharacters {
 			get {
-				if (NumberOfCharacters != null) {
-					LoggingService.LogError ("Missing NumberOfCharacters");
+				try {
+					return NumberOfCharacters ();
+				} catch (Exception e) {
+					LoggingService.LogInternalError (e);
 					return -1;
 				}
-				return NumberOfCharacters ();
 			}
 		}
 
 		public override NSRange AccessibilityVisibleCharacterRange {
 			get {
-				if (GetVisibleCharacterRange == null) {
-					LoggingService.LogError ("Missing GetVisibleCharacterRange");
+				try {
+					var realRange = GetVisibleCharacterRange ();
+					return new NSRange (realRange.Location, realRange.Length);
+				} catch (Exception e) {
+					LoggingService.LogInternalError (e);
 					return default;
 				}
-				var realRange = GetVisibleCharacterRange ();
-				return new NSRange (realRange.Location, realRange.Length);
 			}
 		}
 
@@ -1568,18 +1571,19 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityFrameForRange:")]
 		CGRect AccessibilityFrameForRange (NSRange range)
 		{
-			if (GetFrameForRange == null) {
-				LoggingService.LogError ("Missing GetFrameForRange");
-				return CGRect.Empty;
-			}
-
 			parentRef.TryGetTarget (out var parent);
 			if (parent == null) {
 				return CGRect.Empty;
 			}
 
 			var realRange = new AtkCocoa.Range { Location = (int)range.Location, Length = (int)range.Length };
-			var frame = GetFrameForRange (realRange);
+			Rectangle frame;
+			try {
+				frame = GetFrameForRange (realRange);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
+				return CGRect.Empty;
+			}
 
 			int parentX, parentY;
 
@@ -1600,72 +1604,73 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 		[Export ("accessibilityLineForIndex:")]
 		nint AccessibilityLineForIndex (nint index)
 		{
-			if (GetLineForIndex == null) {
-				LoggingService.LogError ("Missing GetLineForIndex");
+			try {
+				return GetLineForIndex ((int)index);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
 				return -1;
 			}
-			return GetLineForIndex ((int)index);
 		}
 
 		[Export ("accessibilityRangeForLine:")]
 		NSRange AccessibilityRangeForLine (nint line)
 		{
-			if (GetRangeForLine == null) {
-				LoggingService.LogError ("Missing GetRangeForLine");
+			try {
+				var range = GetRangeForLine ((int)line + 1);
+				return new NSRange (range.Location, range.Length);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
 				return default;
 			}
-
-			var range = GetRangeForLine ((int)line + 1);
-			return new NSRange (range.Location, range.Length);
 		}
 
 		[Export ("accessibilityStringForRange:")]
 		string AccessibilityStringForRange (NSRange range)
 		{
-			if (GetStringForRange == null) {
-				LoggingService.LogError ("Missing GetStringForRange");
+			try {
+				var realRange = new AtkCocoa.Range { Location = (int)range.Location, Length = (int)range.Length };
+				return GetStringForRange (realRange);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
 				return null;
 			}
-
-			var realRange = new AtkCocoa.Range { Location = (int)range.Location, Length = (int)range.Length };
-			return GetStringForRange (realRange);
 		}
 
 		[Export ("accessibilityRangeForIndex:")]
 		NSRange AccessibilityRangeForIndex (nint index)
 		{
-			if (GetRangeForIndex == null) {
-				LoggingService.LogError ("Missing GetRangeForIndex");
+			try {
+				var realRange = GetRangeForIndex ((int)index);
+				return new NSRange (realRange.Location, realRange.Length);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
 				return default;
 			}
-
-			var realRange = GetRangeForIndex ((int)index);
-			return new NSRange (realRange.Location, realRange.Length);
 		}
 
 		[Export ("accessibilityStyleRangeForIndex:")]
 		NSRange AccessibililtyStyleRangeForIndex (nint index)
 		{
-			if (GetStyleRangeForIndex == null) {
-				LoggingService.LogError ("Missing GetStyleRangeForIndex");
+			try {
+				var realRange = GetStyleRangeForIndex ((int)index);
+				return new NSRange (realRange.Location, realRange.Length);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
 				return default;
 			}
-
-			var realRange = GetStyleRangeForIndex ((int)index);
-			return new NSRange (realRange.Location, realRange.Length);
 		}
 
 		[Export ("accessibilityRangeForPosition:")]
 		NSRange AccessibilityRangeForPosition (CGPoint position)
 		{
-			if (GetRangeForPosition == null) {
-				LoggingService.LogError ("Missing GetRangeForPosition");
+			try {
+				var point = new Point ((int)position.X, (int)position.Y);
+				var realRange = GetRangeForPosition (point);
+				return new NSRange (realRange.Location, realRange.Length);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
 				return default;
 			}
-
-			var point = new Point ((int)position.X, (int)position.Y);
-			var realRange = GetRangeForPosition (point);
-			return new NSRange (realRange.Location, realRange.Length);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -625,9 +625,31 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			return new AccessibilityElementProxy (new RealAccessibilityElementButtonProxy ());
 		}
 
-		public static AccessibilityElementProxy TextElementProxy ()
+		public static AccessibilityElementProxy TextElementProxy (Func<string> contents,
+																  Func<int> numberOfCharacters,
+																  Func<int> insertionPointLineNumber,
+																  Func<AtkCocoa.Range, Rectangle> frameForRange,
+																  Func<int, int> lineForIndex,
+																  Func<int, AtkCocoa.Range> rangeForLine,
+																  Func<AtkCocoa.Range, string> stringForRange,
+																  Func<int, AtkCocoa.Range> rangeForIndex,
+																  Func<int, AtkCocoa.Range> styleRangeForIndex,
+																  Func<Point, AtkCocoa.Range> rangeForPosition,
+																  Func<AtkCocoa.Range> visibleCharacterRange)
 		{
-			return new AccessibilityElementProxy (new RealAccessibilityElementNavigableStaticTextProxy ());
+			return new AccessibilityElementProxy (new RealAccessibilityElementNavigableStaticTextProxy () {
+				Contents = contents,
+				NumberOfCharacters = numberOfCharacters,
+				InsertionPointLineNumber = insertionPointLineNumber,
+				GetFrameForRange = frameForRange,
+				GetLineForIndex = lineForIndex,
+				GetRangeForLine = rangeForLine,
+				GetStringForRange = stringForRange,
+				GetRangeForIndex = rangeForIndex,
+				GetStyleRangeForIndex = styleRangeForIndex,
+				GetRangeForPosition = rangeForPosition,
+				GetVisibleCharacterRange = visibleCharacterRange
+			});
 		}
 
 		public string Identifier {


### PR DESCRIPTION
If we try to call a null func<> then we'll get an NRE, so check they're set and warn if not.

Fixes VSTS #780731