### PR TITLE
[Core] Build all frameworks in multi-target project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1374,7 +1374,7 @@ namespace MonoDevelop.Projects
 			string [] evaluateItems = context != null ? context.ItemsToEvaluate.ToArray () : new string [0];
 			string [] evaluateProperties = context != null ? context.PropertiesToEvaluate.ToArray () : new string [0];
 
-			var globalProperties = CreateGlobalProperties ();
+			var globalProperties = CreateGlobalProperties (target);
 			if (context != null) {
 				var md = (ProjectItemMetadata)context.GlobalProperties;
 				md.SetProject (sourceProject);
@@ -1569,11 +1569,15 @@ namespace MonoDevelop.Projects
 			return null;
 		}
 
-		internal Dictionary<string, string> CreateGlobalProperties ()
+		/// <summary>
+		/// Sets a global TargetFramework property for multi-target projects so MSBuild targets work.
+		/// For Build and Clean the TargetFramework property is not set so all frameworks are built.
+		/// </summary>
+		internal Dictionary<string, string> CreateGlobalProperties (string target)
 		{
 			var properties = new Dictionary<string, string> ();
 			string framework = activeTargetFramework;
-			if (framework != null)
+			if (framework != null && target != ProjectService.BuildTarget && target != ProjectService.CleanTarget)
 				properties ["TargetFramework"] = framework;
 			return properties;
 		}

--- a/main/tests/test-projects/multi-target/MyClass.cs
+++ b/main/tests/test-projects/multi-target/MyClass.cs
@@ -1,0 +1,5 @@
+using System;
+
+class MyClass
+{
+}

--- a/main/tests/test-projects/multi-target/multi-target2.csproj
+++ b/main/tests/test-projects/multi-target/multi-target2.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1;netstandard1.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When running MSBuild targets the TargetFramework property was explicitly
set so that multi-target framework projects work for targets such as
ResolveAssemblyReferences. However setting this property prevents
MSBuild from building all frameworks for a project using the
cross-target MSBuild targets. To fix this when the Build or Clean
MSBuild targets are run the TargetFramework is not set. This allows
all frameworks to be built by MSBuild.

Fixes VSTS #572330 - Support building multi-targeted projects