### PR TITLE
[Core] Fix error saving project with ToolsVersion set to Current

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildFileFormat.cs
@@ -74,6 +74,9 @@ namespace MonoDevelop.Projects.MSBuild
 
 		public static bool ToolsSupportMonikers (string toolsVersion)
 		{
+			if (StringComparer.OrdinalIgnoreCase.Equals ("Current", toolsVersion))
+				return true;
+
 			return new Version (toolsVersion) >= new Version ("4.0");
 		}
 		

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectLoadSaveTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectLoadSaveTests.cs
@@ -1393,6 +1393,19 @@ namespace MonoDevelop.Projects
 				Assert.That (p.LoadError, Contains.Substring ("circular dependency"));
 			}
 		}
+
+		[Test]
+		public async Task Save_SdkProject_ToolsVersionCurrent ()
+		{
+			string projectFile = Util.GetSampleProject ("tools-version-current", "netstandard.csproj");
+			using (var p = await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFile) as DotNetProject) {
+				p.DefaultNamespace = "Test";
+				await p.SaveAsync (Util.GetMonitor ());
+
+				Assert.IsTrue (MSBuildFileFormat.ToolsSupportMonikers ("Current"));
+				Assert.IsTrue (MSBuildFileFormat.ToolsSupportMonikers ("current"));
+			}
+		}
 	}
 
 	class CustomItem : ProjectItem

--- a/main/tests/test-projects/tools-version-current/netstandard.csproj
+++ b/main/tests/test-projects/tools-version-current/netstandard.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Saving an SDK style project that set ToolsVersion="Current" would
fail as an attempt was made to parse the version using System.Version.

    System.ArgumentException: Version string portion was too short or too long.
    Parameter name: input
      at System.Version.ParseVersion

Fixes VSTS #897947 - SDK Projects with ToolsVersion="Current"