### PR TITLE
[release-8.1] [Logging] Fix stacktraces not being written to log files

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -266,6 +266,12 @@ namespace MonoDevelop.MacIntegration
 			}
 
 			public override string StackTrace { get; }
+
+			public override string ToString ()
+			{
+				// Matches normal exception format:
+				return GetType () + ": " + Message + Environment.NewLine + StackTrace;
+			}
 		}
 
 		[DllImport (FoundationLib)]

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs
@@ -289,12 +289,18 @@ namespace MonoDevelop.Ide.Gui
 
 		sealed class CriticalGtkException : Exception
 		{
-			public CriticalGtkException(string message, string stacktrace) : base(message)
+			public CriticalGtkException (string message, string stacktrace) : base (message)
 			{
 				StackTrace = stacktrace;
 			}
 
 			public override string StackTrace { get; }
+
+			public override string ToString ()
+			{
+				// Matches normal exception format:
+				return GetType() + ": " + Message + Environment.NewLine + StackTrace;
+			}
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MonoDevelop.Core;
 using MonoDevelop.Core.LogReporting;
 using NUnit.Framework;
@@ -36,7 +37,7 @@ namespace MonoDevelop.Ide.Gui
 	public class GLibLoggingTests
 	{
 		[Test]
-		public void ValidateCrashIsSentForGLibExceptions()
+		public void ValidateCrashIsSentForGLibExceptions ()
 		{
 			var old = GLibLogging.Enabled;
 			var crashReporter = new CapturingCrashReporter ();
@@ -54,14 +55,43 @@ namespace MonoDevelop.Ide.Gui
 				Assert.That (crashReporter.LastException.Source, Is.Not.Null);
 
 				var stacktrace = crashReporter.LastException.StackTrace;
-				Assert.That (stacktrace, Contains.Substring ("at MonoDevelopProcessHost.Main"));
-				Assert.That (stacktrace, Contains.Substring ("at GLib.Log.g_logv"));
-				Assert.That (stacktrace, Contains.Substring ("at MonoDevelop.Ide.Gui.GLibLoggingTests.ValidateCrashIsSentForGLibExceptions"));
+				AssertGLibStackTrace (stacktrace);
+
 				// Error will cause the application to exit, so we can't test for that, but it follows the same code as Critical.
 			} finally {
 				LoggingService.UnregisterCrashReporter (crashReporter);
 				GLibLogging.Enabled = old;
 			}
+		}
+
+		[Test]
+		public void CriticalErrorsExceptionsHaveFullStacktracesInLog ()
+		{
+			var old = GLibLogging.Enabled;
+			var logger = new CapturingLogger {
+				EnabledLevel = Core.Logging.EnabledLoggingLevel.Error,
+			};
+
+			try {
+				LoggingService.AddLogger (logger);
+				GLibLogging.Enabled = true;
+
+				GLib.Log.Write ("Gtk", GLib.LogLevelFlags.Critical, "{0}", "critical should be captured");
+				var (_, message) = logger.LogMessages.Single (x => x.Level == Core.Logging.LogLevel.Error);
+				AssertGLibStackTrace (message);
+			} finally {
+				LoggingService.RemoveLogger (logger.Name);
+				GLibLogging.Enabled = old;
+			}
+		}
+
+		static void AssertGLibStackTrace(string stacktrace)
+		{
+			Assert.That (stacktrace, Contains.Substring ("at MonoDevelopProcessHost.Main"));
+			Assert.That (stacktrace, Contains.Substring ("at GLib.Log.g_logv"));
+			Assert.That (stacktrace, Contains.Substring ("at MonoDevelop.Ide.Gui.GLibLogging.LoggerMethod"));
+			Assert.That (stacktrace, Contains.Substring ("at MonoDevelop.Ide.Gui.GLibLoggingTests"));
+
 		}
 	}
 }

--- a/main/tests/UnitTests/CapturingLogger.cs
+++ b/main/tests/UnitTests/CapturingLogger.cs
@@ -1,0 +1,48 @@
+//
+// CapturingLogger.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using MonoDevelop.Core.Logging;
+
+namespace UnitTests
+{
+	public class CapturingLogger : ILogger
+	{
+		public List<(LogLevel Level, string Message)> LogMessages { get; } = new List<(LogLevel, string)> ();
+
+		public CapturingLogger ([CallerMemberName] string caller = null, int count = 0)
+		{
+			Name = "CapturingLogger_" + count.ToString () + caller;
+		}
+
+		public string Name { get; }
+		public EnabledLoggingLevel EnabledLevel { get; set; } = EnabledLoggingLevel.All;
+
+		public void Log (LogLevel level, string message) => LogMessages.Add ((level, message));
+	}
+}

--- a/main/tests/UnitTests/UnitTests.csproj
+++ b/main/tests/UnitTests/UnitTests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="ObjectReference.cs" />
     <Compile Include="RequireServiceAttribute.cs" />
     <Compile Include="CapturingCrashReporter.cs" />
+    <Compile Include="CapturingLogger.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">


### PR DESCRIPTION
Log files use Exception.ToString() for string formatting, thus do not benefit from our improved stacktrace gathering for native exceptions

Fix that by overriding the tostring method
Fixes VSTS #897159 - GLib Error Logging does not include stack trace

Backport of #7663.

/cc @Therzok 