### PR TITLE
[Core] Make Task.Ignore only attach run continuation on task failure

### DIFF
--- a/main/src/core/MonoDevelop.Core/CoreExtensions.cs
+++ b/main/src/core/MonoDevelop.Core/CoreExtensions.cs
@@ -258,9 +258,8 @@ namespace System
 		public static void Ignore (this Task task)
 		{
 			task.ContinueWith (t => {
-				if (t.IsFaulted)
-					LoggingService.LogError ("Async operation failed", t.Exception);
-			});
+				LoggingService.LogError ("Async operation failed", t.Exception);
+			}, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Instead of running the continuation and scheduling a task on every ignored one