### PR TITLE
Fix issues when opening a document

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -90,7 +90,7 @@ namespace MonoDevelop.Debugger
 				labelDisassembly.Markup = GettextCatalog.GetString ("View disassembly in the {0}", "<a href=\"clicked\">" + GettextCatalog.GetString ("Disassembly Tab") + "</a>");
 				labelDisassembly.LinkClicked += (sender, e) => {
 					DebuggingService.ShowDisassembly ();
-					this.WorkbenchWindow.Document.Close (false).Ignore ();
+					Document.Close (false).Ignore ();
 				};
 				box.PackStart (labelDisassembly);
 			}
@@ -135,7 +135,7 @@ namespace MonoDevelop.Debugger
 
 						var doc = await IdeApp.Workbench.OpenDocument (newFilePath, null, sf.SourceLocation.Line, 1, OpenDocumentOptions.Debugger);
 						if (doc != null) {
-							await this.WorkbenchWindow.Document.Close (false);
+							await Document.Close (false);
 						}
 					}
 				} else {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -72,8 +72,6 @@ namespace MonoDevelop.Ide.Gui.Documents
 		bool hasFocus;
 		bool disposed;
 
-		internal IWorkbenchWindow WorkbenchWindow { get; set; }
-
 		ExtensionChain extensionChain;
 		DocumentControllerExtension itemExtension;
 		private bool showNotification;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -522,8 +522,10 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 			var window = await workbench.ShowView (documentOpenInfo.DocumentController, documentOpenInfo.DockNotebook, commandHandler);
 
-			var doc = new Document (this, workbench, documentOpenInfo.DocumentController, documentOpenInfo.DocumentControllerDescription);
-			await doc.InitializeWindow (window);
+			var doc = new Document (this, workbench, documentOpenInfo.DocumentController, documentOpenInfo.DocumentControllerDescription, window);
+
+			// Don't wait for the view to be initialized. The document can be made visible and can be functional before getting the view.
+			doc.InitializeViewAsync ().Ignore ();
 
 			doc.Closing += OnWindowClosing;
 			doc.Closed += OnWindowClosed;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
@@ -201,7 +201,8 @@ namespace MonoDevelop.Ide.Gui.Shell
 			// Focus the tab in the next iteration since presenting the window may take some time
 			Application.Invoke ((o, args) => {
 				DockNotebook.ActiveNotebook = tabControl;
-				view.Load ().Ignore ();
+				if (view != null)
+					view.Load ().Ignore ();
 			});
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -270,6 +270,11 @@ namespace MonoDevelop.Ide.Gui
 			view.ActiveViewInHierarchyChanged += ActiveViewInHierarchyChanged;
 			view.IsRoot = true;
 			window.SetRootView (view.CreateShellView (window));
+
+			// The view may provide additional content, so raise the content change.
+			// The document can be returned before the view is initialized, so
+			// there may already be content subscribers.
+			OnContentChanged ();
 		}
 
 		void SubscribeControllerEvents ()

--- a/main/tests/IdeUnitTests/MockShellWindow.cs
+++ b/main/tests/IdeUnitTests/MockShellWindow.cs
@@ -36,6 +36,7 @@ namespace IdeUnitTests
 	public class MockShellWindow: IWorkbenchWindow
 	{
 		EventHandler<NotebookChangeEventArgs> notebookChanged;
+		TaskCompletionSource<bool> rootAssigned = new TaskCompletionSource<bool> ();
 
 		public MockShellWindow (MockShell shell, DocumentController controller, MockShellNotebook notebook)
 		{
@@ -91,10 +92,12 @@ namespace IdeUnitTests
 		void IWorkbenchWindow.SetRootView (IShellDocumentViewItem view)
 		{
 			RootView = (MockShellDocumentView)view;
+			rootAssigned.TrySetResult (true);
 		}
 
 		public async Task Show ()
 		{
+			await rootAssigned.Task;
 			if (RootView != null)
 				await RootView.Show ();
 		}


### PR DESCRIPTION
When opening a document, the view may take long time to initialize (for example when loading a designer). This used to delay the whole document initialization sequence. During that initialization the corresponding tab in the shell was already visible, and that caused some bugs since there was
code expecting a fully initialized document.

Two things have been done to solve this problem. First, the document initialization doesn't wait anymore for the view to be initialized, so that when the tab is show, the document initialization is complete. Second, checks have been added to the Document and SdiWorkspaceWindow classes
to properly handle documents that don't yet have a view.

Also removed obsolete WorkbenchWindow api.

Fixes VSTS #889288 - Opening a document does not focus the new document
Fixes VSTS #889300 - NavigationHistoryService triggers an exception which crashes the IDE