### PR TITLE
[release-8.1] Fix tab stacking issue in designers

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -722,21 +722,13 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		void OnDocumentOpened (DocumentEventArgs e)
 		{
-			try {
-				DocumentOpened?.SafeInvoke (this, e);
-			} catch (Exception ex) {
-				LoggingService.LogError ("Exception while opening documents", ex);
-			}
+			DocumentOpened?.SafeInvoke (this, e);
 		}
 
 		void OnDocumentClosed (Document doc)
 		{
-			try {
-				var e = new DocumentEventArgs (doc);
-				DocumentClosed?.SafeInvoke (this, e);
-			} catch (Exception ex) {
-				LoggingService.LogError ("Exception while closing documents", ex);
-			}
+			var e = new DocumentEventArgs (doc);
+			DocumentClosed?.SafeInvoke (this, e);
 		}
 
 		async Task OnDocumentClosing (DocumentCloseEventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerSplit.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerSplit.cs
@@ -209,6 +209,11 @@ namespace MonoDevelop.Ide.Gui.Shell
 			return paned.Children.Cast<GtkShellDocumentViewItem> ();
 		}
 
+		public GtkShellDocumentViewItem GetChild (int index)
+		{
+			return (GtkShellDocumentViewItem) paned.Children [index];
+		}
+
 		public void SetViewTitle (GtkShellDocumentViewItem view, string label, Xwt.Drawing.Image icon, string accessibilityDescription)
 		{
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerTabs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerTabs.cs
@@ -156,6 +156,11 @@ namespace MonoDevelop.Ide.Gui.Shell
 			return tabstrip.Tabs.Select (t => t.Tag).Cast<GtkShellDocumentViewItem> ();
 		}
 
+		public GtkShellDocumentViewItem GetChild (int index)
+		{
+			return (GtkShellDocumentViewItem)tabstrip.Tabs [index].Tag;
+		}
+
 		public void SetViewTitle (GtkShellDocumentViewItem view, string label, Xwt.Drawing.Image icon, string accessibilityDescription)
 		{
 			var tab = tabstrip.Tabs.FirstOrDefault (t => t.Tag == view);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewItem.cs
@@ -63,12 +63,10 @@ namespace MonoDevelop.Ide.Gui.Shell
 			Title = label;
 			Icon = icon;
 			AccessibilityDescription = accessibilityDescription;
-			var parent = Parent;
-			while (parent != null && !(parent is GtkShellDocumentViewContainer))
-				parent = parent.Parent;
-			if (parent is GtkShellDocumentViewContainer container)
-				container.SetViewTitle (this, label, icon, accessibilityDescription);
+			ParentContainer?.SetViewTitle (this, label, icon, accessibilityDescription);
 		}
+
+		public GtkShellDocumentViewContainer ParentContainer { get; set; }
 
 		public string Title { get; set; }
 		public Xwt.Drawing.Image Icon { get; set; }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
@@ -288,7 +288,7 @@ namespace MonoDevelop.Ide.Gui.Shell
 
 		public void Close ()
 		{
-			view.DetachFromView ();
+			view?.DetachFromView ();
 			Destroy ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Styles.cs
@@ -379,7 +379,7 @@ namespace MonoDevelop.Ide.Gui
 			PadLabelColor = BaseForegroundColor;
 			SubTabBarActiveBackgroundColor = BaseSelectionBackgroundColor;
 			SubTabBarActiveTextColor = BaseSelectionTextColor;
-			SubTabBarSeparatorColor = SubTabBarTextColor;
+			SubTabBarSeparatorColor = ThinSplitterColor;
 			InactiveBrowserPadBackground = InactivePadBackground;
 
 			// Tabs


### PR DESCRIPTION
When a tabbed view has attached views, there is a tab stacking effect
that is very confusing.

To avoid this problem, when a tabbed view has a child that also has
tabs, the tabs are now shown in the parent's tab area, next to the
parent's tabs.

Before:

<img width="348" alt="Captura de Pantalla 2019-05-24 a les 19 30 20" src="https://user-images.githubusercontent.com/260349/58346164-7d8c1680-7e5a-11e9-8414-828b1f73b1bc.png">

After:

<img width="441" alt="Captura de Pantalla 2019-05-24 a les 19 30 30" src="https://user-images.githubusercontent.com/260349/58346180-85e45180-7e5a-11e9-83eb-0e290b25a246.png">

Fixes VSTS# 893310 - New split view results in stacked tabs with the
same name

Backport of #7667.

/cc @slluis 