### PR TITLE
Fixes VSTS Bug 895926: Version Control > Log jumps to wrong tag

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Commands.cs
@@ -1,4 +1,4 @@
-
+﻿
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Projects;
 using MonoDevelop.Ide;
@@ -243,27 +243,47 @@ namespace MonoDevelop.VersionControl
 		}
 	}
 
-	class CurrentFileViewHandler<T> : FileVersionControlCommandHandler
+	abstract class CurrentFileViewHandler<T> : FileVersionControlCommandHandler
 	{
+		protected bool CanRunCommand { get => IdeApp.Workbench.ActiveDocument?.GetContent<VersionControlDocumentController> () != null; }
+
 		protected override bool RunCommand (VersionControlItemList items, bool test)
 		{
-			if (test)
-				return true;
-
-			IdeApp.Workbench.ActiveDocument?.GetContent<VersionControlDocumentController> ()?.ShowDiffView ();
-			return true;
+			return CanRunCommand;
 		}
 	}
 
 	class CurrentFileDiffHandler : CurrentFileViewHandler<IDiffView>
 	{
+		protected override bool RunCommand (VersionControlItemList items, bool test)
+		{
+			if (test)
+				return CanRunCommand;
+			IdeApp.Workbench.ActiveDocument?.GetContent<VersionControlDocumentController> ()?.ShowDiffView ();
+			return true;
+		}
 	}
-	
+
 	class CurrentFileBlameHandler : CurrentFileViewHandler<IBlameView>
 	{
+		protected override bool RunCommand (VersionControlItemList items, bool test)
+		{
+			if (test)
+				return CanRunCommand;
+			IdeApp.Workbench.ActiveDocument?.GetContent<VersionControlDocumentController> ()?.ShowBlameView ();
+			return true;
+		}
+
 	}
-	
+
 	class CurrentFileLogHandler : CurrentFileViewHandler<ILogView>
 	{
+		protected override bool RunCommand (VersionControlItemList items, bool test)
+		{
+			if (test)
+				return CanRunCommand;
+			IdeApp.Workbench.ActiveDocument?.GetContent<VersionControlDocumentController> ()?.ShowLogView ();
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
Fixes VSTS Bug 895925: Version Control > Authors jumps to wrong tab

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/895926
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/895925

These two are very similiar. That patch fixes blame command as well.
The command handlers for these were not implemented and simply fell
back to the diff command handler.