### PR TITLE
Launch settings fix

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
@@ -183,6 +183,28 @@ namespace MonoDevelop.AspNetCore.Tests
 			Assert.That (config.Name, Is.EqualTo ("Default"));
 		}
 
+		[Test]
+		public async Task SyncRunConfigurations_syncs_RunConfigs ()
+		{
+			var solutionFileName = Util.GetSampleProject ("aspnetcore-empty-22", "aspnetcore-empty-22.sln");
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = (DotNetProject)solution.GetAllProjects ().Single ();
+
+			project.RunConfigurations.Clear ();
+			Assert.That (project.RunConfigurations, Is.Empty);
+			
+			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
+			System.IO.File.WriteAllText (launchProfileProvider.LaunchSettingsJsonPath, LaunchSettings);
+			launchProfileProvider.LoadLaunchSettings ();
+			launchProfileProvider.SyncRunConfigurations (project);
+
+			Assert.That (project.RunConfigurations, Has.Count.EqualTo (2));
+			Assert.That (project.RunConfigurations [0].Name, Is.EqualTo ("Kestrel Staging"));
+			Assert.False (project.RunConfigurations [0].StoreInUserFile);
+			Assert.That (project.RunConfigurations [1].Name, Is.EqualTo ("EnvironmentsSample"));
+			Assert.False (project.RunConfigurations [1].StoreInUserFile);
+		}
+
 		[TearDown]
 		public override void TearDown ()
 		{

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.AspNetCore.Tests
 			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = (DotNetProject)solution.GetAllProjects ().Single ();
 
-			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory,project.DefaultNamespace);
+			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
 			launchProfileProvider.LoadLaunchSettings ();
 
 			Assert.That (launchProfileProvider.ProfilesObject, Is.Not.Null);
@@ -110,7 +110,7 @@ namespace MonoDevelop.AspNetCore.Tests
 		{
 			var solutionFileName = Util.GetSampleProject ("aspnetcore-empty-22", "aspnetcore-empty-22.sln");
 			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
-			var project = (DotNetProject) solution.GetAllProjects ().Single ();
+			var project = (DotNetProject)solution.GetAllProjects ().Single ();
 
 			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
 			launchProfileProvider.LoadLaunchSettings ();
@@ -122,9 +122,9 @@ namespace MonoDevelop.AspNetCore.Tests
 			//modifiying launchSettings.json externally and loading it again
 			System.IO.File.WriteAllText (launchProfileProvider.LaunchSettingsJsonPath, LaunchSettings);
 			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
-            project = (DotNetProject)solution.GetAllProjects ().Single ();
+			project = (DotNetProject)solution.GetAllProjects ().Single ();
 
-			var config = project.GetDefaultRunConfiguration() as AspNetCoreRunConfiguration;
+			var config = project.GetDefaultRunConfiguration () as AspNetCoreRunConfiguration;
 
 			Assert.That (config, Is.Not.Null, "GetDefaultRunConfiguration cast to AspNetCoreRunConfiguration is null");
 			Assert.That (project.RunConfigurations, Has.Count.EqualTo (3));

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreExecutionHandler.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreExecutionHandler.cs
@@ -36,10 +36,7 @@ namespace MonoDevelop.AspNetCore
 {
 	class AspNetCoreExecutionHandler : IExecutionHandler
 	{
-		public bool CanExecute (ExecutionCommand command)
-		{
-			return command is AspNetCoreExecutionCommand;
-		}
+		public bool CanExecute (ExecutionCommand command) => command is AspNetCoreExecutionCommand;
 
 		public ProcessAsyncOperation Execute (ExecutionCommand command, OperationConsole console)
 		{
@@ -67,12 +64,10 @@ namespace MonoDevelop.AspNetCore
 		public static async Task LaunchBrowserAsync (string appUrl, string launchUrl, ExecutionTarget target, Task processTask)
 		{
 			launchUrl = launchUrl ?? "";
-			Uri launchUri;
 			//Check if lanuchUrl is valid absolute url and use it if it is...
-			if (!Uri.TryCreate (launchUrl, UriKind.Absolute, out launchUri)) {
+			if (!Uri.TryCreate (launchUrl, UriKind.Absolute, out var launchUri)) {
 				//Otherwise check if appUrl is valid absolute and lanuchUrl is relative then concat them...
-				Uri appUri;
-				if (!Uri.TryCreate (appUrl, UriKind.Absolute, out appUri)) {
+				if (!Uri.TryCreate (appUrl, UriKind.Absolute, out var appUri)) {
 					LoggingService.LogWarning ("Failed to launch browser because invalid launch and app urls.");
 					return;
 				}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -43,18 +43,17 @@ namespace MonoDevelop.AspNetCore
 
 		bool updating;
 		Dictionary<string, AspNetCoreRunConfiguration> aspNetCoreRunConfs = new Dictionary<string, AspNetCoreRunConfiguration> ();
-		readonly object profiles = new object ();
 		LaunchProfileProvider launchProfileProvider;
 
 		protected override ProjectRunConfiguration OnCreateRunConfiguration (string name)
 		{
 			InitLaunchSettingsProvider ();
 
-			if (aspNetCoreRunConfs.ContainsKey (name))
-				return aspNetCoreRunConfs [name];
+			if (aspNetCoreRunConfs.TryGetValue (name, out var aspNetCoreRunConfiguration))
+				return aspNetCoreRunConfiguration;
 
 			var profile = new LaunchProfileData ();
-			if (!launchProfileProvider.Profiles.ContainsKey (name)) {
+			if (!launchProfileProvider.Profiles.TryGetValue (name, out var _)) {
 				if (name == "Default") {
 					profile = launchProfileProvider.AddNewProfile (Project.DefaultNamespace);
 					launchProfileProvider.Profiles [Project.DefaultNamespace] = profile;
@@ -234,64 +233,64 @@ namespace MonoDevelop.AspNetCore
 			if (launchSettings == null)
 				return;
 
-			lock (profiles) {
-				updating = true;
+			updating = true;
 
-				launchProfileProvider.LoadLaunchSettings ();
+			launchProfileProvider.LoadLaunchSettings ();
 
-				foreach (var profile in launchProfileProvider.Profiles) {
-					if (profile.Value.CommandName != "Project")
-						continue;
+			foreach (var profile in launchProfileProvider.Profiles) {
+				if (profile.Value.CommandName != "Project")
+					continue;
 
-					var key = string.Empty;
+				var key = string.Empty;
 
-					if (profile.Key == this.Project.DefaultNamespace) {
-						key = "Default";
-					} else {
-						key = profile.Key;
-					}
-
-					var runConfig = this.Project.RunConfigurations.FirstOrDefault (x => x.Name == key);
-					if (runConfig == null) {
-						var projectRunConfiguration = new AspNetCoreRunConfiguration (key, profile.Value) {
-							StartAction = "Project"
-						};
-						this.Project.RunConfigurations.Add (projectRunConfiguration);
-					} else {
-                        if (runConfig is AspNetCoreRunConfiguration aspNetCoreRunConfiguration) {
-							var index = Project.RunConfigurations.IndexOf (runConfig);
-							aspNetCoreRunConfiguration.CurrentProfile = profile.Value;
-							this.Project.RunConfigurations [index] = runConfig;
-						}
-					}
+				if (profile.Key == this.Project.DefaultNamespace) {
+					key = "Default";
+				} else {
+					key = profile.Key;
 				}
 
-				var itemsRemoved = new RunConfigurationCollection ();
-
-				foreach (var config in Project.RunConfigurations) {
-					var key = config.Name;
-
-					if (config.Name == "Default") {
-						key = this.Project.DefaultNamespace;
+				var runConfig = this.Project.RunConfigurations.FirstOrDefault (x => x.Name == key);
+				if (runConfig == null) {
+					var projectRunConfiguration = new AspNetCoreRunConfiguration (key, profile.Value) {
+						StartAction = "Project"
+					};
+					this.Project.RunConfigurations.Add (projectRunConfiguration);
+				} else {
+					if (runConfig is AspNetCoreRunConfiguration aspNetCoreRunConfiguration) {
+						var index = Project.RunConfigurations.IndexOf (runConfig);
+						aspNetCoreRunConfiguration.CurrentProfile = profile.Value;
+						this.Project.RunConfigurations [index] = runConfig;
 					}
-
-					if (launchProfileProvider.Profiles.ContainsKey (key))
-						continue;
-
-					itemsRemoved.Add (config);
 				}
-
-				Project.RunConfigurations.RemoveRange (itemsRemoved);
-
-				updating = false;
 			}
+
+			var itemsRemoved = new RunConfigurationCollection ();
+
+			foreach (var config in Project.RunConfigurations) {
+				var key = config.Name;
+
+				if (config.Name == "Default") {
+					key = this.Project.DefaultNamespace;
+				}
+
+				if (launchProfileProvider.Profiles.TryGetValue (key, out var _))
+					continue;
+
+				itemsRemoved.Add (config);
+			}
+
+			Project.RunConfigurations.RemoveRange (itemsRemoved);
+
+			updating = false;
 		}
 
-		protected override void OnRemoveRunConfiguration (string name)
+		protected override void OnRemoveRunConfiguration (IEnumerable<SolutionItemRunConfiguration> items)
 		{
 			if (updating || launchProfileProvider == null)
 				return;
-			launchProfileProvider.Profiles.TryRemove (name, out var _);
+			foreach (var item in items) {
+				launchProfileProvider.Profiles.TryRemove (item.Name, out var _);
+			}
 			launchProfileProvider.SaveLaunchSettings ();
 		}
 	}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -53,16 +53,14 @@ namespace MonoDevelop.AspNetCore
 				return aspNetCoreRunConfiguration;
 
 			var profile = new LaunchProfileData ();
-			if (!launchProfileProvider.Profiles.TryGetValue (name, out var _)) {
-				if (name == "Default") {
-					profile = launchProfileProvider.AddNewProfile (Project.DefaultNamespace);
-					launchProfileProvider.Profiles [Project.DefaultNamespace] = profile;
-				} else {
-					profile = launchProfileProvider.AddNewProfile (name);
-					launchProfileProvider.Profiles [name] = profile;
-				}
+
+			var key = name != "Default" ? name : this.Project.DefaultNamespace;
+
+			if (!launchProfileProvider.Profiles.TryGetValue (key, out var _)) {
+				profile = launchProfileProvider.AddNewProfile (key);
+				launchProfileProvider.Profiles [key] = profile;
 			} else {
-				profile = launchProfileProvider.Profiles [name];
+				profile = launchProfileProvider.Profiles [key];
 			}
 
 			var aspnetconf = new AspNetCoreRunConfiguration (name, profile);

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -35,19 +35,55 @@ using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 
 namespace MonoDevelop.AspNetCore
-{
+{   
 	[ExportProjectModelExtension]
 	class AspNetCoreProjectExtension : DotNetCoreProjectExtension
 	{
-		AspNetCoreRunConfiguration aspNetCoreRunConf;
 		public const string TypeScriptCompile = "TypeScriptCompile";
 
+		bool updating;
+		readonly Dictionary<string, AspNetCoreRunConfiguration> aspNetCoreRunConfs = new Dictionary<string, AspNetCoreRunConfiguration> ();
+		readonly object profiles = new object ();
+        LaunchProfileProvider launchProfileProvider;
+         
 		protected override ProjectRunConfiguration OnCreateRunConfiguration (string name)
 		{
-			if (aspNetCoreRunConf == null) {
-				aspNetCoreRunConf = new AspNetCoreRunConfiguration (name, this.Project);
+			InitLaunchSettingsProvider ();
+
+			if (aspNetCoreRunConfs.ContainsKey (name))
+				return aspNetCoreRunConfs [name];
+
+			var profile = new LaunchProfileData ();
+			if (!launchProfileProvider.Profiles.ContainsKey (name)) {
+				if (name == "Default") {
+					profile = launchProfileProvider.AddNewProfile (Project.DefaultNamespace);
+					launchProfileProvider.Profiles [Project.DefaultNamespace] = profile;
+				} else {
+					profile = launchProfileProvider.AddNewProfile (name);
+					launchProfileProvider.Profiles [name] = profile;
+				}
+			} else {
+				profile = launchProfileProvider.Profiles [name];
 			}
-			return aspNetCoreRunConf;
+
+			var aspnetconf = new AspNetCoreRunConfiguration (name, profile);
+            aspnetconf.SaveRequested += Aspnetconf_Save;
+			aspNetCoreRunConfs.Add (name, aspnetconf);
+			return aspnetconf;
+		}
+
+		void Aspnetconf_Save (object sender, EventArgs e)
+		{
+            if (sender is AspNetCoreRunConfiguration config && config.IsDirty)
+			    launchProfileProvider.SaveLaunchSettings ();
+		}
+
+        void InitLaunchSettingsProvider ()
+		{
+			if (launchProfileProvider == null) {
+				launchProfileProvider = new LaunchProfileProvider (this.Project.BaseDirectory, this.Project.DefaultNamespace);
+				launchProfileProvider.LoadLaunchSettings ();
+			}
 		}
 
 		protected override bool SupportsObject (WorkspaceObject item)
@@ -76,8 +112,7 @@ namespace MonoDevelop.AspNetCore
 		private ExecutionCommand CreateAspNetCoreExecutionCommand (ConfigurationSelector configSel, DotNetProjectConfiguration configuration, ProjectRunConfiguration runConfiguration)
 		{
 			FilePath outputFileName;
-			var aspnetCoreRunConfiguration = runConfiguration as AspNetCoreRunConfiguration;
-			if (aspnetCoreRunConfiguration == null)
+			if (!(runConfiguration is AspNetCoreRunConfiguration aspnetCoreRunConfiguration))
 				return null;
 			if (aspnetCoreRunConfiguration.StartAction == AssemblyRunConfiguration.StartActions.Program)
 				outputFileName = aspnetCoreRunConfiguration.StartProgram;
@@ -150,27 +185,109 @@ namespace MonoDevelop.AspNetCore
 
 			return base.OnGetDefaultBuildAction (fileName);
 		}
-
+		
 		protected override void OnItemReady ()
 		{
 			base.OnItemReady ();
 			FileService.FileChanged += FileService_FileChanged;
+
+			InitLaunchSettingsProvider ();
+
+			foreach (var profile in launchProfileProvider.Profiles) {
+
+				if (profile.Value.CommandName != "Project")
+					continue;
+
+				var key = string.Empty;
+
+				if (profile.Key == this.Project.DefaultNamespace) {
+					key = "Default";
+				} else {
+					key = profile.Key;
+				}
+
+				var runConfig = this.Project.RunConfigurations.FirstOrDefault (x => x.Name == key);
+				if (runConfig == null) {
+					var projectRunConfiguration = new AspNetCoreRunConfiguration (key, profile.Value) {
+						StartAction = "Project"
+					};
+					this.Project.RunConfigurations.Add (projectRunConfiguration);
+				}
+			}
 		}
 
 		public override void Dispose ()
 		{
 			base.Dispose ();
 			FileService.FileChanged -= FileService_FileChanged;
+			foreach (var conf in aspNetCoreRunConfs) {
+				conf.Value.SaveRequested -= Aspnetconf_Save;
+			}
 		}
 
 		void FileService_FileChanged (object sender, FileEventArgs e)
 		{
-			var launchSettingsPath = aspNetCoreRunConf?.launchProfileProvider?.launchSettingsJsonPath;
+			var launchSettingsPath = launchProfileProvider?.LaunchSettingsJsonPath;
 			var launchSettings = e.FirstOrDefault (x => x.FileName == launchSettingsPath && !x.FileName.IsDirectory);
 			if (launchSettings == null)
 				return;
+			
+			lock (profiles) {
+				updating = true;
 
-			aspNetCoreRunConf.RefreshLaunchSettings ();
+				launchProfileProvider.LoadLaunchSettings ();
+				
+				foreach (var profile in launchProfileProvider.Profiles) {
+					if (profile.Value.CommandName != "Project")
+						continue;
+
+					var key = string.Empty;
+
+					if (profile.Key == this.Project.DefaultNamespace) {
+						key = "Default";
+					} else {
+						key = profile.Key;
+					}
+
+					var runConfig = this.Project.RunConfigurations.FirstOrDefault (x => x.Name == key);
+					if (runConfig == null) {
+						var projectRunConfiguration = new AspNetCoreRunConfiguration (key, profile.Value) {
+							StartAction = "Project"
+						};
+						this.Project.RunConfigurations.Add (projectRunConfiguration);
+					} else {
+						var index = Project.RunConfigurations.IndexOf (runConfig);
+						this.Project.RunConfigurations [index] = runConfig;
+					}
+				}
+
+				var itemsRemoved = new RunConfigurationCollection ();
+
+                foreach (var config in Project.RunConfigurations) {
+					var key = config.Name;
+
+					if (config.Name == "Default") {
+						key = this.Project.DefaultNamespace;
+					}
+
+					if (launchProfileProvider.Profiles.ContainsKey (key))
+						continue;
+
+					itemsRemoved.Add (config);
+				}
+
+				Project.RunConfigurations.RemoveRange (itemsRemoved);
+
+				updating = false;
+			}
+		}
+
+		protected override void OnRemoveRunConfiguration (string name)
+		{
+			if (updating || launchProfileProvider == null)
+				return;
+			launchProfileProvider.Profiles.TryRemove (name, out var _);
+			launchProfileProvider.SaveLaunchSettings ();
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -35,17 +35,17 @@ using MonoDevelop.Ide;
 using MonoDevelop.Projects;
 
 namespace MonoDevelop.AspNetCore
-{   
+{
 	[ExportProjectModelExtension]
 	class AspNetCoreProjectExtension : DotNetCoreProjectExtension
 	{
 		public const string TypeScriptCompile = "TypeScriptCompile";
 
 		bool updating;
-		readonly Dictionary<string, AspNetCoreRunConfiguration> aspNetCoreRunConfs = new Dictionary<string, AspNetCoreRunConfiguration> ();
+		Dictionary<string, AspNetCoreRunConfiguration> aspNetCoreRunConfs = new Dictionary<string, AspNetCoreRunConfiguration> ();
 		readonly object profiles = new object ();
-        LaunchProfileProvider launchProfileProvider;
-         
+		LaunchProfileProvider launchProfileProvider;
+
 		protected override ProjectRunConfiguration OnCreateRunConfiguration (string name)
 		{
 			InitLaunchSettingsProvider ();
@@ -67,18 +67,18 @@ namespace MonoDevelop.AspNetCore
 			}
 
 			var aspnetconf = new AspNetCoreRunConfiguration (name, profile);
-            aspnetconf.SaveRequested += Aspnetconf_Save;
+			aspnetconf.SaveRequested += Aspnetconf_Save;
 			aspNetCoreRunConfs.Add (name, aspnetconf);
 			return aspnetconf;
 		}
 
 		void Aspnetconf_Save (object sender, EventArgs e)
 		{
-            if (sender is AspNetCoreRunConfiguration config && config.IsDirty)
-			    launchProfileProvider.SaveLaunchSettings ();
+			if (sender is AspNetCoreRunConfiguration config && config.IsDirty)
+				launchProfileProvider.SaveLaunchSettings ();
 		}
 
-        void InitLaunchSettingsProvider ()
+		void InitLaunchSettingsProvider ()
 		{
 			if (launchProfileProvider == null) {
 				launchProfileProvider = new LaunchProfileProvider (this.Project.BaseDirectory, this.Project.DefaultNamespace);
@@ -185,7 +185,7 @@ namespace MonoDevelop.AspNetCore
 
 			return base.OnGetDefaultBuildAction (fileName);
 		}
-		
+
 		protected override void OnItemReady ()
 		{
 			base.OnItemReady ();
@@ -223,6 +223,8 @@ namespace MonoDevelop.AspNetCore
 			foreach (var conf in aspNetCoreRunConfs) {
 				conf.Value.SaveRequested -= Aspnetconf_Save;
 			}
+			aspNetCoreRunConfs.Clear ();
+			aspNetCoreRunConfs = null;
 		}
 
 		void FileService_FileChanged (object sender, FileEventArgs e)
@@ -231,12 +233,12 @@ namespace MonoDevelop.AspNetCore
 			var launchSettings = e.FirstOrDefault (x => x.FileName == launchSettingsPath && !x.FileName.IsDirectory);
 			if (launchSettings == null)
 				return;
-			
+
 			lock (profiles) {
 				updating = true;
 
 				launchProfileProvider.LoadLaunchSettings ();
-				
+
 				foreach (var profile in launchProfileProvider.Profiles) {
 					if (profile.Value.CommandName != "Project")
 						continue;
@@ -256,14 +258,17 @@ namespace MonoDevelop.AspNetCore
 						};
 						this.Project.RunConfigurations.Add (projectRunConfiguration);
 					} else {
-						var index = Project.RunConfigurations.IndexOf (runConfig);
-						this.Project.RunConfigurations [index] = runConfig;
+                        if (runConfig is AspNetCoreRunConfiguration aspNetCoreRunConfiguration) {
+							var index = Project.RunConfigurations.IndexOf (runConfig);
+							aspNetCoreRunConfiguration.CurrentProfile = profile.Value;
+							this.Project.RunConfigurations [index] = runConfig;
+						}
 					}
 				}
 
 				var itemsRemoved = new RunConfigurationCollection ();
 
-                foreach (var config in Project.RunConfigurations) {
+				foreach (var config in Project.RunConfigurations) {
 					var key = config.Name;
 
 					if (config.Name == "Default") {

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -211,6 +211,8 @@ namespace MonoDevelop.AspNetCore
 						StartAction = "Project"
 					};
 					this.Project.RunConfigurations.Add (projectRunConfiguration);
+				} else if (runConfig is AspNetCoreRunConfiguration config) {
+					config.CurrentProfile = profile.Value;
 				}
 			}
 		}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -212,7 +212,7 @@ namespace MonoDevelop.AspNetCore
 					};
 					this.Project.RunConfigurations.Add (projectRunConfiguration);
 				} else if (runConfig is AspNetCoreRunConfiguration config) {
-					config.CurrentProfile = profile.Value;
+					config.UpdateProfile (profile.Value);
 				}
 			}
 		}
@@ -260,7 +260,7 @@ namespace MonoDevelop.AspNetCore
 				} else {
 					if (runConfig is AspNetCoreRunConfiguration aspNetCoreRunConfiguration) {
 						var index = Project.RunConfigurations.IndexOf (runConfig);
-						aspNetCoreRunConfiguration.CurrentProfile = profile.Value;
+						aspNetCoreRunConfiguration.UpdateProfile (profile.Value);
 						this.Project.RunConfigurations [index] = runConfig;
 					}
 				}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -79,7 +79,6 @@ namespace MonoDevelop.AspNetCore
 		{
 			if (launchProfileProvider == null) {
 				launchProfileProvider = new LaunchProfileProvider (this.Project.BaseDirectory, this.Project.DefaultNamespace);
-				launchProfileProvider.LoadLaunchSettings ();
 			}
 		}
 
@@ -189,30 +188,12 @@ namespace MonoDevelop.AspNetCore
 			FileService.FileChanged += FileService_FileChanged;
 
 			InitLaunchSettingsProvider ();
+			updating = true;
 
-			foreach (var profile in launchProfileProvider.Profiles) {
+			launchProfileProvider.LoadLaunchSettings ();
+			launchProfileProvider.SyncRunConfigurations (Project);
 
-				if (profile.Value.CommandName != "Project")
-					continue;
-
-				var key = string.Empty;
-
-				if (profile.Key == this.Project.DefaultNamespace) {
-					key = "Default";
-				} else {
-					key = profile.Key;
-				}
-
-				var runConfig = this.Project.RunConfigurations.FirstOrDefault (x => x.Name == key);
-				if (runConfig == null) {
-					var projectRunConfiguration = new AspNetCoreRunConfiguration (key, profile.Value) {
-						StartAction = "Project"
-					};
-					this.Project.RunConfigurations.Add (projectRunConfiguration);
-				} else if (runConfig is AspNetCoreRunConfiguration config) {
-					config.UpdateProfile (profile.Value);
-				}
-			}
+			updating = false;
 		}
 
 		public override void Dispose ()
@@ -236,52 +217,9 @@ namespace MonoDevelop.AspNetCore
 			updating = true;
 
 			launchProfileProvider.LoadLaunchSettings ();
+			launchProfileProvider.SyncRunConfigurations (Project);
 
-			foreach (var profile in launchProfileProvider.Profiles) {
-				if (profile.Value.CommandName != "Project")
-					continue;
-
-				var key = string.Empty;
-
-				if (profile.Key == this.Project.DefaultNamespace) {
-					key = "Default";
-				} else {
-					key = profile.Key;
-				}
-
-				var runConfig = this.Project.RunConfigurations.FirstOrDefault (x => x.Name == key);
-				if (runConfig == null) {
-					var projectRunConfiguration = new AspNetCoreRunConfiguration (key, profile.Value) {
-						StartAction = "Project"
-					};
-					this.Project.RunConfigurations.Add (projectRunConfiguration);
-				} else {
-					if (runConfig is AspNetCoreRunConfiguration aspNetCoreRunConfiguration) {
-						var index = Project.RunConfigurations.IndexOf (runConfig);
-						aspNetCoreRunConfiguration.UpdateProfile (profile.Value);
-						this.Project.RunConfigurations [index] = runConfig;
-					}
-				}
-			}
-
-			var itemsRemoved = new RunConfigurationCollection ();
-
-			foreach (var config in Project.RunConfigurations) {
-				var key = config.Name;
-
-				if (config.Name == "Default") {
-					key = this.Project.DefaultNamespace;
-				}
-
-				if (launchProfileProvider.Profiles.TryGetValue (key, out var _))
-					continue;
-
-				itemsRemoved.Add (config);
-			}
-
-			Project.RunConfigurations.RemoveRange (itemsRemoved);
-
-			await IdeApp.ProjectOperations.SaveAsync (this.Project);
+			await IdeApp.ProjectOperations.SaveAsync (Project);
 
 			updating = false;
 		}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -226,7 +226,7 @@ namespace MonoDevelop.AspNetCore
 			aspNetCoreRunConfs = null;
 		}
 
-		void FileService_FileChanged (object sender, FileEventArgs e)
+		async void FileService_FileChanged (object sender, FileEventArgs e)
 		{
 			var launchSettingsPath = launchProfileProvider?.LaunchSettingsJsonPath;
 			var launchSettings = e.FirstOrDefault (x => x.FileName == launchSettingsPath && !x.FileName.IsDirectory);
@@ -280,6 +280,8 @@ namespace MonoDevelop.AspNetCore
 			}
 
 			Project.RunConfigurations.RemoveRange (itemsRemoved);
+
+			await IdeApp.ProjectOperations.SaveAsync (this.Project);
 
 			updating = false;
 		}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
@@ -38,7 +38,7 @@ namespace MonoDevelop.AspNetCore
 		[ItemProperty (DefaultValue = null)]
 		public PipeTransportSettings PipeTransport { get; set; }
 
-		internal LaunchProfileData CurrentProfile { get; set; }
+		internal LaunchProfileData CurrentProfile { get; private set; }
 
 		[Obsolete ("Use MonoDevelop.AspNetCore.AspNetCoreRunConfiguration.CurrentProfile property")]
 		public bool LaunchBrowser { get; set; } = true;
@@ -179,5 +179,11 @@ namespace MonoDevelop.AspNetCore
 		}
 
 		public void OnSaveRequested () => SaveRequested?.Invoke (this, EventArgs.Empty);
+
+		internal void UpdateProfile (LaunchProfileData launchProfile)
+		{
+			CurrentProfile = launchProfile;
+			LoadEnvVariables ();
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.AspNetCore
 
 		public bool IsDirty { get; set; } = true;
 
-		public event EventHandler SaveRequested;
+		internal event EventHandler SaveRequested;
 
 		public AspNetCoreRunConfiguration (string name, LaunchProfileData profile)
 			: base (name)
@@ -89,7 +89,7 @@ namespace MonoDevelop.AspNetCore
 			base.Read (pset);
 			ExternalConsole = pset.GetValue (nameof (ExternalConsole), false);
 
-            // read from run config if CurrentProfile.* is empty, for backward compatibility
+			// read from run config if CurrentProfile.* is empty, for backward compatibility
 			if (!pset.HasProperty (nameof (EnvironmentVariables)) && EnvironmentVariables.Count == 0)
 				EnvironmentVariables.Add ("ASPNETCORE_ENVIRONMENT", "Development");
 #pragma warning disable CS0618 //disables warnings threw by obsolete methods used in nameof()
@@ -106,7 +106,7 @@ namespace MonoDevelop.AspNetCore
 		{
 			EnvironmentVariables.Clear ();
 			foreach (var pair in CurrentProfile.EnvironmentVariables) {
-					EnvironmentVariables [pair.Key] = pair.Value;
+				EnvironmentVariables [pair.Key] = pair.Value;
 			}
 		}
 
@@ -117,14 +117,14 @@ namespace MonoDevelop.AspNetCore
 			pset.SetValue (nameof (ExternalConsole), ExternalConsole, false);
 			if (EnvironmentVariables.Count == 1 && EnvironmentVariables.ContainsKey ("ASPNETCORE_ENVIRONMENT") && EnvironmentVariables ["ASPNETCORE_ENVIRONMENT"] == "Development")
 				pset.RemoveProperty (nameof (EnvironmentVariables));
-                
+
 			if (CurrentProfile == null) {
 				return;
 			}
 
 			CurrentProfile.EnvironmentVariables.Clear ();
 			foreach (var pair in EnvironmentVariables) {
-					CurrentProfile.EnvironmentVariables [pair.Key] = pair.Value;
+				CurrentProfile.EnvironmentVariables [pair.Key] = pair.Value;
 			}
 
 			OnSaveRequested ();
@@ -134,8 +134,8 @@ namespace MonoDevelop.AspNetCore
 			pset.SetValue (nameof (LaunchBrowser), CurrentProfile.LaunchBrowser, true);
 			pset.SetValue (nameof (LaunchUrl), string.IsNullOrWhiteSpace (CurrentProfile.LaunchUrl) ? null : CurrentProfile.LaunchUrl, null);
 			var appUrl = CurrentProfile.TryGetApplicationUrl ();
-            if (!string.IsNullOrEmpty (appUrl))
-				pset.SetValue (nameof (ApplicationURL), appUrl , "http://localhost:5000/");
+			if (!string.IsNullOrEmpty (appUrl))
+				pset.SetValue (nameof (ApplicationURL), appUrl, "http://localhost:5000/");
 #pragma warning restore CS0618
 
 			IsDirty = false;

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
@@ -51,7 +51,7 @@ namespace MonoDevelop.AspNetCore
 
 		internal event EventHandler SaveRequested;
 
-		public AspNetCoreRunConfiguration (string name, LaunchProfileData profile)
+		internal AspNetCoreRunConfiguration (string name, LaunchProfileData profile)
 			: base (name)
 		{
 			CurrentProfile = profile;

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
@@ -95,8 +95,13 @@ namespace MonoDevelop.AspNetCore
 #pragma warning disable CS0618 //disables warnings threw by obsolete methods used in nameof()
 			if (CurrentProfile.LaunchBrowser == null)
 				CurrentProfile.LaunchBrowser = pset.GetValue (nameof (LaunchBrowser), true);
-			if (string.IsNullOrEmpty (CurrentProfile.TryGetApplicationUrl ()))
-				CurrentProfile.OtherSettings ["applicationUrl"] = pset.GetValue (nameof (ApplicationURL), "http://localhost:5000/");
+			if (string.IsNullOrEmpty (CurrentProfile.TryGetApplicationUrl ())) {
+
+				if (CurrentProfile.OtherSettings == null)
+					CurrentProfile.OtherSettings = new Dictionary<string, object> (StringComparer.Ordinal);
+
+				CurrentProfile.OtherSettings ["applicationUrl"] = pset.GetValue (nameof (ApplicationURL), "http://localhost:5000/"); 
+			}
 			if (string.IsNullOrEmpty (CurrentProfile.LaunchUrl))
 				CurrentProfile.LaunchUrl = pset.GetValue (nameof (LaunchUrl), null);
 #pragma warning restore CS0618
@@ -150,8 +155,13 @@ namespace MonoDevelop.AspNetCore
 			CurrentProfile.LaunchBrowser = other.CurrentProfile.LaunchBrowser ?? true;
 			CurrentProfile.LaunchUrl = other.CurrentProfile.LaunchUrl;
 			var applicationUrl = other.CurrentProfile.TryGetApplicationUrl ();
-			if (!string.IsNullOrEmpty (applicationUrl))
+			if (!string.IsNullOrEmpty (applicationUrl)) {
+
+				if (CurrentProfile.OtherSettings == null)
+					CurrentProfile.OtherSettings = new Dictionary<string, object> (StringComparer.Ordinal);
+
 				CurrentProfile.OtherSettings ["applicationUrl"] = applicationUrl;
+			}
 
 			if (other.PipeTransport == null)
 				PipeTransport = null;
@@ -183,6 +193,8 @@ namespace MonoDevelop.AspNetCore
 		internal void UpdateProfile (LaunchProfileData launchProfile)
 		{
 			CurrentProfile = launchProfile;
+			if (CurrentProfile.EnvironmentVariables == null)
+				CurrentProfile.EnvironmentVariables = new Dictionary<string, string> (StringComparer.Ordinal);
 			LoadEnvVariables ();
 		}
 	}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfigurationEditor.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfigurationEditor.cs
@@ -158,6 +158,8 @@ namespace MonoDevelop.AspNetCore
 			config.CurrentProfile.LaunchUrl = launchUrl.Text;
 			if (!string.IsNullOrEmpty (applicationUrl.Text))
 				config.CurrentProfile.OtherSettings ["applicationUrl"] = applicationUrl.Text;
+
+			config.IsDirty = true;
 		}
 
 		public bool ValidateCore ()

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ILaunchProfile.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ILaunchProfile.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 namespace MonoDevelop.AspNetCore
 {
-	interface ILaunchProfile
+	public interface ILaunchProfile
 	{
 		string Name { get; }
 		string CommandName { get; }

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ILaunchProfile.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/ILaunchProfile.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 namespace MonoDevelop.AspNetCore
 {
-	public interface ILaunchProfile
+	internal interface ILaunchProfile
 	{
 		string Name { get; }
 		string CommandName { get; }

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileData.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileData.cs
@@ -10,9 +10,8 @@ using Newtonsoft.Json.Linq;
 
 namespace MonoDevelop.AspNetCore
 {
-
 	[JsonObject (MemberSerialization.OptIn)]
-	internal class LaunchProfileData
+	public class LaunchProfileData
 	{
 		// Well known properties
 		private const string Prop_commandName = "commandName";

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileData.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileData.cs
@@ -142,7 +142,7 @@ namespace MonoDevelop.AspNetCore
 		/// Helper to convert an ILaunchProfile back to its serializable form. Basically, it
 		/// converts it to a dictionary of settings. This preserves custom values
 		/// </summary>
-		public static Dictionary<string, object> ToSerializableForm (ILaunchProfile profile)
+		internal static Dictionary<string, object> ToSerializableForm (ILaunchProfile profile)
 		{
 			var data = new Dictionary<string, object> (StringComparer.Ordinal);
 
@@ -188,7 +188,7 @@ namespace MonoDevelop.AspNetCore
 		/// Helper to convert an ILaunchProfile back to its serializable form. It does some
 		/// fixup. Like setting empty values to null.
 		/// </summary>
-		public static LaunchProfileData FromILaunchProfile (ILaunchProfile profile)
+		internal static LaunchProfileData FromILaunchProfile (ILaunchProfile profile)
 		{
 			return new LaunchProfileData () {
 				Name = profile.Name,

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileData.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileData.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json.Linq;
 namespace MonoDevelop.AspNetCore
 {
 	[JsonObject (MemberSerialization.OptIn)]
-	public class LaunchProfileData
+	internal class LaunchProfileData
 	{
 		// Well known properties
 		private const string Prop_commandName = "commandName";

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileProvider.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileProvider.cs
@@ -34,7 +34,7 @@ using Newtonsoft.Json.Linq;
 
 namespace MonoDevelop.AspNetCore
 {
-	internal class LaunchProfileProvider 
+	internal class LaunchProfileProvider
 	{
 		readonly string baseDirectory;
 		readonly string defaultNamespace;
@@ -50,9 +50,9 @@ namespace MonoDevelop.AspNetCore
 
 		public LaunchProfileData DefaultProfile {
 			get {
-				if (!Profiles.ContainsKey (defaultNamespace)) { 
-                    var defaultProfile = CreateDefaultProfile ();
-					Profiles[defaultNamespace] = defaultProfile;
+				if (!Profiles.ContainsKey (defaultNamespace)) {
+					var defaultProfile = CreateDefaultProfile ();
+					Profiles [defaultNamespace] = defaultProfile;
 					return defaultProfile;
 				}
 				return Profiles [defaultNamespace];
@@ -70,7 +70,7 @@ namespace MonoDevelop.AspNetCore
 		{
 			if (!File.Exists (LaunchSettingsJsonPath)) {
 				CreateAndAddDefaultLaunchSettings ();
-				return; 
+				return;
 			}
 
 			var launchSettingsJson = TryParse ();
@@ -91,8 +91,7 @@ namespace MonoDevelop.AspNetCore
 		{
 			try {
 				return JObject.Parse (File.ReadAllText (LaunchSettingsJsonPath));
-			}
-			catch {
+			} catch {
 				return new JObject ();
 			}
 		}
@@ -141,7 +140,7 @@ namespace MonoDevelop.AspNetCore
 				Profiles = new ConcurrentDictionary<string, LaunchProfileData> ();
 
 			var newProfile = CreateProfile (name);
-			Profiles [name] =  newProfile;
+			Profiles [name] = newProfile;
 			return newProfile;
 		}
 

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileProvider.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileProvider.cs
@@ -66,6 +66,7 @@ namespace MonoDevelop.AspNetCore
 			this.baseDirectory = baseDirectory;
 			this.defaultNamespace = defaultNamespace;
 			GlobalSettings = new Dictionary<string, JToken> ();
+			Profiles = new ConcurrentDictionary<string, LaunchProfileData> ();
 		}
 
 		public void LoadLaunchSettings ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3070,6 +3070,8 @@ namespace MonoDevelop.Projects
 			runConfig.Read (grp);
 		}
 
+		//TODO: OnRunConfigurationsAdded: hand items in the same way than NotifyItemsAdded.
+		//NOTE that this method does not call ProjectExtension since OnRunConfigurationAdded does not exist
 		internal void OnRunConfigurationsAdded (IEnumerable<SolutionItemRunConfiguration> items)
 		{
 			// Initialize the property group only if the project is not being loaded (in which case it will
@@ -3083,8 +3085,7 @@ namespace MonoDevelop.Projects
 
 		internal void OnRunConfigurationRemoved (IEnumerable<SolutionItemRunConfiguration> items)
 		{
-			foreach (var s in items)
-				ProjectExtension.OnRemoveRunConfiguration (s.Name);
+			ProjectExtension.OnRemoveRunConfiguration (items);
 		}
 
 		internal void LoadProjectItems (MSBuildProject msproject, ProjectItemFlags flags, HashSet<MSBuildItem> loadedItems)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -370,9 +370,9 @@ namespace MonoDevelop.Projects
 			// If the project doesn't have a Default run configuration, create one
 			if (!defaultRunConfigurationCreated) {
 				if (!runConfigurations.Any (c => c.IsDefaultConfiguration)) {
-					defaultBlankRunConfiguration = CreateRunConfigurationInternal ("Default");
-					ImportDefaultRunConfiguration (defaultBlankRunConfiguration);
-					runConfigurations.Insert (0, defaultBlankRunConfiguration);
+					var rc = CreateRunConfigurationInternal ("Default");
+					ImportDefaultRunConfiguration (rc);
+					runConfigurations.Insert (0, rc);
 					defaultRunConfigurationCreated = true;
 				}
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4988,6 +4988,10 @@ namespace MonoDevelop.Projects
 			{
 				Project.OnItemsRemoved (objs);
 			}
+
+			internal protected override void OnRemoveRunConfiguration (IEnumerable<SolutionItemRunConfiguration> objs)
+			{
+			}
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1,4 +1,4 @@
-//  Project.cs
+﻿//  Project.cs
 //
 // Author:
 //   Lluis Sanchez Gual <lluis@novell.com>
@@ -369,11 +369,11 @@ namespace MonoDevelop.Projects
 		{
 			// If the project doesn't have a Default run configuration, create one
 			if (!defaultRunConfigurationCreated) {
-				defaultRunConfigurationCreated = true;
 				if (!runConfigurations.Any (c => c.IsDefaultConfiguration)) {
-					var rc = CreateRunConfigurationInternal ("Default");
-					ImportDefaultRunConfiguration (rc);
-					runConfigurations.Insert (0, rc);
+					defaultBlankRunConfiguration = CreateRunConfigurationInternal ("Default");
+					ImportDefaultRunConfiguration (defaultBlankRunConfiguration);
+					runConfigurations.Insert (0, defaultBlankRunConfiguration);
+					defaultRunConfigurationCreated = true;
 				}
 			}
 		}
@@ -3083,7 +3083,8 @@ namespace MonoDevelop.Projects
 
 		internal void OnRunConfigurationRemoved (IEnumerable<SolutionItemRunConfiguration> items)
 		{
-
+			foreach (var s in items)
+				ProjectExtension.OnRemoveRunConfiguration (s.Name);
 		}
 
 		internal void LoadProjectItems (MSBuildProject msproject, ProjectItemFlags flags, HashSet<MSBuildItem> loadedItems)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -79,7 +79,7 @@ namespace MonoDevelop.Projects
 
 		internal protected virtual void OnRemoveRunConfiguration (string name)
 		{
-            next.OnRemoveRunConfiguration (name);
+			next.OnRemoveRunConfiguration (name);
 		}
 
 		internal protected virtual void OnReadRunConfiguration (ProgressMonitor monitor, ProjectRunConfiguration config, IPropertySet properties)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -77,6 +77,11 @@ namespace MonoDevelop.Projects
 			return next.OnCreateRunConfiguration (name);
 		}
 
+		internal protected virtual void OnRemoveRunConfiguration (string name)
+		{
+            next.OnRemoveRunConfiguration (name);
+		}
+
 		internal protected virtual void OnReadRunConfiguration (ProgressMonitor monitor, ProjectRunConfiguration config, IPropertySet properties)
 		{
 			next.OnReadRunConfiguration (monitor, config, properties);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -77,9 +77,9 @@ namespace MonoDevelop.Projects
 			return next.OnCreateRunConfiguration (name);
 		}
 
-		internal protected virtual void OnRemoveRunConfiguration (string name)
+		internal protected virtual void OnRemoveRunConfiguration (IEnumerable<SolutionItemRunConfiguration> items)
 		{
-			next.OnRemoveRunConfiguration (name);
+			next.OnRemoveRunConfiguration (items);
 		}
 
 		internal protected virtual void OnReadRunConfiguration (ProgressMonitor monitor, ProjectRunConfiguration config, IPropertySet properties)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/862782
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918958
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/933588
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/933582
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/934345
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/934367
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/934322
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918985
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/755485
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958219

Specs https://microsoft-my.sharepoint.com/:w:/p/mhutch/EfsOmr-aDnJMkI1Dv1QQIrcBd-kon2e8qB9QicNVkq3E-A?e=mYbAcu

Mote: rebased

User Cases:

given a ASP.NET Core project 

- when a new project is created then it should contain a default launchSettings.json profile called like project name and it should be a Default run config
- when a new Run Config is added then it should update launchSettings.json and add a new profile
- when a Run Config is removed then it should update launchSettings.json and remove that profile
- when a run config is modified the it should update launchSettings.json and the profile updated
- when a profile is added in the launchSettings.json then it should add a new Run Config
- when a profile is removed in the launchSettings.json then it should remove that Run Config
- when a profile is updated in the launchSettings.json then it should update the Run Config
- when a project with more than one profiles in the launchSettings.json is loaded then it should create a new Run Config for each profile which type == "Project"

