### PR TITLE
Fix document reuse logic

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -70,6 +70,9 @@ namespace MonoDevelop.Ide.Gui.Documents
 				workbench.NotebookClosed += Workbench_NotebookClosed;
 			});
 
+			serviceProvider.WhenServiceInitialized<NavigationHistoryService> (s => navigationHistoryManager = s);
+
+
 			FileService.FileRemoved += CheckRemovedFile;
 			FileService.FileMoved += CheckRenamedFile;
 			FileService.FileRenamed += CheckRenamedFile;
@@ -205,6 +208,18 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		public async Task<Document> OpenDocument (ModelDescriptor modelDescriptor, DocumentControllerRole? role = null, bool bringToFront = true)
 		{
+			// Try to reuse existing documents
+
+			foreach (Document doc in Documents) {
+				if (doc.TryReuseDocument (modelDescriptor)) {
+					if (bringToFront) {
+						doc.Select ();
+						navigationHistoryManager?.LogActiveDocument ();
+					}
+					return doc;
+				}
+			}
+
 			var documentControllerService = await ServiceProvider.GetService<DocumentControllerService> ();
 			var factories = (await documentControllerService.GetSupportedControllers (modelDescriptor)).Where (c => role == null || c.Role == role).ToList ();
 			var controllerDesc = factories.FirstOrDefault (c => c.CanUseAsDefault);
@@ -240,9 +255,6 @@ namespace MonoDevelop.Ide.Gui.Documents
 			if (string.IsNullOrEmpty (info.FileName))
 				return null;
 
-			if (navigationHistoryManager == null)
-				navigationHistoryManager = await ServiceProvider.GetService<NavigationHistoryService> ();
-
 			// Make sure composition manager is ready since ScrollToRequestedCaretLocation will use it
 			await Runtime.GetService<CompositionManager> ();
 
@@ -250,27 +262,26 @@ namespace MonoDevelop.Ide.Gui.Documents
 			var fileDescriptor = new FileDescriptor (info.FileName, null, info.Owner);
 
 			using (Counters.OpenDocumentTimer.BeginTiming ("Opening file " + info.FileName, metadata)) {
-				navigationHistoryManager.LogActiveDocument ();
+				navigationHistoryManager?.LogActiveDocument ();
 				Counters.OpenDocumentTimer.Trace ("Look for open document");
 				foreach (Document doc in Documents) {
 
-					// Search all ViewContents to see if they can "re-use" this filename.
-					if (!doc.TryReuseDocument (fileDescriptor))
+					if (info.Options.HasFlag (OpenDocumentOptions.TryToReuseViewer) && doc.TryReuseDocument (fileDescriptor)) {
+						// If TryReuseDocument returns true it means that the document can be reused and has been reused, so look no further
+						ReuseDocument (doc, info);
+						return doc;
+					}
+
+					// If the document can't explicitly handle the new descriptor, check the file names.
+					// If the file of the document is the same, let's just focus it
+
+					if (!doc.IsFile || doc.FilePath != fileDescriptor.FilePath)
 						continue;
 
-					//if found, try to reuse or close the old view
-					// reuse the view if the binidng didn't change
+					// Reuse the document if the controller factory didn't change
+
 					if (info.Options.HasFlag (OpenDocumentOptions.TryToReuseViewer) || doc.DocumentControllerDescription == info.DocumentControllerDescription) {
-						if (info.Owner != null && doc.Owner != info.Owner) {
-							doc.AttachToProject (info.Owner);
-						}
-
-						ScrollToRequestedCaretLocation (doc, info);
-
-						if (info.Options.HasFlag (OpenDocumentOptions.BringToFront)) {
-							doc.Select ();
-							navigationHistoryManager.LogActiveDocument ();
-						}
+						ReuseDocument (doc, info);
 						return doc;
 					} else {
 						if (!await doc.Close ())
@@ -282,7 +293,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 				var progressMonitorManager = await ServiceProvider.GetService<ProgressMonitorManager> ();
 				var pm = progressMonitorManager.GetStatusProgressMonitor (
 					GettextCatalog.GetString ("Opening {0}", info.Owner is SolutionFolderItem item ?
-						info.FileName.ToRelative (item.ParentSolution.BaseDirectory) :
+						info.FileName.ToRelative (item?.ParentSolution?.BaseDirectory ?? item.BaseDirectory) :
 						info.FileName),
 					Stock.StatusWorking,
 					true
@@ -302,6 +313,19 @@ namespace MonoDevelop.Ide.Gui.Documents
 					return doc;
 				}
 				return null;
+			}
+		}
+
+		void ReuseDocument (Document doc, FileOpenInformation info)
+		{
+			if (info.Owner != null && doc.Owner != info.Owner)
+				doc.AttachToProject (info.Owner);
+
+			ScrollToRequestedCaretLocation (doc, info);
+
+			if (info.Options.HasFlag (OpenDocumentOptions.BringToFront)) {
+				doc.Select ();
+				navigationHistoryManager?.LogActiveDocument ();
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/FileDocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/FileDocumentController.cs
@@ -137,7 +137,12 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		protected override bool OnTryReuseDocument (ModelDescriptor modelDescriptor)
 		{
-			return modelDescriptor is FileDescriptor file && file.FilePath.CanonicalPath == filePath;
+			if (modelDescriptor is FileDescriptor file && file.FilePath.CanonicalPath == FilePath) {
+				if (file.Owner != null && Owner != file.Owner)
+					Owner = file.Owner;
+				return true;
+			}
+			return false;
 		}
 
 		protected virtual void OnFileNameChanged ()

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentManagerTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentManagerTests.cs
@@ -26,12 +26,14 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using IdeUnitTests;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Shell;
 using MonoDevelop.Ide.TypeSystem;
+using MonoDevelop.Projects;
 using NUnit.Framework;
 using UnitTests;
 
@@ -202,19 +204,28 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			var doc = await documentManager.OpenDocument (new TestController ());
 
-			documentManager.DocumentClosing += async (o, e) => {
-				await Task.Delay (100); e.Cancel = true;
-			};
+			documentManager.DocumentClosing += DontClose;
 
-			eventTracker.Reset ();
+			try {
 
-			bool result = await doc.Close ();
-			Assert.IsFalse (result);
+				eventTracker.Reset ();
 
-			Assert.AreEqual (1, shell.Windows.Count);
-			Assert.AreEqual (1, documentManager.Documents.Count);
-			Assert.AreEqual (0, eventTracker.DocumentClosedEvents.Count);
-			Assert.AreEqual (0, eventTracker.ActiveDocumentChangedEvents.Count);
+				bool result = await doc.Close ();
+				Assert.IsFalse (result);
+
+				Assert.AreEqual (1, shell.Windows.Count);
+				Assert.AreEqual (1, documentManager.Documents.Count);
+				Assert.AreEqual (0, eventTracker.DocumentClosedEvents.Count);
+				Assert.AreEqual (0, eventTracker.ActiveDocumentChangedEvents.Count);
+			} finally {
+				documentManager.DocumentClosing -= DontClose;
+			}
+		}
+
+		async Task DontClose (object s, DocumentCloseEventArgs e)
+		{
+			await Task.Delay (100);
+			e.Cancel = true;
 		}
 
 		[Test]
@@ -366,6 +377,188 @@ namespace MonoDevelop.Ide.Gui.Documents
 			container.SetActive ();
 			Assert.AreEqual (subView1, root.ActiveViewInHierarchy);
 			Assert.AreEqual (subView1, container.ActiveViewInHierarchy);
+		}
+
+		[Test]
+		public async Task ReuseFileDocument ()
+		{
+			var f1 = new ReusableControllerFactory ();
+			var f2 = new ReusableFileControllerFactory ();
+			documentControllerService.RegisterFactory (f1);
+			documentControllerService.RegisterFactory (f2);
+
+			var foo_dll_test = GetTempFile (".dll_test");
+			var bar_dll_test = GetTempFile (".dll_test");
+			var bar_exe_test = GetTempFile (".exe_test");
+			var foo_txt = GetTempFile (".txt");
+
+			try {
+				var controller = new ReusableFileController ();
+				var descriptor = new FileDescriptor (foo_dll_test, null, null);
+				await controller.Initialize (descriptor);
+				var doc = await documentManager.OpenDocument (controller);
+				Assert.NotNull (doc);
+
+				var doc2 = await documentManager.OpenDocument (new FileDescriptor (foo_dll_test, null, null));
+				Assert.AreSame (doc, doc2);
+
+				doc2 = await documentManager.OpenDocument (new FileDescriptor (bar_dll_test, null, null));
+				Assert.AreSame (doc, doc2);
+
+				doc2 = await documentManager.OpenDocument (new FileDescriptor (bar_exe_test, null, null));
+				Assert.AreSame (doc, doc2);
+
+				doc2 = await documentManager.OpenDocument (new FileDescriptor (foo_txt, null, null));
+				Assert.AreNotSame (doc, doc2);
+				await doc2.Close ();
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (foo_dll_test));
+				Assert.AreSame (doc, doc2);
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (bar_dll_test));
+				Assert.AreSame (doc, doc2);
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (bar_exe_test));
+				Assert.AreSame (doc, doc2);
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (foo_txt));
+				Assert.AreNotSame (doc, doc2);
+				await doc2.Close ();
+
+				await documentManager.CloseAllDocuments (false);
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (foo_dll_test) { Options = OpenDocumentOptions.None });
+				Assert.AreNotSame (doc, doc2);
+				await doc2.Close ();
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (bar_dll_test) { Options = OpenDocumentOptions.None });
+				Assert.AreNotSame (doc, doc2);
+				await doc2.Close ();
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (bar_exe_test) { Options = OpenDocumentOptions.None });
+				Assert.AreNotSame (doc, doc2);
+				await doc2.Close ();
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (foo_txt) { Options = OpenDocumentOptions.None });
+				Assert.AreNotSame (doc, doc2);
+				await doc2.Close ();
+			} finally {
+				documentControllerService.UnregisterFactory (f1);
+				documentControllerService.UnregisterFactory (f2);
+				File.Delete (foo_dll_test);
+				File.Delete (bar_dll_test);
+				File.Delete (bar_exe_test);
+				File.Delete (foo_txt);
+			}
+		}
+
+		string GetTempFile (string extension)
+		{
+			var tempFile = Path.GetTempFileName ();
+			var finalFile = tempFile + extension;
+			File.Copy (GetType ().Assembly.Location, finalFile, true); // We need a binary file to avoid the file being opened in the text editor by default
+			return finalFile;
+		}
+
+		[Test]
+		public async Task ReuseFileDocumentChangingOwner()
+		{
+			var f2 = new ReusableFileControllerFactory ();
+			documentControllerService.RegisterFactory (f2);
+			var project = Services.ProjectService.CreateDotNetProject ("C#");
+			var project2 = Services.ProjectService.CreateDotNetProject ("C#");
+
+			var file = GetTempFile (".dll_test");
+
+			try {
+				var doc = await documentManager.OpenDocument (new FileOpenInformation (file, project));
+				Assert.NotNull (doc);
+				Assert.AreSame (project, doc.DocumentController.Owner);
+
+				// Reuse
+
+				var doc2 = await documentManager.OpenDocument (new FileOpenInformation (file, project));
+				Assert.AreSame (doc, doc2);
+				Assert.AreSame (project, doc.DocumentController.Owner);
+
+				// Reuse, changing owner
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (file, project2));
+				Assert.AreSame (doc, doc2);
+				Assert.AreSame (project2, doc.DocumentController.Owner);
+
+			} finally {
+				documentControllerService.UnregisterFactory (f2);
+				project.Dispose ();
+				project2.Dispose ();
+				File.Delete (file);
+			}
+		}
+
+		[Test]
+		public async Task ReuseFileDocumentWithNoReuseFlag ()
+		{
+			var f1 = new ReusableFileControllerFactory ();
+			var f2 = new ReusableFileControllerFactory ();
+
+			documentControllerService.RegisterFactory (f1);
+			documentControllerService.RegisterFactory (f2);
+
+			f1.Enabled = true;
+			f2.Enabled = false;
+
+			var project = Services.ProjectService.CreateDotNetProject ("C#");
+
+			var file = GetTempFile (".dll_test");
+
+			try {
+				var doc = await documentManager.OpenDocument (new FileOpenInformation (file, project));
+				Assert.NotNull (doc);
+				var controller = (ReusableFileController)doc.DocumentController;
+				controller.AllowReuse = false;
+
+				// If the reusable flag is set, reuse the doc since even if TryReuseDocument returns false, the file names match.
+
+				var doc2 = await documentManager.OpenDocument (new FileOpenInformation (file, project) { Options = OpenDocumentOptions.TryToReuseViewer });
+				Assert.AreSame (doc, doc2);
+
+				// If the reusable flag is not set, the document can't be reused, even if names match
+
+				doc2 = await documentManager.OpenDocument (new FileOpenInformation (file, project) { Options = OpenDocumentOptions.None });
+				Assert.AreNotSame (doc, doc2);
+
+				// The old non-reusable document must have been closed
+				Assert.AreEqual (1, documentManager.Documents.Count);
+
+			} finally {
+				documentControllerService.UnregisterFactory (f1);
+				documentControllerService.UnregisterFactory (f2);
+				project.Dispose ();
+				File.Delete (file);	
+			}
+		}
+
+		[Test]
+		public async Task ReuseDocumentIdentifiedByDescriptor ()
+		{
+			var f1 = new ReusableControllerFactory ();
+			documentControllerService.RegisterFactory (f1);
+			try {
+				var controller = new ReusableController ();
+				var descriptor = new ReusableDescriptor ();
+				await controller.Initialize (descriptor);
+				var doc = await documentManager.OpenDocument (controller);
+
+				Assert.NotNull (doc);
+
+				var doc2 = await documentManager.OpenDocument (descriptor);
+				Assert.AreSame (doc, doc2);
+
+				var doc3 = await documentManager.OpenDocument (new ReusableDescriptor ());
+				Assert.AreNotSame (doc, doc3);
+			} finally {
+				documentControllerService.UnregisterFactory (f1);
+			}
 		}
 
 		[Test]
@@ -657,5 +850,70 @@ namespace MonoDevelop.Ide.Gui.Documents
 			DocumentClosingEvents.Clear ();
 			ActiveDocumentChangedEvents.Clear ();
 		}
+	}
+
+	class ReusableController : DocumentController
+	{
+		ModelDescriptor modelDescriptor;
+
+		protected override Task OnInitialize (ModelDescriptor modelDescriptor, Properties status)
+		{
+			this.modelDescriptor = modelDescriptor;
+			return base.OnInitialize (modelDescriptor, status);
+		}
+
+		protected override bool OnTryReuseDocument (ModelDescriptor modelDescriptor)
+		{
+			if (this.modelDescriptor == modelDescriptor)
+				return true;
+			return base.OnTryReuseDocument (modelDescriptor);
+		}
+	}
+
+	class ReusableFileController : FileDocumentController
+	{
+		public bool AllowReuse { get; set; } = true;
+		
+		protected override bool OnTryReuseDocument (ModelDescriptor modelDescriptor)
+		{
+			var fileDesc = modelDescriptor as FileDescriptor;
+			var ext = fileDesc.FilePath.Extension;
+			return AllowReuse && (ext == ".dll_test" || ext == ".exe_test");
+		}
+	}
+
+	class ReusableFileControllerFactory : FileDocumentControllerFactory
+	{
+		public bool Enabled { get; set; } = true;
+
+		public override Task<DocumentController> CreateController (FileDescriptor modelDescriptor, DocumentControllerDescription controllerDescription)
+		{
+			return Task.FromResult<DocumentController> (new ReusableFileController ());
+		}
+
+		protected override IEnumerable<DocumentControllerDescription> GetSupportedControllers (FileDescriptor modelDescriptor)
+		{
+			if (Enabled && (modelDescriptor.FilePath.Extension == ".dll_test" || modelDescriptor.FilePath.Extension == ".exe_test"))
+				yield return new DocumentControllerDescription ("Assembly_Test", true, DocumentControllerRole.Tool);
+		}
+	}
+
+	class ReusableControllerFactory : DocumentControllerFactory
+	{
+		public override Task<DocumentController> CreateController (ModelDescriptor modelDescriptor, DocumentControllerDescription controllerDescription)
+		{
+			return Task.FromResult<DocumentController> (new ReusableController ());
+		}
+
+		protected override IEnumerable<DocumentControllerDescription> GetSupportedControllers (ModelDescriptor modelDescriptor)
+		{
+			if (modelDescriptor is ReusableDescriptor)
+				yield return new DocumentControllerDescription ("Reusable", true, DocumentControllerRole.Tool);
+		}
+	}
+
+
+	class ReusableDescriptor : ModelDescriptor
+	{
 	}
 }


### PR DESCRIPTION
Fixed the logic that determines if a document can be reused or not, it didn't work properly when opening a document using a custom model descriptor.

Also adjusted the logic for reusing file documents and added unit tests.

Fixes bug #891266 - Assembly browser back/forward navigation opens new Assembly Browser window