### PR TITLE
[Watson] Fixes NRE when FindDockGroupItem doesn't find any item

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockContainer.cs
@@ -457,24 +457,28 @@ namespace MonoDevelop.Components.Docking
 		{
 			if (placeholderWindow == null || !placeholderWindow.Visible)
 				return;
-			
-			if (placeholderWindow.AllowDocking && placeholderWindow.DockDelegate != null) {
-				item.Status = DockItemStatus.Dockable;
-				DockGroupItem dummyItem = new DockGroupItem (frame, new DockItem (frame, "__dummy"));
-				DockGroupItem gitem = layout.FindDockGroupItem (item.Id);
-				gitem.ParentGroup.ReplaceItem (gitem, dummyItem);
-				placeholderWindow.DockDelegate (item);
-				dummyItem.ParentGroup.Remove (dummyItem);
-				RelayoutWidgets ();
-			} else {
-				int px, py;
-				GetPointer (out px, out py);
-				DockGroupItem gi = FindDockGroupItem (item.Id);
-				int pw, ph;
-				placeholderWindow.GetPosition (out px, out py);
-				placeholderWindow.GetSize (out pw, out ph);
-				gi.FloatRect = new Rectangle (px, py, pw, ph);
-				item.Status = DockItemStatus.Floating;
+
+			try {
+				if (placeholderWindow.AllowDocking && placeholderWindow.DockDelegate != null) {
+					item.Status = DockItemStatus.Dockable;
+					DockGroupItem dummyItem = new DockGroupItem (frame, new DockItem (frame, "__dummy"));
+					DockGroupItem gitem = layout.FindDockGroupItem (item.Id);
+					gitem.ParentGroup.ReplaceItem (gitem, dummyItem);
+					placeholderWindow.DockDelegate (item);
+					dummyItem.ParentGroup.Remove (dummyItem);
+					RelayoutWidgets ();
+				} else {
+					int px, py;
+					GetPointer (out px, out py);
+					DockGroupItem gi = FindDockGroupItem (item.Id);
+					int pw, ph;
+					placeholderWindow.GetPosition (out px, out py);
+					placeholderWindow.GetSize (out pw, out ph);
+					gi.FloatRect = new Rectangle (px, py, pw, ph);
+					item.Status = DockItemStatus.Floating;
+				}
+			} catch (Exception ex) {
+				LoggingService.LogInternalError ("Updating the dock container placeholder failed", ex);
 			}
 		}
 		


### PR DESCRIPTION
This issue was detected by Watson and I can't reproduce it, but my feeling: this is it happening with dock panels with AllowDocking = false (like the Solution Explorer).

This call FindDockGroupItem will end in NRE (id not found) if we try to dock this panel at the same time we the system is Splitting a groupview or an item is Removed for some reason (the collection is cleaned on this cases). 

Fixes VSTS #861013 - [Watson] System.NullReferenceException in MonoDevelop.Components.Docking.DockContainer::DockInPlaceholder (MonoDevelop.Ide.dll)