### PR TITLE
[GetToCode] Uses hideWelcomePage flag in WelcomePageService

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Ide.WelcomePage
 		public static event EventHandler WelcomePageShown;
 		public static event EventHandler WelcomePageHidden;
 
-		internal static async Task Initialize ()
+		internal static async Task Initialize (bool hideWelcomePage)
 		{
 			IdeApp.Initialized += (s, args) => {
 				IdeApp.Workbench.RootWindow.Hidden += (sender, e) => {
@@ -78,7 +78,7 @@ namespace MonoDevelop.Ide.WelcomePage
 				};
 			};
 
-			if (HasWindowImplementation) {
+			if (!hideWelcomePage && HasWindowImplementation) {
 				await Runtime.GetService<DesktopService> ();
 				var commandManager = await Runtime.GetService<CommandManager> ();
 				await ShowWelcomeWindow (new WelcomeWindowShowOptions (false));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -144,7 +144,7 @@ namespace MonoDevelop.Ide.WelcomePage
 
 		public static async Task<bool> ShowWelcomeWindow (WelcomeWindowShowOptions options)
 		{
-			if (WelcomeWindowProvider == null) {
+			if (!HasWindowImplementation) {
 				return false;
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -180,7 +180,7 @@ namespace MonoDevelop.Ide
 			}
 		}
 
-		public static async Task Initialize (ProgressMonitor monitor)
+		public static async Task Initialize (ProgressMonitor monitor, bool hideWelcomePage = false)
 		{
 			// Already done in IdeSetup, but called again since unit tests don't use IdeSetup.
 			DispatchService.Initialize ();
@@ -206,7 +206,7 @@ namespace MonoDevelop.Ide
 			}
 
 			Counters.Initialization.Trace ("Initializing WelcomePage service");
-			WelcomePage.WelcomePageService.Initialize ().Ignore ();
+			WelcomePage.WelcomePageService.Initialize (hideWelcomePage).Ignore ();
 
 			// Pump the UI thread to make the start window visible
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -279,7 +279,7 @@ namespace MonoDevelop.Ide
 				Counters.Initialization.Trace ("Initializing IdeApp");
 
 				hideWelcomePage = options.NoStartWindow || startupInfo.HasFiles || IdeApp.Preferences.StartupBehaviour.Value != OnStartupBehaviour.ShowStartWindow;
-				await IdeApp.Initialize (monitor);
+				await IdeApp.Initialize (monitor, hideWelcomePage);
 
 				IdeStartupTracker.StartupTracker.MarkSection ("AppInitialization");
 


### PR DESCRIPTION
GetToCode includes a setting configuration with 3 options : Allways show Startwindow, Load previous solutions on startup and show empty environtment

![image](https://user-images.githubusercontent.com/1587480/58568272-42139280-8234-11e9-9852-1a00c094ebf4.png)

Looks like in recent changes we stop using this flag to shop the dialog and we were allways showing it.

This PR allows check this flag from the WelcomeService on the initialization

![lol5](https://user-images.githubusercontent.com/1587480/58569202-f2ce6180-8235-11e9-89c0-2305e7ca1701.gif)

Fixes VSTS #894451 - Start window shown despite preference setting to display empty environment on load
