### PR TITLE
Fix 895583: Breakpoints not visible after renaming file

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/Tags/AbstractCurrentStatementTagger.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/Tags/AbstractCurrentStatementTagger.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using MonoDevelop.Debugger;
-using MonoDevelop.Ide.Editor;
 using MonoDevelop.Ide;
 using Mono.Debugging.Client;
 using MonoDevelop.Core;
@@ -15,7 +14,7 @@ namespace MonoDevelop.Debugger
 	{
 		private readonly ITextBuffer textBuffer;
 		private readonly T tag;
-		private readonly string filePath;
+		private readonly ITextDocument textDocument;
 		private readonly bool isGreen;
 		private ITextSnapshot snapshotAtStartOfDebugging;
 
@@ -23,7 +22,7 @@ namespace MonoDevelop.Debugger
 		{
 			this.textBuffer = textBuffer;
 			this.snapshotAtStartOfDebugging = textBuffer.CurrentSnapshot;
-			this.filePath = textBuffer.GetFilePathOrNull ();
+			textBuffer.Properties.TryGetProperty (typeof (ITextDocument), out textDocument);
 			this.tag = tag;
 			this.isGreen = isGreen;
 			DebuggingService.CurrentFrameChanged += OnDebuggerCurrentStatementChanged;
@@ -68,8 +67,8 @@ namespace MonoDevelop.Debugger
 
 		SourceLocation CheckLocationIsInFile (SourceLocation location)
 		{
-			if (!string.IsNullOrEmpty (filePath) && location != null && !string.IsNullOrEmpty (location.FileName)
-				&& ((FilePath)location.FileName).FullPath == ((FilePath)filePath).FullPath)
+			if (!string.IsNullOrEmpty (textDocument?.FilePath) && location != null && !string.IsNullOrEmpty (location.FileName)
+				&& ((FilePath)location.FileName).FullPath == ((FilePath)textDocument.FilePath).FullPath)
 				return location;
 			return null;
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -112,6 +112,15 @@ namespace MonoDevelop.Debugger
 				evaluators = null;
 			});
 			IdeApp.Exiting += IdeApp_Exiting;
+			FileService.FileRenamed += FileService_FileRenamed;
+			FileService.FileMoved += FileService_FileRenamed;
+		}
+
+		private static void FileService_FileRenamed (object sender, FileCopyEventArgs e)
+		{
+			foreach (var file in e) {
+				breakpoints.FileRenamed (file.SourceFile, file.TargetFile);
+			}
 		}
 
 		static void IdeApp_Exiting (object sender, ExitEventArgs args)


### PR DESCRIPTION
This is two part fix, part is in DebuggingService which is updating actual breakpoint to new file
And other part is in new editor breakpoint integration which now doesn't use `readonly string file` but instead `textDocument.FilePath` which is mutable and updates when file is renamed and also listens for additional event.