### PR TITLE
[Ide] Added a disposed token to the document controller API.

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
@@ -64,7 +64,6 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			DocumentTitle = GettextCatalog.GetString ("Assembly Browser");
 			widget = new AssemblyBrowserWidget ();
-			IsDisposed = false;
 			FillWidget ();
 		}
 
@@ -104,14 +103,8 @@ namespace MonoDevelop.AssemblyBrowser
 			widget.EnsureDefinitionsLoaded (definitions);
 		}
 
-		public bool IsDisposed {
-			get;
-			private set;
-		}
-
 		protected override void OnDispose ()
 		{
-			IsDisposed = true;
 			if (currentWs != null) 
 				currentWs.WorkspaceLoaded -= Handle_WorkspaceLoaded;
 

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Microsoft Corp. (https://www.microsoft.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -291,13 +291,10 @@ namespace MonoDevelop.TextEditor
 
 		Components.Control control;
 
-		bool isDisposed;
 		protected override void OnDispose ()
 		{
-			if (isDisposed)
+			if (IsDisposed)
 				return;
-
-			isDisposed = true;
 
 			textBufferRegistration?.Dispose ();
 			textBufferRegistration = null;
@@ -579,7 +576,7 @@ namespace MonoDevelop.TextEditor
 		Task autoSaveTask;
 		void InformAutoSave ()
 		{
-			if (isDisposed)
+			if (IsDisposed)
 				return;
 			RemoveAutoSaveTimer ();
 			autoSaveTimer = GLib.Timeout.Add (500, delegate {
@@ -725,7 +722,7 @@ namespace MonoDevelop.TextEditor
 			void ReloadFromDisk ()
 			{
 				try {
-					if (isDisposed || !File.Exists (FilePath))
+					if (IsDisposed || !File.Exists (FilePath))
 						return;
 
 					Load (true);
@@ -739,7 +736,7 @@ namespace MonoDevelop.TextEditor
 
 			void KeepChanges ()
 			{
-				if (isDisposed)
+				if (IsDisposed)
 					return;
 				ShowNotification = false;
 				DismissInfoBar ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputViewContent.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // BuildOutputView.cs
 //
 // Author:
@@ -110,16 +110,14 @@ namespace MonoDevelop.Ide.BuildOutputView
 			return control;
 		}
 
-		bool disposed = false;
 
 		protected override void OnDispose ()
 		{
-			if (!disposed) {
+			if (!IsDisposed) {
 				if (control != null) {
 					control.FileNameChanged -= FileNameChanged;
 					control.Dispose ();
 				}
-				disposed = true;
 			}
 			base.OnDispose ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // DocumentController.cs
 //
 // Author:
@@ -384,11 +384,25 @@ namespace MonoDevelop.Ide.Gui.Documents
 			}
 		}
 
+		CancellationTokenSource disposedTokenSource = new CancellationTokenSource ();
+
+		/// <summary>
+		/// Returns a dispose token that's canceled when the document controller disposes.
+		/// </summary>
+		protected CancellationToken DisposedToken { get; }
+
+		protected bool IsDisposed { get => disposed; }
+
 		protected virtual bool ControllerIsViewOnly => false;
 
 		internal FilePath OriginalContentName { get; set; }
 
 		internal bool Initialized => initialized;
+
+		public DocumentController ()
+		{
+			DisposedToken = disposedTokenSource.Token;
+		}
 
 		/// <summary>
 		/// Initializes the controller
@@ -413,6 +427,9 @@ namespace MonoDevelop.Ide.Gui.Documents
 		public void Dispose ()
 		{
 			if (!disposed) {
+				disposedTokenSource.Cancel ();
+				disposedTokenSource.Dispose ();
+				disposedTokenSource = null;
 				linkedController?.Dispose ();
 				disposed = true;
 				OnDispose ();


### PR DESCRIPTION
The disposed token can be used by continue with calls that shouldn't
continue on disposed instances.