### PR TITLE
[NuGet] Fix restore menu incorrectly disabled.  

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackagesCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackagesCommandHandler.cs
@@ -59,35 +59,31 @@ namespace MonoDevelop.PackageManagement.Commands
 			return CurrentSelectedProject as DotNetProject;
 		}
 
-		protected bool SelectedDotNetProjectHasPackages ()
-		{
-			DotNetProject project = GetSelectedDotNetProject ();
-			return (project != null) && project.HasPackages ();
-		}
-
 		protected bool IsDotNetSolutionSelected ()
 		{
 			return CurrentSelectedSolution != null;
 		}
 
-		protected bool SelectedDotNetSolutionHasPackages ()
-		{
-			Solution solution = CurrentSelectedSolution;
-			if (solution == null) {
-				return false;
-			}
-
-			return solution.HasAnyProjectWithPackages ();
-		}
-
-		protected bool SelectedDotNetProjectOrSolutionHasPackages ()
+		protected bool CanRestoreSelectedDotNetProjectOrSolution ()
 		{
 			if (IsDotNetProjectSelected ()) {
-				return SelectedDotNetProjectHasPackages ();
+				return CanRestorePackagesForSelectedDotNetProject ();
 			} else if (IsDotNetSolutionSelected ()) {
-				return SelectedDotNetSolutionHasPackages ();
+				return CanRestorePackagesForSelectedSolution ();
 			}
 			return false;
+		}
+
+		protected bool CanRestorePackagesForSelectedDotNetProject ()
+		{
+			DotNetProject project = GetSelectedDotNetProject ();
+			return project?.CanRestorePackages () == true;
+		}
+
+		bool CanRestorePackagesForSelectedSolution ()
+		{
+			Solution solution = CurrentSelectedSolution;
+			return solution?.CanRestorePackages () == true;
 		}
 
 		protected Solution GetSelectedSolution ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackagesCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/PackagesCommandHandler.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		protected DotNetProject GetSelectedDotNetProject ()
 		{
-			return IdeApp.ProjectOperations.CurrentSelectedProject as DotNetProject;
+			return CurrentSelectedProject as DotNetProject;
 		}
 
 		protected bool SelectedDotNetProjectHasPackages ()
@@ -67,12 +67,12 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		protected bool IsDotNetSolutionSelected ()
 		{
-			return IdeApp.ProjectOperations.CurrentSelectedSolution != null;
+			return CurrentSelectedSolution != null;
 		}
 
 		protected bool SelectedDotNetSolutionHasPackages ()
 		{
-			Solution solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+			Solution solution = CurrentSelectedSolution;
 			if (solution == null) {
 				return false;
 			}
@@ -96,7 +96,7 @@ namespace MonoDevelop.PackageManagement.Commands
 			if (project != null) {
 				return project.ParentSolution;
 			}
-			return IdeApp.ProjectOperations.CurrentSelectedSolution;
+			return CurrentSelectedSolution;
 		}
 
 		protected bool CanUpdatePackagesForSelectedDotNetProject ()
@@ -107,7 +107,7 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		bool CanUpdatePackagesForSelectedDotNetSolution ()
 		{
-			Solution solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+			Solution solution = CurrentSelectedSolution;
 			return solution?.CanUpdatePackages () == true;
 		}
 
@@ -119,6 +119,20 @@ namespace MonoDevelop.PackageManagement.Commands
 				return CanUpdatePackagesForSelectedDotNetSolution ();
 			}
 			return false;
+		}
+
+		/// <summary>
+		/// Used by unit tests to avoid having to initialize the IDE workspace.
+		/// </summary>
+		protected virtual Solution CurrentSelectedSolution {
+			get { return IdeApp.ProjectOperations.CurrentSelectedSolution; }
+		}
+
+		/// <summary>
+		/// Used by unit tests to avoid having to initialize the IDE workspace.
+		/// </summary>
+		protected virtual Project CurrentSelectedProject {
+			get { return IdeApp.ProjectOperations.CurrentSelectedProject; }
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesHandler.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		protected override void Update (CommandInfo info)
 		{
-			info.Enabled = SelectedDotNetProjectOrSolutionHasPackages ();
+			info.Enabled = CanRestoreSelectedDotNetProjectOrSolution ();
 		}
 
 		public static void Run (Solution solution)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesInProjectHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Commands/RestorePackagesInProjectHandler.cs
@@ -40,7 +40,7 @@ namespace MonoDevelop.PackageManagement.Commands
 
 		protected override void Update (CommandInfo info)
 		{
-			info.Enabled = SelectedDotNetProjectHasPackages ();
+			info.Enabled = CanRestorePackagesForSelectedDotNetProject ();
 		}
 
 		public static void Run (DotNetProject project)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableRestorePackagesHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableRestorePackagesHandler.cs
@@ -1,10 +1,10 @@
 //
-// FakeNuGetAwareProject.cs
+// TestableRestorePackagesHandler.cs
 //
 // Author:
 //       Matt Ward <matt.ward@microsoft.com>
 //
-// Copyright (c) 2018 Microsoft
+// Copyright (c) 2019 Microsoft
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,40 +24,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using NuGet.ProjectManagement;
+using MonoDevelop.Components.Commands;
+using MonoDevelop.PackageManagement.Commands;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
-	class FakeNuGetAwareProject : DummyDotNetProject, INuGetAwareProject
+	class TestableRestorePackagesHandler : RestorePackagesHandler
 	{
-		public FakeNuGetAwareProject ()
-		{
-			Initialize (this);
+		CommandInfo info = new CommandInfo ();
+		Project project;
+		Solution solution;
+
+		public bool Enabled {
+			get { return info.Enabled; }
 		}
 
-		public NuGetProject CreateNuGetProject ()
+		public void RunUpdate (Solution solution, Project project)
 		{
-			throw new NotImplementedException ();
+			this.solution = solution;
+			this.project = project;
+
+			base.Update (info);
 		}
 
-		public Task<bool> HasMissingPackages (IMonoDevelopSolutionManager solutionManager)
-		{
-			throw new NotImplementedException ();
-		}
-
-		public bool HasPackagesReturnValue;
-
-		public bool HasPackages ()
-		{
-			return HasPackagesReturnValue;
-		}
-
-		public Task RestorePackagesAsync (IMonoDevelopSolutionManager solutionManager, INuGetProjectContext context, CancellationToken token)
-		{
-			throw new NotImplementedException ();
-		}
+		protected override Project CurrentSelectedProject => project;
+		protected override Solution CurrentSelectedSolution => solution;
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableRestorePackagesInProjectHandler.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableRestorePackagesInProjectHandler.cs
@@ -1,10 +1,10 @@
 //
-// FakeNuGetAwareProject.cs
+// TestableRestorePackagesInProjectHandler.cs
 //
 // Author:
 //       Matt Ward <matt.ward@microsoft.com>
 //
-// Copyright (c) 2018 Microsoft
+// Copyright (c) 2019 Microsoft
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,40 +24,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using NuGet.ProjectManagement;
+using MonoDevelop.Components.Commands;
+using MonoDevelop.PackageManagement.Commands;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
-	class FakeNuGetAwareProject : DummyDotNetProject, INuGetAwareProject
+	class TestableRestorePackagesInProjectHandler : RestorePackagesInProjectHandler
 	{
-		public FakeNuGetAwareProject ()
-		{
-			Initialize (this);
+		CommandInfo info = new CommandInfo ();
+		Project project;
+		Solution solution;
+
+		public bool Enabled {
+			get { return info.Enabled; }
 		}
 
-		public NuGetProject CreateNuGetProject ()
+		public void RunUpdate (Solution solution, Project project)
 		{
-			throw new NotImplementedException ();
+			this.solution = solution;
+			this.project = project;
+
+			base.Update (info);
 		}
 
-		public Task<bool> HasMissingPackages (IMonoDevelopSolutionManager solutionManager)
-		{
-			throw new NotImplementedException ();
-		}
-
-		public bool HasPackagesReturnValue;
-
-		public bool HasPackages ()
-		{
-			return HasPackagesReturnValue;
-		}
-
-		public Task RestorePackagesAsync (IMonoDevelopSolutionManager solutionManager, INuGetProjectContext context, CancellationToken token)
-		{
-			throw new NotImplementedException ();
-		}
+		protected override Project CurrentSelectedProject => project;
+		protected override Solution CurrentSelectedSolution => solution;
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -151,6 +151,9 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests\FullyQualifiedReferencePathTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\MSBuildPackageSpecCreatorTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\InstallPackageWithAvailableItemNameTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\PackagesCommandHandlerTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableRestorePackagesHandler.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableRestorePackagesInProjectHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetProjectExtensionsTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/DotNetProjectExtensionsTests.cs
@@ -49,6 +49,12 @@ namespace MonoDevelop.PackageManagement.Tests
 			DotNetProjectExtensions.FileExists = existingFiles.Contains;
 		}
 
+		[TearDown]
+		public void TearDown ()
+		{
+			DotNetProjectExtensions.FileExists = File.Exists;
+		}
+
 		void CreateProject (string fileName, string projectName)
 		{
 			project = new FakeDotNetProject (fileName.ToNativePath ()) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackagesCommandHandlerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackagesCommandHandlerTests.cs
@@ -121,9 +121,78 @@ namespace MonoDevelop.PackageManagement.Tests
 		}
 
 		[Test]
+		public async Task SdkProject_NoPackageReferences ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("netstandard-sdk", "netstandard-sdk.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+		}
+
+		[Test]
+		public async Task SdkProject_NetFramework472 ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("netframework-sdk", "netframework-sdk.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+		}
+
+		[Test]
 		public async Task PackageReferenceProject_NonSdk ()
 		{
 			FilePath solutionFileName = Util.GetSampleProject ("package-reference", "package-reference.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+		}
+
+		[Test]
+		public async Task RestoreProjectStyle_NoPackageReferences ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("RestoreStylePackageReference", "RestoreStylePackageReference.sln");
 
 			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = solution.GetAllDotNetProjects ().Single ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackagesCommandHandlerTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackagesCommandHandlerTests.cs
@@ -1,0 +1,188 @@
+﻿//
+// PackagesCommandHandlerTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class PackagesCommandHandlerTests : RestoreTestBase
+	{
+		TestableRestorePackagesHandler restorePackagesHandler;
+		TestableRestorePackagesInProjectHandler restorePackagesInProjectHandler;
+
+		[SetUp]
+		public void Init ()
+		{
+			restorePackagesHandler = new TestableRestorePackagesHandler ();
+			restorePackagesInProjectHandler = new TestableRestorePackagesInProjectHandler ();
+		}
+
+		[Test]
+		public async Task ProjectWithNoPackages ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("csharp-console", "csharp-console.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsFalse (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled);
+		}
+
+		[Test]
+		public async Task ProjectWithPackagesConfig ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("csharp-console", "csharp-console.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			var packagesConfigFileName = project.BaseDirectory.Combine ("packages.config");
+			File.WriteAllText (packagesConfigFileName, "<packages />");
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected"); 
+		}
+
+		[Test]
+		public async Task SdkProject_PackageReference ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("NetStandardXamarinForms", "NetStandardXamarinForms.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+		}
+
+		[Test]
+		public async Task PackageReferenceProject_NonSdk ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("package-reference", "package-reference.sln");
+
+			solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = solution.GetAllDotNetProjects ().Single ();
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+		}
+
+		[Test]
+		public void NuGetAwareProject ()
+		{
+			var project = new FakeNuGetAwareProject ();
+			var solution = new Solution ();
+			solution.RootFolder.AddItem (project);
+
+			// No packages in project.
+			project.HasPackagesReturnValue = false;
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsFalse (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+
+			// Project has packages.
+			project.HasPackagesReturnValue = true;
+
+			// Project selected.
+			restorePackagesHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project);
+			Assert.IsTrue (restorePackagesInProjectHandler.Enabled);
+
+			// Solution only selected
+			restorePackagesHandler.RunUpdate (solution, project: null);
+			Assert.IsTrue (restorePackagesHandler.Enabled);
+
+			restorePackagesInProjectHandler.RunUpdate (solution, project: null);
+			Assert.IsFalse (restorePackagesInProjectHandler.Enabled, "Should be false - no project selected");
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -312,5 +312,16 @@ namespace MonoDevelop.PackageManagement
 
 			return HasPackages (project.BaseDirectory, project.Name) || project.Items.OfType<ProjectPackageReference> ().Any ();
 		}
+
+		public static bool CanRestorePackages (this DotNetProject project)
+		{
+			var nugetAwareProject = project as INuGetAwareProject;
+			if (nugetAwareProject != null)
+				return nugetAwareProject.HasPackages ();
+
+			return HasPackages (project.BaseDirectory, project.Name) ||
+				DotNetCoreNuGetProject.CanCreate (project) ||
+				PackageReferenceNuGetProject.CanCreate (project);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SolutionExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SolutionExtensions.cs
@@ -48,16 +48,18 @@ namespace MonoDevelop.PackageManagement
 				.Where (project => project.HasPackages ());
 		}
 
-		public static bool HasAnyProjectWithPackages (this Solution solution)
-		{
-			return solution.GetAllProjectsWithPackages ().Any ();
-		}
-
 		public static bool CanUpdatePackages (this Solution solution)
 		{
 			return solution
 				.GetAllDotNetProjects ()
 				.Any (project => project.CanUpdatePackages ());
+		}
+
+		public static bool CanRestorePackages (this Solution solution)
+		{
+			return solution
+				.GetAllDotNetProjects ()
+				.Any (project => project.CanRestorePackages ());
 		}
 	}
 }

--- a/main/tests/test-projects/netframework-sdk/Class1.cs
+++ b/main/tests/test-projects/netframework-sdk/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace netstandard_sdk
+{
+	public class Class1
+	{
+	}
+}

--- a/main/tests/test-projects/netframework-sdk/netframework-sdk.csproj
+++ b/main/tests/test-projects/netframework-sdk/netframework-sdk.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/netframework-sdk/netframework-sdk.sln
+++ b/main/tests/test-projects/netframework-sdk/netframework-sdk.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netframework-sdk", "netframework-sdk.csproj", "{5B443F8D-6C84-443F-A395-5429E8F4A47D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/package-reference/library/library.csproj
+++ b/main/tests/test-projects/package-reference/library/library.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4E1821DD-EE60-48C1-8552-05B2793263DC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>LibraryProject</RootNamespace>
+    <AssemblyName>LibraryProject</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/package-reference/package-reference.sln
+++ b/main/tests/test-projects/package-reference/package-reference.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "library", "library\library.csproj", "{4E1821DD-EE60-48C1-8552-05B2793263DC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E1821DD-EE60-48C1-8552-05B2793263DC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION

The restore menu when right clicking a solution or the packages folder
is no longer disabled when an SDK style project targets .NET Framework
or when the project has RestoreProjectStyle set to PackageReference but
has no PackageReferences.

Fixes VSTS #764063 - NuGet extension ignores RestoreProjectStyle
Fixes VSTS #814579 - Restore NuGet packages menu disabled for sdk style
project targeting net47