### PR TITLE
Fixes VSTS 733501: Go To Line Number

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
@@ -88,5 +88,6 @@
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindPrevious" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindPreviousCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.Replace" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.ReplaceCommandArgs" />
 		<Map id="MonoDevelop.Refactoring.Navigate.GotoBaseMember" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.Navigation.GoToBaseMemberCommandArgs" />
+		<Map id="MonoDevelop.Ide.Commands.SearchCommands.GotoLineNumber" argsType="Microsoft.VisualStudio.Text.Extras.GoToLine.GoToLineCommandArgs" />
 	</Extension>
 </ExtensionModel>


### PR DESCRIPTION
This is the PR to light up the Go To Line functionality in the IDE, implemented in https://github.com/xamarin/vs-editor-core/pull/319. 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/733501