### PR TITLE
[master] Fix some NullReferences in Json files

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -145,6 +145,12 @@ namespace MonoDevelop.CodeActions
 			return Task.Run (async delegate {
 				try {
 					var root = await ad.GetSyntaxRootAsync (cancellationToken);
+					if (root == null) {
+						// WebEditorRoslynWorkspace adds .json, .css, .html etc. files to the workspace
+						// but they don't support syntax trees or semantic model
+						return CodeActionContainer.Empty;
+					}
+
 					if (root.Span.End < span.End) {
 						LoggingService.LogError ($"Error in GetCurrentFixesAsync span {span.Start}/{span.Length} not inside syntax root {root.Span.End} document length {Editor.Length}.");
 						return CodeActionContainer.Empty;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TagCommentsTextEditorExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/TagCommentsTextEditorExtension.cs
@@ -74,7 +74,12 @@ namespace MonoDevelop.Ide.Editor.Extension
 			if (DocumentContext.AnalysisDocument == null || DocumentContext.AnalysisDocument.Id != args.DocumentId)
 				return;
 
-			var ws = (MonoDevelopWorkspace)args.Workspace;
+			var ws = args.Workspace as MonoDevelopWorkspace;
+			if (ws == null) {
+				// could be WebEditorRoslynWorkspace
+				return;
+			}
+
 			var doc = ws.GetDocument (args.DocumentId);
 			if (doc == null)
 				return;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -126,8 +126,15 @@ namespace MonoDevelop.Ide.WelcomePage
 				}
 				WelcomePageShown?.Invoke (welcomePage, EventArgs.Empty);
 				welcomePage.UpdateProjectBar ();
-				((DefaultWorkbench)IdeApp.Workbench.RootWindow).BottomBar.Visible = false;
-				((DefaultWorkbench)IdeApp.Workbench.RootWindow).DockFrame.AddOverlayWidget (welcomePage, animate);
+				
+				var rootWindow = (DefaultWorkbench)IdeApp.Workbench.RootWindow;
+				if (rootWindow.BottomBar is MonoDevelopStatusBar statusBar) {
+					statusBar.Visible = false;
+				}
+
+				if (rootWindow.DockFrame is Components.Docking.DockFrame dockFrame) {
+					dockFrame.AddOverlayWidget (welcomePage, animate);
+				}
 				welcomePage.GrabFocus ();
 			}
 		}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/861121 - "System.NullReferenceException" when closing a solution while a json file is open & the solution doesn't close.

This is the MonoDevelop side of the fix for 861121. For non-C# files they could still be a part of WebEditorRoslynWorkspace, and not MonoDevelopWorkspace, and we need to gracefully deal with that.

Backport of #7700.

/cc @slluis @KirillOsenkov