### PR TITLE
[release-8.1] [Mac] Use the main DispatchQueue when processing memory pressure events

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1360,7 +1360,7 @@ namespace MonoDevelop.MacIntegration
 
 			public MacMemoryMonitor ()
 			{
-				DispatchSource = new DispatchSource.MemoryPressure (notificationFlags, DispatchQueue.DefaultGlobalQueue);
+				DispatchSource = new DispatchSource.MemoryPressure (notificationFlags, DispatchQueue.MainQueue);
 				DispatchSource.SetEventHandler (() => {
 					var metadata = CreateMemoryMetadata (DispatchSource.PressureFlags);
 


### PR DESCRIPTION
Processing this on a background thread will cause an AppKit NSEventThread to spin up on a background thread, which would never finish running
This thread would also be running at 100% CPU, causing a specific thread to loop and burn until the process ends

Fixes VSTS #894581 - VS Mac processes still running after quitting the app?
Fixes VSTS #802626 - [Feedback] VS usually consumes an entire CPU core when idle, killing battery life (and making my lap hot)

Backport of #7734.

/cc @Therzok 