### PR TITLE
[release-8.1] Handle exceptions coming in from glib and objc in a better way

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -249,28 +249,26 @@ namespace MonoDevelop.MacIntegration
 
 			var nsException = ObjCRuntime.Runtime.GetNSObject<NSException> (exceptionPtr);
 			try {
-				throw new MarshalledObjCException (nsException, Environment.StackTrace);
+				throw new MarshalledObjCException (nsException);
 			} catch (MarshalledObjCException e) {
+				LoggingService.LogInternalError ("Unhandled ObjC Exception", e);
 				// Is there a way to figure out if it's going to crash us? Maybe check MarshalObjectiveCExceptionMode and MarshalManagedExceptionMode?
-				LoggingService.LogInternalError ("Unhandled ObjC exception", e);
 			}
 
+			// Invoke the default xamarin.mac one, so if it bubbles up an exception, the caller receives it.
 			oldHandler?.Invoke (exceptionPtr);
 		}
 
 		sealed class MarshalledObjCException : ObjCException
 		{
-			public MarshalledObjCException (NSException exception, string stacktrace) : base (exception)
+			public MarshalledObjCException (NSException exception) : base (exception)
 			{
-				StackTrace = stacktrace;
-			}
+				const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.SetField;
 
-			public override string StackTrace { get; }
-
-			public override string ToString ()
-			{
-				// Matches normal exception format:
-				return GetType () + ": " + Message + Environment.NewLine + StackTrace;
+				var trace = new [] { new StackTrace (true), };
+				//// Otherwise exception stacktrace is not gathered.
+				typeof (Exception)
+					.InvokeMember ("captured_traces", flags, null, this, new object [] { trace });
 			}
 		}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui/GLibLoggingTests.cs
@@ -91,7 +91,6 @@ namespace MonoDevelop.Ide.Gui
 			Assert.That (stacktrace, Contains.Substring ("at GLib.Log.g_logv"));
 			Assert.That (stacktrace, Contains.Substring ("at MonoDevelop.Ide.Gui.GLibLogging.LoggerMethod"));
 			Assert.That (stacktrace, Contains.Substring ("at MonoDevelop.Ide.Gui.GLibLoggingTests"));
-
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes up exception handling so we always and properly attach stacktraces under mono.

Also, fixes stacktraces for non-error glib events

Backport of #7733.

/cc @slluis @Therzok