### PR TITLE
[Mac] ObjCMarshalledException is still not reported right

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -251,7 +251,7 @@ namespace MonoDevelop.MacIntegration
 			try {
 				throw new MarshalledObjCException (nsException);
 			} catch (MarshalledObjCException e) {
-				LoggingService.LogInternalError ("Unhandled ObjC Exception", e);
+				LoggingService.LogFatalError ("Unhandled ObjC Exception", e);
 				// Is there a way to figure out if it's going to crash us? Maybe check MarshalObjectiveCExceptionMode and MarshalManagedExceptionMode?
 			}
 

--- a/main/tests/MacPlatform.Tests/MacPlatformTest.cs
+++ b/main/tests/MacPlatform.Tests/MacPlatformTest.cs
@@ -181,7 +181,7 @@ namespace MacPlatform.Tests
 		public void CriticalErrorsExceptionsHaveFullStacktracesInLog ()
 		{
 			var logger = new CapturingLogger {
-				EnabledLevel = EnabledLoggingLevel.Error,
+				EnabledLevel = EnabledLoggingLevel.Fatal,
 			};
 
 			try {

--- a/main/tests/MacPlatform.Tests/MacPlatformTest.cs
+++ b/main/tests/MacPlatform.Tests/MacPlatformTest.cs
@@ -192,7 +192,7 @@ namespace MacPlatform.Tests
 
 				Assert.Throws<ObjCException> (() => void_objc_msgSend (ex.Handle, selector));
 
-				var (_, message) = logger.LogMessages.Single (x => x.Level == LogLevel.Error);
+				var (_, message) = logger.LogMessages.Single (x => x.Level == LogLevel.Fatal);
 				AssertMacPlatformStacktrace (message);
 			} finally {
 				LoggingService.RemoveLogger (logger.Name);


### PR DESCRIPTION
The app crashes before the handler is reached, fix this by reporting it as fatal - usually the app really just does crash.