### PR TITLE
[release-8.1] [IDE] only popup the menu on single clicks.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -179,7 +179,9 @@ namespace MonoDevelop.Ide.Projects
 				return;
 			}
 
-			if (languageCellRenderer.IsLanguageButtonPressed (args.Event)) {
+			// Only display the popup menu on a single press, ignore anything else
+			// Fixes a crash when triple clicking. VSTS #849556
+			if (args.Event.Type == Gdk.EventType.ButtonPress && languageCellRenderer.IsLanguageButtonPressed (args.Event)) {
 				HandlePopup (template, args.Event.Time);
 			}
 		}


### PR DESCRIPTION
The way Gtk treats double/triple clicks is breaking something in Xwt and crashing when triple clicking on the language
button

Fixes VSTS #849556

Backport of #7748.

/cc @iainx 