### PR TITLE
Update BinaryCompat for Mono 6.0

### DIFF
--- a/main/build/MacOSX/BinaryCompatBaseline.txt
+++ b/main/build/MacOSX/BinaryCompatBaseline.txt
@@ -2,18 +2,18 @@ In VisualStudio.exe.config: couldn't find assembly 'Microsoft.Build.Framework' w
 In VisualStudio.exe.config: couldn't find assembly 'Microsoft.Build' with version 15.1.0.0.
 In VisualStudio.exe.config: couldn't find assembly 'System.Net.Http.Extensions' with version 2.2.29.0.
 In VisualStudio.exe.config: couldn't find assembly 'System.Net.Http.Primitives' with version 4.2.29.0.
-Could not load file or assembly 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'Microsoft.Developer.IdentityService.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'Microsoft.ServiceHub.Client, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'Microsoft.TestPlatform.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'MonoTouch.Hosting, Version=0.0.0.0, Culture=neutral, PublicKeyToken=5caa9e03e69a5abd' or one of its dependencies
-Could not load file or assembly 'System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'System.Runtime.Loader, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies
-Could not load file or assembly 'System.Web.DataVisualization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies
-Could not load file or assembly 'Xamarin.Ide.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies
-Could not load file or assembly 'Xamarin.MacDev.Ide, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies
+Could not load the file 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'Microsoft.Developer.IdentityService.Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'Microsoft.ServiceHub.Client, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'Microsoft.TestPlatform.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'MonoTouch.Hosting, Version=0.0.0.0, Culture=neutral, PublicKeyToken=5caa9e03e69a5abd'.
+Could not load the file 'System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'System.Runtime.Loader, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+Could not load the file 'System.Web.DataVisualization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
+Could not load the file 'Xamarin.Ide.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.
+Could not load the file 'Xamarin.MacDev.Ide, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.
 In assembly 'Google.Apis.Core, Version=1.9.0.26010, Culture=neutral, PublicKeyToken=null': unable to resolve reference to 'System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 In assembly 'Microsoft.CodeAnalysis.Scripting, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35': unable to resolve reference to 'System.Runtime.Loader, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 In assembly 'Microsoft.CodeAnalysis.TypeScript.EditorFeatures, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a': unable to resolve reference to 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'


### PR DESCRIPTION
Mono 6.0 has changed the assembly resolution error message from:

Could not load file or assembly 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies

To:

Could not load the file 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.