### PR TITLE
[release-8.1] Handle exceptions in memory monitor and cleanup EventHandler SafeInvoke

### DIFF
--- a/main/src/core/MonoDevelop.Core/CoreExtensions.cs
+++ b/main/src/core/MonoDevelop.Core/CoreExtensions.cs
@@ -267,17 +267,14 @@ namespace System
 		/// Invokes a callback catching and reporting exceptions thrown by handlers
 		/// </summary>
 		/// <typeparam name="T">Type of the event arguments</typeparam>
-		/// <param name="event">Event to invoke</param>
+		/// <param name="events">Event to invoke</param>
 		/// <param name="sender">Sender of the event</param>
 		/// <param name="args">Arguments of the event</param>
-		public static void SafeInvoke<T> (this EventHandler<T> @event, object sender, T args)
+		public static void SafeInvoke<T> (this EventHandler<T> events, object sender, T args)
 		{
-			var events = @event;
-			if (events == null)
-				return;
 			foreach (var ev in events.GetInvocationList ()) {
 				try {
-					((EventHandler < T > )ev) (sender, args);
+					((EventHandler<T>)ev) (sender, args);
 				} catch (Exception ex) {
 					LoggingService.LogInternalError (ex);
 				}
@@ -287,14 +284,11 @@ namespace System
 		/// <summary>
 		/// Invokes a callback catching and reporting exceptions thrown by handlers
 		/// </summary>
-		/// <param name="event">Event to invoke</param>
+		/// <param name="events">Event to invoke</param>
 		/// <param name="sender">Sender of the event</param>
 		/// <param name="args">Arguments of the event</param>
-		public static void SafeInvoke (this EventHandler @event, object sender, EventArgs args)
+		public static void SafeInvoke (this EventHandler events, object sender, EventArgs args)
 		{
-			var events = @event;
-			if (events == null)
-				return;
 			foreach (var ev in events.GetInvocationList ()) {
 				try {
 					((EventHandler)ev) (sender, args);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/MemoryMonitor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/MemoryMonitor.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.Ide.Desktop
 		/// </summary>
 		protected virtual void OnStatusChanged (PlatformMemoryStatusEventArgs args)
 		{
-			StatusChanged?.Invoke (this, args);
+			StatusChanged?.SafeInvoke (this, args);
 		}
 
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -97,12 +97,12 @@ namespace MonoDevelop.Ide
 			return Task.CompletedTask;
 		}
 
-		void OnMemoryStatusChanged (object sender, PlatformMemoryStatusEventArgs args)
+		static void OnMemoryStatusChanged (object sender, PlatformMemoryStatusEventArgs args)
 		{
 			Counters.MemoryPressure.Inc (args.CounterMetadata);
 		}
 
-		void OnThermalStatusChanged (object sender, PlatformThermalStatusEventArgs args)
+		static void OnThermalStatusChanged (object sender, PlatformThermalStatusEventArgs args)
 		{
 			Counters.ThermalNotification.Inc (args.CounterMetadata);
 		}


### PR DESCRIPTION
See individual commits.

Fixes VSTS #901407 - [Watson] ObjectDisposedException due to MemoryMonitor not having a catch block (MonoDevelop.Ide.dll)

Backport of #7759.

/cc @Therzok 