### PR TITLE
Fixes resize dock containers in our dock system moving  SplitterWidget to native

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
@@ -62,22 +62,25 @@ namespace MonoDevelop.Components.Docking
 		public override void MouseExited (NSEvent theEvent)
 		{
 			if (!dragging) {
-				NSCursor.ArrowCursor.Set ();
+				SetDefaultCursor ();
 			}
 			hover = false;
 			base.MouseExited (theEvent);
 		}
 
+		NSCursor currentCursor;
+
 		void SetResizeCursor ()
 		{
-			if (dockGroup == null) {
+			if (dockGroup == null || currentCursor != null) {
 				return;
 			}
 			if (dockGroup.Type == DockGroupType.Horizontal) {
-				NSCursor.ResizeLeftRightCursor.Set ();
+				currentCursor = NSCursor.ResizeLeftRightCursor;
 			} else {
-				NSCursor.ResizeUpDownCursor.Set ();
+				currentCursor = NSCursor.ResizeUpDownCursor;
 			}
+			currentCursor.Push ();
 		}
 
 		public override void MouseMoved (NSEvent theEvent)
@@ -120,12 +123,20 @@ namespace MonoDevelop.Components.Docking
 			AddRemoveFilter (true);
 		}
 
+		void SetDefaultCursor ()
+		{
+			if (currentCursor != null) {
+				currentCursor.Pop ();
+				currentCursor = null;
+			}
+		}
+
 		public override void MouseUp (NSEvent theEvent)
 		{
 			if (hover) {
 				SetResizeCursor ();
 			} else {
-				NSCursor.ArrowCursor.Set ();
+				SetDefaultCursor ();
 			}
 			RaiseEndDrag ();
 			base.MouseUp (theEvent);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
@@ -48,8 +48,7 @@ namespace MonoDevelop.Components.Docking
 		{
 			var options = NSTrackingAreaOptions.ActiveInKeyWindow |
 				NSTrackingAreaOptions.InVisibleRect |
-				NSTrackingAreaOptions.MouseEnteredAndExited |
-				NSTrackingAreaOptions.EnabledDuringMouseDrag;
+				NSTrackingAreaOptions.MouseEnteredAndExited;
 			var trackingArea = new NSTrackingArea (default, options, this, null);
 			AddTrackingArea (trackingArea);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
@@ -3,7 +3,6 @@
 // Author:
 //   Jose Medrano
 //
-
 //
 // Copyright (C) 2918 Microsoft
 //
@@ -31,7 +30,6 @@
 using System;
 using AppKit;
 using Gtk;
-using MonoDevelop.Components.Mac;
 
 namespace MonoDevelop.Components.Docking
 {
@@ -39,7 +37,6 @@ namespace MonoDevelop.Components.Docking
 	{
 		DockGroup dockGroup;
 		int dockIndex;
-		Widget parent;
 
 		int dragPos, dragSize;
 		bool hover, dragging;
@@ -164,8 +161,8 @@ namespace MonoDevelop.Components.Docking
 			else
 				Gdk.Window.RemoveFilterForAll (Filter);
 		}
-		static Gdk.FilterReturn Filter (IntPtr xevent, Gdk.Event evnt) => Gdk.FilterReturn.Remove;
 
+		static Gdk.FilterReturn Filter (IntPtr xevent, Gdk.Event evnt) => Gdk.FilterReturn.Remove;
 	}
 
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
@@ -1,0 +1,174 @@
+﻿//
+//
+// Author:
+//   Jose Medrano
+//
+
+//
+// Copyright (C) 2918 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+#if MAC
+
+using System;
+using AppKit;
+using Gtk;
+using MonoDevelop.Components.Mac;
+
+namespace MonoDevelop.Components.Docking
+{
+	internal class MacSplitterWidget : NSView
+	{
+		DockGroup dockGroup;
+		int dockIndex;
+		Widget parent;
+
+		int dragPos, dragSize;
+		bool hover, dragging;
+
+		public MacSplitterWidget ()
+		{
+			var options = NSTrackingAreaOptions.ActiveInKeyWindow |
+				NSTrackingAreaOptions.InVisibleRect |
+				NSTrackingAreaOptions.MouseEnteredAndExited |
+				NSTrackingAreaOptions.EnabledDuringMouseDrag;
+			var trackingArea = new NSTrackingArea (default, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			if (!dragging) {
+				SetResizeCursor ();
+			}
+			hover = true;
+			base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			if (!dragging) {
+				NSCursor.ArrowCursor.Set ();
+			}
+			hover = false;
+			base.MouseExited (theEvent);
+		}
+
+		void SetResizeCursor ()
+		{
+			if (dockGroup == null) {
+				return;
+			}
+			if (dockGroup.Type == DockGroupType.Horizontal) {
+				NSCursor.ResizeLeftRightCursor.Set ();
+			} else {
+				NSCursor.ResizeUpDownCursor.Set ();
+			}
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			if (!dragging) {
+				SetResizeCursor ();
+			}
+			base.MouseMoved (theEvent);
+		}
+
+		void RaiseEndDrag ()
+		{
+			if (dragging) {
+				dragging = false;
+				AddRemoveFilter (false);
+			}
+		}
+
+		public void Init (DockGroup grp, int index)
+		{
+			dockGroup = grp;
+			dockIndex = index;
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			dragging = true;
+
+			var point = NSEvent.CurrentMouseLocation;
+			var obj = dockGroup.VisibleObjects [dockIndex];
+
+			if (dockGroup.Type == DockGroupType.Horizontal) {
+				dragPos = (int)point.X;
+				dragSize = obj.Allocation.Width;
+			} else {
+				dragPos = (int)point.Y;
+				dragSize = obj.Allocation.Height;
+			}
+
+			AddRemoveFilter (true);
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			if (hover) {
+				SetResizeCursor ();
+			} else {
+				NSCursor.ArrowCursor.Set ();
+			}
+			RaiseEndDrag ();
+			base.MouseUp (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			SetResizeCursor ();
+
+			var point = NSEvent.CurrentMouseLocation;
+			int newpos;
+			if (dockGroup.Type == DockGroupType.Horizontal) {
+				newpos = (int)point.X;
+			} else {
+				newpos = (int)point.Y;
+			}
+
+			if (newpos != dragPos) {
+				int nsize;
+				if (dockGroup.Type == DockGroupType.Horizontal) {
+					nsize = dragSize + (newpos - dragPos);
+				} else {
+					nsize = dragSize - (newpos - dragPos);
+				}
+				dockGroup.ResizeItem (dockIndex, nsize);
+			}
+		}
+
+		void AddRemoveFilter (bool enable)
+		{
+			if (enable)
+				Gdk.Window.AddFilterForAll (Filter);
+			else
+				Gdk.Window.RemoveFilterForAll (Filter);
+		}
+		static Gdk.FilterReturn Filter (IntPtr xevent, Gdk.Event evnt) => Gdk.FilterReturn.Remove;
+
+	}
+
+}
+
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/MacSplitterWidget.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Components.Docking
 
 		public MacSplitterWidget ()
 		{
-			var options = NSTrackingAreaOptions.ActiveInKeyWindow |
+			const NSTrackingAreaOptions options = NSTrackingAreaOptions.ActiveInKeyWindow |
 				NSTrackingAreaOptions.InVisibleRect |
 				NSTrackingAreaOptions.MouseEnteredAndExited;
 			var trackingArea = new NSTrackingArea (default, options, this, null);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterGtkNSViewHostWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterGtkNSViewHostWidget.cs
@@ -1,0 +1,80 @@
+﻿// SplitterContainerWidget.cs
+//
+// Author:
+//   Jose Medrano
+//
+
+//
+// Copyright (C) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if MAC
+
+using Gdk;
+using Gtk;
+
+namespace MonoDevelop.Components.Docking
+{
+	sealed class SplitterMacHostWidget : ISplitterWidget
+	{
+		readonly GtkNSViewHost host;
+		readonly MacSplitterWidget view;
+
+		public SplitterMacHostWidget ()
+		{
+			view = new MacSplitterWidget ();
+			host = new GtkNSViewHost (view);
+		}
+
+		public void Init (DockGroup grp, int index)
+		{
+			view.Init (grp, index);
+		}
+
+		public Widget Parent => host.Parent;
+
+		public bool Visible {
+			get => host.Visible;
+			set => host.Visible = value;
+		}
+
+		public Widget Widget => host;
+
+		public void SizeAllocate (Rectangle rect)
+		{
+			host.SizeAllocate (rect);
+		}
+
+		public void Hide ()
+		{
+			host.Hide ();
+		}
+
+		public void Show ()
+		{
+			host.Show ();
+		}
+
+	}
+}
+
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterMacHostWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterMacHostWidget.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Components.Docking
 		public SplitterMacHostWidget ()
 		{
 			view = new MacSplitterWidget ();
-			host = new GtkNSViewHost (view);
+			host = new GtkNSViewHost (view, AppKit.NSWindowOrderingMode.Above);
 		}
 
 		public Widget Parent => host.Parent;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterMacHostWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterMacHostWidget.cs
@@ -45,11 +45,6 @@ namespace MonoDevelop.Components.Docking
 			host = new GtkNSViewHost (view);
 		}
 
-		public void Init (DockGroup grp, int index)
-		{
-			view.Init (grp, index);
-		}
-
 		public Widget Parent => host.Parent;
 
 		public bool Visible {
@@ -59,21 +54,13 @@ namespace MonoDevelop.Components.Docking
 
 		public Widget Widget => host;
 
-		public void SizeAllocate (Rectangle rect)
-		{
-			host.SizeAllocate (rect);
-		}
+		public void Init (DockGroup grp, int index) => view.Init (grp, index);
 
-		public void Hide ()
-		{
-			host.Hide ();
-		}
+		public void SizeAllocate (Rectangle rect) => host.SizeAllocate (rect);
 
-		public void Show ()
-		{
-			host.Show ();
-		}
+		public void Hide () => host.Hide ();
 
+		public void Show () => host.Show ();
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterWidgetWrapper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterWidgetWrapper.cs
@@ -45,13 +45,8 @@ namespace MonoDevelop.Components.Docking
 
 	class SplitterWidgetWrapper : ISplitterWidget
 	{
-		public Gtk.Widget Parent {
-			get => nativeWidget.Parent;
-		}
-
-		public Gtk.Widget Widget {
-			get => nativeWidget.Widget;
-		}
+		public Gtk.Widget Parent => nativeWidget.Parent;
+		public Gtk.Widget Widget => nativeWidget.Widget;
 
 		public bool Visible {
 			get => nativeWidget.Visible;
@@ -65,24 +60,11 @@ namespace MonoDevelop.Components.Docking
 			nativeWidget = splitterWidget;
 		}
 
-		public void Init (DockGroup grp, int index)
-		{
-			nativeWidget.Init (grp, index);
-		}
+		public void Init (DockGroup grp, int index) => nativeWidget.Init (grp, index);
 
-		public void SizeAllocate (Rectangle rect)
-		{
-			nativeWidget.SizeAllocate (rect);
-		}
+		public void SizeAllocate (Rectangle rect) => nativeWidget.SizeAllocate (rect);
 
-		public void Show ()
-		{
-			nativeWidget.Show ();
-		}
-
-		public void Hide ()
-		{
-			nativeWidget.Hide ();
-		}
+		public void Show () => nativeWidget.Show ();
+		public void Hide () => nativeWidget.Hide ();
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterWidgetWrapper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/SplitterWidgetWrapper.cs
@@ -1,0 +1,88 @@
+﻿//
+//
+// Author:
+//   Lluis Sanchez Gual
+//
+
+//
+// Copyright (C) 2007 Novell, Inc (http://www.novell.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using Gdk;
+using Gtk;
+
+namespace MonoDevelop.Components.Docking
+{
+	interface ISplitterWidget
+	{
+		Gtk.Widget Parent { get; }
+		void Init (DockGroup grp, int index);
+		void SizeAllocate (Gdk.Rectangle rect);
+		bool Visible { get; set; }
+		void Hide ();
+		void Show ();
+		Gtk.Widget Widget { get; }
+	}
+
+	class SplitterWidgetWrapper : ISplitterWidget
+	{
+		public Gtk.Widget Parent {
+			get => nativeWidget.Parent;
+		}
+
+		public Gtk.Widget Widget {
+			get => nativeWidget.Widget;
+		}
+
+		public bool Visible {
+			get => nativeWidget.Visible;
+			set => nativeWidget.Visible = value;
+		}
+
+		ISplitterWidget nativeWidget;
+
+		public SplitterWidgetWrapper (ISplitterWidget splitterWidget)
+		{
+			nativeWidget = splitterWidget;
+		}
+
+		public void Init (DockGroup grp, int index)
+		{
+			nativeWidget.Init (grp, index);
+		}
+
+		public void SizeAllocate (Rectangle rect)
+		{
+			nativeWidget.SizeAllocate (rect);
+		}
+
+		public void Show ()
+		{
+			nativeWidget.Show ();
+		}
+
+		public void Hide ()
+		{
+			nativeWidget.Hide ();
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -67,12 +67,18 @@ namespace Gtk
 		NSView view;
 		NSView superview;
 		bool sizeAllocated;
+		NSWindowOrderingMode? zOrder;
 
 		public GtkNSViewHost (NSView view)
 		{
 			this.view = view ?? throw new ArgumentNullException (nameof (view));
 
 			WidgetFlags |= WidgetFlags.NoWindow;
+		}
+
+		public GtkNSViewHost (NSView view, NSWindowOrderingMode position) : this (view)
+		{
+			zOrder = position;
 		}
 
 		void UpdateViewFrame ()
@@ -153,8 +159,12 @@ namespace Gtk
 						superview = Runtime.GetNSObject<NSView> (superviewHandle);
 				}
 
-				if (superview != null && view != null)
-					superview.AddSubview (view);
+				if (superview != null && view != null) {
+					if (zOrder.HasValue)
+						superview.AddSubview (view, zOrder.Value, null);
+					else
+						superview.AddSubview (view);
+				}
 
 				base.OnRealized ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4247,6 +4247,9 @@
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopErrorLoggerService.cs" />
     <Compile Include="MonoDevelop.Components.Commands\IdeCommandManager.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\WorkbenchStatusBar.cs" />
+    <Compile Include="MonoDevelop.Components.Docking\MacSplitterWidget.cs" />
+    <Compile Include="MonoDevelop.Components.Docking\SplitterWidgetWrapper.cs" />
+    <Compile Include="MonoDevelop.Components.Docking\SplitterGtkNSViewHostWidget.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4249,7 +4249,7 @@
     <Compile Include="MonoDevelop.Ide.Gui\WorkbenchStatusBar.cs" />
     <Compile Include="MonoDevelop.Components.Docking\MacSplitterWidget.cs" />
     <Compile Include="MonoDevelop.Components.Docking\SplitterWidgetWrapper.cs" />
-    <Compile Include="MonoDevelop.Components.Docking\SplitterGtkNSViewHostWidget.cs" />
+    <Compile Include="MonoDevelop.Components.Docking\SplitterMacHostWidget.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />


### PR DESCRIPTION
This PR fixes the resize behaviour in dock containers when mouse is over native embed areas

To solve this, we had to deal with some problems:
- Create a MacSplitterWidget (because we need this view above the GTK layer to capture some mouse over events),
- Doesn't break GTK
- Capture and not let GTK swallow the mouse events 
- Introduces SplitterGtkNSViewHostWidget based in a new GtkNSViewHostWidget, this layer encapsules  the logic to handle drag logic between toolkits

In order not to break GTK, I tried first to encapsule both backends and expose it over a wrapper class  SplitterWidgetWrapper with same interface.

In case of the cocoa backend, I created a native view (MacSplitterWidget) which GTK embeds into a SplitterGtkNSViewHostWidget extending from GtkNSViewHostWidget. This host widget has a DragCaptureEventMonitor with some logic to capture cocoa events and not let GTK swallow the mouse events.

![scroll](https://user-images.githubusercontent.com/1587480/58715825-fabe0b00-83c7-11e9-9366-7b5368cf992d.gif)

Fixes VSTS #790689 - Pads can only be resized if mousing left to right over edge

