### PR TITLE
[release-8.1] [Mac] Don't force resize the window when positioning it

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1281,7 +1281,7 @@ namespace MonoDevelop.MacIntegration
 			y += GetTitleBarHeight (w);
 			var dr = FromDesktopRect (new Gdk.Rectangle (x, y, width, height));
 			var r = w.FrameRectFor (dr);
-			w.SetFrame (r, true);
+
 			base.PlaceWindow (window, x, y, width, height);
 		}
 


### PR DESCRIPTION
Stop force resizing the window, because in some situations it can cause the NSWindow and the GtkWindow to be different
sizes.

Fixes VSTS #900933

Backport of #7764.

/cc @iainx 