### PR TITLE
[release-8.2] Fixes VSTS Bug 904321: [Feedback] Xamarin Android Breakpoint not work

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -1953,7 +1953,7 @@ namespace Mono.TextEditor
 				}
 			}
 
-			var metrics  = new LineMetrics {
+			var metrics = new LineMetrics {
 				LineSegment = line,
 				Layout = layout,
 
@@ -1976,16 +1976,25 @@ namespace Mono.TextEditor
 				if (!marker.IsVisible)
 					continue;
 
-				if (marker.DrawBackground (textEditor, cr, metrics)) {
-					isSelectionDrawn |= (marker.Flags & TextLineMarkerFlags.DrawsSelection) == TextLineMarkerFlags.DrawsSelection;
+				try {
+					if (marker.DrawBackground (textEditor, cr, metrics)) {
+						isSelectionDrawn |= (marker.Flags & TextLineMarkerFlags.DrawsSelection) == TextLineMarkerFlags.DrawsSelection;
+					}
+				} catch (Exception e) {
+					LoggingService.LogInternalError ("Error while drawing backround marker " + marker, e);
 				}
 			}
 
 			var textSegmentMarkers = TextDocument.OrderTextSegmentMarkersByInsertion (Document.GetVisibleTextSegmentMarkersAt (line)).ToList ();
 			foreach (var marker in textSegmentMarkers) {
-				if (layout.Layout != null)
+				if (layout.Layout == null)
+					continue;
+				try {
 					marker.DrawBackground (textEditor, cr, metrics, offset, offset + length);
-			}
+				} catch (Exception e) {
+					LoggingService.LogInternalError ("Error while drawing backround marker " + marker, e);
+				}
+		    }
 
 
 			if (DecorateLineBg != null)
@@ -2171,17 +2180,24 @@ namespace Mono.TextEditor
 					}
 				}
 			}
-			foreach (TextLineMarker marker in textEditor.Document.GetMarkers (line)) {
-				if (!marker.IsVisible)
+			foreach (var marker in textEditor.Document.GetMarkers (line)) {
+				if (!marker.IsVisible || layout.Layout == null)
 					continue;
-
-				if (layout.Layout != null)
+				try {
 					marker.Draw (textEditor, cr, metrics);
+				} catch (Exception e) {
+					LoggingService.LogInternalError ("Error while drawing line marker " + marker, e);
+				}
 			}
 
 			foreach (var marker in textSegmentMarkers) {
-				if (layout.Layout != null)
+				if (layout.Layout == null)
+					continue;
+				try {
 					marker.Draw (textEditor, cr, metrics, offset, offset + length);
+				} catch (Exception e) {
+					LoggingService.LogInternalError ("Error while drawing segment marker " + marker, e);
+				}
 			}
 			position += System.Math.Floor (layout.LastLineWidth);
 

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextSegmentMarker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/TextSegmentMarker.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // TextSegmentMarker.cs
 //
 // Author:
@@ -152,18 +152,26 @@ namespace Mono.TextEditor
 				int /*lineNr,*/ x_pos;
 				uint curIndex = 0;
 				uint byteIndex = 0;
-				uint idx = (uint)Math.Min (Math.Max (0, start - startOffset), metrics.Layout.Text.Length - 1);
-				metrics.Layout.TranslateToUTF8Index (idx, ref curIndex, ref byteIndex);
-				
-				x_pos = layout.IndexToPos (System.Math.Max (0, (int)byteIndex)).X;
-				@from = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
 
-				idx = (uint)Math.Min (Math.Max (0, end - startOffset), metrics.Layout.Text.Length - 1);
-				metrics.Layout.TranslateToUTF8Index (idx, ref curIndex, ref byteIndex);
+				var textLength = metrics.Layout.Text.Length;
+				if (textLength > 0) {
+					uint idx = (uint)Math.Min (Math.Max (0, start - startOffset), textLength - 1);
+					metrics.Layout.TranslateToUTF8Index (idx, ref curIndex, ref byteIndex);
+
+					x_pos = layout.IndexToPos (System.Math.Max (0, (int)byteIndex)).X;23
+					@from = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
+
+					idx = (uint)Math.Min (Math.Max (0, end - startOffset), textLength - 1);
+					metrics.Layout.TranslateToUTF8Index (idx, ref curIndex, ref byteIndex);
+
+					x_pos = layout.IndexToPos (System.Math.Max (0, (int)byteIndex)).X;
+
+					to = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
+				} else {
+					@from = startXPos;
+					to = startXPos + editor.TextViewMargin.CharWidth;
+				}
 				
-				x_pos = layout.IndexToPos (System.Math.Max (0, (int)byteIndex)).X;
-				
-				to = startXPos + (int)(x_pos / Pango.Scale.PangoScale);
 				var line = editor.GetLineByOffset (endOffset);
 				if (markerEnd > endOffset || @from == to) {
 					to += editor.TextViewMargin.CharWidth;


### PR DESCRIPTION
in debug

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/904321

Exception from feedback ticket :
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/896686

Produces many out of range exceptions in text segment marker. This
checks now for empty lines - can happen during an edit session when a
line is cleared. Exceptions in that case prevent further drawing in
that line. This is now changed and the drawing code is hardened
against exceptions in line markers.

Backport of #7772.

/cc @mkrueger 