### PR TITLE
Fix mime type assignment issues in FileModel

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentModel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentModel.cs
@@ -103,13 +103,19 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		public void CreateNew ()
 		{
+			InitializeNew ();
+			ModelRepresentation.CreateNew ();
+		}
+
+		protected void InitializeNew ()
+		{
 			if (IsLoaded)
 				throw new InvalidOperationException ("Model already loaded");
 			if (Data.IsLinked)
 				throw new InvalidOperationException ("Model already linked");
 			isNew = true;
-			ModelRepresentation.CreateNew ();
 		}
+
 
 		public bool IsNew {
 			get {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/FileDocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/FileDocumentController.cs
@@ -110,7 +110,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 					if (!typeof (FileModel).IsAssignableFrom (FileModelType))
 						throw new InvalidOperationException ("Invalid file model type: " + FileModelType);
 					var fileModel = (FileModel)Activator.CreateInstance (FileModelType);
-					fileModel.CreateNew ();
+					fileModel.CreateNew (fileDescriptor.FilePath, fileDescriptor.MimeType);
 					await fileModel.SetContent (fileDescriptor.Content);
 					if (fileDescriptor.Encoding != null && fileModel is TextFileModel textFileModel)
 						textFileModel.Encoding = fileDescriptor.Encoding;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/ModelRepresentation.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/ModelRepresentation.cs
@@ -68,6 +68,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			try {
 				await WaitHandle.WaitAsync ();
+				await CheckIdChange ();
 				if (IsLoaded)
 					return;
 				if (DocumentModelData.IsLinked)
@@ -96,6 +97,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			try {
 				await WaitHandle.WaitAsync ();
+				await CheckIdChange ();
 				await OnLoad ();
 				IsLoaded = true;
 				HasUnsavedChanges = false;
@@ -108,6 +110,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			try {
 				await WaitHandle.WaitAsync ();
+				await CheckIdChange ();
 				await OnSave ();
 				HasUnsavedChanges = false;
 			} finally {
@@ -137,6 +140,25 @@ namespace MonoDevelop.Ide.Gui.Documents
 		}
 
 		protected abstract void OnCreateNew ();
+
+		/// <summary>
+		/// Invoked just before a load or save operation when the Id of a model has changed
+		/// </summary>
+		protected virtual Task OnIdChanged ()
+		{
+			return Task.CompletedTask;
+		}
+
+		object id;
+
+		Task CheckIdChange ()
+		{
+			if (id != Id) {
+				id = Id;
+				return OnIdChanged ();
+			} else
+				return Task.CompletedTask;
+		}
 
 		protected abstract Task OnLoad ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/TextBufferFileModel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/TextBufferFileModel.cs
@@ -66,8 +66,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 			protected override async Task OnLoad ()
 			{
 				var text = await TextFileUtility.GetTextAsync (FilePath, CancellationToken.None);
-				MimeType = (await Runtime.GetService<DesktopService> ()).GetMimeTypeForUri (FilePath);
-				var contentType = (MimeType == null) ? PlatformCatalog.Instance.TextBufferFactoryService.InertContentType : GetContentTypeFromMimeType (FilePath, MimeType);
+				var contentType = GetContentTypeFromMimeType ();
 				if (textDocument != null) {
 					// Reloading
 					try {
@@ -115,6 +114,10 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 			protected override Task OnSave ()
 			{
+				var contentType = GetContentTypeFromMimeType ();
+				if (textDocument.TextBuffer.ContentType != contentType)
+					textDocument.TextBuffer.ChangeContentType (contentType, null);
+
 				// OnLoad is always called before anything else, so the document should be ready
 				textDocument.SaveAs (FilePath, true);
 				cleanReiteratedVersion = textDocument.TextBuffer.CurrentSnapshot.Version.ReiteratedVersionNumber;
@@ -126,17 +129,18 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 			ITextDocument CreateTextDocument (string text)
 			{
-				var contentType = (MimeType == null)
-					? PlatformCatalog.Instance.TextBufferFactoryService.InertContentType
-					: GetContentTypeFromMimeType (FilePath, MimeType);
+				var contentType = GetContentTypeFromMimeType ();
 				var buffer = PlatformCatalog.Instance.TextBufferFactoryService.CreateTextBuffer (text, contentType);
 				var doc = PlatformCatalog.Instance.TextDocumentFactoryService.CreateTextDocument (buffer, FilePath.ToString () ?? "");
 				return doc;
 			}
 
-			protected static IContentType GetContentTypeFromMimeType (string filePath, string mimeType)
+			IContentType GetContentTypeFromMimeType ()
 			{
-				return MimeTypeCatalog.Instance.GetContentTypeForMimeType (mimeType, filePath)
+				if (MimeType == null)
+					return PlatformCatalog.Instance.TextBufferFactoryService.InertContentType;
+
+				return MimeTypeCatalog.Instance.GetContentTypeForMimeType (MimeType, FilePath)
 					?? PlatformCatalog.Instance.ContentTypeRegistryService.GetContentType ("text");
 			}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.DocumentModels/TextBufferFileModelTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.DocumentModels/TextBufferFileModelTests.cs
@@ -24,7 +24,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.IO;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui.Documents;
+using NUnit.Framework;
 
 namespace MonoDevelop.Ide.Gui.DocumentModels
 {
@@ -33,6 +37,33 @@ namespace MonoDevelop.Ide.Gui.DocumentModels
 		public override DocumentModel CreateModel ()
 		{
 			return new TextBufferFileModel ();
+		}
+
+		[Test]
+		public void CreateNewTextBufferFile ()
+		{
+			using (var model = new TextBufferFileModel ()) {
+				model.CreateNew ("foo.cs", null);
+				Assert.AreEqual ("CSharp", model.TextBuffer.ContentType.TypeName);
+			}
+			using (var model = new TextBufferFileModel ()) {
+				model.CreateNew (null, "text/x-csharp");
+				Assert.AreEqual ("CSharp", model.TextBuffer.ContentType.TypeName);
+			}
+		}
+
+		[Test]
+		public async Task CreateNewTextBufferFileRenameWhenSaving ()
+		{
+			using (var model = new TextBufferFileModel ()) {
+				model.CreateNew ("foo.cs", null);
+				Assert.AreEqual ("CSharp", model.TextBuffer.ContentType.TypeName);
+
+				var dir = UnitTests.Util.CreateTmpDir ("CreateNewFileRenameWhenSaving");
+				var file = Path.Combine (dir, "bar.txt");
+				await model.SaveAs (file);
+				Assert.AreEqual ("text", model.TextBuffer.ContentType.TypeName);
+			}
 		}
 	}
 }


### PR DESCRIPTION
The MimeType property was not properly set in some cases, such as when
creating a new file, or when saving a file with a new name and extension.

FileModel now ensures that the MimeType property is always up to date,
and TextBufferFileModel now updates the content type of the buffer
when creating a new document or when saving a document.

Fixes VSTS #825629 - No error message shows up in TypeScript files
Fixes VSTS #889145 - First time to add MVC View Page file(.cshtml), the intellisense and colorization doesn't work at once and shows un-save state. It needs to reopen or insert.
Fixes VSTS #894970 - Double quotes are not automatically matched after tapping the quote key