### PR TITLE
[release-8.1] Fix 901093: Completing a snippet adds a newline

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/ExpansionManager.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/ExpansionManager.cs
@@ -67,6 +67,8 @@ namespace MonoDevelop.TextEditor.Cocoa
 		{
 			var codeSnippet = new CodeSnippet ();
 			codeSnippet.Code = codeTemplate.Code;
+			if (!codeSnippet.Code.Contains ("$end$"))
+				codeSnippet.Code += "$end$";
 			codeSnippet.Description = codeTemplate.Description;
 			codeSnippet.Fields = new List<ExpansionField> ();
 			foreach (var variable in codeTemplate.Variables) {


### PR DESCRIPTION
Fix 901091: Caret jumps to previous line after completing a prop snippet

Backport of #7774.

/cc @abock @DavidKarlas