### PR TITLE
Adds feature to center current open panel based in parent window

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.MacIntegration
 		bool CenterToParent { get; set; }
 	}
 
-	class OpenPanel : NSOpenPanel, ICentrablePanel
+	sealed class OpenPanel : NSOpenPanel, ICentrablePanel
 	{
 	    public bool CenterToParent { get; set; }
 
@@ -53,15 +53,7 @@ namespace MonoDevelop.MacIntegration
 		{
 		}
 
-		public OpenPanel (NSCoder coder) : base (coder)
-		{
-		}
-
-		protected OpenPanel (NSObjectFlag t) : base (t)
-		{
-		}
-
-		protected internal OpenPanel (IntPtr handle) : base (handle)
+		internal OpenPanel (IntPtr handle) : base (handle)
 		{
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/IOpenFileDialogHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/IOpenFileDialogHandler.cs
@@ -64,7 +64,12 @@ namespace MonoDevelop.Ide.Extensions
 		/// Set to true if the workspace has to be closed before opening a solution. To be set by the handler.
 		/// </summary>
 		public bool CloseCurrentWorkspace { get; set; }
-		
+
+		/// <summary>
+		/// Set to true if we want change the default behaviour to center dialog to parent window
+		/// </summary>
+		public bool CenterToParent { get; set; }
+
 		/// <summary>
 		/// Selected viewer. To be set by the handler.
 		/// </summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OpenFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OpenFileDialog.cs
@@ -91,7 +91,15 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		public FileViewer SelectedViewer {
 			get { return data.SelectedViewer; }
 		}
-		
+
+		/// <summary>
+		/// Set to true if we want change the default behaviour to center dialog to parent window
+		/// </summary>
+		public bool CenterToParent {
+			get { return data.CenterToParent; }
+			set { data.CenterToParent = value; }
+		}
+
 		protected override bool RunDefault ()
 		{
 			var win = new FileSelectorDialog (Title, Action.ToGtkAction ());

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -435,7 +435,7 @@ namespace MonoDevelop.Ide
 		}
 
 		/// <summary>Centers a window relative to its parent.</summary>
-		static void CenterWindow (Window childControl, Window parentControl)
+		internal static void CenterWindow (Window childControl, Window parentControl)
 		{
 			var gtkChild = childControl?.nativeWidget as Gtk.Window;
 			var gtkParent = parentControl?.nativeWidget as Gtk.Window;


### PR DESCRIPTION
This PR depends on: https://github.com/xamarin/md-addins/pull/4765

By default OpenPanel dialog opens at center of the screen but in case of GTC, we need consistency in the current OperationButtons (Open File and NewProjectDialog) behaviour, this by default opens centered by based in the parent window.

Fixes VSTS #859111 - Inconsistent dialog locations

![centered](https://user-images.githubusercontent.com/1587480/58892293-3a4d6580-86ee-11e9-89b9-3d2c1674ebf3.gif)




