### PR TITLE
[release-8.1] Fixes VSTS Bug 901463: Copy and paste is broken or copies wrong text

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // BlameView.cs
 //
 // Author:
@@ -32,6 +32,8 @@ using System;
 using System.Linq;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text;
+using MonoDevelop.Components.Commands;
+using MonoDevelop.Ide.Commands;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -39,7 +41,7 @@ namespace MonoDevelop.VersionControl.Views
 	{	
 	}
 	
-	internal class BlameView : DocumentController, IBlameView, IClipboardHandler
+	internal class BlameView : DocumentController, IBlameView
 	{
 		BlameWidget widget;
 		VersionControlDocumentInfo info;
@@ -111,57 +113,25 @@ namespace MonoDevelop.VersionControl.Views
 		#endregion
 
 		#region IClipboardHandler implementation
-		void IClipboardHandler.Cut ()
+
+		[CommandUpdateHandler (EditCommands.Copy)]
+		protected void OnUpdateCopy (CommandInfo info)
 		{
+			info.Enabled = this.widget.Editor.IsSomethingSelected;
 		}
 
-		void IClipboardHandler.Copy ()
+		[CommandHandler (EditCommands.Copy)]
+		protected void Copy ()
 		{
 			this.widget.Editor.RunAction (ClipboardActions.Copy);
 		}
 
-		void IClipboardHandler.Paste ()
-		{
-		}
-
-		void IClipboardHandler.Delete ()
-		{
-		}
-
-		void IClipboardHandler.SelectAll ()
+		[CommandHandler (EditCommands.SelectAll)]
+		protected void SelectAll ()
 		{
 			this.widget.Editor.RunAction (SelectionActions.SelectAll);
 		}
 
-		bool IClipboardHandler.EnableCut {
-			get {
-				return false;
-			}
-		}
-
-		bool IClipboardHandler.EnableCopy {
-			get {
-				return this.widget.Editor.IsSomethingSelected;
-			}
-		}
-
-		bool IClipboardHandler.EnablePaste {
-			get {
-				return false;
-			}
-		}
-
-		bool IClipboardHandler.EnableDelete {
-			get {
-				return false;
-			}
-		}
-
-		bool IClipboardHandler.EnableSelectAll {
-			get {
-				return true;
-			}
-		}
 		#endregion
 	}
 }

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // VersionControlView.cs
 //  
 // Author:
@@ -33,6 +33,8 @@ using MonoDevelop.Ide.Gui.Documents;
 using MonoDevelop.Ide;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text;
+using MonoDevelop.Components.Commands;
+using MonoDevelop.Ide.Commands;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -40,7 +42,7 @@ namespace MonoDevelop.VersionControl.Views
 	{
 	}
 	
-	class DiffView : DocumentController, IDiffView, IUndoHandler, IClipboardHandler
+	class DiffView : DocumentController, IDiffView, IUndoHandler
 	{
 		DiffWidget widget;
 
@@ -172,7 +174,8 @@ namespace MonoDevelop.VersionControl.Views
 		#endregion
 
 		#region IClipboardHandler implementation
-		void IClipboardHandler.Cut ()
+		[CommandHandler (EditCommands.Cut)]
+		protected void Cut ()
 		{
 			var editor = this.widget.FocusedEditor;
 			if (editor == null)
@@ -180,7 +183,8 @@ namespace MonoDevelop.VersionControl.Views
 			editor.RunAction (Mono.TextEditor.ClipboardActions.Cut);
 		}
 
-		void IClipboardHandler.Copy ()
+		[CommandHandler (EditCommands.Copy)]
+		protected void Copy ()
 		{
 			var editor = this.widget.FocusedEditor;
 			if (editor == null)
@@ -188,7 +192,8 @@ namespace MonoDevelop.VersionControl.Views
 			editor.RunAction (Mono.TextEditor.ClipboardActions.Copy);
 		}
 
-		void IClipboardHandler.Paste ()
+		[CommandHandler (EditCommands.Paste)]
+		protected void Paste ()
 		{
 			var editor = this.widget.FocusedEditor;
 			if (editor == null)
@@ -196,7 +201,8 @@ namespace MonoDevelop.VersionControl.Views
 			editor.RunAction (Mono.TextEditor.ClipboardActions.Paste);
 		}
 
-		void IClipboardHandler.Delete ()
+		[CommandHandler (EditCommands.Delete)]
+		protected void Delete ()
 		{
 			var editor = this.widget.FocusedEditor;
 			if (editor == null)
@@ -208,7 +214,8 @@ namespace MonoDevelop.VersionControl.Views
 			}
 		}
 
-		void IClipboardHandler.SelectAll ()
+		[CommandHandler (EditCommands.SelectAll)]
+		protected void SelectAll ()
 		{
 			var editor = this.widget.FocusedEditor;
 			if (editor == null)
@@ -216,47 +223,28 @@ namespace MonoDevelop.VersionControl.Views
 			editor.RunAction (Mono.TextEditor.SelectionActions.SelectAll);
 		}
 
-		bool IClipboardHandler.EnableCut {
-			get {
-				var editor = this.widget.FocusedEditor;
-				if (editor == null)
-					return false;
-				return editor.IsSomethingSelected && !editor.Document.IsReadOnly;
-			}
+		[CommandUpdateHandler (EditCommands.Cut)]
+		protected void OnUpdateCut (CommandInfo info)
+		{
+			var editor = this.widget.FocusedEditor;
+			info.Enabled = editor != null && editor.IsSomethingSelected && !editor.Document.IsReadOnly;
 		}
 
-		bool IClipboardHandler.EnableCopy {
-			get {
-				var editor = this.widget.FocusedEditor;
-				if (editor == null)
-					return false;
-				return editor.IsSomethingSelected;
-			}
+		[CommandUpdateHandler (EditCommands.Copy)]
+		protected void OnUpdateCopy (CommandInfo info)
+		{
+			var editor = this.widget.FocusedEditor;
+			info.Enabled = editor != null && editor.IsSomethingSelected;
 		}
 
-		bool IClipboardHandler.EnablePaste {
-			get {
-				var editor = this.widget.FocusedEditor;
-				if (editor == null)
-					return false;
-				return !editor.Document.IsReadOnly;
-			}
+		[CommandUpdateHandler (EditCommands.Paste)]
+		[CommandUpdateHandler (EditCommands.Delete)]
+		protected void OnUpdatePasteDelete (CommandInfo info)
+		{
+			var editor = this.widget.FocusedEditor;
+			info.Enabled = editor != null && !editor.Document.IsReadOnly;
 		}
 
-		bool IClipboardHandler.EnableDelete {
-			get {
-				var editor = this.widget.FocusedEditor;
-				if (editor == null)
-					return false;
-				return !editor.Document.IsReadOnly;
-			}
-		}
-
-		bool IClipboardHandler.EnableSelectAll {
-			get {
-				return true;
-			}
-		}
 		#endregion
 	}
 }


### PR DESCRIPTION
in "Changes" window

Bug 901463: Copy and paste is broken or copies wrong text in "Changes"
window

Fixes VSTS Bug 901464: Copy/paste is broken in "authors" tab (wrong text or nothing happens)

DiffView was still using the old SharpDevelop clipboard command system
for cut/copy/paste. Moved to monodevelop command handlers.

Backport of #7788.

/cc @mkrueger 