### PR TITLE
Fix 901424: After click in the document navigation editor doesn't get focus

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpPathedDocumentExtension.DataProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpPathedDocumentExtension.DataProvider.cs
@@ -244,9 +244,6 @@ namespace MonoDevelop.CSharp
 				//FIXME: use the snapshot that the nodes came from
 				var point = new VirtualSnapshotPoint (editor.TextBuffer.CurrentSnapshot, offset);
 				EditorOperations.SelectAndMoveCaret (point, point, TextSelectionMode.Stream, EnsureSpanVisibleOptions.AlwaysCenter);
-
-				// TOTEST
-				// editor.Properties.GetProperty<DocumentController> (typeof (DocumentController)).GrabFocus ();
 			}
 
 			public int IconCount {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
@@ -92,6 +92,8 @@ namespace MonoDevelop.Components
 				var sel = list.Selection;
 				if (sel >= 0 && sel < DataProvider.IconCount) {
 					DataProvider.ActivateItem (sel);
+					// This is so parent window of dropdown regains focus
+					TransientFor.Present ();
 					Destroy ();
 				}
 			};


### PR DESCRIPTION
Just wanted to note, same problem is in old editor, and this fix fixes both.