### PR TITLE
Fix 801652: New Editor: broken history of references navigation

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.TextViewNavigationPoint.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.TextViewNavigationPoint.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.TextEditor
 
 		void TryLogNavPoint (bool transient)
 		{
-			if (TextView != null && TextView.Properties.TryGetProperty<Document> (typeof (Document), out var doc) && doc == Ide.IdeApp.Workbench.ActiveDocument) {
+			if (TextView != null && TextView.TryGetParentDocument () is Ide.Gui.Document doc && doc == Ide.IdeApp.Workbench.ActiveDocument) {
 				IdeServices.NavigationHistoryService.LogNavigationPoint (new TextViewNavigationPoint (doc, TextView), transient);
 			}
 		}

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewExtensions.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewExtensions.cs
@@ -21,6 +21,7 @@
 
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using MonoDevelop.Ide.Gui.Documents;
 
 namespace MonoDevelop.TextEditor
 {
@@ -31,9 +32,8 @@ namespace MonoDevelop.TextEditor
 		/// </summary>
 		public static Ide.Gui.Document TryGetParentDocument (this ITextView view)
 		{
-			// TOTEST
-			if (view.Properties.TryGetProperty<Ide.Gui.Document> (typeof (Ide.Gui.Document), out var document)) {
-				return document;
+			if (view.Properties.TryGetProperty<DocumentController> (typeof (DocumentController), out var document)) {
+				return document.Document;
 			}
 			return null;
 		}


### PR DESCRIPTION
This fix restores functionality to what it was before  new document model change that changed what is stored in `textView.Properties` bag which made navigation to not work anymore.