### PR TITLE
[Workspace] Swap the order of cache clearing in the manager.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopMetadataReferenceManager.cs
@@ -217,8 +217,11 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		public void ClearCache ()
 		{
-			_metadataCache.ClearCache();
+			// Clear the reference cache before the metadata cache
+			// as the FileWatcher updates can technically trigger while the metadata cache
+			// is being cleared, avoiding unnecessary work and possible items not being invalidated.
 			_metadataReferenceCache.ClearCache ();
+			_metadataCache.ClearCache();
 		}
 
 


### PR DESCRIPTION
By doing so, we ensure that any in-flight operation to update an assembly from disk must happen before we clear the caches.