### PR TITLE
[release-8.1] [Mac] Retry unmounting because of an issue in the Mojave bots

### DIFF
--- a/main/build/MacOSX/make-dmg-bundle.sh
+++ b/main/build/MacOSX/make-dmg-bundle.sh
@@ -75,7 +75,13 @@ fi
 SetFile -a C "$MOUNT_POINT"
 
 echo "Detaching from disk image..."
-hdiutil detach "$MOUNT_POINT" -quiet || exit $?
+for n in `seq 1 5`
+do
+	hdiutil detach "$MOUNT_POINT" && break
+	if [ $n = 5 ]; then
+		exit $?
+	fi
+done
 
 mv "$DMG_FILE" "$DMG_FILE.master"
 


### PR DESCRIPTION
With the move to Xcode 10.2, we need to build on Mojave bots, and there's
a bug (https://github.com/al45tair/dmgbuild/issues/10) that makes unmounting
time out on the bots, which is fixed by just retrying :/

Backport of #7809.

/cc @rodrmoya 