### PR TITLE
[Version Control] Popping a git stash that has conflicts gives invalid warning and no further logs

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -200,7 +200,9 @@ namespace MonoDevelop.VersionControl.Git
 			FileService.FreezeEvents ();
 			ThreadPool.QueueUserWorkItem (delegate {
 				try {
-					GitService.ReportStashResult (Repository.PopStash (monitor, 0));
+					int stashCount = Repository.GetStashes ().Count ();
+					StashApplyStatus stashApplyStatus = Repository.PopStash (monitor, 0);
+					GitService.ReportStashResult (Repository, stashApplyStatus, stashCount);
 				} catch (Exception ex) {
 					MessageService.ShowError (GettextCatalog.GetString ("Stash operation failed"), ex);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -223,15 +223,15 @@ namespace MonoDevelop.VersionControl.Git
 				{
 					case StashResultType.Error:
 						IdeApp.Workbench.StatusBar.ShowError (msg);
-					    MessageService.ShowError (msg);
+						MessageService.ShowError (msg);
 						break;
 					case StashResultType.Message:
 						IdeApp.Workbench.StatusBar.ShowMessage (msg);
 						break;
 					case StashResultType.Warning:
 						IdeApp.Workbench.StatusBar.ShowWarning (msg);
-					    MessageService.ShowWarning (msg);
-					    break;
+						MessageService.ShowWarning (msg);
+						break;
 				}
 			});
 		}


### PR DESCRIPTION
Applied changes to show more information about the stash operation status (conflicts, stash not found, uncommitted changes, etc.).

Fixes VSTS #901094