### PR TITLE
[CompositionManager] Allow the IDE to recover from a state where the …

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
@@ -15,6 +15,7 @@
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.EditorOptions.Implementation.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.Extras.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.Implementation.StandaloneUndo.dll" />
+		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.Internal.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.Logic.Utilities.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.Model.Implementation.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.MultiCaret.Implementation.dll" />
@@ -64,6 +65,7 @@
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.EditorOptions.Implementation.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.Extras.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.Implementation.StandaloneUndo.dll" />
+		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.Internal.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.Logic.Utilities.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.Model.Implementation.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.MultiCaret.Implementation.dll" />

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
@@ -22,6 +22,7 @@
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.PatternMatching.Implementation.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.UI.Cocoa.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.UI.Utilities.dll" />
+		<Import assembly="../../../bin/Microsoft.VisualStudio.Text.UI.Wpf.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.UI.Text.Commanding.Implementation.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.UI.Text.EditorOperations.Implementation.dll" />
 		<Import assembly="../../../bin/Microsoft.VisualStudio.UI.Text.EditorPrimitives.Implementation.dll" />
@@ -69,6 +70,7 @@
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.Outlining.Implementation.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.PatternMatching.Implementation.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.UI.Utilities.dll" />
+		<Assembly file="../../../bin/Microsoft.VisualStudio.Text.UI.Wpf.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.UI.Text.Commanding.Implementation.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.UI.Text.EditorOperations.Implementation.dll" />
 		<Assembly file="../../../bin/Microsoft.VisualStudio.UI.Text.EditorPrimitives.Implementation.dll" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.Caching.cs
@@ -193,6 +193,8 @@ namespace MonoDevelop.Ide.Composition
 							cachingFaultInjector?.FaultWritingComposition ();
 							await WriteMefCache (runtimeComposition, catalog, cacheManager);
 						} catch (Exception ex) {
+							DeleteFiles ();
+
 							Runtime.RunInMainThread (() => {
 								exceptionHandler.HandleException ("Failed to write MEF cache", ex);
 							}).Ignore ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -254,7 +254,7 @@ namespace MonoDevelop.Ide.Composition
 				if (e is IOException)
 					return;
 
-				if (!IdeApp.Initialized) {
+				if (!IdeApp.IsInitialized) {
 					Console.WriteLine (e);
 					return;
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -241,17 +241,34 @@ namespace MonoDevelop.Ide.Composition
 
 		sealed class IdeRuntimeCompositionExceptionHandler : RuntimeCompositionExceptionHandler
 		{
+			static class Strings
+			{
+				public static string Quit = GettextCatalog.GetString ("Quit");
+				public static string Restart = GettextCatalog.GetString ("Restart");
+			}
+
 			public override void HandleException (string message, Exception e)
 			{
 				base.HandleException (message, e);
 
-				if (e is InvalidRuntimeCompositionException) {
+				if (!(e is IOException)) {
 					// TODO: Fix text.
-					var text = GettextCatalog.GetString ("Some extensions failed to initialize, requiring a restart of {0}", BrandingService.ApplicationName);
-					var restartLabel = GettextCatalog.GetString ("Restart");
+					var text = GettextCatalog.GetString ("There was a problem loading one or more extensions and {0} needs to be restarted.", BrandingService.ApplicationName);
+					var quitButton = new AlertButton (Strings.Quit);
+					var restartButton = new AlertButton (Strings.Restart);
 
-					MessageService.GenericAlert (IdeServices.DesktopService.GetFocusedTopLevelWindow (), Gui.Stock.Error, text, secondaryText: null, new AlertButton (restartLabel));
-					IdeApp.Restart (false).Ignore ();
+					var result = MessageService.GenericAlert (
+						IdeServices.DesktopService.GetFocusedTopLevelWindow (),
+						Gui.Stock.Error,
+						text,
+						secondaryText: null,
+						quitButton,
+						restartButton
+					);
+					if (result == restartButton)
+						IdeApp.Restart (false).Ignore ();
+					else
+						IdeApp.Exit ().Ignore ();
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -251,26 +251,31 @@ namespace MonoDevelop.Ide.Composition
 			{
 				base.HandleException (message, e);
 
-				if (!(e is IOException)) {
-					// TODO: Fix text.
-					var text = GettextCatalog.GetString ("There was a problem loading one or more extensions and {0} needs to be restarted.", BrandingService.ApplicationName);
-					var quitButton = new AlertButton (Strings.Quit);
-					var restartButton = new AlertButton (Strings.Restart);
+				if (e is IOException)
+					return;
 
-					var result = MessageService.GenericAlert (
-						IdeServices.DesktopService.GetFocusedTopLevelWindow (),
-						Gui.Stock.Error,
-						text,
-						secondaryText: null,
-						defaultButton: 1,
-						quitButton,
-						restartButton
-					);
-					if (result == restartButton)
-						IdeApp.Restart (false).Ignore ();
-					else
-						IdeApp.Exit ().Ignore ();
+				if (!IdeApp.Initialized) {
+					Console.WriteLine (e);
+					return;
 				}
+
+				var text = GettextCatalog.GetString ("There was a problem loading one or more extensions and {0} needs to be restarted.", BrandingService.ApplicationName);
+				var quitButton = new AlertButton (Strings.Quit);
+				var restartButton = new AlertButton (Strings.Restart);
+
+				var result = MessageService.GenericAlert (
+					IdeServices.DesktopService.GetFocusedTopLevelWindow (),
+					Gui.Stock.Error,
+					text,
+					secondaryText: null,
+					defaultButton: 1,
+					quitButton,
+					restartButton
+				);
+				if (result == restartButton)
+					IdeApp.Restart (false).Ignore ();
+				else
+					IdeApp.Exit ().Ignore ();
 			}
 		}
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -262,6 +262,7 @@ namespace MonoDevelop.Ide.Composition
 						Gui.Stock.Error,
 						text,
 						secondaryText: null,
+						defaultButton: 1,
 						quitButton,
 						restartButton
 					);

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Composition/CompositionManagerTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Composition/CompositionManagerTests.cs
@@ -39,14 +39,14 @@ namespace MonoDevelop.Ide.Composition
 		public async Task ValidateRuntimeCompositionIsValid ()
 		{
 			var mefAssemblies = CompositionManager.ReadAssembliesFromAddins ();
-			var caching = new CompositionManager.Caching (mefAssemblies, file => {
+			var caching = new CompositionManager.Caching (mefAssemblies, new ThrowingHandler (), file => {
 				var tmpDir = Path.Combine (Util.TmpDir, "mef", nameof(ValidateRuntimeCompositionIsValid));
 				if (Directory.Exists (tmpDir)) {
 					Directory.Delete (tmpDir, true);
 				}
 				Directory.CreateDirectory (tmpDir);
 				return Path.Combine (tmpDir, file);
-			}, exceptionHandler: new ThrowingHandler ());
+			});
 
 			var (composition, catalog) = await CompositionManager.CreateRuntimeCompositionFromDiscovery (caching);
 			var cacheManager = new CachedComposition ();
@@ -54,7 +54,7 @@ namespace MonoDevelop.Ide.Composition
 			await caching.Write (composition, catalog, cacheManager);
 		}
 
-		class ThrowingHandler : CompositionManager.RuntimeCompositionExceptionHandler
+		sealed class ThrowingHandler : CompositionManager.RuntimeCompositionExceptionHandler
 		{
 			public override void HandleException (string message, Exception e)
 			{


### PR DESCRIPTION
…composition is broken

Prompt the user with a dialog telling them that the current IDE state is broken and requires a restart, clearing the MEF caches.

Fixes VSTS #892931 - MEF Cache goes haywire