### PR TITLE
[Ide] Handle exception disposing pad on closing the workbench.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -655,8 +655,13 @@ namespace MonoDevelop.Ide.Gui
 				Remove (rootWidget);
 
 				foreach (PadCodon content in PadContentCollection) {
-					if (content.Initialized)
-						content.PadContent.Dispose ();
+					if (content.Initialized) {
+						try {
+							content.PadContent.Dispose ();
+						} catch (Exception ex) {
+							LoggingService.LogInternalError ("Failed to dispose pad " + content.PadId, ex);
+						}
+					}
 				}
 
 				rootWidget.Destroy ();


### PR DESCRIPTION
An error disposing a pad on closing the workbench results in
a fatal exception which may crash the IDE. Handle any error on
disposing the pad with a try/catch.

Fixes VSTS #911276 - [Watson] Crash in PackageConsolePad