### PR TITLE
Handle AppResult.GetPropertyValue as it can lead to fatal ObjC crash

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -152,9 +152,16 @@ namespace MonoDevelop.Components.AutoTest
 				if (propertyInfo == null)
 					LoggingService.LogError ($"GetPropertyValue : propertyName {propertyName} not found on object {requestedObject}.");
 				if (propertyInfo != null && propertyInfo.CanRead && !propertyInfo.GetIndexParameters ().Any ()) {
-					var propertyValue = propertyInfo.GetValue (requestedObject);
-					if (propertyValue != null) {
-						return propertyValue;
+					try {
+						var propertyValue = propertyInfo.GetValue (requestedObject);
+						if (propertyValue != null) {
+							return propertyValue;
+						}
+					} catch {
+						// Supress the exception as we have faced unhandled ObjC exceptions. e.g.
+						// FATAL ERROR[2019-06-07 14:17:58Z]: Unhandled ObjC Exception
+						// MonoDevelop.MacIntegration.MacPlatformService + MarshalledObjCException: NSInvalidArgumentException: 
+						// -[MonoDevelop_MacIntegration_ThemedMacDialogBackend appearanceSource]: unrecognized selector sent to instance 
 					}
 				}
 


### PR DESCRIPTION
e.g this stack trace when trying to get the properties

```
MonoDevelop.MacIntegration.MacPlatformService+MarshalledObjCException: NSInvalidArgumentException: -[MonoDevelop_MacIntegration_ThemedMacDialogBackend appearanceSource]: unrecognized selector sent to instance 0x7ff7d1658560
  at MonoDevelop.MacIntegration.MacPlatformService+MarshalledObjCException..ctor (Foundation.NSException exception) [0x00007] in /Users/vsts/agent/2.152.1/work/1/s/monodevelop/main/src/addins/MacPlatform/MacPlatform.cs:268
  at MonoDevelop.MacIntegration.MacPlatformService.HandleUncaughtException (System.IntPtr exceptionPtr) [0x00007] in /Users/vsts/agent/2.152.1/work/1/s/monodevelop/main/src/addins/MacPlatform/MacPlatform.cs:252
  at ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (System.IntPtr , System.IntPtr ) [0x00000] in <48bb081765a04a89bc3019ce9185675b>:0
  at AppKit.NSWindow.get_AppearanceSource () [0x0002d] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.6.0.25/src/Xamarin.Mac/AppKit/NSWindow.g.cs:8330
  at System.Reflection.MonoMethod.InternalInvoke (System.Reflection.MonoMethod , System.Object , System.Object[] , System.Exception& ) [0x00000] in <a2bfeec6715c4fdfa8972c2780c54eba>:0
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
  at System.Reflection.MonoProperty.GetValue (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] index, System.Globalization.CultureInfo culture) [0x00038] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/MonoProperty.cs:418
  at System.Reflection.PropertyInfo.GetValue (System.Object obj) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/PropertyInfo.cs:102
  at MonoDevelop.Components.AutoTest.AppResult+<>c__DisplayClass45_0.<GetPropertyValue>b__0 () [0x0005b] in /Users/vsts/agent/2.152.1/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs:155
  at MonoDevelop.Components.AutoTest.AutoTestSession+<>c__DisplayClass18_0.<Sync>b__0 (System.Object o, System.EventArgs args) [0x00000] in /Users/vsts/agent/2.152.1/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AutoTestSession.cs:158
...
```