### PR TITLE
[IDE] Restore the memento after the toolbar has been attached

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1281,7 +1281,7 @@ namespace MonoDevelop.MacIntegration
 			y += GetTitleBarHeight (w);
 			var dr = FromDesktopRect (new Gdk.Rectangle (x, y, width, height));
 			var r = w.FrameRectFor (dr);
-
+			w.SetFrame (r, true);
 			base.PlaceWindow (window, x, y, width, height);
 		}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
@@ -553,7 +553,7 @@ namespace MonoDevelop.Debugger
 		protected override void Run ()
 		{
 			if (!IdeApp.Workbench.Visible) {
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 			}
 			var breakpointsPad = IdeApp.Workbench.Pads.FirstOrDefault (p => p.Id == "MonoDevelop.Debugger.BreakpointPad");
 			if (breakpointsPad != null) {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Extensions.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.Debugger
 		public static AsyncOperation DebugApplication (this ProjectOperations opers, string executableFile, string args, string workingDir, IDictionary<string,string> envVars)
 		{
 			if (!IdeApp.Workbench.Visible) {
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 			}
 
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileName (executableFile));
@@ -84,7 +84,7 @@ namespace MonoDevelop.Debugger
 		public static AsyncOperation AttachToProcess (this ProjectOperations opers, DebuggerEngine debugger, ProcessInfo proc)
 		{
 			if (!IdeApp.Workbench.Visible) {
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 			}
 
 			var oper = DebuggingService.AttachToProcess (debugger, proc);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -134,27 +134,22 @@ namespace MonoDevelop.Ide.Gui
 			Counters.Initialization.Trace ("Realizing Root Window");
 			RootWindow.Realize ();
 
-			Counters.Initialization.Trace ("Loading memento");
-			var memento = IdeApp.Preferences.WorkbenchMemento.Value;
-			Counters.Initialization.Trace ("Setting memento");
-			workbench.Memento = memento;
-
 			Counters.Initialization.Trace ("Initializing monitors");
 		}
 
+		[Obsolete ("Use Present () instead")]
 		internal void Show ()
 		{
-			EnsureLayout ();
 			Present ();
 		}
 
 		internal void EnsureLayout ()
 		{
 			if (!hasEverBeenShown) {
-
 				Realize ();
 				workbench.InitializeWorkspace ();
 				workbench.InitializeLayout ();
+
 				statusBar.Attach (workbench.StatusBar);
 
 				workbench.CurrentLayout = "Solution";
@@ -162,6 +157,11 @@ namespace MonoDevelop.Ide.Gui
 				// now we have an layout set notify it
 				if (LayoutChanged != null)
 					LayoutChanged (this, EventArgs.Empty);
+
+				Counters.Initialization.Trace ("Loading memento");
+				var memento = IdeApp.Preferences.WorkbenchMemento.Value;
+				Counters.Initialization.Trace ("Setting memento");
+				workbench.Memento = memento;
 
 				hasEverBeenShown = true;
 			} else if (!RootWindow.Visible) {
@@ -174,7 +174,7 @@ namespace MonoDevelop.Ide.Gui
 		internal void EnsureShown ()
 		{
 			if (!RootWindow.Visible)
-				Show ();
+				Present ();
 		}
 
 		internal void Hide ()
@@ -348,7 +348,7 @@ namespace MonoDevelop.Ide.Gui
 		public void GrabDesktopFocus ()
 		{
 			if (!Visible)
-				Show ();
+				Present ();
 			else
 				IdeServices.DesktopService.GrabDesktopFocus (RootWindow);
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -438,9 +438,9 @@ namespace MonoDevelop.Ide
 			if (!hideWelcomePage && !WelcomePage.WelcomePageService.HasWindowImplementation) {
 				WelcomePage.WelcomePageService.ShowWelcomePage ();
 				Counters.Initialization.Trace ("Showed welcome page");
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 			} else if (hideWelcomePage && !startupInfo.OpenedFiles) {
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 			}
 
 			return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -624,7 +624,7 @@ namespace MonoDevelop.Ide
 		internal async Task<bool> OpenWorkspaceItem (FilePath file, bool closeCurrent, bool loadPreferences, OpenWorkspaceItemMetadata metadata)
 		{
 			if (IdeApp.IsInitialized)
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 
 			lock (loadLock) {
 				if (++loadOperationsCount == 1)
@@ -661,7 +661,7 @@ namespace MonoDevelop.Ide
 		internal async Task<bool> OpenWorkspaceItemInternal (FilePath file, bool closeCurrent, bool loadPreferences, OpenWorkspaceItemMetadata metadata, ProgressMonitor loadMonitor)
 		{
 			if (IdeApp.IsInitialized)
-				IdeApp.Workbench.Show ();
+				IdeApp.Workbench.Present ();
 			var item = GetAllItems<WorkspaceItem> ().FirstOrDefault (w => w.FileName == file.FullPath);
 			if (item != null) {
 				CurrentSelectedWorkspaceItem = item;


### PR DESCRIPTION
The memento needs to be restored after the toolbar has been attached to the window to take it into consideration in the size calculations. This caused problems when combined with Workbench.Present: If the workbench window was first shown using Present, subsequent calls to EnsureLayout would never update the window size to take the toolbar height into consideration, which caused the mouse pointer offset bugs.

Also unify the confusion between Workbench.Show and Workbench.Present, deprecating the former.

Fixes VSTS #911290