### PR TITLE
[Watson][Toolbox] Ensures ItemSize is always positive and log if exception occurs

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -270,36 +270,32 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		public void RedrawItems (bool invalidates, bool reloads)
 		{
-			try {
-				NSIndexPath selected = null;
-				if (SelectionIndexPaths.Count > 0) {
-					selected = (NSIndexPath)SelectionIndexPaths.ElementAt (0);
-				}
-				if (IsListMode) {
-					flowLayout.ItemSize = new CGSize (Math.Max (Frame.Width - IconMargin, 1), LabelCollectionViewItem.ItemHeight);
-				} else {
-					flowLayout.ItemSize = new CGSize (ImageCollectionViewItem.Size.Width, ImageCollectionViewItem.Size.Height);
-				}
-				if (ShowCategories) {
-					collectionViewDelegate.Width = Frame.Width - IconMargin;
-					collectionViewDelegate.Height = HeaderCollectionViewItem.SectionHeight;
-				} else {
-					collectionViewDelegate.Width = 0;
-					collectionViewDelegate.Height = 0;
-				}
+			NSIndexPath selected = null;
+			if (SelectionIndexPaths.Count > 0) {
+				selected = (NSIndexPath)SelectionIndexPaths.ElementAt (0);
+			}
+			if (IsListMode) {
+				flowLayout.ItemSize = new CGSize (Math.Max (Frame.Width - IconMargin, 1), LabelCollectionViewItem.ItemHeight);
+			} else {
+				flowLayout.ItemSize = new CGSize (ImageCollectionViewItem.Size.Width, ImageCollectionViewItem.Size.Height);
+			}
+			if (ShowCategories) {
+				collectionViewDelegate.Width = (nfloat) Math.Max (Frame.Width - IconMargin, 1);
+				collectionViewDelegate.Height = HeaderCollectionViewItem.SectionHeight;
+			} else {
+				collectionViewDelegate.Width = 0;
+				collectionViewDelegate.Height = 0;
+			}
 
-				if (invalidates) {
-					CollectionViewLayout.InvalidateLayout ();
-				}
-				if (reloads) {
-					ReloadData ();
-				}
+			if (invalidates) {
+				CollectionViewLayout.InvalidateLayout ();
+			}
+			if (reloads) {
+				ReloadData ();
+			}
 
-				if (selected != null) {
-					SelectionIndexPaths = new NSSet (selected);
-				}
-			} catch (Exception ex) {
-				Core.LoggingService.LogInternalError (ex);
+			if (selected != null) {
+				SelectionIndexPaths = new NSSet (selected);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -270,35 +270,38 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		public void RedrawItems (bool invalidates, bool reloads)
 		{
-			NSIndexPath selected = null;
-			if (SelectionIndexPaths.Count > 0) {
-				selected = (NSIndexPath)SelectionIndexPaths.ElementAt (0);
-			}
-			if (IsListMode) {
-				flowLayout.ItemSize = new CGSize (Frame.Width - IconMargin, LabelCollectionViewItem.ItemHeight);
-			} else {
-				flowLayout.ItemSize = new CGSize (ImageCollectionViewItem.Size.Width, ImageCollectionViewItem.Size.Height);
-			}
-			if (ShowCategories) {
-				collectionViewDelegate.Width = Frame.Width - IconMargin;
-				collectionViewDelegate.Height = HeaderCollectionViewItem.SectionHeight;
-			} else {
-				collectionViewDelegate.Width = 0;
-				collectionViewDelegate.Height = 0;
-			}
+			try {
+				NSIndexPath selected = null;
+				if (SelectionIndexPaths.Count > 0) {
+					selected = (NSIndexPath)SelectionIndexPaths.ElementAt (0);
+				}
+				if (IsListMode) {
+					flowLayout.ItemSize = new CGSize (Math.Max (Frame.Width - IconMargin, 1), LabelCollectionViewItem.ItemHeight);
+				} else {
+					flowLayout.ItemSize = new CGSize (ImageCollectionViewItem.Size.Width, ImageCollectionViewItem.Size.Height);
+				}
+				if (ShowCategories) {
+					collectionViewDelegate.Width = Frame.Width - IconMargin;
+					collectionViewDelegate.Height = HeaderCollectionViewItem.SectionHeight;
+				} else {
+					collectionViewDelegate.Width = 0;
+					collectionViewDelegate.Height = 0;
+				}
 
-			if (invalidates) {
-				CollectionViewLayout.InvalidateLayout ();
-			}
-			if (reloads) {
-				ReloadData ();
-			}
+				if (invalidates) {
+					CollectionViewLayout.InvalidateLayout ();
+				}
+				if (reloads) {
+					ReloadData ();
+				}
 
-			if (selected != null) {
-				SelectionIndexPaths = new NSSet (selected);
+				if (selected != null) {
+					SelectionIndexPaths = new NSSet (selected);
+				}
+			} catch (Exception ex) {
+				Core.LoggingService.LogInternalError (ex);
 			}
 		}
-
 
 		public override void RightMouseUp (NSEvent theEvent)
 		{

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -69,9 +69,11 @@ namespace MonoDevelop.DesignerSupport
 			toolbox.ContentFocused += Toolbox_ContentFocused;
 			toolbox.DragSourceSet += Toolbox_DragSourceSet;
 			toolbox.DragBegin += Toolbox_DragBegin;
+		
+			widget.ShowAll ();
+
 			toolbox.Refresh ();
 
-			widget.ShowAll ();
 #else
 			widget = new Toolbox.Toolbox (DesignerSupport.Service.ToolboxService, window);
 #endif


### PR DESCRIPTION
We are hitting this issue from Catalina users, not tested yet in a Catalina machine.
probably happens because we are calling the Refresh after resize the toolbox pad, and to calculate the item size it a list mode it uses the Frame.width.  
I moved Refresh call after the ShowAll call from the gtk widget, and also added a condition to ensure never our item size is going to be negative, and also added a try/catch with some logging information

Fixes VSTS #905849 - NSInternalInconsistencyException negative or zero item sizes are not supported in the flow layout in MacToolboxWidget 
