### PR TITLE
Fixes VSTS Bug 911693: New document model dispose logic was regressed

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -426,14 +426,19 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		public void Dispose ()
 		{
-			if (!disposed) {
+			if (disposed)
+				return;
+			try {
+				linkedController?.Dispose ();
+				OnDispose ();
+				extensionChain?.Dispose ();
+			} catch (Exception e) {
+				LoggingService.LogInternalError ($"Error while disposing document controller {this}", e);
+			} finally {
 				disposedTokenSource.Cancel ();
 				disposedTokenSource.Dispose ();
 				disposedTokenSource = null;
-				linkedController?.Dispose ();
 				disposed = true;
-				OnDispose ();
-				extensionChain?.Dispose ();
 			}
 		}
 


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/911693

Revert "[Ide] Added a disposed token to the document controller API."

This reverts commit 800c10b8d37ebc6aeb9367390bc3015244614701.