### PR TITLE
Fixes VSTS 891769: Go To Matching Brace does not work

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
@@ -130,7 +130,8 @@
 		
 		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeTemplateWindow" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InsertSnippetCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCodeSurroundingsWindow" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.SurroundWithCommandArgs" />
-
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.GotoMatchingBrace" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.GoToMatchingBraceCommandArgs" />
+		
 	</Extension>
 
 	<!--


### PR DESCRIPTION
This PR lights up support for `Go To Matching Brace` command in the new editor. 

**Note: it requires an API Sync to happen.**

VSTS: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/891769
VSEC PR: https://github.com/xamarin/vs-editor-core/pull/335