### PR TITLE
[IDE] Listen for NSNotification to know if the app was started from Finder

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -286,11 +286,7 @@ namespace MonoDevelop.MacIntegration
 
 		public override Xwt.Toolkit LoadNativeToolkit ()
 		{
-			var path = Path.GetDirectoryName (GetType ().Assembly.Location);
-			Assembly.LoadFrom (Path.Combine (path, "Xwt.XamMac.dll"));
-
-			// Also calls NSApplication.Init();
-			var loaded = Xwt.Toolkit.Load (Xwt.ToolkitType.XamMac);
+			var loaded = NativeToolkitHelper.LoadCocoa ();
 
 			loaded.RegisterBackend<Xwt.Backends.IDialogBackend, ThemedMacDialogBackend> ();
 			loaded.RegisterBackend<Xwt.Backends.IWindowBackend, ThemedMacWindowBackend> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NativeToolkitHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NativeToolkitHelper.cs
@@ -1,0 +1,65 @@
+//
+// NativeToolkitHelper.cs
+//
+// Author:
+//       iain <iaholmes@microsoft.com>
+//
+// Copyright (c) 2019 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if MAC
+using System;
+using System.IO;
+
+using AppKit;
+using Foundation;
+
+using MonoDevelop.Core;
+using MonoDevelop.Ide;
+
+namespace MonoDevelop.Components.Mac
+{
+	internal static class NativeToolkitHelper
+	{
+		static Xwt.Toolkit toolkit;
+		internal static Xwt.Toolkit LoadCocoa ()
+		{
+			if (toolkit != null) {
+				return toolkit;
+			}
+
+			var path = Path.GetDirectoryName (typeof (IdeTheme).Assembly.Location);
+			System.Reflection.Assembly.LoadFrom (Path.Combine (path, "Xwt.XamMac.dll"));
+			toolkit = Xwt.Toolkit.Load (Xwt.ToolkitType.XamMac);
+
+			NSNotificationCenter.DefaultCenter.AddObserver (NSApplication.DidFinishLaunchingNotification, (note) => {
+				if (note.UserInfo.TryGetValue (NSApplication.LaunchIsDefaultLaunchKey, out var val)) {
+					if (val is NSNumber num) {
+						IdeApp.LaunchReason = num.BoolValue ? IdeApp.LaunchType.Normal : IdeApp.LaunchType.LaunchedFromFileManager;
+						LoggingService.LogDebug ($"Startup was {IdeApp.LaunchReason}");
+					}
+				}
+			});
+
+			return toolkit;
+		}
+	}
+}
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4247,6 +4247,7 @@
     <Compile Include="MonoDevelop.Ide.RoslynServices\MonoDevelopErrorLoggerService.cs" />
     <Compile Include="MonoDevelop.Components.Commands\IdeCommandManager.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\WorkbenchStatusBar.cs" />
+    <Compile Include="MonoDevelop.Components\Mac\NativeToolkitHelper.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -180,6 +180,18 @@ namespace MonoDevelop.Ide
 			}
 		}
 
+		public enum LaunchType
+		{
+			Normal,
+			LaunchedFromFileManager
+		}
+
+		static LaunchType launchReason = LaunchType.Normal;
+		public static LaunchType LaunchReason {
+			get => launchReason;
+			set => launchReason = value;
+		}
+
 		public static async Task Initialize (ProgressMonitor monitor, bool hideWelcomePage = false)
 		{
 			// Already done in IdeSetup, but called again since unit tests don't use IdeSetup.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -117,6 +117,11 @@ namespace MonoDevelop.Ide
 			IdeTheme.InitializeGtk (BrandingService.ApplicationName, ref args);
 
 			startupInfo = new StartupInfo (options, args);
+			if (startupInfo.HasFiles) {
+				// If files are present, consider started from the commandline as being the same as file manager.
+				// On macOS, we need to wait until the DidFinishLaunching notification to find out we were launched from the Finder
+				IdeApp.LaunchReason = IdeApp.LaunchType.LaunchedFromFileManager;
+			}
 
 			IdeApp.Customizer = options.IdeCustomizer ?? new IdeCustomizer ();
 			try {


### PR DESCRIPTION

On Mac  when the app is started from Finder, the requested files are passed to the app asynchronously, so we need to listen for the event.

Fixes VSTS #737145