### PR TITLE
[master] [release-8.2][Core] Fix GTK# assembly reference resolution on Mono 6.0

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/SystemAssemblyService.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.Core.Assemblies
 	public sealed class SystemAssemblyService
 	{
 		object frameworkWriteLock = new object ();
-		Dictionary<TargetFrameworkMoniker,TargetFramework> frameworks = new Dictionary<TargetFrameworkMoniker, TargetFramework> ();
+		SortedDictionary<TargetFrameworkMoniker,TargetFramework> frameworks = new SortedDictionary<TargetFrameworkMoniker, TargetFramework> ();
 		List<TargetRuntime> runtimes;
 		TargetRuntime defaultRuntime;
 
@@ -88,7 +88,7 @@ namespace MonoDevelop.Core.Assemblies
 		void UpdateFrameworks (IEnumerable<TargetFramework> toAdd)
 		{
 			lock (frameworkWriteLock) {
-				var newFxList = new Dictionary<TargetFrameworkMoniker,TargetFramework> (frameworks);
+				var newFxList = new SortedDictionary<TargetFrameworkMoniker,TargetFramework> (frameworks);
 				bool changed = false;
 				foreach (var fx in toAdd) {
 					TargetFramework existing;
@@ -339,13 +339,13 @@ namespace MonoDevelop.Core.Assemblies
 		}
 
 		//warning: this may mutate `frameworks` and any newly-added TargetFrameworks in it
-		static void BuildFrameworkRelations (Dictionary<TargetFrameworkMoniker, TargetFramework> frameworks)
+		static void BuildFrameworkRelations (SortedDictionary<TargetFrameworkMoniker, TargetFramework> frameworks)
 		{
 			foreach (TargetFramework fx in frameworks.Values)
 				BuildFrameworkRelations (fx, frameworks);
 		}
 
-		static void BuildFrameworkRelations (TargetFramework fx, Dictionary<TargetFrameworkMoniker, TargetFramework> frameworks)
+		static void BuildFrameworkRelations (TargetFramework fx, SortedDictionary<TargetFrameworkMoniker, TargetFramework> frameworks)
 		{
 			if (fx.RelationsBuilt)
 				return;

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
@@ -37,7 +37,7 @@ namespace MonoDevelop.Core.Assemblies
 	/// Unique identifier for a target framework.
 	/// </summary>
 	[Serializable]
-	public class TargetFrameworkMoniker : IEquatable<TargetFrameworkMoniker>
+	public class TargetFrameworkMoniker : IEquatable<TargetFrameworkMoniker>, IComparable<TargetFrameworkMoniker>
 	{
 		string identifier, version, profile, shortName;
 		
@@ -264,6 +264,25 @@ namespace MonoDevelop.Core.Assemblies
 		static bool IsNetFramework (TargetFrameworkMoniker framework)
 		{
 			return framework.Identifier == ".NETFramework";
+		}
+
+		public int CompareTo (TargetFrameworkMoniker other)
+		{
+			int result = string.Compare (Identifier, other.Identifier, StringComparison.OrdinalIgnoreCase);
+			if (result != 0)
+				return result;
+
+			if (System.Version.TryParse (version, out Version v1) && System.Version.TryParse (other.Version, out Version v2)) {
+				result = v1.CompareTo (v2);
+				if (result != 0)
+					return result;
+			} else {
+				result = string.Compare (Version, other.Version, StringComparison.OrdinalIgnoreCase);
+				if (result != 0)
+					return result;
+			}
+
+			return string.Compare (profile ?? string.Empty, other.Profile ?? string.Empty, StringComparison.OrdinalIgnoreCase);
 		}
 
 		public static TargetFrameworkMoniker Default {


### PR DESCRIPTION
Mono 6.0 returns files and directories unsorted which was resulting
in .NET 4.5 being used as the target framework for resolved GTK#
assemblies instead of the oldest target framework 4.0. This caused
some ProjectReference validation tests to fail since they were using
.NET 4.0 projects. To fix this the target framework information is
sorted so older frameworks are checked before newer target frameworks,
so the oldest supported framework is used.

Backport of #7860.

/cc @slluis @mrward