### PR TITLE
[CSharpBinding] Allow choosing C# 8

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
@@ -53,8 +53,6 @@ namespace MonoDevelop.CSharp.Project
 		ListStore classListStore;
 		bool classListFilled;
 		LanguageVersion[] unsupportedLanguageVersions = {
-			LanguageVersion.CSharp8,
-			LanguageVersion.LatestMajor,
 			LanguageVersion.Preview
 		};
 


### PR DESCRIPTION
Remove `CSharp8` and `LatestMajor` from unsupported list.

Fixes https://devdiv.visualstudio.com/DevDiv/_workItems/edit/916849