### PR TITLE
[TextEditor] Allow extensions to opt file types into new editor

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
@@ -13,6 +13,11 @@
 		<Description>Context menu for the navigation bar.</Description>
 		<ExtensionNode name="Map" type="MonoDevelop.TextEditor.CommandMappingExtensionNode" />
 	</ExtensionPoint>
+
+	<ExtensionPoint path="/MonoDevelop/TextEditor/SupportedFileTypes" name="Opts in file types to be opened in the new editor">
+		<ExtensionNode name="SupportedFileType" type="MonoDevelop.TextEditor.SupportedFileTypeExtensionNode" />
+	</ExtensionPoint>
+
 <!--
 	<ExtensionPoint path = "/MonoDevelop/TextEditor/ContextMenu/NavigationBar" name = "Navigation bar context menu">
 		<Description>Context menu for the navigation bar.</Description>
@@ -42,7 +47,9 @@
 		<ExtensionNode name="Class" />
 	</ExtensionPoint>
 
-	--><!-- Extensions -->
+	-->
+
+	<!-- Extensions -->
 
   	<Extension path="/MonoDevelop/Ide/Composition">
 		<!--
@@ -50,6 +57,12 @@
 		<Assembly file="../../../bin/Microsoft.VisualStudio.Platform.VSEditor.dll"/>
 		-->
 		<Assembly file="MonoDevelop.TextEditor.dll"/>
+	</Extension>
+
+	<Extension path="/MonoDevelop/TextEditor/SupportedFileTypes">
+		<SupportedFileType id="csharp" extensions=".cs,.csx" />
+		<SupportedFileType id="xaml" extensions=".xaml" FeatureSwitch="DesignersNewEditor" />
+		<SupportedFileType id="androidxml" extensions=".xml,.axml" BuildAction="AndroidResource" FeatureSwitch="DesignersNewEditor" />
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/Commands">

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/SupportedFileTypeExtensionNode.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/SupportedFileTypeExtensionNode.cs
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corp. (https://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Mono.Addins;
+
+namespace MonoDevelop.TextEditor
+{
+	sealed class SupportedFileTypeExtensionNode : ExtensionNode
+	{
+		[NodeAttribute ("extensions", "Comma separated list of file extensions. The file must match one of these or one of the mime types.")]
+		public string [] Extensions { get; private set; }
+
+		[NodeAttribute ("mimeTypes", "Comma separated list of mime types. The file must match one of these or one of the extensions.")]
+		public string [] MimeTypes { get; private set; }
+
+		[NodeAttribute ("buildAction", Description = "If specified, the file must have this build action")]
+		public string BuildAction { get; private set; }
+
+		[NodeAttribute ("featureFlag", Description = "ID of a feature flag that can be used to enable/disable editing of this file type in the new editor")]
+		public string FeatureFlag { get; private set; }
+
+		[NodeAttribute ("featureFlagDefault", Description = "Default value of the feature flag")]
+		public bool FeatureFlagDefault { get; private set; }
+	}
+}


### PR DESCRIPTION
This adds a new extension point that extensions can use to opt individual file types into the new editor, optionally controlled by feature flags.

This means that extensions can light up new file types in the new editor without changing the new editor itself.
