### PR TITLE
Delete reference to RazorCSharpEditorExtension that no longer exists.

### DIFF
--- a/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
+++ b/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
@@ -345,7 +345,6 @@
 	<Extension path = "/MonoDevelop/Ide/TextEditorExtensions">
 		<Class fileExtensions=".aspx, .ascx, .master" class = "MonoDevelop.AspNet.WebForms.WebFormsEditorExtension" />
 		<Class mimeTypes="text/html,application/x-spark" class = "MonoDevelop.AspNet.Html.HtmlEditorExtension" />
-		<Class mimeTypes="text/x-cshtml" class = "MonoDevelop.AspNet.Razor.RazorCSharpEditorExtension" />
 	</Extension>
 
 	<Extension path = "/MonoDevelop/Html/DocTypes">


### PR DESCRIPTION
The extension was removed with https://github.com/mono/monodevelop/commit/4971b9d3563fa4660e022177194263803df9d968