### PR TITLE
[Watson] Fixes exception in cases of cocoa resources not fully initialized

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -72,8 +72,13 @@ namespace MonoDevelop.MacIntegration
 					else
 						alert.Icon = img.ToNSImage ();
 				} else {
-					//for some reason the NSAlert doesn't pick up the app icon by default
-					alert.Icon = NSApplication.SharedApplication.ApplicationIconImage;
+					try {
+						//for some reason the NSAlert doesn't pick up the app icon by default
+						//this call could fail in cases of cocoa not fully initialized (resources not available)
+						alert.Icon = NSApplication.SharedApplication.ApplicationIconImage;
+					} catch (Exception ex) {
+						LoggingService.LogInternalError (ex);
+					}
 				}
 
 				alert.MessageText = data.Message.Text;


### PR DESCRIPTION
Watson detected some cases where call to NSApplication.SharedApplication.ApplicationIconImage property (get_ApplicationIconImage) is giving us an internal exception

![image](https://user-images.githubusercontent.com/1587480/59373262-9b59e680-8d49-11e9-911b-d1af19e082a8.png)


NSApplication.SharedApplication.ApplicationIconImage is a native cocoa API, which checks into the .app manifest from the current instance the IconFile record. In our case (VisualStudio) is the VisualStudio.icns file.

This file contains all the icons in images for different resolutions in a custom format, and the API returns a NSImage (probably the used in the current instance).

It's not clear why this could be giving us an exception in that point, there are some theories, maybe the application is not fully loaded and then because some unexpected thing we show an alert dialog?

Tested in different machines (mohave and Catalina and trying to show this dialog in different stages on initializing) but it works great for me.

I added a try / catch block with the registry to at least not break the current running instance (it will show a default icon).

Fixes Bug #905844 - MacAlertDialogHandler causes NSImageCacheException that crashes VS for Mac

