### PR TITLE
Fix split editor view with the new editor

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebookContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.DockNotebook/DockNotebookContainer.cs
@@ -224,19 +224,10 @@ namespace MonoDevelop.Components.DockNotebook
 			return newNotebook;
 		}
 
-		static HPaned CreatePaned ()
-		{
-			// FIXME: Bug #910879: HPanedThin is not functional with the new editor,
-			//        fall-back to the regular Gtk paned until we find the right solution
-			if (Ide.Editor.DefaultSourceEditorOptions.Instance.EnableNewEditor)
-				return new HPaned ();
-			return new HPanedThin { GrabAreaSize = 6 };
-		}
-
 		public DockNotebook InsertLeft (SdiWorkspaceWindow window)
 		{
 			return Insert (window, container => {
-				var box = CreatePaned ();
+				var box = new HPanedThin { GrabAreaSize = 6 };
 				var new_container = new DockNotebookContainer (tabControl);
 
 				box.Pack1 (container, true, true);
@@ -248,7 +239,7 @@ namespace MonoDevelop.Components.DockNotebook
 		public DockNotebook InsertRight (SdiWorkspaceWindow window)
 		{
 			return Insert (window, container => {
-				var box = CreatePaned ();
+				var box = new HPanedThin () { GrabAreaSize = 6 };
 				var new_container = new DockNotebookContainer (tabControl);
 
 				box.Pack1 (new_container, true, true);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
@@ -248,14 +248,9 @@ namespace MonoDevelop.Components
 
 			if (owner.TryGetTarget (out var paned)) {
 				var point = NSEvent.CurrentMouseLocation;
-
-				if (horizontal) {
-					int newpos = initialPanedPos + ((int)point.X - initialPos);
-					paned.Position = newpos >= 10 ? newpos : 10;
-				} else {
-					int newpos = initialPanedPos + ((int)point.Y - initialPos);
-					paned.Position = newpos >= 10 ? newpos : 10;
-				}
+				int relativeTo = horizontal ? (int)point.X : (int)point.Y;
+				int newpos = initialPanedPos + relativeTo - initialPos;
+				paned.Position = newpos >= 10 ? newpos : 10;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
@@ -97,6 +97,15 @@ namespace MonoDevelop.Components
 		}
 	}
 
+	abstract class CustomPanedHandle : Gtk.EventBox
+	{
+		internal const int HandleGrabWidth = 4;
+
+		public abstract int GrabAreaSize { get; set; }
+
+		public virtual Gtk.Widget HandleWidget { get; set; }
+	}
+
 #if MAC
 
 	sealed class CustomMacPanedHandle : CustomPanedHandle
@@ -223,15 +232,6 @@ namespace MonoDevelop.Components
 	}
 
 #endif
-
-	abstract class CustomPanedHandle: Gtk.EventBox
-	{
-		internal const int HandleGrabWidth = 4;
-
-		abstract public int GrabAreaSize { get; set; }
-
-		virtual public Gtk.Widget HandleWidget { get; set; }
-	}
 
 	sealed class CustomGtkPanedHandle: CustomPanedHandle
 	{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
@@ -108,6 +108,7 @@ namespace MonoDevelop.Components
 
 		public CustomMacPanedHandle (Gtk.Paned parent)
 		{
+			VisibleWindow = false;
 			this.parent = parent;
 			HPanedThin.InitStyle (parent, 1);
 			horizontal = parent is HPanedThin;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
@@ -204,6 +204,22 @@ namespace MonoDevelop.Components
 				owner.Position = newpos >= 10 ? newpos : 10;
 			}
 		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			base.UpdateTrackingAreas ();
+			// this will be called after layout changes, let's make sure that we're still the topmost view
+			EnsureViewIsTopmost ();
+		}
+
+		void EnsureViewIsTopmost ()
+		{
+			if (Superview?.Subviews?.Length > 1 && Superview.Subviews [Superview.Subviews.Length - 1] != this) {
+				var superview = Superview;
+				RemoveFromSuperview ();
+				superview.AddSubview (this, NSWindowOrderingMode.Above, null);
+			}
+		}
 	}
 
 #endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HPanedThin.cs
@@ -99,7 +99,7 @@ namespace MonoDevelop.Components
 
 #if MAC
 
-	class CustomMacPanedHandle : CustomPanedHandle
+	sealed class CustomMacPanedHandle : CustomPanedHandle
 	{
 		readonly Gtk.GtkNSViewHost host;
 		readonly MacPanedHandleView handle;
@@ -155,7 +155,7 @@ namespace MonoDevelop.Components
 		}
 	}
 
-	class MacPanedHandleView: DragEventTrapView
+	sealed class MacPanedHandleView: DragEventTrapView
 	{
 		readonly Gtk.Paned owner;
 		readonly bool horizontal;
@@ -233,7 +233,7 @@ namespace MonoDevelop.Components
 		virtual public Gtk.Widget HandleWidget { get; set; }
 	}
 
-	class CustomGtkPanedHandle: CustomPanedHandle
+	sealed class CustomGtkPanedHandle: CustomPanedHandle
 	{
 		static Gdk.Cursor resizeCursorW = new Gdk.Cursor (Gdk.CursorType.SbHDoubleArrow);
 		static Gdk.Cursor resizeCursorH = new Gdk.Cursor (Gdk.CursorType.SbVDoubleArrow);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/DragEventTrapView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/DragEventTrapView.cs
@@ -1,0 +1,210 @@
+//
+// PointerEventTrapView.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2019 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if MAC
+
+using System;
+using AppKit;
+
+namespace MonoDevelop.Components.Mac
+{
+	/// <summary>
+	/// DragEventTrapView base class to disable GDK events while an NSView is being dragged
+	/// </summary>
+	/// <remarks>
+	/// This NSView tracks pointer events and disables GDK events during a dragging operation.
+	/// This allows the cursor to shortly leave the view bounds and prevents losing of events
+	/// if the pointer enters a different view or Gtk widget shortly.
+	///
+	/// The main purpose is to support native views inside splitters without losing splitter
+	/// drag support. See <see cref="Docking.MacSplitterWidget"/> and <see cref="HPanedThin"/> for examples.
+	///
+	/// However DragEventTrapView does not handle the actual drag operation, so it could
+	/// be used for other use cases, where GDK events or other NSViews might interfere and
+	/// steal pointer events.
+	///
+	/// NOTE: this view should be added with NSWindowOrderingMode.Above to its superview, to
+	///       make sure the it's the first widget to receive pointer events.
+	/// </remarks>
+	abstract class DragEventTrapView : NSView
+	{
+		NSCursor currentCursor;
+		bool hover, dragging;
+
+		double lastEventTimestamp = Foundation.NSProcessInfo.ProcessInfo.SystemUptime;
+		bool enableGdkEventFiler;
+		bool gdkEventFilterInserted;
+		bool isDisposed;
+
+		protected DragEventTrapView ()
+		{
+			const NSTrackingAreaOptions options = NSTrackingAreaOptions.ActiveInKeyWindow |
+				NSTrackingAreaOptions.InVisibleRect |
+				NSTrackingAreaOptions.MouseEnteredAndExited;
+			var trackingArea = new NSTrackingArea (default, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		/// <summary>
+		/// Override to supply a custom NSCursor during a drag operation
+		/// </summary>
+		/// <returns>NSCursor to be shown while dragging, or null to disable cursor changes</returns>
+		protected virtual NSCursor GetDragCursor ()
+		{
+			return null;
+		}
+
+		void SetDefaultCursor ()
+		{
+			if (currentCursor != null) {
+				currentCursor.Pop ();
+				currentCursor = null;
+			}
+		}
+
+		void SetDragCursor ()
+		{
+			var cursor = GetDragCursor ();
+			if (currentCursor != null) {
+				if (currentCursor == cursor)
+					return;
+				currentCursor.Pop ();
+			}
+			currentCursor = cursor;
+			currentCursor.Push ();
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			lastEventTimestamp = theEvent.Timestamp;
+			if (!dragging) {
+				SetDragCursor ();
+			}
+			hover = true;
+			base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			lastEventTimestamp = theEvent.Timestamp;
+			if (!dragging) {
+				SetDefaultCursor ();
+			}
+			hover = false;
+			base.MouseExited (theEvent);
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			lastEventTimestamp = theEvent.Timestamp;
+			if (!dragging) {
+				SetDragCursor ();
+			}
+			base.MouseMoved (theEvent);
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			lastEventTimestamp = theEvent.Timestamp;
+			dragging = true;
+
+			AddGdkEventFilter ();
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			lastEventTimestamp = theEvent.Timestamp;
+			if (hover) {
+				SetDragCursor ();
+			} else {
+				SetDefaultCursor ();
+			}
+			RaiseEndDrag ();
+			base.MouseUp (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			lastEventTimestamp = theEvent.Timestamp;
+			SetDragCursor ();
+		}
+
+		void RaiseEndDrag ()
+		{
+			if (dragging) {
+				dragging = false;
+				RemoveGdkEventFilter ();
+			}
+		}
+
+		public override void RemoveFromSuperview ()
+		{
+			RemoveGdkEventFilter ();
+			base.RemoveFromSuperview ();
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			isDisposed = true;
+			if (disposing)
+				RemoveGdkEventFilter ();
+			base.Dispose (disposing);
+		}
+
+		void AddGdkEventFilter ()
+		{
+			enableGdkEventFiler = true;
+			if (!gdkEventFilterInserted) {
+				Gdk.Window.AddFilterForAll (Filter);
+				gdkEventFilterInserted = true;
+			}
+		}
+
+		void RemoveGdkEventFilter ()
+		{
+			enableGdkEventFiler = false;
+			if (gdkEventFilterInserted) {
+				Gdk.Window.RemoveFilterForAll (Filter);
+				gdkEventFilterInserted = false;
+			}
+		}
+
+		Gdk.FilterReturn Filter (IntPtr xevent, Gdk.Event evnt)
+		{
+			if (enableGdkEventFiler && !isDisposed && Window != null) {
+				// always recover GDK events after 2 seconds of inactivity, this makes sure
+				// that we don't lose GDK events forever if some other native view steals events
+				// which are required for the drag exit condition.
+				if (Foundation.NSProcessInfo.ProcessInfo.SystemUptime - lastEventTimestamp < 2.0)
+					return Gdk.FilterReturn.Remove;
+			}
+			RemoveGdkEventFilter ();
+			return Gdk.FilterReturn.Continue;
+		}
+	}
+}
+
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs
@@ -35,7 +35,7 @@ namespace MonoDevelop.Components
 		public VPanedThin ()
 		{
 			GtkWorkarounds.FixContainerLeak (this);
-			handle = new CustomPanedHandle (this);
+			handle = new CustomGtkPanedHandle (this);
 			handle.Parent = this;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4250,6 +4250,7 @@
     <Compile Include="MonoDevelop.Components.Docking\MacSplitterWidget.cs" />
     <Compile Include="MonoDevelop.Components.Docking\SplitterWidgetWrapper.cs" />
     <Compile Include="MonoDevelop.Components.Docking\SplitterMacHostWidget.cs" />
+    <Compile Include="MonoDevelop.Components\Mac\DragEventTrapView.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />


### PR DESCRIPTION
Use the same technique we use for Pad resizing in #7762 to fix the resizing in the document split view.

> Fixes VSTS [#910879](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/910879)