### PR TITLE
[release-8.1] Fixes VSTS 918117: Extract Interface Dialog buttons don't close dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.ExtractInterface/ExtractInterfaceOptionService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.ExtractInterface/ExtractInterfaceOptionService.cs
@@ -59,31 +59,32 @@ namespace MonoDevelop.Refactoring.ExtractInterface
 		{
 			await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync ();
 
-			var dialog = new ExtractInterfaceDialog ();
+			using (var dialog = new ExtractInterfaceDialog ()) {
 
-			dialog.Init (
-				syntaxFactsService,
-				notificationService,
-				extractableMembers,
-				defaultInterfaceName,
-				conflictingTypeNames,
-				defaultNamespace,
-				generatedNameTypeParameterSuffix,
-				languageName);
+				dialog.Init (
+					syntaxFactsService,
+					notificationService,
+					extractableMembers,
+					defaultInterfaceName,
+					conflictingTypeNames,
+					defaultNamespace,
+					generatedNameTypeParameterSuffix,
+					languageName);
 
-			bool performChange = dialog.Run () == Xwt.Command.Ok;
-			if (!performChange)
-				return ExtractInterfaceOptionsResult.Cancelled;
+				bool performChange = dialog.Run () == Xwt.Command.Ok;
+				if (!performChange)
+					return ExtractInterfaceOptionsResult.Cancelled;
 
-			return new ExtractInterfaceOptionsResult (
-				false,
-				dialog.IncludedMembers.AsImmutable (),
-				dialog.InterfaceName,
-				dialog.FileName,
-				dialog.UseSameFile
-					? ExtractInterfaceOptionsResult.ExtractLocation.SameFile
-					: ExtractInterfaceOptionsResult.ExtractLocation.NewFile
-			);
+				return new ExtractInterfaceOptionsResult (
+					false,
+					dialog.IncludedMembers.AsImmutable (),
+					dialog.InterfaceName,
+					dialog.FileName,
+					dialog.UseSameFile
+						? ExtractInterfaceOptionsResult.ExtractLocation.SameFile
+						: ExtractInterfaceOptionsResult.ExtractLocation.NewFile
+				);
+			}
 		}
 	}
 }


### PR DESCRIPTION
It appears a [change](https://github.com/mono/monodevelop/commit/5f30ab59a877f97724d68350d0b846822b2c4e23#diff-43ce8a1c5ce56b4b8c9e5bde48d8efe9) removed an explicit call to `Dispose` the dialog. That meant that while the service received and acted upon the return value (i.e. it generated the extracted interface, etc.) the actual dialog was never closed/disposed of. 

I've wrapped it in a `using` statement, which seems to have done the trick.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/918117/

Backport of #7850.

/cc @abock @avodovnik