### PR TITLE
Fixed Snippets Drag&Drop and added ability for Android Designer to do D&D

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IDragDataToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IDragDataToolboxNode.cs
@@ -1,0 +1,49 @@
+//
+// IDragDataToolboxNode.cs
+//
+// Author:
+//       David Karlaš <david.karlas@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+
+namespace MonoDevelop.DesignerSupport.Toolbox
+{
+	/// <summary>
+	/// ToolBox node can implement this interface if it wants to add
+	/// custom format and data for that format to drag operation.
+	/// </summary>
+	public interface IDragDataToolboxNode
+	{
+		/// <summary>
+		/// List of formats that ToolboxNode wants to attach to drag.
+		/// </summary>
+		IEnumerable<string> Formats { get; }
+
+		/// <summary>
+		/// Data to be attached for specific format from <see cref="Formats"/> list.
+		/// </summary>
+		/// <param name="format"></param>
+		/// <returns></returns>
+		byte[] GetData (string format);
+	}
+}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.csproj
@@ -145,6 +145,7 @@
     <Compile Include="MonoDevelop.DesignerSupport\NativePropertyEditors\PropertyInfo\FlagDescriptorPropertyInfo.cs" />
     <Compile Include="MonoDevelop.DesignerSupport\NativePropertyEditors\PropertyPadItem.cs" />
     <Compile Include="MonoDevelop.DesignerSupport\MonoDevelopHostResourceProvider.cs" />
+    <Compile Include="MonoDevelop.DesignerSupport.Toolbox\IDragDataToolboxNode.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.DesignerSupport.addin.xml" />

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/ToolboxDropHandler.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/ToolboxDropHandler.cs
@@ -1,0 +1,85 @@
+using System;
+using System.ComponentModel.Composition;
+using AppKit;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.DragDrop;
+using Microsoft.VisualStudio.Utilities;
+using MonoDevelop.DesignerSupport;
+using MonoDevelop.DesignerSupport.Toolbox;
+using MonoDevelop.Ide.Gui.Documents;
+
+namespace MonoDevelop.TextEditor
+{
+	[Export (typeof (IDropHandlerProvider))]
+	[DropFormat (ToolboxPad.ToolBoxDragDropFormat)]
+	[Name (nameof(MonoDevelopToolBoxDropHandlerProvider))]
+	sealed class MonoDevelopToolBoxDropHandlerProvider : IDropHandlerProvider
+	{
+		public IDropHandler GetAssociatedDropHandler (ICocoaTextView cocoaTextView)
+		{
+			return new MonoDevelopToolBoxDropHandler (cocoaTextView);
+		}
+	}
+
+	sealed class MonoDevelopToolBoxDropHandler : IDropHandler
+	{
+		private ICocoaTextView cocoaTextView;
+
+		public MonoDevelopToolBoxDropHandler (ICocoaTextView cocoaTextView)
+		{
+			this.cocoaTextView = cocoaTextView;
+		}
+
+		private bool TryGetConsumer (out IToolboxConsumer toolboxConsumer)
+		{
+			if (cocoaTextView.Properties.TryGetProperty<DocumentController> (typeof (DocumentController), out var controller)) {
+				if (controller.GetContent<IToolboxConsumer> () is IToolboxConsumer consumer) {
+					var selectedItem = DesignerSupport.DesignerSupport.Service.ToolboxService.SelectedItem;
+					if (DesignerSupport.DesignerSupport.Service.ToolboxService.IsSupported (selectedItem, consumer)) {
+						toolboxConsumer = consumer;
+						return true;
+					}
+				}
+			}
+			toolboxConsumer = null;
+			return false;
+		}
+
+		public DragDropPointerEffects HandleDataDropped (DragDropInfo dragDropInfo)
+		{
+			if (TryGetConsumer (out var consumer)) {
+				cocoaTextView.Caret.MoveTo (dragDropInfo.VirtualBufferPosition);
+				consumer.ConsumeItem (DesignerSupport.DesignerSupport.Service.ToolboxService.SelectedItem);
+				return DragDropPointerEffects.Move | DragDropPointerEffects.Track;
+			}
+			return DragDropPointerEffects.None;
+		}
+
+		public void HandleDragCanceled ()
+		{
+
+		}
+
+		public DragDropPointerEffects HandleDraggingOver (DragDropInfo dragDropInfo)
+		{
+			if (TryGetConsumer (out var _))
+				return DragDropPointerEffects.Move | DragDropPointerEffects.Track;
+			else
+				return DragDropPointerEffects.None;
+		}
+
+		public DragDropPointerEffects HandleDragStarted (DragDropInfo dragDropInfo)
+		{
+			if (TryGetConsumer (out var _))
+				return DragDropPointerEffects.Move | DragDropPointerEffects.Track;
+			else
+				return DragDropPointerEffects.None;
+		}
+
+		public bool IsDropEnabled (DragDropInfo dragDropInfo)
+		{
+			return true;
+		}
+	}
+
+}


### PR DESCRIPTION
Dropping things on `ITextView` is handled by different `IDropHandler`s. `IDropHandler` is chosen based on `[DropFormat ("XXX")]` and priority... So now when ToolboxPad starts dragging session we always insert `MonoDevelopToolBox` so our `MonoDevelopToolBoxDropHandler` is picked to handle dropping. Which then executes `ConsumeItem` for currently selected item on `Document` that is parent of `textView` that was dropped on.
I also added `IDragDataToolboxNode` interface which allows others e.g. Android Designer to define their own `DropFormat` and `byte[]` data when dragging starts that they want to pass to their own `IDropHandler`.