### PR TITLE
Map "Show import items" option to equivalent Roslyn feature

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -446,7 +446,9 @@ namespace MonoDevelop.CSharp.Completion
 			Counters.ProcessCodeCompletion.Trace ("C#: Getting completions");
 			var customOptions = DocumentContext.RoslynWorkspace.Options
 				.WithChangedOption (CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, true)
-				.WithChangedOption (CompletionOptions.HideAdvancedMembers, LanguageNames.CSharp, IdeApp.Preferences.CompletionOptionsHideAdvancedMembers);
+				.WithChangedOption (CompletionOptions.HideAdvancedMembers, LanguageNames.CSharp, IdeApp.Preferences.CompletionOptionsHideAdvancedMembers)
+				// Roslyn's implementation of this feature doesn't work correctly in old editor
+				.WithChangedOption (CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, false);
 			var completionList = await Task.Run (() => cs.GetCompletionsAsync (analysisDocument, Editor.CaretOffset, trigger, options: customOptions, cancellationToken: token)).ConfigureAwait (false);
 			Counters.ProcessCodeCompletion.Trace ("C#: Got completions");
 

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/CompletionOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/CompletionOptionsPanel.cs
@@ -94,6 +94,7 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 		{
 			DefaultSourceEditorOptions.Instance.EnableAutoCodeCompletion = autoCodeCompletionCheckbutton.Active;
 			IdeApp.Preferences.AddImportedItemsToCompletionList.Value = showImportsCheckbutton.Active;
+			IdeApp.Preferences.Roslyn.CSharp.ShowItemsFromUnimportedNamespaces.Value = showImportsCheckbutton.Active;
 			IdeApp.Preferences.IncludeKeywordsInCompletionList.Value = includeKeywordsCheckbutton.Active;
 			IdeApp.Preferences.IncludeCodeSnippetsInCompletionList.Value = includeCodeSnippetsCheckbutton.Active;
 			IdeApp.Preferences.ForceSuggestionMode.Value = !automaticCompletionModeCheckbutton.Active;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
@@ -72,6 +72,7 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			public readonly ConfigurationProperty<bool> FormatOnPaste;
 			public readonly ConfigurationProperty<bool> PlaceSystemNamespaceFirst;
 			public readonly ConfigurationProperty<bool> SeparateImportDirectiveGroups;
+			public readonly ConfigurationProperty<bool?> ShowItemsFromUnimportedNamespaces;
 			public readonly ConfigurationProperty<bool> SuggestForTypesInNuGetPackages;
 			public readonly ConfigurationProperty<bool> SolutionCrawlerClosedFileDiagnostic;
 
@@ -112,6 +113,12 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 				SeparateImportDirectiveGroups = preferences.Wrap<bool> (
 					new OptionKey (Microsoft.CodeAnalysis.Editing.GenerationOptions.SeparateImportDirectiveGroups, language),
 					language + ".SeparateImportDirectiveGroups"
+				);
+
+				ShowItemsFromUnimportedNamespaces = preferences.Wrap<bool?> (
+					new OptionKey (CompletionOptions.ShowItemsFromUnimportedNamespaces, language),
+					IdeApp.Preferences.AddImportedItemsToCompletionList.Value,
+					language + ".ShowItemsFromUnimportedNamespaces"
 				);
 
 				SuggestForTypesInNuGetPackages = preferences.Wrap (


### PR DESCRIPTION
Roslyn implemented this feature as a per-language setting, not a global
intellisense setting like MonoDevelop has. In the future, we should
reorganize this setting to reflect that (and match Windows).

Ensure that the Roslyn feature is disabled in old editor completion. The
items show up correctly in the list, but insertion fails to actually add
the `using` statement. The old editor can continue using its existing
implementation of this feature.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/756548