### PR TITLE
[Core] Fix file nesting after installing NuGet package in a F# project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildItem.cs
@@ -342,8 +342,10 @@ namespace MonoDevelop.Projects.MSBuild
 			get {
 				if (sourceItem is MSBuildItem)
 					return (MSBuildItem) sourceItem;
-				else
-					return SourceItems.LastOrDefault (); 
+				else {
+					var lastSourceItem = SourceItems.LastOrDefault (item => item.ParentProject == metadata.ParentProject);
+					return lastSourceItem ?? SourceItems.LastOrDefault ();
+				}
 			}
 		}
 

--- a/main/tests/test-projects/FSharpForms/FSharpForms.sln
+++ b/main/tests/test-projects/FSharpForms/FSharpForms.sln
@@ -1,0 +1,29 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpForms", "FSharpForms\FSharpForms.fsproj", "{BC24106A-7259-45C8-87EC-D849CDF80800}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Release|iPhone.Build.0 = Release|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC24106A-7259-45C8-87EC-D849CDF80800}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/FSharpForms/FSharpForms/App.fs
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/App.fs
@@ -1,0 +1,36 @@
+﻿//
+// App.fs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace FSharpForms
+
+open Xamarin.Forms
+
+type App() =
+    inherit Application()
+    let stack = StackLayout(VerticalOptions = LayoutOptions.Center)
+    let label = Label(XAlign = TextAlignment.Center, Text = "Welcome to F# Xamarin.Forms!")
+    do
+        stack.Children.Add(label)
+        base.MainPage <- ContentPage(Content = stack)

--- a/main/tests/test-projects/FSharpForms/FSharpForms/App.xaml
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/App.xaml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Application xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="FSharpForms.App">
+	<Application.Resources>
+		<!-- Application resource dictionary -->
+	</Application.Resources>
+</Application>

--- a/main/tests/test-projects/FSharpForms/FSharpForms/App.xaml.fs
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/App.xaml.fs
@@ -1,0 +1,31 @@
+﻿//
+// App.xaml.fs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace FSharpForms
+
+open Xamarin.Forms
+
+type App() =
+    inherit Application(MainPage = MainPage())

--- a/main/tests/test-projects/FSharpForms/FSharpForms/AssemblyInfo.fs
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/AssemblyInfo.fs
@@ -1,0 +1,42 @@
+﻿//
+// AssemblyInfo.fs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace FSharpForms
+
+open System.Reflection
+open System.Runtime.CompilerServices
+
+[<assembly:AssemblyTitle("FSharpForms")>]
+[<assembly:AssemblyDescription("")>]
+[<assembly:AssemblyConfiguration("")>]
+[<assembly:AssemblyCompany("Microsoft")>]
+[<assembly:AssemblyProduct("")>]
+[<assembly:AssemblyCopyright("Microsoft")>]
+[<assembly:AssemblyTrademark("")>]
+[<assembly:AssemblyVersion("1.0.0.0")>]
+()
+// The assembly version has the format {Major}.{Minor}.{Build}.{Revision}
+//[<assembly: AssemblyDelaySign(false)>]
+//[<assembly: AssemblyKeyFile("")>]

--- a/main/tests/test-projects/FSharpForms/FSharpForms/FSharpForms.fsproj
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/FSharpForms.fsproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="MainPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <Compile Include="MainPage.xaml.fs">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </Compile>
+    <EmbeddedResource Include="App.xaml" />
+    <Compile Include="App.xaml.fs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="AssemblyInfo.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/FSharpForms/FSharpForms/MainPage.xaml
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/MainPage.xaml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:local="clr-namespace:FSharpForms" x:Class="FSharpForms.MainPage">
+	<Label Text="Welcome to Xamarin Forms!" VerticalOptions="Center" HorizontalOptions="Center" />
+</ContentPage>

--- a/main/tests/test-projects/FSharpForms/FSharpForms/MainPage.xaml.fs
+++ b/main/tests/test-projects/FSharpForms/FSharpForms/MainPage.xaml.fs
@@ -1,0 +1,33 @@
+﻿//
+// MainPage.xaml.fs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace FSharpForms
+
+open Xamarin.Forms
+open Xamarin.Forms.Xaml
+
+type MainPage() =
+    inherit ContentPage()
+    let _ = base.LoadFromXaml(typeof<MainPage>)


### PR DESCRIPTION
Creating a blank F# Xamarin.Forms project and then installing a NuGet
package into the .NET Standard project would result in the file
nesting being broken in the Solution pad. The MainPage.xaml.fs file
would be nested underneath the App.xaml file.

The problem was that on saving the project the MSBuildItem that was
associated with the Update glob was being used as the SourceItem for the
.xaml.fs files. This resulted in the Update glob item that defined
the DependentUpon metadata value of '%(FileName)' being modified on
saving with the evaluated name of the .xaml file. Then when the
project was re-evaluated the file nesting was then broken since the
DependentUpon had App.xaml set for all files.

To fix this the MSBuildItem will look for a SourceItem that has the
same parent as itself. For the .fsproj this means the last MSBuild
item in the project for that file will be used instead of the MSBuild
item from any .targets imported afterwards, such as the
Xamarin.Forms.DefaultItems.targets file.

Fixes VSTS #636641 - Adding a nuget to an F# Xamarin Forms app breaks
the file nesting