### PR TITLE
[release-8.1] vs-editor-api: switch to official Microsoft repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,5 +54,5 @@
 	branch = master
 [submodule "main/external/vs-editor-api"]
 	path = main/external/vs-editor-api
-	url = https://github.com/KirillOsenkov/vs-editor-api.git
-	branch = monodevelop/release-8.1
+	url = https://github.com/microsoft/vs-editor-api.git
+	branch = vsmac/release-8.1


### PR DESCRIPTION
Need to switch off of Kirill's fork to the new official repo for servicing 8.1 as well.