### PR TITLE
Bump to new MD analyzer nuget

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -13,7 +13,7 @@
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
     <NuGetVersionMicrosoftTemplateEngine>1.0.0-beta3-20171117-314</NuGetVersionMicrosoftTemplateEngine>
     <NuGetVersionMicrosoftTestPlatform>15.5.0-preview-20170919-04</NuGetVersionMicrosoftTestPlatform>
-    <NuGetVersionMonoDevelopAnalyzers>0.1.0.1</NuGetVersionMonoDevelopAnalyzers>
+    <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>
     <NuGetVersionNewtonsoftJson>10.0.3</NuGetVersionNewtonsoftJson>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>

--- a/main/src/addins/MacPlatform/MacInterop/Carbon.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Carbon.cs
@@ -221,7 +221,7 @@ namespace MonoDevelop.MacInterop
 			try {
 				if (GetCurrentProcess (out ProcessSerialNumber psn) == 0)
 					CPSSetProcessName (ref psn, name);
-			} catch (TypeLoadException e) {} //EntryPointNotFoundException?
+			} catch (TypeLoadException) {} //EntryPointNotFoundException?
 		}
 
 		struct ProcessSerialNumber {
@@ -241,7 +241,7 @@ namespace MonoDevelop.MacInterop
 				try {
 					SelectionRange range = GetEventParameter<SelectionRange> (eventRef, CarbonEventParameterName.AEPosition, CarbonEventParameterType.Char);
 					line = range.lineNum+1;
-				} catch (Exception e) {
+				} catch (Exception) {
 					line = 0;
 				}
 				

--- a/main/src/addins/MacPlatform/MacInterop/Carbon.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Carbon.cs
@@ -215,15 +215,15 @@ namespace MonoDevelop.MacInterop
 		
 		[DllImport (CarbonLib)]
 		static extern int CPSSetProcessName (ref ProcessSerialNumber psn, string name);
-		
+
 		public static void SetProcessName (string name)
 		{
 			try {
 				if (GetCurrentProcess (out ProcessSerialNumber psn) == 0)
 					CPSSetProcessName (ref psn, name);
-			} catch {} //EntryPointNotFoundException?
+			} catch (TypeLoadException e) {} //EntryPointNotFoundException?
 		}
-		
+
 		struct ProcessSerialNumber {
 #pragma warning disable 0169
 			uint highLongOfPSN;
@@ -237,11 +237,12 @@ namespace MonoDevelop.MacInterop
 		{
 			AEDesc list = GetEventParameter<AEDesc> (eventRef, CarbonEventParameterName.DirectObject, CarbonEventParameterType.AEList);
 			try {
-				int line = 0;
+				int line;
 				try {
 					SelectionRange range = GetEventParameter<SelectionRange> (eventRef, CarbonEventParameterName.AEPosition, CarbonEventParameterType.Char);
 					line = range.lineNum+1;
-				} catch {
+				} catch (Exception e) {
+					line = 0;
 				}
 				
 				var arr = AppleEvent.GetListFromAEDesc<string,FSRef> (ref list, CoreFoundation.FSRefToString,

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -502,7 +502,9 @@ namespace MonoDevelop.MacIntegration
 						m.Dispose ();
 					}
 					NSApplication.SharedApplication.HelpMenu = null;
-				} catch {}
+				} catch (Exception e2) {
+					LoggingService.LogError ("Could not uninstall global menu", e2);
+				}
 				LoggingService.LogError ("Could not install global menu", ex);
 				setupFail = true;
 				return false;


### PR DESCRIPTION
Exception handlers considered empty will trigger a build and edit-time warning.

Fixes VSTS #774649 - SDL - Validate all new code is free of 'swallow everything' exception handlers