### PR TITLE
[release-8.2] [TextEditor] Use feature flag instead of global option to enable new editor for C#

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/CSharpEnableNewEditorSwitchController.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/CSharpEnableNewEditorSwitchController.cs
@@ -1,0 +1,44 @@
+//
+// CSharpEnableNewEditorSwitchController.cs
+//
+// Author:
+//       Jérémie Laval <jelaval@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using MonoDevelop.Core.FeatureConfiguration;
+using MonoDevelop.Ide.Editor;
+
+namespace MonoDevelop.TextEditor
+{
+	public class CSharpEnableNewEditorSwitchController : IFeatureSwitchController
+	{
+		const string FeatureName = "CSharpEnableNewEditor";
+
+		public bool? IsFeatureEnabled (string featureName)
+		{
+			if (!string.Equals (featureName, FeatureName, StringComparison.Ordinal))
+				return null;
+			return DefaultSourceEditorOptions.Instance.EnableNewEditor;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/CSharpEnableNewEditorSwitchController.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/CSharpEnableNewEditorSwitchController.cs
@@ -30,7 +30,7 @@ using MonoDevelop.Ide.Editor;
 
 namespace MonoDevelop.TextEditor
 {
-	public class CSharpEnableNewEditorSwitchController : IFeatureSwitchController
+	sealed class CSharpEnableNewEditorSwitchController : IFeatureSwitchController
 	{
 		const string FeatureName = "CSharpEnableNewEditor";
 

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
@@ -60,9 +60,11 @@
 	</Extension>
 
 	<Extension path="/MonoDevelop/TextEditor/SupportedFileTypes">
-		<SupportedFileType id="csharp" extensions=".cs,.csx" />
-		<SupportedFileType id="xaml" extensions=".xaml" FeatureSwitch="DesignersNewEditor" />
-		<SupportedFileType id="androidxml" extensions=".xml,.axml" BuildAction="AndroidResource" FeatureSwitch="DesignersNewEditor" />
+		<SupportedFileType id="csharp" extensions=".cs,.csx" featureFlag="CSharpEnableNewEditor" />
+	</Extension>
+
+	<Extension path="/MonoDevelop/Core/FeatureConfiguration/FeatureSwitchChecks">
+		<Type id="CSharpEnableNewEditor" class="MonoDevelop.TextEditor.CSharpEnableNewEditorSwitchController" />
 	</Extension>
 
 	<Extension path="/MonoDevelop/Ide/Commands">

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewDisplayBinding.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewDisplayBinding.cs
@@ -41,10 +41,6 @@ namespace MonoDevelop.TextEditor
 
 		protected override IEnumerable<DocumentControllerDescription> GetSupportedControllers (FileDescriptor modelDescriptor)
 		{
-			if (!DefaultSourceEditorOptions.Instance.EnableNewEditor) {
-				yield break;
-			}
-
 			var nodes = Mono.Addins.AddinManager.GetExtensionNodes<SupportedFileTypeExtensionNode> ("/MonoDevelop/TextEditor/SupportedFileTypes");
 
 			bool supported =


### PR DESCRIPTION
Fix AB#918947

Additionally this PR removes the entries for XAML and Android resource files which are now exported by their respective addins.

Backport of #7929.

/cc @abock @garuma