### PR TITLE
Bump Roslyn to 3.2.0-beta4-19317-08

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -17,7 +17,7 @@
     <NuGetVersionNewtonsoftJson>10.0.3</NuGetVersionNewtonsoftJson>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
-    <NuGetVersionRoslyn>3.2.0-beta4-19312-10</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.2.0-beta4-19317-08</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>


### PR DESCRIPTION
FYI @sandyarmstrong

Changes since [2e7c46d683](https://www.github.com/dotnet/roslyn/commit/2e7c46d683):
- [Merge pull request #36345 from jasonmalinowski/unskip-test](https://www.github.com/dotnet/roslyn/pull/36345)
- [Add option to emit nullable metadata for public members only (#36398)](https://www.github.com/dotnet/roslyn/pull/36398)
- [Added null checks on F# external access services (#36469)](https://www.github.com/dotnet/roslyn/pull/36469)
- [Merge pull request #36465 from dotnet/revert-36006-extract_open_file_tracker](https://www.github.com/dotnet/roslyn/pull/36465)
- [Merge pull request #36463 from tmeschter/ShortenLongResourceID-190614](https://www.github.com/dotnet/roslyn/pull/36463)
- [Merge pull request #36462 from dotnet/dev/jorobich/add-wpf-reference](https://www.github.com/dotnet/roslyn/pull/36462)
- [Merge pull request #36433 from dpoeschl/NamingSpecificationsLoc](https://www.github.com/dotnet/roslyn/pull/36433)
- [Ensure NullableWalker.AsMemberOfType locates the right new container for the member. (#36406)](https://www.github.com/dotnet/roslyn/pull/36406)
- [ Replace `dynamic` with `object` when substituting constraints. (#36379)](https://www.github.com/dotnet/roslyn/pull/36379)
- [Adjust type of out var based on parameter state (#36284)](https://www.github.com/dotnet/roslyn/pull/36284)
- [Merge pull request #36380 from Andrew-Hanlon/master](https://www.github.com/dotnet/roslyn/pull/36380)
- [Merge pull request #36283 from JoeRobich/reduce-dependencies](https://www.github.com/dotnet/roslyn/pull/36283)
- [move to sha2 (#36399)](https://www.github.com/dotnet/roslyn/pull/36399)
- [Merge pull request #36006 from dibarbet/extract_open_file_tracker](https://www.github.com/dotnet/roslyn/pull/36006)
- [Propogate nullable type information for EncapsulateFieldService (#36286)](https://www.github.com/dotnet/roslyn/pull/36286)
- [ISymbol - added missing tag (#36386)](https://www.github.com/dotnet/roslyn/pull/36386)
- [Update PublishData.json for divisional snap (#36382)](https://www.github.com/dotnet/roslyn/pull/36382)
- [Remove support for explicit `object` generic type constraints (#36269)](https://www.github.com/dotnet/roslyn/pull/36269)
- [Allow EnCWhileDebuggingFromImmediateWindow to fail in 16.2 Preview (#36402)](https://www.github.com/dotnet/roslyn/pull/36402)
- [Move DIM proposal to C# 8 folder (#36332)](https://www.github.com/dotnet/roslyn/pull/36332)
- [Update some LDM champs from 7.3 (#36186)](https://www.github.com/dotnet/roslyn/pull/36186)
- [Merge pull request #36173 from jasonmalinowski/fix-generate-field-nullability](https://www.github.com/dotnet/roslyn/pull/36173)
- [Optimize indexer access of an inline range expression (#36147)](https://www.github.com/dotnet/roslyn/pull/36147)
- [Fix namespace for nullable annotations attributes (#36369)](https://www.github.com/dotnet/roslyn/pull/36369)
- [Override completion must not include parameter attributes (#36163)](https://www.github.com/dotnet/roslyn/pull/36163)
- [Report passing a maybe-null int? to [DisallowNull] parameter (#36263)](https://www.github.com/dotnet/roslyn/pull/36263)
- [Dont try and check tuple conversions in error cases: (#36188)](https://www.github.com/dotnet/roslyn/pull/36188)
- [Merge pull request #36326 from sharwell/pattern-object](https://www.github.com/dotnet/roslyn/pull/36326)