### PR TITLE
Add IVT to the new WebEditors addin.

### DIFF
--- a/main/msbuild/ReferencesVSEditor.Windows.props
+++ b/main/msbuild/ReferencesVSEditor.Windows.props
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(NuGetVersionVSEditor)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="$(NuGetVersionRoslyn)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(NuGetVersionVSEditor)" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
-    <PackageReference Include="Microsoft.VisualStudio.InteractiveWindow" Version="2.0.0-rc3-61304-01" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
+    <PackageReference Include="Microsoft.VisualStudio.InteractiveWindow" Version="2.8.0" PrivateAssets="$(ReferencesVSEditorPrivateAssets)" ExcludeAssets="$(ReferencesVSEditorExcludeAssets)" />
     <PackageReference Include="Microsoft.CodeAnalysis.InteractiveHost" Version="$(NuGetVersionRoslyn)" ExcludeAssets="all" />
   </ItemGroup>
 

--- a/main/src/core/MonoDevelop.Ide/AssemblyInfo.cs
+++ b/main/src/core/MonoDevelop.Ide/AssemblyInfo.cs
@@ -8,3 +8,5 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription ("The MonoDevelop IDE application.")]
 [assembly: AssemblyVersion ("2.6")]
 [assembly: AssemblyCopyright ("LGPL")]
+
+[assembly: InternalsVisibleTo("WebEditors, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]


### PR DESCRIPTION
It uses the Microsoft public key, so we can't just use the MSBuild InternalsVisibleTo item, because it presupposes the MonoDevelop public key.

Also fix Windows build while i'm at it.