### PR TITLE
Add an extension point to provide projection buffers during text view construction

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Extensions/IProjectionBufferProvider.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Extensions/IProjectionBufferProvider.cs
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corp. (https://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace Microsoft.VisualStudio.Text.Projection
+{
+	/// <summary>
+	/// An extension point for the text view construction process to provide
+	/// a surface projection buffer for the ITextDataModel.
+	/// Razor provides an implementation that returns the top HtmlxProjection
+	/// buffer, which projects into C#, CSS, JavaScript, inert and ultimately
+	/// RazorCoreCSharp (disk buffer).
+	/// </summary>
+	public interface IProjectionBufferProvider
+	{
+		/// <summary>
+		/// Given the disk buffer (bottom buffer) return an optional projection buffer
+		/// to use as the top buffer (surface buffer) in the buffer graph.
+		/// </summary>
+		/// <param name="diskBuffer">Buffer that corresponds to the text document on disk.</param>
+		/// <param name="projectionBuffer">Buffer that should be used as the surface buffer of the text view.</param>
+		/// <returns>true if the projection buffer was provided, false to fall back to the default (no projection).</returns>
+		bool TryGetProjectionBuffer (ITextBuffer diskBuffer, out ITextBuffer projectionBuffer);
+	}
+}

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -131,9 +131,18 @@ namespace MonoDevelop.TextEditor
 			UpdateTextBufferRegistration ();
 
 			var roles = GetAllPredefinedRoles ();
+
+			ITextBuffer projectionBuffer = null;
+			foreach (var projectionBufferProvider in Imports.ProjectionBufferProviders) {
+				if (projectionBufferProvider.Value.TryGetProjectionBuffer (TextBuffer, out projectionBuffer)) {
+					break;
+				}
+			}
+
+			var dataModel = new ProjectionTextDataModel (TextBuffer, projectionBuffer);
+
 			//we have multiple copies of VacuousTextDataModel for back-compat reasons
 #pragma warning disable CS0436 // Type conflicts with imported type
-			var dataModel = new VacuousTextDataModel (TextBuffer);
 			var viewModel = UIExtensionSelector.InvokeBestMatchingFactory (
 				Imports.TextViewModelProviders,
 				dataModel.ContentType,

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewImports.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewImports.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Find;
+using Microsoft.VisualStudio.Text.Projection;
 
 namespace MonoDevelop.TextEditor
 {
@@ -50,6 +51,9 @@ namespace MonoDevelop.TextEditor
 
 		[ImportMany]
 		public List<Lazy<ITextViewModelProvider, IContentTypeAndTextViewRoleMetadata>> TextViewModelProviders { get; set; }
+
+		[ImportMany]
+		public List<Lazy<IProjectionBufferProvider>> ProjectionBufferProviders { get; set; }
 
 		[Import]
 		public IGuardedOperations GuardedOperations { get; set; }

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Text.Editor
 		public event EventHandler<TextDataModelContentTypeChangedEventArgs> ContentTypeChanged;
 
 		public ITextBuffer DocumentBuffer { get; }
-		public ITextBuffer DataBuffer { get; private set; }
+		public ITextBuffer DataBuffer { get; set; }
 
 		public IContentType ContentType => DocumentBuffer.ContentType;
 

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
@@ -1,0 +1,49 @@
+//
+// Copyright (c) Microsoft Corp. (https://www.microsoft.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Text.Editor
+{
+	public class ProjectionTextDataModel : ITextDataModel
+	{
+		public ProjectionTextDataModel (ITextBuffer diskBuffer, ITextBuffer projectedBuffer = null)
+		{
+			projectedBuffer = projectedBuffer ?? diskBuffer ?? throw new ArgumentNullException (nameof (diskBuffer));
+			DataBuffer = projectedBuffer;
+			DocumentBuffer = diskBuffer;
+			diskBuffer.ContentTypeChanged += OnDocumentBufferContentTypeChanged;
+		}
+
+		public event EventHandler<TextDataModelContentTypeChangedEventArgs> ContentTypeChanged;
+
+		public ITextBuffer DocumentBuffer { get; private set; }
+		public ITextBuffer DataBuffer { get; private set; }
+
+		public IContentType ContentType => DocumentBuffer.ContentType;
+
+		private void OnDocumentBufferContentTypeChanged (object sender, ContentTypeChangedEventArgs e)
+		{
+			ContentTypeChanged?.Invoke (this, new TextDataModelContentTypeChangedEventArgs (e.BeforeContentType, e.AfterContentType));
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
@@ -24,7 +24,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Text.Editor
 {
-	public class ProjectionTextDataModel : ITextDataModel
+	sealed class ProjectionTextDataModel : ITextDataModel
 	{
 		public ProjectionTextDataModel (ITextBuffer diskBuffer, ITextBuffer projectedBuffer = null)
 		{

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Text.Editor
 
 		public event EventHandler<TextDataModelContentTypeChangedEventArgs> ContentTypeChanged;
 
-		public ITextBuffer DocumentBuffer { get; private set; }
+		public ITextBuffer DocumentBuffer { get; }
 		public ITextBuffer DataBuffer { get; private set; }
 
 		public IContentType ContentType => DocumentBuffer.ContentType;

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Util/ProjectionTextDataModel.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Text.Editor
 		public event EventHandler<TextDataModelContentTypeChangedEventArgs> ContentTypeChanged;
 
 		public ITextBuffer DocumentBuffer { get; }
-		public ITextBuffer DataBuffer { get; set; }
+		public ITextBuffer DataBuffer { get; }
 
 		public IContentType ContentType => DocumentBuffer.ContentType;
 


### PR DESCRIPTION
This will be used by the new web editors to provide the surface Htmlx buffer for .cshtml views.

If the projection buffer is not specified the behavior is identical to the regular vanilla VacuousTextDataModel.