### PR TITLE
 TextViewContent: Show column rulers, including new editorconfig value

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/ThemeToClassification.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/ThemeToClassification.cs
@@ -206,6 +206,7 @@ namespace MonoDevelop.TextEditor
 			// all the themes expect that. Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/804158
 			CreateResourceDictionary (editorFormat, defaultSettings, "CurrentLineActiveFormat", EditorThemeColors.LineHighlight, EditorFormatDefinition.BackgroundColorId);
 			CreateResourceDictionary (editorFormat, defaultSettings, "Block Structure Adornments", EditorThemeColors.IndentationGuide);
+			CreateResourceDictionary (editorFormat, defaultSettings, "RulerFormat", EditorThemeColors.Ruler);
 			CreateResourceDictionary (editorFormat, defaultSettings, "NavigableSymbolFormat", EditorThemeColors.Link, EditorFormatDefinition.ForegroundColorId);
 			CreateResourceDictionary (editorFormat, defaultSettings, "urlformat", EditorThemeColors.Link, EditorFormatDefinition.ForegroundColorId);
 			CreateResourceDictionary (editorFormat, defaultSettings, "Track Changes before save", EditorThemeColors.QuickDiffDirty);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/EditorConfigService.cs
@@ -39,6 +39,8 @@ namespace MonoDevelop.Ide.Editor
 	static class EditorConfigService
 	{
 		public readonly static string MaxLineLengthConvention = "max_line_length";
+		public readonly static string RulersConvention = "rulers";
+
 		readonly static object contextCacheLock = new object ();
 		readonly static ICodingConventionsManager codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager (new ConventionsFileManager());
 		static ImmutableDictionary<string, ICodingConventionContext> contextCache = ImmutableDictionary<string, ICodingConventionContext>.Empty;


### PR DESCRIPTION
Prefer new `rulers` value from editorconfig, which allows setting
multiple vertical rulers (like in vscode).

Then, check `max_line_length` like the old editor does.

Finally, use the VSmac preference/policy system.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/798040