### PR TITLE
Services.CounterReport() - increase array size to hold all 16 counters

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Services.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.Ide
 
 		public static string[] CounterReport ()
 		{
-			string[] reports = new string[15];
+			string[] reports = new string[16];
 			reports [0] = Initialization.ToString ();
 			reports [1] = OpenDocuments.ToString ();
 			reports [2] = DocumentsInMemory.ToString ();


### PR DESCRIPTION
Services.CounterReport() tries to insert 16 counters in the array, but the predefined array size is just 15 which leads to `IndexOutOfBoundsException`