### PR TITLE
[release-8.2] C#: Add some missing options

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormattingPanel.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormattingPanel.cs
@@ -65,6 +65,8 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 			readonly CheckBox formatOnCloseBraceCheckBox;
 			readonly CheckBox formatOnReturnCheckBox;
 			readonly CheckBox formatOnPasteCheckBox;
+			readonly CheckBox showFilterButtonsCheckBox;
+			readonly CheckBox triggerCompletionOnDeletionCheckBox;
 			readonly Ide.RoslynServices.Options.RoslynPreferences.PerLanguagePreferences preferences;
 
 			public OnTheFlyFormattingPanelWidget ()
@@ -95,6 +97,14 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 				formatOnPasteCheckBox.Active = preferences.FormatOnPaste;
 				PackStart (formatOnPasteCheckBox);
 				FormatOnTypeCheckBox_Toggled (this, EventArgs.Empty);
+
+				showFilterButtonsCheckBox = new CheckBox (GettextCatalog.GetString ("Show completion item filters"));
+				showFilterButtonsCheckBox.Active = preferences.ShowCompletionItemFilters;
+				PackStart (showFilterButtonsCheckBox);
+
+				triggerCompletionOnDeletionCheckBox = new CheckBox (GettextCatalog.GetString ("Show completion list after a character is deleted"));
+				triggerCompletionOnDeletionCheckBox.Active = preferences.TriggerOnDeletion.Value ?? false;
+				PackStart (triggerCompletionOnDeletionCheckBox);
 			}
 
 			void FormatOnTypeCheckBox_Toggled (object sender, System.EventArgs e)
@@ -110,6 +120,8 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 				preferences.AutoFormattingOnCloseBrace.Value = formatOnCloseBraceCheckBox.Active;
 				preferences.AutoFormattingOnReturn.Value = formatOnReturnCheckBox.Active;
 				preferences.FormatOnPaste.Value = formatOnPasteCheckBox.Active;
+				preferences.ShowCompletionItemFilters.Value = showFilterButtonsCheckBox.Active;
+				preferences.TriggerOnDeletion.Value = triggerCompletionOnDeletionCheckBox.Active;
 				PropertyService.SaveProperties ();
 
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
@@ -72,9 +72,11 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			public readonly ConfigurationProperty<bool> FormatOnPaste;
 			public readonly ConfigurationProperty<bool> PlaceSystemNamespaceFirst;
 			public readonly ConfigurationProperty<bool> SeparateImportDirectiveGroups;
+			public readonly ConfigurationProperty<bool> ShowCompletionItemFilters;
 			public readonly ConfigurationProperty<bool?> ShowItemsFromUnimportedNamespaces;
 			public readonly ConfigurationProperty<bool> SuggestForTypesInNuGetPackages;
 			public readonly ConfigurationProperty<bool> SolutionCrawlerClosedFileDiagnostic;
+			public readonly ConfigurationProperty<bool?> TriggerOnDeletion;
 
 			internal PerLanguagePreferences (string language, RoslynPreferences preferences)
 			{
@@ -115,6 +117,11 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 					language + ".SeparateImportDirectiveGroups"
 				);
 
+				ShowCompletionItemFilters = preferences.Wrap<bool> (
+					new OptionKey (CompletionOptions.ShowCompletionItemFilters, language),
+					language + ".ShowCompletionItemFilters"
+				);
+
 				ShowItemsFromUnimportedNamespaces = preferences.Wrap<bool?> (
 					new OptionKey (CompletionOptions.ShowItemsFromUnimportedNamespaces, language),
 					IdeApp.Preferences.AddImportedItemsToCompletionList.Value,
@@ -129,6 +136,11 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 				SolutionCrawlerClosedFileDiagnostic = new ClosedFileDiagnosticProperty (preferences.Wrap<bool?> (
 					new OptionKey (ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language)
 				), language, roslynPreferences);
+
+				TriggerOnDeletion = preferences.Wrap<bool?> (
+					new OptionKey (CompletionOptions.TriggerOnDeletion, language),
+					language + ".TriggerOnDeletion"
+				);
 			}
 
 			class ClosedFileDiagnosticProperty : ConfigurationProperty<bool>


### PR DESCRIPTION
* ShowCompletionItemFilters (new UI landing in editor)
* TriggerOnDeletion (forced in old editor, configurable in new)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/914033

Backport of #7976.

/cc @sandyarmstrong 