### PR TITLE
[release-8.2] Fixes VSTS #934603 - Improve padding of InfoBar items when no button is present

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -47,6 +47,7 @@ namespace MonoDevelop.Ide.Gui.Components
 
 			var mainBox = new HBox {
 				BackgroundColor = Styles.NotificationBar.BarBackgroundColor,
+				MinHeight = 30
 			};
 
 			mainBox.PackStart (new ImageView (ImageService.GetIcon (Stock.Information, Gtk.IconSize.Menu)), marginLeft: 11);


### PR DESCRIPTION
The InfoBar padding is different for bars with buttons and those without.

<img width="1685" alt="Screen Shot 2019-06-19 at 9 51 03 PM" src="https://user-images.githubusercontent.com/898335/59813132-5fd99200-92de-11e9-8906-ddc2beb7fcc4.png">

<img width="1695" alt="Screen Shot 2019-06-19 at 9 59 14 PM" src="https://user-images.githubusercontent.com/898335/59813139-6700a000-92de-11e9-9ef6-ade80d964270.png">

By setting a `MinHeight` on the inner InfoBar HBox, we can have the same padding appear for both, making them consistent.

<img width="1684" alt="Screen Shot 2019-06-19 at 10 01 14 PM" src="https://user-images.githubusercontent.com/898335/59813157-80a1e780-92de-11e9-8884-2c478d13c08e.png">

<img width="1686" alt="Screen Shot 2019-06-19 at 9 56 56 PM" src="https://user-images.githubusercontent.com/898335/59813163-85ff3200-92de-11e9-9369-ead271da68e6.png">

Fixes VSTS #934603 - Improve padding of InfoBar items when no button is present

 

Backport of #7964.

/cc @sevoku @drasticactions