### PR TITLE
[release-8.1] Fixes exception trying to call terminal.app from Catalina

### DIFF
--- a/main/src/addins/MacPlatform/MacExternalConsoleProcess.cs
+++ b/main/src/addins/MacPlatform/MacExternalConsoleProcess.cs
@@ -80,12 +80,18 @@ using exec -a to name the process has problems because the terminal can get into
 where running an explicit exec causes it to quit after the exec runs, so we can't use the 
 bash pause on exit trick
 */ 
-
 		//use full path to fix command failure when users have another app called "Terminal"
 		//this happens with Parallels exporting a stub for the Unbuntu "Terminal"
-		const string TERMINAL_APP = "/Applications/Utilities/Terminal.app";
+		const string TERMINAL_APP_PATH = "/Applications/Utilities/Terminal.app";
+
+		//Terminal default path was changes after MacOS Catalina (10.15)
+		const string TERMINAL_APP_CATALINA_PATH = "/System/Applications/Utilities/Terminal.app";
 
 		string windowId;
+
+		//TODO: This path is strongly typed and could change it easily by user
+		static string TERMINAL_APP = MacSystemInformation.OsVersion >= MacSystemInformation.Catalina ?
+			 TERMINAL_APP_CATALINA_PATH : TERMINAL_APP_PATH;
 
 		public MacExternalConsoleProcess (string command, string arguments, string workingDirectory,
 			IDictionary<string, string> environmentVariables,

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/MacSystemInformation.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/MacSystemInformation.cs
@@ -30,6 +30,7 @@ namespace MonoDevelop.Core
 {
 	public class MacSystemInformation : UnixSystemInformation
 	{
+		public static readonly Version Catalina = new Version (10, 15);
 		public static readonly Version Mojave = new Version (10, 14);
 		public static readonly Version HighSierra = new Version (10, 13);
 		public static readonly Version Sierra = new Version (10, 12);


### PR DESCRIPTION
This problem arises when trying to Debug / Run a normal console application.

The exception:
![image](https://user-images.githubusercontent.com/1587480/59783010-77555280-92bf-11e9-9342-c64ef5404261.png)


This was caused by the fact that the Terminal.app has changed in Catalina and it's now in:
/System/Applications/Utilities/Terminal.app


With the fix:

![lola](https://user-images.githubusercontent.com/1587480/59780577-84bc0e00-92ba-11e9-9106-ca3b7dc4e53c.gif)


Fixes VSTS #918848 - [Catalina] Cannot debug a normal console application


Backport of #7954.

/cc @sevoku @netonjm