### PR TITLE
[release-8.2] Add some null checks that would prevent showing an info bar if an item array wasn't passed.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -32,7 +32,7 @@ using Xwt.Drawing;
 
 namespace MonoDevelop.Ide.Gui.Components
 {
-	class XwtInfoBar : Widget
+	sealed class XwtInfoBar : Widget
 	{
 		static Image closeImage = Image.FromResource ("pad-close-9.png");
 		static Image closeImageInactive = Image.FromResource ("pad-close-9.png").WithAlpha (0.5);
@@ -43,6 +43,8 @@ namespace MonoDevelop.Ide.Gui.Components
 
 		public XwtInfoBar (string description, Action onDispose, params InfoBarItem[] items)
 		{
+			items ??= Array.Empty<InfoBarItem> ();
+
 			this.onDispose = onDispose;
 
 			var mainBox = new HBox {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopInfoBarService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopInfoBarService.cs
@@ -23,6 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+using System;
 using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor;
@@ -72,11 +73,9 @@ namespace MonoDevelop.Ide.RoslynServices
 					infoBarHost.AddInfoBar (options);
 				}
 			}, _listener.BeginAsyncOperation (nameof (ShowInfoBar)));
-		}
 
-		static InfoBarItem [] ToUIItems (InfoBarUI [] items)
-		{
-			return items.Select (x => new InfoBarItem (x.Title, ToUIKind (x.Kind), x.Action, x.CloseAfterAction)).ToArray ();
+			static InfoBarItem [] ToUIItems (InfoBarUI [] items)
+				=> items?.Select (x => new InfoBarItem (x.Title, ToUIKind (x.Kind), x.Action, x.CloseAfterAction)).ToArray ();
 		}
 
 		static InfoBarItemKind ToUIKind (InfoBarUI.UIKind kind)


### PR DESCRIPTION


Backport of #7965.

/cc @Therzok 