### PR TITLE
Fixes VSTS Bug 935392: System.NullReferenceException exception in

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -99,7 +99,7 @@ namespace MonoDevelop.SourceEditor
 
 		internal ExtensibleTextEditor TextEditor {
 			get {
-				return widget.TextEditor;
+				return widget?.TextEditor;
 			}
 		}
 
@@ -3400,10 +3400,13 @@ namespace MonoDevelop.SourceEditor
 
 		void ITextEditorImpl.GrabFocus ()
 		{
-			var topLevelWindow = this.TextEditor.Toplevel as Gtk.Window;
+			var editor = this.TextEditor;
+			if (editor == null)
+				return;
+			var topLevelWindow = editor.Toplevel as Gtk.Window;
 			if (topLevelWindow != null)
 				topLevelWindow.Present ();
-			this.TextEditor.GrabFocus ();
+			editor.GrabFocus ();
 		}
 
 		void ITextEditorImpl.ShowTooltipWindow (Components.Window window, TooltipWindowOptions options)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -930,6 +930,8 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		internal void GrabFocusForView (DocumentView view)
 		{
+			if (disposed)
+				return;
 			if (linkedController != null)
 				linkedController?.GrabFocusForView (view);
 			else

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -260,6 +260,9 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 			await Task.Yield ();
 
+			if (disposed)
+				return;
+
 			if (SourceController != null)
 				SourceController.GrabFocusForView (this);
 			else


### PR DESCRIPTION
MonoDevelop.SourceEditor.SourceEditorView.MonoDevelop.Ide.Editor.ITextEditorImpl.GrabFocus()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935392

Without a repro it's hard to tell where that happens. I added dispose
checks & a null check on different levels of the call. It's caused by
the document level - GrabFocus beeing called on a disposed editor.