### PR TITLE
Fixes VSTS Bug 936228: Exact match and regex match mimetypes no longer

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/FileNameEvalutor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Extensions/FileNameEvalutor.cs
@@ -54,6 +54,16 @@ namespace MonoDevelop.Ide.Extensions
 
 		public abstract bool SupportsFile (string fileName);
 
+		static string SafeGetFileName (string fileName)
+		{
+			try {
+				return System.IO.Path.GetFileName (fileName);
+			} catch (Exception e) {
+				LoggingService.LogInternalError (e);
+				return fileName;
+			}
+		}
+
 		class RegexFileNameEvaluator : FileNameEvalutor
 		{
 			Regex regex;
@@ -81,7 +91,7 @@ namespace MonoDevelop.Ide.Extensions
 
 			public override bool SupportsFile (string fileName)
 			{
-				return regex.IsMatch (fileName);
+				return regex.IsMatch (SafeGetFileName (fileName));
 			}
 		}
 
@@ -133,6 +143,7 @@ namespace MonoDevelop.Ide.Extensions
 
 			public override bool SupportsFile (string fileName)
 			{
+				fileName = SafeGetFileName (fileName);
 				foreach (var name in names)
 					if (name.Equals (fileName, StringComparison.OrdinalIgnoreCase))
 						return true;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/FileNameEvaluatorTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/FileNameEvaluatorTests.cs
@@ -75,5 +75,19 @@ namespace MonoDevelop.Ide
 				new string[] { "base.test", }
 			).SetName ("test"),
 		};
+
+		/// <summary>
+		/// Bug 936228: Exact match and regex match mimetypes no longer match
+		/// </summary>
+		[Test]
+		public void TestVSTSBug936228 ()
+		{
+			var evaluator = FileNameEvalutor.CreateFileNameEvaluator (new string [] { "Makefile|Makefile.am|Makefile.in" });
+
+			Assert.IsTrue (evaluator.SupportsFile ("Makefile.am"));
+			Assert.IsTrue (evaluator.SupportsFile ("/Makefile"));
+			Assert.IsTrue (evaluator.SupportsFile ("/a/b/Makefile.in"));
+			Assert.IsFalse (evaluator.SupportsFile ("NoMakefile.am"));
+		}
 	}
 }


### PR DESCRIPTION
match

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/936228

The file name evaluator didn't take the full path - it only worked
with file name. Which is an unusual API. I changed it that it works
with full path as well so a future mis-use of the API is prevented.