### PR TITLE
[release-8.2] Fixes VSTS Bug 930131: [Watson] NullReferenceException in

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1204,9 +1204,10 @@ namespace MonoDevelop.MacIntegration
 		internal override void RemoveWindowShadow (Gtk.Window window)
 		{
 			if (window == null)
-				throw new ArgumentNullException ("window");
-			NSWindow w = GtkQuartz.GetWindow (window);
-			w.HasShadow = false;
+				throw new ArgumentNullException (nameof(window));
+			var w = GtkQuartz.GetWindow (window);
+			if (w != null)
+				w.HasShadow = false;
 		}
 
 		internal override IMainToolbarView CreateMainToolbar (Gtk.Window window)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PopoverWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PopoverWindow.cs
@@ -245,9 +245,12 @@ namespace MonoDevelop.Components
 			QueueResize ();
 		}
 
+		bool IsDestroyed { get; set; }
+
 		protected override void OnDestroyed ()
 		{
 			this.AbortAnimation ("Resize");
+			IsDestroyed = true;
 			base.OnDestroyed ();
 		}
 
@@ -277,7 +280,7 @@ namespace MonoDevelop.Components
 
 		public virtual void RepositionWindow (Gdk.Rectangle? newCaret = null)
 		{
-			if (!HasParent)
+			if (!HasParent || IsDestroyed)
 				return;
 
 			if (newCaret.HasValue) {//Update caret if parameter is given
@@ -399,7 +402,7 @@ namespace MonoDevelop.Components
 
 			Move (x, y);
 			Show ();
-			if (!ShowWindowShadow)
+			if (!ShowWindowShadow && !IsDestroyed)
 				IdeServices.DesktopService.RemoveWindowShadow (this);
 		}
 		


### PR DESCRIPTION
MonoDevelop.MacIntegration.MacPlatformService.RemoveWindowShadow

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/930131

Hard to tell how that happened - but added some checks that should
prevent the exception.

Backport of #7968.

/cc @sevoku @mkrueger