### PR TITLE
[release-8.2] [Shell] Fix fatal error changing keybindings prefs to ReSharper 

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -564,8 +564,7 @@ namespace MonoDevelop.Components.Commands
 				if (cinfo.Enabled && cinfo.Visible) {
 					if (!dispatched)
 						dispatched = DispatchCommand (command.Id, null, null, CommandSource.Keybinding, ev.Time, cinfo);
-					if (command != null)
-						conflict.Add (command);
+					conflict.Add (command);
 				} else
 					bypass = true; // allow Gtk to handle the event if the command is disabled
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -552,7 +552,8 @@ namespace MonoDevelop.Components.Commands
 			var dispatched = false;
 
 			for (int i = 0; i < commands.Count; i++) {
-				CommandInfo cinfo = GetCommandInfo (commands[i].Id, new CommandTargetRoute ());
+				Command command = commands [i];
+				CommandInfo cinfo = GetCommandInfo (command.Id, new CommandTargetRoute ());
 				if (cinfo.IsUpdatingAsynchronously)
 					cinfo.UpdateTask.Wait (); // Not nice, but we need a synchronous result here
 				if (cinfo.Bypass) {
@@ -562,8 +563,9 @@ namespace MonoDevelop.Components.Commands
 
 				if (cinfo.Enabled && cinfo.Visible) {
 					if (!dispatched)
-						dispatched = DispatchCommand (commands [i].Id, null, null, CommandSource.Keybinding, ev.Time, cinfo);
-					conflict.Add (commands [i]);
+						dispatched = DispatchCommand (command.Id, null, null, CommandSource.Keybinding, ev.Time, cinfo);
+					if (command != null)
+						conflict.Add (command);
 				} else
 					bypass = true; // allow Gtk to handle the event if the command is disabled
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -552,8 +552,7 @@ namespace MonoDevelop.Components.Commands
 			var dispatched = false;
 
 			for (int i = 0; i < commands.Count; i++) {
-				Command command = commands [i];
-				CommandInfo cinfo = GetCommandInfo (command.Id, new CommandTargetRoute ());
+				CommandInfo cinfo = GetCommandInfo (commands [i].Id, new CommandTargetRoute ());
 				if (cinfo.IsUpdatingAsynchronously)
 					cinfo.UpdateTask.Wait (); // Not nice, but we need a synchronous result here
 				if (cinfo.Bypass) {
@@ -563,8 +562,10 @@ namespace MonoDevelop.Components.Commands
 
 				if (cinfo.Enabled && cinfo.Visible) {
 					if (!dispatched)
-						dispatched = DispatchCommand (command.Id, null, null, CommandSource.Keybinding, ev.Time, cinfo);
-					conflict.Add (command);
+						dispatched = DispatchCommand (commands [i].Id, null, null, CommandSource.Keybinding, ev.Time, cinfo);
+					if (!bindings.BindingExists (binding))
+						break;
+					conflict.Add (commands [i]);
 				} else
 					bypass = true; // allow Gtk to handle the event if the command is disabled
 			}


### PR DESCRIPTION
The crash:
```
FATAL ERROR [2019-04-30 14:04:35Z]: Visual Studio failed to start. Some of the assemblies required to run Visual Studio (for example gtk-sharp)may not be properly installed in the GAC.
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
  at System.Collections.Generic.List`1[T].get_Item (System.Int32 index) [0x0000e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/List.cs:163 
  at MonoDevelop.Components.Commands.CommandManager.ProcessKeyEventCore (Gdk.EventKey ev) [0x0016e] in /Users/vsts/agent/2.150.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:544 
  at MonoDevelop.Components.Commands.CommandManager.ProcessKeyEvent (Gdk.EventKey ev) [0x00000] in /Users/vsts/agent/2.150.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:452 
  at MonoDevelop.Components.Commands.CommandManager.OnNSEventKeyPress (AppKit.NSEvent ev) [0x0006b] in /Users/vsts/agent/2.150.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:352 
  at ObjCRuntime.Trampolines+SDLocalEventHandler.Invoke (System.IntPtr block, System.IntPtr theEvent) [0x00014] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.6.0.25/src/Xamarin.Mac/ObjCRuntime/Trampolines.g.cs:1032 
  at (wrapper native-to-managed) ObjCRuntime.Trampolines+SDLocalEventHandler.Invoke(intptr,intptr)
  at (wrapper managed-to-native) Gtk.Application.gtk_main()
  at Gtk.Application.Run () [0x00001] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:145 
  at MonoDevelop.Ide.IdeStartup.Run (MonoDevelop.Ide.MonoDevelopOptions options) [0x00429] in /Users/vsts/agent/2.150.0/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:216 
```

Fixes VSTS #860275

Backport of #7773.

/cc @sevoku @jsuarezruiz