### PR TITLE
[release-8.2] Fixes VSTS Bug 935202: System.NullReferenceException exception in

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -1004,8 +1004,9 @@ namespace MonoDevelop.Ide.Gui
 		public void ReparseOpenDocuments ()
 		{
 			foreach (var doc in Documents) {
-				if (doc.DocumentContext.ParsedDocument != null)
-					doc.DocumentContext.ReparseDocument ();
+				var ctx = doc.DocumentContext;
+				if (ctx?.ParsedDocument != null)
+					ctx.ReparseDocument ();
 			}
 		}
 


### PR DESCRIPTION
MonoDevelop.Ide.Gui.Workbench.ReparseOpenDocuments()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935202

Backport of #8010.

/cc @slluis @mkrueger