### PR TITLE
[release-8.2] [GetToCode] Adds EnsureInitializedAsync alternative method to wait the initialization from the Ide

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/IWelcomeWindowProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/IWelcomeWindowProvider.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Ide.WelcomePage
 	public interface IWelcomeWindowProvider
 	{
 		Task ShowWindow (WelcomeWindowShowOptions options);
-		void HideWindow ();
+		Task HideWindow ();
 		bool IsWindowVisible { get; }
 		Window WindowInstance { get; }
 	}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.WelcomePage/WelcomePageService.cs
@@ -105,14 +105,13 @@ namespace MonoDevelop.Ide.WelcomePage
 			}
 		}
 
-		public static void HideWelcomePageOrWindow ()
+		public static async void HideWelcomePageOrWindow ()
 		{
 			if (WelcomeWindowProvider != null) {
-				WelcomeWindowProvider.HideWindow ();
+				await WelcomeWindowProvider.HideWindow ();
 			} else {
 				HideWelcomePage (true);
 			}
-
 			visible = false;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -295,6 +295,11 @@ namespace MonoDevelop.Ide
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/StartupHandlers", OnExtensionChanged);
 		}
 
+		public static Task EnsureInitializedAsync ()
+		{
+			return initializationTask.Task;
+		}
+
 		public static void BringToFront ()
 		{
 			Initialized += (sender, e) => {


### PR DESCRIPTION
Adds EnsureInitializedAsync alternative method to wait the initialization from the Ide

This PR is necessary in: https://github.com/xamarin/md-addins/pull/4855

Backport of #7771.

/cc @sevoku @netonjm