### PR TITLE
Bump Roslyn to 3.2.0-beta4-19324-01

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -17,7 +17,7 @@
     <NuGetVersionNewtonsoftJson>10.0.3</NuGetVersionNewtonsoftJson>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
-    <NuGetVersionRoslyn>3.2.0-beta4-19317-08</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.2.0-beta4-19324-01</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormatter.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormatter.cs
@@ -50,6 +50,7 @@ using MonoDevelop.CSharp.OptionProvider;
 using Microsoft.VisualStudio.CodingConventions;
 using System.Linq;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 
 namespace MonoDevelop.CSharp.Formatting
 {
@@ -159,6 +160,9 @@ namespace MonoDevelop.CSharp.Formatting
 		{
 			readonly OptionSet optionSet;
 			readonly ICodingConventionsSnapshot codingConventionsSnapshot;
+			private static readonly ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> s_convertedDictionaryCache =
+				new ConditionalWeakTable<IReadOnlyDictionary<string, object>, IReadOnlyDictionary<string, string>> ();
+
 
 			public DocumentOptions (OptionSet optionSet, ICodingConventionsSnapshot codingConventionsSnapshot)
 			{
@@ -166,20 +170,24 @@ namespace MonoDevelop.CSharp.Formatting
 				this.codingConventionsSnapshot = codingConventionsSnapshot;
 			}
 
-			public bool TryGetDocumentOption (OptionKey option, OptionSet underlyingOptions, out object value)
+			public bool TryGetDocumentOption (OptionKey option, out object value)
 			{
 				if (codingConventionsSnapshot != null) {
 					var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation> ().SingleOrDefault ();
 					if (editorConfigPersistence != null) {
-						
-						var tempRawConventions = codingConventionsSnapshot.AllRawConventions;
-						// HACK: temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This will go away in a future commit.
-						// see https://github.com/dotnet/roslyn/commit/6a5be42f026f8d0432cfe8ee7770ff8f6be01bd6#diff-626aa9dd2f6e07eafa8eac7ddb0eb291R34
-						var allRawConventions = ImmutableDictionary.CreateRange (tempRawConventions.Select (c => Roslyn.Utilities.KeyValuePairUtil.Create (c.Key, c.Value.ToString ())));
+						// Temporarly map our old Dictionary<string, object> to a Dictionary<string, string>. This can go away once we either
+						// eliminate the legacy editorconfig support, or we change IEditorConfigStorageLocation.TryGetOption to take
+						// some interface that lets us pass both the Dictionary<string, string> we get from the new system, and the
+						// Dictionary<string, object> from the old system.
+						//
+						// We cache this with a conditional weak table so we're able to maintain the assumptions in EditorConfigNamingStyleParser
+						// that the instance doesn't regularly change and thus can be used for further caching
+						var allRawConventions = s_convertedDictionaryCache.GetValue (
+							codingConventionsSnapshot.AllRawConventions,
+							d => ImmutableDictionary.CreateRange (d.Select (c => KeyValuePairUtil.Create (c.Key, c.Value.ToString ()))));
 
 						try {
-							var underlyingOption = underlyingOptions.GetOption (option);
-							if (editorConfigPersistence.TryGetOption (underlyingOption, allRawConventions, option.Option.Type, out value))
+							if (editorConfigPersistence.TryGetOption (allRawConventions, option.Option.Type, out value))
 								return true;
 						} catch (Exception ex) {
 							LoggingService.LogError ("Error while getting editor config preferences.", ex);
@@ -188,10 +196,6 @@ namespace MonoDevelop.CSharp.Formatting
 				}
 
 				var result = optionSet.GetOption (option);
-				if (result == underlyingOptions.GetOption (option)) {
-					value = null;
-					return false;
-				}
 				value = result;
 				return true;
 			}
@@ -210,7 +214,7 @@ namespace MonoDevelop.CSharp.Formatting
 
 			public override object GetOption (OptionKey optionKey)
 			{
-				if (optionsProvider.TryGetDocumentOption (optionKey, fallbackOptionSet, out object value))
+				if (optionsProvider.TryGetDocumentOption (optionKey, out object value))
 					return value;
 				return fallbackOptionSet.GetOption (optionKey);
 			}

--- a/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TextEditorInitializationService.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/VSEditor/TextEditorInitializationService.cs
@@ -66,6 +66,9 @@ namespace Microsoft.VisualStudio.Text.Editor.Implementation
         internal ITextSearchService2 TextSearchService { get; set; }
 
         [Import]
+        internal IFeatureServiceFactory FeatureServiceFactory { get; set; }
+
+        [Import]
         internal ITextStructureNavigatorSelectorService TextStructureNavigatorSelectorService { get; set; }
 
         [Import]
@@ -140,6 +143,8 @@ namespace Microsoft.VisualStudio.Text.Editor.Implementation
             view.Initialize(viewModel, roles, this.EditorOptionsFactoryService.GlobalOptions, this);
             view.Properties.AddProperty(typeof(MonoDevelop.Ide.Editor.TextEditor), textEditor);
 
+            FeatureServiceFactory.GetOrCreate(view).Disable(PredefinedEditorFeatureNames.AsyncCompletion, EmptyFeatureController.Instance);
+
             this.TextViewCreated?.Invoke(this, new TextViewCreatedEventArgs(view));
 
             return view;
@@ -189,6 +194,15 @@ namespace Microsoft.VisualStudio.Text.Editor.Implementation
             for (int i = 0; (i < orderedManagers.Count); ++i)
             {
                 this.OrderedSpaceReservationManagerDefinitions.Add(orderedManagers[i].Metadata.Name, i);
+            }
+        }
+
+        sealed class EmptyFeatureController : IFeatureController
+        {
+            internal static readonly EmptyFeatureController Instance = new EmptyFeatureController();
+
+            private EmptyFeatureController()
+            {
             }
         }
     }

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -238,12 +238,6 @@ namespace MonoDevelop.TextEditor
 				textBufferRegistration = IdeServices.TypeSystemService.RegisterOpenDocument (Owner, FilePath, TextBuffer);
 		}
 
-		protected override void OnGrabFocus (DocumentView view)
-		{
-			DefaultSourceEditorOptions.SetUseAsyncCompletion (true);
-			base.OnGrabFocus (view);
-		}
-
 		protected override void OnFileNameChanged ()
 		{
 			base.OnFileNameChanged ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DefaultSourceEditorOptions.cs
@@ -993,20 +993,6 @@ namespace MonoDevelop.Ide.Editor
 		}
 
 		public event EventHandler Changed;
-
-		/// <summary>
-		/// This is to allow setting UseAsyncCompletion to true for the Cocoa editor and to false for the Gtk editor.
-		/// Currently Roslyn doesn't allow setting this option per view, so we have to work around.
-		/// See here for details: https://github.com/dotnet/roslyn/issues/33807
-		/// </summary>
-		internal static void SetUseAsyncCompletion(bool useAsyncCompletion)
-		{
-			var asyncCompletionService = Composition.CompositionManager.Instance.GetExportedValue<Microsoft.CodeAnalysis.Editor.IAsyncCompletionService> ();
-			var field = asyncCompletionService.GetType ().GetField (
-				"_newCompletionAPIEnabled",
-				System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-			field.SetValue (asyncCompletionService, useAsyncCompletion);
-		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -397,11 +397,6 @@ namespace MonoDevelop.Ide.Editor
 		protected override void OnGrabFocus (DocumentView view)
 		{
 			textEditor.GrabFocus ();
-			try {
-				DefaultSourceEditorOptions.SetUseAsyncCompletion (false);
-			} catch (Exception e) {
-				LoggingService.LogInternalError ("Error while setting up async completion.", e);
-			}
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TextPolicyDocumentOptionsProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TextPolicyDocumentOptionsProvider.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				this.policy = policy;
 			}
 
-			public bool TryGetDocumentOption (OptionKey option, OptionSet underlyingOptions, out object value)
+			public bool TryGetDocumentOption (OptionKey option, out object value)
 			{
 				if (option.Option == FormattingOptions.UseTabs) {
 					value = !policy.TabsToSpaces;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.RoslynServices/RoslynServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.RoslynServices/RoslynServiceTests.cs
@@ -70,15 +70,5 @@ namespace MonoDevelop.Ide.RoslynServices
 
 			Assert.AreEqual (2, x);
 		}
-
-		/// <summary>
-		/// This verifies that the Reflection logic in <see cref="DefaultSourceEditorOptions.SetUseAsyncCompletion(bool)"/>
-		/// is still compatible with the Roslyn build we're using
-		/// </summary>
-		[TestCase]
-		public void TestAsyncCompletionServiceReflection ()
-		{
-			DefaultSourceEditorOptions.SetUseAsyncCompletion (true);
-		}
 	}
 }

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpCodeActionEditorExtensionTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Refactoring/CSharpCodeActionEditorExtensionTests.cs
@@ -56,7 +56,8 @@ namespace MonoDevelop.CSharpBinding.Refactoring
 				},
 				CodeRefactoringData = new CodeActionData [] {
 					new CodeActionData { Message = "To public" },
-					new CodeActionData { Message = "Move to namespace..." },
+					// NOTE: This will return when we implement UI for it
+					//new CodeActionData { Message = "Move to namespace..." },
 					new CodeActionData { Message = "Generate overrides..." },
 					new CodeActionData { Message = "Generate constructor 'MyClass()'" },
 					new CodeActionData { Message = "Rename file to MyClass.cs" },
@@ -95,7 +96,8 @@ namespace MonoDevelop.CSharpBinding.Refactoring
 					new CodeActionData { Message = "Fix formatting" },
 				}.OrderBy(d => d.Message).ToArray(),
 				CodeRefactoringData = new CodeActionData [] {
-					new CodeActionData { Message = "Move to namespace..." },
+					// NOTE: This will return when we implement UI for it
+					//new CodeActionData { Message = "Move to namespace..." },
 				},
 			};
 


### PR DESCRIPTION
FYI @sandyarmstrong 

Updating roslyn to [2768eee](https://www.github.com/dotnet/roslyn/commit/2768eeeb2f449f768fe5233291dec940441b7f4f)

Changes since [09ead1c](https://www.github.com/dotnet/roslyn/commit/09ead1c8036683f2939e9bc22508a33c1ea6c8bd)
- [[master] Update dependencies from dotnet/arcade (#36651)](https://www.github.com/dotnet/roslyn/pull/36651)
- [Merge pull request #36671 from sharwell/update-analyzers-easy](https://www.github.com/dotnet/roslyn/pull/36671)
- [Merge pull request #36500 from ericmutta/patch-1](https://www.github.com/dotnet/roslyn/pull/36500)
- [added NFW to get some data on incremental parsing bug where source si. (#36620)](https://www.github.com/dotnet/roslyn/pull/36620)
- [Honor Disallow/AllowNull and Maybe/NotNull on properties (#36444)](https://www.github.com/dotnet/roslyn/pull/36444)
- [Merge pull request #36584 from sharwell/feature-service](https://www.github.com/dotnet/roslyn/pull/36584)
- [Use the arcade toolset project to build in determinism (#36623)](https://www.github.com/dotnet/roslyn/pull/36623)
- [Wire NullableWalker snapshotting to the public SpeculativeSemanticModel apis (#36563)](https://www.github.com/dotnet/roslyn/pull/36563)
- [Merge pull request #36605 from jasonmalinowski/add-tests-for-generate-type](https://www.github.com/dotnet/roslyn/pull/36605)
- [Add nullable to IntroduceVariableService (#36416)](https://www.github.com/dotnet/roslyn/pull/36416)
- [Merge pull request #36607 from sharwell/fix-test](https://www.github.com/dotnet/roslyn/pull/36607)
- [Merge pull request #36459 from jasonmalinowski/fix-code-generation-helpers](https://www.github.com/dotnet/roslyn/pull/36459)
- [Don't complete statement when typing semicolon inside comments in an argument list (#36521)](https://www.github.com/dotnet/roslyn/pull/36521)
- [Add 'annotations' and 'warnings' support to nullable directive (#36464)](https://www.github.com/dotnet/roslyn/pull/36464)
- [Fixed IDE services touching `notnull` constraint (#36508)](https://www.github.com/dotnet/roslyn/pull/36508)
- [Merge pull request #36586 from chborl/MoveCaretCheck](https://www.github.com/dotnet/roslyn/pull/36586)
- [Update compiler toolset to arcade version (#36549)](https://www.github.com/dotnet/roslyn/pull/36549)
- [Do not include value types in NullableAttribute byte[] (#36519)](https://www.github.com/dotnet/roslyn/pull/36519)
- [Merge pull request #36551 from sharwell/timeout-replacetext](https://www.github.com/dotnet/roslyn/pull/36551)
- [Merge pull request #36366 from sharwell/order-naming-rules](https://www.github.com/dotnet/roslyn/pull/36366)
- [Merge pull request #27942 from sharwell/isolate-editorconfig](https://www.github.com/dotnet/roslyn/pull/27942)
- [Change `??=` for nullable value types as specified in LDM (#36329)](https://www.github.com/dotnet/roslyn/pull/36329)
- [Merge pull request #36534 from heejaechang/addCompletionStatementTelemetry](https://www.github.com/dotnet/roslyn/pull/36534)
- [Merge pull request #36523 from jasonmalinowski/fix-shared-project-non-fatal-watson](https://www.github.com/dotnet/roslyn/pull/36523)
- [Revert 35746 (#36512)](https://www.github.com/dotnet/roslyn/pull/36512)
- [Fix stack overflow in requesting syntax directives (#36347)](https://www.github.com/dotnet/roslyn/pull/36347)
- [crash on ClassifyUpdate for EventFields (#35962)](https://www.github.com/dotnet/roslyn/pull/35962)
- [Merge pull request #36517 from jasonmalinowski/fix-typeinferer-crash-with-method-inference](https://www.github.com/dotnet/roslyn/pull/36517)
- [Merge pull request #36088 from avodovnik/dev/anvod/exclusivecompletion](https://www.github.com/dotnet/roslyn/pull/36088)
- [Disable move type when the options service isn't present (#36334)](https://www.github.com/dotnet/roslyn/pull/36334)
- [Merge pull request #36494 from YairHalberstadt/use-compound-assignment-not-suggested-when-right-hand-is-throw-expression](https://www.github.com/dotnet/roslyn/pull/36494)
- [Fix parsing bug in invalid using statements (#36428)](https://www.github.com/dotnet/roslyn/pull/36428)
- [Merge pull request #36458 from jasonmalinowski/fix-use-local-function](https://www.github.com/dotnet/roslyn/pull/36458)
- [Merge pull request #36470 from sharwell/fix-config](https://www.github.com/dotnet/roslyn/pull/36470)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935206/