### PR TITLE
[release-8.1] Fixes VSTS Bug 936306: [Feedback] The "Publish in version control"

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/PublishCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/PublishCommand.cs
@@ -5,11 +5,31 @@ using MonoDevelop.Projects;
 using MonoDevelop.Core;
 using MonoDevelop.VersionControl.Dialogs;
 using MonoDevelop.Ide;
+using MonoDevelop.Components.Commands;
 
 namespace MonoDevelop.VersionControl 
 {
-	internal class PublishCommand 
+	internal class PublishCommand : CommandHandler
 	{
+		protected override void Update (CommandInfo info)
+		{
+			info.Enabled = info.Visible = false;
+			if (!VersionControlService.IsGloballyDisabled) {
+				var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+				if (solution == null)
+					return;
+				info.Enabled = info.Visible = Publish (solution, solution.BaseDirectory, true);
+			}
+		}
+
+		protected override void Run ()
+		{
+			var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+			if (solution == null)
+				return;
+			Publish (solution, solution.BaseDirectory, false);
+		}
+
 		public static bool Publish (WorkspaceObject entry, FilePath localPath, bool test)
 		{
 			if (test)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/VersionControl.addin.xml
@@ -150,6 +150,7 @@
 			defaultHandler="MonoDevelop.VersionControl.UpdateCommandHandler"
 			description = "Updates the local copy with remote changes."/>
 		<Command id = "MonoDevelop.VersionControl.Commands.Publish"
+			defaultHandler = "MonoDevelop.VersionControl.PublishCommand"
 			_label = "_Publish in Version Control..."
 			icon = "vc-push"
 			description = "Publish actual project into repository."/>


### PR DESCRIPTION
option is always disabled

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/936306

Command was put in main menu but the command was not implemented for
the main menu case.

Backport of #7994.

/cc @sevoku @mkrueger