### PR TITLE
[release-8.1] [Ide] Fix state corruption with new-document-model and old editor

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/TextEditorViewContent.cs
@@ -61,6 +61,7 @@ namespace MonoDevelop.Ide.Editor
 
 		public TextEditorViewContent ()
 		{
+			HasUnsavedChangesChanged += TextEditorViewContent_HasUnsavedChangesChanged;
 		}
 
 		protected override async Task OnLoad (bool reloading)
@@ -159,6 +160,15 @@ namespace MonoDevelop.Ide.Editor
 		{
 			HasUnsavedChanges = textEditorImpl.IsDirty;
 			InformAutoSave ();
+		}
+
+		void TextEditorViewContent_HasUnsavedChangesChanged (object sender, EventArgs e)
+		{
+			// Synchronize state
+			if (textEditor != null && textEditor.IsDirty && !HasUnsavedChanges) {
+				textEditor.SetNotDirtyState ();
+				textEditor.IsDirty = false;
+			}
 		}
 
 		void HandleTextChanged (object sender, TextChangeEventArgs e)
@@ -356,6 +366,8 @@ namespace MonoDevelop.Ide.Editor
 				return;
 
 			isDisposed = true;
+
+			HasUnsavedChangesChanged -= TextEditorViewContent_HasUnsavedChangesChanged;
 
 			if (textEditorImpl != null) {
 


### PR DESCRIPTION
The controller for the old editor didn't properly synchronize the value of HasUnsavedChanges with the internal textEditor dirty flag.

This would cause normal saves of the model to perpetuate a state where the editor controller's HasUnsavedChanges flag would never get reset to true because the internal dirty state would have been kept back.

Fixes VSTS #936466

Backport of #8001.

/cc @sevoku @garuma