### PR TITLE
[release-8.2] [aspnet] Prevents NRE when no project is loaded

### DIFF
--- a/main/src/addins/AspNet/WebForms/WebFormsTypeContext.cs
+++ b/main/src/addins/AspNet/WebForms/WebFormsTypeContext.cs
@@ -454,6 +454,9 @@ namespace MonoDevelop.AspNet.WebForms
 		MetadataReference LoadMetadataReference (string path)
 		{
 			var roslynProject = IdeApp.TypeSystemService.GetProject (Project);
+			if (roslynProject == null) {
+				return null; //this happens when a WebForm file is edited independently (no project loaded)
+			}	
 			var workspace = (MonoDevelopWorkspace)roslynProject.Solution.Workspace;
 			var reference = workspace.MetadataReferenceManager.GetOrCreateMetadataReferenceSnapshot (path, MetadataReferenceProperties.Assembly);
 


### PR DESCRIPTION
When opening and editing a WebForm.aspx file directly within the IDE (no project associated and loaded) this throws a NRE.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935179
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/860971

Backport of #8018.

/cc @rodrmoya @jtorres