### PR TITLE
[C#] Fix unhandled exception that is thrown when completion is canceled

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -228,7 +228,7 @@ namespace MonoDevelop.CSharp.Completion
 						result.AutoCompleteUniqueMatch = false;
 						result.AutoCompleteEmptyMatch = false;
 						return (ICompletionDataList)result;
-					});
+					}, token, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Current);
 				} catch (Exception e) {
 					LoggingService.LogError ("Unexpected code completion exception." + Environment.NewLine +
 											 "FileName: " + DocumentContext.Name + Environment.NewLine +


### PR DESCRIPTION
Add a OnlyOnRanRanToCompletion option and execute synchronously.

Fixes VSTS #798074 - Unobserved exception in CSharpCompletionTextEditorExtension