### PR TITLE
Fixes VSTS Bug 935201: System.ArgumentOutOfRangeException exception in

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -658,10 +658,11 @@ namespace MonoDevelop.Ide.Gui.Documents
 					var offset = info.Offset;
 					if (offset < 0) {
 						var line = textView.TextSnapshot.GetLineFromLineNumber (info.Line - 1);
-						if (info.Column >= 1)
-							offset = line.Start + info.Column - 1;
-						else
+						if (info.Column >= 1) {
+							offset = line.Start + Math.Min (info.Column - 1, line.Length);
+						} else {
 							offset = line.Start;
+						}
 					}
 					if (editorOperationsFactoryService != null) {
 						var editorOperations = editorOperationsFactoryService.GetEditorOperations (textView);


### PR DESCRIPTION
Microsoft.VisualStudio.Text.SnapshotPoint..ctor()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935201

line.Start + Column - 1 will throw if Column is at EOL the - 1 is
interpreted as (Start + Column) - 1. Using brackets to evaluate it
differently : Start + (Column - 1) would fix the issue but I added the
bounds check to prevent the exeception from happening in all cases.