### PR TITLE
[Core] Fix null ref if RunTarget called after Project is disposed

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1091,7 +1091,7 @@ namespace MonoDevelop.Projects
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 				context.GlobalProperties.SetValue ("Silent", true);
 
-				var result = await RunTarget (monitor, "ResolveAssemblyReferences", configuration, context);
+				var result = await RunTargetInternal (monitor, "ResolveAssemblyReferences", configuration, context);
 
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();
 
@@ -1152,7 +1152,7 @@ namespace MonoDevelop.Projects
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 
-				var result = await RunTarget (monitor, "ResolvePackageDependenciesDesignTime", configuration, context);
+				var result = await RunTargetInternal (monitor, "ResolvePackageDependenciesDesignTime", configuration, context);
 
 				if (result == null)
 					return new List<PackageDependency> ();

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
@@ -382,8 +382,8 @@ namespace MonoDevelop.Projects
 
 				InitBuildSyncEvent (project1);
 
-				// Start the build. Use RunTarget to avoid the BindTask which will cancel the build on project dispose.
-				var build1 = project1.RunTarget (Util.GetMonitor (), "Build", sol.Configurations [0].Selector);
+				// Start the build. Use RunTargetInternal to avoid the BindTask which will cancel the build on project dispose.
+				var build1 = project1.RunTargetInternal (Util.GetMonitor (), "Build", sol.Configurations [0].Selector);
 
 				// Wait for the build to reach the sync task
 				await WaitForBuildSyncEvent (project1);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1098,6 +1098,26 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task ProjectDisposed_RunTarget_NullReferenceExceptionNotThrown ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var p = (DotNetProject)sol.Items [0];
+			sol.Dispose ();
+
+			Assert.IsNull (p.MSBuildProject);
+
+			try {
+				// RunTarget should fail since BindTask will not register a task after Project has been disposed
+				await p.RunTarget (Util.GetMonitor (), "ResolveAssemblyReferences", ConfigurationSelector.Default);
+				Assert.Fail ("Should not reach here.");
+			} catch (TaskCanceledException) {
+				// Expected exception.
+			}
+		}
+
+		[Test]
 		public async Task ProjectExtensionOnModifiedCalledWhenProjectModified ()
 		{
 			var fn = new CustomItemNode<TestModifiedProjectExtension> ();


### PR DESCRIPTION
Project.RunTarget now uses BindTask so the target will complete
before the Project is disposed. This will also prevent a null
reference exception that could occur when the MSBuildProject was
accessed in RunMSBuildTarget when RunTarget is called after the
Project is disposed. A TaskCancelationException is thrown if
RunTarget is called after the Project has been disposed.

Fixes VSTS #935875 - High exception count in MSBuild as run by the
Android Designer

Could not reproduce the above bug testing the designer. Assumption
based on the exception callstack is that RunTarget is being called
after the Project is disposed.