### PR TITLE
Fixes VSTS Bug 936021: "Go to Task" is broken in Tasks panel

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTasksProvider.cs
@@ -100,7 +100,7 @@ namespace MonoDevelop.Ide.Tasks
 			if (!TryGetDocument (args, out var doc, out var project))
 				return null;
 
-			var file = doc.Name;
+			var file = doc.FilePath;
 			var tags = args.TodoItems.Length == 0 ? (IReadOnlyList<Tag>)null : args.TodoItems.SelectAsArray (x => x.ToTag ());
 			return new CommentTaskChange (file, tags, project);
 		}


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/936021

doc.Name is just the file name - the task list requires the full path.