### PR TITLE
[release-8.2] [Perf Tests] Add type system perf test

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -331,7 +331,7 @@ namespace MonoDevelop.Projects
 					var oldLink = link;
 					link = value;
 
-					OnVirtualPathChanged (oldLink, link);
+					VirtualPathChanged?.Invoke (this, new ProjectFileVirtualPathChangedEventArgs (this, oldLink, link));
 					OnChanged ("Link");
 				}
 			}
@@ -479,7 +479,7 @@ namespace MonoDevelop.Projects
 			base.OnProjectSet ();
 			if (Project != null) {
 				base.Include = Include;
-				OnVirtualPathChanged (FilePath.Null, ProjectVirtualPath);
+				VirtualPathChanged?.Invoke (this, new ProjectFileVirtualPathChangedEventArgs (this, FilePath.Null, ProjectVirtualPath));
 			}
 		}
 
@@ -506,14 +506,6 @@ namespace MonoDevelop.Projects
 		}
 
 		internal event EventHandler<ProjectFileVirtualPathChangedEventArgs> VirtualPathChanged;
-
-		void OnVirtualPathChanged (FilePath oldVirtualPath, FilePath newVirtualPath)
-		{
-			var handler = VirtualPathChanged;
-
-			if (handler != null)
-				handler (this, new ProjectFileVirtualPathChangedEventArgs (this, oldVirtualPath, newVirtualPath));
-		}
 
 		internal event EventHandler<ProjectFilePathChangedEventArgs> PathChanged;
 

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/Baseline_MonoDevelop.Ide.PerfTests.xml
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/Baseline_MonoDevelop.Ide.PerfTests.xml
@@ -61,6 +61,16 @@
                       </test-case>
                     </results>
                   </test-suite>
+                  <test-suite type="TestFixture" name="TestTypeSystemServiceLoad" executed="True" result="Success" success="True" time="28.637" asserts="0">
+                    <results>
+                      <test-case name="MonoDevelop.Ide.PerfTests.TestTypeSystemServiceLoad.TestLoad" executed="True" result="Success" success="True" time="28.633" asserts="1">
+                        <properties>
+                          <property name="Time" value="3.95" />
+                          <property name="Tolerance" value="0.3" />
+                        </properties>
+                      </test-case>
+                    </results>
+                  </test-suite>
                 </results>
               </test-suite>
             </results>

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/MonoDevelop.Ide.PerfTests.csproj
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/MonoDevelop.Ide.PerfTests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="TestSolutionLoad.cs" />
     <Compile Include="TestSolutionBuild.cs" />
     <Compile Include="TestFileWatcherHandlers.cs" />
+    <Compile Include="TestTypeSystemServiceLoad.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/TestTypeSystemServiceLoad.cs
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/TestTypeSystemServiceLoad.cs
@@ -1,0 +1,57 @@
+//
+// TestTypeSystemServiceLoad.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Core.Instrumentation;
+using MonoDevelop.PerformanceTesting;
+using MonoDevelop.UserInterfaceTesting;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.PerfTests
+{
+	public class TestTypeSystemServiceLoad : UITestBase
+	{
+		public override void SetUp ()
+		{
+			InstrumentationService.Enabled = true;
+			PreStart ();
+		}
+
+		[Test]
+		[Benchmark (Tolerance = 0.3)]
+		public void TestLoad ()
+		{
+			OpenApplicationAndWait ();
+
+			Session.RunAndWaitForTimer (() => {
+				OpenSolutionAndWait (out _, "console-with-libs", "console-with-libs.sln");
+			}, "Ide.CodeAnalysis");
+
+			var t = Session.GetTimerDuration ("Ide.CodeAnalysis");
+
+			Benchmark.SetTime (t.TotalSeconds);
+		}
+	}
+}

--- a/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting/UITestBase.cs
+++ b/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting/UITestBase.cs
@@ -115,6 +115,7 @@ namespace MonoDevelop.UserInterfaceTesting
 
 		public void PreStart ()
 		{
+			UnitTests.Util.ClearTmpDir ();
 			SetupTestResultFolder ();
 			SetupTestLogger ();
 			SetupScreenshotsFolder ();

--- a/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting/UITestBase.cs
+++ b/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting/UITestBase.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // UserInterfaceTest.cs
 //
 // Author:
@@ -143,7 +143,12 @@ namespace MonoDevelop.UserInterfaceTesting
 
 		public string OpenExampleSolutionAndWait (out bool waitForPackages)
 		{
-			var sln = UnitTests.Util.GetSampleProject ("performance", "sdk-library", "sdk-library.sln");
+			return OpenSolutionAndWait (out waitForPackages, "performance", "sdk-library", "sdk-library.sln");
+		}
+
+		public string OpenSolutionAndWait (out bool waitForPackages, params string[] projectName)
+		{
+			FilePath sln = UnitTests.Util.GetSampleProject (projectName);
 
 			if (!File.Exists (sln)) {
 				throw new FileNotFoundException ("Could not find test solution", sln);
@@ -151,7 +156,7 @@ namespace MonoDevelop.UserInterfaceTesting
 
 			// Tell the app to track time to code
 			Session.GlobalInvoke ("MonoDevelop.Ide.IdeStartupTracker.StartupTracker.StartTimeToCodeLoadTimer", null);
-			Session.RunAndWaitForTimer (() => Session.GlobalInvoke ("MonoDevelop.Ide.IdeApp.Workspace.OpenWorkspaceItem", (Core.FilePath)sln), "Ide.Shell.SolutionOpened", 60000);
+			Session.RunAndWaitForTimer (() => Session.GlobalInvoke ("MonoDevelop.Ide.IdeApp.Workspace.OpenWorkspaceItem", sln), "Ide.Shell.SolutionOpened", 60000);
 			Session.GlobalInvoke ("MonoDevelop.Ide.IdeStartupTracker.StartupTracker.TrackTimeToCode", MonoDevelop.Ide.TimeToCodeMetadata.DocumentType.Solution);
 
 			// Currently we only have one solution which needs packages waited for.


### PR DESCRIPTION
 - Added a perf tests for the type system service loading.
 - Ensure UI Tests clear the tmp directory before running a test to prevent old files being used.

Optimisations:

 - Improve ProjectFile.get_ProjectVirtualPath efficiency (it's always computed, slow)
   - Not done. This value is used once by the type system service. Does not seem to be any benefit to caching it.
 - Improve ProjectFile.set_Project on ProjectFile when it's done in its initializer
 - Move ProjectSystemHandler.updatingProjectDataLock might be overzealous? Make it smaller scope, just projectDataMap manipulation?
    - Already implemented previously

TODO:

 - [x] Update benchmark baseline timings

Fixes VSTS #700297 - Gathering typesystem information can be optimized

Backport of #7901.

/cc @mrward 