### PR TITLE
[master] Fix 937834: In the new editor, the Chinese input repeats.

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
@@ -87,8 +87,10 @@
 		<StockIcon stockid="vs-signature-help-next" resource="go-down-16.png" size="Menu" imageid="{95fdedcb-dc13-48a8-8165-ed1fff877d9a}#2" />
 	</Extension>
 	<Extension path = "/MonoDevelop/TextEditor/CommandMapping">
+	<!--
+		Don't re-add this! See bug 937834 for more details. Basically let native editor handle this. 
 		<Map id="MonoDevelop.Ide.Commands.EditCommands.DeleteKey" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.BackspaceKeyCommandArgs" />
-
+	-->
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.Find" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindNext" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindNextCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindPrevious" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindPreviousCommandArgs" />


### PR DESCRIPTION
Removed `<Map` for Backspace command/key. So it’s not handled by MonoDevelop, hence its passed to native editor so `KeyDown` method is called which calls `InterpretKeyEvents` so native IME processing logic updates its internal state so IME input after typing more characters after Backspace is correct, otherwise IME reinserts deleted chars

Backport of #8040.

/cc @slluis @DavidKarlas