### PR TITLE
[release-8.2] [Version Control] Fixes error adding new files to the Solution Items under Version Control

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -25,8 +25,7 @@ namespace MonoDevelop.VersionControl
 
 		int references;
 
-		public FilePath RootPath
-		{
+		public FilePath RootPath {
 			get;
 			protected set;
 		}
@@ -97,7 +96,6 @@ namespace MonoDevelop.VersionControl
 		protected virtual void Dispose (bool disposing)
 		{
 			IsDisposed = true;
-
 			if (queryRunning) {
 				lock (queryLock) {
 					fileQueryQueue.Clear ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlNodeExtension.cs
@@ -25,7 +25,9 @@ namespace MonoDevelop.VersionControl
 			return typeof(ProjectFile).IsAssignableFrom (dataType)
 				|| typeof(SystemFile).IsAssignableFrom (dataType)
 				|| typeof(ProjectFolder).IsAssignableFrom (dataType)
-				|| typeof(WorkspaceObject).IsAssignableFrom (dataType);
+				|| typeof(WorkspaceObject).IsAssignableFrom (dataType) 
+                || typeof (SolutionFolder).IsAssignableFrom (dataType)
+				|| typeof (SolutionFolderFileNode).IsAssignableFrom (dataType);
 		}
 		
 		protected override void Initialize ()
@@ -60,6 +62,14 @@ namespace MonoDevelop.VersionControl
 				if (rep != null) {
 					rep.GetDirectoryVersionInfo (ce.BaseDirectory, false, false);
 					AddFolderOverlay (rep, ce.BaseDirectory, nodeInfo, false);
+				}
+				return;
+			} else if (dataObject is SolutionFolderFileNode) {
+				SolutionFolderFileNode sn = (SolutionFolderFileNode) dataObject;
+				Repository rep = VersionControlService.GetRepository (sn.Parent);
+				if (rep != null) {
+					rep.GetDirectoryVersionInfo (sn.Path, false, false);
+					AddFolderOverlay (rep, sn.Path, nodeInfo, false);
 				}
 				return;
 			} else if (dataObject is ProjectFolder) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderFileNodeBuilder.cs
@@ -160,7 +160,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		}
 	}
 
-	class SolutionFolderFileNode: IFileItem
+	public class SolutionFolderFileNode: IFileItem
 	{
 		FilePath path;
 		SolutionFolder parent;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFileNodeBuilder.cs
@@ -176,7 +176,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 						}
 						else {
 							Solution sol = node.GetParentDataItem (typeof(Solution), true) as Solution;
-							sol.RootFolder.Files.Add (file.Path);
+							sol.DefaultSolutionFolder.Files.Add (file.Path);
 							projects.Add (sol);
 						}
 					}


### PR DESCRIPTION
We have some changes here. The first one was adding the file in the solution. If there is no "Solution Items" folder, we create it.
On the other hand, trying to add the file to the repository (Add command) a validation was made taking into account the ActiveDocument that we will only have if the document is open (it is not always the case, or can even deal with a file that is not text). Validation changed.

Fixes VSTS #715157

Backport of #7340.

/cc @sevoku @jsuarezruiz