### PR TITLE
[release-8.2] [Version Control] Popping a git stash that has conflicts gives invalid warning and no further logs

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -199,7 +199,7 @@ namespace MonoDevelop.VersionControl.Git
 			FileService.FreezeEvents ();
 			ThreadPool.QueueUserWorkItem (delegate {
 				try {
-					GitService.ReportStashResult (Repository.PopStash (monitor, 0));
+					GitService.ReportStashResult (Repository, Repository.PopStash (monitor, 0));
 				} catch (Exception ex) {
 					MessageService.ShowError (GettextCatalog.GetString ("Stash operation failed"), ex);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -199,7 +199,9 @@ namespace MonoDevelop.VersionControl.Git
 			FileService.FreezeEvents ();
 			ThreadPool.QueueUserWorkItem (delegate {
 				try {
-					GitService.ReportStashResult (Repository, Repository.PopStash (monitor, 0), Repository.GetStashes().Count());
+					int stashCount = Repository.GetStashes ().Count ();
+					StashApplyStatus stashApplyStatus = Repository.PopStash (monitor, 0);
+					GitService.ReportStashResult (Repository, stashApplyStatus, stashCount);
 				} catch (Exception ex) {
 					MessageService.ShowError (GettextCatalog.GetString ("Stash operation failed"), ex);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -199,7 +199,7 @@ namespace MonoDevelop.VersionControl.Git
 			FileService.FreezeEvents ();
 			ThreadPool.QueueUserWorkItem (delegate {
 				try {
-					GitService.ReportStashResult (Repository, Repository.PopStash (monitor, 0));
+					GitService.ReportStashResult (Repository, Repository.PopStash (monitor, 0), Repository.GetStashes().Count());
 				} catch (Exception ex) {
 					MessageService.ShowError (GettextCatalog.GetString ("Stash operation failed"), ex);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -176,15 +176,14 @@ namespace MonoDevelop.VersionControl.Git
 				msg = GettextCatalog.GetString ("A conflicting change has been detected in the index.");
 
 				// Include conflicts in the msg
-				using (var RootRepository = new LibGit2Sharp.Repository (repo.RootPath)) {
-					if (!RootRepository.Index.IsFullyMerged) {
+				if (repo is GitRepository gitRepo) {
+					if (!gitRepo.RootRepository.Index.IsFullyMerged) {
 						msg += GettextCatalog.GetString ("The following conflicts have been found:") + Environment.NewLine;
-						foreach (var conflictFile in RootRepository.Index.Conflicts) {
+						foreach (var conflictFile in gitRepo.RootRepository.Index.Conflicts) {
 							msg += conflictFile.Ancestor.Path + Environment.NewLine;
 						}
 					}
 				}
-
 				stashResultType = StashResultType.Warning;
 				break;
 			case StashApplyStatus.UncommittedChanges:

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Text;
 using System.Linq;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
@@ -174,19 +175,20 @@ namespace MonoDevelop.VersionControl.Git
 			switch (status) {
 			case StashApplyStatus.Conflicts:
 				bool stashApplied = false;
-				msg = GettextCatalog.GetString ("A conflicting change has been detected in the index. ");
+				StringBuilder info = new StringBuilder (GettextCatalog.GetString ("A conflicting change has been detected in the index. "));
 				// Include conflicts in the msg
 				if (stashCount != null && repo is GitRepository gitRepo) {
 					int actualStashCount = gitRepo.GetStashes ().Count ();
 					stashApplied = actualStashCount != stashCount;
 					if (stashApplied) {
-						msg += GettextCatalog.GetString ("The following conflicts have been found:") + Environment.NewLine;
+						info.AppendLine (GettextCatalog.GetString ("The following conflicts have been found:"));
 						foreach (var conflictFile in gitRepo.RootRepository.Index.Conflicts) {
-							msg += conflictFile.Ancestor.Path + Environment.NewLine;
+							info.AppendLine (conflictFile.Ancestor.Path);
 						}
 					} else
-						msg += GettextCatalog.GetString ("Stash not applied.");
+						info.Append (GettextCatalog.GetString ("Stash not applied."));
 				}
+				msg = info.ToString ();
 				stashResultType = !stashApplied ? StashResultType.Error : StashResultType.Warning;
 				break;
 			case StashApplyStatus.UncommittedChanges:

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -168,18 +168,54 @@ namespace MonoDevelop.VersionControl.Git
 
 		public static void ReportStashResult (StashApplyStatus status)
 		{
-			if (status == StashApplyStatus.Conflicts) {
-				string msg = GettextCatalog.GetString ("Stash applied with conflicts");
-				Runtime.RunInMainThread (delegate {
-					IdeApp.Workbench.StatusBar.ShowWarning (msg);
-				});
+			string msg;
+			StashResultType stashResultType;
+
+			switch (status) {
+			case StashApplyStatus.Conflicts:
+				msg = GettextCatalog.GetString ("A conflicting change has been detected in the index.");
+				stashResultType = StashResultType.Warning;
+				break;
+			case StashApplyStatus.UncommittedChanges:
+				msg = GettextCatalog.GetString ("The stash application was aborted due to uncommitted changes in the index.");
+				stashResultType = StashResultType.Warning;
+				break;
+			case StashApplyStatus.NotFound:
+				msg = GettextCatalog.GetString ("The stash index given was not found.");
+				stashResultType = StashResultType.Error;
+				break;
+			default:
+				msg = GettextCatalog.GetString ("Stash successfully applied.");
+				stashResultType = StashResultType.Message;
+				break;
 			}
-			else {
-				string msg = GettextCatalog.GetString ("Stash successfully applied");
-				Runtime.RunInMainThread (delegate {
-					IdeApp.Workbench.StatusBar.ShowMessage (msg);
-				});
-			}
+
+			ShowStashResult (msg, stashResultType);
+		}
+
+		enum StashResultType
+		{
+			Error,
+			Message,
+			Warning
+		}
+
+		static void ShowStashResult (string msg, StashResultType stashResultType)
+		{
+			Runtime.RunInMainThread (delegate {
+				switch (stashResultType)
+				{
+					case StashResultType.Error:
+						IdeApp.Workbench.StatusBar.ShowError (msg);
+						break;
+					case StashResultType.Message:
+						IdeApp.Workbench.StatusBar.ShowMessage (msg);
+						break;
+					case StashResultType.Warning:
+						IdeApp.Workbench.StatusBar.ShowWarning (msg);
+						break;
+				}
+			});
 		}
 	}
 }


### PR DESCRIPTION
Applied changes to show more information about the stash operation status (conflicts, stash not found, uncommitted changes, etc.).

Fixes VSTS #901094

Backport of #7813.

/cc @sevoku @jsuarezruiz