### PR TITLE
[release-8.2] [Ide] Optimize typesystem loading a bit

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -153,7 +153,7 @@ namespace MonoDevelop.Core
 		public bool HasExtension (string extension)
 		{
 			return fileName.Length > extension.Length
-				&& fileName.EndsWith (extension, StringComparison.OrdinalIgnoreCase)
+				&& fileName.EndsWith (extension, PathComparison)
 				&& fileName[fileName.Length - extension.Length - 1] != Path.PathSeparator;
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -525,7 +525,7 @@ namespace MonoDevelop.Projects
 
 		public virtual SourceCodeKind SourceCodeKind {  
 			get {
-				if (filename.Extension == ".sketchcs" || filename.Extension == ".sketchvb")
+				if (filename.HasExtension (".sketchcs") || filename.HasExtension (".sketchvb"))
 					return SourceCodeKind.Script;
 				return SourceCodeKind.Regular;
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -523,13 +523,10 @@ namespace MonoDevelop.Projects
 				Project.NotifyFilePropertyChangedInProject (this, property);
 		}
 
-		public virtual SourceCodeKind SourceCodeKind {  
-			get {
-				if (filename.HasExtension (".sketchcs") || filename.HasExtension (".sketchvb"))
-					return SourceCodeKind.Script;
-				return SourceCodeKind.Regular;
-			}
-		}
+		public virtual SourceCodeKind SourceCodeKind
+			=> filename.HasExtension (".csx") || filename.HasExtension (".vbx")
+				? SourceCodeKind.Script
+				: SourceCodeKind.Regular;
 	}
 
 	class ProjectFileVirtualPathChangedEventArgs : EventArgs

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
@@ -117,6 +117,7 @@ namespace MonoDevelop.Core
 			var path = new FilePath ("asdf.txt");
 			Assert.AreEqual ("asdf.txt", path.FileName);
 			Assert.IsTrue (path.HasExtension (".txt"));
+			Assert.AreEqual (FilePath.PathComparison == StringComparison.OrdinalIgnoreCase, path.HasExtension (".TXT"));
 			Assert.AreEqual (".txt", path.Extension);
 			Assert.AreEqual ("asdf", path.FileNameWithoutExtension);
 


### PR DESCRIPTION
Remove 2 redundant string allocations coming in from FilePath.Extension, and use FilePath.HasExtension for optimized results.

Backport of #8064.

/cc @Therzok 