### PR TITLE
Change Key binding scheme for Visual Studio for Mac 

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BrandingService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/BrandingService.cs
@@ -79,7 +79,7 @@ namespace MonoDevelop.Core
 				}
 			}
 		}
-
+		public static string DefaultKeybindingSchemeName { get; set; }
 		public static string PrivacyStatement { get; set; }
 		public static string PrivacyStatementUrl { get; set; }
 		public static string LicenseTermsUrl { get; set; }
@@ -114,6 +114,7 @@ namespace MonoDevelop.Core
 				}
 				ApplicationName = GetString ("ApplicationName");
 				ApplicationLongName = GetString ("ApplicationLongName") ?? ApplicationName;
+				DefaultKeybindingSchemeName = GetString ("DefaultKeybindingSchemeName") ?? ApplicationName;
 				SuiteName = GetString ("SuiteName");
 				ProfileDirectoryName = GetString ("ProfileDirectoryName");
 				StatusSteadyIconId = GetString ("StatusAreaSteadyIcon");

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingService.cs
@@ -211,8 +211,7 @@ namespace MonoDevelop.Components.Commands
 			get {
 				if (BrandingService.ApplicationName == "MonoDevelop")
 					return AddinManager.CurrentLocalizer.GetString ("Default");
-				else
-					return BrandingService.ApplicationName;
+				return BrandingService.DefaultKeybindingSchemeName;
 			}
 		}
 		


### PR DESCRIPTION
We want to change key binding scheme for Visual Studio for Mac from "Visual Studio" to "Visual Studio for Mac". To do this (and since the previous branding properties did not fit) a new property (DefaultKeybindingSchemeName) has been created in the Branding.xml file.

<img width="224" alt="Screenshot 2019-06-28 at 12 50 53" src="https://user-images.githubusercontent.com/6755973/60338704-fb39c980-99a6-11e9-9424-a0ebc4ceb36f.png">

Fixes VSTS #936531