### PR TITLE
[release-8.1] [Core] Fix null ref if RunTarget called after Project is disposed

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1071,7 +1071,7 @@ namespace MonoDevelop.Projects
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 				context.GlobalProperties.SetValue ("Silent", true);
 
-				var result = await RunTarget (monitor, "ResolveAssemblyReferences", configuration, context);
+				var result = await RunTargetInternal (monitor, "ResolveAssemblyReferences", configuration, context);
 
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();
 
@@ -1132,7 +1132,7 @@ namespace MonoDevelop.Projects
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 
-				var result = await RunTarget (monitor, "ResolvePackageDependenciesDesignTime", configuration, context);
+				var result = await RunTargetInternal (monitor, "ResolvePackageDependenciesDesignTime", configuration, context);
 
 				if (result == null)
 					return new List<PackageDependency> ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -705,7 +705,7 @@ namespace MonoDevelop.Projects
 						ctx.BuilderQueue = BuilderQueue.ShortOperations;
 						ctx.LogVerbosity = MSBuildVerbosity.Quiet;
 
-						var evalResult = await project.RunTarget (monitor, dependsList, config.Selector, ctx);
+						var evalResult = await project.RunTargetInternal (monitor, dependsList, config.Selector, ctx);
 						if (evalResult != null && evalResult.Items != null) {
 							result = ProcessMSBuildItems (evalResult.Items, project);
 						}
@@ -1240,6 +1240,13 @@ namespace MonoDevelop.Projects
 		/// Configuration to use to run the target
 		/// </param>
 		public Task<TargetEvaluationResult> RunTarget (ProgressMonitor monitor, string target, ConfigurationSelector configuration, TargetEvaluationContext context = null)
+		{
+			return BindTask<TargetEvaluationResult> (cancelToken => {
+				return RunTargetInternal (monitor.WithCancellationToken (cancelToken), target, configuration, context);
+			});
+		}
+
+		internal Task<TargetEvaluationResult> RunTargetInternal (ProgressMonitor monitor, string target, ConfigurationSelector configuration, TargetEvaluationContext context = null)
 		{
 			// Initialize the evaluation context. This initialization is shared with FastCheckNeedsBuild.
 			// Extenders will override OnConfigureTargetEvaluationContext to add custom properties and do other
@@ -1851,7 +1858,7 @@ namespace MonoDevelop.Projects
 		protected override async Task<BuildResult> OnBuild (ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext operationContext)
 		{
 			var newContext = operationContext as TargetEvaluationContext ?? new TargetEvaluationContext (operationContext);
-			return (await RunTarget (monitor, "Build", configuration, newContext)).BuildResult;
+			return (await RunTargetInternal (monitor, "Build", configuration, newContext)).BuildResult;
 		}
 
 		async Task<TargetEvaluationResult> RunBuildTarget (ProgressMonitor monitor, ConfigurationSelector configuration, TargetEvaluationContext context)
@@ -2236,7 +2243,7 @@ namespace MonoDevelop.Projects
 		protected override async Task<BuildResult> OnClean (ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext buildSession)
 		{
 			var newContext = buildSession as TargetEvaluationContext ?? new TargetEvaluationContext (buildSession);
-			return (await RunTarget (monitor, "Clean", configuration, newContext)).BuildResult;
+			return (await RunTargetInternal (monitor, "Clean", configuration, newContext)).BuildResult;
 		}
 
 		Task<TargetEvaluationResult> RunCleanTarget (ProgressMonitor monitor, ConfigurationSelector configuration, TargetEvaluationContext context)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
@@ -382,8 +382,8 @@ namespace MonoDevelop.Projects
 
 				InitBuildSyncEvent (project1);
 
-				// Start the build. Use RunTarget to avoid the BindTask which will cancel the build on project dispose.
-				var build1 = project1.RunTarget (Util.GetMonitor (), "Build", sol.Configurations [0].Selector);
+				// Start the build. Use RunTargetInternal to avoid the BindTask which will cancel the build on project dispose.
+				var build1 = project1.RunTargetInternal (Util.GetMonitor (), "Build", sol.Configurations [0].Selector);
 
 				// Wait for the build to reach the sync task
 				await WaitForBuildSyncEvent (project1);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -964,6 +964,26 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task ProjectDisposed_RunTarget_NullReferenceExceptionNotThrown ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
+
+			var p = (DotNetProject)sol.Items [0];
+			sol.Dispose ();
+
+			Assert.IsNull (p.MSBuildProject);
+
+			try {
+				// RunTarget should fail since BindTask will not register a task after Project has been disposed
+				await p.RunTarget (Util.GetMonitor (), "ResolveAssemblyReferences", ConfigurationSelector.Default);
+				Assert.Fail ("Should not reach here.");
+			} catch (TaskCanceledException) {
+				// Expected exception.
+			}
+		}
+
+		[Test]
 		public async Task ProjectExtensionOnModifiedCalledWhenProjectModified ()
 		{
 			var fn = new CustomItemNode<TestModifiedProjectExtension> ();


### PR DESCRIPTION
Project.RunTarget now uses BindTask so the target will complete
before the Project is disposed. This will also prevent a null
reference exception that could occur when the MSBuildProject was
accessed in RunMSBuildTarget when RunTarget is called after the
Project is disposed. A TaskCancelationException is thrown if
RunTarget is called after the Project has been disposed.

Fixes VSTS #935875 - High exception count in MSBuild as run by the
Android Designer

Could not reproduce the above bug testing the designer. Assumption
based on the exception callstack is that RunTarget is being called
after the Project is disposed.

Backport of #8039.

/cc @mrward 