### PR TITLE
Fix the workspace logic to apply new text to a buffer.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -690,18 +690,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			using (var edit = buffer.CreateEdit (options, reiteratedVersionNumber: null, editTag: null)) {
 				var oldSnapshot = buffer.CurrentSnapshot;
-				var oldText = oldSnapshot.AsText ();
-				var changes = newText.GetTextChanges (oldText);
-				//if (Microsoft.CodeAnalysis.Workspace.TryGetWorkspace(oldText.Container, out var workspace))
-				//{
-				//    var undoService = workspace.Services.GetService<ISourceTextUndoService>();
-				//    undoService.BeginUndoTransaction(oldSnapshot);
-				//}
-
-				foreach (var change in changes) {
-					edit.Replace (change.Span.Start, change.Span.Length, change.NewText);
-				}
-
+				edit.Replace (0, oldSnapshot.Length, newText.ToString ());
 				edit.Apply ();
 			}
 		}


### PR DESCRIPTION
The previous logic relied on the new Roslyn text deriving from the old Roslyn text via a chain of changes. We have seen a case in XAML where an extra change came from somewhere, deleting a random character. The change couldn't be explained by diffing between the old text and the new text.

The right thing to do here (and that's what VS Windows does) is to just give the desired new text to the Editor and let the Editor diff it. We pass the ComputeMinimalChange option so the editor will arrive at a minimal set of correct edits without Roslyn help.

We shouldn't worry about performance here because it's an infrequent scenario and the editor is really good at diffing efficiently, and the files of average size aren't a concern in terms of allocating the string.