### PR TITLE
Revert "[mdtool] Call terminate when ending (#7982)"

### DIFF
--- a/main/src/tools/mdtool/mdtool.csproj
+++ b/main/src/tools/mdtool/mdtool.csproj
@@ -29,11 +29,6 @@
       <Name>Mono.Addins.Setup</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\..\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
-      <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
-      <Name>MonoDevelop.Ide</Name>
-      <Private>False</Private>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\AssemblyInfo.cs" />

--- a/main/src/tools/mdtool/src/mdtool.cs
+++ b/main/src/tools/mdtool/src/mdtool.cs
@@ -145,7 +145,6 @@ class MonoDevelopProcessHost
 			var task = tool.Run (toolArgs);
 			task.ContinueWith ((t) => sc.ExitLoop ());
 			sc.RunMainLoop ();
-
 			return task.Result;
 
 		} catch (UserException ex) {
@@ -156,18 +155,12 @@ class MonoDevelopProcessHost
 			return -1;
 		} finally {
 			try {
-				Shutdown ();
+				Runtime.Shutdown ();
 			} catch {
 				// Ignore shutdown exceptions
 			}
 			LoggingService.Shutdown ();
 		}
-	}
-
-	static void Shutdown ()
-	{
- 		Runtime.Shutdown ();
-		MonoDevelop.Components.GtkWorkarounds.Terminate ();
 	}
 
 	static void ShowHelp (bool shortHelp, string exeName)


### PR DESCRIPTION
This reverts commit 2299cacfc9b17f29f5a59c5663edd69b074965cd.

Opened PR to validate that VSTS is not reporting errors in test suites correctly:
https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-releaseManagement-web.hub-explorer?releaseId=372751&_a=release-environment-extension&environmentId=1749792&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab

```
MonoDevelop.CSharpBinding.CSharpCompletionTextEditorTests.TestVSTSBug564610
MonoDevelop.CSharpBinding.Tests.Features.Completion.ProtocolMemberCompletionTests.TestBug39428
```

Both currently fail in CI, but the status is reported as green. I suspect it's because we call terminate indiscriminately.

[725899](https://dev.azure.com/DevDiv/DevDiv/_workitems/edit/725899) did mention we need to call exit in non-normal conditions, terminate in normal ones.