### PR TITLE
Fixes VSTS Bug 776934: TreeBuilderContext.GetTreeBuilder() null

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -2159,8 +2159,11 @@ namespace MonoDevelop.Ide.Gui.Components
 				SelectionChanged (this, EventArgs.Empty);
 		}
 
+		public bool IsDestroyed { get; set; }
+
 		void Destroy ()
 		{
+			IsDestroyed = true;
 			IdeApp.Preferences.CustomPadFont.Changed -= CustomFontPropertyChanged;
 			if (pix_render != null) {
 				pix_render.Destroy ();
@@ -2175,11 +2178,6 @@ namespace MonoDevelop.Ide.Gui.Components
 				text_render = null;
 			}
 
-			if (store != null) {
-				Clear ();
-				store = null;
-			}
-
 			if (builders != null) {
 				foreach (NodeBuilder nb in builders) {
 					try {
@@ -2190,6 +2188,12 @@ namespace MonoDevelop.Ide.Gui.Components
 				}
 				builders = null;
 			}
+
+			if (store != null) {
+				Clear ();
+				store = null;
+			}
+
 			builderChains.Clear ();
 		}
 
@@ -2229,6 +2233,8 @@ namespace MonoDevelop.Ide.Gui.Components
 
 			public ITreeBuilder GetTreeBuilder ()
 			{
+				if (pad.IsDestroyed)
+					throw new InvalidOperationException ("TreeView is destroyed.");
 				Gtk.TreeIter iter;
 				if (!pad.store.GetIterFirst (out iter))
 					return pad.CreateBuilder (Gtk.TreeIter.Zero);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ShowAllFilesBuilderExtension.cs
@@ -248,6 +248,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		void OnSystemFileAdded (object sender, FileEventArgs args)
 		{
+			if (Context.Tree.IsDestroyed)
+				return;
 			foreach (FileEventInfo e in args) {
 				Project project = GetProjectForFile (e.FileName);
 				if (project == null) return;
@@ -263,6 +265,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		void OnSystemFileDeleted (object sender, FileEventArgs args)
 		{
+			if (Context.Tree.IsDestroyed)
+				return;
 			foreach (FileEventInfo e in args) {
 				try {
 					Project project = GetProjectForFile (e.FileName);
@@ -298,6 +302,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		void OnSystemFileRenamed (object sender, FileCopyEventArgs args)
 		{
+			if (Context.Tree.IsDestroyed)
+				return;
 			foreach (FileEventInfo e in args) {
 				Project project = GetProjectForFile (e.SourceFile);
 				if (project == null) return;


### PR DESCRIPTION
reference exception

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/776934

Setting the store to null after the node builders are destoyed should
fix the issue theoretically. I couldn't reproduce it on my machine so
I added some insanity checks in the event handlers as well.