### PR TITLE
Fixes VSTS Bug 938346: [Feedback] How to use subverision over svn+ssh

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/UrlBasedRepositoryEditor.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/UrlBasedRepositoryEditor.cs
@@ -31,6 +31,7 @@ namespace MonoDevelop.VersionControl
 
 			updating = true;
 			repositoryUrlEntry.Text = repo.Url;
+			repositoryPortSpin.Adjustment.Lower = -1.0;
 			Fill ();
 			UpdateControls ();
 			updating = false;


### PR DESCRIPTION
WITHOUT a port?

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/938346

Port -1 is now the value to omit the port in the uri.