### PR TITLE
[CSharpBinding] Fixed failing editor tests.

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Completion/CSharpCompletionTextEditorExtension.cs
@@ -480,21 +480,6 @@ namespace MonoDevelop.CSharp.Completion
 			var semanticModel = await partialDoc.GetSemanticModelAsync (token).ConfigureAwait (false);
 			var syntaxContext = CSharpSyntaxContext.CreateContext (DocumentContext.RoslynWorkspace, semanticModel, completionContext.TriggerOffset, token);
 
-			if (addProtocolCompletion) {
-				var provider = new ProtocolMemberCompletionProvider ();
-
-				var protocolMemberContext = new CompletionContext (provider, analysisDocument, completionContext.TriggerOffset, new TextSpan (completionContext.TriggerOffset, completionContext.TriggerWordLength), trigger, customOptions, token);
-
-				await provider.ProvideCompletionsAsync (protocolMemberContext);
-
-				foreach (var item in protocolMemberContext.Items) {
-					if (string.IsNullOrEmpty (item.DisplayText))
-						continue;
-					var data = new CSharpCompletionData (analysisDocument, triggerSnapshot, cs, item);
-					result.Add (data);
-				}
-			}
-
 			if (forceSymbolCompletion || IdeApp.Preferences.AddImportedItemsToCompletionList) {
 				Counters.ProcessCodeCompletion.Trace ("C#: Adding import completion data");
 				AddImportCompletionData (syntaxContext, result, semanticModel, completionContext.TriggerOffset, token);

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/Features/Completion/AbstractCSharpCompletionProviderTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/Features/Completion/AbstractCSharpCompletionProviderTests.cs
@@ -37,10 +37,11 @@ using NUnit.Framework;
 using Microsoft.CodeAnalysis.CSharp.Completion;
 using System.Collections.Generic;
 using System.Threading;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.CSharpBinding.Tests.Features.Completion
 {
-	abstract class AbstractCSharpCompletionProviderTests : TestBase
+	abstract class AbstractCSharpCompletionProviderTests : CSharpCompletionTextEditorTests
 	{
 		protected abstract IEnumerable<CompletionProvider> CreateCompletionProvider ();
 

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/Features/Completion/ProtocolMemberCompletionTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/Features/Completion/ProtocolMemberCompletionTests.cs
@@ -28,6 +28,9 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Completion;
 using MonoDevelop.CSharp.Completion.Provider;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using MonoDevelop.Ide;
+using System.Linq;
 
 namespace MonoDevelop.CSharpBinding.Tests.Features.Completion
 {
@@ -92,9 +95,9 @@ class FooBar : ProtocolClass
 		/// Bug 39428 - [iOS] Override of protocol method shows 2 completions
 		/// </summary>
 		[Test]
-		public void TestBug39428 ()
+		public async Task TestBug39428 ()
 		{
-			VerifyItemIsAbsent (Header + @"
+			await TestCompletion (Header + @"
 
 class MyProtocol
 {
@@ -119,7 +122,8 @@ class FooBar : ProtocolClass
 override $$
 }
 
-", "FooBar");
+", (doc, list) => Assert.AreEqual (1, list.Where (d => d.CompletionText == "FooBar").Count ()));
 		}
+
 	}
 }

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompletionTextEditorTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompletionTextEditorTests.cs
@@ -155,12 +155,12 @@ namespace console61
 
 		}
 
-		Task TestCompletion (string text, Action<Document, ICompletionDataList> action, Action<Document> preCompletionAction = null)
+		protected Task TestCompletion (string text, Action<Document, ICompletionDataList> action, Action<Document> preCompletionAction = null)
 		{
 			return TestCompletion (text, action, CompletionTriggerInfo.CodeCompletionCommand, preCompletionAction);
 		}
 
-		async Task TestCompletion (string text, Action<Document, ICompletionDataList> action, CompletionTriggerInfo triggerInfo, Action<Document> preCompletionAction = null)
+		protected async Task TestCompletion (string text, Action<Document, ICompletionDataList> action, CompletionTriggerInfo triggerInfo, Action<Document> preCompletionAction = null)
 		{
 			int endPos = text.IndexOf ('$');
 			if (endPos >= 0)


### PR DESCRIPTION
ProtocolCompletionProvider was called twice. Removed the redundant call.