### PR TITLE
[release-8.2] [Shell] InvalidOperationException updating MDMenuItem

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -125,7 +125,7 @@ namespace MonoDevelop.Components.Mac
 				}
 				Update (parent, ref index, info);
 			} catch(Exception ex) {
-				LoggingService.LogInternalError (ex);
+				LoggingService.LogInternalError ($"Updating MDMenu for {ce.CommandId} failed.", ex);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs
@@ -111,18 +111,22 @@ namespace MonoDevelop.Components.Mac
 
 		public void Update (MDMenu parent, ref int index)
 		{
-			var info = manager.GetCommandInfo (ce.CommandId, new CommandTargetRoute (initialCommandTarget));
-			if (lastInfo != info) {
-				if (lastInfo != null) {
-					lastInfo.CancelAsyncUpdate ();
-					lastInfo.Changed -= OnLastInfoChanged;
+			try {
+				var info = manager.GetCommandInfo (ce.CommandId, new CommandTargetRoute (initialCommandTarget));
+				if (lastInfo != info) {
+					if (lastInfo != null) {
+						lastInfo.CancelAsyncUpdate ();
+						lastInfo.Changed -= OnLastInfoChanged;
+					}
+					lastInfo = info;
+					if (lastInfo.IsUpdatingAsynchronously) {
+						lastInfo.Changed += OnLastInfoChanged;
+					}
 				}
-				lastInfo = info;
-				if (lastInfo.IsUpdatingAsynchronously) {
-					lastInfo.Changed += OnLastInfoChanged;
-				}
+				Update (parent, ref index, info);
+			} catch(Exception ex) {
+				LoggingService.LogInternalError (ex);
 			}
-			Update (parent, ref index, info);
 		}
 
 		void OnLastInfoChanged (object sender, EventArgs args)


### PR DESCRIPTION
The problem is:

```
MonoDevelop.Components.Commands.CommandManager.GetCommandInfo(Object,CommandTargetRoute,CancellationToken)
MonoDevelop.Components.Commands.CommandManager.GetCommandInfo(Object,CommandTargetRoute)
MonoDevelop.Components.Mac.MDMenuItem.Update(MDMenu,Int32&)
MonoDevelop.Components.Mac.MDMenu.UpdateCommands()
MonoDevelop.Components.Mac.MDMenu.MenuNeedsUpdate(NSMenu)
Gtk.Application.Run()
MonoDevelop.Ide.IdeStartup.Run(MonoDevelopOptions)
MonoDevelop.Ide.IdeStartup.Main(String[],IdeCustomizer)
```

However, I can not reproduce the issue. In the logs appear addins like MFractor, LiveXAML and others. I have tried with all installed without success.

> Fixes VSTS #935128

Backport of #8090.

/cc @sevoku @jsuarezruiz