### PR TITLE
Bump Roslyn to 3.3.0-beta2-19351-03

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -17,7 +17,7 @@
     <NuGetVersionNewtonsoftJson>10.0.3</NuGetVersionNewtonsoftJson>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
-    <NuGetVersionRoslyn>3.2.0-beta4-19324-01</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.3.0-beta2-19351-03</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>


### PR DESCRIPTION
FYI @sandyarmstrong 

Updating Roslyn to [9b85b12](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/builds/2815585/sources)

Changes since [2768eee](https://www.github.com/dotnet/roslyn/commit/2768eee)

- [Fix IntelliCode-related Completion Tests (#36875)](https://www.github.com/dotnet/roslyn/pull/36875)
- [Merge pull request #36834 from jasonmalinowski/fix-formatting-issues](https://www.github.com/dotnet/roslyn/pull/36834)
- [Bump master to 3.3.0-beta2 (#36842)](https://www.github.com/dotnet/roslyn/pull/36842)
- [Update PublishData.json (#36843)](https://www.github.com/dotnet/roslyn/pull/36843)
- [Merge pull request #36713 from CyrusNajmabadi/simplifySigHelp](https://www.github.com/dotnet/roslyn/pull/36713)
- [Move EnC manager implementation down to Features layer (#36727)](https://www.github.com/dotnet/roslyn/pull/36727)
- [Merge pull request #36821 from dotnet/merges/release/dev16.3-preview1-to-master](https://www.github.com/dotnet/roslyn/pull/36821)
- [Update dependencies from https://github.com/dotnet/arcade build 20190626.44 (#36815)](https://www.github.com/dotnet/roslyn/pull/36815)
- [Merge pull request #36818 from mavasani/UnusedParameterFixes](https://www.github.com/dotnet/roslyn/pull/36818)
- [Avoid a first-chance FileNotFoundException when a ruleset include is not found. (#34696)](https://www.github.com/dotnet/roslyn/pull/34696)
- [Merge pull request #36827 from dotnet/merges/master-to-master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36827)
- [Merge pull request #36826 from dotnet/merges/release/dev16.3-preview1-to-release/dev16.3-preview1-vs-deps](https://www.github.com/dotnet/roslyn/pull/36826)
- [Merge pull request #36820 from dotnet/merges/release/dev16.2-to-release/dev16.3-preview1](https://www.github.com/dotnet/roslyn/pull/36820)
- [Merge pull request #36824 from dotnet/merges/release/dev16.3-preview1-vs-deps-to-master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36824)
- [Merge pull request #36807 from dotnet/merges/master-to-master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36807)
- [Merge pull request #36793 from dotnet/release/dev16.2](https://www.github.com/dotnet/roslyn/pull/36793)
- [Merge pull request #36808 from dotnet/merges/release/dev16.3-preview1-to-release/dev16.3-preview1-vs-deps](https://www.github.com/dotnet/roslyn/pull/36808)
- [Merge pull request #36798 from dotnet/dev/jorobich/skip-enc-tests](https://www.github.com/dotnet/roslyn/pull/36798)
- [Merge pull request #36799 from dotnet/dev/jorobich/skip-enc-tests](https://www.github.com/dotnet/roslyn/pull/36799)
- [Merge pull request #36801 from RikkiGibson/merge-3p1-to-master](https://www.github.com/dotnet/roslyn/pull/36801)
- [Merge pull request #36731 from jasonmalinowski/show-nullability-in-quick-info](https://www.github.com/dotnet/roslyn/pull/36731)
- [Revert "use the source instead of the name to find nuget packa. (#36802)](https://www.github.com/dotnet/roslyn/pull/36802)
- [Skip nullable transform for simple value types (#36784)](https://www.github.com/dotnet/roslyn/pull/36784)
- [Merge pull request #36790 from mavasani/FixUnitTests](https://www.github.com/dotnet/roslyn/pull/36790)
- [Merge pull request #36795 from RikkiGibson/merge-to-master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36795)
- [Merge pull request #36789 from agocke/update-16.3p1](https://www.github.com/dotnet/roslyn/pull/36789)
- [Merge pull request #36764 from dotnet/dev/jorobich/skip-enc-tests](https://www.github.com/dotnet/roslyn/pull/36764)
- [Merge pull request #36249 from dibarbet/only_lsp_merge](https://www.github.com/dotnet/roslyn/pull/36249)
- [Merge pull request #36785 from dibarbet/remove_experiment_names](https://www.github.com/dotnet/roslyn/pull/36785)
- [Merge pull request #35822 from YairHalberstadt/dont-suggest-this-in-static-local-functions](https://www.github.com/dotnet/roslyn/pull/35822)
- [Use TestRuntimeAdditionalArguments from Arcade: (#34296)](https://www.github.com/dotnet/roslyn/pull/34296)
- [Merge pull request #36728 from heejaechang/commandLineOB](https://www.github.com/dotnet/roslyn/pull/36728)
- [Honor attributes on fields (#36704)](https://www.github.com/dotnet/roslyn/pull/36704)
- [Update dependencies from https://github.com/dotnet/arcade build 20190626.2 (#36779)](https://www.github.com/dotnet/roslyn/pull/36779)
- [Do not warn about an oblivious mismatch for an explicitly implemented interface. (#36761)](https://www.github.com/dotnet/roslyn/pull/36761)
- [Merge pull request #35613 from jcouv/hash-code](https://www.github.com/dotnet/roslyn/pull/35613)
- [Merge pull request #36719 from heejaechang/OptOutFromdeferUntilIntellisenseIsReady](https://www.github.com/dotnet/roslyn/pull/36719)
- [Merge pull request #36743 from dotnet/merge-16.3-p1](https://www.github.com/dotnet/roslyn/pull/36743)
- [Merge pull request #36740 from mavasani/Issue36304](https://www.github.com/dotnet/roslyn/pull/36740)
- [Merge pull request #36734 from mavasani/UsingDeclarationsWorkarounds](https://www.github.com/dotnet/roslyn/pull/36734)
- [Update dependencies from https://github.com/dotnet/arcade build 20190624.24 (#36732)](https://www.github.com/dotnet/roslyn/pull/36732)
- [Merge pull request #36670 from jasonmalinowski/fix-editorconfig-feature-flag](https://www.github.com/dotnet/roslyn/pull/36670)
- [Merge pull request #36592 from petrroll/refact-select-fix](https://www.github.com/dotnet/roslyn/pull/36592)
- [Nullable Analysis Pay-for-play (#36714)](https://www.github.com/dotnet/roslyn/pull/36714)
- [Merge pull request #36183 from josh-127/fix-typo-1](https://www.github.com/dotnet/roslyn/pull/36183)
- [Add NullableContextAttribute (#36152)](https://www.github.com/dotnet/roslyn/pull/36152)
- [Merge pull request #36697 from dotnet/merges/master-to-release/dev16.3-preview1](https://www.github.com/dotnet/roslyn/pull/36697)
- [Semantic model tuple types (#36628)](https://www.github.com/dotnet/roslyn/pull/36628)
- [Merge pull request #36723 from dotnet/merges/master-to-master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36723)
- [Merge pull request #36733 from mavasani/AD0001_Fix](https://www.github.com/dotnet/roslyn/pull/36733)
- [Merge pull request #36689 from dotnet/merges/master-vs-deps-to-release/dev16.3-preview1-vs-deps](https://www.github.com/dotnet/roslyn/pull/36689)
- [Merge pull request #36680 from dotnet/merges/release/dev16.3-preview1-to-release/dev16.3-preview1-vs-deps](https://www.github.com/dotnet/roslyn/pull/36680)
- [Merge pull request #36718 from jasonmalinowski/fix-passing-wrapped-symbols-to-lookupsymbols](https://www.github.com/dotnet/roslyn/pull/36718)
- [Merge pull request #36653 from v-zbsail/loc_20190621_master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36653)
- [Rename IsNotNullableIfReferenceType to IsNotNullable (#36708)](https://www.github.com/dotnet/roslyn/pull/36708)
- [Merge pull request #36640 from ivanbasov/capital](https://www.github.com/dotnet/roslyn/pull/36640)
- [Add more nullability awareness in code generation (#36668)](https://www.github.com/dotnet/roslyn/pull/36668)
- [recognize @code as code block (#36677)](https://www.github.com/dotnet/roslyn/pull/36677)
- [Merge pull request #36674 from mavasani/DisposeAnalysisFalsePositives](https://www.github.com/dotnet/roslyn/pull/36674)
- [Change Range precedence to be just below unary (#36543)](https://www.github.com/dotnet/roslyn/pull/36543)
- [Merge pull request #36566 from jasonmalinowski/change-compiler-editorconfig-settings](https://www.github.com/dotnet/roslyn/pull/36566)
- [Update dependencies from https://github.com/dotnet/arcade build 20190623.4 (#36701)](https://www.github.com/dotnet/roslyn/pull/36701)
- [Support nullable variance in interface and partial method implementation. (#36663)](https://www.github.com/dotnet/roslyn/pull/36663)
- [Merge pull request #36657 from dotnet/merges/master-to-release/dev16.3-preview1](https://www.github.com/dotnet/roslyn/pull/36657)
- [Merge pull request #36645 from dotnet/merges/master-vs-deps-to-release/dev16.3-preview1-vs-deps](https://www.github.com/dotnet/roslyn/pull/36645)
- [Merge pull request #36582 from mavasani/Issue36215](https://www.github.com/dotnet/roslyn/pull/36582)
- ["Extract Interface ..." preserves banner at the top of the file (#36533)](https://www.github.com/dotnet/roslyn/pull/36533)
- [Merge pull request #36539 from sharwell/formatter-benchmark](https://www.github.com/dotnet/roslyn/pull/36539)
- [Merge pull request #35486 from filipw/feature/default-ns-public](https://www.github.com/dotnet/roslyn/pull/35486)
- [Merge pull request #36067 from mavasani/DiagnosticSuppressorForCompilerAndAnalyzerDiagnostics](https://www.github.com/dotnet/roslyn/pull/36067)
- [existing code loaded everyone in VS who MEF exported ITableColumnDefinition. now we make sure we only load one that we care (#36562)](https://www.github.com/dotnet/roslyn/pull/36562)
- [Merge pull request #36522 from ivanbasov/speculative-t](https://www.github.com/dotnet/roslyn/pull/36522)
- [Merge pull request #36518 from dibarbet/extract_open_file_tracker](https://www.github.com/dotnet/roslyn/pull/36518)
- [completion: CTRL+Space is not applicable in Delete/Backspace triggered session (#36331)](https://www.github.com/dotnet/roslyn/pull/36331)
- [Merge pull request #36006 from dibarbet/extract_open_file_tracker](https://www.github.com/dotnet/roslyn/pull/36006)
- [Merge pull request #36482 from dotnet/merges/master-to-release/dev16.3-preview1](https://www.github.com/dotnet/roslyn/pull/36482)
- [Merge pull request #34477 from sharwell/cleanup-features](https://www.github.com/dotnet/roslyn/pull/34477)
- [Merge pull request #29704 from sharwell/unused-usings](https://www.github.com/dotnet/roslyn/pull/29704)
- [Merge pull request #32558 from siegfriedpammer/dev/siegfriedpammer/decompiler-upgrade-r4521](https://www.github.com/dotnet/roslyn/pull/32558)
- [Store checksums as a first-class piece of data in our persistence layer. (#31538)](https://www.github.com/dotnet/roslyn/pull/31538)
- [Merge pull request #36368 from sharwell/update-packages](https://www.github.com/dotnet/roslyn/pull/36368)
- [Merge pull request #36456 from dotnet/revert-36445-dev/jorobich/revert-only-restricted-ivts](https://www.github.com/dotnet/roslyn/pull/36456)
- [Merge pull request #34117 from sharwell/single-streaming-presenter](https://www.github.com/dotnet/roslyn/pull/34117)
- [Merge pull request #36445 from dotnet/dev/jorobich/revert-only-restricted-ivts](https://www.github.com/dotnet/roslyn/pull/36445)
- [Allow Inline Rename to also apply a file rename (#36041)](https://www.github.com/dotnet/roslyn/pull/36041)
- [VSSDK update (#35934)](https://www.github.com/dotnet/roslyn/pull/35934)
- [Merge pull request #35691 from mavasani/ConfigureEditorConfig](https://www.github.com/dotnet/roslyn/pull/35691)
- [Merge pull request #36184 from sharwell/syntax-tree-benchmarks](https://www.github.com/dotnet/roslyn/pull/36184)
- [Merge pull request #36151 from sharwell/restricted-ivt](https://www.github.com/dotnet/roslyn/pull/36151)
- [Update Version.props for 16.3 preview 1 (#36292)](https://www.github.com/dotnet/roslyn/pull/36292)
- [Merge pull request #35692 from sharwell/nested-code-action](https://www.github.com/dotnet/roslyn/pull/35692)
- [Merge pull request #35810 from sharwell/rm-inprocessonly](https://www.github.com/dotnet/roslyn/pull/35810)
- [Merge pull request #19183 from sharwell/rm-lock](https://www.github.com/dotnet/roslyn/pull/19183)
- [Merge pull request #28957 from sharwell/fix-mef-usage](https://www.github.com/dotnet/roslyn/pull/28957)
- [Merge pull request #34028 from sharwell/ide-benchmarks](https://www.github.com/dotnet/roslyn/pull/34028)
- [Merge pull request #35814 from sharwell/sync-analyzer](https://www.github.com/dotnet/roslyn/pull/35814)
- [Merge pull request #34801 from sharwell/languages-layering](https://www.github.com/dotnet/roslyn/pull/34801)