### PR TITLE
[Core] Fix null ref in DotNetProject.OnGetReferencedAssemblies

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -33,6 +33,7 @@ using NUnit.Framework;
 using UnitTests;
 using MonoDevelop.Core;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MonoDevelop.Projects.Policies;
 using System.Xml;
@@ -1151,6 +1152,87 @@ namespace MonoDevelop.Projects
 			{
 				base.OnModified (args);
 				ModifiedEventArgs.Add (args);
+			}
+		}
+
+		/// <summary>
+		/// Tests that the project will be disposed even if something fails when the Func passed to
+		/// BindTask throws an exception. We want to ensure that the active task is cleared if there is
+		/// an error to avoid the project waiting forever for this task to finish on disposing.
+		/// </summary>
+		[Test]
+		public async Task BindTask_FuncThrowsException_ProjectIsDisposed_ProjectDoesNotWaitForTask ()
+		{
+			string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+			using (Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (DotNetProject)sol.Items [0];
+
+				Task task = null;
+				try {
+					task = p.BindTask (arg => throw new ApplicationException ("Test"));
+					await task;
+					Assert.Fail ("Should not reach this line");
+				} catch (ApplicationException) {
+				}
+
+				Assert.IsNotNull (task);
+
+				Task<string> task2 = null;
+				try {
+					task2 = p.BindTask<string> (arg => throw new ApplicationException ("Test 2"));
+					await task2;
+					Assert.Fail ("Should not reach this line - BindTask<T>");
+				} catch (ApplicationException) {
+				}
+
+				Assert.IsNotNull (task2);
+
+				p.Dispose ();
+
+				const int timeout = 5000; // ms
+				int howLong = 0;
+				const int interval = 200; // ms
+
+				while (p.MSBuildProject != null) {
+					if (howLong >= timeout)
+						Assert.Fail ("Timed out waiting for project to be disposed");
+
+					await Task.Delay (interval);
+					howLong += interval;
+				}
+			}
+		}
+
+		[Test]
+		public async Task GetReferences_ProjectDisposed_BeforeTaskIsBound_DoesNotThrowNullReferenceException ()
+		{
+			var fn = new CustomItemNode<TestGetReferencesProjectExtension> ();
+			WorkspaceObject.RegisterCustomExtension (fn);
+
+			try {
+				string solFile = Util.GetSampleProject ("console-project", "ConsoleProject.sln");
+				using (Solution sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+					var p = (DotNetProject)sol.Items [0];
+
+					// The TestGetReferencesProjectExtension will call Project.Dispose during the GetReferences call.
+					// Previously the GetReferences would throw a TaskCanceledException and Project.OnGetReferences would
+					// throw a unhandled NullReferenceException since the project was disposed which results in MSBuildProject
+					// being set to null.
+					var refs = await p.GetReferences (ConfigurationSelector.Default, CancellationToken.None);
+					Assert.IsTrue (refs.Any (r => r.FilePath.FileName == "System.Xml.dll"));
+				}
+			} finally {
+				WorkspaceObject.UnregisterCustomExtension (fn);
+			}
+		}
+
+		class TestGetReferencesProjectExtension : DotNetProjectExtension
+		{
+			protected internal override Task<List<AssemblyReference>> OnGetReferences (ConfigurationSelector configuration, CancellationToken token)
+			{
+				// Simulate the project being disposed whilst BindTask is called.
+				Project.Dispose ();
+				return base.OnGetReferences (configuration, token);
 			}
 		}
 	}


### PR DESCRIPTION
Fixed a race condition in WorkspaceObject.BindTask. If a project is
disposed during the BindTask call but before the task was added to
activeTasks the MSBuildProject would be set null causing a null
reference exception in DotNetProject.OnGetReferencedAssemblies. This
would also resulted in an unobserved task exception since BindTask
would return a different canceled task.

To prevent this BindTask registers a TaskCompletionSource to the
list of activeTasks before it calls the Func that returns the Task.
This ensures that the project will not be disposed whilst that Func
is being called.

Also if an exception being thrown by the Func the TaskCompletionSource
task is removed from the active tasks to avoid the project waiting
forever for all active tasks to finish and the project's OnDispose
method never being called.

Fixes VSTS #849584 - [Watson] NullReferenceException in
DotNetProject.OnGetReferencedAssemblies