### PR TITLE
[release-8.2] [CSharpBinding] Fix path bar sometimes not showing owner projects

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpPathedDocumentExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpPathedDocumentExtension.cs
@@ -69,6 +69,10 @@ namespace MonoDevelop.CSharp
 			isPathSet = false;
 			view.Caret.PositionChanged += CaretPositionChanged;
 			view.TextBuffer.PostChanged += TextBufferChanged;
+
+			// WorkspaceChanged event is not always fired so run the logic to update the owner projects to
+			// ensure they are available in the path bar.
+			WorkspaceChanged (null, null);
 		}
 
 		private void WorkspaceChanged (object sender, EventArgs e)


### PR DESCRIPTION
Opening a C# file from a shared project would sometimes not show
the owner projects in the path bar. Also affects multi-target
projects. The WorkspaceRegistration.WorkspaceChanged event would
sometimes not be generated on opening the text editor so the
owner projects were not added. To prevent the code is run on
creating the CSharpPathedDocumentExtension so that the owner
projects have been added in case the WorkspaceChanged event does
not fire.

Fixes VSTS #934792 - Editor path bar sometimes does not list
project information

Backport of #7984.

/cc @mrward 