### PR TITLE
Fix F# semantic highlighting

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpParser.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpParser.fs
@@ -104,7 +104,7 @@ type FSharpParser() =
             let shortFilename = Path.GetFileName filename
             try
                 if not token.IsCancellationRequested then
-                    match MonoDevelop.tryGetVisibleDocument filename with
+                    match MonoDevelop.tryGetVisibleDocument (filename |> FilePath) with
                     | Some doc ->
                         let newVersion = doc.Editor.Version
                         if newVersion.BelongsToSameDocumentAs(version) && newVersion.CompareAge(version) = 0 then
@@ -128,7 +128,7 @@ type FSharpParser() =
 
         let proj = parseOptions.Project
 
-        let doc = MonoDevelop.tryGetVisibleDocument fileName
+        let doc = MonoDevelop.tryGetVisibleDocument (fileName |> FilePath)
 
         if doc.IsNone || not (FileService.supportedFileName (fileName)) then null else
         

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
@@ -1,14 +1,11 @@
 ﻿namespace MonoDevelop.FSharp
 
-open System
 open System.Collections.Generic
-open System.Collections.Immutable
 open MonoDevelop.FSharp.Shared
-open MonoDevelop.Ide
 open MonoDevelop.Ide.Editor
 open MonoDevelop.Ide.Editor.Highlighting
+open MonoDevelop.Ide.Gui
 open MonoDevelop.Core
-open Mono.TextEditor.Highlighting
 open FSharp.Compiler
 open FSharp.Compiler.SourceCodeServices
 open ExtCore.Control
@@ -357,18 +354,13 @@ module Patterns =
             | _ -> Seq.empty
 
 
-type FSharpSyntaxMode(editor, context) =
+type FSharpSyntaxMode(editor, context: DocumentContext) =
     inherit SemanticHighlighting(editor, context)
     let tokenssymbolscolours = ref None
-    //let style = ref (getColourScheme())
-    //let colourSchemChanged =
-    //    IdeApp.Preferences.ColorScheme.Changed.Subscribe
-    //        (fun _ (eventArgs:EventArgs) ->
-    //                          let colourStyles = SyntaxModeService.GetColorStyle(IdeApp.Preferences.ColorScheme.Value)
-    //                          (*style := colourStyles*) )
-                                  
+    let roslynContext = context :?> RoslynDocumentContext
+
     override x.DocumentParsed() =
-        if MonoDevelop.isDocumentVisible context.Name then
+        if MonoDevelop.isDocumentVisible roslynContext.FileName then
             SyntaxMode.tryGetTokensSymbolsAndColours context
             |> Option.iter (fun tsc -> tokenssymbolscolours := Some tsc
                                        Application.Invoke(fun _ _ -> x.NotifySemanticHighlightingUpdate()))
@@ -378,6 +370,4 @@ type FSharpSyntaxMode(editor, context) =
         let lineNumber = line.LineNumber
         let txt = editor.GetLineText line
 
-        SyntaxMode.getColouredSegment !tokenssymbolscolours lineNumber line.Offset txt// !style
-        
-    //interface IDisposable with member x.Dispose() = colourSchemChanged.Dispose()
+        SyntaxMode.getColouredSegment !tokenssymbolscolours lineNumber line.Offset txt

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
@@ -75,11 +75,11 @@ module MonoDevelop =
 
     let isDocumentVisible filename =
         visibleDocuments()
-        |> Seq.exists (fun d -> d.FileName.ToString() = filename)
+        |> Seq.exists (fun d -> d.FileName = filename)
 
     let tryGetVisibleDocument filename =
         visibleDocuments()
-        |> Seq.tryFind (fun d -> d.FileName.ToString() = filename)
+        |> Seq.tryFind (fun d -> d.FileName = filename)
 
 
 /// Provides functionality for working with the F# interactive checker running in background


### PR DESCRIPTION
Fixes VSTS #939713

Semantic highlighting was not working at all. Only regex highlighting was being used.