### PR TITLE
[release-8.1] Fix F# semantic highlighting

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpParser.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpParser.fs
@@ -104,7 +104,7 @@ type FSharpParser() =
             let shortFilename = Path.GetFileName filename
             try
                 if not token.IsCancellationRequested then
-                    match MonoDevelop.tryGetVisibleDocument filename with
+                    match MonoDevelop.tryGetVisibleDocument (filename |> FilePath) with
                     | Some doc ->
                         let newVersion = doc.Editor.Version
                         if newVersion.BelongsToSameDocumentAs(version) && newVersion.CompareAge(version) = 0 then
@@ -128,7 +128,7 @@ type FSharpParser() =
 
         let proj = parseOptions.Project
 
-        let doc = MonoDevelop.tryGetVisibleDocument fileName
+        let doc = MonoDevelop.tryGetVisibleDocument (fileName |> FilePath)
 
         if doc.IsNone || not (FileService.supportedFileName (fileName)) then null else
         

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
@@ -75,11 +75,11 @@ module MonoDevelop =
 
     let isDocumentVisible filename =
         visibleDocuments()
-        |> Seq.exists (fun d -> d.FileName.ToString() = filename)
+        |> Seq.exists (fun d -> d.FileName = filename)
 
     let tryGetVisibleDocument filename =
         visibleDocuments()
-        |> Seq.tryFind (fun d -> d.FileName.ToString() = filename)
+        |> Seq.tryFind (fun d -> d.FileName = filename)
 
 
 /// Provides functionality for working with the F# interactive checker running in background


### PR DESCRIPTION
Fixes VSTS #939713

Semantic highlighting was not working at all. Only regex highlighting was being used.