### PR TITLE
[release-8.2] [Mac] Fix keyboard input in Global Search when in fullscreen

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -70,11 +70,11 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		void AttachToolbarEvents (SearchBar bar)
 		{
-			bar.Changed += (o, e) => {
-				SearchEntryChanged?.Invoke (o, e);
+			bar.PerformCommand += (o, e) => {
+				PerformCommand?.Invoke (o, e);
 			};
 			bar.KeyPressed += (o, e) => {
-				SearchEntryKeyPressed?.Invoke (o, e);
+				SearchEntryChanged?.Invoke (o, e);
 			};
 			bar.LostFocus += (o, e) => {
 				SearchEntryLostFocus?.Invoke (o, e);
@@ -209,6 +209,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public event EventHandler RunButtonClicked;
 		public event EventHandler SearchEntryChanged;
 		public event EventHandler<Xwt.KeyEventArgs> SearchEntryKeyPressed;
+		public event EventHandler<SearchEntryCommandArgs> PerformCommand;
 		public event EventHandler SearchEntryLostFocus;
 
 		#pragma warning disable 0067

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.Components.Commands
 		internal static readonly object CommandRouteTerminator = new object ();
 		
 		internal bool handlerFoundInMulticast;
-		Gtk.Widget lastActiveWidget;
+		Gtk.Widget activeWidget;
 
 #if MAC
 		Foundation.NSObject keyMonitor;
@@ -107,6 +107,9 @@ namespace MonoDevelop.Components.Commands
 				return conflicts;
 			}
 		}
+
+		WeakReference lastCommandTarget;
+		internal object LastCommandTarget => lastCommandTarget?.Target; 
 
 		public CommandManager (): this (null)
 		{
@@ -2277,10 +2280,11 @@ namespace MonoDevelop.Components.Commands
 
 				widget = GetFocusedChild (widget);
 			}
-			if (widget != lastActiveWidget) {
+			if (widget != activeWidget) {
 				if (ActiveWidgetChanged != null)
-					ActiveWidgetChanged (this, new ActiveWidgetEventArgs () { OldActiveWidget = lastActiveWidget, NewActiveWidget = widget });
-				lastActiveWidget = widget;
+					ActiveWidgetChanged (this, new ActiveWidgetEventArgs () { OldActiveWidget = activeWidget, NewActiveWidget = widget });
+				lastCommandTarget = new WeakReference (activeWidget);
+				activeWidget = widget;
 			}
 			return widget;
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
@@ -77,7 +77,8 @@ namespace MonoDevelop.Components.MainToolbar
 				try {
 					if (pattern.HasLineNumber)
 						return;
-					CommandTargetRoute route = new CommandTargetRoute (MainToolbar.LastCommandTarget);
+					var route = new CommandTargetRoute (IdeApp.CommandService.LastCommandTarget);
+
 					var matcher = StringMatcher.GetMatcher (pattern.Pattern, false);
 
 					foreach (var cmdTuple in allCommands) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IMainToolbarView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/IMainToolbarView.cs
@@ -39,6 +39,16 @@ namespace MonoDevelop.Components.MainToolbar
 		Stop
 	}
 
+	public enum SearchPopupCommand
+	{
+		PreviousItem,
+		NextItem,
+		PreviousCategory,
+		NextCategory,
+		Cancel,
+		Activate
+	};
+
 	/// <summary>
 	/// Event arguments which specify if the event succeeded in at least one handler.
 	/// </summary>
@@ -197,6 +207,7 @@ namespace MonoDevelop.Components.MainToolbar
 		/// Occurs when a key is pressed in the search entry.
 		/// </summary>
 		event EventHandler<Xwt.KeyEventArgs> SearchEntryKeyPressed;
+		event EventHandler<SearchEntryCommandArgs> PerformCommand;
 
 		/// <summary>
 		/// Occurs when the search entry is resized.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbar.cs
@@ -23,6 +23,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#if !MAC
+
 using System;
 using Gtk;
 using MonoDevelop.Components.Commands;
@@ -43,6 +45,7 @@ using System.Threading;
 using MonoDevelop.Ide.Editor;
 using System.Text;
 using MonoDevelop.Components.AtkCocoaHelper;
+using System.Diagnostics;
 
 namespace MonoDevelop.Components.MainToolbar
 {
@@ -88,10 +91,6 @@ namespace MonoDevelop.Components.MainToolbar
 			get {
 				return statusArea;
 			}
-		}
-
-		internal static object LastCommandTarget {
-			get { return lastCommandTarget != null ? lastCommandTarget.Target : null; }
 		}
 
 		static bool RuntimeIsSeparator (TreeModel model, TreeIter iter)
@@ -271,10 +270,6 @@ namespace MonoDevelop.Components.MainToolbar
 
 			button.Clicked += HandleStartButtonClicked;
 
-			IdeApp.CommandService.ActiveWidgetChanged += (sender, e) => {
-				lastCommandTarget = new WeakReference (e.OldActiveWidget);
-			};
-
 			this.ShowAll ();
 			this.statusArea.statusIconBox.HideAll ();
 		}
@@ -323,21 +318,54 @@ namespace MonoDevelop.Components.MainToolbar
 
 		void HandleSearchEntryKeyPressed (object sender, KeyPressEventArgs e)
 		{
-			if (SearchEntryKeyPressed != null) {
-				// TODO: Refactor this in Xwt as an extension method.
-				var k = (Xwt.Key)e.Event.KeyValue;
-				var m = Xwt.ModifierKeys.None;
-				if ((e.Event.State & Gdk.ModifierType.ShiftMask) != 0)
-					m |= Xwt.ModifierKeys.Shift;
-				if ((e.Event.State & Gdk.ModifierType.ControlMask) != 0)
-					m |= Xwt.ModifierKeys.Control;
-				if ((e.Event.State & Gdk.ModifierType.Mod1Mask) != 0)
-					m |= Xwt.ModifierKeys.Alt;
-				// TODO: Backport this one.
-				if ((e.Event.State & Gdk.ModifierType.Mod2Mask) != 0)
-					m |= Xwt.ModifierKeys.Command;
-				var kargs = new Xwt.KeyEventArgs (k, m, false, (long)e.Event.Time);
-				SearchEntryKeyPressed (sender, kargs);
+			if (PerformCommand != null) {
+				bool cmdPressed = (e.Event.State & Gdk.ModifierType.Mod2Mask) != 0;
+				SearchPopupCommand command;
+
+				switch ((Gdk.Key)e.Event.KeyValue) {
+				case Gdk.Key.Down:
+				case Gdk.Key.downarrow:
+					if (cmdPressed) {
+						goto case Gdk.Key.Page_Down;
+					}
+
+					command = SearchPopupCommand.NextItem;
+					break;
+
+				case Gdk.Key.Up:
+				case Gdk.Key.uparrow:
+					if (cmdPressed) {
+						goto case Gdk.Key.Page_Up;
+					}
+
+					command = SearchPopupCommand.PreviousItem;
+					break;
+
+				case Gdk.Key.KP_Page_Down:
+				case Gdk.Key.Page_Down:
+					command = SearchPopupCommand.NextCategory;
+					break;
+
+				case Gdk.Key.KP_Page_Up:
+				case Gdk.Key.Page_Up:
+					command = SearchPopupCommand.PreviousCategory;
+					break;
+
+				case Gdk.Key.Escape:
+					command = SearchPopupCommand.Cancel;
+					break;
+
+				case Gdk.Key.Return:
+				case Gdk.Key.KP_Enter:
+					command = SearchPopupCommand.Activate;
+					break;
+
+				default:
+					return;
+				}
+
+				var kargs = new SearchEntryCommandArgs (command);
+				PerformCommand?.Invoke (sender, kargs);
 				e.RetVal = kargs.Handled;
 			}
 		}
@@ -582,6 +610,7 @@ namespace MonoDevelop.Components.MainToolbar
 		public event EventHandler SearchEntryChanged;
 		public event EventHandler SearchEntryActivated;
 		public event EventHandler<Xwt.KeyEventArgs> SearchEntryKeyPressed;
+		public event EventHandler<SearchEntryCommandArgs> PerformCommand;
 		public event EventHandler SearchEntryResized;
 		public event EventHandler SearchEntryLostFocus;
 
@@ -628,3 +657,4 @@ namespace MonoDevelop.Components.MainToolbar
 	}
 }
 
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -77,6 +77,7 @@ namespace MonoDevelop.Components.MainToolbar
 			ToolbarView.SearchEntryChanged += HandleSearchEntryChanged;
 			ToolbarView.SearchEntryActivated += HandleSearchEntryActivated;
 			ToolbarView.SearchEntryKeyPressed += HandleSearchEntryKeyPressed;
+			ToolbarView.PerformCommand += HandleSearchEntryCommand;
 			ToolbarView.SearchEntryResized += (o, e) => PositionPopup ();
 			ToolbarView.SearchEntryLostFocus += (o, e) => {
 				ToolbarView.SearchText = "";
@@ -741,6 +742,21 @@ namespace MonoDevelop.Components.MainToolbar
 				popup.OpenFile ();
 		}
 
+		void HandleSearchEntryCommand (object sender, SearchEntryCommandArgs args)
+		{
+			if (args.Command == SearchPopupCommand.Cancel) {
+				DestroyPopup ();
+				var doc = IdeApp.Workbench.ActiveDocument;
+				if (doc != null)
+					doc.Select ();
+				return;
+			}
+
+			if (popup != null) {
+				args.Handled = popup.ProcessCommand (args.Command);
+			}
+		}
+
 		void HandleSearchEntryKeyPressed (object sender, Xwt.KeyEventArgs e)
 		{
 			if (e.Key == Xwt.Key.Escape) {
@@ -1179,6 +1195,16 @@ namespace MonoDevelop.Components.MainToolbar
 			public string DisplayString { get; private set; }
 			public string Category { get; set; }
 			public event EventHandler Activated;
+		}
+	}
+
+	public class SearchEntryCommandArgs : HandledEventArgs
+	{
+		public SearchPopupCommand Command { get; private set; }
+
+		public SearchEntryCommandArgs (SearchPopupCommand command)
+		{
+			Command = command;
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -81,6 +81,11 @@ namespace MonoDevelop.Components.MainToolbar
 			Content.OpenFile ();
 		}
 
+		internal bool ProcessCommand (SearchPopupCommand command)
+		{
+			return Content.ProcessCommand (command);
+		}
+
 		internal bool ProcessKey (Key key, ModifierKeys state)
 		{
 			return Content.ProcessKey (key, state);
@@ -779,6 +784,31 @@ namespace MonoDevelop.Components.MainToolbar
 			);
 			ShowTooltip ();
 			QueueDraw ();
+		}
+
+		internal bool ProcessCommand (SearchPopupCommand command)
+		{
+			switch (command) {
+			case SearchPopupCommand.PreviousItem:
+				SelectItemUp ();
+				return true;
+			case SearchPopupCommand.NextItem:
+				SelectItemDown ();
+				return true;
+			case SearchPopupCommand.NextCategory:
+				SelectNextCategory ();
+				return true;
+			case SearchPopupCommand.PreviousCategory:
+				SelectPrevCategory ();
+				return true;
+			case SearchPopupCommand.Activate:
+				OnItemActivated (EventArgs.Empty);
+				return true;
+
+			default:
+				break;
+			}
+			return false;
 		}
 
 		internal bool ProcessKey (Xwt.Key key, Xwt.ModifierKeys state)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchResult.cs
@@ -269,7 +269,7 @@ namespace MonoDevelop.Components.MainToolbar
 						return false;
 					}
 					Runtime.RunInMainThread (delegate {
-						ci = IdeApp.CommandService.GetCommandInfo (command.Id, new CommandTargetRoute (MainToolbar.LastCommandTarget));
+						ci = IdeApp.CommandService.GetCommandInfo (command.Id, new CommandTargetRoute (IdeApp.CommandService.LastCommandTarget));
 					}).Wait ();
 				}
 				return ci.Enabled && ci.Visible;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -409,14 +409,21 @@ namespace MonoDevelop.Ide.Desktop
 
 		internal virtual IMainToolbarView CreateMainToolbar (Gtk.Window window)
 		{
+			// This is overridden by MacPlatform
+#if MAC
+			return null;
+#else
 			return new MainToolbar ();
+#endif
 		}
 
 		internal virtual void AttachMainToolbar (Gtk.VBox parent, IMainToolbarView toolbar)
 		{
+#if !MAC
 			var toolbarBox = new Gtk.HBox ();
 			parent.PackStart (toolbarBox, false, false, 0);
 			toolbarBox.PackStart ((MainToolbar)toolbar, true, true, 0);
+#endif
 		}
 
 		public virtual bool GetIsFullscreen (Window window)


### PR DESCRIPTION
In fullscreen Cocoa stops delivering performKeyEquivalent messages to the
SearchBar which breaks handling of cursor keys and similar. Instead of using
it, use our own delegate to catch control:textView:doCommandBySelector: and
create a command from the selector.

Fixes VSTS #937857

Backport of #8111.

/cc @iainx 