### PR TITLE
Fix 935181: TryGetBreakpointSpan called with invalid position

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Debugger/CSharpBreakpointSpanResolver.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Debugger/CSharpBreakpointSpanResolver.cs
@@ -50,9 +50,9 @@ namespace MonoDevelop.CSharp.Debugger
 			var document = buffer.AsTextContainer ().GetOpenDocumentInCurrentContext ();
 			var tree = await document.GetSyntaxTreeAsync (cancellationToken);
 
-			BreakpointSpans.TryGetBreakpointSpan (tree, position, cancellationToken, out var span);
-
-			return new Span (span.Start, span.Length);
+			if (BreakpointSpans.TryGetBreakpointSpan (tree, Math.Max (0, Math.Min (position, tree.Length - 1)), cancellationToken, out var span))
+				return new Span (span.Start, span.Length);
+			return buffer.CurrentSnapshot.GetLineFromPosition (Math.Max (0, Math.Min (position, buffer.CurrentSnapshot.Length - 1))).Extent.Span;
 		}
 	}
 }

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Debugger/CSharpBreakpointSpanResolver.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Debugger/CSharpBreakpointSpanResolver.cs
@@ -47,11 +47,12 @@ namespace MonoDevelop.CSharp.Debugger
 
 		public async Task<Span> GetBreakpointSpanAsync (ITextBuffer buffer, int position, CancellationToken cancellationToken)
 		{
-			var document = buffer.AsTextContainer ().GetOpenDocumentInCurrentContext ();
-			var tree = await document.GetSyntaxTreeAsync (cancellationToken);
+			var document = buffer.AsTextContainer ()?.GetOpenDocumentInCurrentContext ();
+			var tree = document != null ? await document.GetSyntaxTreeAsync (cancellationToken) : null;
 
-			if (BreakpointSpans.TryGetBreakpointSpan (tree, Math.Max (0, Math.Min (position, tree.Length - 1)), cancellationToken, out var span))
+			if (tree != null && BreakpointSpans.TryGetBreakpointSpan (tree, Math.Max (0, Math.Min (position, tree.Length - 1)), cancellationToken, out var span))
 				return new Span (span.Start, span.Length);
+
 			return buffer.CurrentSnapshot.GetLineFromPosition (Math.Max (0, Math.Min (position, buffer.CurrentSnapshot.Length - 1))).Extent.Span;
 		}
 	}


### PR DESCRIPTION
I also added logic to fallback to whole line breakpoint in case Roslyn fails to find matching statement to place breakpoint on.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935181/
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935126/