### PR TITLE
[release-8.2] Fixes VSTS 935137: Null Reference Exceptions when disposing TextViewContent

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -321,12 +321,22 @@ namespace MonoDevelop.TextEditor
 
 		protected virtual void UnsubscribeFromEvents ()
 		{
-			sourceEditorOptions.Changed -= UpdateTextEditorOptions;
-			if (TextDocument != null) {
+			if (sourceEditorOptions != null)
+				sourceEditorOptions.Changed -= UpdateTextEditorOptions;
+
+			if (TextDocument != null)
 				TextDocument.DirtyStateChanged -= HandleTextDocumentDirtyStateChanged;
+
+			if (TextBuffer != null)
 				TextBuffer.Changed -= HandleTextBufferChanged;
+
+			// while this actually generates a "warning" about potentially comparing value types,
+			// we can be fairly confident that's not actually going to happen - and while the correct
+			// change would be to ensure TView is a "class", that's too big of a change to try and
+			// and combat this bug with.
+			// In addition, this will get JITTed into a cast to Object and a check for null.
+			if (TextView != null && TextView.Options != null)
 				TextView.Options.OptionChanged -= TextBufferOptionsChanged;
-			}
 		}
 
 		void UpdateBufferOptions ()


### PR DESCRIPTION
This is an attempt to fix Null Reference Exceptions that happen when `TextViewContent` is disposed.

There were two potential cases where this would have potentially happened, one, where `sourceEditorOptions` was null, and second, when `TextView` was null in the call to `TextView.Options`.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935137/

Backport of #8097.

/cc @abock @avodovnik