### PR TITLE
[Backport] Fixes VSTS 917028: Calling ScrollToRequestedCaretLocation with an invalid line number caused an exception

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -657,11 +657,24 @@ namespace MonoDevelop.Ide.Gui.Documents
 				} else {
 					var offset = info.Offset;
 					if (offset < 0) {
-						var line = textView.TextSnapshot.GetLineFromLineNumber (info.Line - 1);
-						if (info.Column >= 1) {
-							offset = line.Start + Math.Min (info.Column - 1, line.Length);
-						} else {
-							offset = line.Start;
+						try {
+							if (info.Line - 1 > (textView?.TextSnapshot?.LineCount ?? 0)) {
+								LoggingService.LogInfo ($"ScrollToRequestedCaretLocation line was over the snapshot's line count. "
+									+ $"Called with {info.Line - 1} but line count was {textView?.TextSnapshot?.LineCount}");
+								return;
+							}
+
+							var line = textView.TextSnapshot.GetLineFromLineNumber (info.Line - 1);
+							if (info.Column >= 1) {
+								offset = line.Start + Math.Min (info.Column - 1, line.Length);
+							} else {
+								offset = line.Start;
+							}
+						} catch (ArgumentException ae) {
+							LoggingService.LogError ($"Calling GetLineFromLineNumber resulted in an argument exception."
+								+ $"We tried calling with line number: {info.Line - 1}", ae);
+							// we should just abort in this case, since we can't really do anything
+							return;
 						}
 					}
 					if (editorOperationsFactoryService != null) {


### PR DESCRIPTION
In some cases (like a deletion of code from the document, then trying to double click an existing Search Result), this method might have been called with a line number that no longer exists. This resulted in a call to the API that threw an exception. Now, the method checks the line count in the snapshot, and aborts. Both cases (a graceful failure, and an exception) are logged, so we can see if this continues to happen.

Original PR: #8105 