### PR TITLE
Fixes VSTS Bug 942353: [FATAL] System.NullReferenceException exception

### DIFF
--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditor.cs
@@ -53,7 +53,7 @@ namespace Mono.MHex
 		
 		public IHexEditorOptions Options {
 			get;
-			set;
+			private set;
 		}
 		
 		IconMargin iconMargin;
@@ -169,15 +169,24 @@ namespace Mono.MHex
 			Options.Changed += OptionsChanged;
 		}
 
+
 		protected override void Dispose (bool disposing)
 		{
-			Options.Changed -= OptionsChanged;
-			if (caretTimer != null) { 
-				caretTimer.Elapsed -= UpdateCaret;
-				caretTimer.Dispose ();
-				caretTimer = null;
+			try {
+				base.Dispose (disposing);
+
+				if (disposing) {
+					if (Options != null)
+						Options.Changed -= OptionsChanged;
+					if (caretTimer != null) {
+						caretTimer.Elapsed -= UpdateCaret;
+						caretTimer.Dispose ();
+						caretTimer = null;
+					}
+				}
+			} catch (Exception e) {
+				LoggingService.LogInternalError ("Error while disposing hex editor", e);
 			}
-			base.Dispose (disposing);
 		}
 		
 		public void PurgeLayoutCaches ()

--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditorDebugger.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex/HexEditorDebugger.cs
@@ -47,9 +47,6 @@ namespace Mono.MHex
 			get {
 				return editor.Options;
 			}
-			set {
-				editor.Options = value;
-			}
 		}
 
 		public void PurgeLayoutCaches ()


### PR DESCRIPTION
in Mono.MHex.HexEditor.Dispose()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/942353

Can't really determine the cause - Options should always be != null
but it's the only thing that can throw a null ref exception. But in
any case Dispose shouldn't cause a fatal exception.