### PR TITLE
Fixes VSTS Bug 940831: "Authors" (Blame) tab fails to load

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -39,6 +39,7 @@ using MonoDevelop.Ide.Fonts;
 using MonoDevelop.Ide.Editor;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text;
+using MonoDevelop.Core.Text;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -115,7 +116,6 @@ namespace MonoDevelop.VersionControl.Views
 			GtkWorkarounds.FixContainerLeak (this);
 			
 			this.info = info;
-			var textView = info.Controller.GetContent<ITextView> ();
 
 			vAdjustment = new Adjustment (0, 0, 0, 0, 0, 0);
 			vAdjustment.Changed += HandleAdjustmentChanged;
@@ -129,10 +129,19 @@ namespace MonoDevelop.VersionControl.Views
 			hScrollBar = new HScrollbar (hAdjustment);
 			AddChild (hScrollBar);
 
-			var doc = new TextDocument (textView.TextSnapshot.GetText()) {
-				IsReadOnly = true,
-				MimeType = IdeServices.DesktopService.GetMimeTypeForContentType (textView.TextBuffer.ContentType)
-			};
+			var textView = info.Controller.GetContent<ITextView> ();
+			TextDocument doc;
+			if (textView != null) {
+				doc = new TextDocument (textView.TextSnapshot.GetText ()) {
+					IsReadOnly = true,
+					MimeType = IdeServices.DesktopService.GetMimeTypeForContentType (textView.TextBuffer.ContentType)
+				};
+			} else {
+				doc = new TextDocument (TextFileUtility.GetText (info.Item.Path)) {
+					IsReadOnly = true,
+					MimeType = IdeServices.DesktopService.GetMimeTypeForUri (info.Item.Path)
+				};
+			}
 			var options = new CustomEditorOptions (DefaultSourceEditorOptions.Instance);
 			options.TabsToSpaces = false;
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/ComparisonWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/ComparisonWidget.cs
@@ -271,16 +271,18 @@ namespace MonoDevelop.VersionControl.Views
 			
 			public void ActivateItem (int n)
 			{
+				var textEditor = (MonoTextEditor)box.Tag;
 				if (n == 0) {
 					box.SetItem (GettextCatalog.GetString ("Local"), null, new object());
-					widget.SetLocal (((MonoTextEditor)box.Tag).GetTextEditorData ());
+					widget.SetLocal (textEditor.GetTextEditorData ());
 					return;
 				}
-				widget.RemoveLocal (((MonoTextEditor)box.Tag).GetTextEditorData ());
-				((MonoTextEditor)box.Tag).Document.IsReadOnly = true;
+				widget.RemoveLocal (textEditor.GetTextEditorData ());
+				textEditor.Document.IsReadOnly = true;
+
 				if (n == 1) {
 					box.SetItem (GettextCatalog.GetString ("Base"), null, new object());
-					if (((MonoTextEditor)box.Tag) == widget.editors[0]) {
+					if (textEditor == widget.editors[0]) {
 						widget.diffRevision = null;
 					} else {
 						widget.originalRevision = null;
@@ -292,14 +294,14 @@ namespace MonoDevelop.VersionControl.Views
 						text = string.Format (GettextCatalog.GetString ("Error while getting the base text of {0}:\n{1}"), widget.info.Item.Path, ex.ToString ());
 						MessageService.ShowError (text);
 					}
-					
-					((MonoTextEditor)box.Tag).Document.Text = text;
+
+					textEditor.Document.Text = text;
 					widget.CreateDiff ();
 					return;
 				}
 				
 				Revision rev = widget.info.History[n - 2];
-				widget.SetRevision ((MonoTextEditor)box.Tag, rev);
+				widget.SetRevision (textEditor, rev);
 			}
 
 			public int IconCount {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
@@ -608,9 +608,16 @@ namespace MonoDevelop.VersionControl.Views
 		public void UpdateLocalText ()
 		{
 			var textBuffer = info.Controller.GetContent<ITextBuffer> ();
+			string localText = null;
+			if (textBuffer != null) {
+				localText = textBuffer.CurrentSnapshot.GetText ();
+			} else {
+				localText = TextFileUtility.GetText (info.Item.Path);
+			}
+			 
 			foreach (var data in dict.Values) {
 				data.Document.TextChanged -= HandleDataDocumentTextReplaced;
-				data.Document.Text = textBuffer.CurrentSnapshot.GetText ();
+				data.Document.Text = localText;
 				data.Document.TextChanged += HandleDataDocumentTextReplaced;
 			}
 			CreateDiff ();
@@ -624,10 +631,13 @@ namespace MonoDevelop.VersionControl.Views
 
 			var editor = info.Document.GetContent<ITextBuffer> ();
 			if (editor != null) {
-				data.Document.Text = editor.CurrentSnapshot.GetText();
+				data.Document.Text = editor.CurrentSnapshot.GetText ();
 				data.Document.IsReadOnly = editor.IsReadOnly (0);
+			} else {
+				data.Document.Text = TextFileUtility.GetText (info.Item.Path);
+				data.Document.IsReadOnly = true;
 			}
-			
+
 			CreateDiff ();
 			data.Document.TextChanged += HandleDataDocumentTextReplaced;
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/BlameCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/BlameCommand.cs
@@ -39,10 +39,11 @@ namespace MonoDevelop.VersionControl
 		
 		static bool CanShow (VersionControlItem item)
 		{
+			var controller = IdeApp.Workbench.GetDocument (item.Path)?.DocumentController;
 			return !item.IsDirectory
 				// FIXME: Review appending of Annotate support and use it.
 				&& item.VersionInfo.IsVersioned
-				&& AddinManager.GetExtensionObjects<IVersionControlViewHandler> (BlameViewHandlers).Any (h => h.CanHandle (item, null));
+				&& AddinManager.GetExtensionObjects<IVersionControlViewHandler> (BlameViewHandlers).Any (h => h.CanHandle (item, controller));
 		}
 		
 		public static async Task<bool> Show (VersionControlItemList items, bool test)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultBlameViewHandler.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultBlameViewHandler.cs
@@ -29,15 +29,22 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.VersionControl.Views;
 using MonoDevelop.Projects.Text;
 using MonoDevelop.Ide.Gui.Documents;
+using MonoDevelop.Ide.Editor;
+using Microsoft.VisualStudio.Text;
 
 namespace MonoDevelop.VersionControl
 {
 	public class DefaultBlameViewHandler : IVersionControlViewHandler
 	{
-		public bool CanHandle (VersionControlItem item, DocumentController controller)
+		public static bool DefaultVCSViewCanHandle (VersionControlItem item, DocumentController controller)
 		{
-			return (controller is FileDocumentController || controller == null) && item.Repository.GetFileIsText (item.Path);
+			if (controller == null)
+				return item.Repository.GetFileIsText (item.Path);
+
+			return controller is TextEditorViewContent || controller.GetContent<ITextBuffer> () != null;
 		}
+
+		public bool CanHandle (VersionControlItem item, DocumentController controller) => DefaultVCSViewCanHandle (item, controller);
 
 		public DocumentController CreateView (VersionControlDocumentInfo info)
 		{

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultDiffViewHandler.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultDiffViewHandler.cs
@@ -34,10 +34,7 @@ namespace MonoDevelop.VersionControl
 {
 	public class DefaultDiffViewHandler : IVersionControlViewHandler
 	{
-		public bool CanHandle (VersionControlItem item, DocumentController controller)
-		{
-			return (controller is FileDocumentController || controller == null) && item.Repository.GetFileIsText (item.Path);
-		}
+		public bool CanHandle (VersionControlItem item, DocumentController controller) => DefaultBlameViewHandler.DefaultVCSViewCanHandle (item, controller);
 
 		public DocumentController CreateView (VersionControlDocumentInfo info)
 		{

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultMergeViewHandler.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultMergeViewHandler.cs
@@ -34,10 +34,7 @@ namespace MonoDevelop.VersionControl
 {
 	public class DefaultMergeViewHandler : IVersionControlViewHandler
 	{
-		public bool CanHandle (VersionControlItem item, DocumentController controller)
-		{
-			return (controller is FileDocumentController || controller == null) && item.Repository.GetFileIsText (item.Path);
-		}
+		public bool CanHandle (VersionControlItem item, DocumentController controller) => DefaultBlameViewHandler.DefaultVCSViewCanHandle (item, controller);
 
 		public DocumentController CreateView (VersionControlDocumentInfo info)
 		{

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DiffCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DiffCommand.cs
@@ -39,9 +39,10 @@ namespace MonoDevelop.VersionControl
 		
 		static bool CanShow (VersionControlItem item)
 		{
+			var controller = IdeApp.Workbench.GetDocument (item.Path)?.DocumentController;
 			return !item.IsDirectory 
 				&& item.VersionInfo.IsVersioned
-				&& AddinManager.GetExtensionObjects<IVersionControlViewHandler> (DiffViewHandlers).Any (h => h.CanHandle (item, null));
+				&& AddinManager.GetExtensionObjects<IVersionControlViewHandler> (DiffViewHandlers).Any (h => h.CanHandle (item, controller));
 		}
 		
 		public static async Task<bool> Show (VersionControlItemList items, bool test)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/MergeCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/MergeCommand.cs
@@ -38,9 +38,10 @@ namespace MonoDevelop.VersionControl
 		
 		static bool CanShow (VersionControlItem item)
 		{
+			var controller = IdeApp.Workbench.GetDocument (item.Path)?.DocumentController;
 			return !item.IsDirectory
 				&& item.VersionInfo.IsVersioned
-				&& AddinManager.GetExtensionObjects<IVersionControlViewHandler> (MergeViewHandlers).Any (h => h.CanHandle (item, null));
+				&& AddinManager.GetExtensionObjects<IVersionControlViewHandler> (MergeViewHandlers).Any (h => h.CanHandle (item, controller));
 		}
 		
 		public static async Task<bool> Show (VersionControlItemList items, bool test)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlCommandHandler.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlCommandHandler.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.VersionControl
 			this.items = items;
 		}
 		
-		protected override bool MultipleSelectedNodes {
+		protected internal override bool MultipleSelectedNodes {
 			get {
 				if (items != null)
 					return items.Count > 1;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlDocumentController.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlDocumentController.cs
@@ -75,7 +75,7 @@ namespace MonoDevelop.VersionControl
 			return versionInfo.IsVersioned;
 		}
 
-		protected override async Task<DocumentView> OnInitializeView ()
+		protected internal override async Task<DocumentView> OnInitializeView ()
 		{
 			var mainView = await base.OnInitializeView ();
 			var controller = (FileDocumentController)Controller;
@@ -96,6 +96,8 @@ namespace MonoDevelop.VersionControl
 				.FirstOrDefault (h => h.CanHandle (info.Item, info.VersionControlExtension.Controller));
 			if (handler != null) {
 				var controller = handler.CreateView (info);
+				if (controller == null)
+					return null;
 				await controller.Initialize (null, null);
 				var item = await controller.GetDocumentView ();
 				item.Title = title;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4344,6 +4344,7 @@
     <InternalsVisibleTo Include="MonoDevelop.Xml" />
     <InternalsVisibleTo Include="MonoDevelop.Xml.Tests" />
     <InternalsVisibleTo Include="MonoDevelop.UserInterfaceTesting" />
+    <InternalsVisibleTo Include="MonoDevelop.VersionControl" />
     <InternalsVisibleTo Include="WebToolingAddin" />
     <InternalsVisibleTo Include="WindowsPlatform" />
     <InternalsVisibleTo Include="Xamarin.Forms.Addin" />


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/940831

Blame/Diff now works without an text editor attached. The default view
handlers hide the diff/blame/merge view and commands because they need
the current text from somewhere - that's done through the ITextBuffer
API which needs to be provided by the document controller. But for
read-only views it would be possible to use these commands with
potential custom view handlers that enable these controllers on
specific view contents.