### PR TITLE
[CSharpBinding] Fix crash on opening C# format profile dialog

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingProfileDialog.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingProfileDialog.cs
@@ -138,7 +138,6 @@ namespace MonoDevelop.CSharp.Formatting
 			texteditor.IsReadOnly = true;
 			texteditor.MimeType = CSharpFormatter.MimeType;
 			scrolledwindow.AddWithViewport (texteditor);
-			ShowAll ();
 			
 			#region Indent options
 			indentationOptions = new TreeStore (typeof(string), typeof(string), typeof(string), typeof(bool), typeof(bool));


### PR DESCRIPTION
In Preferences - Source Code - Code Formatting - C# when the Edit
button was clicked in the Format tab the IDE would crash. The problem
was that the dialog being displayed was being used as its own parent
in MessageService. Which was causing a stack overflow.

```
Stack overflow: IP: 0x7fff57f71b9c, fault addr: 0x7ffeed8e6ff8
Stacktrace:
  at <unknown> <0xffffffff>
  at AppKit.NSWindow.AddChildWindow (AppKit.NSWindow,AppKit.NSWindowOrderingMode) [0x00032] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.14.0.83/src/Xamarin.Mac/AppKit/NSWindow.g.cs:2089
  <...>
  at MonoDevelop.Ide.MessageService.ShowCustomModalDialog (Gtk.Window,MonoDevelop.Components.Window) [0x00042] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs:398
  at MonoDevelop.Ide.MessageService/<>c__DisplayClass34_0.<RunCustomDialog>b__0 () [0x0006a] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs:361
  at MonoDevelop.Core.Runtime.RunInMainThread (System.Action) [0x0000d] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs:334
  at MonoDevelop.Ide.MessageService.RunCustomDialog (MonoDevelop.Components.Dialog,MonoDevelop.Components.Window) [0x000d6] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs:348
  at MonoDevelop.Ide.MessageService.ShowCustomDialog (MonoDevelop.Components.Dialog,MonoDevelop.Components.Window) [0x00007] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs:306
  at MonoDevelop.Ide.MessageService.ShowCustomDialog (MonoDevelop.Components.Dialog) [0x00000] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs:299
  at MonoDevelop.CSharp.Formatting.CSharpFormattingPolicyPanelWidget.HandleButtonEditClicked (object,System.EventArgs) [0x0000c] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/CSharpFormattingPolicyPanelWidget.cs:99
```

To fix this the dialog does not show itself before MessageService's
ShowCustomDialog is called. Note that setting an explicit parent
in the call to ShowCustomDialog to be the TopLevel of the
CSharpFormattingPolicyPanelWidget also fixed the problem but this
resulted in the dialog not being centered on the screen. Instead it was
placed so its left edge and top edge were inside the options panel.

Fixes VSTS #942740 - Crash when trying to change C# formatting settings