### PR TITLE
[release-8.2] [Version Control] Fix exception opening the StatusView

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs
@@ -36,7 +36,8 @@ namespace MonoDevelop.Components
 		{
 			GtkWorkarounds.FixContainerLeak (this);
 			handle = new CustomGtkPanedHandle (this);
-			handle.Parent = this;
+			if(handle.Parent == null)
+				handle.Parent = this;
 		}
 
 		public int GrabAreaSize {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs
@@ -36,8 +36,6 @@ namespace MonoDevelop.Components
 		{
 			GtkWorkarounds.FixContainerLeak (this);
 			handle = new CustomGtkPanedHandle (this);
-			if(handle.Parent == null)
-				handle.Parent = this;
 		}
 
 		public int GrabAreaSize {


### PR DESCRIPTION
Each time the StatusView is opened, we get the following exception.Seems to be a problem related to Splitter initialization.
```
Stack trace: 
  at MonoDevelop.Ide.Gui.GLibLogging.LoggerMethod (System.IntPtr logDomainPtr, MonoDevelop.Ide.Gui.GLibLogging+LogLevelFlags logLevel, System.IntPtr messagePtr) [0x00039] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs:259 
  at MonoDevelop.Ide.Gui.GLibLogging+Log+<>c.<.cctor>b__23_0 (System.IntPtr domain, MonoDevelop.Ide.Gui.GLibLogging+LogLevelFlags level, System.IntPtr message, MonoDevelop.Ide.Gui.GLibLogging+LogFunc user_data) [0x00001] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/GLibLogging.cs:103 
  at Gtk.Widget.gtk_widget_set_parent (System.IntPtr , System.IntPtr ) [0x00000] in <40f46e55eb67454ab904dc9e5644a3a1>:0 
  at Gtk.Widget.set_Parent (Gtk.Widget value) [0x00022] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-02/external/bockbuild/builds/gtk-sharp-None/gtk/generated/Widget.cs:37 
  at MonoDevelop.Components.VPanedThin..ctor () [0x0001b] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/VPanedThin.cs:39 
  at MonoDevelop.VersionControl.Views.StatusView.Init () [0x006a2] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs:251 
  at MonoDevelop.VersionControl.Views.StatusView..ctor (System.String filepath, MonoDevelop.VersionControl.Repository vc, MonoDevelop.VersionControl.VersionControlItemList list) [0x000a6] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs:291 
  at MonoDevelop.VersionControl.Views.StatusView.Show (MonoDevelop.VersionControl.VersionControlItemList items, System.Boolean test, System.Boolean solution) [0x000aa] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/StatusView.cs:124 
  at MonoDevelop.VersionControl.StatusCommandHandler.RunCommand (MonoDevelop.VersionControl.VersionControlItemList items, System.Boolean test) [0x00001] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Commands.cs:144 
  at MonoDevelop.VersionControl.SolutionVersionControlCommandHandler.Run () [0x00007] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Commands.cs:60 
  at MonoDevelop.Components.Commands.CommandHandler.Run (System.Object dataItem) [0x00001] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandHandler.cs:75 
  at MonoDevelop.Components.Commands.CommandHandler.InternalRun (System.Object dataItem) [0x00001] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandHandler.cs:39 
  at MonoDevelop.Components.Commands.CommandManager.DefaultDispatchCommand (MonoDevelop.Components.Commands.ActionCommand cmd, MonoDevelop.Components.Commands.CommandInfo info, System.Object dataItem, System.Object target, MonoDevelop.Components.Commands.CommandSource source) [0x00096] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1641 
  at MonoDevelop.Components.Commands.CommandManager.DispatchCommand (System.Object commandId, System.Object dataItem, System.Object initialTarget, MonoDevelop.Components.Commands.CommandSource source, System.Nullable`1[T] time, MonoDevelop.Components.Commands.CommandInfo sourceUpdateInfo) [0x00453] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1604 
  at MonoDevelop.Components.Commands.CommandManager.DispatchCommand (System.Object commandId, System.Object dataItem, System.Object initialTarget, MonoDevelop.Components.Commands.CommandSource source, MonoDevelop.Components.Commands.CommandInfo sourceUpdateInfo) [0x00001] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs:1477 
  at MonoDevelop.Components.Mac.MDMenuItem+<>c__DisplayClass14_0.<Run>b__0 () [0x00065] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDMenuItem.cs:90 
  at GLib.Timeout+TimeoutProxy.HandlerInternal (System.IntPtr data) [0x00017] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-02/external/bockbuild/builds/gtk-sharp-None/glib/Timeout.cs:38 
  at Gtk.Application.gtk_main () [0x00000] in <40f46e55eb67454ab904dc9e5644a3a1>:0 
  at Gtk.Application.Run () [0x00001] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-02/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:145 
  at MonoDevelop.Ide.IdeStartup.Run (MonoDevelop.Ide.MonoDevelopOptions options) [0x00507] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:228 
  at MonoDevelop.Ide.IdeStartup.Main (System.String[] args, MonoDevelop.Ide.Extensions.IdeCustomizer customizer) [0x000d4] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs:736 
  at MonoDevelop.Startup.MonoDevelopMain.Main (System.String[] args) [0x00001] in /Users/jsuarezruiz/Projects/MonoDevelop/monodevelop/main/src/core/MonoDevelop.Startup/MonoDevelop.Startup/MonoDevelopMain.cs:40 

```
Fix VSTS #941754 

Backport of #8149.

/cc @sevoku @jsuarezruiz