### PR TITLE
[GetToCode] Adds ShowAsync method in NewProjectController with TaskCo…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -713,7 +713,12 @@ namespace MonoDevelop.Ide
 			newProjectDialog.OpenSolution = true;
 			newProjectDialog.SelectedTemplateId = defaultTemplate;
 			newProjectDialog.ShowTemplateSelection = showTemplateSelection;
-			return newProjectDialog.Show ();
+			var show = newProjectDialog.Show ();
+			if (show) {
+				WelcomePage.WelcomePageService.HideWelcomePageOrWindow ();
+				return await newProjectDialog.ProjectCreation;
+			}
+			return false;
 		}
 		
 		public Task<WorkspaceItem> AddNewWorkspaceItem (Workspace parentWorkspace)


### PR DESCRIPTION
This PR fixes a problem waiting the response from NewProject window probably introduced by 
https://github.com/mono/monodevelop/commit/1578ca3ed2ebfc96890e23fe580f6ede097221b8#diff-e3e1db8132f317c043c737963f36d108

The problem is now we close the dialog very quickly without wait the creation of the project, then the variable is modified after return the value.

This is necessary to fix, because GTC in case of project creation needs to disable the window to don't allow the user to click buttons meanwhile we open the project.