### PR TITLE
[release-8.1] [Mac] Don't reshow the popover when the view has been removed from th…

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -700,6 +700,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 		public override void ViewDidMoveToWindow ()
 		{
 			base.ViewDidMoveToWindow ();
+
 			ReconstructString ();
 			RepositionContents ();
 		}
@@ -720,7 +721,13 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 				imageView.Image = image;
 				if (updatePopover) {
 					DestroyPopover (null, null);
-					ShowPopoverForStatusBar ();
+
+					// Window will be null if the StatusBar has been removed from its parent
+					// In that case we want to destroy the popover, but we don't want to show
+					// it again
+					if (Window != null) {
+						ShowPopoverForStatusBar ();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
…e window

ViewDidMoveToWindow can be called when removing the view from a parent window,
in which case we should not try to redisplay any popovers

Fixes VSTS #929008

Backport of #8156.

/cc @sevoku @iainx