### PR TITLE
[debugger] Use store instead of Model

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValueTreeView.cs
@@ -1670,7 +1670,7 @@ namespace MonoDevelop.Debugger
 
 		bool ValidObjectForPreviewIcon (TreeIter it)
 		{
-			var obj = Model.GetValue (it, ObjectColumn) as ObjectValue;
+			var obj = store.GetValue (it, ObjectColumn) as ObjectValue;
 			if (obj == null) {
 				return false;
 			} else {


### PR DESCRIPTION
A bit of a long shot, but it should/could fix the NRE here. We fixed one possible NRE with DisplayValue but we see the same error since that fix. The offset is +0 so I'm thinking that it's early in the method and the only thing I can think of here is that Get_Model is not returning the store from Gtk. We can use store here in its place since they are (or should be) the same object.

Fixes VSTS 849589
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849589