### PR TITLE
[A11y] Check for selector before trying to call accessibility method

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -313,6 +313,8 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 
 		static readonly IntPtr selSetAccessibilityServesAsTitleForUIElements_Handle = Selector.GetHandle ("setAccessibilityServesAsTitleForUIElements:");
 		static readonly IntPtr selAccessibilityServesAsTitleForUIElements_Handle = Selector.GetHandle ("accessibilityServesAsTitleForUIElements:");
+		static readonly Selector selAccessibilityServesAsTitleForUIElements = new Selector ("accessibilityServesAsTitleForUIElements:");
+
 		public static void SetTitleFor (this Atk.Object o, params Atk.Object [] objects)
 		{
 			var nsa = GetNSAccessibilityElement (o);
@@ -356,6 +358,12 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 			var nsa = GetNSAccessibilityElement (o);
 
 			if (nsa == null || titleNsa == null) {
+				return;
+			}
+
+			// bug #940756 suggests that some elements do not respond to this selector
+			// so check before sending so it doesn't throw an ObjC exception
+			if (!((NSObject)titleNsa).RespondsToSelector (selAccessibilityServesAsTitleForUIElements)) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes VSTS #940756