### PR TITLE
[release-8.2] [C#] Fix crasher in code actions in the old editor

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs
@@ -129,11 +129,13 @@ namespace MonoDevelop.CodeActions
 		{
 			var loc = Editor.CaretOffset;
 			var ad = DocumentContext.AnalysisDocument;
+			var workspace = ad?.Project?.Solution?.Workspace;
 			var line = Editor.GetLine (Editor.CaretLine);
 
-			if (ad == null) {
+			if (ad == null || workspace == null) {
 				return Task.FromResult (CodeActionContainer.Empty);
 			}
+
 			TextSpan span;
 			if (Editor.IsSomethingSelected) {
 				var selectionRange = Editor.SelectionRange;
@@ -158,7 +160,7 @@ namespace MonoDevelop.CodeActions
 
 					var lineSpan = new TextSpan (line.Offset, line.Length);
 					var fixes = await codeFixService.GetFixesAsync (ad, lineSpan, true, cancellationToken);
-					fixes = await Runtime.RunInMainThread(() => FilterOnUIThread (fixes, DocumentContext.RoslynWorkspace));
+					fixes = await Runtime.RunInMainThread(() => FilterOnUIThread (fixes, workspace));
 
 					var refactorings = await codeRefactoringService.GetRefactoringsAsync (ad, span, cancellationToken);
 					var codeActionContainer = new CodeActionContainer (fixes, refactorings);


### PR DESCRIPTION
```
ERROR [2019-07-03 23:58:10Z]: An unhandled exception has occurred. Terminating Visual Studio? False
System.NullReferenceException: Object reference not set to an instance of an object
  at MonoDevelop.CodeActions.CodeActionEditorExtension+<>c__DisplayClass14_1.<GetCurrentFixesAsync>b__2 () [0x00000] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs:161
  at (wrapper delegate-invoke) System.Func`1[System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CodeFixes.CodeFixCollection]].invoke_TResult()
  at MonoDevelop.Core.Runtime+<>c__44`1[T].<RunInMainThread>b__44_0 (System.Object state) [0x00013] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/core/MonoDevelop.Core/MonoDevelop.Core/Runtime.cs:369
--- End of stack trace from previous location where exception was thrown ---

  at MonoDevelop.CodeActions.CodeActionEditorExtension+<>c__DisplayClass14_0.<GetCurrentFixesAsync>b__0 () [0x0020d] in /Users/vsts/agent/2.153.2/work/1/s/monodevelop/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.CodeActions/CodeActionEditorExtension.cs:161
```

Surfaced by VSTS #942255 - VSMac hang

Backport of #8170.

/cc @Therzok 