### PR TITLE
Fixes 832745, 937869, 918951 - Implement Sort and Join Lines

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
@@ -120,6 +120,11 @@ namespace MonoDevelop.TextEditor
 			[EditCommands.LowercaseSelection] = op => op.MakeLowercase (),
 			[EditCommands.RemoveTrailingWhiteSpaces] = op => op.TrimTrailingWhiteSpace (),
 
+#if !WINDOWS
+			[EditCommands.JoinWithNextLine] = op => op.JoinSelectedLines (),
+			[EditCommands.SortSelectedLines] = op => op.SortSelectedLines (),
+#endif
+
 			[ViewCommands.CenterAndFocusCurrentDocument] = op => op.ScrollLineCenter ()
 		};
 


### PR DESCRIPTION
The IDE side of wiring up Sort and Join Lines.

Needs a VSEA sync and VSEC bump that includes https://github.com/xamarin/vs-editor-core/pull/358. 

## Known Issues:
- a mixture of normal and box selections when joining/merging lines results in some _wonky_ text as the result
- a boxed selection is not correctly restored when sorting the lines

## TODO

- This should use the commanding approach that we use for most other things

## VSTS items

- Fixes https://vsmac.dev/832745
- Fixes https://vsmac.dev/937869
- Fixes https://vsmac.dev/918951