### PR TITLE
Fixes VSTS FeedbackTicket 943824: Diff Incorrect

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/BlameCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/BlameCommand.cs
@@ -26,6 +26,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text.Editor;
 using Mono.Addins;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Gui;
@@ -53,7 +54,11 @@ namespace MonoDevelop.VersionControl
 			
 			foreach (var item in items) {
 				var document = await IdeApp.Workbench.OpenDocument (item.Path, item.ContainerProject, OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer);
-				document?.GetContent<VersionControlDocumentController> ()?.ShowBlameView ();
+				if (document == null)
+					continue;
+				document.RunWhenContentAdded<ITextView> (tv => {
+					document.GetContent<VersionControlDocumentController> ()?.ShowBlameView ();
+				});
 			}
 			
 			return true;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DiffCommand.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DiffCommand.cs
@@ -26,6 +26,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text.Editor;
 using Mono.Addins;
 using MonoDevelop.Ide;
 using MonoDevelop.Ide.Gui;
@@ -52,7 +53,11 @@ namespace MonoDevelop.VersionControl
 			
 			foreach (var item in items) {
 				var document = await IdeApp.Workbench.OpenDocument (item.Path, item.ContainerProject, OpenDocumentOptions.Default | OpenDocumentOptions.OnlyInternalViewer);
-				document?.GetContent<VersionControlDocumentController> ()?.ShowDiffView ();
+				if (document == null)
+					continue;
+				document.RunWhenContentAdded<ITextView> (tv => {
+					document.GetContent<VersionControlDocumentController> ()?.ShowDiffView ();
+				});
 			}
 
 			return true;


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/943824

Fixes VSTS Bug 946944: [Feedback] Diff Incorrect

Diff View could be loaded before the text view had the text - that
caused that the "local" text was empty. The blame view had the same
issue (but crashed) - fixed that as well.