### PR TITLE
Fixes VSTS Bug 940635: Cloning project with submodules is stops with

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -693,7 +693,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 				var exception = e.InnerException;
 				// libgit2 < 0.26 will throw NotFoundException (result -3)
 				// libgit2 >= 0.26 will throw generic LibGit2SharpException (result -1), assert the expected message
-				Assert.That (exception, Is.InstanceOf<LibGit2Sharp.NotFoundException> ().Or.Message.EqualTo ("reference 'refs/heads/master' not found"));
+				Assert.That (exception, Is.InstanceOf<LibGit2Sharp.NotFoundException> ().Or.InstanceOf<LibGit2Sharp.NameConflictException> ().Or.Message.EqualTo ("reference 'refs/heads/master' not found"));
 				return;
 			} finally {
 				toCheckout.Dispose ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1401,7 +1401,7 @@ namespace MonoDevelop.VersionControl.Git
 			try {
 				monitor.BeginTask (GettextCatalog.GetString ("Cloning…"), 2);
 				RunOperation (() => RetryUntilSuccess (monitor, credType => {
-				var options = new CloneOptions {
+					var options = new CloneOptions {
 						CredentialsProvider = (url, userFromUrl, types) => {
 							transferProgress = checkoutProgress = 0;
 							return GitCredentials.TryGet (url, userFromUrl, types, credType);
@@ -1418,7 +1418,7 @@ namespace MonoDevelop.VersionControl.Git
 							Runtime.RunInMainThread (() => {
 								monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out file '{0}'"), path);
 							});
-						},
+						}
 					};
 					RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1421,8 +1421,13 @@ namespace MonoDevelop.VersionControl.Git
 							});
 						}
 					};
-					RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
 
+					try {
+						RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
+					} catch (AggregateException ae) {
+						ae.Flatten ().Handle (inner => inner is LibGit2Sharp.UserCancelledException);
+						return;
+					}
 					var updateOptions = new SubmoduleUpdateOptions {
 						Init = true,
 						CredentialsProvider = options.CredentialsProvider,

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1399,45 +1399,47 @@ namespace MonoDevelop.VersionControl.Git
 			int checkoutProgress = 0;
 
 			try {
-				monitor.BeginTask ("Cloning...", 2);
-
+				monitor.BeginTask (GettextCatalog.GetString ("Cloning…"), 2);
 				RunOperation (() => RetryUntilSuccess (monitor, credType => {
-					try {
-						RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, new CloneOptions {
-							CredentialsProvider = (url, userFromUrl, types) => {
-								transferProgress = checkoutProgress = 0;
-								return GitCredentials.TryGet (url, userFromUrl, types, credType);
-							},
-							RepositoryOperationStarting = ctx => {
-								Runtime.RunInMainThread (() => {
-									monitor.Log.WriteLine ("Checking out repository at '{0}'", ctx.RepositoryPath);
-								});
-								return true;
-							},
-							OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
-							OnCheckoutProgress = (path, completedSteps, totalSteps) => {
-								OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
-								Runtime.RunInMainThread (() => {
-									monitor.Log.WriteLine ("Checking out file '{0}'", path);
-								});
-							},
-						});
-					} catch (Exception e) {
-						LoggingService.LogInternalError ("Error while cloning repository " + rev + " recuse: " + recurse, e);
-						throw e;
-					}
+				var options = new CloneOptions {
+						CredentialsProvider = (url, userFromUrl, types) => {
+							transferProgress = checkoutProgress = 0;
+							return GitCredentials.TryGet (url, userFromUrl, types, credType);
+						},
+						RepositoryOperationStarting = ctx => {
+							Runtime.RunInMainThread (() => {
+								monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out repository at '{0}'"), ctx.RepositoryPath);
+							});
+							return true;
+						},
+						OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
+						OnCheckoutProgress = (path, completedSteps, totalSteps) => {
+							OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
+							Runtime.RunInMainThread (() => {
+								monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out file '{0}'"), path);
+							});
+						},
+					};
+					RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
+
+					var updateOptions = new SubmoduleUpdateOptions {
+						Init = true,
+						CredentialsProvider = options.CredentialsProvider,
+						OnTransferProgress = options.OnTransferProgress,
+						OnCheckoutProgress = options.OnCheckoutProgress,
+					};
+					monitor.Step (1);
+
+					RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
 				}), true);
 
 				if (monitor.CancellationToken.IsCancellationRequested || RootPath.IsNull)
 					return Task.CompletedTask;
 
-				monitor.Step (1);
-
 				RootPath = RootPath.CanonicalPath.ParentDirectory;
+
 				RootRepository = new LibGit2Sharp.Repository (RootPath);
 				InitFileWatcher ();
-
-				RunOperation (() => RecursivelyCloneSubmodules (RootRepository, monitor), true);
 				return Task.CompletedTask;
 			} catch (Exception e) {
 				LoggingService.LogInternalError ("Error while cloning repository " + rev + " recuse: " + recurse, e);
@@ -1447,57 +1449,38 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		static void RecursivelyCloneSubmodules (LibGit2Sharp.Repository rootRepository, ProgressMonitor monitor)
+		static void RecursivelyCloneSubmodules (string repoPath, SubmoduleUpdateOptions updateOptions, ProgressMonitor monitor)
 		{
 			var submodules = new List<string> ();
-			RetryUntilSuccess (monitor, credType => {
+			using (var repo = new LibGit2Sharp.Repository (repoPath)) {
+				// Iterate through the submodules (where the submodule is in the index),
+				// and clone them.
+				var submoduleArray = repo.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
+				monitor.BeginTask (GettextCatalog.GetString ("Cloning sub modules…"), submoduleArray.Length);
 				try {
-					int transferProgress = 0, checkoutProgress = 0;
-					SubmoduleUpdateOptions updateOptions = new SubmoduleUpdateOptions () {
-						Init = true,
-						CredentialsProvider = (url, userFromUrl, types) => {
-							transferProgress = checkoutProgress = 0;
-							return GitCredentials.TryGet (url, userFromUrl, types, credType);
-						},
-						OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
-						OnCheckoutProgress = (file, completedSteps, totalSteps) => {
-							OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
-							Runtime.RunInMainThread (() => {
-								monitor.Log.WriteLine ("Checking out file '{0}'", file);
-							});
-						},
-					};
-
-					// Iterate through the submodules (where the submodule is in the index),
-					// and clone them.
-					var submoduleArray = rootRepository.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
-					monitor.BeginTask (submoduleArray.Length);
 					foreach (var sm in submoduleArray) {
 						if (monitor.CancellationToken.IsCancellationRequested) {
 							throw new UserCancelledException ("Recursive clone of submodules was cancelled.");
 						}
 
 						Runtime.RunInMainThread (() => {
-							monitor.Log.WriteLine ("Checking out submodule at '{0}'", sm.Path);
+							monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out submodule at '{0}'"), sm.Path);
+							monitor.Step (1);
 						});
-						rootRepository.Submodules.Update (sm.Name, updateOptions);
-						monitor.Step (1);
+						repo.Submodules.Update (sm.Name, updateOptions);
 
-						submodules.Add (Path.Combine (rootRepository.Info.WorkingDirectory, sm.Path));
+						submodules.Add (Path.Combine (repo.Info.WorkingDirectory, sm.Path));
 					}
+				} finally {
 					monitor.EndTask ();
-				} catch (Exception e) {
-					LoggingService.LogInternalError ("Error RecursivelyCloneSubmodules " + rootRepository, e);
-					throw e;
 				}
-			});
+			}
 
 			// If we are continuing the recursive operation, then
 			// recurse into nested submodules.
 			// Check submodules to see if they have their own submodules.
 			foreach (string path in submodules) {
-				using (var submodule = new LibGit2Sharp.Repository (path))
-					RecursivelyCloneSubmodules (submodule, monitor);
+				RecursivelyCloneSubmodules (path, updateOptions, monitor);
 			}
 		}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1437,6 +1437,7 @@ namespace MonoDevelop.VersionControl.Git
 						LoggingService.LogError ("Cloning submodules failed", e);
 						Directory.Delete (RootPath, true);
 						skipSubmodules = true;
+						throw e;
 					}
 				}), true);
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1434,7 +1434,7 @@ namespace MonoDevelop.VersionControl.Git
 						if (!skipSubmodules)
 							RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
 					} catch (Exception e) {
-						LoggingService.LogError ("Error while cloning sub modules", e);
+						LoggingService.LogError ("Cloning submodules failed", e);
 						Directory.Delete (RootPath, true);
 						skipSubmodules = true;
 					}
@@ -1448,7 +1448,7 @@ namespace MonoDevelop.VersionControl.Git
 				RootRepository = new LibGit2Sharp.Repository (RootPath);
 				InitFileWatcher ();
 				if (skipSubmodules) {
-					MessageService.ShowError (GettextCatalog.GetString("Can't clone sub modules. Please use the command line client to init the sub modules."));
+					MessageService.ShowError (GettextCatalog.GetString("Cloning submodules failed"), GettextCatalog.GetString ("Please use the command line client to init the submodules manually."));
 				}
 				return Task.CompletedTask;
 			} catch (Exception e) {
@@ -1466,7 +1466,7 @@ namespace MonoDevelop.VersionControl.Git
 				// Iterate through the submodules (where the submodule is in the index),
 				// and clone them.
 				var submoduleArray = repo.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
-				monitor.BeginTask (GettextCatalog.GetString ("Cloning sub modules…"), submoduleArray.Length);
+				monitor.BeginTask (GettextCatalog.GetString ("Cloning submodules…"), submoduleArray.Length);
 				try {
 					foreach (var sm in submoduleArray) {
 						if (monitor.CancellationToken.IsCancellationRequested) {
@@ -1474,7 +1474,7 @@ namespace MonoDevelop.VersionControl.Git
 						}
 
 						Runtime.RunInMainThread (() => {
-							monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out submodule at '{0}'"), sm.Path);
+							monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out submodule at '{0}'…", sm.Path));
 							monitor.Step (1);
 						});
 						repo.Submodules.Update (sm.Name, updateOptions);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1424,8 +1424,7 @@ namespace MonoDevelop.VersionControl.Git
 
 					try {
 						RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
-					} catch (AggregateException ae) {
-						ae.Flatten ().Handle (inner => inner is LibGit2Sharp.UserCancelledException);
+					} catch (UserCancelledException) {
 						return;
 					}
 					var updateOptions = new SubmoduleUpdateOptions {
@@ -1440,7 +1439,7 @@ namespace MonoDevelop.VersionControl.Git
 							RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
 					} catch (Exception e) {
 						LoggingService.LogError ("Cloning submodules failed", e);
-						Directory.Delete (RootPath, true);
+						FileService.DeleteDirectory (RootPath);
 						skipSubmodules = true;
 						throw e;
 					}


### PR DESCRIPTION
error 'Version control operation filed'

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/940635

I think we're running into a libgit bug. Libgit2 works correctly if
the library itself does the submodule checkout - it's more reliable
for us to let do libgit2 the job as well.