### PR TITLE
ui: Remove trailing period from exception dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -399,7 +399,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			}
 			var actionArea = new HBox (false, 0) { BorderWidth = 14 };
 
-			OnlyShowMyCodeCheckbox = new CheckButton (GettextCatalog.GetString ("_Only show my code."));
+			OnlyShowMyCodeCheckbox = new CheckButton (GettextCatalog.GetString ("_Only show my code"));
 			OnlyShowMyCodeCheckbox.Toggled += OnlyShowMyCodeToggled;
 			OnlyShowMyCodeCheckbox.Show ();
 			OnlyShowMyCodeCheckbox.Active = DebuggingService.GetUserOptions ().ProjectAssembliesOnly;


### PR DESCRIPTION
Anything else that needs to happen here? Update the translatable string?