### PR TITLE
[release-8.2] Fixes VSTS Bug 941853: Unknown icon shown in status bar when opening a

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchStatusBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/WorkbenchStatusBar.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.Ide.Gui
 				statusBar.AutoPulse = true;
 			if (inProgress) {
 				if (progressImage != IconId.Null)
-					statusBar.BeginProgress (progressMessage, progressImage);
+					statusBar.BeginProgress (progressImage, progressMessage);
 				else
 					statusBar.BeginProgress (progressMessage);
 			}


### PR DESCRIPTION
file

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/941853

The BeginProgress API is the cause of that - IconID can beconverted to
a string. Other calls of that method are ok.

Backport of #8208.

/cc @slluis @mkrueger