### PR TITLE
[release-8.2] [Mac] Fix NSImageCacheException exception when getting the app icon

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.MacIntegration
 						alert.Icon = img.ToNSImage ();
 				} else {
 					//for some reason the NSAlert doesn't pick up the app icon by default
-					alert.Icon = NSApplication.SharedApplication.ApplicationIconImage;
+					alert.Icon = MacPlatformService.ApplicationIcon;
 				}
 
 				alert.MessageText = data.Message.Text;

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -774,8 +774,8 @@ namespace MonoDevelop.MacIntegration
 				}
 				return applicationIcon;
 			}
-			set {
-				applicationIcon = value;
+			private set {
+				NSApplication.SharedApplication.ApplicationIconImage = applicationIcon = value;
 			}
 		}
 
@@ -806,7 +806,7 @@ namespace MonoDevelop.MacIntegration
 				var imageFile = new NSString (iconFile);
 
 				IntPtr p = IntPtr_objc_msgSend_IntPtr (image.Handle, Selector.GetHandle ("initByReferencingFile:"), imageFile.Handle);
-				NSApplication.SharedApplication.ApplicationIconImage = applicationIcon = ObjCRuntime.Runtime.GetNSObject<NSImage> (p);
+				ApplicationIcon = ObjCRuntime.Runtime.GetNSObject<NSImage> (p);
 			}
 		}
 

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -763,6 +763,22 @@ namespace MonoDevelop.MacIntegration
 		[DllImport ("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public extern static IntPtr IntPtr_objc_msgSend_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1);
 
+		private static NSImage applicationIcon;
+		internal static NSImage ApplicationIcon {
+			get {
+				if (applicationIcon == null) {
+					// use the bundle icon by default
+					// if run from a bundle, this will be the icon from the bundle icon file.
+					// if not run from a bundle, this will be the default file icon of the mono framework folder.
+					applicationIcon = NSWorkspace.SharedWorkspace.IconForFile (NSBundle.MainBundle.BundlePath);
+				}
+				return applicationIcon;
+			}
+			set {
+				applicationIcon = value;
+			}
+		}
+
 		static void SetupDockIcon ()
 		{
 			NSObject initialBundleIconFileValue;
@@ -790,7 +806,7 @@ namespace MonoDevelop.MacIntegration
 				var imageFile = new NSString (iconFile);
 
 				IntPtr p = IntPtr_objc_msgSend_IntPtr (image.Handle, Selector.GetHandle ("initByReferencingFile:"), imageFile.Handle);
-				NSApplication.SharedApplication.ApplicationIconImage = ObjCRuntime.Runtime.GetNSObject<NSImage> (p);
+				NSApplication.SharedApplication.ApplicationIconImage = applicationIcon = ObjCRuntime.Runtime.GetNSObject<NSImage> (p);
 			}
 		}
 

--- a/main/src/addins/MacPlatform/MacProxyCredentialProvider.cs
+++ b/main/src/addins/MacPlatform/MacProxyCredentialProvider.cs
@@ -122,7 +122,7 @@ namespace MonoDevelop.MacIntegration
 						var okButton = alert.AddButton (GettextCatalog.GetString ("OK"));
 						var cancelButton = alert.AddButton (GettextCatalog.GetString ("Cancel"));
 
-						alert.Icon = NSApplication.SharedApplication.ApplicationIconImage;
+						alert.Icon = MacPlatformService.ApplicationIcon;
 
 						var view = new NSView (new CGRect (0, 0, 313, 91));
 


### PR DESCRIPTION
SharedApplication.ApplicationIconImage is not meant to be used
to retrieve the actual bundle icon, but only to change the default icon.

Instead of SharedApplication.ApplicationIconImage get the icon
directly from the bundle by default and fall-back to BrandingService
if not running from an app bundle.

Fixes VSTS #905844

Backport of #8213.

/cc @sevoku 