### PR TITLE
[Ide][Mac] Add Help button support to MessageService

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs
@@ -42,6 +42,23 @@ using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.MacIntegration
 {
+	sealed class AlertDelegate : NSAlertDelegate
+	{
+		readonly string HelpUrl;
+		public AlertDelegate (string helpUrl)
+		{
+			HelpUrl = helpUrl;
+		}
+
+		public override bool ShowHelp (NSAlert alert)
+		{
+			if (!string.IsNullOrEmpty (HelpUrl)) {
+				IdeServices.DesktopService.ShowUrl (HelpUrl);
+			}
+			return true;
+		}
+	}
+
 	class MacAlertDialogHandler : IAlertDialogHandler
 	{
 		public bool Run (AlertDialogData data)
@@ -77,6 +94,11 @@ namespace MonoDevelop.MacIntegration
 				}
 
 				alert.MessageText = data.Message.Text;
+
+				if (!string.IsNullOrEmpty (data.Message.HelpUrl)) {
+					alert.Delegate = new AlertDelegate (data.Message.HelpUrl);
+					alert.ShowsHelp = true;
+				}
 
 				int accessoryViewItemsCount = data.Options.Count;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -661,6 +661,7 @@ namespace MonoDevelop.Ide
 		
 		public string Text { get; set; }
 		public string SecondaryText { get; set; }
+		public string HelpUrl { get; set; }
 		public bool AllowApplyToAll { get; set; }
 		public int DefaultButton { get; set; }
 		public CancellationToken CancellationToken { get; private set; }


### PR DESCRIPTION
Adds an optional `MessageDescription.HelpUrl`, depending on the platform a special help button will be shown in the message dialog, which will open the given Url in the browser. For now only on Mac, since Gtk has no special Help button in dialogs (needs design) and we have no native WPF impl. for windows.