### PR TITLE
[release-8.2] Fixed Bug 820341: [Feedback] Unable to print code

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorPrintOperation.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorPrintOperation.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.SourceEditor
 			SetFooterFormat (settings.FooterFormat);
 			
 			style = SyntaxHighlightingService.GetEditorTheme (settings.EditorTheme);
-			
+
 			pageWidth = context.PageSetup.GetPageWidth (Unit.Pixel);
 			pageHeight = context.PageSetup.GetPageHeight (Unit.Pixel);
 			double contentHeight = pageHeight
@@ -107,11 +107,11 @@ namespace MonoDevelop.SourceEditor
 			
 				int startLine = pageNr * linesPerPage;
 				int endLine = Math.Min (startLine + linesPerPage - 1, editor.LineCount);
-				var theme =editor.Options.GetEditorTheme ();
 
 				//FIXME: use proper 1-layout-per-line
 				for (int i = startLine; i < endLine; i++) {
 					var line = editor.GetLine (i + 1);
+					layout.FontDescription = settings.Font;
 					if (!settings.UseHighlighting) {
 						string text = editor.GetTextAt (line);
 						text = text.Replace ("\t", new string (' ', settings.TabSize));
@@ -127,7 +127,7 @@ namespace MonoDevelop.SourceEditor
 					var highlightedLine = await editor.SyntaxHighlighting.GetHighlightedLineAsync (line, default(CancellationToken));
 					var lineOffset = line.Offset;
 					foreach (var chunk in highlightedLine.Segments) {
-						var chunkStyle = theme.GetChunkStyle (chunk.ScopeStack);
+						var chunkStyle = style.GetChunkStyle (chunk.ScopeStack);
 						string text = editor.GetTextAt (lineOffset + chunk.Offset, chunk.Length);
 						text = text.Replace ("\t", new string (' ', settings.TabSize));
 						layout.SetText (text);
@@ -296,12 +296,13 @@ namespace MonoDevelop.SourceEditor
 			}
 			if (Font == null || String.IsNullOrEmpty (Font.Family))
 				Font = Pango.FontDescription.FromString (TextEditorOptions.DEFAULT_FONT);
-			//if (Font != null)
-			//	Font.Size = (int)(Font.Size * DefaultSourceEditorOptions.Instance.Zoom);
+			if (Font != null) {
+				Font.Size = (int)(Font.Size * 0.5);
+			}
 			TabSize = DefaultSourceEditorOptions.Instance.TabSize;
 			HeaderFormat = "%F";
 			FooterFormat = GettextCatalog.GetString ("Page %N of %Q");
-			EditorTheme = MonoDevelop.Ide.Editor.Highlighting.EditorTheme.DefaultThemeName;
+			EditorTheme = SyntaxHighlightingService.GetDefaultColorStyleName (MonoDevelop.Ide.Theme.Light);
 			HeaderSeparatorWeight = FooterSeparatorWeight = 0.5;
 			HeaderPadding = FooterPadding = 6;
 			UseHighlighting = true;


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/820341

The only way to ensure that the theme can be printed in a good quality
is to use the default light theme for printing. The same with the font
size - it used to be the editor zoom factor but setting it to a
constant zoom facotr gives the print code the control over the size.
Fonts currently are way bigger than they should be in printing.

Backport of #8225.

/cc @mkrueger 