### PR TITLE
Fixes VSTS Bug 948635: [Feedback] Tab doesn't work in text files

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/ExtensibleTextEditor.cs
@@ -550,8 +550,12 @@ namespace MonoDevelop.SourceEditor
 				LoggingService.LogError ("DoInsertTemplate(): Can't find valid document");
 				return false;
 			}
-
-			return DoInsertTemplate (EditorExtension.Editor, doc.DocumentContext);
+			try {
+				return DoInsertTemplate (doc.Editor, doc.DocumentContext);
+			} catch (Exception e) {
+				LoggingService.LogInternalError ($"Error while trying to insert template: Editor={doc.Editor}, Ctx={doc.DocumentContext}.", e);
+				return false;
+			}
 		}
 
 		public bool DoInsertTemplate (TextEditor editor, DocumentContext ctx)


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/948635

EditorExtension no longer works on that level - it's moved to IDE
TextEditor for handling. Using the TextEditor from the document is
safer.