### PR TITLE
[IDE] Handle bindings returning null commands

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -478,8 +478,14 @@ namespace MonoDevelop.Components.Commands
 			}
 #endif
 			// Handle the GDK key via MD commanding
-			if (ProcessKeyEventCore (ev))
-				return true;
+			try {
+				if (ProcessKeyEventCore (ev)) {
+					return true;
+				}
+			} catch (Exception ex) {
+				LoggingService.LogInternalError ("Exception while parsing command", ex);
+				return false;
+			}
 
 #if MAC
 			// Otherwise if we have a native first responder that is not the GdkQuartzView
@@ -544,6 +550,10 @@ namespace MonoDevelop.Components.Commands
 				chord = null;
 				
 				NotifyKeyPressed (ev);
+				return false;
+			}
+
+			if (commands == null) {
 				return false;
 			}
 


### PR DESCRIPTION
KeyBindingManager.Commands can return null, so handle a null return. Wrap the
call to ProcessKeyEventCore in a try catch block to make sure we handle and log
any other possible problems with it.

Fixes VSTS #944669