### PR TITLE
[GetToCode] Adds a PostUpdate in CommandHandler to base logic based in inheritance

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugCommands.cs
@@ -152,8 +152,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 	
-	class DebugApplicationHandler: CommandHandler
+	class DebugApplicationHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			var dlg = new DebugApplicationDialog ();
@@ -201,8 +203,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 	
-	class AttachToProcessHandler: CommandHandler
+	class AttachToProcessHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			var dlg = new AttachToProcessDialog ();
@@ -308,8 +312,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 	
-	class ClearAllBreakpointsHandler: CommandHandler
+	class ClearAllBreakpointsHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			var breakpoints = DebuggingService.Breakpoints;
@@ -503,8 +509,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 
-	class NewBreakpointHandler: CommandHandler
+	class NewBreakpointHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			BreakEvent bp = null;
@@ -523,8 +531,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 
-	class NewFunctionBreakpointHandler: CommandHandler
+	class NewFunctionBreakpointHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			BreakEvent bp = null;
@@ -543,8 +553,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 
-	class NewCatchpointHandler: CommandHandler
+	class NewCatchpointHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			BreakEvent bp = null;
@@ -563,8 +575,10 @@ namespace MonoDevelop.Debugger
 		}
 	}
 
-	class ShowBreakpointsHandler: CommandHandler
+	class ShowBreakpointsHandler: IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.DisabledWhenIdeIsHidden;
+
 		protected override void Run ()
 		{
 			if (!IdeApp.Workbench.Visible) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandHandler.cs
@@ -32,6 +32,46 @@ using System.Threading.Tasks;
 
 namespace MonoDevelop.Components.Commands
 {
+	/// <summary>
+	/// This commandhandler base class handles the logic to operate in commands based in Ide states in some Post upate operations
+	/// </summary>
+	public abstract class IdeCommandHandler : CommandHandler
+	{
+		[Flags]
+		protected enum CommandInfoStates
+		{
+			None = 0,
+			DisabledWhenIdeIsHidden = 1 << 0,
+			HiddenWhenIdeIsHidden = 2 << 0
+		}
+
+		protected abstract CommandInfoStates States { get; }
+	
+		internal override void OnPostUpdate (CommandArrayInfo info)
+		{
+			if (Ide.IdeApp.Workbench.Visible) {
+				return;
+			}
+			foreach (var item in info) {
+				if (States.HasFlag (CommandInfoStates.DisabledWhenIdeIsHidden))
+					item.Enabled = false;
+				if (States.HasFlag (CommandInfoStates.HiddenWhenIdeIsHidden))
+					item.Visible = false;
+			}
+		}
+
+		internal override void OnPostUpdate (CommandInfo info)
+		{
+			if (Ide.IdeApp.Workbench.Visible) {
+				return;
+			}
+			if (States.HasFlag (CommandInfoStates.DisabledWhenIdeIsHidden))
+				info.Enabled = false;
+			if (States.HasFlag (CommandInfoStates.HiddenWhenIdeIsHidden))
+				info.Visible = false;
+		}
+	}
+
 	public abstract class CommandHandler
 	{
 		internal void InternalRun (object dataItem)
@@ -47,11 +87,23 @@ namespace MonoDevelop.Components.Commands
 		internal void InternalUpdate (CommandInfo info)
 		{
 			Update (info);
+			OnPostUpdate (info);
 		}
 	
 		internal void InternalUpdate (CommandArrayInfo info)
 		{
 			Update (info);
+			OnPostUpdate (info);
+		}
+
+		internal virtual void OnPostUpdate (CommandInfo info)
+		{
+			//to implement
+		}
+
+		internal virtual void OnPostUpdate (CommandArrayInfo info)
+		{
+			//to implement
 		}
 
 		/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ViewCommands.cs
@@ -137,8 +137,10 @@ namespace MonoDevelop.Ide.Commands
 	}
 
 	// MonoDevelop.Ide.Commands.ViewCommands.LayoutList
-	public class LayoutListHandler : CommandHandler
+	public class LayoutListHandler : IdeCommandHandler
 	{
+		protected override CommandInfoStates States => CommandInfoStates.HiddenWhenIdeIsHidden;
+
 		static internal readonly Dictionary<string, string> NameMapping;
 
 		static LayoutListHandler ()


### PR DESCRIPTION
Created a subclass IdeCommandHandler which allows to handle easy some logic in CommandHandlers related to IDE statements, instead of add conditional cases in each CommandHandler independiently which that makes something unbeatable in the long term.

At the moment I added logic to:
Disables Debug commands when IDE is hidden
Hides Layout commands when IDE is hidden

Fixes VSTS #935559 - [Shell] Some menus should be disabled in only GTC mode

![lol](https://user-images.githubusercontent.com/1587480/61553729-61bc7f80-aa5b-11e9-9c73-c729922b7c2c.gif)
