### PR TITLE
[Ide] Small cleanup and optimization in RootWorkspace

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -694,14 +694,6 @@ namespace MonoDevelop.Ide.Gui.Documents
 				navigator.JumpToLine (fileInfo.Line, fileInfo.Column);*/
 		}
 
-		Document FindDocument (IWorkbenchWindow window)
-		{
-			foreach (Document doc in Documents)
-				if (doc.Window == window)
-					return doc;
-			return null;
-		}
-
 		void WatchDocument (Document doc)
 		{
 			if (doc.IsFile) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -565,8 +565,11 @@ namespace MonoDevelop.Ide
 
 			if (RequestItemUnload (item)) {
 				if (closeItemFiles && documentManager != null) {
-					var projects = item.GetAllItems<Project> ();
-					foreach (Document doc in documentManager.Documents.Where (d => d.Owner != null && projects.Contains (d.Owner)).ToArray ()) {
+					var projects = new Lazy<List<Project>> (() => item.GetAllItems<Project> ().ToList ());
+					foreach (Document doc in documentManager.Documents) {
+						if (doc.Owner is null || !projects.Value.Contains (doc.Owner))
+							continue;
+
 						if (!await doc.Close ())
 							return;
 					}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -530,7 +530,7 @@ namespace MonoDevelop.Ide
 						await SavePreferencesAsync ();
 
 					if (closeProjectFiles && documentManager != null) {
-						foreach (Document doc in documentManager.Documents.ToArray ()) {
+						foreach (Document doc in documentManager.Documents) {
 							if (!await doc.Close (force))
 								return false;
 						}


### PR DESCRIPTION
Avoid enumerating GetAllItems for each open document

This should fix some performance issue when closing a decently sized workspace with 20 open documents and 2 solutions.