### PR TITLE
[Core] Add extension on Array to shadow IEnumerable.Contains

### DIFF
--- a/main/src/core/MonoDevelop.Core/CoreExtensions.Array.cs
+++ b/main/src/core/MonoDevelop.Core/CoreExtensions.Array.cs
@@ -1,0 +1,33 @@
+//
+// CoreExtensions.Array.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace System
+{
+	public static partial class CoreExtensions
+	{
+		internal static bool Contains<T> (this T [] arr, T value) => Array.IndexOf (arr, value) != -1;
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -740,6 +740,7 @@
     <Compile Include="CoreExtensions.IEnumerable.cs" />
     <Compile Include="CoreExtensions.Memoize.cs" />
     <Compile Include="CoreExtensions.EventHandlers.cs" />
+    <Compile Include="CoreExtensions.Array.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="BuildVariables.cs.in" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -3998,7 +3998,7 @@ namespace MonoDevelop.Projects
 				if (p2 == null)
 					return false;
 				if (!p.ValueType.Equals (p.Value, p2.UnevaluatedValue)) {
-					if (p2.UnevaluatedValue != null && p2.UnevaluatedValue.Contains ('%')) {
+					if (p2.UnevaluatedValue != null && p2.UnevaluatedValue.IndexOf ('%') != -1) {
 						// Check evaluated value is a match.
 						if (!p.ValueType.Equals (p.Value, p2.Value))
 							return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/Sublime3Format.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/Sublime3Format.cs
@@ -340,7 +340,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 							break;
 						case 'S': // A non-whitespace character: /[^ \t\r\n\f]/
 							for (int i = 0; i < table.Length; i++) {
-								if (" \\t\\r\\n\\f".Contains ((char)i))
+								if (" \\t\\r\\n\\f".IndexOf ((char)i) != -1)
 									continue;
 								table [i] = negativeGroup ? -1 : 1;
 							}
@@ -432,7 +432,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			{
 				for (int i = 0; i < table.Length; i++) {
 					var cat = char.GetUnicodeCategory ((char)i);
-					if (categories.Contains (cat)) {
+					if (categories.IndexOf (cat) != -1) {
 						table [i] = negativeGroup ? -1 : 1;
 					}
 				}
@@ -562,7 +562,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 
 			void AddChar (StringBuilder result, char ch)
 			{
-				if ("[]\\".Contains (ch)) {
+				if ("[]\\".IndexOf (ch) != -1) {
 					result.Append ('\\');
 					result.Append (ch);
 					return;


### PR DESCRIPTION
This helps avoid boxing of the array for Contains and routes into an optimized implementation on Array for most usages.

And modify some other usages not covered which are potentially called a lot.