### PR TITLE
[Core] Optimize Sdk project extension handling of imported files

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -148,7 +148,7 @@ namespace MonoDevelop.Core
 		{
 			return fileName.Length > name.Length
 				&& fileName.EndsWith (name, PathComparison)
-				&& fileName [fileName.Length - name.Length - 1] == Path.PathSeparator;
+				&& fileName [fileName.Length - name.Length - 1] == Path.DirectorySeparatorChar;
 		}
 
 		public string Extension {
@@ -161,8 +161,8 @@ namespace MonoDevelop.Core
 		public bool HasExtension (string extension)
 		{
 			return fileName.Length > extension.Length
-				&& fileName.EndsWith (extension, PathComparison)
-				&& fileName[fileName.Length - extension.Length - 1] != Path.PathSeparator;
+				&& extension.Length == 0
+				|| (extension[0] == '.' && fileName.EndsWith (extension, PathComparison));
 		}
 
 		public string FileNameWithoutExtension {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -162,28 +162,25 @@ namespace MonoDevelop.Core
 		{
 			return fileName.Length > extension.Length
 				&& (extension == string.Empty
-					? HasNoExtension (fileName, extension)
+					? HasNoExtension (fileName)
 					: fileName.EndsWith (extension, PathComparison) && fileName [fileName.Length - extension.Length] == '.');
 
-			static bool HasNoExtension (string path, string extension)
+			static bool HasNoExtension (string path)
 			{
-				if (extension != string.Empty)
-					return false;
-
-				if (path [path.Length - 1] == '.')
-					return true;
-
 				// Look for the last dot that's after the last path separator
 				for (int i = path.Length - 1; i >= 0; --i) {
 					var ch = path [i];
-					if (ch == '.')
-						return false;
+					if (ch == '.') {
+						// Check if it's the dot is the last character
+						// if it is, then we have no extension
+						return i == path.Length - 1;
+					}
 
 					if (ch == Path.DirectorySeparatorChar)
 						return true;
 				}
 
-				return false;
+				return true;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -143,6 +143,14 @@ namespace MonoDevelop.Core
 			}
 		}
 
+		[Pure]
+		internal bool HasFileName (string name)
+		{
+			return fileName.Length > name.Length
+				&& fileName.EndsWith (name, PathComparison)
+				&& fileName [fileName.Length - name.Length - 1] == Path.PathSeparator;
+		}
+
 		public string Extension {
 			get {
 				return Path.GetExtension (fileName);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -161,8 +161,30 @@ namespace MonoDevelop.Core
 		public bool HasExtension (string extension)
 		{
 			return fileName.Length > extension.Length
-				&& extension.Length == 0
-				|| (extension[0] == '.' && fileName.EndsWith (extension, PathComparison));
+				&& (extension == string.Empty
+					? HasNoExtension (fileName, extension)
+					: fileName.EndsWith (extension, PathComparison) && fileName [fileName.Length - extension.Length] == '.');
+
+			static bool HasNoExtension (string path, string extension)
+			{
+				if (extension != string.Empty)
+					return false;
+
+				if (path [path.Length - 1] == '.')
+					return true;
+
+				// Look for the last dot that's after the last path separator
+				for (int i = path.Length - 1; i >= 0; --i) {
+					var ch = path [i];
+					if (ch == '.')
+						return false;
+
+					if (ch == Path.DirectorySeparatorChar)
+						return true;
+				}
+
+				return false;
+			}
 		}
 
 		public string FileNameWithoutExtension {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectExtension.cs
@@ -55,8 +55,7 @@ namespace MonoDevelop.Projects
 		/// </summary>
 		internal static bool FileShouldBeHidden (FilePath file)
 		{
-			return file.HasExtension (".userprefs") ||
-				file.FileName == ".DS_Store";
+			return file.HasExtension (".userprefs") || file.HasFileName (".DS_Store");
 		}
 
 		public IEnumerable<string> TargetFrameworks {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectExtension.cs
@@ -129,36 +129,15 @@ namespace MonoDevelop.Projects
 		{
 			var sourceFiles = await base.OnGetSourceFiles (monitor, configuration);
 
-			return AddMissingProjectFiles (sourceFiles, configuration);
-		}
-
-		ImmutableArray<ProjectFile> AddMissingProjectFiles (ImmutableArray<ProjectFile> files, ConfigurationSelector configuration)
-		{
-			ImmutableArray<ProjectFile>.Builder missingFiles = null;
-			foreach (ProjectFile existingFile in Project.Files.Where (file => file.BuildAction == BuildAction.Compile)) {
-				if (!files.Any (file => file.FilePath == existingFile.FilePath)) {
-					if (missingFiles == null)
-						missingFiles = ImmutableArray.CreateBuilder<ProjectFile> ();
-					missingFiles.Add (existingFile);
-				}
-			}
-
 			// Ensure generated assembly info file is available to type system. It is created in the obj
 			// directory and is excluded from the project with a wildcard exclude but the type system needs it to
 			// ensure the project's assembly information is correct to prevent diagnostic errors.
 			var generatedAssemblyInfoFile = GetGeneratedAssemblyInfoFile (configuration);
 			if (generatedAssemblyInfoFile != null) {
-				if (missingFiles == null)
-					missingFiles = ImmutableArray.CreateBuilder<ProjectFile> ();
-				missingFiles.Add (generatedAssemblyInfoFile);
+				return sourceFiles.Add (generatedAssemblyInfoFile);
 			}
 
-			if (missingFiles == null)
-				return files;
-
-			missingFiles.Capacity = missingFiles.Count + files.Length;
-			missingFiles.AddRange (files);
-			return missingFiles.MoveToImmutable ();
+			return sourceFiles;
 		}
 
 		ProjectFile GetGeneratedAssemblyInfoFile (ConfigurationSelector configuration)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
@@ -126,8 +126,12 @@ namespace MonoDevelop.Core
 		[TestCase ("test.txt", ".TxT", null)]
 		[TestCase ("test.txt", ".cs", false)]
 		[TestCase ("test.txt", ".longer", false)]
+		[TestCase ("test.txt", "", false)]
 		[TestCase (".gitignore", ".gitignore", true)]
 		[TestCase (".gitignore", ".git", false)]
+		[TestCase (".gitignore", "", false)]
+		[TestCase ("a", "", true)]
+		[TestCase ("a.", "", true)]
 		public void HasExtensionChecks (string fileName, string assertExtension, bool? expected)
 		{
 			IEqualityComparer<string> comparer = FilePath.PathComparer;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
@@ -132,6 +132,8 @@ namespace MonoDevelop.Core
 		[TestCase (".gitignore", "", false)]
 		[TestCase ("a", "", true)]
 		[TestCase ("a.", "", true)]
+		[TestCase ("", "", true)]
+		[TestCase ("", "a", false)]
 		public void HasExtensionChecks (string fileName, string assertExtension, bool? expected)
 		{
 			IEqualityComparer<string> comparer = FilePath.PathComparer;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectWithWildcardsTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectWithWildcardsTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // ProjectWithWildcardsTests.cs
 //
 // Author:
@@ -338,7 +338,7 @@ namespace MonoDevelop.Projects
 		}
 
 		/// <summary>
-		/// If an MSBuild item has a property on loading then if all the properties are removed the 
+		/// If an MSBuild item has a property on loading then if all the properties are removed the
 		/// project file when saved will still have an end element. So this test uses a different
 		/// .saved5 file compared with the previous test and includes the extra end tag for the
 		/// EmbeddedResource.
@@ -1067,6 +1067,8 @@ namespace MonoDevelop.Projects
 	class SupportImportedProjectFilesDotNetProjectExtension : DotNetProjectExtension
 	{
 		internal protected override bool OnGetSupportsImportedItem (IMSBuildItemEvaluated buildItem)
-			=> BuildAction.DotNetActions.Contains (buildItem.Name);
+		{
+			return BuildAction.DotNetActions.Contains (buildItem.Name);
+		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectWithWildcardsTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectWithWildcardsTests.cs
@@ -1067,8 +1067,6 @@ namespace MonoDevelop.Projects
 	class SupportImportedProjectFilesDotNetProjectExtension : DotNetProjectExtension
 	{
 		internal protected override bool OnGetSupportsImportedItem (IMSBuildItemEvaluated buildItem)
-		{
-			return BuildAction.DotNetActions.Contains (buildItem.Name);
-		}
+			=> BuildAction.DotNetActions.Contains (buildItem.Name);
 	}
 }


### PR DESCRIPTION
Remove workaround for BXC 53138 - does not seem to be needed anymore

Optimize imported item filtering by using a pre-computed hashset.

Optimize a legacy F# SDK workaround by caching the computed value.

Optimize file hiding by reducing string allocations.