### PR TITLE
[Core] Optimize globbing handling in the project model

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -862,7 +862,7 @@ namespace MonoDevelop.Projects.MSBuild
 				return CreateEvaluatedItem (context, pinfo, project, sourceItem, include, file, recursiveDir);
 			};
 			MSBuildProject rootProject = pinfo.GetRootMSBuildProject ();
-			return ExpandWildcardFilePath (rootProject, rootProject.BaseDirectory, FilePath.Null, false, subpath.AsSpan (), func, directoryExcludeRegex);
+			return ExpandWildcardFilePath (rootProject, rootProject.BaseDirectory, FilePath.Null, false, subpath, func, directoryExcludeRegex);
 		}
 
 		static IEnumerable<string> GetIncludesForWildcardFilePath (MSBuildProject project, string path, Regex directoryExcludeRegex = null)
@@ -870,7 +870,7 @@ namespace MonoDevelop.Projects.MSBuild
 			var subpath = SplitWildcardFilePath (path);
 
 			WildcardExpansionFunc<string> func = (file, include, recursiveDir) => include;
-			return ExpandWildcardFilePath (project, project.BaseDirectory, FilePath.Null, false, subpath.AsSpan (), func, directoryExcludeRegex);
+			return ExpandWildcardFilePath (project, project.BaseDirectory, FilePath.Null, false, subpath, func, directoryExcludeRegex);
 		}
 
 		static string[] SplitWildcardFilePath (string path)
@@ -883,7 +883,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		delegate T WildcardExpansionFunc<T> (string filePath, string include, string recursiveDir);
 
-		static IEnumerable<T> ExpandWildcardFilePath<T> (MSBuildProject project, FilePath basePath, FilePath baseRecursiveDir, bool recursive, Span<string> filePath, WildcardExpansionFunc<T> func, Regex directoryExcludeRegex)
+		static IEnumerable<T> ExpandWildcardFilePath<T> (MSBuildProject project, FilePath basePath, FilePath baseRecursiveDir, bool recursive, in ReadOnlySpan<string> filePath, WildcardExpansionFunc<T> func, Regex directoryExcludeRegex)
 		{
 			var res = Enumerable.Empty<T> ();
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -913,10 +913,10 @@ namespace MonoDevelop.Projects.MSBuild
 				if (baseRecursiveDir.IsNullOrEmpty)
 					baseRecursiveDir = basePath;
 
-				res = res.Concat (ExpandWildcardFilePath (project, basePath, baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
+				res = FastConcat (res, ExpandWildcardFilePath (project, basePath, baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
 
 				foreach (var dir in Directory.EnumerateDirectories (basePath, "*", SearchOption.AllDirectories))
-					res = res.Concat (ExpandWildcardFilePath (project, dir, baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
+					res = FastConcat (res, ExpandWildcardFilePath (project, dir, baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
 
 				return res;
 			}
@@ -938,13 +938,16 @@ namespace MonoDevelop.Projects.MSBuild
 
 				if (path.IndexOfAny (wildcards) != -1) {
 					foreach (var dir in Directory.EnumerateDirectories (basePath, path)) {
-						res = res.Concat (ExpandWildcardFilePath (project, dir, baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
+						res = FastConcat (res, ExpandWildcardFilePath (project, dir, baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
 					}
 				} else
-					res = res.Concat (ExpandWildcardFilePath (project, basePath.Combine (path), baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
+					res = FastConcat (res, ExpandWildcardFilePath (project, basePath.Combine (path), baseRecursiveDir, filePath.Slice (1), func, directoryExcludeRegex));
 			}
 
 			return res;
+
+			static IEnumerable<T> FastConcat (IEnumerable<T> first, IEnumerable<T> maybeEmpty)
+				=> maybeEmpty == Enumerable.Empty<T> () ? first : first.Concat (maybeEmpty);
 		}
 
 		static string ExcludeToRegex (string exclude, bool excludeDirectoriesOnly = false)


### PR DESCRIPTION
ExpandWildcardFilePath implementation is optimized to reduce the recursion level and allocations by not concatenating empty enumerables.