### PR TITLE
[Core] Remove redundant condition checks

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/DefaultMSBuildEngine.cs
@@ -333,8 +333,9 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildPropertyGroup group)
 		{
-			if (!string.IsNullOrEmpty (group.Condition) && !SafeParseAndEvaluate (project, context, group.Condition, true))
+			if (!SafeParseAndEvaluate (project, context, group.Condition, true)) {
 				return;
+			}
 
 			foreach (var prop in group.GetProperties ())
 				Evaluate (project, context, prop);
@@ -342,14 +343,11 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItemGroup items)
 		{
-			bool conditionIsTrue = true;
-
-			if (!string.IsNullOrEmpty (items.Condition))
-				conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition);
+			bool conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition);
 
 			foreach (var item in items.Items) {
 
-				var trueCond = conditionIsTrue && (string.IsNullOrEmpty (item.Condition) || SafeParseAndEvaluate (project, context, item.Condition));
+				var trueCond = conditionIsTrue && SafeParseAndEvaluate (project, context, item.Condition);
 
 				if (!string.IsNullOrEmpty (item.Update)) {
 					var update = context.EvaluateString (item.Update);
@@ -472,7 +470,7 @@ namespace MonoDevelop.Projects.MSBuild
 			var rootProject = project.GetRootMSBuildProject ();
 
 			foreach (var p in item.Metadata.GetProperties ()) {
-				if (string.IsNullOrEmpty (p.Condition) || SafeParseAndEvaluate (project, context, p.Condition, true)) {
+				if (SafeParseAndEvaluate (project, context, p.Condition, true)) {
 					string evaluatedValue = context.EvaluateString (p.Value);
 					string unevaluatedValue = p.Value;
 
@@ -643,7 +641,7 @@ namespace MonoDevelop.Projects.MSBuild
 						}
 						// Now override metadata from the new item definition
 						foreach (var c in item.Metadata.GetProperties ()) {
-							if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (project, context, c.Condition, true))
+							if (SafeParseAndEvaluate (project, context, c.Condition, true))
 								md [c.Name] = new MSBuildPropertyEvaluated (project.Project, c.Name, c.Value, context.EvaluateString (c.Value));
 						}
 						((MSBuildPropertyGroupEvaluated)newItem.Metadata).SetProperties (md);
@@ -840,7 +838,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildImportGroup imports, bool evalItems)
 		{
-			if (!string.IsNullOrEmpty (imports.Condition) && !SafeParseAndEvaluate (project, context, imports.Condition, true))
+			if (!SafeParseAndEvaluate (project, context, imports.Condition, true))
 				return;
 
 			foreach (var item in imports.Imports)
@@ -1006,7 +1004,7 @@ namespace MonoDevelop.Projects.MSBuild
 				try {
 					context.SetItemContext (include, evaluatedFile, recursiveDir);
 					foreach (var c in sourceItem.Metadata.GetProperties ()) {
-						if (string.IsNullOrEmpty (c.Condition) || SafeParseAndEvaluate (pinfo, context, c.Condition, true))
+						if (SafeParseAndEvaluate (pinfo, context, c.Condition, true))
 							md [c.Name] = new MSBuildPropertyEvaluated (project, c.Name, c.Value, context.EvaluateString (c.Value)) { Condition = c.Condition };
 					}
 				} finally {
@@ -1023,14 +1021,16 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildProperty prop)
 		{
-			if (string.IsNullOrEmpty (prop.Condition) || SafeParseAndEvaluate (project, context, prop.Condition, true)) {
-				bool needsItemEvaluation;
-				var val = context.Evaluate (prop.UnevaluatedValue, out needsItemEvaluation);
-				if (needsItemEvaluation)
-					context.SetPropertyNeedsTransformEvaluation (prop.Name);
-				StoreProperty (project, prop.Name, prop.UnevaluatedValue, val);
-				context.SetPropertyValue (prop.Name, val);
+			if (!SafeParseAndEvaluate (project, context, prop.Condition, true)) {
+				return;
 			}
+
+			bool needsItemEvaluation;
+			var val = context.Evaluate (prop.UnevaluatedValue, out needsItemEvaluation);
+			if (needsItemEvaluation)
+				context.SetPropertyNeedsTransformEvaluation (prop.Name);
+			StoreProperty (project, prop.Name, prop.UnevaluatedValue, val);
+			context.SetPropertyValue (prop.Name, val);
 		}
 
 		MSBuildItemEvaluated Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItem item)
@@ -1167,7 +1167,7 @@ namespace MonoDevelop.Projects.MSBuild
 			} else
 				basePath = project.Project.BaseDirectory;
 
-			if (!string.IsNullOrEmpty (import.Condition) && !SafeParseAndEvaluate (project, context, import.Condition, true, basePath)) {
+			if (!SafeParseAndEvaluate (project, context, import.Condition, true, basePath)) {
 				// Condition evaluates to false. Keep searching because maybe another value for the path property makes
 				// the condition evaluate to true.
 				keepSearching = true;
@@ -1259,13 +1259,10 @@ namespace MonoDevelop.Projects.MSBuild
 
 		void Evaluate (ProjectInfo project, MSBuildEvaluationContext context, MSBuildItemDefinitionGroup items)
 		{
-			bool conditionIsTrue = true;
-
-			if (!string.IsNullOrEmpty (items.Condition))
-				conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition);
+			bool conditionIsTrue = SafeParseAndEvaluate (project, context, items.Condition);
 
 			foreach (var item in items.Items) {
-				var trueCond = conditionIsTrue && (string.IsNullOrEmpty (item.Condition) || SafeParseAndEvaluate (project, context, item.Condition));
+				var trueCond = conditionIsTrue && SafeParseAndEvaluate (project, context, item.Condition);
 				if (trueCond) {
 					var it = CreateEvaluatedItem (context, project, project.Project, item, string.Empty);
 					project.EvaluatedItemDefinitions.Add (it);
@@ -1277,7 +1274,7 @@ namespace MonoDevelop.Projects.MSBuild
 		bool SafeParseAndEvaluate (ProjectInfo project, MSBuildEvaluationContext context, string condition, bool collectConditionedProperties = false, string customEvalBasePath = null)
 		{
 			try {
-				if (String.IsNullOrEmpty (condition))
+				if (string.IsNullOrEmpty (condition))
 					return true;
 
 				context.CustomFullDirectoryName = customEvalBasePath;


### PR DESCRIPTION
SafeParseAndEvaluate already does a check for the condition being empty. Remove the redundant checks and invert some conditions