### PR TITLE
[A11y] Check selector before trying to call accessibility method

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AtkCocoaHelper/AtkCocoaHelperMac.cs
@@ -384,6 +384,12 @@ namespace MonoDevelop.Components.AtkCocoaHelper
 				return;
 			}
 
+			// bug #940756 suggests that some elements do not respond to this selector
+			// so check before sending so it doesn't throw an ObjC exception
+			if (!((NSObject)titleNsa).RespondsToSelector (selAccessibilityServesAsTitleForUIElements)) {
+				return;
+			}
+
 			IntPtr ptr = Messaging.IntPtr_objc_msgSend (titleNsa.Handle, selAccessibilityServesAsTitleForUIElements_Handle);
 			using (var array = Runtime.GetNSObject<NSArray> (ptr)) {
 				if (array == null)


### PR DESCRIPTION
Check accessibilityServesAsTitleForUIElements selector is available
for UI element when trying to remove the accessibility element
from the title.

Unhandled ObjC Exception
MonoDevelop.MacIntegration.MacPlatformService+MarshalledObjCException: NSInvalidArgumentException: -[ACAccessibilityElement accessibilityServesAsTitleForUIElements:]: unrecognized selector sent to instance

	  at <unknown> <0xffffffff>
	  at MonoDevelop.Components.Mac.Messaging:IntPtr_objc_msgSend <0x00111>
	  at MonoDevelop.Components.AtkCocoaHelper.AtkCocoaMacExtensions:RemoveElementFromTitle <0x0027a>
	  at MonoDevelop.Ide.WelcomePage.WelcomePageSection:RemoveAccessibiltyTitledWidget <0x0018a>
	  at MonoDevelop.Ide.WelcomePage.WelcomePageRecentProjectsList:RecentFilesChanged <0x00282>
	  at MonoDevelop.Ide.Desktop.RecentFileStorage:<OnRecentFilesChanged>b__31_0 <0x000fa>

A fix was added where we check when adding an accessibility element
for a title but not when removing.

Related commit: 96d23ffac8f497aad89ba21d67020d2eec9b2be4

Fixes VSTS #950645 - Unrecognised selector crash