### PR TITLE
[Ide] Fix InfoBar button alignments

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/InfoBar.cs
@@ -55,8 +55,17 @@ namespace MonoDevelop.Ide.Gui.Components
 			mainBox.PackStart (new ImageView (ImageService.GetIcon (Stock.Information, Gtk.IconSize.Menu)), marginLeft: 11);
 			mainBox.PackStart (descriptionLabel = new Label (description));
 
+			int firstItem = 0;
 			if (items.Length > 0 && items[0].Kind == InfoBarItemKind.Hyperlink) {
+				firstItem = 1;
+				var link = new InfoBarLink {
+					Text = items [0].Title,
+				};
+				link.AddAction (items [0].Action);
+				if (items [0].CloseAfter)
+					link.AddAction (() => Dispose ());
 				mainBox.PackStart (new Label ("–"));
+				mainBox.PackStart (link);
 			}
 
 			var closeButton = new InfoBarCloseButton {
@@ -65,7 +74,10 @@ namespace MonoDevelop.Ide.Gui.Components
 			};
 			closeButton.AddAction (() => Dispose ());
 
-			foreach (var item in items) {
+			var widgets = new List<Widget> (items.Length);
+
+			for (int i = items.Length - 1; i >= firstItem; i--) {
+				var item = items [i];
 				// TODO: abstract this into a factory.
 				Widget toAdd = null;
 				switch (item.Kind)
@@ -101,10 +113,12 @@ namespace MonoDevelop.Ide.Gui.Components
 				}
 
 				if (toAdd != null)
-					mainBox.PackStart (toAdd);
+					widgets.Add (toAdd);
 			}
 
 			mainBox.PackEnd (closeButton);
+			foreach (var widget in widgets)
+				mainBox.PackEnd (widget);
 
 			if (IdeApp.Preferences == null || IdeApp.Preferences.UserInterfaceTheme == Theme.Light) {
 				Content = new FrameBox (mainBox) {


### PR DESCRIPTION
* Align all buttons to the right side
* Align the first hyperlink item to the end of the text
* Fix jumping buttons on window resize

Screencast (this is just an example based on existing code):

![InfoBar Bug Fixed](https://user-images.githubusercontent.com/951587/61712447-a8112780-ad56-11e9-875b-b03fda49e847.gif)


Fixes VSTS #948301