### PR TITLE
Fixes VSTS 950315: Code Folding menu toggle does not work in new editor 

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -369,6 +369,9 @@ namespace MonoDevelop.TextEditor
 		{
 			UpdateLineNumberMarginOption ();
 
+			var foldMargin = PropertyService.Get<bool> ("ShowFoldMargin");
+			Imports.OutliningManagerService.GetOutliningManager (TextView).Enabled = foldMargin;
+
 			var newPolicyContainer = (Owner as IPolicyProvider)?.Policies;
 			if (newPolicyContainer != policyContainer) {
 				if (policyContainer != null)
@@ -439,9 +442,6 @@ namespace MonoDevelop.TextEditor
 				EditorOptions.SetOptionValue (DefaultOptions.NewLineCharacterOptionName, lineEnding);
 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out var allowTrailingWhitespace))
 				EditorOptions.SetOptionValue (DefaultOptions.TrimTrailingWhiteSpaceOptionName, !allowTrailingWhitespace);
-
-			var foldMargin = PropertyService.Get<bool>("ShowFoldMargin");
-			Imports.OutliningManagerService.GetOutliningManager (this.TextView as ITextView).Enabled = foldMargin;
 
 			var setVerticalRulers = false;
 			int [] verticalRulers = null;

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.cs
@@ -440,6 +440,9 @@ namespace MonoDevelop.TextEditor
 			if (editorConfigContext.CurrentConventions.UniversalConventions.TryGetAllowTrailingWhitespace (out var allowTrailingWhitespace))
 				EditorOptions.SetOptionValue (DefaultOptions.TrimTrailingWhiteSpaceOptionName, !allowTrailingWhitespace);
 
+			var foldMargin = PropertyService.Get<bool>("ShowFoldMargin");
+			Imports.OutliningManagerService.GetOutliningManager (this.TextView as ITextView).Enabled = foldMargin;
+
 			var setVerticalRulers = false;
 			int [] verticalRulers = null;
 

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewImports.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewImports.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Find;
 using Microsoft.VisualStudio.Text.Projection;
+using Microsoft.VisualStudio.Text.Outlining;
 
 namespace MonoDevelop.TextEditor
 {
@@ -78,5 +79,8 @@ namespace MonoDevelop.TextEditor
 
 		[Import(AllowDefault = true)]
 		internal IInfoBarPresenterFactory InfoBarPresenterFactory { get; set; }
+
+		[Import]
+		internal IOutliningManagerService OutliningManagerService { get; set; }
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
@@ -522,15 +522,11 @@ namespace MonoDevelop.Ide.Gui
 		protected void UpdateEnableDisableFolding (CommandInfo info)
 		{
 			info.Text = IsFoldMarkerMarginEnabled ? GettextCatalog.GetString ("Disable _Folding") : GettextCatalog.GetString ("Enable _Folding");
-			info.Enabled = GetContent<IFoldable> () != null;
-
+			info.Enabled = GetContent<IFoldable> () != null ||
+				GetContent<Microsoft.VisualStudio.Text.Editor.ITextView3> () != null;
 			// As we need to support both the new and the legacy editor, we need to check if perhaps
 			// we are running in the new one. The legacy editor already implements <see cref="ITextView"/>
 			// so we can't simply look for that and we do not want to import anything related to Cocoa. 
-			if (!info.Enabled) {
-				var textView = GetContent<Microsoft.VisualStudio.Text.Editor.ITextView3> ();
-				info.Enabled = textView != null;
-			}
 		}
 
 		[CommandUpdateHandler (EditCommands.ToggleAllFoldings)]
@@ -550,7 +546,6 @@ namespace MonoDevelop.Ide.Gui
 		[CommandHandler (EditCommands.FoldDefinitions)]
 		protected void FoldDefinitions ()
 		{
-			Microsoft.VisualStudio.Text.Editor.ITextView textView;
 			GetContent <IFoldable> ().FoldDefinitions ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ViewCommandHandlers.cs
@@ -523,6 +523,14 @@ namespace MonoDevelop.Ide.Gui
 		{
 			info.Text = IsFoldMarkerMarginEnabled ? GettextCatalog.GetString ("Disable _Folding") : GettextCatalog.GetString ("Enable _Folding");
 			info.Enabled = GetContent<IFoldable> () != null;
+
+			// As we need to support both the new and the legacy editor, we need to check if perhaps
+			// we are running in the new one. The legacy editor already implements <see cref="ITextView"/>
+			// so we can't simply look for that and we do not want to import anything related to Cocoa. 
+			if (!info.Enabled) {
+				var textView = GetContent<Microsoft.VisualStudio.Text.Editor.ITextView3> ();
+				info.Enabled = textView != null;
+			}
 		}
 
 		[CommandUpdateHandler (EditCommands.ToggleAllFoldings)]
@@ -542,6 +550,7 @@ namespace MonoDevelop.Ide.Gui
 		[CommandHandler (EditCommands.FoldDefinitions)]
 		protected void FoldDefinitions ()
 		{
+			Microsoft.VisualStudio.Text.Editor.ITextView textView;
 			GetContent <IFoldable> ().FoldDefinitions ();
 		}
 


### PR DESCRIPTION
I’ve modified the way the editor reacts to Toggle Folding/Outlining.

We used to rely on the command being remapped to a handler in VSEC, but that caused a few additional problems, like the menu text not always being in sync. 

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/950315/