### PR TITLE
Fixes VSTS 948416: Document Outline does not refresh

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtensionProvider.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.ClassOutline/CSharpOutlineTextEditorExtensionProvider.cs
@@ -35,6 +35,6 @@ namespace MonoDevelop.CSharp
 	[TextViewRole (PredefinedTextViewRoles.PrimaryDocument)]
 	class CSharpOutlineTextEditorExtensionProvider : EditorContentInstanceProvider<CSharpOutlineTextEditorExtension>
 	{
-		protected override CSharpOutlineTextEditorExtension CreateInstance (ITextView view) => new CSharpOutlineTextEditorExtension (view.TextSnapshot.GetOpenDocumentInCurrentContextWithChanges ());
+		protected override CSharpOutlineTextEditorExtension CreateInstance (ITextView view) => new CSharpOutlineTextEditorExtension (view);
 	}
 }


### PR DESCRIPTION
Wiring the change handlers for Document Outline control.

Fixes https://vsmac.dev/948416/.