### PR TITLE
Bump Roslyn to 3.3.0-beta2-19374-02

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -18,7 +18,7 @@
     <NuGetVersionNuGet>5.2.0-rtm.6067</NuGetVersionNuGet>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
-    <NuGetVersionRoslyn>3.3.0-beta1-19360-03</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.3.0-beta2-19374-02</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.PackageInstaller/PackageInstallerService.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.PackageInstaller/PackageInstallerService.cs
@@ -128,6 +128,9 @@ namespace MonoDevelop.Refactoring.PackageInstaller
 					installedPackages.ContainsKey (packageName);
 			}
 
+			public bool CanShowManagePackagesDialog ()
+				=> true;
+
 			public void ShowManagePackagesDialog (string packageName)
 			{
 				PackageServices.ShowManagePackagesDialog (packageName);


### PR DESCRIPTION
Changes since [7d47461](https://www.github.com/dotnet/roslyn/commit/7d47461):
- [Merge pull request #37416 from jnm2/sort_traits_features](https://www.github.com/dotnet/roslyn/pull/37416)
- [Remove naming styles before generating field/property/parameter in constructor related refactorings (#36220)](https://www.github.com/dotnet/roslyn/pull/36220)
- [Merge pull request #37403 from dotnet/dev/jorobich/publish-dotnet-format](https://www.github.com/dotnet/roslyn/pull/37403)
- [Update dependencies from https://github.com/dotnet/arcade build 20190719.2 (#37393)](https://www.github.com/dotnet/roslyn/pull/37393)
- [Merge pull request #37149 from ryzngard/issue/33287_generateconstructorwithdialog_vb](https://www.github.com/dotnet/roslyn/pull/37149)
- [Include netstandard2.1 in the set of default C# 8 frameworks (#37365)](https://www.github.com/dotnet/roslyn/pull/37365)
- [Syntax factory for switch statement adds parens when needed. (#37301)](https://www.github.com/dotnet/roslyn/pull/37301)
- [Update the LangVersion and Nullable command line text (#37351)](https://www.github.com/dotnet/roslyn/pull/37351)
- [Respect root editorconfig files when getting options for a file (#37283)](https://www.github.com/dotnet/roslyn/pull/37283)
- [Merge pull request #37298 from diryboy/T](https://www.github.com/dotnet/roslyn/pull/37298)
- [Merge pull request #37373 from mavasani/Issue37213](https://www.github.com/dotnet/roslyn/pull/37373)
- [Merge pull request #37108 from amcasey/BlockingLightbulb](https://www.github.com/dotnet/roslyn/pull/37108)
- [Merge pull request #37360 from dibarbet/initialize_liveshare_workspace_on_ui](https://www.github.com/dotnet/roslyn/pull/37360)
- [Merge pull request #37140 from CyrusNajmabadi/publicSymbolKey](https://www.github.com/dotnet/roslyn/pull/37140)
- [Merge pull request #37272 from petrroll/move-refa-to-helpers4](https://www.github.com/dotnet/roslyn/pull/37272)
- [Merge pull request #37330 from mavasani/Issue37326](https://www.github.com/dotnet/roslyn/pull/37330)
- [Replace ApplyPartialNgenOptimization with ApplyNgenOptimization (#37327)](https://www.github.com/dotnet/roslyn/pull/37327)
- [Merge pull request #37311 from jasonmalinowski/consume-construction-with-nullable-in-type-inferrer](https://www.github.com/dotnet/roslyn/pull/37311)
- [Merge master to master-vs-deps (#37317)](https://www.github.com/dotnet/roslyn/pull/37317)
- [Merge pull request #37236 from petrroll/SyntaxKindsService-cleanup](https://www.github.com/dotnet/roslyn/pull/37236)
- [Merge pull request #37307 from cston/uninitialized-message](https://www.github.com/dotnet/roslyn/pull/37307)
- [Merge pull request #37151 from tmeschter/QueryForMaxSupportedLangVersion-190711](https://www.github.com/dotnet/roslyn/pull/37151)
- [Update System.Threading.Tasks.Extensions to 4.5.3 (#37316)](https://www.github.com/dotnet/roslyn/pull/37316)
- [Merge pull request #37196 from petrroll/move-refa-to-helpers3](https://www.github.com/dotnet/roslyn/pull/37196)
- [Merge pull request #37248 from dotnet/remove-lspSupport](https://www.github.com/dotnet/roslyn/pull/37248)
- [Add compilerNext packages to be published to myget (#37240)](https://www.github.com/dotnet/roslyn/pull/37240)
- [Merge pull request #37305 from tmat/FixMerge](https://www.github.com/dotnet/roslyn/pull/37305)
- [Merge pull request #37291 from CyrusNajmabadi/fileMatch](https://www.github.com/dotnet/roslyn/pull/37291)
- [EnC support of static local functions (#36800)](https://www.github.com/dotnet/roslyn/pull/36800)
- [ENC editing tests for C# 8.0 pattern matching (#37015)](https://www.github.com/dotnet/roslyn/pull/37015)
- [Merge pull request #37294 from CyrusNajmabadi/consistentRefactorings](https://www.github.com/dotnet/roslyn/pull/37294)
- [Merge pull request #37270 from mavasani/Issue36330](https://www.github.com/dotnet/roslyn/pull/37270)
- [Merge pull request #37284 from jasonmalinowski/fix-missing-nullable-annotations](https://www.github.com/dotnet/roslyn/pull/37284)
- [Merge release/dev16.3-preview1-vs-deps to master-vs-deps (#37285)](https://www.github.com/dotnet/roslyn/pull/37285)
- [Merge master to master-vs-deps (#37293)](https://www.github.com/dotnet/roslyn/pull/37293)
- [Merge pull request #37266 from diryboy/foreach_ref](https://www.github.com/dotnet/roslyn/pull/37266)
- [Merge pull request #37275 from jasonmalinowski/support-tuple-nullable-annotations](https://www.github.com/dotnet/roslyn/pull/37275)
- [Merge pull request #37170 from jasonmalinowski/ensure-sethost-to-null-twice-does-not-throw](https://www.github.com/dotnet/roslyn/pull/37170)
- [Merge pull request #36012 from CyrusNajmabadi/noIndenter](https://www.github.com/dotnet/roslyn/pull/36012)
- [Merge pull request #37263 from CyrusNajmabadi/introLocal](https://www.github.com/dotnet/roslyn/pull/37263)
- [Merge release/dev16.3-preview1-vs-deps to master-vs-deps (#37253)](https://www.github.com/dotnet/roslyn/pull/37253)
- [Add INamedTypeSymbol.Construct overload with nullable annotations (#37271)](https://www.github.com/dotnet/roslyn/pull/37271)
- [Add nullable context api definitions (#37017)](https://www.github.com/dotnet/roslyn/pull/37017)
- [Merge pull request #37250 from mavasani/MoveToLatestFlowAnalysisPackage](https://www.github.com/dotnet/roslyn/pull/37250)
- [ Fix EnC debug information emitted for patterns (#37239)](https://www.github.com/dotnet/roslyn/pull/37239)
- [Fix NullableAttribute.Flags->NullableFlags in docs (#36907)](https://www.github.com/dotnet/roslyn/pull/36907)
- [Merge pull request #37207 from CyrusNajmabadi/usePatternMatching](https://www.github.com/dotnet/roslyn/pull/37207)
- [Merge pull request #37036 from huoyaoyuan/fix-chinese-loc](https://www.github.com/dotnet/roslyn/pull/37036)
- [Add MaxLangVersion (#37244)](https://www.github.com/dotnet/roslyn/pull/37244)
- [Let #nullable directive enable/disable all nullable-related warnings (#37242)](https://www.github.com/dotnet/roslyn/pull/37242)
- [Reinfer discard in assignment and out vars (#37214)](https://www.github.com/dotnet/roslyn/pull/37214)
- [Honor NotNullIfNotNull(string) (#37201)](https://www.github.com/dotnet/roslyn/pull/37201)
- [Warn on implicit copies for event assignment within readonly members (#35710)](https://www.github.com/dotnet/roslyn/pull/35710)
- [EnC support for DIM (#37115)](https://www.github.com/dotnet/roslyn/pull/37115)
- [Merge pull request #36890 from JoeRobich/expand-introduced-using](https://www.github.com/dotnet/roslyn/pull/36890)
- [Report nullable warnings for receiver of pattern indexers (#37216)](https://www.github.com/dotnet/roslyn/pull/37216)
- [Make IEquatable contravariant for the purpose of nullability (#37215)](https://www.github.com/dotnet/roslyn/pull/37215)
- [Check for implicit 'this' copy when binding pattern indexers (#37194)](https://www.github.com/dotnet/roslyn/pull/37194)
- [Merge pull request #37116 from jasonmalinowski/enable-editorconfig-discovery-by-default](https://www.github.com/dotnet/roslyn/pull/37116)
- [Target-typed switch expression (#37052)](https://www.github.com/dotnet/roslyn/pull/37052)
- [Merge pull request #35006 from canton7/feature/string-concat-order](https://www.github.com/dotnet/roslyn/pull/35006)
- [Fix parsing for double-slash langver (#37202)](https://www.github.com/dotnet/roslyn/pull/37202)
- [Update dependencies from https://github.com/dotnet/arcade build 20190714.1 (#37227)](https://www.github.com/dotnet/roslyn/pull/37227)
- [Fix typo in EmitStreamSignKind (#36895)](https://www.github.com/dotnet/roslyn/pull/36895)
- [Add a test related to #33344 (#36193)](https://www.github.com/dotnet/roslyn/pull/36193)
- [Remove the temporary mechanism for "external" nullable annotations. (#34916)](https://www.github.com/dotnet/roslyn/pull/34916)
- [Merge pull request #36925 from dibarbet/merge_lsp_to_master](https://www.github.com/dotnet/roslyn/pull/36925)
- [Remove support for '#pragma warning enable' directive (take 2) (#37192)](https://www.github.com/dotnet/roslyn/pull/37192)
- [[master] Update dependencies from dotnet/arcade (#37189)](https://www.github.com/dotnet/roslyn/pull/37189)
- [Merge pull request #37034 from mavasani/InfoBar_FxCopAnalyzers](https://www.github.com/dotnet/roslyn/pull/37034)
- [Fix attribute params with regards to nullability (#37156)](https://www.github.com/dotnet/roslyn/pull/37156)
- [Merge pull request #36936 from genlu/CompletionTimebox](https://www.github.com/dotnet/roslyn/pull/36936)
- [Tweak interaction of Maybe/NotNull with Not/MaybeNullWhen (#37159)](https://www.github.com/dotnet/roslyn/pull/37159)
- [Make C# 8.0 the default, latest, and latest-major language version (#37074)](https://www.github.com/dotnet/roslyn/pull/37074)
- [Merge pull request #37072 from petrroll/move-refa-to-helpers2](https://www.github.com/dotnet/roslyn/pull/37072)
- [Merge pull request #37162 from CyrusNajmabadi/moveWrappingDown](https://www.github.com/dotnet/roslyn/pull/37162)
- [Handle synthesized top-level types in EnC symbol matcher (#36854)](https://www.github.com/dotnet/roslyn/pull/36854)
- [Rename TypeArgumentsNullableAnnotations to TypeArgumentNullabl╬ô├ç┬¬ (#37158)](https://www.github.com/dotnet/roslyn/pull/37158)
- [Full-ngen ResultProvider (#37186)](https://www.github.com/dotnet/roslyn/pull/37186)
- [Add nullability parameters to Compilation.Create*Type() (#37048)](https://www.github.com/dotnet/roslyn/pull/37048)
- [Apply Maybe/NotNull when getting default value of fields and properties (#37135)](https://www.github.com/dotnet/roslyn/pull/37135)
- [Fix master build (#37163)](https://www.github.com/dotnet/roslyn/pull/37163)
- [Merge pull request #37150 from dotnet/darc-master-41472f43-c7c3-42da-9ef2-0abcf29790e5](https://www.github.com/dotnet/roslyn/pull/37150)
- [Merge pull request #37053 from sharwell/cleanup-cleanup](https://www.github.com/dotnet/roslyn/pull/37053)
- [Add error for multiple null suppressions (#37139)](https://www.github.com/dotnet/roslyn/pull/37139)
- [Check for uninitialized non-nullable field-like events (#37073)](https://www.github.com/dotnet/roslyn/pull/37073)
- [EnC emit tests for C# 8.0 patterns (#37025)](https://www.github.com/dotnet/roslyn/pull/37025)
- [Merge pull request #36965 from jasonmalinowski/workspace-nullable-annotations](https://www.github.com/dotnet/roslyn/pull/36965)
- [[master] Update dependencies from dotnet/arcade (#37001)](https://www.github.com/dotnet/roslyn/pull/37001)
- [Update to System.Memory 4.5.3 (#36956)](https://www.github.com/dotnet/roslyn/pull/36956)
- [Copy sources from Versions.props to NuGet.config (#37123)](https://www.github.com/dotnet/roslyn/pull/37123)
- [Add netstandard to the exclusion list for the AnalyzerConsistencyChecker (#36976)](https://www.github.com/dotnet/roslyn/pull/36976)
- [Fix crash in semantic model when using unmanaged constraint (#37022)](https://www.github.com/dotnet/roslyn/pull/37022)
- [Merge pull request #36395 from genlu/AttributeCompletion](https://www.github.com/dotnet/roslyn/pull/36395)
- [Merge pull request #37117 from mavasani/Issue36866](https://www.github.com/dotnet/roslyn/pull/37117)
- [Merge pull request #37066 from ivanbasov/intellicode](https://www.github.com/dotnet/roslyn/pull/37066)
- [Add nullability information to GetSymbolInfo for invocations. (#36975)](https://www.github.com/dotnet/roslyn/pull/36975)
- [Merge pull request #31951 from CyrusNajmabadi/fluentWrapping](https://www.github.com/dotnet/roslyn/pull/31951)
- [Merge pull request #37085 from mavasani/IssueLightBulb](https://www.github.com/dotnet/roslyn/pull/37085)
- [Merge pull request #34001 from CyrusNajmabadi/noBlankLineIndentation](https://www.github.com/dotnet/roslyn/pull/34001)
- [Enable EnC tests on Core (#37083)](https://www.github.com/dotnet/roslyn/pull/37083)
- [Include AttributeUsageAttribute with synthesized nullable attributes (#36958)](https://www.github.com/dotnet/roslyn/pull/36958)
- [Remark about F# not supported (#37042)](https://www.github.com/dotnet/roslyn/pull/37042)
- [Editing tests for support nullable in ENC (#36770)](https://www.github.com/dotnet/roslyn/pull/36770)
- [C# SymbolMatcher tests for nullables (#36681)](https://www.github.com/dotnet/roslyn/pull/36681)
- [ Honor DoesNotReturn and DoesNotReturnIf (#36810)](https://www.github.com/dotnet/roslyn/pull/36810)
- [Ensure we have stack spilling support for the recently-added expression node `BoundReadOnlySpanFromArray` (#37057)](https://www.github.com/dotnet/roslyn/pull/37057)
- [Merge pull request #36914 from dpoeschl/TargetTypedCompletionConversionCache](https://www.github.com/dotnet/roslyn/pull/36914)
- [Merge pull request #36982 from jasonmalinowski/fix-stale-filepath-bug](https://www.github.com/dotnet/roslyn/pull/36982)
- [Merge pull request #37014 from RikkiGibson/nullable-compareexchange](https://www.github.com/dotnet/roslyn/pull/37014)
- [Avoid generating or emitting NullablePublicOnlyAttribute when no other nullable attributes are emitted (#37019)](https://www.github.com/dotnet/roslyn/pull/37019)
- [Merge pull request #36879 from petrroll/move-refa-to-helpers](https://www.github.com/dotnet/roslyn/pull/36879)
- [Merge pull request #37045 from dibarbet/merges/master-to-features/lspSupport](https://www.github.com/dotnet/roslyn/pull/37045)
- [Merge pull request #32943 from CyrusNajmabadi/cleanup](https://www.github.com/dotnet/roslyn/pull/32943)
- [Merge pull request #36996 from dibarbet/fix_master_to_lsp_merge](https://www.github.com/dotnet/roslyn/pull/36996)
- [Merge pull request #37020 from genlu/OptimizeFlowAnalysis](https://www.github.com/dotnet/roslyn/pull/37020)
- [Turn on nullable semantic analysis by default (#36869)](https://www.github.com/dotnet/roslyn/pull/36869)
- [Merge pull request #36994 from gnovack/readonly-modifier](https://www.github.com/dotnet/roslyn/pull/36994)
- [Use pattern-matching in MetadataWriter for readability and possibly performance. (#36219)](https://www.github.com/dotnet/roslyn/pull/36219)
- [Merge pull request #36959 from dibarbet/port_new_liveshare](https://www.github.com/dotnet/roslyn/pull/36959)
- [Merge pull request #36098 from heejaechang/lazyLoadErrorList2](https://www.github.com/dotnet/roslyn/pull/36098)
- [Merge pull request #36924 from CyrusNajmabadi/indexRangeStringsArrays](https://www.github.com/dotnet/roslyn/pull/36924)
- [Merge pull request #36864 from heejaechang/partialMode](https://www.github.com/dotnet/roslyn/pull/36864)
- [Merge pull request #36935 from dotnet/dev/jorobich/unskip-enc-tests](https://www.github.com/dotnet/roslyn/pull/36935)
- [Merge pull request #36939 from dotnet/dev/jorobich/update-build-sdk](https://www.github.com/dotnet/roslyn/pull/36939)
- [Fix broken See also links (#36948)](https://www.github.com/dotnet/roslyn/pull/36948)
- [Merge pull request #33989 from CyrusNajmabadi/mergeIdentation](https://www.github.com/dotnet/roslyn/pull/33989)
- [Merge pull request #36493 from gnovack/local-function-static](https://www.github.com/dotnet/roslyn/pull/36493)
- [Enable nullable for BoundNodes (#36896)](https://www.github.com/dotnet/roslyn/pull/36896)
- [Merge pull request #36916 from dibarbet/add_forwarders](https://www.github.com/dotnet/roslyn/pull/36916)
- [Merge pull request #36886 from CyrusNajmabadi/thisNone](https://www.github.com/dotnet/roslyn/pull/36886)
- [Learn from calls to Equals methods in NullableWalker (#36722)](https://www.github.com/dotnet/roslyn/pull/36722)
- [Merge pull request #36898 from davkean/Editors](https://www.github.com/dotnet/roslyn/pull/36898)
- [Don't update analyzed nullability for parameter conversions (#36881)](https://www.github.com/dotnet/roslyn/pull/36881)
- [Merge pull request #36873 from CyrusNajmabadi/cleanup5](https://www.github.com/dotnet/roslyn/pull/36873)
- [Make IRecursivePatternOperation public (#36709)](https://www.github.com/dotnet/roslyn/pull/36709)
- [Use toolset version from Arcade (#36754)](https://www.github.com/dotnet/roslyn/pull/36754)
- [Merge pull request #36567 from panopticoncentral/metadata](https://www.github.com/dotnet/roslyn/pull/36567)
- [Merge pull request #36712 from AlekseyTs/MonoTests_01](https://www.github.com/dotnet/roslyn/pull/36712)
- [Wire GetSpeculativeTypeInfo with nullability information (#36833)](https://www.github.com/dotnet/roslyn/pull/36833)
- [Fix IntelliCode-related Completion Tests (#36875)](https://www.github.com/dotnet/roslyn/pull/36875)
- [Don't treat zero-length deconstruction as an error when binding patterns. (#36678)](https://www.github.com/dotnet/roslyn/pull/36678)
- [Small Compiler Refactors (#36841)](https://www.github.com/dotnet/roslyn/pull/36841)
- [Fix header reading for Narrator on Pull Members Up dialog (#36836)](https://www.github.com/dotnet/roslyn/pull/36836)
- [Merge pull request #36729 from petrroll/refact-select-fix-foreach](https://www.github.com/dotnet/roslyn/pull/36729)
- [Merge pull request #36855 from dibarbet/fix_code_actions_projects](https://www.github.com/dotnet/roslyn/pull/36855)
- [Merge pull request #35575 from CyrusNajmabadi/cleanup4](https://www.github.com/dotnet/roslyn/pull/35575)
- [Merge pull request #36834 from jasonmalinowski/fix-formatting-issues](https://www.github.com/dotnet/roslyn/pull/36834)
- [Bump master to 3.3.0-beta2 (#36842)](https://www.github.com/dotnet/roslyn/pull/36842)
- [Update PublishData.json (#36843)](https://www.github.com/dotnet/roslyn/pull/36843)
- [Merge pull request #36713 from CyrusNajmabadi/simplifySigHelp](https://www.github.com/dotnet/roslyn/pull/36713)
- [Update dependencies from https://github.com/dotnet/arcade build 20190626.44 (#36815)](https://www.github.com/dotnet/roslyn/pull/36815)
- [Avoid a first-chance FileNotFoundException when a ruleset include is not found. (#34696)](https://www.github.com/dotnet/roslyn/pull/34696)
- [Merge pull request #36344 from dibarbet/remove_liveshare_dependencies](https://www.github.com/dotnet/roslyn/pull/36344)
- [Merge pull request #36799 from dotnet/dev/jorobich/skip-enc-tests](https://www.github.com/dotnet/roslyn/pull/36799)
- [Merge pull request #36801 from RikkiGibson/merge-3p1-to-master](https://www.github.com/dotnet/roslyn/pull/36801)
- [Merge pull request #36804 from dibarbet/features/lspSupport_merge_lsp_only](https://www.github.com/dotnet/roslyn/pull/36804)
- [Merge pull request #36795 from RikkiGibson/merge-to-master-vs-deps](https://www.github.com/dotnet/roslyn/pull/36795)
- [Merge pull request #35822 from YairHalberstadt/dont-suggest-this-in-static-local-functions](https://www.github.com/dotnet/roslyn/pull/35822)
- [Use TestRuntimeAdditionalArguments from Arcade: (#34296)](https://www.github.com/dotnet/roslyn/pull/34296)
- [Merge pull request #36569 from dibarbet/merge_163](https://www.github.com/dotnet/roslyn/pull/36569)
- [Merge pull request #36094 from dibarbet/upgrade_lsp_version](https://www.github.com/dotnet/roslyn/pull/36094)
- [Merge pull request #35781 from dibarbet/liveshare_client_rebase_rebase](https://www.github.com/dotnet/roslyn/pull/35781)
- [Merge pull request #35214 from dibarbet/features/lspSupport_liveshare2](https://www.github.com/dotnet/roslyn/pull/35214)
- [Merge pull request #34794 from dibarbet/features/lspSupport_migrate](https://www.github.com/dotnet/roslyn/pull/34794)
- [Merge pull request #34370 from dibarbet/features/lspSupport](https://www.github.com/dotnet/roslyn/pull/34370)
