### PR TITLE
Build: Use a property to access the vs-editor-api directory

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -4,7 +4,8 @@
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>
     <PackagesDirectory>$(RootDirectory)packages</PackagesDirectory>
     <MdAddinsDirectory>$(MSBuildThisFileDirectory)..\..\md-addins\</MdAddinsDirectory>
-    <VSEditorCoreDirectory>$(MdAddinsDirectory)external\vs-editor-core\</VSEditorCoreDirectory>
+    <VSEditorCoreDirectory Condition="'$(VSEditorCoreDirectory)' == ''">$(MdAddinsDirectory)external\vs-editor-core\</VSEditorCoreDirectory>
+    <VSEditorApiDirectory Condition="'$(VSEditorApiDirectory)' == ''">$(MSBuildThisFileDirectory)external\vs-editor-api\</VSEditorApiDirectory>
     <ReferencesVSEditor Condition=" '$(OS)' == 'Windows_NT' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Windows.props</ReferencesVSEditor>
     <ReferencesVSEditor Condition=" '$(OS)' != 'Windows_NT' ">$(RootDirectory)\msbuild\ReferencesVSEditor.Mac.props</ReferencesVSEditor>
     <ReferencesGtk>$(RootDirectory)\msbuild\ReferencesGtk.props</ReferencesGtk>

--- a/main/msbuild/ReferencesVSEditor.Mac.props
+++ b/main/msbuild/ReferencesVSEditor.Mac.props
@@ -51,15 +51,15 @@
     <IncludeCopyLocal Include="Microsoft.VisualStudio.UI.Text.CurrentLineHighlighter.Implementation.dll" />
   </ItemGroup>
 
-  <Import Project="$(RootDirectory)external\vs-editor-api\build\Environment.props" />
-  <Import Project="$(RootDirectory)external\vs-editor-api\ProjectReferences.projitems" />
+  <Import Project="$(VSEditorApiDirectory)build\Environment.props" />
+  <Import Project="$(VSEditorApiDirectory)ProjectReferences.projitems" />
 
   <!-- MSBuild doesn't copy the FPF references as they match BCL assembly names -->
   <Target Name="CopyFPFAssemblies" AfterTargets="_CopyFilesMarkedCopyLocal" Condition="'$(ReferencesVSEditorCopyToOutput)'=='true'">
     <PropertyGroup>
       <FPFConfiguration>Release</FPFConfiguration>
       <FPFConfiguration Condition="$(Configuration.Contains('Debug'))">Debug</FPFConfiguration>
-      <FPFOutputPath>$(RootDirectory)external\vs-editor-api\bin\FPF\$(FPFConfiguration)\net472\</FPFOutputPath>
+      <FPFOutputPath>$(VSEditorApiDirectory)bin\FPF\$(FPFConfiguration)\net472\</FPFOutputPath>
     </PropertyGroup>
     <ItemGroup>
       <FPFOutputFiles Include="$(FPFOutputPath)PresentationCore.*" />

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.csproj
@@ -84,9 +84,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\VacuousTextDataModel.cs" Link="Util\VacuousTextDataModel.cs" />
-    <Compile Include="..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\VacuousTextViewModel.cs" Link="Util\VacuousTextViewModel.cs" />
-    <Compile Include="..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\UIExtensionSelector.cs" Link="Util\UIExtensionSelector.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\VacuousTextDataModel.cs" Link="Util\VacuousTextDataModel.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\VacuousTextViewModel.cs" Link="Util\VacuousTextViewModel.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\UIExtensionSelector.cs" Link="Util\UIExtensionSelector.cs" />
     <None Include="MonoDevelop.SourceEditor.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/MonoDevelop.TextEditor.Cocoa.csproj
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/MonoDevelop.TextEditor.Cocoa.csproj
@@ -73,10 +73,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\..\..\..\..\md-addins\external\vs-editor-core\bin\TextMate\Onig\libonig.dylib">
+    <None Include="$(VSEditorCoreDirectory)bin\TextMate\Onig\libonig.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\..\..\..\..\md-addins\external\vs-editor-core\src\TextMate\VSWindows\Setup\**\*">
+    <None Include="$(VSEditorCoreDirectory)src\TextMate\VSWindows\Setup\**\*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Wpf/MonoDevelop.TextEditor.Wpf.csproj
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Wpf/MonoDevelop.TextEditor.Wpf.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Language" Version="$(NuGetVersionVSEditor)" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(NuGetVersionVSEditor)" PrivateAssets="all" ExcludeAssets="runtime" />
     <ProjectReference Include="..\MonoDevelop.TextEditor\MonoDevelop.TextEditor.csproj" Private="False" />
-    <ProjectReference Include="..\..\..\..\external\vs-editor-api\src\Editor\Imaging\Def\Imaging.csproj" />
-    <ProjectReference Include="..\..\..\..\external\vs-editor-api\src\Editor\Text\Def\Extras\Extras.csproj" />
+    <ProjectReference Include="$(VSEditorApiDirectory)src\Editor\Imaging\Def\Imaging.csproj" />
+    <ProjectReference Include="$(VSEditorApiDirectory)src\Editor\Text\Def\Extras\Extras.csproj" />
     <ProjectReference Include="..\..\..\..\external\xwt\Xwt\Xwt.csproj" Private="False" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/MonoDevelop.TextEditor.csproj
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/MonoDevelop.TextEditor.csproj
@@ -10,7 +10,7 @@
     <DefineConstants Condition="$(OS) == 'Windows_NT'">$(DefineConstants);WINDOWS;WIN32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\external\vs-editor-api\src\Editor\Text\Def\Extras\Extras.csproj" />
+    <ProjectReference Include="$(VSEditorApiDirectory)src\Editor\Text\Def\Extras\Extras.csproj" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.TextEditor.Cocoa" />
@@ -20,8 +20,8 @@
     <ProjectReference Include="..\..\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.csproj" Private="false" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\VacuousTextDataModel.cs" Link="Util\VacuousTextDataModel.cs" />
-    <Compile Include="..\..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\UIExtensionSelector.cs" Link="Util\UIExtensionSelector.cs" />
-    <Compile Include="..\..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\VacuousTextViewModel.cs" Link="Util\VacuousTextViewModel.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\VacuousTextDataModel.cs" Link="Util\VacuousTextDataModel.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\UIExtensionSelector.cs" Link="Util\UIExtensionSelector.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\VacuousTextViewModel.cs" Link="Util\VacuousTextViewModel.cs" />
   </ItemGroup>
 </Project>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4227,8 +4227,8 @@
     <Compile Include="MonoDevelop.Ide.Composition\VisualStudioMefHostServices.cs" />
     <Compile Include="MonoDevelop.Ide.Projects\NewSolutionRunConfigurationDialog.cs" />
     <Compile Include="MonoDevelop.Ide.TypeSystem\WorkspaceFilesCache.cs" />
-    <Compile Include="..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\VacuousTextDataModel.cs" Link="Util\VacuousTextDataModel.cs" />
-    <Compile Include="..\..\..\external\vs-editor-api\src\Editor\Text\Util\TextUIUtil\VacuousTextViewModel.cs" Link="Util\VacuousTextViewModel.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\VacuousTextDataModel.cs" Link="Util\VacuousTextDataModel.cs" />
+    <Compile Include="$(VSEditorApiDirectory)src\Editor\Text\Util\TextUIUtil\VacuousTextViewModel.cs" Link="Util\VacuousTextViewModel.cs" />
     <Compile Include="MonoDevelop.Ide.Editor\EditorPreferences.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.Dialogs\NewFolderDialog.cs" />
     <Compile Include="MonoDevelop.Ide.Gui.Pads.ProjectPad\IProjectPadNodeSelector.cs" />


### PR DESCRIPTION
This should make it easier for us to have all vs-editor-api references
point to vs-editor-core when available. There are some blockers to that
change, so for now just take this one preparatory step.