### PR TITLE
Editor: Respect pref to not show completion window while typing

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/CompletionOptionsPanel.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor.OptionPanels/CompletionOptionsPanel.cs
@@ -93,6 +93,7 @@ namespace MonoDevelop.SourceEditor.OptionPanels
 		void IOptionsPanel.ApplyChanges ()
 		{
 			DefaultSourceEditorOptions.Instance.EnableAutoCodeCompletion = autoCodeCompletionCheckbutton.Active;
+			IdeApp.Preferences.Roslyn.CSharp.TriggerOnTypingLetters.Value = autoCodeCompletionCheckbutton.Active;
 			IdeApp.Preferences.AddImportedItemsToCompletionList.Value = showImportsCheckbutton.Active;
 			IdeApp.Preferences.Roslyn.CSharp.ShowItemsFromUnimportedNamespaces.Value = showImportsCheckbutton.Active;
 			IdeApp.Preferences.IncludeKeywordsInCompletionList.Value = includeKeywordsCheckbutton.Active;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferences.cs
@@ -77,6 +77,8 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 			public readonly ConfigurationProperty<bool> SuggestForTypesInNuGetPackages;
 			public readonly ConfigurationProperty<bool> SolutionCrawlerClosedFileDiagnostic;
 			public readonly ConfigurationProperty<bool?> TriggerOnDeletion;
+			readonly Lazy<ConfigurationProperty<bool>> triggerOnTypingLetters;
+			public ConfigurationProperty<bool> TriggerOnTypingLetters => triggerOnTypingLetters.Value;
 
 			internal PerLanguagePreferences (string language, RoslynPreferences preferences)
 			{
@@ -141,6 +143,12 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 					new OptionKey (CompletionOptions.TriggerOnDeletion, language),
 					language + ".TriggerOnDeletion"
 				);
+
+				triggerOnTypingLetters = new Lazy<ConfigurationProperty<bool>> (() => preferences.Wrap<bool> (
+					new OptionKey (CompletionOptions.TriggerOnTypingLetters, language),
+					MonoDevelop.Ide.Editor.DefaultSourceEditorOptions.Instance.EnableAutoCodeCompletion,
+					language + ".TriggerOnTypingLetters"
+				));
 			}
 
 			class ClosedFileDiagnosticProperty : ConfigurationProperty<bool>


### PR DESCRIPTION
In the new editor (as on Windows), this is controlled at the language
service level, not the editor level. So, just like with
"Show import items", it should really be a per-language setting.

Just like with "Show import items", set the C#-specific preference
along with the global preference. This does not address the problem for
other languages that default to new editor (like XAML and AXML).

Note that the associated `ConfigurationProperty` is initialized lazily,
because otherwise its dependency on `DefaultSourceEditorOptions` leads
to a circular initialization dependency and hangs the IDE.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/950309