### PR TITLE
[build] Update min Mono version to 6.4.0.94

### DIFF
--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -260,7 +260,7 @@ main (int argc, char **argv)
 		}
 
 		// can be overridden with plist string MonoMinVersion
-		NSString *req_mono_version = @"6.0.0.296";
+		NSString *req_mono_version = @"6.4.0.94";
 
 		NSDictionary *plist = [mainBundle infoDictionary];
 		if (plist) {


### PR DESCRIPTION
App bundle will not start unless Mono 6.4.0.94 or later is installed.
Xamarin.Mac 5.16 depends requires Mono 6.4.0.94 or later.

Visual Studio failed to start. Some of the assemblies required to run Visual Studio (for example gtk-sharp)may not be properly installed in the GAC.
System.Exception: Toolkit could not be loaded ---> System.NotSupportedException: This version of Xamarin.Mac requires Mono 6.4.0.94, but found Mono 6.0.0.311.
  at ObjCRuntime.Runtime.VerifyMonoVersion () [0x000b1] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.16.1.0/src/Xamarin.Mac/ObjCRuntime/Runtime.mac.cs:153

Fixes VSTS #953417 - No error message when running VS Mac with
unsupported Mono version