### PR TITLE
[MSBuild] Bump MSBuild Tasks to target .NET 4.7.2

### DIFF
--- a/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
+++ b/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutDir>bin</OutDir>
   </PropertyGroup>
   <ItemGroup>

--- a/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
+++ b/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
+    <PackageReference Include="System.IO.Compression" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\MDBuildTasks.targets">

--- a/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
+++ b/main/msbuild/MDBuildTasks/MDBuildTasks.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
-    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="System.IO.Compression" Version="4.0.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\MDBuildTasks.targets">


### PR DESCRIPTION
`msbuild -t:Pack -p:Configuration=Debug -p:TargetFramework=net472` fails