### PR TITLE
Change Xwt project type to multi-targeted SDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,7 +47,7 @@
 [submodule "main/external/xwt"]
 	path = main/external/xwt
 	url = git://github.com/mono/xwt
-	branch = master
+	branch = wpf-sdk-project
 [submodule "main/external/Xamarin.PropertyEditing"]
 	path = main/external/Xamarin.PropertyEditing
 	url = https://github.com/xamarin/Xamarin.PropertyEditing


### PR DESCRIPTION
For future a11y work we need to conditionally support different .NET versions and therefore we need to change the project type of Xwt and Xwt.WPF projects.

This depends on / bumps to: https://github.com/mono/xwt/pull/954