### PR TITLE
[Debugger] Fixed toggling of breakpoints at the end of a line

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/BreakpointManager.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/BreakpointManager.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.Debugger
 					needsUpdate = true;
 
 				var line = snapshot.GetLineFromLineNumber (breakpoint.Line - 1);
-				var position = line.Start.Position + breakpoint.Column;
+				var position = line.Start.Position + breakpoint.Column - 1;
 				var span = await DebuggingService.GetBreakpointSpanAsync (textDocument, position);
 
 				if (breakpoints.TryGetValue (breakpoint, out var existingBreakpoint)) {


### PR DESCRIPTION
Just like line numbers, column numbers are also 1-based, but when
calculating the byte position, we need to adjust for 0-based indexes.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/917922/