### PR TITLE
Fixes VSTS Bug 952599: Version control document views are missing with

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultBlameViewHandler.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/DefaultBlameViewHandler.cs
@@ -38,10 +38,7 @@ namespace MonoDevelop.VersionControl
 	{
 		public static bool DefaultVCSViewCanHandle (VersionControlItem item, DocumentController controller)
 		{
-			if (controller == null)
-				return item.Repository.GetFileIsText (item.Path);
-
-			return controller is TextEditorViewContent || controller.GetContent<ITextBuffer> () != null;
+			return item.Repository.GetFileIsText (item.Path);
 		}
 
 		public bool CanHandle (VersionControlItem item, DocumentController controller) => DefaultVCSViewCanHandle (item, controller);


### PR DESCRIPTION
the new editor

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/952599

The base class of the new editor has changed so it no longer works.
Checking the file model is the faster solution in any case.