### PR TITLE
[release-8.2] Fix stack overflow at startup

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -541,9 +541,9 @@ namespace MonoDevelop.Ide
 
 			// If the user interacted with the IDE just a moment ago, wait a bit more time before
 			// running the action
-			var interactionSpan = (int)(DateTime.Now - commandService.LastUserInteraction).TotalMilliseconds;
+			var interactionSpan = Math.Max (0, (DateTime.Now - commandService.LastUserInteraction).TotalMilliseconds);
 			if (interactionSpan < 500) {
-				DispatchIdleActions (500 - interactionSpan);
+				DispatchIdleActions (500 - (int) interactionSpan);
 				return;
 			}
 


### PR DESCRIPTION
The IdeApp.DispatchIdleActions method is sometimes called just after startup.
When that happens, if the user has not had any interaction with the ide,
the CommandService.LastUserInteration property will have the default DateTime
value. The old code was substracting that value from the current time, which
would be a huge amount of milliseconds, and would overflow when converting
to int. It all would result with DispatchIdleActions being called over and over
with a negative number, finally causing a stack overflow.

Fixes VSTS #958148

Backport of #8309.

/cc @slluis 