### PR TITLE
[Project Model] Shortcut for add new class in C# projects

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -245,6 +245,11 @@
 			_label = "New _File..."
 			_description = "Create a new file"
 			icon  = "gtk-new" />
+			
+	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.AddEmptyClass"
+			 _label="New _Class..."
+			 _description="Create a new empty class"/>
+			
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles"
 			_description = "Add existing files to the project"
 			macShortcut = "Alt|Meta|A"

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -62,7 +62,6 @@ namespace MonoDevelop.Ide.Commands
 		
 		AddReference,
 		AddNewFiles,
-		AddEmptyClass,
 		AddFiles,
 		NewFolder,
 		AddFilesFromFolder,
@@ -90,7 +89,8 @@ namespace MonoDevelop.Ide.Commands
 		SelectActiveRuntime,
 		EditSolutionItem,
 		Unload,
-		SetStartupProjects
+		SetStartupProjects,
+		AddEmptyClass
 	}
 
 	internal class SolutionOptionsHandler : CommandHandler

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -62,6 +62,7 @@ namespace MonoDevelop.Ide.Commands
 		
 		AddReference,
 		AddNewFiles,
+		AddEmptyClass,
 		AddFiles,
 		NewFolder,
 		AddFilesFromFolder,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -90,7 +90,7 @@ namespace MonoDevelop.Ide.Commands
 		EditSolutionItem,
 		Unload,
 		SetStartupProjects,
-		AddEmptyClass
+		AddEmptyClass,
 	}
 
 	internal class SolutionOptionsHandler : CommandHandler

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -452,7 +452,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		{
 			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
 			if (project != null) {
-				info.Visible = project.SupportedLanguages.Contains ("C#");
+				info.Visible = IdeApp.ProjectOperations.CanCreateProjectFile (project, GetFolderPath (CurrentNode.DataItem), "EmptyClass");
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -435,7 +435,24 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			if (IdeApp.Workbench.ActiveDocument != null)
 				IdeApp.Workbench.ActiveDocument.Select ();
 		}
-		
+
+		[CommandHandler (ProjectCommands.AddEmptyClass)]
+		protected void OnAddCSharpClass ()
+		{
+			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
+			if (IdeApp.ProjectOperations.CreateProjectFile (project, GetFolderPath (CurrentNode.DataItem), "EmptyClass")) {
+				CurrentNode.Expanded = true;
+			}
+		}
+
+		[CommandUpdateHandler (ProjectCommands.AddEmptyClass)]
+		protected void UpdateAddEmptyClass (CommandInfo info)
+		{
+			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
+			info.Visible = project.SupportedLanguages.Contains ("C#");
+		}
+
+
 		void OnFileInserted (ITreeNavigator nav)
 		{
 			nav.Selected = true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -437,7 +437,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		}
 
 		[CommandHandler (ProjectCommands.AddEmptyClass)]
-		protected void OnAddCSharpClass ()
+		protected void OnAddEmptyClass ()
 		{
 			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
 			if (project != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -453,6 +453,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
 			if (project != null) {
 				info.Visible = IdeApp.ProjectOperations.CanCreateProjectFile (project, GetFolderPath (CurrentNode.DataItem), "EmptyClass");
+			} else {
+				info.Visible = false;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -440,8 +440,10 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		protected void OnAddCSharpClass ()
 		{
 			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
-			if (IdeApp.ProjectOperations.CreateProjectFile (project, GetFolderPath (CurrentNode.DataItem), "EmptyClass")) {
-				CurrentNode.Expanded = true;
+			if (project != null) {
+				if (IdeApp.ProjectOperations.CreateProjectFile (project, GetFolderPath (CurrentNode.DataItem), "EmptyClass")) {
+					CurrentNode.Expanded = true;
+				}
 			}
 		}
 
@@ -449,7 +451,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		protected void UpdateAddEmptyClass (CommandInfo info)
 		{
 			var project = (Project)CurrentNode.GetParentDataItem (typeof (Project), true);
-			info.Visible = project.SupportedLanguages.Contains ("C#");
+			if (project != null) {
+				info.Visible = project.SupportedLanguages.Contains ("C#");
+			}
 		}
 
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -78,6 +78,9 @@
 		</Condition>
 		<Condition id="ItemType" value="Project|ProjectFolder|Solution|SolutionFolder">
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewFiles" />
+				<Condition id="ItemType" value="Project|ProjectFolder">
+					<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddEmptyClass" />
+				</Condition>
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles" />
 		</Condition>
 		<Condition id="ItemType" value="Project|ProjectFolder">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -889,12 +889,13 @@ namespace MonoDevelop.Ide
 		{
 			var projectLangs = parentProject.SupportedLanguages;
 			var template = FileTemplate.GetFileTemplateByID (selectedTemplateId);
-
-			var templateLangs = template.GetCompatibleLanguages (parentProject, basePath);
-			if (templateLangs != null) {
-				foreach (var projectLang in projectLangs) {
-					if (templateLangs.Contains (projectLang))
-						return true;
+			if(template != null) {
+				var templateLangs = template.GetCompatibleLanguages (parentProject, basePath);
+				if (templateLangs != null) {
+					foreach (var projectLang in projectLangs) {
+						if (templateLangs.Contains (projectLang))
+							return true;
+					}
 				}
 			}
 			return false;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -50,6 +50,7 @@ using MonoDevelop.Projects.MSBuild;
 using ExecutionContext = MonoDevelop.Projects.ExecutionContext;
 using MonoDevelop.Ide.Gui.Documents;
 using MonoDevelop.Ide.Projects.OptionPanels;
+using MonoDevelop.Ide.Templates;
 
 namespace MonoDevelop.Ide
 {
@@ -882,6 +883,21 @@ namespace MonoDevelop.Ide
 					nfd.SelectTemplate (selectedTemplateId);
 				return MessageService.ShowCustomDialog (nfd) == (int)Gtk.ResponseType.Ok;
 			}
+		}
+
+		public bool CanCreateProjectFile (Project parentProject, string basePath, string selectedTemplateId)
+		{
+			var projectLangs = parentProject.SupportedLanguages;
+			var template = FileTemplate.GetFileTemplateByID (selectedTemplateId);
+
+			var templateLangs = template.GetCompatibleLanguages (parentProject, basePath);
+			if (templateLangs != null) {
+				foreach (var projectLang in projectLangs) {
+					if (templateLangs.Contains (projectLang))
+						return true;
+				}
+			}
+			return false;
 		}
 
 		public bool CreateSolutionFolderFile (SolutionFolder parentSolutionFolder,string selectedTemplateId = null)


### PR DESCRIPTION
Create shortcut for New Class... from the folder context-menu within the solution pad. From the Add menu, if New Class... is clicked, in the New File dialog, General | Empty Class is always selected.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/643343