### PR TITLE
Tasks: Stop highlighting "undone"

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTag.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/CommentTag.cs
@@ -44,7 +44,7 @@ namespace MonoDevelop.Ide.Tasks
 		
 		public static event EventHandler SpecialCommentTagsChanged;
 		
-		const string defaultTags = "FIXME:2;TODO:1;HACK:1;UNDONE:0";
+		const string defaultTags = "FIXME:2;TODO:1;HACK:1";
 		static List<CommentTag> specialCommentTags;
 		
 		public static List<CommentTag> SpecialCommentTags {


### PR DESCRIPTION
I don't know if this was originally supposed to be "undome", but as-is
it doesn't seem like a word that denotes a task.

I looked to see when this was added to see if I could learn more, but
there's not much info in https://github.com/mono/monodevelop/commit/05db27cf6c06423d8dae5e71e0b9d1dc60388af7.