### PR TITLE
Make LibGit2Sharp not a local reference in the test project

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
@@ -51,6 +51,8 @@
     <ProjectReference Include="..\..\..\..\external\libgit2sharp\LibGit2Sharp\LibGit2Sharp.csproj">
       <Project>{EE6ED99F-CB12-4683-B055-D28FC7357A34}</Project>
       <Name>LibGit2Sharp</Name>
+      <IncludeInPackage>true</IncludeInPackage>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
       <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>


### PR DESCRIPTION
LibGit2Sharp is failing to load in the unit tests. Not marking it as a local copy reference seems to fix it.

<img width="454" alt="eb57ed3a-545a-43de-af7f-90244a14ac25" src="https://user-images.githubusercontent.com/2041/62256060-83a3f380-b3c5-11e9-8d78-7dfd001718e8.png">

Fixes VSTS #958036