### PR TITLE
[CSharp] Enable Preview

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CompilerOptionsPanelWidget.cs
@@ -53,7 +53,6 @@ namespace MonoDevelop.CSharp.Project
 		ListStore classListStore;
 		bool classListFilled;
 		LanguageVersion[] unsupportedLanguageVersions = {
-			LanguageVersion.Preview
 		};
 
 		public CompilerOptionsPanelWidget (DotNetProject project)


### PR DESCRIPTION
Allow users to set Preview in the C# compiler options panel, which
had previously been disabled as part of #816208.

Fixes VSTS #950743