### PR TITLE
Fixes VSTS 945987: Format document doesn't work from Navigate To when using the new editor

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -2238,9 +2238,8 @@ namespace MonoDevelop.Components.Commands
 						if (win == null)
 							win = w;
 					}
-					if (lastFocused.nativeWidget == w) {
-						lastFocusedExists = true;
-					}
+
+					lastFocusedExists |= lastFocused?.nativeWidget == w;
 				}
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.Components.Commands
 		CommandTargetChain globalHandlerChain;
 		List<object> commandUpdateErrors = new List<object> ();
 		List<ICommandTargetVisitor> visitors = new List<ICommandTargetVisitor> ();
-		LinkedList<Gtk.Window> topLevelWindows = new LinkedList<Gtk.Window> ();
+		LinkedList<Window> topLevelWindows = new LinkedList<Window> ();
 		Stack delegatorStack = new Stack ();
 
 		HashSet<object> visitedTargets = new HashSet<object> ();
@@ -86,13 +86,13 @@ namespace MonoDevelop.Components.Commands
 		
 		// Fields used to keep track of the application focus
 		bool appHasFocus;
-		Gtk.Window lastFocused;
+		Window lastFocused;
 		DateTime focusCheckDelayTimeout = DateTime.MinValue;
 		
 		internal static readonly object CommandRouteTerminator = new object ();
 		
 		internal bool handlerFoundInMulticast;
-		Gtk.Widget activeWidget;
+		Control lastActiveWidget;
 
 #if MAC
 		Foundation.NSObject keyMonitor;
@@ -334,8 +334,8 @@ namespace MonoDevelop.Components.Commands
 				{
 					// If the window is a gtk window and is registered in the command manager
 					// process the events through the handler.
-					var gtkWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetGtkWindow(window);
-					if (gtkWindow != null && !TopLevelWindowStack.Contains(gtkWindow))
+					var gtkWindow = Mac.GtkMacInterop.GetGtkWindow(window);
+					if (gtkWindow != null && !TopLevelWindowStack.Any (w => w.nativeWidget == gtkWindow))
 						return null;
 				}
 			}
@@ -346,7 +346,7 @@ namespace MonoDevelop.Components.Commands
 				return ev;
 			}
 
-			var gdkev = MonoDevelop.Components.Mac.GtkMacInterop.ConvertKeyEvent (ev);
+			var gdkev = Mac.GtkMacInterop.ConvertKeyEvent (ev);
 			if (gdkev != null) {
 				if (ProcessKeyEvent (gdkev))
 					return null;
@@ -741,11 +741,11 @@ namespace MonoDevelop.Components.Commands
 			RegisterTopWindow (rootWidget);
 		}
 
-		internal IEnumerable<Gtk.Window> TopLevelWindowStack {
+		internal IEnumerable<MonoDevelop.Components.Window> TopLevelWindowStack {
 			get { return topLevelWindows; }
 		}
-		
-		internal void RegisterTopWindow (Gtk.Window win)
+
+		internal void RegisterTopWindow (Window win)
 		{
 			if (topLevelWindows.First != null && topLevelWindows.First.Value == win)
 				return;
@@ -762,16 +762,18 @@ namespace MonoDevelop.Components.Commands
 
 			var node = topLevelWindows.Find (win);
 			if (node != null) {
-				if (win.HasToplevelFocus) {
+				if (win.HasFocus) {
 					topLevelWindows.Remove (node);
 					topLevelWindows.AddFirst (node);
 				}
 			} else {
 				topLevelWindows.AddFirst (win);
-				win.KeyPressEvent += OnKeyPressed;
-				win.KeyReleaseEvent += OnKeyReleased;
-				win.ButtonPressEvent += HandleButtonPressEvent;
-				win.Destroyed += TopLevelDestroyed;
+				if (win.nativeWidget is Gtk.Window gtkWin) {
+					gtkWin.KeyPressEvent += OnKeyPressed;
+					gtkWin.KeyReleaseEvent += OnKeyReleased;
+					gtkWin.ButtonPressEvent += HandleButtonPressEvent;
+					gtkWin.Destroyed += TopLevelDestroyed;
+				}
 			}
 		}
 
@@ -800,7 +802,7 @@ namespace MonoDevelop.Components.Commands
 			}
 #endif
 
-			if (w == lastFocused)
+			if (w == lastFocused.nativeWidget)
 				lastFocused = null;
 		}
 		
@@ -2113,10 +2115,10 @@ namespace MonoDevelop.Components.Commands
 			return h;
 		}
 
-		Gtk.Window GetCurrentFocusedTopLevelWindow ()
+		Window GetCurrentFocusedTopLevelWindow ()
 		{
 			foreach (var window in topLevelWindows) {
-				if (window.HasToplevelFocus)
+				if (window.HasFocus)
 					return window;
 			}
 			return rootWidget;
@@ -2214,7 +2216,7 @@ namespace MonoDevelop.Components.Commands
 			return null;
 		}
 		
-		Gtk.Window GetActiveWindow (Gtk.Window win)
+		Window GetActiveWindow (Window win)
 		{
 			Gtk.Window[] wins = Gtk.Window.ListToplevels ();
 			
@@ -2231,7 +2233,7 @@ namespace MonoDevelop.Components.Commands
 						if (win == null)
 							win = w;
 					}
-					if (lastFocused == w) {
+					if (lastFocused.nativeWidget == w) {
 						lastFocusedExists = true;
 					}
 				}
@@ -2241,7 +2243,9 @@ namespace MonoDevelop.Components.Commands
 			if (!hasFocus) {
 				var nsWindow = AppKit.NSApplication.SharedApplication.KeyWindow;
 				hasFocus = nsWindow != null;
-				lastFocused = win = Mac.GtkMacInterop.GetGtkWindow (nsWindow);
+                if (hasFocus) {
+					lastFocused = win = nsWindow;
+				}
 			} else {
 				lastFocused = newFocused;
 			}
@@ -2259,15 +2263,15 @@ namespace MonoDevelop.Components.Commands
 				return null;
 		}
 		
-		object GetActiveWidget (Gtk.Window win)
+		object GetActiveWidget (Window win)
 		{
 			win = GetActiveWindow (win);
 
-			Gtk.Widget widget = win;
+			Control widget = win;
 			if (win != null) {
 
 				#if MAC
-				var nw = MonoDevelop.Components.Mac.GtkMacInterop.GetNSWindow (win);
+				var nw = win.nativeWidget as AppKit.NSWindow;
 				if (nw != null) {
 					var v = nw.FirstResponder as AppKit.NSView;
 					if (v != null && !IsRootGdkQuartzView (v)) {
@@ -2290,11 +2294,11 @@ namespace MonoDevelop.Components.Commands
 
 				widget = GetFocusedChild (widget);
 			}
-			if (widget != activeWidget) {
+			if (widget != lastActiveWidget) {
 				if (ActiveWidgetChanged != null)
-					ActiveWidgetChanged (this, new ActiveWidgetEventArgs () { OldActiveWidget = activeWidget, NewActiveWidget = widget });
-				lastCommandTarget = new WeakReference (activeWidget);
-				activeWidget = widget;
+					ActiveWidgetChanged (this, new ActiveWidgetEventArgs () { OldActiveWidget = lastActiveWidget, NewActiveWidget = widget });
+				lastCommandTarget = new WeakReference (lastActiveWidget);
+				lastActiveWidget = widget;
 			}
 			return widget;
 		}
@@ -2450,8 +2454,10 @@ namespace MonoDevelop.Components.Commands
 			waitingForUserInteraction = true;
 			toolbarUpdaterRunning = false;
 			foreach (var win in topLevelWindows) {
-				win.MotionNotifyEvent += HandleWinMotionNotifyEvent;
-				win.FocusInEvent += HandleFocusInEventHandler;
+				if (!(win.nativeWidget is Gtk.Window gtkWindow))
+					continue;
+				gtkWindow.MotionNotifyEvent += HandleWinMotionNotifyEvent;
+				gtkWindow.FocusInEvent += HandleFocusInEventHandler;
 			}
 		}
 		
@@ -2461,8 +2467,10 @@ namespace MonoDevelop.Components.Commands
 				return;
 			waitingForUserInteraction = false;
 			foreach (var win in topLevelWindows) {
-				win.MotionNotifyEvent -= HandleWinMotionNotifyEvent;
-				win.FocusInEvent -= HandleFocusInEventHandler;
+				if (!(win.nativeWidget is Gtk.Window gtkWindow))
+					continue;
+				gtkWindow.MotionNotifyEvent -= HandleWinMotionNotifyEvent;
+				gtkWindow.FocusInEvent -= HandleFocusInEventHandler;
 			}
 
 			StartStatusUpdater ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Control.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Control.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.Components
 			throw new NotSupportedException ();
 		}
 
-		public T GetNativeWidget<T> ()
+		public T GetNativeWidget<T> () where T : class
 		{
 			if (nativeWidget == null) {
 				var toCache = this;
@@ -87,8 +87,10 @@ namespace MonoDevelop.Components
 			}
 			if (nativeWidget is T resultWidget)
 				return resultWidget;
-			else
-				throw new NotSupportedException ();
+
+			// we used to throw a NotSupportedException, however, that prevented us from
+			// doing anything with native controls, see: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/945987
+			return null; 
 		}
 
 		void OnGtkDestroyed (object sender, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Control.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Control.cs
@@ -88,9 +88,7 @@ namespace MonoDevelop.Components
 			if (nativeWidget is T resultWidget)
 				return resultWidget;
 
-			// we used to throw a NotSupportedException, however, that prevented us from
-			// doing anything with native controls, see: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/945987
-			return null; 
+			throw new NotSupportedException ($"Cannot get native widget {typeof (T)}");
 		}
 
 		void OnGtkDestroyed (object sender, EventArgs args)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
@@ -37,6 +37,30 @@ namespace MonoDevelop.Components
 		{
 		}
 
+		public bool IsRealized {
+			get {
+				if (nativeWidget is Gtk.Window)
+					return ((Gtk.Window)nativeWidget).IsRealized;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow)
+					return ((AppKit.NSWindow)nativeWidget).IsVisible;
+#endif
+				return false;
+			}
+		}
+
+		public override bool HasFocus {
+			get {
+				if (nativeWidget is Gtk.Window)
+					return ((Gtk.Window)nativeWidget).HasToplevelFocus;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow)
+					return nativeWidget == AppKit.NSApplication.SharedApplication.KeyWindow;
+#endif
+				return false;
+			}
+		}
+
 		public static implicit operator Gtk.Window (Window d)
 		{
 			if (d is XwtWindowControl)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
@@ -37,6 +37,12 @@ namespace MonoDevelop.Components
 		{
 		}
 
+		/// <summary>
+		/// If the wrapped (native) control is a GTK Window, this method will return
+		/// true, for when that window is realized (which will be true if the window
+		/// is visible, but can also be true even if it isn't). If the native control
+		/// is an NSWindow, this will return the value of the IsVisible property. 
+		/// </summary>
 		public bool IsRealized {
 			get {
 				if (nativeWidget is Gtk.Window)


### PR DESCRIPTION
This is the second attempt at fixing VSTS 945987, where Format Document doesn't work if invoked from the Navigate To window. The first PR https://github.com/mono/monodevelop/pull/8265 attempted to resolve in a way that would allow commands to execute correctly on the handler, but as was pointed out, we also needed a way to allow native widgets to be focused. 

I built on changes from here #7521 and extended the fix as it kept throwing exceptions. 

Fixes https://vsmac.dev/945987 