### PR TITLE
Artificially rank the commands from the current add-in higher in Navigate To

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/ActionCommand.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/ActionCommand.cs
@@ -109,15 +109,16 @@ namespace MonoDevelop.Components.Commands
 						info.Visible = false;
 					return;
 				}
-				defaultHandler = (CommandHandler) Activator.CreateInstance (DefaultHandlerType);
+				defaultHandler = (CommandHandler)Activator.CreateInstance (DefaultHandlerType);
 			}
 			if (commandArray) {
 				info.ArrayInfo = new CommandArrayInfo (info);
 				defaultHandler.InternalUpdate (info.ArrayInfo);
-			}
-			else
+			} else
 				defaultHandler.InternalUpdate (info);
 		}
+
+		internal RuntimeAddin RuntimeAddin => defaultHandlerAddin;
 	}
 }
 


### PR DESCRIPTION
This will help surface IDE commands higher than those coming from addins, which is helpful when the addins don't follow convention or create the same commands under new ids (i.e. Format Document).

![image](https://user-images.githubusercontent.com/1932563/61800486-6606e500-ae2d-11e9-8242-55251a466d39.png)

This is an example of how the WebAddin contributes commands that somehow overpower the Format Document command we surface. I feel we should rank _internal_ ones higher. 

This will surface with users when this is merged: https://github.com/mono/monodevelop/pull/8323 
