### PR TITLE
[Ide] Document.Select no longer calls GrabFocus.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -685,6 +685,10 @@ namespace MonoDevelop.Ide.Gui.Documents
 						LoggingService.LogError ("Missing editor operations");
 					}
 				}
+				// Run grab focus on next iteration.
+				Gtk.Application.Invoke (delegate {
+					doc.GrabFocus ();
+				});
 			});
 
 /*			var navigator = (ISourceFileNavigator)newContent.GetContent (typeof (ISourceFileNavigator));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Document.cs
@@ -366,7 +366,6 @@ namespace MonoDevelop.Ide.Gui
 		public void Select ()
 		{
 			window?.SelectWindow ();
-			view?.GrabFocus ();
 		}
 
 		public TextEditor Editor {


### PR DESCRIPTION
GrabFocus focuses the editor causing a selected sub view change. This is a side effect happening in VCS view commands.
Selecting a view programatically shouldn't automatically change sub view selections or focused controls.

Fixes VSTS #963585 – Diff/View commands broken in SolutonPad