### PR TITLE
Build: Move Roslyn version to separate props file

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="$(MSBuildThisFileDirectory)msbuild\RoslynVersion.props"/>
 
   <PropertyGroup>
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>
@@ -19,7 +20,6 @@
     <NuGetVersionNuGet>5.2.0-rtm.6067</NuGetVersionNuGet>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
-    <NuGetVersionRoslyn>3.3.0-beta2-19374-02</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>

--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <NuGetVersionRoslyn>3.3.0-beta2-19374-02</NuGetVersionRoslyn>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This makes it easier to `Import` elsewhere (say, submodules or other repos with their own `Directory.Build.props`) so that Roslyn version can be more easily unified in IDE components.