### PR TITLE
Add .NET 4.7.2 target moniker, set it to default for templates and update NUnit Library project to use NUnit 3.12.0

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/templates/NUnitProject.xpt.xml
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/templates/NUnitProject.xpt.xml
@@ -32,7 +32,7 @@
 			</References>
 
 			<Packages>
-				<Package ID="NUnit" Version="2.6.4" />
+				<Package ID="NUnit" Version="3.12.0" />
 			</Packages>
 
 			<Files>

--- a/main/src/addins/MonoDevelop.UnitTesting.NUnit/templates/NUnitProjectVBNet.xpt.xml
+++ b/main/src/addins/MonoDevelop.UnitTesting.NUnit/templates/NUnitProjectVBNet.xpt.xml
@@ -32,7 +32,7 @@
 			</References>
 
 			<Packages>
-				<Package ID="NUnit" Version="2.6.4" />
+				<Package ID="NUnit" Version="3.12.0" />
 			</Packages>
 
 			<Files>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
@@ -333,6 +333,10 @@ namespace MonoDevelop.Core.Assemblies
 			get { return new TargetFrameworkMoniker ("4.7.1"); }
 		}
 
+		public static TargetFrameworkMoniker NET_4_7_2 {
+			get { return new TargetFrameworkMoniker ("4.7.2"); }
+		}
+
 		public static TargetFrameworkMoniker PORTABLE_4_0 {
 			get { return new TargetFrameworkMoniker (ID_PORTABLE, "4.0", "Profile1"); }
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Projects
 		TargetFramework defaultTargetFramework;
 		
 		string defaultPlatformTarget = "anycpu";
-		static readonly TargetFrameworkMoniker DefaultTargetFrameworkId = TargetFrameworkMoniker.NET_4_7;
+		static readonly TargetFrameworkMoniker DefaultTargetFrameworkId = TargetFrameworkMoniker.NET_4_7_2;
 		
 		public const string BuildTarget = "Build";
 		public const string CleanTarget = "Clean";


### PR DESCRIPTION
- Bug 960218: .NET templates defaults to v4.7 instead of v4.7.2
- Bug 960219: NUnit Library Project should use NUnit 3.12 instead of 2.6.x

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/960218
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/960219