### PR TITLE
Bump Roslyn to 3.3.0-beta2-19401-05

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/RoslynHelpers.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/RoslynHelpers.fs
@@ -40,4 +40,5 @@ module RoslynHelpers =
             member x.ToMinimalDisplayString (_semanticModel, _position, _format) = symbolUse.Symbol.DisplayName //TODO format?
             member x.ToMinimalDisplayParts (_semanticModel, _position, _format) = ImmutableArray.Empty //TODO
             member x.HasUnsupportedMetadata = false //TODO
+            member x.Equals (other:Microsoft.CodeAnalysis.ISymbol, equalityComparer:Microsoft.CodeAnalysis.SymbolEqualityComparer) = equalityComparer.Equals(x, other)
             member x.Equals (other:Microsoft.CodeAnalysis.ISymbol) = x.Equals(other)

--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.3.0-beta2-19374-02</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.3.0-beta2-19401-05</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes since [e4e7c09](https://www.github.com/dotnet/roslyn/commit/e4e7c09):
- [Make Microsoft.CodeAnalysis.Analyzers reference conditional in╬ô├ç┬¬ (#37619)](https://www.github.com/dotnet/roslyn/pull/37619)
- [Merge pull request #37600 from petrroll/release/dev16.3-preview2](https://www.github.com/dotnet/roslyn/pull/37600)
- [Merge pull request #37623 from mavasani/FixTypingCrash](https://www.github.com/dotnet/roslyn/pull/37623)
- [Merge pull request #37620 from dotnet/release/dev16.2](https://www.github.com/dotnet/roslyn/pull/37620)
- [Merge pull request #37534 from dotnet/dev/jorobich/update-dependencies](https://www.github.com/dotnet/roslyn/pull/37534)
- [Handle checking for language version in speculative semantic model (#37513) (#37583)](https://www.github.com/dotnet/roslyn/pull/37583)
- [LambdaRewriter.SubstituteTypeArguments should make progress (#37487) (#37535)](https://www.github.com/dotnet/roslyn/pull/37535)
- [Merge pull request #37525 from CyrusNajmabadi/removeMethods](https://www.github.com/dotnet/roslyn/pull/37525)
- [Merge pull request #37331 from dibarbet/move_lsp_code_actions](https://www.github.com/dotnet/roslyn/pull/37331)
- [Report WRN_UninitializedNonNullableField for uninitialized static members (#37507)](https://www.github.com/dotnet/roslyn/pull/37507)
- [Simplify readonly MetadataAsSource (#37486)](https://www.github.com/dotnet/roslyn/pull/37486)
- [Don't drop a token passed to a syntax factory method. (#37493)](https://www.github.com/dotnet/roslyn/pull/37493)
- [Support GetDeclaredSymbol on ForeachStatementSyntax and add te╬ô├ç┬¬ (#37492)](https://www.github.com/dotnet/roslyn/pull/37492)
- [IDE EnC support for all C# 8.0 features (#37173)](https://www.github.com/dotnet/roslyn/pull/37173)
- [Fix region tracking for regions with local functions (#37450)](https://www.github.com/dotnet/roslyn/pull/37450)
- [Use signature return type to determine task type in NullableWalker (#37488)](https://www.github.com/dotnet/roslyn/pull/37488)
- [LambdaRewriter.SubstituteTypeArguments should make progress (#37487)](https://www.github.com/dotnet/roslyn/pull/37487)
- [Merge pull request #37433 from sharwell/update-codestyle-analyzer](https://www.github.com/dotnet/roslyn/pull/37433)
- [Merge NullableAnnotation.NotApplicable and Disabled to None, a╬ô├ç┬¬ (#37442)](https://www.github.com/dotnet/roslyn/pull/37442)
- [Add initial GetDeclaredSymbol support for inferred VariableDec╬ô├ç┬¬ (#37322)](https://www.github.com/dotnet/roslyn/pull/37322)
- [Merge pull request #37437 from dibarbet/split_liveshare_handlers](https://www.github.com/dotnet/roslyn/pull/37437)
- [Merge pull request #37390 from heejaechang/vssearch](https://www.github.com/dotnet/roslyn/pull/37390)
- [Merge pull request #37466 from sharwell/fix-format-perf](https://www.github.com/dotnet/roslyn/pull/37466)
- [Remove Microsoft.Tpl.Dataflow references (#37452)](https://www.github.com/dotnet/roslyn/pull/37452)
- [Merge pull request #35667 from sharwell/quickinfo-styles](https://www.github.com/dotnet/roslyn/pull/35667)
- [Support local constants being captured in static local functions (#37459)](https://www.github.com/dotnet/roslyn/pull/37459)
- [Merge pull request #37303 from mavasani/AnalyzerPerfFix](https://www.github.com/dotnet/roslyn/pull/37303)
- [Use NullableAnnotation.NotAnnotated for value types (#37431)](https://www.github.com/dotnet/roslyn/pull/37431)
- [Add IMethodSymbol.Construct overload with nullable annotations (#37445)](https://www.github.com/dotnet/roslyn/pull/37445)
- [Merge pull request #37016 from meziantou/fix-ide0066](https://www.github.com/dotnet/roslyn/pull/37016)
- [Add CI telemetry for bootstrap build and test (#37396)](https://www.github.com/dotnet/roslyn/pull/37396)
- [Update TPL Dataflow to 4.9.0 (#37449)](https://www.github.com/dotnet/roslyn/pull/37449)
- [Merge pull request #37426 from daytonellwanger/dev/dayton/LiveShareAPIChanges](https://www.github.com/dotnet/roslyn/pull/37426)
- [Merge pull request #34384 from Paxxi/issue_32739](https://www.github.com/dotnet/roslyn/pull/34384)
- [Symbol equality comparer (#37247)](https://www.github.com/dotnet/roslyn/pull/37247)
