### PR TITLE
 TextEditor: "Use Selection for Find" fixes

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/Properties/MonoDevelop.TextEditor.Cocoa.addin.xml
@@ -97,8 +97,12 @@
 	-->
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.Find" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindNext" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindNextCommandArgs" />
+		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindNextSelection" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindNextLikeSelectionCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindPrevious" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindPreviousCommandArgs" />
+		<Map id="MonoDevelop.Ide.Commands.SearchCommands.FindPreviousSelection" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.FindPreviousLikeSelectionCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.Replace" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.ReplaceCommandArgs" />
+		<Map id="MonoDevelop.Ide.Commands.SearchCommands.UseSelectionForReplace" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.ReplaceCommandArgs" />
+		<Map id="MonoDevelop.Ide.Commands.SearchCommands.UseSelectionForFind" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.SetSearchStringFromSelectionCommandArgs" />
 		<Map id="MonoDevelop.Refactoring.Navigate.GotoBaseMember" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.Navigation.GoToBaseMemberCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.SearchCommands.GotoLineNumber" argsType="Microsoft.VisualStudio.Text.Extras.GoToLine.GoToLineCommandArgs" />
 	</Extension>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -945,7 +945,7 @@
 			_label = "Find Next Like Selection"
 			_description = "Search forwards for the selected text"
 			shortcut = "Control|F3"
-			macShortcut = "Meta|E Meta|F3" />
+			macShortcut = "Meta|F3" />
 	<Command id = "MonoDevelop.Ide.Commands.SearchCommands.FindPreviousSelection"
 			_label = "Find Previous Like Selection"
 			_description = "Search backwards for the selected text"
@@ -1022,10 +1022,11 @@
 			shortcut = "Control|I"
 			macShortcut = "Meta|L" />
 	<Command id = "MonoDevelop.Ide.Commands.SearchCommands.UseSelectionForFind"
-			_label = "Find Like Selection"
-			_description = "Uses the current selection as find string"/>
+			_label = "Use Selection for Find"
+			_description = "Uses the current selection as find string"
+			macShortcut = "Meta|E" />
 	<Command id = "MonoDevelop.Ide.Commands.SearchCommands.UseSelectionForReplace"
-			_label = "Replace Like Selection"
+			_label = "Use Selection for Replace"
 			_description = "Uses the current selection as replace string"/>
 	</Category>
 

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -157,7 +157,7 @@
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.FindPrevious" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.FindNext" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.FindNextSelection" />
-	
+		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.UseSelectionForFind" />
 		<SeparatorItem id = "SearchSeparator2" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.FindInFiles" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.ReplaceInFiles" />


### PR DESCRIPTION
1. Rename "Use Selection for *" commands to have proper macOS labels
2. Move cmd+e keybinding from `FindNextSelection` command to
   `UseSelectionForFind`.
3. Add `UseSelectionForFind` command to main menu.
4. Add support for missing find commands to new editor.

It's unfortunate that we have two similar commands here but it's
important that cmd+e behaves as the user expects (it should not have
"find next" behavior...it just sets search text and keeps focus in
editor).

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/947125