### PR TITLE
[Ide] Log information about the IDE initialization section duration

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
@@ -38,8 +38,7 @@ namespace MonoDevelop.Ide
 {
 	internal class IdeStartupTracker
 	{
-		static Lazy<IdeStartupTracker> startupTracker = new Lazy<IdeStartupTracker> (() => new IdeStartupTracker ());
-		static internal IdeStartupTracker StartupTracker => startupTracker.Value;
+		static internal IdeStartupTracker StartupTracker { get; } = new IdeStartupTracker ();
 
 		const long ttcDuration = 3 * TimeSpan.TicksPerSecond; // Wait 3 seconds before ignoring TTC events
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
@@ -79,6 +79,7 @@ namespace MonoDevelop.Ide
 			}
 
 			StartupCompleted (startupInfo, result);
+			sectionTimings = null;
 		}
 
 		internal void StartupCompleted (StartupInfo startupInfo, IPlatformTelemetryDetails platformTelemetryDetails)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
@@ -43,12 +43,12 @@ namespace MonoDevelop.Ide
 		const long ttcDuration = 3 * TimeSpan.TicksPerSecond; // Wait 3 seconds before ignoring TTC events
 
 		Stopwatch startupTimer = new Stopwatch ();
-		Stopwatch startupSectionTimer = new Stopwatch ();
+		Stopwatch startupSectionTimer;
 		Stopwatch timeToCodeTimer = new Stopwatch ();
 		Stopwatch timeToCodeSolutionTimer = new Stopwatch ();
 		Stopwatch timeToCodeWorkspaceTimer;
 
-		Dictionary<string, long> sectionTimings = new Dictionary<string, long> ();
+		Dictionary<string, long> sectionTimings;
 		TimeToCodeMetadata ttcMetadata;
 
 		IdeStartupTracker ()
@@ -62,8 +62,9 @@ namespace MonoDevelop.Ide
 			// TimerCounter.BeginTiming here would occur before any timer
 			// handlers can be registered. So instead the startup duration is
 			// set as a metadata property on the Counters.Startup counter.
-			startupTimer.Start ();
-			startupSectionTimer.Start ();
+			startupTimer = Stopwatch.StartNew ();
+			startupSectionTimer = Stopwatch.StartNew();
+			sectionTimings = new Dictionary<string, long> ();
 			timeToCodeTimer.Start ();
 		}
 
@@ -78,6 +79,7 @@ namespace MonoDevelop.Ide
 			}
 
 			StartupCompleted (startupInfo, result);
+			startupSectionTimer = null;
 			sectionTimings = null;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartupTracker.cs
@@ -93,6 +93,11 @@ namespace MonoDevelop.Ide
 			ttcMetadata.AddProperties (startupMetadata);
 
 			LoggingService.LogDebug ("TTC starting");
+
+			foreach (var kvp in sectionTimings) {
+				LoggingService.LogInfo ("Startup section {0} {1} ms", kvp.Key, kvp.Value);
+			}
+			LoggingService.LogInfo ("Startup sections {0} ms", startupTimer.ElapsedMilliseconds);
 		}
 
 		internal void MarkSection (string name)


### PR DESCRIPTION
Fixes VSTS #960621 - Startup section timings are not logged in the IDE log

Also some miscellaneous object retention and cleanup