### PR TITLE
[Ide] Fix unobserved task exception in CustomToolService

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CustomTools/CustomToolService.cs
@@ -310,8 +310,6 @@ namespace MonoDevelop.Ide.CustomTools
 
 			// Execute the generator
 
-			Exception error = null;
-
 			// Share the one pad for all Tool output.
 			Pad pad = null;
 
@@ -337,7 +335,6 @@ namespace MonoDevelop.Ide.CustomTools
 				try {
 					await tool.Generate (monitor, project, file, result);
 				} catch (Exception ex) {
-					error = ex;
 					result.UnhandledException = ex;
 				}
 
@@ -360,11 +357,7 @@ namespace MonoDevelop.Ide.CustomTools
 				UpdateCompleted (monitor, file, genFile, result, false);
 			} finally {
 				FileService.ThawEvents ();
-				if (error == null)
-					newTask.SetResult (true);
-				else {
-					newTask.SetException (error);
-				}
+				newTask.TrySetResult (true);
 			}
 		}
 		


### PR DESCRIPTION
If an exception is thrown by a custom tool then this may result in
an unobserved task exception. The exception is set on a task
completion source whose task is only observed if a build is waiting
for custom tools to complete or another custom tool is run again for
the same file.

There does not seem to be any need to set the exception on the task
completion source since all errors are reported in the IDE and
callers of the CustomToolService Update or UpdateAsync do not get
access to this task. Now the task completion source has its result
set instead of setting the exception since the only thing needed is
to ensure the task is completed.

Fixes VSTS #958223 - System.Threading.Tasks.TaskCanceledException exception
in System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess()