### PR TITLE
[Project Model] Fix the text color issue in the Exception Caught Window

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Styles.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Styles.cs
@@ -100,7 +100,7 @@ namespace MonoDevelop.Debugger
 
 			// Shared
 			ObjectValueTreeSelectedTextColor = Ide.Gui.Styles.BaseSelectionTextColor.ToHexString (false);
-			ObjectValueTreeForegroundTextColor = Ide.Gui.Styles.BaseSelectionTextColor.ToHexString (false);
+			ObjectValueTreeForegroundTextColor = Ide.Gui.Styles.BaseForegroundColor.ToHexString (false);
 			ObjectValueTreeExternalCodeForegroundTextColor = ExceptionCaughtDialog.ExternalCodeTextColor.ToHexString (false);
 
 			ObjectValueTreeValueErrorText = Ide.Gui.Styles.WarningForegroundColor;


### PR DESCRIPTION
Set the foreground color to be the correct foreground color in style. Solve the white text on white background issue for Exception Caught Window. (Works with both light and dark theme)

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/961237