### PR TITLE
[Mac] Add some more entitlements

### DIFF
--- a/main/build/MacOSX/Entitlements.plist
+++ b/main/build/MacOSX/Entitlements.plist
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Add entitlements to allow MonoDevelop to use AppleScript and debug apps