### PR TITLE
Fixes VSTS Bug 951152: [Feedback] Visual Studio Commmunity lacks UTF-8

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -37,6 +37,7 @@ using MonoDevelop.Ide;
 using MonoDevelop.Ide.Extensions;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.MacInterop;
+using MonoDevelop.Projects.Text;
 
 
 namespace MonoDevelop.MacIntegration
@@ -115,7 +116,7 @@ namespace MonoDevelop.MacIntegration
 						data.SelectedFiles = MacSelectFileDialogHandler.GetSelectedFiles (panel);
 
 					if (state.EncodingSelector != null)
-						data.Encoding = state.EncodingSelector.SelectedEncodingId > 0 ? Encoding.GetEncoding (state.EncodingSelector.SelectedEncodingId) : null;
+						data.Encoding = state.EncodingSelector.SelectedEncoding?.Encoding;
 
 					if (state.ViewerSelector != null) {
 						if (state.CloseSolutionButton != null)
@@ -141,9 +142,8 @@ namespace MonoDevelop.MacIntegration
 			List<FileViewer> currentViewers = null;
 
 			if (data.ShowEncodingSelector) {
-				encodingSelector = new SelectEncodingPopUpButton (data.Action != FileChooserAction.Save) {
-					SelectedEncodingId = data.Encoding != null ? data.Encoding.CodePage : 0
-				};
+				encodingSelector = new SelectEncodingPopUpButton (data.Action != FileChooserAction.Save);
+				encodingSelector.SelectedEncoding = TextEncoding.GetEncoding (data.Encoding);
 
 				controls.Add ((encodingSelector, GettextCatalog.GetString ("Encoding:")));
 			}

--- a/main/src/addins/MacPlatform/Dialogs/SelectEncodingPopUpButton.cs
+++ b/main/src/addins/MacPlatform/Dialogs/SelectEncodingPopUpButton.cs
@@ -32,6 +32,7 @@ using AppKit;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects.Text;
+using System.Text;
 
 namespace MonoDevelop.MacIntegration
 {
@@ -41,7 +42,6 @@ namespace MonoDevelop.MacIntegration
 		ObjCRuntime.Selector addRemoveActivationSel = new ObjCRuntime.Selector ("addRemoveActivated:");
 		
 		NSMenuItem autoDetectedItem, addRemoveItem;
-		int[] encodings;
 		
 		public SelectEncodingPopUpButton (bool showAutoDetected)
 		{
@@ -64,27 +64,24 @@ namespace MonoDevelop.MacIntegration
 			};
 			
 			Populate (false);
-			SelectedEncodingId = 0;
 		}
 		
-		public int SelectedEncodingId {
+		public TextEncoding SelectedEncoding {
 			get {
 				var idx = Cell.MenuItem.Tag;
 				if (idx <= 0)
-					return 0;
-				return encodings[idx - 1];
+					return null;
+				return TextEncoding.ConversionEncodings [idx - 1];
 			}
 			set {
 				NSMenuItem item = null;
-				if (value > 0) {
-					int i = 1;
-					foreach (var e in encodings) {
-						if (e == value) {
-							item = Menu.ItemWithTag (i);
-							break;
-						}
-						i++;
+				int i = 1;
+				foreach (var e in TextEncoding.ConversionEncodings) {
+					if (e == value) {
+						item = Menu.ItemWithTag (i);
+						break;
 					}
+					i++;
 				}
 				Cell.SelectItem (Cell.MenuItem = item ?? Cell.Menu.ItemAt (0));
 			}
@@ -95,8 +92,7 @@ namespace MonoDevelop.MacIntegration
 			if (clear)
 				Menu.RemoveAllItems ();
 				
-			encodings = TextEncoding.ConversionEncodings.Select ((e) => e.CodePage).ToArray ();
-			
+
 			if (autoDetectedItem != null) {
 				Menu.AddItem (autoDetectedItem);
 				Cell.MenuItem = autoDetectedItem;
@@ -122,11 +118,11 @@ namespace MonoDevelop.MacIntegration
 		{
 			Cell.SelectItem (Cell.MenuItem);
 			
-			var selection = SelectedEncodingId;
+			var selection = SelectedEncoding;
 			var dlg = new SelectEncodingPanel ();
 			if (dlg.RunModalSheet (Window) != 0) {
 				Populate (true);
-				SelectedEncodingId = selection;
+				SelectedEncoding = selection;
 			}
 		}
 		

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/FileSelectorDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/FileSelectorDialog.cs
@@ -107,18 +107,18 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			if (action != Gtk.FileChooserAction.Open)
 				closeWorkspaceCheck.Visible = ShowViewerSelector = false;
 		}
-		
-		public int SelectedEncoding {
+
+		public TextEncoding SelectedEncoding {
 			get {
 				if (!ShowEncodingSelector)
-					return -1;
+					return null;
 				else if (encodingMenu.History < firstEncIndex || encodingMenu.History == selectOption)
-					return -1;
-				return TextEncoding.ConversionEncodings [encodingMenu.History - firstEncIndex].CodePage;
+					return null;
+				return TextEncoding.ConversionEncodings [encodingMenu.History - firstEncIndex];
 			}
 			set {
 				for (uint n=0; n < TextEncoding.ConversionEncodings.Length; n++) {
-					if (TextEncoding.ConversionEncodings [n].CodePage == value) {
+					if (TextEncoding.ConversionEncodings [n] == value) {
 						encodingMenu.SetHistory (n + (uint)firstEncIndex);
 						Menu menu = (Menu)encodingMenu.Menu;
 						RadioMenuItem rm = (RadioMenuItem) menu.Children [n + firstEncIndex];
@@ -165,7 +165,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 				firstEncIndex = 0;
 			
 			foreach (var textEncoding in TextEncoding.ConversionEncodings) {
-				var enc = Encoding.GetEncoding (textEncoding.CodePage);
+				var enc = textEncoding.Encoding;
 				RadioMenuItem mitem = new RadioMenuItem (enc.EncodingName + " (" + enc.WebName + ")");
 				menu.Append (mitem);
 				if (defaultActivated == null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OpenFileDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/OpenFileDialog.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Components.Extensions;
 using System.Collections.Generic;
 using Mono.Addins;
 using System.Text;
+using MonoDevelop.Projects.Text;
 
 namespace MonoDevelop.Ide.Gui.Dialogs
 {
@@ -95,7 +96,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		protected override bool RunDefault ()
 		{
 			var win = new FileSelectorDialog (Title, Action.ToGtkAction ());
-			win.SelectedEncoding = Encoding != null ? Encoding.CodePage : 0;
+			win.SelectedEncoding = TextEncoding.GetEncoding (Encoding);
 			win.ShowEncodingSelector = ShowEncodingSelector;
 			win.ShowViewerSelector = ShowViewerSelector;
 			bool pathAlreadySet = false;
@@ -114,7 +115,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 				var result = MessageService.RunCustomDialog (win, TransientFor ?? MessageService.RootWindow);
 				if (result == (int)Gtk.ResponseType.Ok) {
 					GetDefaultProperties (win);
-					data.Encoding = win.SelectedEncoding > 0 ? Encoding.GetEncoding (win.SelectedEncoding) : null;
+					data.Encoding = win.SelectedEncoding?.Encoding;
 					data.CloseCurrentWorkspace = win.CloseCurrentWorkspace;
 					data.SelectedViewer = win.SelectedViewer;
 					return true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/SelectEncodingsDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/SelectEncodingsDialog.cs
@@ -61,7 +61,7 @@ namespace MonoDevelop.Ide
 				}
 				
 				foreach (var e in TextEncoding.ConversionEncodings) {
-					var enc = Encoding.GetEncoding (e.CodePage);
+					var enc = e.Encoding;
 					storeSelected.AppendValues (enc.EncodingName, enc.WebName, enc.CodePage);
 				}
 			} catch (Exception  ex) {


### PR DESCRIPTION
(no signature) format

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/951152

Needed to switch away from code page representation. There is no code
page for an UTF-8 encoding without BOM.