### PR TITLE
[Core] Cache ProjectFile.Include to improve project save performance

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs
@@ -75,14 +75,22 @@ namespace MonoDevelop.Projects
 			BuildAction = buildAction;
 		}
 
+		string cachedInclude;
+
 		public override string Include {
 			get {
 				if (Project != null) {
+					if (cachedInclude != null)
+						return cachedInclude;
+
 					string path = MSBuildProjectService.ToMSBuildPath (Project.ItemDirectory, FilePath);
 					if (path.Length > 0) {
 						//directory paths must end with '/'
 						if ((Subtype == Subtype.Directory) && path [path.Length - 1] != '\\')
 							path = path + "\\";
+						// Cache the include path to avoid recalculating MSBuildProjectService.ToMSBuildPath
+						// which can slow down saving SDK style projects that contain thousands of files.
+						cachedInclude = path;
 						return path;
 					}
 				}
@@ -188,6 +196,8 @@ namespace MonoDevelop.Projects
 				// If the file is a link, rename the link too
 				if (IsLink && Link.FileName == oldPath.FileName)
 					link = Path.Combine (Path.GetDirectoryName (link), filename.FileName);
+
+				cachedInclude = null;
 
 				// If a file that belongs to a project is being renamed, update the value of UnevaluatedInclude
 				// since that is used when saving
@@ -485,12 +495,30 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		Project project;
+
 		protected override void OnProjectSet ()
 		{
 			base.OnProjectSet ();
+			if (project != null) {
+				project.Modified -= OnProjectModified;
+				project = null;
+			}
 			if (Project != null) {
 				base.Include = Include;
+				project = Project;
+				project.Modified += OnProjectModified;
 				VirtualPathChanged?.Invoke (this, new ProjectFileVirtualPathChangedEventArgs (this, FilePath.Null, ProjectVirtualPath));
+			}
+		}
+
+		void OnProjectModified (object sender, SolutionItemModifiedEventArgs e)
+		{
+			foreach (var eventInfo in e) {
+				if (eventInfo.Hint == "FileName") {
+					cachedInclude = null;
+					return;
+				}
 			}
 		}
 
@@ -516,6 +544,10 @@ namespace MonoDevelop.Projects
 
 		protected virtual void OnDispose ()
 		{
+			if (project != null) {
+				project.Modified -= OnProjectModified;
+				project = null;
+			}
 		}
 
 		internal event EventHandler<ProjectFileVirtualPathChangedEventArgs> VirtualPathChanged;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1226,6 +1226,32 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Ensure the cached value is updated when the Project or FileName changes.
+		/// </summary>
+		[Test]
+		public void ProjectFileIncludeCachingTests ()
+		{
+			using (var project = Services.ProjectService.CreateDotNetProject ("C#")) {
+				FilePath directory = Util.CreateTmpDir ("ProjectFileIncludeCachingTests");
+				project.FileName = directory.Combine ("Project.csproj");
+
+				var fileName = project.BaseDirectory.Combine ("Source", "Test.cs");
+				var projectFile = new ProjectFile (fileName);
+				projectFile.Project = project;
+
+				Assert.AreEqual (@"Source\Test.cs", projectFile.Include);
+
+				projectFile.Name = projectFile.FilePath.ChangeName ("Changed");
+				Assert.AreEqual (@"Source\Changed.cs", projectFile.Include);
+				Assert.AreEqual (@"Source\Changed.cs", projectFile.UnevaluatedInclude);
+
+				// Change project's ItemDirectory. This will change the ProjectFile's Include.
+				project.FileName = project.BaseDirectory.Combine ("Source", "Project.csproj");
+				Assert.AreEqual ("Changed.cs", projectFile.Include);
+			}
+		}
+
 		class TestGetReferencesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override Task<List<AssemblyReference>> OnGetReferences (ConfigurationSelector configuration, CancellationToken token)


### PR DESCRIPTION
With an SDK style project containing 1500 C# files, adding a new
C# class to the project would result in the saving taking about 20
seconds. The majority of this time was spent in the Project's
SaveProjectItems as it tried to determine if an MSBuild remove item
should be added for the new file. Caching the ProjectFile.Include
takes the save time down to around 300 ms.

Fixes VSTS #947103 - Class creation is very slow in projects with
hundreds of classes