### PR TITLE
Fixes VSTS Bug 961599: [Feedback] Visual Studio crashes/exists when

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.UserGitConfigDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/Gui/MonoDevelop.VersionControl.Git.UserGitConfigDialog.cs
@@ -143,7 +143,6 @@ namespace MonoDevelop.VersionControl.Git
 			}
 			this.DefaultWidth = 332;
 			this.DefaultHeight = 184;
-			this.Show ();
 			this.usernameEntry.Changed += new global::System.EventHandler (this.OnChanged);
 			this.emailEntry.Changed += new global::System.EventHandler (this.OnChanged);
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCommitDialogExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitCommitDialogExtension.cs
@@ -95,7 +95,7 @@ namespace MonoDevelop.VersionControl.Git
 
 			string user;
 			string email;
-			repo.GetUserInfo (out user, out email);
+			repo.GetUserInfo (out user, out email, CommitDialog);
 
 			string val = sol.UserProperties.GetValue<string> ("GitUserInfo");
 			if (val == "UsingMD") {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -895,7 +895,7 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected override async Task<VersionControlOperation> GetSupportedOperationsAsync (VersionInfo vinfo, CancellationToken cancellationToken)
+		protected internal override async Task<VersionControlOperation> GetSupportedOperationsAsync (VersionInfo vinfo, CancellationToken cancellationToken)
 		{
 			VersionControlOperation ops = await base.GetSupportedOperationsAsync (vinfo, cancellationToken);
 			if (await GetCurrentRemoteAsync (cancellationToken) == null)
@@ -1353,7 +1353,7 @@ namespace MonoDevelop.VersionControl.Git
 			return name == null && email == null;
 		}
 
-		public void GetUserInfo (out string name, out string email)
+		public void GetUserInfo (out string name, out string email, Components.Window parent = null)
 		{
 			try {
 				string lname = null, lemail = null;
@@ -1369,7 +1369,7 @@ namespace MonoDevelop.VersionControl.Git
 				Runtime.RunInMainThread (() => {
 					var dlg = new UserGitConfigDialog ();
 					try {
-						if ((Gtk.ResponseType)MessageService.RunCustomDialog (dlg) == Gtk.ResponseType.Ok) {
+						if ((Gtk.ResponseType)MessageService.RunCustomDialog (dlg, parent) == Gtk.ResponseType.Ok) {
 							dlgName = dlg.UserText;
 							dlgEmail = dlg.EmailText;
 							SetUserInfo (dlgName, dlgEmail);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/CommitDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Dialogs/CommitDialog.cs
@@ -91,6 +91,7 @@ namespace MonoDevelop.VersionControl.Dialogs
 					continue;
 				}
 				if (ext.Initialize (changeSet)) {
+					ext.CommitDialog = this;
 					var newTitle = ext.FormatDialogTitle (changeSet, Title);
 					if (newTitle != null)
 						Title = newTitle;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.csproj
@@ -525,6 +525,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MonoDevelop.VersionControl.Git.Tests" />
+    <InternalsVisibleTo Include="MonoDevelop.VersionControl.Git" />
     <InternalsVisibleTo Include="MonoDevelop.MacDev" />
   </ItemGroup>
   <ItemGroup>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CommitDialogExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/CommitDialogExtension.cs
@@ -6,8 +6,9 @@ namespace MonoDevelop.VersionControl
 	/// <summary>
 	/// Base class for commit dialog extensions.
 	/// </summary>
-	public class CommitDialogExtension: Gtk.EventBox
+	public class CommitDialogExtension : Gtk.EventBox
 	{
+		internal VersionControl.Dialogs.CommitDialog CommitDialog  { get; set; }
 		/// <summary>
 		/// Initialize the extension.
 		/// </summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -395,6 +395,8 @@ namespace MonoDevelop.Ide
 			NSWindow nativeParent = null;
 			try {
 				nativeParent = parent;
+				if (nativeParent.Handle == nsdialog.Handle)
+					throw new InvalidOperationException ("Can't add dialog as child to itself.");
 				nativeParent.AddChildWindow (nsdialog, NSWindowOrderingMode.Above);
 			} catch (Exception ex) {
 				LoggingService.LogInternalError ("Failed to get the native parent window", ex);


### PR DESCRIPTION
attempting to commit to Git

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/961599

MessageService was causing a stack Overflow it could add a dialog as
child to itself. However teh git commit dialog should set itself as
parent for the git config dialog.