### PR TITLE
[release-8.2] [Core] Cache ProjectFile.Include to improve project save performance

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1226,6 +1226,32 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Ensure the cached value is updated when the Project or FileName changes.
+		/// </summary>
+		[Test]
+		public void ProjectFileIncludeCachingTests ()
+		{
+			using (var project = Services.ProjectService.CreateDotNetProject ("C#")) {
+				FilePath directory = Util.CreateTmpDir ("ProjectFileIncludeCachingTests");
+				project.FileName = directory.Combine ("Project.csproj");
+
+				var fileName = project.BaseDirectory.Combine ("Source", "Test.cs");
+				var projectFile = new ProjectFile (fileName);
+				projectFile.Project = project;
+
+				Assert.AreEqual (@"Source\Test.cs", projectFile.Include);
+
+				projectFile.Name = projectFile.FilePath.ChangeName ("Changed");
+				Assert.AreEqual (@"Source\Changed.cs", projectFile.Include);
+				Assert.AreEqual (@"Source\Changed.cs", projectFile.UnevaluatedInclude);
+
+				// Change project's ItemDirectory. This will change the ProjectFile's Include.
+				project.FileName = project.BaseDirectory.Combine ("Source", "Project.csproj");
+				Assert.AreEqual ("Changed.cs", projectFile.Include);
+			}
+		}
+
 		class TestGetReferencesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override Task<List<AssemblyReference>> OnGetReferences (ConfigurationSelector configuration, CancellationToken token)


### PR DESCRIPTION
With an SDK style project containing 1500 C# files, adding a new
C# class to the project would result in the saving taking about 20
seconds. The majority of this time was spent in the Project's
SaveProjectItems as it tried to determine if an MSBuild remove item
should be added for the new file. Caching the ProjectFile.Include
takes the save time down to around 300 ms.

Fixes VSTS #947103 - Class creation is very slow in projects with
hundreds of classes

Backport of #8353.

/cc @slluis @mrward