### PR TITLE
[release-8.2] [Project] Change the default DotNetProject platform to anycpu

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectService.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Projects
 
 		TargetFramework defaultTargetFramework;
 		
-		string defaultPlatformTarget = "x86";
+		string defaultPlatformTarget = "anycpu";
 		static readonly TargetFrameworkMoniker DefaultTargetFrameworkId = TargetFrameworkMoniker.NET_4_7;
 		
 		public const string BuildTarget = "Build";


### PR DESCRIPTION
Fixes VSTS 934343
[CSharp] Bad CPU type in executable trying to Debug/Run a default template of a CSharp project in catalina
https://vsmac.dev/934343

Backport of #8281.

/cc @mrward @sgmunn