### PR TITLE
Roslyn: Don't disable Roslyn's semantic QuickInfo after known error

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopExtensionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.RoslynServices/MonoDevelopExtensionManager.cs
@@ -81,6 +81,16 @@ namespace MonoDevelop.Ide.RoslynServices
 					return;
 				}
 #endif
+				// HACK: Let Roslyn's CSharpSemanticQuickInfoProvider throw as many errors as it wants without becoming
+				//       disabled. This is just a temporary workaround until we find the right fix for
+				//       https://devdiv.visualstudio.com/DevDiv/_workitems/edit/960181 .
+				//       Without this, as soon as the above bug is hit, most useful C# tooltips stop appearing until
+				//       you close/reopen the solution.
+				if (provider.GetType().FullName == "Microsoft.CodeAnalysis.CSharp.QuickInfo.CSharpSemanticQuickInfoProvider") {
+					errorLoggerService?.LogException (provider, exception);
+					return;
+				}
+
 				base.HandleException (provider, exception);
 			}
 		}


### PR DESCRIPTION
In some multi-targeting scenarios, `CSharpSemanticQuickInfoProvider` can
throw an error. Roslyn's default extension manager behavior in cases
like this is to disable the offending QuickInfo provider. But if that
happens, the provider is disabled until you close/reopen the solution.

Avoid this, so that the most useful C# tooltips don't go away just
because this error gets hit.

Temporary workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/960181