### PR TITLE
[release-8.3] Icons: Map md-warning to KnownImageIds.IntellisenseWarning

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
@@ -364,7 +364,7 @@
 	<StockIcon stockid="md-package" resource="package-32.png" size="Dnd" />
 	<StockIcon stockid="md-package" resource="package-48.png" size="Dialog" />
 
-	<StockIcon stockid="md-warning" resource="warning-16.png" />
+	<StockIcon stockid="md-warning" resource="warning-16.png" imageid="1591" />
 	<StockIcon stockid="md-warning" resource="warning-16.png" size="Menu" />
 	<StockIcon stockid="md-warning" resource="warning-24.png" size="Button" />
 	<StockIcon stockid="md-warning" resource="warning-24.png" size="LargeToolbar" />


### PR DESCRIPTION
Also filed https://devdiv-design.visualstudio.com/D3%20Studio/_workitems/edit/7661
to get a better-sized icon here.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/943079

Backport of #8363.

/cc @Therzok @sandyarmstrong