### PR TITLE
Revert "Use minimal verbosity for msbuild builds"

### DIFF
--- a/main/xbuild.include
+++ b/main/xbuild.include
@@ -25,7 +25,7 @@ endif
 endif
 
 XBUILD=msbuild
-XBUILD_VERBOSITY ?= minimal
+XBUILD_VERBOSITY ?= normal
 XBUILD_ARGS=/verbosity:$(XBUILD_VERBOSITY) /nologo /property:CodePage=65001 /property:RestorePackages=false /property:DownloadPaket=false
 XBUILD_PROFILE=/property:Configuration=$(PROFILE_NAME)
 


### PR DESCRIPTION
This reverts commit 2842fa9ae48db9afc5c5f0a934d03bc8a77a81b3.

VSTS only seems to properly detect error lines in the log when the MSBuild task is used, not when we have a bash script invoking make.