### PR TITLE
[Ide] Show welcome page after preseting workbench

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -442,9 +442,9 @@ namespace MonoDevelop.Ide
 
 			// OpenDocuments appears when the app is idle.
 			if (!hideWelcomePage && !WelcomePage.WelcomePageService.HasWindowImplementation) {
+				IdeApp.Workbench.Present ();
 				WelcomePage.WelcomePageService.ShowWelcomePage ();
 				Counters.InitializationTracker.Trace ("Showed welcome page");
-				IdeApp.Workbench.Present ();
 			} else if (hideWelcomePage && !startupInfo.OpenedFiles) {
 				IdeApp.Workbench.Present ();
 			}


### PR DESCRIPTION
When Workbench.Present() is executed for the first time
it will set up the layout, hiding the welcome page.