### PR TITLE
[release-8.3] Fixes VSTS Bug 959146: System.NullReferenceException exception in

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Utils/TextBreaker.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor.Utils/TextBreaker.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using MonoDevelop.Core;
 using MonoDevelop.Core.Text;
 
 namespace Mono.TextEditor.Utils
@@ -74,9 +75,17 @@ namespace Mono.TextEditor.Utils
 		/// </param>
 		public static List<ISegment> BreakLinesIntoWords (TextDocument document, int startLine, int lineCount, bool includeDelimiter = true)
 		{
+			if (document is null)
+				throw new ArgumentNullException (nameof (document));
+			if (startLine < 1)
+				throw new ArgumentOutOfRangeException (nameof (startLine), "startLine >= 1, was " + startLine);
+			if (startLine - 1 + lineCount > document.LineCount) 
+				throw new ArgumentOutOfRangeException (nameof (startLine), "startLine + lineCount <= " + (document.LineCount + 1) + ", was " + startLine);
 			var result = new List<ISegment> ();
 			for (int line = startLine; line < startLine + lineCount; line++) {
 				var lineSegment = document.GetLine (line);
+				if (lineSegment == null)
+					continue;
 				int offset = lineSegment.Offset;
 				bool wasIdentifierPart = false;
 				int lastWordEnd = 0;


### PR DESCRIPTION
Mono.TextEditor.Utils.TextBreaker.BreakLinesIntoWords()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/959146

I can't find the cause of it. I checked the parameters of
BreakLinesIntoWords now. The diff must be out of sync with the text
document that should now not happen, it's checked before paint that
the versions match. In any case that implementation is more solid.

Backport of #8360.

/cc @mkrueger 