### PR TITLE
Fixes VSTS Bug 958247: System.NullReferenceException exception in

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
@@ -1263,19 +1263,24 @@ namespace MonoDevelop.AssemblyBrowser
 		{
 			if (ensuredDefinitions == null)
 				throw new ArgumentNullException (nameof (ensuredDefinitions));
-			foreach (var def in ensuredDefinitions) {
-				if (!definitions.Contains (def)) {
-					definitions = definitions.Add (def);
 
-					Application.Invoke ((o, args) => {
-						if (ensuredDefinitions.Count + projects.Count == 1) {
-							TreeView.LoadTree (def.LoadingTask.Result);
-						} else {
-							TreeView.AddChild (def.LoadingTask.Result);
+			Runtime.RunInMainThread (() => {
+				foreach (var def in ensuredDefinitions) {
+					try {
+						if (!definitions.Contains (def)) {
+							definitions = definitions.Add (def);
+							var peFile = def.Assembly;
+							if (ensuredDefinitions.Count + projects.Count == 1) {
+								TreeView.LoadTree (peFile);
+							} else {
+								TreeView.AddChild (peFile);
+							}
 						}
-					});
+					} catch (Exception e) {
+						LoggingService.LogError ($"Can't load definition {def}. File name: {def?.FileName}", e);
+					}
 				}
-			}
+			});
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserWidget.cs
@@ -1277,7 +1277,7 @@ namespace MonoDevelop.AssemblyBrowser
 							}
 						}
 					} catch (Exception e) {
-						LoggingService.LogError ($"Can't load definition {def}. File name: {def?.FileName}", e);
+						LoggingService.LogInternalError ($"Can't load definition {def}. File name: {def?.FileName}", e);
 					}
 				}
 			});


### PR DESCRIPTION
MonoDevelop.AssemblyBrowser.AssemblyBrowserWidget.<>c__XXX.<EnsureDefinitionsLoaded>b__XXX()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958247

It could be that this exception didn't happen anymore however it's
hard to tell - this is basically the last thing that potentially could
be null in that method.