### PR TITLE
[release-8.3] [NuGet] Fix current version label in Manage NuGet packages dialog

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
@@ -1429,5 +1429,71 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("Multiple", package.GetCurrentPackageVersionText ());
 			Assert.AreEqual (expectedAdditionalText, package.GetCurrentPackageVersionAdditionalText ());
 		}
+
+		[Test]
+		public async Task CurrentVersion_SamePackageVersionInstalledInProjects_PackageVersionReturned ()
+		{
+			CreateProject ();
+			CreateProject ();
+			project.Name = "LibC";
+			var nugetProject = CreateNuGetProjectForProject (project);
+			nugetProject.AddPackageReference ("Test", "0.1");
+
+			var project2 = AddProjectToSolution ("LibA");
+			CreateNuGetProjectForProject (project2);
+
+			var project3 = AddProjectToSolution ("LibB");
+			nugetProject = CreateNuGetProjectForProject (project3);
+			nugetProject.AddPackageReference ("Test", "0.1");
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("Test", "0.2");
+
+			viewModel.PageSelected = ManagePackagesPage.Browse;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			var package = viewModel.PackageViewModels.Single ();
+			Assert.AreEqual ("Test", package.Id);
+			Assert.AreEqual ("0.2", package.Version.ToString ());
+			Assert.AreEqual ("0.1", package.GetCurrentPackageVersionText ());
+			Assert.AreEqual (string.Empty, package.GetCurrentPackageVersionAdditionalText ());
+		}
+
+		[Test]
+		public async Task CurrentVersion_TwoProjectsSameVersionOneProjectDifferentVersion_MultipleReturned ()
+		{
+			CreateProject ();
+			CreateProject ();
+			project.Name = "LibC";
+			var nugetProject = CreateNuGetProjectForProject (project);
+			nugetProject.AddPackageReference ("Test", "0.1");
+
+			var project2 = AddProjectToSolution ("LibA");
+			nugetProject = CreateNuGetProjectForProject (project2);
+			nugetProject.AddPackageReference ("Test", "0.1");
+
+			var project3 = AddProjectToSolution ("LibB");
+			nugetProject = CreateNuGetProjectForProject (project3);
+			nugetProject.AddPackageReference ("Test", "0.2");
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("Test", "0.2");
+
+			viewModel.PageSelected = ManagePackagesPage.Browse;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			string expectedAdditionalText = "LibA: 0.1, LibB: 0.2, LibC: 0.1";
+			var package = viewModel.PackageViewModels.Single ();
+			Assert.AreEqual ("Test", package.Id);
+			Assert.AreEqual ("0.2", package.Version.ToString ());
+			Assert.AreEqual ("Multiple", package.GetCurrentPackageVersionText ());
+			Assert.AreEqual (expectedAdditionalText, package.GetCurrentPackageVersionAdditionalText ());
+		}
 	}
 }


### PR DESCRIPTION
The Updates tab would show 'Multiple' for the current version when the
same package version was installed in multiple projects.

Fixes VSTS #963252 - Manage NuGet packages showing multiple current
versions when only one is installed

Backport of #8362.

/cc @mrward 