### PR TITLE
[release-8.3] [Core] Add new MSBuild item to ItemGroup without condition

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProject.cs
@@ -980,6 +980,8 @@ namespace MonoDevelop.Projects.MSBuild
 
 			MSBuildItemGroup insertBefore = null;
 			foreach (MSBuildItemGroup grp in ItemGroups) {
+				if (!string.IsNullOrEmpty (grp.Condition))
+					continue;
 				foreach (MSBuildItem it in grp.Items) {
 					if (ShouldAddItemToGroup (it, newItem)) {
 						bestGroups [groupId] = grp;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -1599,6 +1599,44 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void AddNewPackageReference_ExistingItemGroupHasCondition_NewItemGroupCreated ()
+		{
+			string projectXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFrameworks>netcoreapp1.0;net472</TargetFrameworks>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup Condition=\"'$(TargetFramework)' == 'net472'\">\r\n" +
+				"    <PackageReference Include=\"Newtonsoft.Json\" Version=\"10.0.3\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+
+			var p = new MSBuildProject ();
+			p.LoadXml (projectXml);
+			p.AddKnownItemAttribute ("PackageReference", "Version");
+
+			var item = p.AddNewItem ("PackageReference", "NUnit");
+			item.Metadata.SetValue ("Version", "2.6.4");
+
+			string xml = p.SaveToString ();
+
+			string expectedXml =
+				"<Project Sdk=\"Microsoft.NET.Sdk\">\r\n" +
+				"  <PropertyGroup>\r\n" +
+				"    <TargetFrameworks>netcoreapp1.0;net472</TargetFrameworks>\r\n" +
+				"  </PropertyGroup>\r\n" +
+				"  <ItemGroup Condition=\"'$(TargetFramework)' == 'net472'\">\r\n" +
+				"    <PackageReference Include=\"Newtonsoft.Json\" Version=\"10.0.3\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"  <ItemGroup>\r\n" +
+				"    <PackageReference Include=\"NUnit\" Version=\"2.6.4\" />\r\n" +
+				"  </ItemGroup>\r\n" +
+				"</Project>";
+			Assert.AreEqual (expectedXml, xml);
+			p.Dispose ();
+		}
+
+		[Test]
 		public void ProjectHasNoMainPropertyGroup_AddRemoveProjectTypeGuid ()
 		{
 			string projectXml =


### PR DESCRIPTION
When a new item is added to the project and then the project is saved
the MSBuildProject will try to add the new item to an ItemGroup with
the same MSBuild item types. When adding a PackageReference this may
result in the package being added to an ItemGroup with a condition
which is not expected. Now ItemGroups with conditions are not used
when adding a new MSBuild item to a project.

Fixes VSTS #957474 - Adding a new PackageReference does not consider
conditions

Backport of #8398.

/cc @mrward 