### PR TITLE
[release-8.3] [DotNetCore] Add custom .NET Core sdk package sources

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -52,7 +52,8 @@ namespace MonoDevelop.DotNetCore.Tests
 			}
 
 			// Set environment variable to enable VB.NET support
-			Environment.SetEnvironmentVariable ("MD_FEATURES_ENABLED", "VBNetDotnetCoreTemplates");
+			// Disabled for now due to .NET Core 3.0 preview 8 bug - https://github.com/dotnet/corefx/issues/40012
+			//Environment.SetEnvironmentVariable ("MD_FEATURES_ENABLED", "VBNetDotnetCoreTemplates");
 
 			// Set $PATH to point to the .NET Core SDK we provision, as in VSTS bots are
 			// setup with lots of old and incompatible SDK versions under $HOME/.dotnet

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -231,15 +231,15 @@ namespace MonoDevelop.DotNetCore.Tests
 		[TestCase ("Microsoft.Test.xUnit.FSharp", "UseNetCore30=true")]
 		[TestCase ("Microsoft.Test.MSTest.FSharp", "UseNetCore30=true")]
 
-		[TestCase ("Microsoft.Common.Console.VisualBasic", "UseNetCore30=true")]
-		[TestCase ("Microsoft.Common.Library.VisualBasic-netcoreapp", "UseNetCore30=true;Framework=netcoreapp3.0")]
-		[TestCase ("Microsoft.Test.xUnit.VisualBasic", "UseNetCore30=true")]
-		[TestCase ("Microsoft.Test.MSTest.VisualBasic", "UseNetCore30=true")]
+		//[TestCase ("Microsoft.Common.Console.VisualBasic", "UseNetCore30=true")]
+		//[TestCase ("Microsoft.Common.Library.VisualBasic-netcoreapp", "UseNetCore30=true;Framework=netcoreapp3.0")]
+		//[TestCase ("Microsoft.Test.xUnit.VisualBasic", "UseNetCore30=true")]
+		//[TestCase ("Microsoft.Test.MSTest.VisualBasic", "UseNetCore30=true")]
 
 		// NUnit3 templates come with .NET Core 2.2, but they only support .NET Core 2.1 framework
 		[TestCase ("NUnit3.DotNetNew.Template.CSharp", "UseNetCore30=true")]
 		[TestCase ("NUnit3.DotNetNew.Template.FSharp", "UseNetCore30=true")]
-		[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore30=true")]
+		//[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore30=true")]
 		public async Task NetCore30 (string templateId, string parameters)
 		{
 			if (!IsDotNetCoreSdk30Installed ()) {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -43,6 +43,24 @@ namespace MonoDevelop.DotNetCore.Tests
 	[TestFixture]
 	class DotNetCoreProjectTemplateTests : DotNetCoreTestBase
 	{
+		class DotNetCoreProjectTemplateTest : ProjectTemplateTest
+		{
+			public DotNetCoreProjectTemplateTest (string basename, string templateId) : base (basename, templateId)
+			{
+			}
+
+			protected override string GetExtraNuGetSources ()
+			{
+				return "    <add key=\"dotnet-core\" value=\"https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json\" />\r\n" +
+					"    <add key=\"dotnet-windowsdesktop\" value=\"https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json\" />\r\n" +
+					"    <add key=\"aspnet-aspnetcore\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json\" />\r\n" +
+					"    <add key=\"aspnet-aspnetcore-tooling\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json\" />\r\n" +
+					"    <add key=\"aspnet-entityframeworkcore\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json\" />\r\n" +
+					"    <add key=\"aspnet-extensions\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json\" />\r\n" +
+					"    <add key=\"gRPCrepository\" value=\"https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev\" />\r\n";
+			}
+		}
+
 		[TestFixtureSetUp]
 		public void SetUp ()
 		{
@@ -373,7 +391,7 @@ namespace MonoDevelop.DotNetCore.Tests
 
 		static async Task CreateFromTemplateAndBuild (string basename, string templateId, string parameters, Action<Solution> preBuildChecks = null, bool checkExecutionTargets = false)
 		{
-			using (var ptt = new ProjectTemplateTest (basename, templateId)) {
+			using (var ptt = new DotNetCoreProjectTemplateTest (basename, templateId)) {
 
 				foreach (var templateParameter in TemplateParameter.CreateParameters (parameters)) {
 					ptt.Config.Parameters [templateParameter.Name] = templateParameter.Value;

--- a/main/tests/IdeUnitTests/ProjectTemplateTest.cs
+++ b/main/tests/IdeUnitTests/ProjectTemplateTest.cs
@@ -121,6 +121,13 @@ namespace IdeUnitTests
 				"  <packageSources>\r\n" +
 				"    <clear />\r\n" +
 				"    <add key=\"NuGet v3 Official\" value=\"https://api.nuget.org/v3/index.json\" />\r\n" +
+				"    <add key=\"dotnet-core\" value=\"https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json\" />\r\n" +
+				"    <add key=\"dotnet-windowsdesktop\" value=\"https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json\" />\r\n" +
+				"    <add key=\"aspnet-aspnetcore\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json\" />\r\n" +
+				"    <add key=\"aspnet-aspnetcore-tooling\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json\" />\r\n" +
+				"    <add key=\"aspnet-entityframeworkcore\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json\" />\r\n" +
+				"    <add key=\"aspnet-extensions\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json\" />\r\n" +
+				"    <add key=\"gRPCrepository\" value=\"https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev\" />\r\n" +
 				"  </packageSources>\r\n" +
 				"</configuration>";
 

--- a/main/tests/IdeUnitTests/ProjectTemplateTest.cs
+++ b/main/tests/IdeUnitTests/ProjectTemplateTest.cs
@@ -61,7 +61,7 @@ namespace IdeUnitTests
 			this.templateId = templateId;
 
 			SolutionDirectory = Util.CreateTmpDir (basename);
-			CreateNuGetConfigFile (SolutionDirectory);
+			CreateNuGetConfigFile (this);
 			ProjectName = GetProjectName (templateId);
 
 			Config = new NewProjectConfiguration {
@@ -112,22 +112,18 @@ namespace IdeUnitTests
 			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed. Exit code: {process.ExitCode}. {standardError}");
 		}
 
-		static void CreateNuGetConfigFile (FilePath directory)
+		protected virtual string GetExtraNuGetSources () => string.Empty;
+
+		static void CreateNuGetConfigFile (ProjectTemplateTest test)
 		{
-			var fileName = directory.Combine ("NuGet.Config");
+			var fileName = test.SolutionDirectory.Combine ("NuGet.Config");
 
 			string xml =
 				"<configuration>\r\n" +
 				"  <packageSources>\r\n" +
 				"    <clear />\r\n" +
 				"    <add key=\"NuGet v3 Official\" value=\"https://api.nuget.org/v3/index.json\" />\r\n" +
-				"    <add key=\"dotnet-core\" value=\"https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json\" />\r\n" +
-				"    <add key=\"dotnet-windowsdesktop\" value=\"https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json\" />\r\n" +
-				"    <add key=\"aspnet-aspnetcore\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json\" />\r\n" +
-				"    <add key=\"aspnet-aspnetcore-tooling\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json\" />\r\n" +
-				"    <add key=\"aspnet-entityframeworkcore\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json\" />\r\n" +
-				"    <add key=\"aspnet-extensions\" value=\"https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json\" />\r\n" +
-				"    <add key=\"gRPCrepository\" value=\"https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev\" />\r\n" +
+				test.GetExtraNuGetSources () +
 				"  </packageSources>\r\n" +
 				"</configuration>";
 


### PR DESCRIPTION
See if this fixes the project template tests.

Temporary change - should not be needed when the packages
are published on nuget.org.

Backport of #8379.

/cc @rodrmoya @mrward