### PR TITLE
Directory.Build.props: Remove NuGetVersionRoslyn

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -20,7 +20,6 @@
     <NuGetVersionNuGet>5.2.0-rtm.6067</NuGetVersionNuGet>
     <NuGetVersionNUnit2>2.7.0</NuGetVersionNUnit2>
     <NuGetVersionNUnit3>3.9.0</NuGetVersionNUnit3>
-    <NuGetVersionRoslyn>3.3.0-beta2-19374-02</NuGetVersionRoslyn>
     <NuGetVersionVSCodeDebugProtocol>15.8.20719.1</NuGetVersionVSCodeDebugProtocol>
     <NuGetVersionVSComposition>15.8.112</NuGetVersionVSComposition>
     <NuGetVersionVSEditor>16.1.28-g2ad4df7366</NuGetVersionVSEditor>

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/RoslynHelpers.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/RoslynHelpers.fs
@@ -40,4 +40,5 @@ module RoslynHelpers =
             member x.ToMinimalDisplayString (_semanticModel, _position, _format) = symbolUse.Symbol.DisplayName //TODO format?
             member x.ToMinimalDisplayParts (_semanticModel, _position, _format) = ImmutableArray.Empty //TODO
             member x.HasUnsupportedMetadata = false //TODO
+            member x.Equals (other:Microsoft.CodeAnalysis.ISymbol, equalityComparer:Microsoft.CodeAnalysis.SymbolEqualityComparer) = equalityComparer.Equals(x, other)
             member x.Equals (other:Microsoft.CodeAnalysis.ISymbol) = x.Equals(other)


### PR DESCRIPTION
This property has moved to its own props file.

It was accidentally restored here via bad merge/rebase in
https://github.com/mono/monodevelop/pull/8201, causing
the version in the props file to be overridden.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/959442