### PR TITLE
[NuGet] Make references dialog aware of multi-target projects

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/RestoreTestBase.cs
@@ -39,7 +39,6 @@ using NuGet.Packaging.PackageExtraction;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectManagement;
 using NUnit.Framework;
-using UnitTests;
 
 namespace MonoDevelop.PackageManagement.Tests.Helpers
 {
@@ -72,7 +71,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			File.WriteAllText (fileName, xml);
 		}
 
-		protected static Task<PackageRestoreResult> RestoreNuGetPackages (Solution solution)
+		protected static Task<PackageRestoreResult> RestorePackagesConfigNuGetPackages (Solution solution)
 		{
 			var solutionManager = new MonoDevelopSolutionManager (solution);
 			var context = new FakeNuGetProjectContext {
@@ -117,6 +116,16 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 				logger);
 
 			return context;
+		}
+
+		protected static Task RestoreNuGetPackages (Solution solution)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (solution);
+			var restoreAction = new RestoreNuGetPackagesAction (solution, solutionManager);
+
+			return Task.Run (() => {
+				restoreAction.Execute ();
+			});
 		}
 
 		protected class PackageManagementEventsConsoleLogger : IDisposable

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -154,6 +154,7 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableRestorePackagesInProjectHandler.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\ManagePackagesViewModelTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableManagePackagesViewModel.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\PackageManagementCanReferenceProjectExtensionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/AssemblyReferenceWithConditionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/AssemblyReferenceWithConditionTests.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.PackageManagement.Tests
 				CreateNuGetConfigFile (solution.BaseDirectory);
 				var project = (DotNetProject)solution.FindProjectByName ("PackageAssemblyReferenceCondition");
 
-				var restoreResult = await RestoreNuGetPackages (solution);
+				var restoreResult = await RestorePackagesConfigNuGetPackages (solution);
 				Assert.IsTrue (restoreResult.Restored);
 				Assert.AreEqual (1, restoreResult.RestoredPackages.Count ());
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/FullyQualifiedReferencePathTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/FullyQualifiedReferencePathTests.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.PackageManagement.Tests
 				CreateNuGetConfigFile (solution.BaseDirectory);
 				var project = (DotNetProject)solution.FindProjectByName ("ReferenceFullPath");
 
-				var restoreResult = await RestoreNuGetPackages (solution);
+				var restoreResult = await RestorePackagesConfigNuGetPackages (solution);
 				Assert.IsTrue (restoreResult.Restored);
 				Assert.AreEqual (1, restoreResult.RestoredPackages.Count ());
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageManagementCanReferenceProjectExtensionTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/PackageManagementCanReferenceProjectExtensionTests.cs
@@ -1,0 +1,86 @@
+//
+// PackageManagementCanReferenceProjectExtensionTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	class PackageManagementCanReferenceProjectExtensionTests : RestoreTestBase
+	{
+		/// <summary>
+		/// Ensures that all frameworks are considered when referencing a multi-target project or a
+		/// multi-target project references another project.
+		/// </summary>
+		[Test]
+		public async Task MultiTargetProjects ()
+		{
+			string solutionFileName = Util.GetSampleProject ("CanReferenceProjectTests", "CanReferenceProjectTests.sln");
+			using (solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName)) {
+				CreateNuGetConfigFile (solution.BaseDirectory);
+
+				await RestoreNuGetPackages (solution);
+
+				var netstandard11 = (DotNetProject)solution.FindProjectByName ("NetStandard11");
+				var netcore21net472 = (DotNetProject)solution.FindProjectByName ("NetCore21Net472");
+				var net472 = (DotNetProject)solution.FindProjectByName ("Net472");
+				var net46netstandard10 = (DotNetProject)solution.FindProjectByName ("Net46NetStandard10");
+
+				// Multi-target frameworks included in reason why project cannot be referenced
+				string reason = null;
+				bool result = netstandard11.CanReferenceProject (netcore21net472, out reason);
+				Assert.IsFalse (result);
+				Assert.AreEqual ("Incompatible target frameworks: .NETCoreApp,Version=v2.1, .NETFramework,Version=v4.7.2", reason);
+
+				// netstandard11 cannot reference net472
+				result = netstandard11.CanReferenceProject (net472, out reason);
+				Assert.IsFalse (result);
+				Assert.AreEqual ("Incompatible target framework: .NETFramework,Version=v4.7.2", reason);
+
+				// .NET 4.7.2 can reference a multi-target project that includes .NET 4.7.2
+				result = net472.CanReferenceProject (netcore21net472, out reason);
+				Assert.IsTrue (result);
+
+				// netcoreapp2.1 - net472 multi-target project can reference a net472 project.
+				result = netcore21net472.CanReferenceProject (net472, out reason);
+				Assert.IsTrue (result);
+
+				// netcoreapp2.1 - net472 can reference net46 - netstandard10 multi-target project.
+				result = netcore21net472.CanReferenceProject (net46netstandard10, out reason);
+				Assert.IsTrue (result);
+
+				// net46 - netstandard10 cannot reference netcoreapp2.1 - net472 multi-target project.
+				result = net46netstandard10.CanReferenceProject (netcore21net472, out reason);
+				Assert.IsFalse (result);
+				Assert.AreEqual ("Incompatible target frameworks: .NETCoreApp,Version=v2.1, .NETFramework,Version=v4.7.2", reason);
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateXamarinFormsBuildTest.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateXamarinFormsBuildTest.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.PackageManagement.Tests
 			CreateNuGetConfigFile (solution.BaseDirectory);
 			var pclProject = (DotNetProject)solution.FindProjectByName ("PclProject");
 
-			var restoreResult = await RestoreNuGetPackages (solution);
+			var restoreResult = await RestorePackagesConfigNuGetPackages (solution);
 			Assert.IsTrue (restoreResult.Restored);
 			Assert.AreEqual (2, restoreResult.RestoredPackages.Count ());
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -191,6 +191,7 @@
 
 	<Extension path="/MonoDevelop/ProjectModel/ProjectModelExtensions">
 		<Class class="MonoDevelop.PackageManagement.PackageManagementMSBuildExtension" />
+		<Class class="MonoDevelop.PackageManagement.PackageManagementCanReferenceProjectExtension" />
 		<Class class="MonoDevelop.PackageManagement.PackageManagementSdkProjectExtension" />
 	</Extension>
 	<!--

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -365,6 +365,7 @@
     <Compile Include="MonoDevelop.PackageManagement\SelectProjectsViewModel.cs" />
     <Compile Include="MonoDevelop.PackageManagement\RecentManagedNuGetPackagesRepository.cs" />
     <Compile Include="MonoDevelop.PackageManagement\ManageProjectViewModel.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\PackageManagementCanReferenceProjectExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCanReferenceProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCanReferenceProjectExtension.cs
@@ -1,0 +1,100 @@
+//
+// PackageManagementCanReferenceProjectExtension.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using MonoDevelop.Core;
+using MonoDevelop.Core.Assemblies;
+using MonoDevelop.Projects;
+using NuGet.Frameworks;
+
+namespace MonoDevelop.PackageManagement
+{
+	class PackageManagementCanReferenceProjectExtension : DotNetProjectExtension
+	{
+		protected override bool OnGetCanReferenceProject (DotNetProject targetProject, out string reason)
+		{
+			if (base.OnGetCanReferenceProject (targetProject, out reason)) {
+				return true;
+			}
+
+			if (CanReferenceProject (targetProject)) {
+				return true;
+			}
+
+			if (targetProject.HasMultipleTargetFrameworks) {
+				reason = GetCanReferenceErrorReason (targetProject);
+			}
+
+			return false;
+		}
+
+		bool CanReferenceProject (DotNetProject targetProject)
+		{
+			foreach (TargetFrameworkMoniker targetFramework in Project.TargetFrameworkMonikers) {
+				var nugetFramework = GetNuGetFramework (targetFramework);
+				if (CanReferenceProject (nugetFramework, targetProject)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		static bool CanReferenceProject (NuGetFramework nugetFramework, DotNetProject targetProject)
+		{
+			foreach (TargetFrameworkMoniker targetFramework in targetProject.TargetFrameworkMonikers) {
+				var targetNuGetFramework = GetNuGetFramework (targetFramework);
+				if (DefaultCompatibilityProvider.Instance.IsCompatible (nugetFramework, targetNuGetFramework)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		static NuGetFramework GetNuGetFramework (TargetFrameworkMoniker targetFramework)
+		{
+			return new NuGetFramework (
+				targetFramework.Identifier,
+				Version.Parse (targetFramework.Version),
+				targetFramework.Profile);
+		}
+
+		static string GetCanReferenceErrorReason (DotNetProject project)
+		{
+			var reason = StringBuilderCache.Allocate ();
+
+			reason.Append (GettextCatalog.GetString ("Incompatible target frameworks: "));
+
+			var frameworks = project.TargetFrameworkMonikers;
+			for (int i = 0; i < frameworks.Length; ++i) {
+				if (i > 0)
+					reason.Append (", ");
+				reason.Append (frameworks [i]);
+			}
+
+			return StringBuilderCache.ReturnAndFree (reason);
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RestoreNuGetPackagesAction.cs
@@ -48,12 +48,17 @@ namespace MonoDevelop.PackageManagement
 		List<INuGetAwareProject> nugetAwareProjects;
 
 		public RestoreNuGetPackagesAction (Solution solution)
+			: this (solution, PackageManagementServices.Workspace.GetSolutionManager (solution))
+		{
+		}
+
+		internal RestoreNuGetPackagesAction (Solution solution, IMonoDevelopSolutionManager solutionManager)
 		{
 			this.solution = solution;
 			packageManagementEvents = PackageManagementServices.PackageManagementEvents;
 			RestorePackagesConfigProjects = true;
 
-			solutionManager = PackageManagementServices.Workspace.GetSolutionManager (solution);
+			this.solutionManager = solutionManager;
 			solutionManager.ClearProjectCache ();
 		}
 

--- a/main/tests/test-projects/CanReferenceProjectTests/CanReferenceProjectTests.sln
+++ b/main/tests/test-projects/CanReferenceProjectTests/CanReferenceProjectTests.sln
@@ -1,0 +1,35 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard11", "NetStandard11\NetStandard11.csproj", "{FC899F17-8CC6-4D85-87B8-09FC18149D3F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCore21Net472", "NetCore21Net472\NetCore21Net472.csproj", "{9F8B4E87-AF6E-4294-AA0D-34027B5B1B0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Net472", "Net472\Net472.csproj", "{A2D131B4-7D16-476F-ADD8-0D96A5FC4455}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Net46NetStandard10", "Net46NetStandard10\Net46NetStandard10.csproj", "{0583B083-6FB6-4FB3-80A5-781A7A68F20B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FC899F17-8CC6-4D85-87B8-09FC18149D3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC899F17-8CC6-4D85-87B8-09FC18149D3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC899F17-8CC6-4D85-87B8-09FC18149D3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC899F17-8CC6-4D85-87B8-09FC18149D3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F8B4E87-AF6E-4294-AA0D-34027B5B1B0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F8B4E87-AF6E-4294-AA0D-34027B5B1B0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F8B4E87-AF6E-4294-AA0D-34027B5B1B0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F8B4E87-AF6E-4294-AA0D-34027B5B1B0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2D131B4-7D16-476F-ADD8-0D96A5FC4455}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2D131B4-7D16-476F-ADD8-0D96A5FC4455}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2D131B4-7D16-476F-ADD8-0D96A5FC4455}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2D131B4-7D16-476F-ADD8-0D96A5FC4455}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0583B083-6FB6-4FB3-80A5-781A7A68F20B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0583B083-6FB6-4FB3-80A5-781A7A68F20B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0583B083-6FB6-4FB3-80A5-781A7A68F20B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0583B083-6FB6-4FB3-80A5-781A7A68F20B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/CanReferenceProjectTests/Net46NetStandard10/Net46NetStandard10.csproj
+++ b/main/tests/test-projects/CanReferenceProjectTests/Net46NetStandard10/Net46NetStandard10.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net46;netstandard10</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/CanReferenceProjectTests/Net472/Net472.csproj
+++ b/main/tests/test-projects/CanReferenceProjectTests/Net472/Net472.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A2D131B4-7D16-476F-ADD8-0D96A5FC4455}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Net472</RootNamespace>
+    <AssemblyName>Net472</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/CanReferenceProjectTests/NetCore21Net472/NetCore21Net472.csproj
+++ b/main/tests/test-projects/CanReferenceProjectTests/NetCore21Net472/NetCore21Net472.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/CanReferenceProjectTests/NetStandard11/NetStandard11.csproj
+++ b/main/tests/test-projects/CanReferenceProjectTests/NetStandard11/NetStandard11.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
The Edit References dialog uses the Project.CanReferenceProject method
to determine if a project can be referenced. This does not consider
multi-target framework projects. Now a DotNetProjectExtension has
been added to the NuGet addin that uses NuGet to determine the
compatibility of all target frameworks the projects use.

Report all target frameworks as incompatible in the Edit References
dialog instead of just the first target framework.

Fixes VSTS #959111 - Unable to add references with multi-target
framework project