### PR TITLE
[IDE] Add "Add Reference" under project context menu

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -128,7 +128,7 @@
 		<Condition id="ItemType" value="Project">
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.AddPackages"
-				insertafter="MonoDevelop.Ide.Commands.ProjectCommands.AddFiles"
+				insertafter="MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 				insertbefore="MonoDevelop.WebReferences.WebReferenceCommands.Add" />
 		</Condition>
 	</Extension>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -128,6 +128,7 @@
 		<Condition id="ItemType" value="Project">
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.AddPackages"
+				_label = "NuGet _Packages..."				
 				insertafter="MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 				insertbefore="MonoDevelop.WebReferences.WebReferenceCommands.Add" />
 		</Condition>

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.addin.xml
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.addin.xml
@@ -38,8 +38,9 @@
 
 	<Extension path = "/MonoDevelop/Ide/ContextMenu/ProjectPad/Add">
 		<Condition id="ItemType" value="DotNetProject">
-			<SeparatorItem insertafter = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles" />
-			<CommandItem id = "MonoDevelop.WebReferences.WebReferenceCommands.Add"/>
+			<CommandItem id = "MonoDevelop.WebReferences.WebReferenceCommands.Add"
+						 insertafter = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"/>
+			<SeparatorItem/>
 		</Condition>
 	</Extension>
 

--- a/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.addin.xml
+++ b/main/src/addins/MonoDevelop.WebReferences/MonoDevelop.WebReferences.addin.xml
@@ -39,6 +39,7 @@
 	<Extension path = "/MonoDevelop/Ide/ContextMenu/ProjectPad/Add">
 		<Condition id="ItemType" value="DotNetProject">
 			<CommandItem id = "MonoDevelop.WebReferences.WebReferenceCommands.Add"
+						 _label = "Web Reference..."
 						 insertafter = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"/>
 			<SeparatorItem/>
 		</Condition>

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -239,7 +239,7 @@
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 			_description = "Add and remove project references"
 			icon = "md-reference"
-			_label = "_Edit References..."
+			_label = "_Add References..."
 			defaultHandler = "MonoDevelop.Ide.Commands.EditReferencesHandler" />
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewFiles"
 			_label = "New _File..."

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -239,7 +239,7 @@
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 			_description = "Add and remove project references"
 			icon = "md-reference"
-			_label = "_Add References..."
+			_label = "_Add Reference..."
 			defaultHandler = "MonoDevelop.Ide.Commands.EditReferencesHandler" />
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewFiles"
 			_label = "New _File..."

--- a/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.SelectReferenceDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/Gui/MonoDevelop.Ide.Projects.SelectReferenceDialog.cs
@@ -40,7 +40,7 @@ namespace MonoDevelop.Ide.Projects
 			this.WidthRequest = 640;
 			this.HeightRequest = 520;
 			this.Name = "MonoDevelop.Ide.Projects.SelectReferenceDialog";
-			this.Title = global::Mono.Unix.Catalog.GetString ("Edit References");
+			this.Title = global::Mono.Unix.Catalog.GetString ("References");
 			this.TypeHint = ((global::Gdk.WindowTypeHint)(1));
 			this.BorderWidth = ((uint)(6));
 			this.DestroyWithParent = true;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -83,9 +83,12 @@
 				</Condition>
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles" />
 		</Condition>
-		<Condition id="ItemType" value="Project|ProjectFolder">
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
+		<Condition id="ItemType" value="Project">
+				<SeparatorItem/>
+				<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 						 _label = "Add Reference..."/>
+		</Condition>
+		<Condition id="ItemType" value="Project|ProjectFolder">
 			<SeparatorItem/>
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFilesFromFolder" />
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddExistingFolder" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -84,6 +84,8 @@
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles" />
 		</Condition>
 		<Condition id="ItemType" value="Project|ProjectFolder">
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
+						 _label = "Add Reference..."/>
 			<SeparatorItem/>
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFilesFromFolder" />
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddExistingFolder" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -66,33 +66,33 @@
 	<SeparatorItem id = "AddSectionStart" />
 	<ItemSet id = "Add" _label = "_Add" autohide="True">
 		<Condition id="ItemType" value="Workspace">
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewSolution" />
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewWorkspace" />
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddItem" />
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewSolution" _label = "New Solution..."/>
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewWorkspace" _label = "New Workspace..."/>
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddItem" _label = "Existing _Item..."/>
 		</Condition>
 		<Condition id="ItemType" value="Solution|SolutionFolder">
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewProject" />
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddProject" />
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewProject"  _label = "New Project..."/>
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddProject" _label = "Existing _Project..."/>
 			<SeparatorItem id = "Separator1" />
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddSolutionFolder" />
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddSolutionFolder" _label ="Solution _Folder"/>
 		</Condition>
 		<Condition id="ItemType" value="Project|ProjectFolder|Solution|SolutionFolder">
 			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddNewFiles" />
 				<Condition id="ItemType" value="Project|ProjectFolder">
 					<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddEmptyClass" />
 				</Condition>
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles" />
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFiles" _label = "Existing Files..."/>
 		</Condition>
 		<Condition id="ItemType" value="Project">
 				<SeparatorItem/>
 				<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
-						 _label = "Add Reference..."/>
+						 _label = "Reference..."/>
 		</Condition>
 		<Condition id="ItemType" value="Project|ProjectFolder">
 			<SeparatorItem/>
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFilesFromFolder" />
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddExistingFolder" />
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.NewFolder" />
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddFilesFromFolder" _label = "Files from Folder..."/>
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.AddExistingFolder" _label = "Existing Folder..."/>
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.NewFolder"/>
 		</Condition>
 	</ItemSet>
 	<Condition id="ItemType" value="ProjectReferenceCollection">


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/947128/

Fixes VSTS #974919  - Change "Add" to "Add Reference," Remove "Add" in front of items in Add menu 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/974919

Fixes VSTS #975256 - Change title of window from "Edit References" to "References"
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/975256

Screenshots:

<img width="306" alt="AddSubMenu" src="https://user-images.githubusercontent.com/372361/64247006-d8c3af80-cf05-11e9-9bb0-b28f3d8a9b93.png">
<img width="147" alt="ReferencesContextMenu" src="https://user-images.githubusercontent.com/372361/64247013-dc573680-cf05-11e9-9dbf-9ea8f5eda63c.png">
<img width="167" alt="AddReferencesDependenciesMenu" src="https://user-images.githubusercontent.com/372361/64247054-f09b3380-cf05-11e9-865e-f2b79f9ed9bc.png">
<img width="444" alt="ReferencesDialog" src="https://user-images.githubusercontent.com/372361/64247018-dfeabd80-cf05-11e9-8481-48ca129dfbdc.png">
<img width="137" alt="ProjectMainMenu" src="https://user-images.githubusercontent.com/372361/64247028-e1b48100-cf05-11e9-92a3-029706e00ed0.png">
