### PR TITLE
[release-8.3] Bug 963968: Avoid deleting user content by accident (svn checkout, maybe others)

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1609,11 +1609,16 @@ namespace MonoDevelop.VersionControl.Git
 							await RevertAsync (path, true, monitor);
 						}
 					}
-				} else {
-					// Untracked files are not deleted by the rm command, so delete them now
-					foreach (var f in localPaths)
-						if (Directory.Exists (f))
-							Directory.Delete (f, true);
+				}
+			}
+
+			if (!keepLocal) {
+				// Untracked files are not deleted by the rm command, so delete them now
+				foreach (var f in localPaths) {
+					if (Directory.Exists (f)) {
+						FileService.AssertCanDeleteDirectory (f, this.RootPath);
+						Directory.Delete (f, true);
+					}
 				}
 			}
 		}
@@ -1625,8 +1630,10 @@ namespace MonoDevelop.VersionControl.Git
 					foreach (var f in localPaths) {
 						if (File.Exists (f))
 							File.Delete (f);
-						else if (Directory.Exists (f))
+						else if (Directory.Exists (f)) {
+							FileService.AssertCanDeleteDirectory (f, RootPath);
 							Directory.Delete (f, true);
+						}
 					}
 
 				RunBlockingOperation (() => {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Unix/MonoDevelop.VersionControl.Subversion.Unix/SvnClient.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion.Unix/MonoDevelop.VersionControl.Subversion.Unix/SvnClient.cs
@@ -804,18 +804,19 @@ namespace MonoDevelop.VersionControl.Subversion.Unix
 			
 			nb = new notify_baton ();
 			IntPtr localpool = IntPtr.Zero;
+			string npath = null;
 			try {
 				localpool = TryStartOperation (monitor);
 				// Using Uri here because the normalization method doesn't remove the redundant port number when using https
 				url = NormalizePath (new Uri(url).ToString(), localpool);
-				string npath = NormalizePath (path, localpool);
+				npath = NormalizePath (path, localpool);
 				CheckError (svn.client_checkout (IntPtr.Zero, url, npath, ref rev, recurse, ctx, localpool));
 			} catch (SubversionException e) {
 				if (e.ErrorCode != 200015)
 					throw;
 
-				if (Directory.Exists (path.ParentDirectory))
-					FileService.DeleteDirectory (path.ParentDirectory);
+				if (npath != null && Directory.Exists (npath))
+					FileService.DeleteDirectory (npath);
 			} finally {
 				TryEndOperation (localpool);
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/MonoDevelop.VersionControl.Subversion/SubversionRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/MonoDevelop.VersionControl.Subversion/SubversionRepository.cs
@@ -515,6 +515,9 @@ namespace MonoDevelop.VersionControl.Subversion
 		protected override async Task OnDeleteDirectoriesAsync (FilePath[] localPaths, bool force, ProgressMonitor monitor, bool keepLocal)
 		{
 			foreach (string path in localPaths) {
+				if (!keepLocal)
+					FileService.AssertCanDeleteDirectory (path, RootPath);
+
 				if (await IsVersionedAsync (path, monitor.CancellationToken)) {
 					string newPath = String.Empty;
 					if (keepLocal) {
@@ -535,8 +538,9 @@ namespace MonoDevelop.VersionControl.Subversion
 								await RevertAsync (path, false, monitor);
 							}
 						}
-					} else
+					} else {
 						Directory.Delete (path, true);
+					}
 				}
 			}
 		}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -782,9 +782,13 @@ namespace MonoDevelop.VersionControl
 					LoggingService.LogError ("Failed to delete directory", e);
 					metadata.SetFailure ();
 					if (!keepLocal)
-						foreach (var path in localPaths) {
-							FileService.AssertCanDeleteDirectory (path, RootPath);
-							Directory.Delete (path, true);
+						try {
+							foreach (var path in localPaths) {
+								FileService.AssertCanDeleteDirectory (path, RootPath);
+								Directory.Delete (path, true);
+							}
+						} catch (Exception e2) {
+							LoggingService.LogInternalError (e2);
 						}
 				}
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -782,8 +782,10 @@ namespace MonoDevelop.VersionControl
 					LoggingService.LogError ("Failed to delete directory", e);
 					metadata.SetFailure ();
 					if (!keepLocal)
-						foreach (var path in localPaths)
+						foreach (var path in localPaths) {
+							FileService.AssertCanDeleteDirectory (path, RootPath);
 							Directory.Delete (path, true);
+						}
 				}
 			}
 			ClearCachedVersionInfo (localPaths);

--- a/main/src/addins/VersionControl/Subversion.Win32/SvnSharpClient.cs
+++ b/main/src/addins/VersionControl/Subversion.Win32/SvnSharpClient.cs
@@ -251,8 +251,8 @@ namespace SubversionAddinWindows
 				try {
 					client.CheckOut (new SvnUriTarget (url, GetRevision (rev)), path, args);
 				} catch (SvnOperationCanceledException) {
-					if (Directory.Exists (path.ParentDirectory))
-						FileService.DeleteDirectory (path.ParentDirectory);
+					if (Directory.Exists (path))
+						FileService.DeleteDirectory (path);
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -204,12 +204,14 @@ namespace MonoDevelop.Core
 		public bool IsChildPathOf (FilePath basePath)
 		{
 			bool startsWith = fileName.StartsWith (basePath.fileName, PathComparison);
-			if (startsWith && basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar) {
+			
+			if (startsWith && (basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar ||
+				basePath.fileName [basePath.fileName.Length - 1] != Path.AltDirectorySeparatorChar)) {
 				// If the last character isn't a path separator character, check whether the string we're searching in
 				// has more characters than the string we're looking for then check the character.
 				// Otherwise, if the path lengths are equal, we return false.
 				if (fileName.Length > basePath.fileName.Length)
-					startsWith &= fileName [basePath.fileName.Length] == Path.DirectorySeparatorChar;
+					startsWith &= fileName [basePath.fileName.Length] == Path.DirectorySeparatorChar || fileName [basePath.fileName.Length] == Path.AltDirectorySeparatorChar;
 				else
 					startsWith = false;
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FilePath.cs
@@ -205,7 +205,7 @@ namespace MonoDevelop.Core
 		{
 			bool startsWith = fileName.StartsWith (basePath.fileName, PathComparison);
 			
-			if (startsWith && (basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar ||
+			if (startsWith && (basePath.fileName [basePath.fileName.Length - 1] != Path.DirectorySeparatorChar &&
 				basePath.fileName [basePath.fileName.Length - 1] != Path.AltDirectorySeparatorChar)) {
 				// If the last character isn't a path separator character, check whether the string we're searching in
 				// has more characters than the string we're looking for then check the character.

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -191,8 +191,9 @@ namespace MonoDevelop.Core
 		/// </summary>
 		/// <param name="path">The path to be checked.</param>
 		/// <param name="requiredParentDirectory">optional parameter that specifies a required parent of the path.</param>
+		/// <param name="includingParent">if true, requiredParentDirectory can be deleted.</param>
 		/// <exception cref="InvalidOperationException">Is thrown when the directory can't be safely deleted.</exception>
-		public static void AssertCanDeleteDirectory (FilePath path, string requiredParentDirectory = null, bool canDeleteParent = true)
+		public static void AssertCanDeleteDirectory (FilePath path, string requiredParentDirectory = null, bool includingParent = true)
 		{
 			path = path.FullPath.CanonicalPath;
 			if (lockedDirectories.Contains (path)) {
@@ -206,7 +207,7 @@ namespace MonoDevelop.Core
 
 			if (requiredParentDirectory != null) {
 				var parent = ((FilePath)requiredParentDirectory).FullPath.CanonicalPath;
-				if (!canDeleteParent && parent == path)
+				if (!includingParent && parent == path)
 					throw new InvalidOperationException ("Can't delete parent path" + path);
 				if (!path.IsChildPathOf (parent) && parent != path)
 					throw new InvalidOperationException (path + " needs to be child of " + requiredParentDirectory);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/FileService.cs
@@ -192,7 +192,7 @@ namespace MonoDevelop.Core
 		/// <param name="path">The path to be checked.</param>
 		/// <param name="requiredParentDirectory">optional parameter that specifies a required parent of the path.</param>
 		/// <exception cref="InvalidOperationException">Is thrown when the directory can't be safely deleted.</exception>
-		public static void AssertCanDeleteDirectory (FilePath path, string requiredParentDirectory = null)
+		public static void AssertCanDeleteDirectory (FilePath path, string requiredParentDirectory = null, bool canDeleteParent = true)
 		{
 			path = path.FullPath.CanonicalPath;
 			if (lockedDirectories.Contains (path)) {
@@ -206,7 +206,9 @@ namespace MonoDevelop.Core
 
 			if (requiredParentDirectory != null) {
 				var parent = ((FilePath)requiredParentDirectory).FullPath.CanonicalPath;
-				if (!parent.IsChildPathOf (path))
+				if (!canDeleteParent && parent == path)
+					throw new InvalidOperationException ("Can't delete parent path" + path);
+				if (!path.IsChildPathOf (parent) && parent != path)
 					throw new InvalidOperationException (path + " needs to be child of " + requiredParentDirectory);
 			}
 		}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/FilePathTests.cs
@@ -108,6 +108,10 @@ namespace MonoDevelop.Core
 			child = parent.Combine ("child");
 			Assert.IsTrue (child.IsChildPathOf (parent));
 
+			// Alternative trailing directory char.
+			parent = FilePath.Build ("base" + Path.AltDirectorySeparatorChar);
+			Assert.IsTrue (child.IsChildPathOf (parent));
+
 			// https://bugzilla.xamarin.com/show_bug.cgi?id=48212
 			Assert.IsFalse (child.IsChildPathOf (child));
 		}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileServiceTests.cs
@@ -194,13 +194,16 @@ namespace MonoDevelop.Projects
 		public void CantDeleteSystemFolders ()
 		{
 			FileService.AssertCanDeleteDirectory (Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData));
+			FileService.AssertCanDeleteDirectory (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments));
+			FileService.AssertCanDeleteDirectory (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 		}
 
 		[Test]
 		[ExpectedException (typeof (InvalidOperationException))]
-		public void CantDeleteLogicalDrive ()
+		public void CantDeleteRoot ()
 		{
-			FileService.AssertCanDeleteDirectory (Directory.GetLogicalDrives () [0]);
+			string root = Platform.IsWindows ? "C:" : "/";
+			FileService.AssertCanDeleteDirectory (root);
 		}
 	}
 }

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileServiceTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/FileServiceTests.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using MonoDevelop.Core;
@@ -176,6 +177,30 @@ namespace MonoDevelop.Projects
 		void OnFileChanged (object sender, FileEventArgs e)
 		{
 			fileChangeEvents.Add (e);
+		}
+
+		[TestCase ("base/child", "base", true)]
+		[TestCase ("/foo", "/foo", true)]
+		[TestCase ("/foo", "/foo", false, ExpectedException = typeof (InvalidOperationException))]
+		[TestCase ("/path/to/child", "/path/to", true)]
+		[TestCase ("base", "other", true, ExpectedException = typeof (InvalidOperationException))]
+		public void CanDeleteFolderWithBaseCheckWorks (string path, string requiredParentDirectory, bool canDeleteParent = true)
+		{
+			FileService.AssertCanDeleteDirectory (path, requiredParentDirectory, canDeleteParent);
+		}
+
+		[Test]
+		[ExpectedException (typeof (InvalidOperationException))]
+		public void CantDeleteSystemFolders ()
+		{
+			FileService.AssertCanDeleteDirectory (Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData));
+		}
+
+		[Test]
+		[ExpectedException (typeof (InvalidOperationException))]
+		public void CantDeleteLogicalDrive ()
+		{
+			FileService.AssertCanDeleteDirectory (Directory.GetLogicalDrives () [0]);
 		}
 	}
 }


### PR DESCRIPTION
Added an insanity check that FileService.DeleteDirectory never tries to delete a system directory.

Fixes VSTS #963968

Backport of #8368.

/cc @mkrueger 