### PR TITLE
[release-8.3] [NuGet] Use different command ids for manage packages commands

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -22,13 +22,13 @@
 			_label = "Add NuGet _Packages..."
 			defaultHandler = "MonoDevelop.PackageManagement.Commands.AddPackagesHandler" />
 		<Command
-			id="MonoDevelop.PackageManagement.Commands.ManagePackages"
+			id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackages"
 			_description="Manage packages for the solution"
 			_label="_Manage NuGet Packages..."
 			_displayName="Manage Packages (Solution)"
 			defaultHandler="MonoDevelop.PackageManagement.ManagePackagesHandler" />
 		<Command
-			id="MonoDevelop.PackageManagement.Commands.ManagePackagesInProject"
+			id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackagesInProject"
 			_description="Manage packages for the project"
 			_label="_Manage NuGet Packages..."
 			_displayName="Manage Packages"
@@ -77,7 +77,7 @@
 	
 	<Extension path="/MonoDevelop/Ide/MainMenu/Project">
 		<SeparatorItem insertafter="MonoDevelop.Ide.Commands.ProjectCommands.AddReference" />
-		<CommandItem id="MonoDevelop.PackageManagement.Commands.ManagePackages" />
+		<CommandItem id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackages" />
 		<CommandItem id="MonoDevelop.PackageManagement.Commands.UpdateAllPackagesInSolution" />
 		<CommandItem id="MonoDevelop.PackageManagement.Commands.RestorePackages" />
 		<SeparatorItem />
@@ -90,12 +90,12 @@
 				insertafter="MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 				insertbefore="AddSectionEnd" />
 			<CommandItem
-				id="MonoDevelop.PackageManagement.Commands.ManagePackages"
+				id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackages"
 				insertafter="MonoDevelop.PackageManagement.ProjectPad.Separator"
 				insertbefore="AddSectionEnd" />
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.UpdateAllPackagesInSolution"
-				insertafter="MonoDevelop.PackageManagement.Commands.ManagePackagese"
+				insertafter="MonoDevelop.PackageManagement.Commands.ManageNuGetPackages"
 				insertbefore="AddSectionEnd" />
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.RestorePackages"
@@ -108,13 +108,13 @@
 				insertafter="MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
 				insertbefore="AddSectionEnd" />
 			<CommandItem
-				id="MonoDevelop.PackageManagement.Commands.ManagePackagesInProject"
+				id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackagesInProject"
 				insertafter="MonoDevelop.PackageManagement.ProjectPad.Separator"
 				insertbefore="AddSectionEnd" />
 		</Condition>
 		<Condition id="ItemType" value="MonoDevelop.PackageManagement.NodeBuilders.ProjectPackagesFolderNode">
 			<CommandItem
-				id="MonoDevelop.PackageManagement.Commands.ManagePackagesInProject" />
+				id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackagesInProject" />
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.PackagesFolderNodeCommands.ReinstallAllPackagesInProject" />
 			<CommandItem


### PR DESCRIPTION
Using the same command ids as those in the separate NuGet extensions
addin can cause odd behaviour if an old NuGet extensions addin is
disabled in the IDE. This can result in the Manage NuGet Packages
not being shown on the Solution window's context menu.

Backport of #8416.

/cc @mrward 