### PR TITLE
[Ide] Fix various leaks causing retention of document model and autotest objects

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkTreeModelResult.cs
@@ -149,7 +149,8 @@ namespace MonoDevelop.Components.AutoTest.Results
 			TreeIter currentIter = (TreeIter) resultIter;
 
 			while (TModel.IterNext (ref currentIter)) {
-				newList.Add (new GtkTreeModelResult (ParentWidget, TModel, Column, currentIter) { SourceQuery = this.SourceQuery });
+				var result = DisposeWithResult (new GtkTreeModelResult (ParentWidget, TModel, Column, currentIter) { SourceQuery = this.SourceQuery });
+				newList.Add (result);
 			}
 
 			return newList;
@@ -188,6 +189,8 @@ namespace MonoDevelop.Components.AutoTest.Results
 						}
 					}
 				}
+
+				DisposeWithResult (FirstChild);
 				return children;
 			}
 
@@ -225,6 +228,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 				}
 			}
 			result.FirstChild = newList.FirstOrDefault ();
+			DisposeWithResult (result.FirstChild);
 			return newList;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/GtkWidgetResult.cs
@@ -93,7 +93,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 		public override AppResult CheckType (Type desiredType)
 		{
 			if (desiredType.IsInstanceOfType (resultWidget)) {
-				return desiredType == typeof(Notebook) ? new GtkNotebookResult (resultWidget) : this;
+				return desiredType == typeof(Notebook) ? DisposeWithResult (new GtkNotebookResult (resultWidget)) : this;
 			}
 
 			return null;
@@ -175,12 +175,12 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 
 			if (column == null) {
-				return new GtkTreeModelResult (resultWidget, model, 0) { SourceQuery = this.SourceQuery };
+				return DisposeWithResult (new GtkTreeModelResult (resultWidget, model, 0) { SourceQuery = this.SourceQuery });
 			}
 
 			// Check if the class has the SemanticModelAttribute
 			var columnNumber = GetColumnNumber (column, model);
-			return columnNumber == -1 ? null : new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery };
+			return columnNumber == -1 ? null : DisposeWithResult (new GtkTreeModelResult (resultWidget, model, columnNumber) { SourceQuery = this.SourceQuery });
 		}
 
 		protected int GetColumnNumber (string column, TreeModel model)
@@ -231,7 +231,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 					continue;
 				}
 
-				siblingResults.Add (new GtkWidgetResult (child) { SourceQuery = this.SourceQuery });
+				siblingResults.Add (DisposeWithResult (new GtkWidgetResult (child) { SourceQuery = this.SourceQuery }));
 			}
 
 			return siblingResults;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -196,7 +196,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 				var children = new List<AppResult> ();
 				for (int i = 0; i < control.RowCount; i++) {
 					LoggingService.LogInfo ($"Found row {i} of NSTableView -  {control.Identifier} - {control.AccessibilityIdentifier}");
-					children.Add (new NSObjectResult (control, i));
+					children.Add (DisposeWithResult (new NSObjectResult (control, i)));
 				}
 				return children;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/WebViewResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/WebViewResult.cs
@@ -100,7 +100,8 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 			DomElement nextSibling = node.NextElementSibling;
 			while (nextSibling != null) {
-				results.Add (new WebViewResult (nextSibling) { SourceQuery = SourceQuery });
+				var result = DisposeWithResult (new WebViewResult (nextSibling) { SourceQuery = SourceQuery });
+				results.Add (result);
 				nextSibling = nextSibling.NextElementSibling;
 			}
 
@@ -114,7 +115,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 				props.Add (attr.Name, new ObjectResult (attr.NodeValue), null);
 			}
 
-			return props;
+			return DisposeWithResult (props);
 		}
 
 		public override AppResult Property (string propertyName, object value)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest/AppResult.cs
@@ -40,6 +40,7 @@ namespace MonoDevelop.Components.AutoTest
 	{
 		//public Gtk.Widget ResultWidget { get; private set; }
 
+		List<IDisposable> itemsToDispose;
 		public AppResult ParentNode { get; set; }
 		public AppResult FirstChild { get; set; }
 		public AppResult PreviousSibling { get; set; }
@@ -197,7 +198,7 @@ namespace MonoDevelop.Components.AutoTest
 				}
 			}
 
-			return propertiesObject;
+			return DisposeWithResult (propertiesObject);
 		}
 
 		protected AppResult MatchProperty (string propertyName, object objectToCompare, object value)
@@ -244,8 +245,22 @@ namespace MonoDevelop.Components.AutoTest
 			NextSibling?.Dispose ();
 
 			FirstChild = NextSibling = ParentNode = PreviousSibling = null;
+
+			if (itemsToDispose != null) {
+				foreach (var properties in itemsToDispose) {
+					properties.Dispose ();
+				}
+				itemsToDispose = null;
+			}
 		}
 
 		public override object InitializeLifetimeService () => null;
+
+		protected T DisposeWithResult<T> (T item) where T:MarshalByRefObject, IDisposable
+		{
+			itemsToDispose ??= new List<IDisposable> ();
+			itemsToDispose.Add (item);
+			return item;
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDLinkMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDLinkMenuItem.cs
@@ -40,14 +40,13 @@ namespace MonoDevelop.Components.Mac
 			this.lce = lce;
 			this.Title = lce.Text;
 
-			Target = this;
-			Action = MDMenuItem.ActionSel;
+			Activated += MDLinkMenuItem_Activated;
 		}
 
-		[Export (MDMenuItem.ActionSelName)]
-		public void Run (NSObject dummy)
+		static void MDLinkMenuItem_Activated (object sender, System.EventArgs e)
 		{
-			MonoDevelop.Ide.IdeServices.DesktopService.ShowUrl (lce.Url);
+			if (sender is MDLinkMenuItem linkMenuItem)
+			MonoDevelop.Ide.IdeServices.DesktopService.ShowUrl (linkMenuItem.lce.Url);
 		}
 
 		public void Update (MDMenu parent, ref int index)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDLinkMenuItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/MDLinkMenuItem.cs
@@ -45,8 +45,9 @@ namespace MonoDevelop.Components.Mac
 
 		static void MDLinkMenuItem_Activated (object sender, System.EventArgs e)
 		{
-			if (sender is MDLinkMenuItem linkMenuItem)
-			MonoDevelop.Ide.IdeServices.DesktopService.ShowUrl (linkMenuItem.lce.Url);
+			if (sender is MDLinkMenuItem linkMenuItem) {
+				MonoDevelop.Ide.IdeServices.DesktopService.ShowUrl (linkMenuItem.lce.Url);
+			}
 		}
 
 		public void Update (MDMenu parent, ref int index)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -473,20 +473,19 @@ namespace MonoDevelop.Ide.Gui.Documents
 			if (mainShellView != null) {
 				mainShellView.GotFocus -= ShellContentView_GotFocus;
 				mainShellView.LostFocus -= ShellContentView_LostFocus;
+				mainShellView = null;
 			}
-			AttachedViews.DetachListener ();
+			if (attachmentsContainer != null) {
+				attachmentsContainer.ActiveViewChanged -= AttachmentsContainer_ActiveViewChanged;
+				attachmentsContainer = null;
+			}
 
 			IsRoot = false;
 			window = null;
-			shellView = null;
 		}
 
 		protected virtual void OnDispose ()
 		{
-			foreach (var c in AttachedViews.ToList ())
-				c.Dispose ();
-			AttachedViews.Clear ();
-
 			if (Parent != null) {
 				Parent.RemoveChild (this);
 				Parent = null;
@@ -496,6 +495,10 @@ namespace MonoDevelop.Ide.Gui.Documents
 				shellView.Dispose ();
 				shellView = null;
 			}
+
+			foreach (var c in AttachedViews.ToList ())
+				c.Dispose ();
+			AttachedViews.Clear ();
 
 			// If this view was created by a controller, dispose the controller here too.
 			SourceController?.Dispose ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -474,6 +474,8 @@ namespace MonoDevelop.Ide.Gui.Documents
 				mainShellView.GotFocus -= ShellContentView_GotFocus;
 				mainShellView.LostFocus -= ShellContentView_LostFocus;
 			}
+			AttachedViews.DetachListener ();
+
 			IsRoot = false;
 			window = null;
 			shellView = null;
@@ -481,12 +483,19 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		protected virtual void OnDispose ()
 		{
-			if (Parent != null)
+			foreach (var c in AttachedViews.ToList ())
+				c.Dispose ();
+			AttachedViews.Clear ();
+
+			if (Parent != null) {
 				Parent.RemoveChild (this);
-			else if (IsRoot)
+				Parent = null;
+			} else if (IsRoot)
 				throw new InvalidOperationException ("Can't dispose the root view of a document");
-			if (shellView != null)
+			if (shellView != null) {
 				shellView.Dispose ();
+				shellView = null;
+			}
 
 			// If this view was created by a controller, dispose the controller here too.
 			SourceController?.Dispose ();
@@ -494,6 +503,9 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		internal virtual void OnClosed ()
 		{
+			foreach (var c in AttachedViews.ToList ())
+				c.Close ();
+
 			// If this view was created by a controller, dispose the controller here too.
 			SourceController?.Close ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentViewContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentViewContainer.cs
@@ -289,6 +289,8 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			foreach (var c in Views.ToList ())
 				c.Dispose ();
+			Views.Clear ();
+
 			base.OnDispose ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainer.cs
@@ -265,8 +265,10 @@ namespace MonoDevelop.Ide.Gui.Shell
 
 		public override void DetachFromView ()
 		{
-			foreach (var child in GetAllViews ())
+			foreach (var child in GetAllViews ()) {
 				child.DetachFromView ();
+			}
+			RemoveAllViews ();
 			base.DetachFromView ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerTabs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerTabs.cs
@@ -37,14 +37,13 @@ namespace MonoDevelop.Ide.Gui.Shell
 		EventBox notebook;
 		Tabstrip tabstrip;
 		VBox rootTabsBox;
-		HBox bottomBarBox;
 
 		public GtkShellDocumentViewContainerTabs ()
 		{
 			rootTabsBox = new VBox ();
 			rootTabsBox.Accessible.SetShouldIgnore (true);
 
-			bottomBarBox = new HBox (false, 0);
+			var bottomBarBox = new HBox (false, 0);
 			bottomBarBox.Show ();
 			rootTabsBox.PackEnd (bottomBarBox, false, false, 0);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContent.cs
@@ -141,8 +141,9 @@ namespace MonoDevelop.Ide.Gui.Shell
 
 		public void HidePathBar ()
 		{
+			DetachPathedDocument ();
+
 			if (pathBar != null) {
-				DetachPathedDocument ();
 				box.Remove (pathBar);
 				pathBar.Destroy ();
 				pathBar = null;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContent.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContent.cs
@@ -164,6 +164,7 @@ namespace MonoDevelop.Ide.Gui.Shell
 
 		public override void DetachFromView ()
 		{
+			HidePathBar ();
 			if (viewControl != null) {
 				box.Remove (viewControl);
 				viewControl = null;

--- a/main/tests/Ide.Tests/MonoDevelop.Components.AutoTest/AppResultTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Components.AutoTest/AppResultTests.cs
@@ -1,0 +1,75 @@
+//
+// AppResultTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace MonoDevelop.Components.AutoTest
+{
+	[TestFixture]
+	public class AppResultTests
+	{
+		[Test]
+		public void TestDisposeCount()
+		{
+			var a = new MockResult ("a");
+			var b = (MockResult)(a.FirstChild = new MockResult("b"));
+			var c = (MockResult)(a.FirstChild.FirstChild = new MockResult ("b"));
+			var d = (MockResult)(a.FirstChild.NextSibling = new MockResult ("c"));
+
+			var aProperties = a.Properties ();
+			var dProperties = d.Properties ();
+
+			var prop = aProperties ["ToString"];
+			Assert.AreEqual ("a", prop.ToString ());
+
+			a.Dispose ();
+
+			Assert.AreEqual (1, a.DisposeCount);
+			Assert.AreEqual (1, b.DisposeCount);
+			Assert.AreEqual (1, c.DisposeCount);
+			Assert.AreEqual (1, d.DisposeCount);
+			Assert.AreEqual ("null", prop.ToString ());
+
+			Assert.Throws<NullReferenceException> (() => _ = aProperties ["ToString"]);
+			Assert.Throws<NullReferenceException> (() => _ = dProperties ["ToString"]);
+		}
+
+		class MockResult : Results.ObjectResult
+		{
+			public int DisposeCount;
+
+			public MockResult (object value) : base (value)
+			{
+			}
+
+			protected override void Dispose (bool disposing)
+			{
+				DisposeCount++;
+				base.Dispose (disposing);
+			}
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentControllerTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentControllerTests.cs
@@ -64,12 +64,14 @@ namespace MonoDevelop.Ide.Gui.Documents
 			Assert.IsNotNull (controller.Child2);
 			Assert.IsNull (controller.Child1.Control);
 			Assert.IsNull (controller.Child2.Control);
+			Assert.IsNull (controller.Attached.Control);
 
 			Assert.AreEqual (1, shell.Windows.Count);
 			await shell.Windows [0].RootView.Show ();
 
 			Assert.IsNotNull (controller.Child1.Control);
 			Assert.IsNotNull (controller.Child2.Control);
+			Assert.IsNotNull (controller.Attached.Control);
 
 			await doc.Close (true);
 
@@ -78,6 +80,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 			Assert.AreEqual (1, controller.Child2.DisposeCount);
 			Assert.AreEqual (1, controller.Child1.Control.DisposeCount);
 			Assert.AreEqual (1, controller.Child2.Control.DisposeCount);
+			Assert.AreEqual (1, controller.Attached.Control.DisposeCount);
 		}
 
 		static object [] LoadControllers = {
@@ -420,6 +423,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 		public ChildDisposableTestController Child1 { get; set; }
 		public ChildDisposableTestController Child2 { get; set; }
+		public ChildDisposableTestController Attached { get; set; }
 
 		protected override void OnDispose ()
 		{
@@ -440,6 +444,11 @@ namespace MonoDevelop.Ide.Gui.Documents
 			await Child2.Initialize (new ModelDescriptor ());
 			var view2 = await Child2.GetDocumentView ();
 			container.Views.Add (view2);
+
+			Attached = new ChildDisposableTestController ();
+			await Attached.Initialize (new ModelDescriptor ());
+			var viewAttached = await Attached.GetDocumentView ();
+			container.AttachedViews.Add (viewAttached);
 
 			return container;
 		}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="MonoDevelop.Ide.Composition\CompositionManagerTests.cs" />
     <Compile Include="MonoDevelop.Ide.Gui\GLibLoggingTests.cs" />
     <Compile Include="MonoDevelop.Ide.Projects.OptionPanels\OutputOptionsPanelTests.cs" />
+    <Compile Include="MonoDevelop.Components.AutoTest\AppResultTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
@@ -198,6 +199,7 @@
     <Folder Include="MonoDevelop.Ide.Gui.DocumentModels\" />
     <Folder Include="MonoDevelop.Ide.Gui.Documents\" />
     <Folder Include="MonoDevelop.Ide.Projects.OptionPanels\" />
+    <Folder Include="MonoDevelop.Components.AutoTest\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Fixes VSTS #964955 - ObjectProperties are leaked due in AutoTest service
Fixes VSTS #965064 - GtkShellDocumentView is not properly disposed