### PR TITLE
[release-8.3] Fixes VSTS Bug 958225: System.NullReferenceException exception in

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/HighlightUrlExtension.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Extension/HighlightUrlExtension.cs
@@ -91,7 +91,7 @@ namespace MonoDevelop.Ide.Editor.Extension
 				cts = new CancellationTokenSource ();
 				src [lineOffset] = cts;
 				var token = cts.Token;
-				RunUpdateTask (input, startLine, endOffset, token);
+				RunUpdateTask (input, startLine, endOffset, Editor.Version, token);
 			}
 		}
 
@@ -100,10 +100,10 @@ namespace MonoDevelop.Ide.Editor.Extension
 			updateAllSrc.Cancel ();
 			DisposeUrlTextMarker ();
 			updateAllSrc = new CancellationTokenSource ();
-			updateAllTask = RunUpdateTask (Editor.CreateSnapshot (), Editor.GetLine (1), Editor.Length, updateAllSrc.Token);
+			updateAllTask = RunUpdateTask (Editor.CreateSnapshot (), Editor.GetLine (1), Editor.Length, Editor.Version, updateAllSrc.Token);
 		}
 
-		Task RunUpdateTask (ITextSource input, IDocumentLine startLine, int endOffset, CancellationToken token)
+		Task RunUpdateTask (ITextSource input, IDocumentLine startLine, int endOffset, ITextSourceVersion textSourceVersion, CancellationToken token)
 		{
 			return Task.Run (delegate {
 				var matches = new List<(UrlType, Match, IDocumentLine)> ();
@@ -142,6 +142,8 @@ namespace MonoDevelop.Ide.Editor.Extension
 
 				Runtime.RunInMainThread (delegate {
 					if (token.IsCancellationRequested || Editor == null)
+						return;
+					if (textSourceVersion.CompareAge (Editor.Version) != 0)
 						return;
 					line = startLine;
 					while (line != null && line.Offset <= endOffset) {


### PR DESCRIPTION
Mono.TextEditor.UrlMarker.Draw()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958225

I assume LineSegment == null in UrlMarker caused the
NullReferenceException.

Extracted 2 methods out of the Draw method in UrlTextMarker + refactored it a bit.

Backport of #8392.

/cc @mkrueger 