### PR TITLE
[release-8.2] Enable notarization

### DIFF
--- a/main/build/MacOSX/Entitlements.plist
+++ b/main/build/MacOSX/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/main/build/MacOSX/Entitlements.plist
+++ b/main/build/MacOSX/Entitlements.plist
@@ -4,5 +4,11 @@
 <dict>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true />
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true />
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true />
 </dict>
 </plist>

--- a/main/build/MacOSX/Entitlements.plist
+++ b/main/build/MacOSX/Entitlements.plist
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 </dict>
 </plist>

--- a/main/build/MacOSX/Entitlements.plist
+++ b/main/build/MacOSX/Entitlements.plist
@@ -5,10 +5,10 @@
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true />
+	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true />
+	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
-	<true />
+	<true/>
 </dict>
 </plist>

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -27,6 +27,10 @@ EXTRA_DIST = dmg-bg.png DS_Store Info.plist.in make-dmg-bundle.sh render.cs
 MONOSTUB_EXTRA_SOURCEFILES = monostub-utils.h
 export MACOSX_DEPLOYMENT_TARGET=10.12
 
+# With the hardened runtime, we need to specify the location of all libraries
+# that we dlopen
+MONOSTUB_RPATH=-Wl,-rpath,/Library/Frameworks/Mono.framework/Libraries/ -Wl,-rpath,@executable_path/../Resources/lib/monodevelop/bin/
+
 all: monostub monostub-nogui monostub-test
 
 render.exe: render.cs
@@ -42,12 +46,12 @@ monostub-nogui.o: monostub.mm $(MONOSTUB_EXTRA_SOURCEFILES)
 	g++ -g $(HYBRID_SUSPEND_ABORT) -DNOGUI -c -Wall -m$(MONOSTUB_ARCH) -o $@ monostub.mm
 
 monostub: monostub.o $(MONOSTUB_STATIC_LINK)
-	clang++ -g -Wall -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup
+	clang++ -g -Wall -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup $(MONOSTUB_RPATH)
 	mkdir -p ../bin
 	cp $@ ../bin/MonoDevelop
 
 monostub-nogui: monostub-nogui.o $(MONOSTUB_STATIC_LINK)
-	clang++ -g -Wall -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup
+	clang++ -g -Wall -m$(MONOSTUB_ARCH) -o $@ -Wl,-all_load $^ -framework AppKit -framework Quartz -undefined dynamic_lookup $(MONOSTUB_RPATH)
 	mkdir -p ../bin
 	cp $@ ../bin/mdtool
 

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -89,6 +89,7 @@ app: monostub monostub-test
 	cp ../../COPYING $(MAC_APP_DIR)/Contents/MacOS/share/monodevelop/COPYING.LGPL2.1
 
 	sed -e "s/@BUNDLE_VERSION@/$(BUNDLE_VERSION)/" -e "s/@APP_NAME@/$(APP_NAME)/" -e "s/@APP_DISPLAY_NAME@/$(APP_DISPLAY_NAME)/" -e "s|@RELEASE_ID@|$(PACKAGE_UPDATE_ID)|" Info.plist.in > $(MAC_APP_DIR)/Contents/Info.plist
+	cp Entitlements.plist $(MAC_APP_DIR)/Contents/Entitlements.plist
 	cp ../../theme-icons/Mac/*.icns $(MAC_APP_DIR)/Contents/Resources/
 
 # Native launch scripts

--- a/main/build/MacOSX/Makefile.am
+++ b/main/build/MacOSX/Makefile.am
@@ -29,7 +29,16 @@ export MACOSX_DEPLOYMENT_TARGET=10.12
 
 # With the hardened runtime, we need to specify the location of all libraries
 # that we dlopen
-MONOSTUB_RPATH=-Wl,-rpath,/Library/Frameworks/Mono.framework/Libraries/ -Wl,-rpath,@executable_path/../Resources/lib/monodevelop/bin/
+MONOSTUB_RPATH=-Wl,-rpath,/Library/Frameworks/Mono.framework/Libraries/ \
+-Wl,-rpath,@executable_path/../Resources/lib/monodevelop/bin/ \
+-Wl,-rpath,@executable_path/../Resources/lib/ \
+-Wl,-rpath,@executable_path/../Resources/lib/monodevelop/AddIns/DisplayBindings/TextEditor.Cocoa/ \
+-Wl,-rpath,@executable_path/../Resources/lib/monodevelop/AddIns/VersionControl/ \
+-Wl,-rpath,@executable_path/../Resources/lib/monodevelop/AddIns/VersionControl/lib/osx/ \
+-Wl,-rpath,/Library/Developer/CommandLineTools/usr/lib/ \
+-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/ \
+-Wl,-rpath,/usr/lib/ \
+-Wl,-rpath,/usr/local/lib/
 
 all: monostub monostub-nogui monostub-test
 

--- a/main/build/MacOSX/render.cs
+++ b/main/build/MacOSX/render.cs
@@ -7,7 +7,7 @@ class X {
 	{
 		var background = new Bitmap ("dmg-bg.png");
 		var ctx = Graphics.FromImage (background);
-		
+
 		//system.drawing doesn't allow setting the actual font weight
 		//so we can't get it as heavy as we need :/
 		var font = new Font ("Helvetica", 12, FontStyle.Bold);

--- a/version-checks
+++ b/version-checks
@@ -17,8 +17,8 @@ DEP[0]=md-addins
 DEP_NAME[0]=MDADDINS
 DEP_PATH[0]=${top_srcdir}/../md-addins
 DEP_MODULE[0]=git@github.com:xamarin/md-addins.git
-DEP_NEEDED_VERSION[0]=a3fbe9133bfd7d648077d75d16efda053ccabc12
-DEP_BRANCH_AND_REMOTE[0]="release-8.2 origin/release-8.2"
+DEP_NEEDED_VERSION[0]=c5881f802719e665960d0902a1601defcdf943ef
+DEP_BRANCH_AND_REMOTE[0]="release-8.2-enable-notarization origin/release-8.2-enable-notarization"
 
 # heap-shot
 DEP[1]=heap-shot


### PR DESCRIPTION
This puts in the necessary changes to make VSMac function after turning on the hardened runtime flag. There's a corresponding PR in xamarin/md-addins#5177.

This needs to land on both master and the current release branches.

@iainx Can you look over this (I just rebased it on top of this morning's master) and get this merged in. Also, I don't know where the current release branches are, so this needs to be backported there as well.

Backport of #8396 
cc @duncanmak 