### PR TITLE
[release-8.3] Fixes VSTS Bug 962517: [Feedback] Application output window is bigger

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockFrame.cs
@@ -913,6 +913,8 @@ namespace MonoDevelop.Components.Docking
 		
 		internal void AddTopLevel (DockFrameTopLevel w, int x, int y, int width, int height)
 		{
+			ValidateWindowBounds (ref x, ref y, ref width, ref height);
+
 			w.X = x;
 			w.Y = y;
 
@@ -952,7 +954,15 @@ namespace MonoDevelop.Components.Docking
 				topLevels.Add (w);
 			}
 		}
-		
+
+		void ValidateWindowBounds (ref int x, ref int y, ref int w, ref int h)
+		{
+			x = Math.Max (0, x);
+			y = Math.Max (0, y);
+			w = Math.Min (mainBox.Allocation.Width - x, w);
+			h = Math.Min (mainBox.Allocation.Height - y, h);
+		}
+
 		internal void RemoveTopLevel (DockFrameTopLevel w)
 		{
 			w.Unparent ();


### PR DESCRIPTION
than the screen

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/962517

It's easy to reproduce - just make the window big, hover -> make
window small - hover. The validation fixes that issue.

Backport of #8414.

/cc @sevoku @mkrueger