### PR TITLE
[release-8.3] Fixes VSTS Bug 950651: VS4MAc does not handle switching branches well

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -94,7 +94,7 @@ namespace MonoDevelop.VersionControl.Git
 	{
 		protected async override void Run (object dataItem)
 		{
-			await GitService.SwitchToBranch (Repository, (string)dataItem).ConfigureAwait (false);
+			await GitService.SwitchToBranchAsync (Repository, (string)dataItem).ConfigureAwait (false);
 		}
 
 		protected override void Update (CommandArrayInfo info)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -256,7 +256,7 @@ namespace MonoDevelop.VersionControl.Git
 			if (!listBranches.Selection.GetSelected (out it))
 				return;
 			var b = (Branch) storeBranches.GetValue (it, 0);
-			if (await GitService.SwitchToBranch (repo, b.FriendlyName))
+			if (await GitService.SwitchToBranchAsync (repo, b.FriendlyName))
 				FillBranches ();
 		}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1873,15 +1873,14 @@ namespace MonoDevelop.VersionControl.Git
 			return RunSafeOperation (() => RootRepository.Head.FriendlyName);
 		}
 
-		void SwitchBranchInternal (ProgressMonitor monitor, string branch)
+		async Task SwitchBranchInternalAsync (ProgressMonitor monitor, string branch)
 		{
 			int progress = 0;
-			RunBlockingOperation (() => LibGit2Sharp.Commands.Checkout (RootRepository, branch, new CheckoutOptions {
+			await ExclusiveOperationFactory.StartNew (() => LibGit2Sharp.Commands.Checkout (RootRepository, branch, new CheckoutOptions {
 				OnCheckoutProgress = (path, completedSteps, totalSteps) => OnCheckoutProgress (completedSteps, totalSteps, monitor, ref progress),
 				OnCheckoutNotify = (string path, CheckoutNotifyFlags flags) => RefreshFile (path, flags),
 				CheckoutNotifyFlags = refreshFlags,
-			}), true, monitor.CancellationToken);
-			monitor.Step (1);
+			}), monitor.CancellationToken);
 
 			if (GitService.StashUnstashWhenSwitchingBranches) {
 				try {
@@ -1893,14 +1892,14 @@ namespace MonoDevelop.VersionControl.Git
 					monitor.ReportError (GettextCatalog.GetString ("Restoring stash for branch {0} failed", branch), e);
 				}
 			}
-			monitor.Step (1);
 
-			Runtime.RunInMainThread (() => {
+			monitor.Step (1);
+			await Runtime.RunInMainThread (() => {
 				BranchSelectionChanged?.Invoke (this, EventArgs.Empty);
-			}).Ignore ();
+			});
 		}
 
-		public bool SwitchToBranch (ProgressMonitor monitor, string branch)
+		public async Task<bool> SwitchToBranchAsync (ProgressMonitor monitor, string branch)
 		{
 			Signature sig = GetSignature ();
 			Stash stash;
@@ -1913,7 +1912,7 @@ namespace MonoDevelop.VersionControl.Git
 			try {
 				// try to switch without stashing
 				monitor.BeginTask (GettextCatalog.GetString ("Switching to branch {0}", branch), 2);
-				SwitchBranchInternal (monitor, branch);
+				await SwitchBranchInternalAsync (monitor, branch);
 				return true;
 			} catch (CheckoutConflictException ex) {
 				// retry with stashing
@@ -1946,11 +1945,10 @@ namespace MonoDevelop.VersionControl.Git
 				monitor.Step (1);
 
 				try {
-					SwitchBranchInternal (monitor, branch);
+					await SwitchBranchInternalAsync (monitor, branch);
 					return true;
 				} catch (Exception e) {
 					monitor.ReportError (GettextCatalog.GetString ("Switching to branch {0} failed", branch), e);
-				} finally {
 				}
 			} catch (Exception ex) {
 				monitor.ReportError (GettextCatalog.GetString ("Switching to branch {0} failed", branch), ex);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitService.cs
@@ -127,23 +127,20 @@ namespace MonoDevelop.VersionControl.Git
 				MessageService.ShowCustomDialog (dlg);
 		}
 
-		public async static Task<bool> SwitchToBranch (GitRepository repo, string branch)
+		public static async Task<bool> SwitchToBranchAsync (GitRepository repo, string branch)
 		{
 			var monitor = new MessageDialogProgressMonitor (true, false, false, true);
 			try {
 				IdeApp.Workbench.AutoReloadDocuments = true;
 				IdeApp.Workbench.LockGui ();
-				var t = await Task.Run (delegate {
-					try {
-						return repo.SwitchToBranch (monitor, branch);
-					} catch (Exception ex) {
-						monitor.ReportError (GettextCatalog.GetString ("Branch switch failed"), ex);
-						return false;
-					} finally {
-						monitor.Dispose ();
-					}
-				});
-				return t;
+				try {
+					return await repo.SwitchToBranchAsync (monitor, branch);
+				} catch (Exception ex) {
+					monitor.ReportError (GettextCatalog.GetString ("Branch switch failed"), ex);
+					return false;
+				} finally {
+					monitor.Dispose ();
+				}
 			} finally {
 				IdeApp.Workbench.AutoReloadDocuments = false;
 				IdeApp.Workbench.UnlockGui ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
@@ -141,7 +141,7 @@ namespace MonoDevelop.VersionControl.Git
 				try {
 					if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
 						repository.CreateBranchFromCommit (dlg.BranchName, s.Base);
-						if (await GitService.SwitchToBranch (repository, dlg.BranchName))
+						if (await GitService.SwitchToBranchAsync (repository, dlg.BranchName))
 							await ApplyStashAndRemove (stashIndex);
 					}
 				} finally {


### PR DESCRIPTION
Hard to tell what did go wrong for the user which opened the bug request.

I made the switch branch code async and cleaned it up a bit - ThawEvents may've been called too soon by RunBlockingOperation and BranchSelectionChanged is now in sync with the whole operation.

Backport of #8415.

/cc @sevoku @mkrueger