### PR TITLE
[release-8.3] Fix NRE when accessing null ParentSolution property on DotNetCoreProject

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -65,7 +65,7 @@ namespace MonoDevelop.DotNetCore
 				// avoid allocation caused by not querying .FileName
 				string fileName = arg.FileName;
 				// make sure the global.json file that has been changed is the one we got when loading the project
-				if (Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] is string globalJsonPath
+				if (Project.ParentSolution?.ExtendedProperties [GlobalJsonPathExtendedPropertyName] is string globalJsonPath
 					&& globalJsonPath.Equals (fileName, StringComparison.OrdinalIgnoreCase)) {
 					DetectSDK (restore: true);
 				}


### PR DESCRIPTION
Repro steps:

1) Create a solution with a .NET Core app project.
2) Add a .Net Core API project to this existing solution.

During project creation the API project will try to access the ParentSolution property in the FileService_FileChanged callback, before it has been set on the project.

This change is the least risky and minimal fix to avoid the NRE exception. A subsequent PR should include broader changes to avoid unnecessary duplication effort of global.json processing at the project level, among other improvements.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/944667

Backport of #8440.

/cc @rodrmoya @iantoalms