### PR TITLE
[release-8.3] [DotNetCore] Fix Manage NuGet Packages menu missing from Dependencies

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
+++ b/main/src/addins/MonoDevelop.DotNetCore/Properties/MonoDevelop.DotNetCore.addin.xml
@@ -1214,7 +1214,7 @@
 			<SeparatorItem
 				id="DependenciesEditReferenceSeparator" />
 			<CommandItem
-				id="MonoDevelop.PackageManagement.Commands.ManagePackagesInProject" />
+				id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackagesInProject" />
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.UpdateAllPackagesInProject" />
 			<CommandItem
@@ -1222,7 +1222,7 @@
 		</Condition>
 		<Condition id="ItemType" value="MonoDevelop.DotNetCore.NodeBuilders.PackageDependenciesNode">
 			<CommandItem
-				id="MonoDevelop.PackageManagement.Commands.ManagePackagesInProject" />
+				id="MonoDevelop.PackageManagement.Commands.ManageNuGetPackagesInProject" />
 			<CommandItem
 				id="MonoDevelop.PackageManagement.Commands.UpdateAllPackagesInProject" />
 			<CommandItem
@@ -1233,7 +1233,7 @@
 			value="MonoDevelop.DotNetCore.NodeBuilders.AssemblyDependenciesNode|MonoDevelop.DotNetCore.NodeBuilders.ProjectDependenciesNode">
 			<CommandItem
 				id="MonoDevelop.Ide.Commands.ProjectCommands.AddReference"
-				insertbefore="MonoDevelop.PackageManagement.Commands.ManagePackagesInProject" />
+				insertbefore="MonoDevelop.PackageManagement.Commands.ManageNuGetPackagesInProject" />
 		</Condition>
 		<Condition id="ItemType" value="UnknownProject|Solution">
 			<CommandItem


### PR DESCRIPTION
The Dependencies and NuGet folder did not show the Manage NuGet Packages
menu item in the project's context menu since the command id had been
renamed.

Backport of #8455.

/cc @mrward 