### PR TITLE
[GtkCore] Fix toolbox items not displayed

### DIFF
--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/CombinedDesignView.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/CombinedDesignView.cs
@@ -197,6 +197,16 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 				ip.SetCaretLocation (line, column);
 			}
 		}
+
+		protected bool IsActiveView (Widget widget)
+		{
+			if (widget == null)
+				return false;
+
+			if (pages.TryGetValue (widget, out DocumentViewContent view))
+				return container.ActiveView == view;
+			return false;
+		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderView.cs
+++ b/main/src/addins/MonoDevelop.GtkCore/MonoDevelop.GtkCore.GuiBuilder/GuiBuilderView.cs
@@ -88,6 +88,19 @@ namespace MonoDevelop.GtkCore.GuiBuilder
 			return view;
 		}
 
+		protected override object OnGetContent (Type type)
+		{
+			// Only show GTK# toolbox items or properties when the GTK# designer is active.
+			if (IsActiveView (designerPage)) {
+				if (type.IsAssignableFrom (typeof (DesignerPage))) {
+					return designerPage;
+				} else if (type.IsAssignableFrom (typeof (ToolboxProvider))) {
+					return ToolboxProvider.Instance;
+				}
+			}
+			return base.OnGetContent (type);
+		}
+
 		void AttachWindow (GuiBuilderWindow window)
 		{
 			gproject = window.Project;


### PR DESCRIPTION
Can now drag and drop GTK# widgets from the Toolbox window to the
GTK# window or widget being designed.

Fixes VSTS #951728 - GTK# toolbox is empty on Visual Studio Community
2019 on the MAC

Fixes github #8278 - When creating a Gtk#2.0 project on Mac OS X, the
toolbox fails to populate for the Designer