### PR TITLE
[release-8.3] [NuGet] Fix duplicate projects in select projects dialog

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakePackageMetadataProvider.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakePackageMetadataProvider.cs
@@ -45,12 +45,15 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public Task<IPackageSearchMetadata> GetLocalPackageMetadataAsync (PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			return GetPackageMetadataAsync (identity, includePrerelease, cancellationToken);
 		}
 
 		public Task<IPackageSearchMetadata> GetPackageMetadataAsync (PackageIdentity identity, bool includePrerelease, CancellationToken cancellationToken)
 		{
-			throw new NotImplementedException ();
+			var metadata = new FakePackageSearchMetadata {
+				Identity = identity
+			};
+			return Task.FromResult<IPackageSearchMetadata> (metadata);
 		}
 
 		public Task<IEnumerable<IPackageSearchMetadata>> GetPackageMetadataListAsync (string packageId, bool includePrerelease, bool includeUnlisted, CancellationToken cancellationToken)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableManagePackagesViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableManagePackagesViewModel.cs
@@ -82,10 +82,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		}
 
 		public FakePackageFeed PackageFeed = new FakePackageFeed ();
+		public Func<PackageLoadContext, IPackageFeed> CreatePackageFeedAction = context => { return null; };
 
 		protected override IPackageFeed CreatePackageFeed (PackageLoadContext context)
 		{
-			return PackageFeed;
+			return CreatePackageFeedAction (context) ?? PackageFeed;
 		}
 
 		protected override Task CreateReadPackagesTask ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
@@ -1654,24 +1654,28 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("TestA", action.PackageId);
 			Assert.AreEqual ("0.3", action.Version.ToString ());
 			Assert.AreEqual ("LibA", action.Project.Name);
+			Assert.IsTrue (action.LicensesMustBeAccepted);
 
 			action = actions [1] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("TestA", action.PackageId);
 			Assert.AreEqual ("0.3", action.Version.ToString ());
 			Assert.AreEqual ("LibB", action.Project.Name);
+			Assert.IsFalse (action.LicensesMustBeAccepted);
 
 			action = actions [2] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("TestB", action.PackageId);
 			Assert.AreEqual ("0.4", action.Version.ToString ());
 			Assert.AreEqual ("LibA", action.Project.Name);
+			Assert.IsTrue (action.LicensesMustBeAccepted);
 
 			action = actions [3] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("TestB", action.PackageId);
 			Assert.AreEqual ("0.4", action.Version.ToString ());
 			Assert.AreEqual ("LibB", action.Project.Name);
+			Assert.IsFalse (action.LicensesMustBeAccepted);
 		}
 
 		[Test]
@@ -1707,12 +1711,14 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("Test", action.PackageId);
 			Assert.AreEqual ("0.1", action.Version.ToString ());
 			Assert.AreEqual ("LibA", action.Project.Name);
+			Assert.IsTrue (action.LicensesMustBeAccepted);
 
 			action = actions [1] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("Test", action.PackageId);
 			Assert.AreEqual ("0.1", action.Version.ToString ());
 			Assert.AreEqual ("LibB", action.Project.Name);
+			Assert.IsFalse (action.LicensesMustBeAccepted);
 		}
 
 		[Test]
@@ -1756,24 +1762,28 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("TestA", action.PackageId);
 			Assert.AreEqual ("0.1", action.Version.ToString ());
 			Assert.AreEqual ("LibA", action.Project.Name);
+			Assert.IsTrue (action.LicensesMustBeAccepted);
 
 			action = actions [1] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("TestA", action.PackageId);
 			Assert.AreEqual ("0.1", action.Version.ToString ());
 			Assert.AreEqual ("LibB", action.Project.Name);
+			Assert.IsFalse (action.LicensesMustBeAccepted);
 
 			action = actions [2] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("TestB", action.PackageId);
 			Assert.AreEqual ("0.2", action.Version.ToString ());
 			Assert.AreEqual ("LibA", action.Project.Name);
+			Assert.IsTrue (action.LicensesMustBeAccepted);
 
 			action = actions [3] as InstallNuGetPackageAction;
 			Assert.AreEqual (PackageActionType.Install, action.ActionType);
 			Assert.AreEqual ("TestB", action.PackageId);
 			Assert.AreEqual ("0.2", action.Version.ToString ());
 			Assert.AreEqual ("LibB", action.Project.Name);
+			Assert.IsFalse (action.LicensesMustBeAccepted);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
@@ -1673,5 +1673,107 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("0.4", action.Version.ToString ());
 			Assert.AreEqual ("LibB", action.Project.Name);
 		}
+
+		[Test]
+		public async Task Install_PackageInTwoProjects_PackageActionsCreatedForBothProjects ()
+		{
+			CreateProject ();
+			project.Name = "LibA";
+			CreateNuGetProjectForProject (project);
+
+			var project2 = AddProjectToSolution ("LibB");
+			CreateNuGetProjectForProject (project2);
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("Test", "0.1");
+			viewModel.PageSelected = ManagePackagesPage.Browse;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			var package = viewModel.PackageViewModels.Single ();
+			viewModel.SelectedPackage = package;
+			Assert.AreEqual ("Test", package.Id);
+			Assert.AreEqual ("0.1", package.Version.ToString ());
+
+			// Check two install actions - one for each project.
+			var selectedProjects = new [] { project, project2 };
+			var actions = viewModel.CreatePackageActions (new [] { package }, selectedProjects).ToList ();
+
+			Assert.AreEqual (2, actions.Count);
+			var action = actions [0] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("Test", action.PackageId);
+			Assert.AreEqual ("0.1", action.Version.ToString ());
+			Assert.AreEqual ("LibA", action.Project.Name);
+
+			action = actions [1] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("Test", action.PackageId);
+			Assert.AreEqual ("0.1", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
+		}
+
+		[Test]
+		public async Task Install_PackagesInTwoProjects_PackageActionsCreatedForBothProjects ()
+		{
+			CreateProject ();
+			project.Name = "LibA";
+			CreateNuGetProjectForProject (project);
+
+			var project2 = AddProjectToSolution ("LibB");
+			CreateNuGetProjectForProject (project2);
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("TestA", "0.1");
+			viewModel.PackageFeed.AddPackage ("TestB", "0.2");
+			viewModel.PageSelected = ManagePackagesPage.Browse;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			var package = viewModel.PackageViewModels [0];
+			viewModel.SelectedPackage = package;
+			package.IsChecked = true;
+			Assert.AreEqual ("TestA", package.Id);
+			Assert.AreEqual ("0.1", package.Version.ToString ());
+
+			package = viewModel.PackageViewModels [1];
+			viewModel.SelectedPackage = package;
+			package.IsChecked = true;
+			Assert.AreEqual ("TestB", package.Id);
+			Assert.AreEqual ("0.2", package.Version.ToString ());
+
+			// Check two install actions - one for each project.
+			var selectedProjects = new [] { project, project2 };
+			var actions = viewModel.CreatePackageActions (viewModel.PackageViewModels, selectedProjects).ToList ();
+
+			Assert.AreEqual (4, actions.Count);
+			var action = actions [0] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestA", action.PackageId);
+			Assert.AreEqual ("0.1", action.Version.ToString ());
+			Assert.AreEqual ("LibA", action.Project.Name);
+
+			action = actions [1] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestA", action.PackageId);
+			Assert.AreEqual ("0.1", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
+
+			action = actions [2] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestB", action.PackageId);
+			Assert.AreEqual ("0.2", action.Version.ToString ());
+			Assert.AreEqual ("LibA", action.Project.Name);
+
+			action = actions [3] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestB", action.PackageId);
+			Assert.AreEqual ("0.2", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ManagePackagesViewModelTests.cs
@@ -31,8 +31,6 @@ using System.Threading.Tasks;
 using MonoDevelop.PackageManagement.Tests.Helpers;
 using NuGet.Configuration;
 using NuGet.PackageManagement.UI;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Versioning;
 using NUnit.Framework;
@@ -1401,7 +1399,6 @@ namespace MonoDevelop.PackageManagement.Tests
 		public async Task CurrentVersion_DifferentPackageVersionInstalledInProjects_MultipleReturned ()
 		{
 			CreateProject ();
-			CreateProject ();
 			project.Name = "LibC";
 			var nugetProject = CreateNuGetProjectForProject (project);
 			nugetProject.AddPackageReference ("Test", "0.1");
@@ -1434,7 +1431,6 @@ namespace MonoDevelop.PackageManagement.Tests
 		public async Task CurrentVersion_SamePackageVersionInstalledInProjects_PackageVersionReturned ()
 		{
 			CreateProject ();
-			CreateProject ();
 			project.Name = "LibC";
 			var nugetProject = CreateNuGetProjectForProject (project);
 			nugetProject.AddPackageReference ("Test", "0.1");
@@ -1466,7 +1462,6 @@ namespace MonoDevelop.PackageManagement.Tests
 		public async Task CurrentVersion_TwoProjectsSameVersionOneProjectDifferentVersion_MultipleReturned ()
 		{
 			CreateProject ();
-			CreateProject ();
 			project.Name = "LibC";
 			var nugetProject = CreateNuGetProjectForProject (project);
 			nugetProject.AddPackageReference ("Test", "0.1");
@@ -1494,6 +1489,189 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.AreEqual ("0.2", package.Version.ToString ());
 			Assert.AreEqual ("Multiple", package.GetCurrentPackageVersionText ());
 			Assert.AreEqual (expectedAdditionalText, package.GetCurrentPackageVersionAdditionalText ());
+		}
+
+		[Test]
+		public async Task Consolidate_PackageInTwoProjects_PackageActionsCreatedForBothProjects ()
+		{
+			CreateProject ();
+			project.Name = "LibA";
+			var nugetProject = CreateNuGetProjectForProject (project);
+			nugetProject.AddPackageReference ("Test", "0.1");
+
+			var project2 = AddProjectToSolution ("LibB");
+			nugetProject = CreateNuGetProjectForProject (project2);
+			nugetProject.AddPackageReference ("Test", "0.2");
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("Test", "0.3");
+			viewModel.PageSelected = ManagePackagesPage.Consolidate;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			var package = viewModel.PackageViewModels.Single ();
+			viewModel.SelectedPackage = package;
+			Assert.AreEqual ("Test", package.Id);
+			Assert.AreEqual ("0.3", package.Version.ToString ());
+
+			// Checked projects first.
+			var projectViewModel = viewModel.ProjectViewModels [0];
+			Assert.AreEqual ("LibA", projectViewModel.ProjectName);
+			Assert.AreEqual ("0.1", projectViewModel.PackageVersion);
+			Assert.IsTrue (projectViewModel.IsChecked);
+
+			projectViewModel = viewModel.ProjectViewModels [1];
+			Assert.AreEqual ("LibB", projectViewModel.ProjectName);
+			Assert.AreEqual ("0.2", projectViewModel.PackageVersion);
+			Assert.IsTrue (projectViewModel.IsChecked);
+
+			Assert.IsTrue (viewModel.CanConsolidate ());
+
+			// Check two install actions - one for each project.
+			var actions = viewModel.CreateConsolidatePackageActions (package).ToList ();
+			Assert.AreEqual (2, actions.Count);
+			var action = actions [0] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("Test", action.PackageId);
+			Assert.AreEqual ("0.3", action.Version.ToString ());
+			Assert.AreEqual ("LibA", action.Project.Name);
+
+			action = actions [1] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("Test", action.PackageId);
+			Assert.AreEqual ("0.3", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
+		}
+
+		[Test]
+		public async Task Consolidate_PackageInNewProject_PackageActionCreatedForNewProject ()
+		{
+			CreateProject ();
+			project.Name = "LibA";
+			var nugetProject = CreateNuGetProjectForProject (project);
+			nugetProject.AddPackageReference ("Test", "0.1");
+
+			var project2 = AddProjectToSolution ("LibB");
+			nugetProject = CreateNuGetProjectForProject (project2);
+			nugetProject.AddPackageReference ("Test", "0.2");
+
+			var project3 = AddProjectToSolution ("LibC");
+			nugetProject = CreateNuGetProjectForProject (project3);
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("Test", "0.3");
+			viewModel.PageSelected = ManagePackagesPage.Consolidate;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			var package = viewModel.PackageViewModels.Single ();
+			viewModel.SelectedPackage = package;
+			Assert.AreEqual ("Test", package.Id);
+			Assert.AreEqual ("0.3", package.Version.ToString ());
+
+			// Checked projects first.
+			var projectViewModel = viewModel.ProjectViewModels [0];
+			Assert.AreEqual ("LibA", projectViewModel.ProjectName);
+			Assert.AreEqual ("0.1", projectViewModel.PackageVersion);
+			Assert.IsTrue (projectViewModel.IsChecked);
+
+			projectViewModel = viewModel.ProjectViewModels [1];
+			Assert.AreEqual ("LibB", projectViewModel.ProjectName);
+			Assert.AreEqual ("0.2", projectViewModel.PackageVersion);
+			Assert.IsTrue (projectViewModel.IsChecked);
+
+			projectViewModel = viewModel.ProjectViewModels [2];
+			Assert.AreEqual ("LibC", projectViewModel.ProjectName);
+			Assert.IsFalse (projectViewModel.IsChecked);
+
+			Assert.IsTrue (viewModel.CanConsolidate ());
+
+			// Check LibC and uncheck LibA
+			viewModel.ProjectViewModels [2].IsChecked = true;
+			viewModel.ProjectViewModels [0].IsChecked = false;
+
+			// Check two install actions - one for each project.
+			var actions = viewModel.CreateConsolidatePackageActions (package).ToList ();
+			Assert.AreEqual (2, actions.Count);
+			var action = actions [0] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("Test", action.PackageId);
+			Assert.AreEqual ("0.3", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
+
+			action = actions [1] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("Test", action.PackageId);
+			Assert.AreEqual ("0.3", action.Version.ToString ());
+			Assert.AreEqual ("LibC", action.Project.Name);
+		}
+
+		[Test]
+		public async Task Consolidate_TwoPackageInTwoProjects_PackageActionsCreatedForBothProjects ()
+		{
+			CreateProject ();
+			project.Name = "LibA";
+			var nugetProject = CreateNuGetProjectForProject (project);
+			nugetProject.AddPackageReference ("TestA", "0.1");
+			nugetProject.AddPackageReference ("TestB", "0.1");
+
+			var project2 = AddProjectToSolution ("LibB");
+			nugetProject = CreateNuGetProjectForProject (project2);
+			nugetProject.AddPackageReference ("TestA", "0.2");
+			nugetProject.AddPackageReference ("TestB", "0.2");
+
+			AddOnePackageSourceToRegisteredSources ();
+			CreateViewModelForSolution ();
+			viewModel.PackageFeed.AddPackage ("TestA", "0.3");
+			viewModel.PackageFeed.AddPackage ("TestB", "0.4");
+			viewModel.PageSelected = ManagePackagesPage.Consolidate;
+
+			viewModel.ReadPackages ();
+			await viewModel.ReadPackagesTask;
+
+			var package = viewModel.PackageViewModels [0];
+			viewModel.SelectedPackage = package;
+			package.IsChecked = true;
+			Assert.AreEqual ("TestA", package.Id);
+			Assert.AreEqual ("0.3", package.Version.ToString ());
+
+			package = viewModel.PackageViewModels [1];
+			viewModel.SelectedPackage = package;
+			package.IsChecked = true;
+			Assert.AreEqual ("TestB", package.Id);
+			Assert.AreEqual ("0.4", package.Version.ToString ());
+
+			// Check install actions - two for each project
+			var actions = viewModel.CreateConsolidatePackageActions (viewModel.PackageViewModels);
+			Assert.AreEqual (4, actions.Count);
+
+			var action = actions [0] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestA", action.PackageId);
+			Assert.AreEqual ("0.3", action.Version.ToString ());
+			Assert.AreEqual ("LibA", action.Project.Name);
+
+			action = actions [1] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestA", action.PackageId);
+			Assert.AreEqual ("0.3", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
+
+			action = actions [2] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestB", action.PackageId);
+			Assert.AreEqual ("0.4", action.Version.ToString ());
+			Assert.AreEqual ("LibA", action.Project.Name);
+
+			action = actions [3] as InstallNuGetPackageAction;
+			Assert.AreEqual (PackageActionType.Install, action.ActionType);
+			Assert.AreEqual ("TestB", action.PackageId);
+			Assert.AreEqual ("0.4", action.Version.ToString ());
+			Assert.AreEqual ("LibB", action.Project.Name);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesProjectInfo.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesProjectInfo.cs
@@ -56,5 +56,17 @@ namespace MonoDevelop.PackageManagement
 
 			return string.Compare (Project.Name, other.Project.Name, StringComparison.CurrentCulture);
 		}
+
+		public bool HasAnyPackage (IEnumerable<string> packageIds)
+		{
+			foreach (PackageIdentity package in Packages) {
+				foreach (string packageId in packageIds) {
+					if (StringComparer.OrdinalIgnoreCase.Equals (package.Id, packageId)) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesViewModel.cs
@@ -857,13 +857,8 @@ namespace MonoDevelop.PackageManagement
 					if (projectInfo.Project != project)
 						continue;
 
-					foreach (PackageIdentity package in projectInfo.Packages) {
-						foreach (string packageId in packageIds) {
-							if (StringComparer.OrdinalIgnoreCase.Equals (package.Id, packageId)) {
-								yield return project;
-							}
-						}
-					}
+					if (projectInfo.HasAnyPackage (packageIds))
+						yield return project;
 				}
 			}
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UninstallNuGetPackageAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UninstallNuGetPackageAction.cs
@@ -83,6 +83,10 @@ namespace MonoDevelop.PackageManagement
 			get { return PackageActionType.Uninstall; }
 		}
 
+		internal IDotNetProject Project {
+			get { return dotNetProject; }
+		}
+
 		public void Execute ()
 		{
 			Execute (CancellationToken.None);


### PR DESCRIPTION
Checking more than one NuGet package in the Manage NuGet packages
dialog when that NuGet package is installed in multiple projects
could result in projects being listed multiple times in the Select
Projects dialog. This was because each checked package id was
being checked against all the packages installed in the project and
for each match the project was being returned. This would result
in the same project being listed multiple times in the dialog which
was confusing.

Fixes VSTS #966636 - NuGet Package Manager dialog after selecting
multiple packages to uninstall unclear

Also added more tests for the Manage NuGet packages dialog.

Fixes VSTS #961926 - [test coverage] nuget - solution wide nuget management

Backport of #8468.

/cc @mrward 