### PR TITLE
[AutoTest] Add logging in NSObjectResult.SetActiveRuntime to trace source of NRE

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -361,10 +361,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 			Type type = ResultObject.GetType ();
 			PropertyInfo pinfo = type.GetProperty ("RuntimeModel");
 			if (pinfo == null) {
+				LoggingService.LogDebug ($"Could not find 'RuntimeModel' property on {type}");
 				return false;
 			}
 
-			IEnumerable<IRuntimeModel> model = (IEnumerable<IRuntimeModel>)pinfo.GetValue (ResultObject, null);
+			var pObject = pinfo.GetValue (ResultObject, null);
+			LoggingService.LogDebug ($"'RuntimeModel' property on '{type}' is '{pObject}' and is of type '{pinfo.PropertyType}'");
+			var model = (IEnumerable<IRuntimeModel>)pObject;
 
 			var runtime = model.FirstOrDefault (r => {
 				var mutableModel = r.GetMutableModel ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -369,6 +369,7 @@ namespace MonoDevelop.Components.AutoTest.Results
 			LoggingService.LogDebug ($"'RuntimeModel' property on '{type}' is '{pObject}' and is of type '{pinfo.PropertyType}'");
 			var topRunTimeModels = (IEnumerable<IRuntimeModel>)pObject;
 			var model = AllRuntimes (topRunTimeModels);
+			model = model.Where (x => !x.IsSeparator);
 
 			var runtime = model.FirstOrDefault (r => {
 				var mutableModel = r.GetMutableModel ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -367,7 +367,8 @@ namespace MonoDevelop.Components.AutoTest.Results
 
 			var pObject = pinfo.GetValue (ResultObject, null);
 			LoggingService.LogDebug ($"'RuntimeModel' property on '{type}' is '{pObject}' and is of type '{pinfo.PropertyType}'");
-			var model = (IEnumerable<IRuntimeModel>)pObject;
+			var topRunTimeModels = (IEnumerable<IRuntimeModel>)pObject;
+			var model = AllRuntimes (topRunTimeModels);
 
 			var runtime = model.FirstOrDefault (r => {
 				var mutableModel = r.GetMutableModel ();
@@ -410,6 +411,16 @@ namespace MonoDevelop.Components.AutoTest.Results
 			}
 			return false;
 		}
+
+		IEnumerable<IRuntimeModel> AllRuntimes (IEnumerable<IRuntimeModel> runtimes)
+		{
+			foreach (var runtime in runtimes) {
+				yield return runtime;
+				foreach (var childRuntime in AllRuntimes (runtime.Children))
+					yield return childRuntime;
+			}
+		}
+
 		#endregion
 
 		protected override void Dispose (bool disposing)


### PR DESCRIPTION
There are times when SelectDevice(udid) fails with NRE in `model` in method NSObjectResult.SetActiveRuntime

Trace where this NRE starts to confirm hypothesis

Fixes #958151
Fixes #941255