### PR TITLE
[FileNesting] Convert PadOption to normal CommandItem

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreNestingRulesProvider.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreNestingRulesProvider.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.AspNetCore
 			SourceFile = AddinManager.CurrentAddin.GetFilePath (Path.Combine ("Resources", "AspNetCore.filenesting.json"));
 		}
 
-		protected override bool AppliesToProject (Project project)
+		public override bool AppliesToProject (Project project)
 		{
 			var dotnetProj = project as DotNetProject;
 			return dotnetProj != null && dotnetProj.ProjectProperties.HasProperty ("UsingMicrosoftNETSdkWeb");

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.FileNesting/FileNestingService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.FileNesting/FileNestingService.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Mono.Addins;
 
@@ -85,7 +86,12 @@ namespace MonoDevelop.Projects.FileNesting
 
 		public static bool IsEnabledForProject (Project project)
 		{
-			return project?.ParentSolution?.UserProperties?.GetValue<bool> ("FileNesting", true) ?? true;
+			return project?.ParentSolution?.UserProperties?.GetValue<bool> ("MonoDevelop.Ide.FileNesting.Enabled", true) ?? true;
+		}
+
+		public static bool AppliesToProject (Project project)
+		{
+			return rulesProviders.Any (rp => rp.AppliesToProject (project));
 		}
 
 		public static ProjectFile GetParentFile (ProjectFile inputFile)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.FileNesting/NestingRulesProvider.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.FileNesting/NestingRulesProvider.cs
@@ -121,7 +121,7 @@ namespace MonoDevelop.Projects.FileNesting
 			return false;
 		}
 
-		protected virtual bool AppliesToProject (Project project) => true;
+		public virtual bool AppliesToProject (Project project) => true;
 
 		public ProjectFile GetParentFile (ProjectFile inputFile)
 		{

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -378,6 +378,9 @@
 	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.RunCodeAnalysisProject"
 			defaultHandler = "MonoDevelop.Ide.Commands.RunCodeAnalysisProjectHandler"
 			_label = "Run Code Analysis on Project" />
+	<Command id = "MonoDevelop.Ide.Commands.ProjectCommands.ToggleFileNesting"
+			 defaultHandler = "MonoDevelop.Ide.Commands.ToggleFileNestingHandler"
+			 _label = "File Nesting" />
 	</Category>
 
 

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Pads.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Pads.addin.xml
@@ -49,7 +49,6 @@
 	<SolutionPad id = "ProjectPad" _label = "Solution" icon = "md-solution-pad" class = "MonoDevelop.Ide.Gui.Pads.ProjectPad.ProjectSolutionPad" defaultLayout="*" defaultPlacement = "Left" group="1Solution">
 		<ContextMenu path="/MonoDevelop/Ide/ContextMenu/ProjectPad" />
 		<PadOption id = "ShowAllFiles" _label = "Show All Files" defaultValue = "False" />
-		<PadOption id = "FileNesting" _label = "File Nesting" defaultValue = "True" />
 		<NodeBuilder class = "MonoDevelop.Ide.Gui.Pads.ProjectPad.WorkspaceNodeBuilder"/>
 		<NodeBuilder class = "MonoDevelop.Ide.Gui.Pads.ProjectPad.SolutionNodeBuilder"/>
 		<NodeBuilder class = "MonoDevelop.Ide.Gui.Pads.ProjectPad.SolutionFolderNodeBuilder"/>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/ProjectCommands.cs
@@ -44,6 +44,7 @@ using System.Linq;
 using MonoDevelop.Ide.Projects;
 using MonoDevelop.Projects.Policies;
 using MonoDevelop.Core.FeatureConfiguration;
+using MonoDevelop.Projects.FileNesting;
 
 namespace MonoDevelop.Ide.Commands
 {
@@ -91,6 +92,7 @@ namespace MonoDevelop.Ide.Commands
 		Unload,
 		SetStartupProjects,
 		AddEmptyClass,
+		ToggleFileNesting
 	}
 
 	internal class SolutionOptionsHandler : CommandHandler
@@ -597,6 +599,25 @@ namespace MonoDevelop.Ide.Commands
 			var context = new ProjectOperationContext ();
 			context.GlobalProperties.SetValue ("RunCodeAnalysisOnce", "true");
 			IdeApp.ProjectOperations.Rebuild (IdeApp.ProjectOperations.CurrentSelectedProject, context);
+		}
+	}
+
+	internal class ToggleFileNestingHandler : CommandHandler
+	{
+		const string PropertyName = "MonoDevelop.Ide.FileNesting.Enabled";
+		protected override void Update (CommandInfo info)
+		{
+			var solution = IdeApp.ProjectOperations.CurrentSelectedSolution;
+			info.Visible = solution != null && solution.GetAllProjects ().Any (FileNestingService.AppliesToProject);
+			if (info.Visible) {
+				info.Checked = IdeApp.ProjectOperations.CurrentSelectedSolution.UserProperties.GetValue<bool> (PropertyName, true);
+			}
+		}
+
+		protected override void Run ()
+		{
+			bool enabled = IdeApp.ProjectOperations.CurrentSelectedSolution.UserProperties.GetValue<bool> (PropertyName, true);
+			IdeApp.ProjectOperations.CurrentSelectedSolution.UserProperties.SetValue (PropertyName, !enabled);
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/ExtensibleTreeView.cs
@@ -1975,6 +1975,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				if (options.Length > 0) {
 					CommandEntrySet opset = new CommandEntrySet ();
 					opset.AddItem (ViewCommands.TreeDisplayOptionList);
+					opset.AddItem (ProjectCommands.ToggleFileNesting);
 					opset.AddItem (Command.Separator);
 					opset.AddItem (ViewCommands.ResetTreeDisplayOptions);
 					return opset;
@@ -1995,6 +1996,7 @@ namespace MonoDevelop.Ide.Gui.Components
 				if (!tnav.Clone ().MoveToParent ()) {
 					CommandEntrySet opset = eset.AddItemSet (GettextCatalog.GetString ("Display Options"));
 					opset.AddItem (ViewCommands.TreeDisplayOptionList);
+					opset.AddItem (ProjectCommands.ToggleFileNesting);
 					opset.AddItem (Command.Separator);
 					opset.AddItem (ViewCommands.ResetTreeDisplayOptions);
 				//	opset.AddItem (ViewCommands.CollapseAllTreeNodes);


### PR DESCRIPTION
This allows us to store the setting in the root of the UserPrefs file, making
it easier to be retrieved from the FileNestingService in .Core.