### PR TITLE
[NuGet] Allow checkboxes to be selected by keyboard in packages dialog

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -101,7 +101,6 @@ namespace MonoDevelop.PackageManagement
 			this.packageSourceComboBox.SelectionChanged += PackageSourceChanged;
 			this.addPackagesButton.Clicked += AddPackagesButtonClicked;
 			this.packageSearchEntry.Changed += PackageSearchEntryChanged;
-			this.packageSearchEntry.Activated += PackageSearchEntryActivated;
 			this.packageVersionComboBox.SelectionChanged += PackageVersionChanged;
 			imageLoader.Loaded += ImageLoaded;
 
@@ -839,45 +838,6 @@ namespace MonoDevelop.PackageManagement
 			ManagePackagesSearchResultViewModel packageViewModel = packageStore.GetValue (e.RowIndex, packageViewModelField);
 			packageViewModel.IsChecked = !packageViewModel.IsChecked;
 			PackageCellViewPackageChecked (null, null);
-		}
-
-		void ManagePackage (ManagePackagesSearchResultViewModel packageViewModel)
-		{
-			try {
-				if (packageViewModel != null) {
-					if (viewModel.IsConsolidatePageSelected) {
-						List<IPackageAction> packageActions = viewModel.CreateConsolidatePackageActions (
-							new ManagePackagesSearchResultViewModel [] { packageViewModel }
-						);
-						RunPackageActions (packageActions);
-					} else {
-						var projects = SelectProjects (packageViewModel).ToList ();
-						if (!projects.Any ())
-							return;
-
-						List<IPackageAction> packageActions = viewModel.CreatePackageActions (
-							new ManagePackagesSearchResultViewModel [] { packageViewModel },
-							projects);
-						RunPackageActions (packageActions);
-					}
-				}
-			} catch (Exception ex) {
-				LoggingService.LogInternalError ("ManagePackage failed.", ex);
-				ShowErrorMessage (ex.Message);
-			}
-		}
-
-		void PackageSearchEntryActivated (object sender, EventArgs e)
-		{
-			if (loadingMessageVisible)
-				return;
-
-			if (PackagesCheckedCount > 0) {
-				AddPackagesButtonClicked (sender, e);
-			} else {
-				ManagePackagesSearchResultViewModel selectedPackageViewModel = GetSelectedPackageViewModel ();
-				ManagePackage (selectedPackageViewModel);
-			}
 		}
 
 		void PackagesListViewScrollValueChanged (object sender, EventArgs e)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -836,12 +836,9 @@ namespace MonoDevelop.PackageManagement
 
 		void PackagesListRowActivated (object sender, ListViewRowEventArgs e)
 		{
-			if (PackagesCheckedCount > 0) {
-				AddPackagesButtonClicked (sender, e);
-			} else {
-				ManagePackagesSearchResultViewModel packageViewModel = packageStore.GetValue (e.RowIndex, packageViewModelField);
-				ManagePackage (packageViewModel);
-			}
+			ManagePackagesSearchResultViewModel packageViewModel = packageStore.GetValue (e.RowIndex, packageViewModelField);
+			packageViewModel.IsChecked = !packageViewModel.IsChecked;
+			PackageCellViewPackageChecked (null, null);
 		}
 
 		void ManagePackage (ManagePackagesSearchResultViewModel packageViewModel)


### PR DESCRIPTION
[NuGet] Allow checkboxes to be selected by keyboard in packages dialog  …
Previously pressing space or enter would cause the selected package,
or multiple packages if checked, to be installed. Now pressing space
or enter checks or unchecks the package.

Fixes VSTS #750399 - Accessibility: Onfocus issue has been observed
while selecting packages from the list

Fixes VSTS #750407 - Accessibility: Checkboxes for selecting multiple
packages are not accessible through keyboard

[NuGet] Do not install package when enter pressed in search text box

No longer installing the selected package in the Manage NuGet Packages
dialog when the enter key is pressed. This has caused a bit of
confusion and can cause a package to be installed when the user is
trying to run the search. Note that the search is a search as you type
so pressing the enter key has no affect.

Fixes VSTS #968790 - Hitting return in a search field installs a package