### PR TITLE
[Core] Add a way to use spindump as a profiler backend

### DIFF
--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -67,7 +67,7 @@ namespace PerformanceDiagnosticsAddIn
 			if (!File.Exists (spinDumpFile)) {
 				var message = new ConfirmationMessage (
 					GettextCatalog.GetString ("{0} requires administrative privileges to run spindump", BrandingService.ApplicationName),
-					GettextCatalog.GetString ("Continue with installing '{0}' so 'spindump' can be run without a password for this user?", spinDumpFile),
+					GettextCatalog.GetString ("Continue with installing '{0}' so 'spindump' can be run without a password for the current user?", spinDumpFile),
 					AlertButton.Proceed) {
 					Icon = MonoDevelop.Ide.Gui.Stock.Warning,
 				};

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -72,8 +72,7 @@ namespace PerformanceDiagnosticsAddIn
 					Icon = MonoDevelop.Ide.Gui.Stock.Warning,
 				};
 
-				if (!MessageService.Confirm (message) || !CreatePrivilegedHelperFile ())
-					return false;
+				return MessageService.Confirm (message) && CreatePrivilegedHelperFile ();
 			}
 
 			return true;

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -11,7 +11,7 @@ using MonoDevelop.Ide.Gui.Dialogs;
 
 namespace PerformanceDiagnosticsAddIn
 {
-	public class StartStopListeningUIThreadMonitorHandler : CommandHandler
+	class StartStopListeningUIThreadMonitorHandler : CommandHandler
 	{
 		protected override void Run ()
 		{
@@ -28,7 +28,7 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	public class ProfileFor5SecondsHandler : CommandHandler
+	class ProfileFor5SecondsHandler : CommandHandler
 	{
 		protected override void Update (CommandInfo info)
 		{
@@ -42,7 +42,7 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	public class SpinDumpFor5SecondsHandler : CommandHandler
+	class SpinDumpFor5SecondsHandler : CommandHandler
 	{
 		protected override void Update (CommandInfo info)
 		{
@@ -56,7 +56,7 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	public class EnhanceSampleFile : CommandHandler
+	class EnhanceSampleFile : CommandHandler
 	{
 		protected override void Run ()
 		{
@@ -66,7 +66,7 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	public class ToggleProfileHandler : CommandHandler
+	class ToggleProfileHandler : CommandHandler
 	{
 		protected override void Update(CommandInfo info)
 		{
@@ -81,7 +81,7 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	public class InitializeGtkHelperHandler : CommandHandler
+	class InitializeGtkHelperHandler : CommandHandler
 	{
 		protected override void Run ()
 		{
@@ -112,7 +112,7 @@ namespace PerformanceDiagnosticsAddIn
 		}
 	}
 
-	public class DumpLiveWidgetsHandler : CommandHandler
+	class DumpLiveWidgetsHandler : CommandHandler
 	{
 		static readonly System.IO.TextWriter log = LoggingService.CreateLogFile ("leak-dump");
 		protected override void Update (CommandInfo info)

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Commands.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Foundation;
 using MonoDevelop.Components.Commands;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 using MonoDevelop.Ide.Gui.Dialogs;
 
 namespace PerformanceDiagnosticsAddIn
@@ -37,7 +38,21 @@ namespace PerformanceDiagnosticsAddIn
 
 		protected override void Run ()
 		{
-			UIThreadMonitor.Instance.Profile (5);
+			UIThreadMonitor.Instance.Profile (spinDump: false, 5);
+		}
+	}
+
+	public class SpinDumpFor5SecondsHandler : CommandHandler
+	{
+		protected override void Update (CommandInfo info)
+		{
+			info.DisableOnShellLock = false;
+			base.Update (info);
+		}
+
+		protected override void Run ()
+		{
+			UIThreadMonitor.Instance.Profile (spinDump: true, 5);
 		}
 	}
 
@@ -62,7 +77,7 @@ namespace PerformanceDiagnosticsAddIn
 
 		protected override void Run ()
 		{
-			UIThreadMonitor.Instance.ToggleProfiling ();
+			UIThreadMonitor.Instance.ToggleProfiling (spinDump: false);
 		}
 	}
 

--- a/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
+++ b/main/src/addins/PerformanceDiagnostics/PerformanceDiagnostics/Properties/PerformanceDiagnostics.addin.xml
@@ -9,6 +9,9 @@
 		<Command id="PerformanceDiagnosticsAddIn.ProfileFor5SecondsHandler"
 			defaultHandler="PerformanceDiagnosticsAddIn.ProfileFor5SecondsHandler"
 			_label="Profile for 5 seconds" />
+		<Command id="PerformanceDiagnosticsAddIn.SpinDumpFor5SecondsHandler"
+			defaultHandler="PerformanceDiagnosticsAddIn.SpinDumpFor5SecondsHandler"
+			_label="SpinDump for 5 seconds" />
 		<Command id="PerformanceDiagnosticsAddIn.DumpLiveWidgetsHandler"
 			defaultHandler="PerformanceDiagnosticsAddIn.DumpLiveWidgetsHandler"
 			_label="Dump live widgets" />
@@ -28,6 +31,7 @@
 			<CommandItem id="PerformanceDiagnosticsAddIn.ToggleProfileHandler" />
 			<CommandItem id="PerformanceDiagnosticsAddIn.EnhanceSampleFile" />
 			<CommandItem id="PerformanceDiagnosticsAddIn.DumpLiveWidgetsHandler" />
+			<CommandItem id="PerformanceDiagnosticsAddIn.SpinDumpFor5SecondsHandler" />
 		</ItemSet>
 	</Extension>
 	<Extension path="/MonoDevelop/Ide/PreStartupHandlers">

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/SampleProfiler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/SampleProfiler.cs
@@ -95,6 +95,9 @@ namespace MonoDevelop.Utilities
 		{
 			const int millisBetweenSamples = 1;
 
+			if (!Platform.IsMac)
+				throw new InvalidOperationException ("Spindump is only available on macOS");
+
 			// We need to delete the file before using it as an output target, otherwise it will error.
 			File.Delete (outputFilePath);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/SampleProfiler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/SampleProfiler.cs
@@ -50,7 +50,7 @@ namespace MonoDevelop.Utilities
 		public bool ToggleProfilingChecked => sampleProcessPid != -1;
 
 		int sampleProcessPid = -1;
-		public void ToggleProfiling ()
+		public void ToggleProfiling (bool spinDump)
 		{
 			if (sampleProcessPid != -1) {
 				Mono.Unix.Native.Syscall.kill (sampleProcessPid, Mono.Unix.Native.Signum.SIGINT);
@@ -58,28 +58,42 @@ namespace MonoDevelop.Utilities
 				return;
 			}
 
-			var outputFilePath = Path.GetTempFileName ();
-			var startInfo = new ProcessStartInfo ("sample");
-			startInfo.UseShellExecute = false;
-			startInfo.Arguments = $"{Process.GetCurrentProcess ().Id} 10000 -file {outputFilePath}";
-			var sampleProcess = Process.Start (startInfo);
-			sampleProcess.EnableRaisingEvents = true;
-			sampleProcess.Exited += delegate {
-				ConvertJITAddressesToMethodNames (outputPath, outputFilePath, "Profile");
-			};
-			sampleProcessPid = sampleProcess.Id;
+			sampleProcessPid = Profile (spinDump, 10000).Id;
 		}
 
-		public void Profile (int seconds)
+		public Process Profile (bool spinDump, int seconds)
 		{
 			var outputFilePath = Path.GetTempFileName ();
-			var startInfo = new ProcessStartInfo ("sample");
-			startInfo.UseShellExecute = false;
-			startInfo.Arguments = $"{Process.GetCurrentProcess ().Id} {seconds} -file {outputFilePath}";
-			var sampleProcess = Process.Start (startInfo);
+			var psi = spinDump ? GetSpinDumpStartInfo (seconds, outputFilePath) : GetSampleStartInfo (seconds, outputFilePath);
+
+			var sampleProcess = Process.Start (psi);
+
 			sampleProcess.EnableRaisingEvents = true;
-			sampleProcess.Exited += delegate {
+			sampleProcess.Exited += (sender, args) => {
+				if (sampleProcess.ExitCode != 0) {
+					const string errorMessage = "Administrative privileges required: spindump profiler is intended as a diagnostic tool. To enable spindump profiler handling, add the required sudoers entry";
+					LoggingService.LogError (errorMessage);
+					return;
+				}
 				ConvertJITAddressesToMethodNames (outputPath, outputFilePath, "Profile");
+			};
+			return sampleProcess;
+		}
+
+		ProcessStartInfo GetSampleStartInfo (int seconds, string outputFilePath)
+			=>  new ProcessStartInfo ("sample") {
+				UseShellExecute = false,
+				Arguments = $"{Process.GetCurrentProcess ().Id} {seconds} -file {outputFilePath}"
+			};
+
+		ProcessStartInfo GetSpinDumpStartInfo (int seconds, string outputFilePath)
+		{
+			File.Delete (outputFilePath);
+			return new ProcessStartInfo ("sudo") {
+				UseShellExecute = false,
+				// Some weird things happen when using -o, so write to stdout and manually pipe the text
+				Arguments = $"-n spindump {Process.GetCurrentProcess ().Id} {seconds} -noBinary -onlyRunnable -onlyTarget -o {outputFilePath}",
+				RedirectStandardOutput = true,
 			};
 		}
 
@@ -89,11 +103,16 @@ namespace MonoDevelop.Utilities
 
 		public static void ConvertJITAddressesToMethodNames (string outputPath, string fileName, string profilingType)
 		{
-			// sample line to replace:
-			// ???  (in <unknown binary>)  [0x103648455]
-			var rx = new Regex (@"\?\?\?  \(in <unknown binary>\)  \[0x([0-9a-f]+)\]", RegexOptions.Compiled);
+			var matchRegexes = new Regex [] {
+				// sample line output
+				// ???  (in <unknown binary>)  [0x103648455]
+				new Regex (@"\?\?\?  \(in <unknown binary>\)  \[0x([0-9a-f]+)\]", RegexOptions.Compiled),
+				// spindump line output
+				new Regex (@"\?\?\? \(.* \+ \d+\) \[0x([0-9a-f]+)\]", RegexOptions.Compiled),
+				new Regex (@"\?\?\? \[0x([0-9a-f]+)\]", RegexOptions.Compiled),
+			};
 
-
+			// When using spindump, this format means kernel code, so don't bother writing it, we have a toplevel usercode function
 			if (File.Exists (fileName) && new FileInfo (fileName).Length > 0) {
 				Directory.CreateDirectory (outputPath);
 				var outputFilename = Path.Combine (outputPath, $"{BrandingService.ApplicationName}_{profilingType}_{DateTime.Now:yyyy-MM-dd__HH-mm-ss}.txt");
@@ -102,26 +121,50 @@ namespace MonoDevelop.Utilities
 				using (var sw = new StreamWriter (outputFilename)) {
 					string line;
 					while ((line = sr.ReadLine ()) != null) {
+						bool printLine = true;
 
-						var match = rx.Match (line);
-						if (match.Success) {
-							var offset = long.Parse (match.Groups[1].Value, NumberStyles.HexNumber);
+						foreach (var rx in matchRegexes) {
+							try {
+								var match = rx.Match (line);
+								if (match.Success) {
+									var offset = long.Parse (match.Groups [1].Value, NumberStyles.HexNumber);
+									if (offset < 0) {
+										// This is kernel code, no use writing redundant stack frames.
+										printLine = false;
+										break;
+									}
 
-							if (!methodsCache.TryGetValue (offset, out var pmipMethodName)) {
-								pmipMethodName = mono_pmip (offset)?.TrimStart ();
-								if (pmipMethodName != null)
-									pmipMethodName = PmipParser.ToSample (pmipMethodName, offset);
-								methodsCache.Add (offset, pmipMethodName);
-							}
+									var pmipMethodName = GetSymbolicatedLine (offset);
+									if (pmipMethodName != null) {
+										line = line
+											.Remove (match.Index, match.Length)
+											.Insert (match.Index, pmipMethodName);
+									}
 
-							if (pmipMethodName != null) {
-								line = line.Remove (match.Index, match.Length);
-								line = line.Insert (match.Index, pmipMethodName);
+									// Stop processing other regexes, we have a match
+									break;
+								}
+							} catch (Exception e) {
+								LoggingService.LogError ($"Failed to parse address sample output line {line}", e);
 							}
 						}
-						sw.WriteLine (line);
+
+						if (printLine)
+							sw.WriteLine (line);
 					}
 				}
+			}
+
+			static string GetSymbolicatedLine (long offset)
+			{
+				if (!methodsCache.TryGetValue (offset, out var pmipMethodName)) {
+					pmipMethodName = mono_pmip (offset)?.TrimStart ();
+					if (pmipMethodName != null)
+						pmipMethodName = PmipParser.ToSample (pmipMethodName, offset);
+					methodsCache.Add (offset, pmipMethodName);
+				}
+
+				return pmipMethodName;
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/SampleProfiler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Utilities/SampleProfiler.cs
@@ -41,10 +41,15 @@ namespace MonoDevelop.Utilities
 {
 	public class SampleProfiler
 	{
-		readonly string outputPath;
+		readonly Func<string> getOutputPath;
+		public SampleProfiler (ConfigurationProperty<string> option)
+		{
+			getOutputPath = () => option.Value;
+		}
+
 		public SampleProfiler (string outputPath)
 		{
-			this.outputPath = outputPath;
+			getOutputPath = () => outputPath;
 		}
 
 		public bool ToggleProfilingChecked => sampleProcessPid != -1;
@@ -75,7 +80,7 @@ namespace MonoDevelop.Utilities
 					LoggingService.LogError (errorMessage);
 					return;
 				}
-				ConvertJITAddressesToMethodNames (outputPath, outputFilePath, "Profile");
+				ConvertJITAddressesToMethodNames (getOutputPath (), outputFilePath, "Profile");
 			};
 			return sampleProcess;
 		}


### PR DESCRIPTION
This commit introduces spindump as a profiling backend, alongside sample.

spindump has the advantage of being able to distinguish running threads
from waiting threads, thus will only generate information about things
spinning on the CPU.

On the other hand, spindump (even the normal report) is not loadable in Instruments.
But given the fact that the data is way smaller:

On the same scenario:
Sample, ~1450 stacktrace lines: https://gist.github.com/Therzok/d81908c632a3b93b30727a2b98c03d0b
Spindump, ~1200 stacktrace lines: https://gist.github.com/Therzok/94a6d3ee44ec26ce76b9266e76fa6dda

But the latter contains only actual running time, nothing that is actually spent waiting on synchronization
primitives.

Introduced a few new regexes to handle spindump format. Keep output that is sample compatible.

Also handle stackframes that are in kernel code by removing them, therefore simplifying the output.

Fixes VSTS #897635 - Consider having a spindump version for profiling, not just sample