### PR TITLE
Add IVT to TypeScriptAddin.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4363,6 +4363,7 @@
     <InternalsVisibleTo Include="MonoDevelop.UserInterfaceTesting" />
     <InternalsVisibleTo Include="MonoDevelop.VersionControl" />
     <InternalsVisibleTo Include="WebToolingAddin" />
+    <InternalsVisibleTo Include="TypeScriptAddin" />
     <InternalsVisibleTo Include="WindowsPlatform" />
     <InternalsVisibleTo Include="Xamarin.Forms.Addin" />
     <InternalsVisibleTo Include="Xamarin.Forms.Addin.Tests" />


### PR DESCRIPTION
The IVT is needed to expose WorkspaceExtensions.RegisterSolutionCrawler() which is internal.