### PR TITLE
[release-8.3] [GlobalSearch] Improves current GlobalSearch performance showing results

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FakeSearchCategory.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FakeSearchCategory.fs
@@ -44,7 +44,7 @@ type FakeSearchResult(solution: Solution, match', matchedString, rank, scriptPat
         fakeProcess.Exited.Add(fun _ -> monitor.Dispose())
 
 type FakeSearchCategory() =
-    inherit SearchCategory("FAKE", sortOrder = SearchCategory.FirstCategory)
+    inherit SearchCategory("FAKE", sortOrder = SearchCategory.FirstCategoryOrder)
 
     override x.get_Tags() = [|"fake"|]
 

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/ProjectSearchCategory.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/ProjectSearchCategory.fs
@@ -179,7 +179,7 @@ type SymbolSearchResult(match', matchedString, rank, symbol:FSharpSymbolUse) =
     override x.Length = snd (offsetAndLength.Force())
 
 type ProjectSearchCategory() =
-    inherit SearchCategory(GettextCatalog.GetString ("Solution"), sortOrder = SearchCategory.FirstCategory)
+    inherit SearchCategory(GettextCatalog.GetString ("Solution"), sortOrder = SearchCategory.FirstCategoryOrder)
 
     //type, module, struct, interface, enum, delegate, union, record
     let typeTags = ["type"; "t"; "c"; "mod"; "s"; "i"; "e"; "d"; "u"; "r" ]

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SearchPackagesSearchCategory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SearchPackagesSearchCategory.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.PackageManagement
 		public SearchPackagesSearchCategory ()
 			: base (GettextCatalog.GetString("Search"))
 		{
-			this.sortOrder = SearchInCategoryOrder;
+			this.sortOrder = SearchPackagesOrder;
 		}
 		public override Task GetResults (ISearchResultCallback searchResultCallback, SearchPopupSearchPattern pattern, CancellationToken token)
 		{

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SearchPackagesSearchCategory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/SearchPackagesSearchCategory.cs
@@ -42,6 +42,7 @@ namespace MonoDevelop.PackageManagement
 		public SearchPackagesSearchCategory ()
 			: base (GettextCatalog.GetString("Search"))
 		{
+			this.sortOrder = SearchInCategoryOrder;
 		}
 		public override Task GetResults (ISearchResultCallback searchResultCallback, SearchPopupSearchPattern pattern, CancellationToken token)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
@@ -56,6 +56,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 		public CommandSearchCategory () : base (GettextCatalog.GetString("Commands"))
 		{
+			sortOrder = CommandCategoryOrder;
 		}
 
 		readonly string[] validTags = { "cmd", "command", "c" };

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/FileSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/FileSearchCategory.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.Components.MainToolbar
 	{
 		public FileSearchCategory () : base (GettextCatalog.GetString ("Files"))
 		{
+			sortOrder = HighPriorityResultsOrder;
 		}
 
 		static FileSearchCategory ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/RoslynSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/RoslynSearchCategory.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Components.MainToolbar
 	{
 		public RoslynSearchCategory () : base (GettextCatalog.GetString ("Solution"))
 		{
-			sortOrder = FirstCategory;
+			sortOrder = FirstCategoryOrder;
 		}
 
 		static readonly string [] tags = new [] {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchCategory.cs
@@ -33,8 +33,14 @@ namespace MonoDevelop.Components.MainToolbar
 {
 	public abstract class SearchCategory : IComparable<SearchCategory>
 	{
-		protected const int FirstCategory = -1000;
-		protected int sortOrder = 0;
+		protected const int FirstCategoryOrder = -100;
+		protected const int HighPriorityResultsOrder = -50;
+		protected const int CommandCategoryOrder = 50;
+		protected const int LoadingCategoryOrder = 100;
+		protected const int SearchInCategoryOrder = 150;
+
+		protected int sortOrder;
+		internal int SortOrder => sortOrder;
 
 		internal class DataItemComparer : IComparer<SearchResult>
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchCategory.cs
@@ -37,7 +37,8 @@ namespace MonoDevelop.Components.MainToolbar
 		protected const int HighPriorityResultsOrder = -50;
 		protected const int CommandCategoryOrder = 50;
 		protected const int LoadingCategoryOrder = 100;
-		protected const int SearchInCategoryOrder = 150;
+		protected const int SearchPackagesOrder = 149;
+		protected const int SearchInSolutionOrder = 150;
 
 		protected int sortOrder;
 		internal int SortOrder => sortOrder;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
@@ -43,6 +43,7 @@ namespace MonoDevelop.Components.MainToolbar
 	{
 		public SearchInSolutionSearchCategory () : base (GettextCatalog.GetString("Search"))
 		{
+			this.sortOrder = SearchInCategoryOrder;
 		}
 
 		public override Task GetResults (ISearchResultCallback searchResultCallback, SearchPopupSearchPattern pattern, CancellationToken token)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Components.MainToolbar
 	{
 		public SearchInSolutionSearchCategory () : base (GettextCatalog.GetString("Search"))
 		{
-			this.sortOrder = SearchInCategoryOrder;
+			this.sortOrder = SearchInSolutionOrder;
 		}
 
 		public override Task GetResults (ISearchResultCallback searchResultCallback, SearchPopupSearchPattern pattern, CancellationToken token)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -361,7 +361,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 			public LoadingSearchProvidersCategory () : base (GettextCatalog.GetString ("Loading"))
 			{
-				
+				this.sortOrder = LoadingCategoryOrder;
 			}
 
 			public void Add (SearchCategory provider)
@@ -404,6 +404,17 @@ namespace MonoDevelop.Components.MainToolbar
 				return tag == "loading";
 			}
 
+		}
+
+		int GetIndexFromCategory (List<Tuple<SearchCategory, IReadOnlyList<SearchResult>>> results, SearchCategory category)
+		{
+			for (int i = 0; i < results.Count; i++) {
+				if (results[i].Item1.SortOrder >= category.SortOrder) {
+					return i;
+				}
+			}
+			//last element
+			return results.Count - 1;
 		}
 
 		public void Update (SearchPopupSearchPattern pattern)
@@ -467,7 +478,9 @@ namespace MonoDevelop.Components.MainToolbar
 							return;
 						}
 
-						newResults.Add (Tuple.Create (col.Category, col.Results));
+						//we want order the new category processed 
+						var indexToInsert = GetIndexFromCategory (newResults, col.Category);
+						newResults.Insert(indexToInsert, Tuple.Create (col.Category, col.Results));
 
 						//que want remove it all the failed results from the search
 						var calculatedResult = GetTopResult (newResults);
@@ -487,7 +500,9 @@ namespace MonoDevelop.Components.MainToolbar
 							newResults.Remove (newResults.FirstOrDefault (s => s.Item1 == searchProvidersCategory));
 
 							if (current < total) {
-								newResults.Add (new Tuple<SearchCategory, IReadOnlyList<SearchResult>> (searchProvidersCategory, searchProvidersCategory.Values));
+								//we want order the new category processed 
+								indexToInsert = GetIndexFromCategory (newResults, searchProvidersCategory);
+								newResults.Insert (indexToInsert, new Tuple<SearchCategory, IReadOnlyList<SearchResult>> (searchProvidersCategory, searchProvidersCategory.Values));
 							}
 						}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -331,7 +331,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 		sealed class ProviderSearchResult : SearchResult
 		{
-			SearchCategory searchCategory;
+			readonly SearchCategory searchCategory;
 			public override bool CanActivate {
 				get {
 					return false;


### PR DESCRIPTION
The Global Search is a very useful tool to search any text in different search providers in MD or extensions
 
![image](https://user-images.githubusercontent.com/1587480/59428730-62b81c80-8dde-11e9-93e9-42b64fb73501.png)

We have a big performance problem in large solutions like MD, on opening a solution it takes about 3 minutes to show any result.

![image](https://user-images.githubusercontent.com/1587480/59429125-5ed8ca00-8ddf-11e9-808b-1fb13386128b.png)

Investigating I found it's happening because we wait to finish all the providers to show any result, and it seems, some search providers takes more time than expected to finish, and this delays all the other results. The problem will grow as we add more suppliers to the search.

To solve this, we now show the search window **instantly**, and we launch all the search provider tasks in parallel and we add each one of the results as they finish the tasks, **that ends up starting to show results in ~1 second**.

On the other hand, I have created a new "Loading" section, containing a list of the providers that have not finished searching and they are eliminated as they end, eliminating this new section when there is not any left.

![image](https://user-images.githubusercontent.com/1587480/59874549-c2926280-939e-11e9-9608-e3d202cd5e73.png)


And this is a screencast about the entire process opening MD solution ( Note that we have not yet begun to restore nugets and we already have results in the search)

![search](https://user-images.githubusercontent.com/1587480/59874569-ce7e2480-939e-11e9-9533-968e4933a494.gif)

Fixes VSTS #902160 - Global search takes long time to show results in solutions with a lot of projects + files





Backport of #7897.

/cc @Therzok @netonjm