### PR TITLE
[Tools] Fix Xamarin.Mac reference in ExtensionTools

### DIFF
--- a/main/src/tools/ExtensionTools/ExtensionTools.csproj
+++ b/main/src/tools/ExtensionTools/ExtensionTools.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Xamarin.Mac" Condition=" '$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac' ">
-      <HintPath>..\..\..\build\bin\Xamarin.Mac.dll</HintPath>
+      <HintPath>..\..\..\external\Xamarin.Mac.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
If the ExtensionTools project is built before MonoDevelop.Ide then
the build will fail since it tries to reference Xamarin.Mac.dll from
main/build/bin instead of external. Changed the project to use
Xamarin.Mac.dll from the external directory.

Had this happen on a release-8.2 based branch. Could not repro locally but it seems like it could happen. The majority of other projects reference it from the external directory not the build/bin directory.