### PR TITLE
[Toolbox][a11y] Some accessibility fixes

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/IToolboxWidget.cs
@@ -36,7 +36,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		bool IsListMode { get; set; }
 		bool CanIconizeToolboxCategories { get; }
 		bool ShowCategories { get; set; }
-		string CustomMessage { get; set; }
 		IEnumerable<ToolboxWidgetCategory> Categories { get; }
 		IEnumerable<ToolboxWidgetItem> AllItems { get; }
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -160,7 +160,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 			#endregion
 
-			toolboxWidget = new MacToolboxWidget (container) {
+			toolboxWidget = new MacToolboxWidget () {
 				AccessibilityTitle = GettextCatalog.GetString ("Toolbox Toolbar"),
 			};
 
@@ -390,6 +390,12 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		void Refilter (bool isNewData)
 		{
+			ToolboxWidgetItem selectedItem = null;
+			//if there is a search our index of the selected item will change and we want get the new one
+			if (!isNewData) {
+				selectedItem = toolboxWidget.SelectedItem;
+			}
+			
 			var cats = categories.Values.ToList ();
 			cats.Sort ((a, b) => a.Priority != b.Priority ? b.Priority.CompareTo (a.Priority) : b.Text.CompareTo (a.Text));
 
@@ -410,7 +416,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				toolboxWidget.AddCategory (category);
 			}
 
-			toolboxWidget.RedrawItems (true, true, isNewData);
+			toolboxWidget.RedrawItems (true, true, isNewData, selectedItem);
 		}
 		
 		async void ToolboxAddButton_Clicked (object sender, EventArgs e)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -511,7 +511,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				DragSourceSet?.Invoke (this, targetTable);
 
 			Refilter (true);
-
+		
 			compactModeToggleButton.Hidden = !toolboxWidget.CanIconizeToolboxCategories;
 			compactModeToggleButton.InvalidateIntrinsicContentSize ();
 		

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -65,11 +65,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			var increment = nextPositionInArray >= 0 ? +1 : -1;
 
 			//with the initial position and increment we return the first view which can be first responder and it's not hidden
-			for (int j = initialPosition; j > 0 && j <= viewsKeyLoopOrder.Count - 1;) {
+			for (int j = initialPosition; j >= 0 && j <= viewsKeyLoopOrder.Count - 1; j += increment) {
 				if (!viewsKeyLoopOrder [j].Hidden && viewsKeyLoopOrder [j].AcceptsFirstResponder ()) {
 					return viewsKeyLoopOrder [j];
 				}
-				j += increment;
 			}
 			return null;
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -38,6 +38,7 @@ using AppKit;
 using CoreGraphics;
 using MonoDevelop.Components;
 using MonoDevelop.Components.Mac;
+using Foundation;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
@@ -274,11 +275,30 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		#endregion
 
+		NSIndexPath GetFirstVisibleItemIndexPath ()
+		{
+			for (int i = 0; i < toolboxWidget.CategoryVisibilities.Count; i++) {
+				if (toolboxWidget.CategoryVisibilities [i].Items.Count > 0) {
+					return NSIndexPath.FromItemSection (0, i);
+				}
+			}
+			return null;
+		}
+
 		private void ToolboxWidget_KeyDownPressed (object sender, NativeViews.NSEventArgs args)
 		{
 			if ((int)args.Event.ModifierFlags == (int)KeyModifierFlag.None && (args.Event.KeyCode == (int)KeyCodes.Enter)) {
-				((MacToolboxWidget)sender).PerformActivateSelectedItem ();
+				toolboxWidget.PerformActivateSelectedItem ();
+				args.Handled = true;
 				return;
+			}
+			if (args.Event.KeyCode == (ushort) NSKey.DownArrow && toolboxWidget.SelectionIndexPaths.Count == 0) {
+				var firstVisibleItemPath = GetFirstVisibleItemIndexPath ();
+				if (firstVisibleItemPath != null) {
+					toolboxWidget.SelectItems (new NSSet (firstVisibleItemPath), NSCollectionViewScrollPosition.CenteredVertically);
+					args.Handled = true;
+					return;
+				}
 			}
 			OnKeyDownKeyLoop (sender, args);
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -232,6 +232,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (nextPositionInArray == 0)
 				return view;
 			for (int i = 0; i < viewsKeyLoopOrder.Length; i++) {
+
 				if (viewsKeyLoopOrder [i] == view) {
 					var viewId = i + nextPositionInArray;
 					if (viewId <= 0 || viewId > viewsKeyLoopOrder.Length - 1)
@@ -524,8 +525,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			// Default configuration
 			categoryPriorities.Clear ();
-			toolboxAddButton.Hidden = false;
-			
+			AllowEditingComponents = true;
 			toolboxService.Customize (container, this);
 		}
 
@@ -593,6 +593,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}
 			set {
 				toolboxAddButton.Hidden = !value;
+				toolboxAddButton.InvalidateIntrinsicContentSize ();
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -175,7 +175,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			toolboxService.ToolboxContentsChanged += ToolboxService_ToolboxContentsChanged;
 			toolboxService.ToolboxConsumerChanged += ToolboxService_ToolboxConsumerChanged;
 
-
 			toolboxWidget.DragBegin += ToolboxWidget_DragBegin;
 			toolboxWidget.ActivateSelectedItem += ToolboxWidget_ActivateSelectedItem;
 			toolboxWidget.MenuOpened += ToolboxWidget_MenuOpened;
@@ -346,11 +345,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}
 		}
 
-		void FilterEntry_Changed (object sender, EventArgs e)
-		{
-			Refilter ();
-		}
-
 		void ToolboxWidget_DragBegin (object sender, EventArgs e)
 		{
 			if (this.toolboxWidget.SelectedItem != null) {
@@ -363,7 +357,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		void ToggleCompactMode (object sender, EventArgs e)
 		{
 			toolboxWidget.IsListMode = !compactModeToggleButton.Active;
-			Refilter ();
+			Refilter (false);
 
 			PropertyService.Set ("ToolboxIsInCompactMode", compactModeToggleButton.Active);
 
@@ -379,7 +373,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		void ToggleCategorisation (object sender, EventArgs e)
 		{
 			this.toolboxWidget.ShowCategories = catToggleButton.Active;
-			Refilter ();
+			Refilter (false);
 			if (catToggleButton.Active) {
 				catToggleButton.AccessibilityTitle = GettextCatalog.GetString ("Hide Categories");
 				catToggleButton.AccessibilityHelp = GettextCatalog.GetString ("Toggle to hide toolbox categories");
@@ -391,10 +385,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		void FilterTextChanged (object sender, EventArgs e)
 		{
-			Refilter ();
+			Refilter (false);
 		}
 
-		void Refilter ()
+		void Refilter (bool isNewData)
 		{
 			var cats = categories.Values.ToList ();
 			cats.Sort ((a, b) => a.Priority != b.Priority ? b.Priority.CompareTo (a.Priority) : b.Text.CompareTo (a.Text));
@@ -416,7 +410,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				toolboxWidget.AddCategory (category);
 			}
 
-			toolboxWidget.RedrawItems (true, true);
+			toolboxWidget.RedrawItems (true, true, isNewData);
 		}
 		
 		async void ToolboxAddButton_Clicked (object sender, EventArgs e)
@@ -510,7 +504,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (targetTable != null)
 				DragSourceSet?.Invoke (this, targetTable);
 
-			Refilter ();
+			Refilter (true);
 
 			compactModeToggleButton.Hidden = !toolboxWidget.CanIconizeToolboxCategories;
 			compactModeToggleButton.InvalidateIntrinsicContentSize ();

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -65,9 +65,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			var increment = nextPositionInArray >= 0 ? +1 : -1;
 
 			//with the initial position and increment we return the first view which can be first responder and it's not hidden
-			for (int j = initialPosition; j >= 0 && j <= viewsKeyLoopOrder.Count - 1; j += increment) {
-				if (!viewsKeyLoopOrder [j].Hidden && viewsKeyLoopOrder [j].AcceptsFirstResponder ()) {
-					return viewsKeyLoopOrder [j];
+			for (int j = initialPosition; j >= 0 && j < viewsKeyLoopOrder.Count; j += increment) {
+				var nextView = viewsKeyLoopOrder [j];
+				if (!nextView.Hidden && nextView.AcceptsFirstResponder ()) {
+					return nextView;
 				}
 			}
 			return null;
@@ -550,6 +551,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing) {
+				filterEntry.Activated -= FilterTextChanged;
+
 				filterEntry.CommandRaised -= FilterEntry_CommandRaised;
 
 				catToggleButton.Activated -= ToggleCategorisation;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxViewItems.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxViewItems.cs
@@ -250,8 +250,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 	{
 		public event EventHandler PerformPress;
 
-		public override bool WantsUpdateLayer => true;
-
 		bool isSelected;
 		public bool IsSelected {
 			get => isSelected;
@@ -260,16 +258,21 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					return;
 				}
 				isSelected = value;
-				if (value) {
-					if (collectionView == null || collectionView.IsFocused) {
-						Layer.BackgroundColor = Styles.CellBackgroundSelectedColor.CGColor;
-					} else {
-						Layer.BackgroundColor = Styles.CellBackgroundUnfocusedSelectedColor.CGColor;
-					}
-				} else {
-					Layer.BackgroundColor = NSColor.Clear.CGColor;
-				}
 
+				RefreshLayer ();
+			}
+		}
+
+		internal void RefreshLayer ()
+		{
+			if (isSelected) {
+				if (collectionView == null || collectionView.IsFocused) {
+					Layer.BackgroundColor = Styles.CellBackgroundSelectedColor.CGColor;
+				} else {
+					Layer.BackgroundColor = Styles.CellBackgroundUnfocusedSelectedColor.CGColor;
+				}
+			} else {
+				Layer.BackgroundColor = NSColor.Clear.CGColor;
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -216,7 +216,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			base.SetFrameSize (newSize);
 		
-			RedrawItems (true, false);
+			RedrawItems (true, false, false);
 		}
 
 		public override void MouseDown (NSEvent theEvent)
@@ -229,10 +229,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			base.MouseDown (theEvent);
 		}
 
-		public void RedrawItems (bool invalidates, bool reloads)
+		public void RedrawItems (bool invalidates, bool reloads,bool isNewData)
 		{
 			NSIndexPath selected = null;
-			if (SelectionIndexPaths.Count > 0) {
+			if (!isNewData && SelectionIndexPaths.Count > 0) {
 				selected = (NSIndexPath)SelectionIndexPaths.ElementAt (0);
 			}
 			if (IsListMode) {
@@ -257,6 +257,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 			if (selected != null) {
 				SelectionIndexPaths = new NSSet (selected);
+			} else {
+				SelectionIndexPaths = new NSSet ();
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -182,10 +182,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		public override void KeyDown (NSEvent theEvent)
 		{
-			base.KeyDown (theEvent);
 			if ((int)theEvent.ModifierFlags == (int)KeyModifierFlag.None && (theEvent.KeyCode == (int)KeyCodes.Enter)) {
 				PerformActivateSelectedItem ();
 			}
+			base.KeyDown (theEvent);
 		}
 
 		void DataSource_RegionCollapsed (object sender, NSIndexPath e)
@@ -218,10 +218,11 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public override void MouseDown (NSEvent theEvent)
 		{
 			collectionViewDelegate.IsLastSelectionFromMouseDown = true;
-			base.MouseDown (theEvent);
 			if (SelectedItem != null && theEvent.ClickCount > 1) {
 				PerformActivateSelectedItem ();
 			}
+
+			base.MouseDown (theEvent);
 		}
 
 		public void RedrawItems (bool invalidates, bool reloads)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -68,9 +68,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			get { return CategoryVisibilities.Select (s => s.Category); }
 		}
 
-		internal void PerformActivateSelectedItem () => OnActivateSelectedItem (EventArgs.Empty);
-
-		void OnActivateSelectedItem (EventArgs args) => ActivateSelectedItem?.Invoke (this, args);
+		internal void PerformActivateSelectedItem () => ActivateSelectedItem?.Invoke (this, EventArgs.Empty);
 
 		NSIndexPath selectedIndexPath;
 		public NSIndexPath SelectedIndexPath {
@@ -222,7 +220,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			collectionViewDelegate.IsLastSelectionFromMouseDown = true;
 			base.MouseDown (theEvent);
 			if (SelectedItem != null && theEvent.ClickCount > 1) {
-				OnActivateSelectedItem (EventArgs.Empty);
+				PerformActivateSelectedItem ();
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -142,24 +142,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}
 		}
 
-		public MacToolboxWidget (IPadWindow container) : base ()
+		public MacToolboxWidget (IPadWindow container)
 		{
 			this.container = container;
-			container.PadContentShown += OnContainerIsShown;
-
-			Initialize ();
-		}
-
-		// Called when created from unmanaged code
-		public MacToolboxWidget (IntPtr handle) : base (handle)
-		{
-			Initialize ();
-		}
-
-		// Called when created directly from a XIB file
-		[Export ("initWithCoder:")]
-		public MacToolboxWidget (NSCoder coder) : base (coder)
-		{
 			Initialize ();
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -298,20 +298,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			return base.BecomeFirstResponder ();
 		}
 
-		#region INativeChildView
-
-		public void OnKeyPressed (object o, Gtk.KeyPressEventArgs ev)
-		{
-
-		}
-
-		public void OnKeyReleased (object s, Gtk.KeyReleaseEventArgs ev)
-		{
-
-		}
-
-		#endregion
-
 		internal void ClearImageCache ()
 		{
 			dataSource.Clear ();

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -57,8 +57,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public event EventHandler<CGPoint> MenuOpened;
 		public event EventHandler ActivateSelectedItem;
 
-		IPadWindow container;
-		
 		MacToolboxWidgetDataSource dataSource;
 
 		bool listMode;
@@ -125,9 +123,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			}
 		}
 
-		public MacToolboxWidget (IPadWindow container)
+		public MacToolboxWidget ()
 		{
-			this.container = container;
 			Initialize ();
 		}
 
@@ -153,7 +150,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		// Shared initialization code
 		public void Initialize ()
 		{
-			TranslatesAutoresizingMaskIntoConstraints = false;
 			AccessibilityRole = NSAccessibilityRoles.ToolbarRole;
 			flowLayout = new NSCollectionViewFlowLayout {
 				SectionHeadersPinToVisibleBounds = false,

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -178,7 +178,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			RegisterClassForItem (typeof (LabelCollectionViewItem), LabelViewItemName);
 			RegisterClassForItem (typeof (ImageCollectionViewItem), ImageViewItemName);
 		}
-
 	
 		public event EventHandler<NativeViews.NSEventArgs> KeyDownPressed;
 
@@ -191,15 +190,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				base.KeyDown (theEvent);
 		}
 
-		void DataSource_RegionCollapsed (object sender, NSIndexPath e)
-		{
-			RegionCollapsed?.Invoke (this, EventArgs.Empty);
-		}
+		void DataSource_RegionCollapsed (object sender, NSIndexPath e) => RegionCollapsed?.Invoke (this, EventArgs.Empty);
 
-		void CollectionViewDelegate_DragBegin (object sender, NSIndexSet e)
-		{
-			DragBegin?.Invoke (this, EventArgs.Empty);
-		}
+		void CollectionViewDelegate_DragBegin (object sender, NSIndexSet e) => DragBegin?.Invoke (this, EventArgs.Empty);
 
 		void CollectionViewDelegate_SelectionChanged (object sender, NSSet e)
 		{
@@ -215,7 +208,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			base.SetFrameSize (newSize);
 		
-			RedrawItems (true, false, false);
+			RedrawItems (true, false, false, SelectedItem);
 		}
 
 		public override void MouseDown (NSEvent theEvent)
@@ -224,15 +217,25 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			if (SelectedItem != null && theEvent.ClickCount > 1) {
 				PerformActivateSelectedItem ();
 			}
-
 			base.MouseDown (theEvent);
 		}
 
-		public void RedrawItems (bool invalidates, bool reloads,bool isNewData)
+		NSIndexPath GetIndexPathFromItem (ToolboxWidgetItem item)
+		{
+			for (int i = 0; i < CategoryVisibilities.Count; i++) {
+				for (int j = 0; j < CategoryVisibilities[i].Items.Count; j++) {
+					if (item == CategoryVisibilities [i].Items[j])
+						return NSIndexPath.FromItemSection (j, i);
+				}
+			}
+			return null;
+		}
+
+		public void RedrawItems (bool invalidates, bool reloads,bool isNewData, ToolboxWidgetItem selectedWidgetItem)
 		{
 			NSIndexPath selected = null;
-			if (!isNewData && SelectionIndexPaths.Count > 0) {
-				selected = (NSIndexPath)SelectionIndexPaths.ElementAt (0);
+			if (!isNewData && selectedWidgetItem != null) {
+				selected = GetIndexPathFromItem (selectedWidgetItem);
 			}
 			if (IsListMode) {
 				flowLayout.ItemSize = new CGSize (Math.Max (Frame.Width - IconMargin, 1), LabelCollectionViewItem.ItemHeight);

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -70,24 +70,23 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		internal void PerformActivateSelectedItem () => ActivateSelectedItem?.Invoke (this, EventArgs.Empty);
 
-		NSIndexPath selectedIndexPath;
 		public NSIndexPath SelectedIndexPath {
-			get {
-				return selectedIndexPath;
-			}
+			get => SelectionIndexPaths.FirstOrDefault () as NSIndexPath;
 			set {
-				if (selectedIndexPath != value) {
-					selectedIndexPath = value;
+				if (value == null) {
+					SelectionIndexPaths = new NSSet ();
+				} else {
+					SelectionIndexPaths = new NSSet (value);
 				}
 			}
 		}
 
 		public ToolboxWidgetItem SelectedItem {
 			get {
-				if (MacToolboxWidgetDataSource.IsIndexOutOfSync (selectedIndexPath, CategoryVisibilities)) {
+				if (MacToolboxWidgetDataSource.IsIndexOutOfSync (SelectedIndexPath, CategoryVisibilities)) {
 					return null;
 				}
-				return CategoryVisibilities [(int)selectedIndexPath.Section].Items [(int)selectedIndexPath.Item];
+				return CategoryVisibilities [(int)SelectedIndexPath.Section].Items [(int)SelectedIndexPath.Item];
 			}
 		}
 
@@ -145,8 +144,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			if (SelectionIndexPaths.Count > 0) {
 				var collectionViewItem = GetItem ((NSIndexPath)SelectionIndexPaths.ElementAt (0));
-				if (collectionViewItem != null && collectionViewItem.View != null) {
-					collectionViewItem.View.NeedsDisplay = true;
+				if (collectionViewItem != null && collectionViewItem.View is ContentCollectionViewItem contentCollectionView) {
+					contentCollectionView.RefreshLayer ();
 				}
 			}
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -38,7 +38,6 @@ using MonoDevelop.Components.Mac;
 
 namespace MonoDevelop.DesignerSupport.Toolbox
 {
-	[Register ("MacToolboxWidget")]
 	class MacToolboxWidget : NSCollectionView, IToolboxWidget
 	{
 		internal const string ImageViewItemName = "ImageViewItem";
@@ -59,7 +58,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public event EventHandler ActivateSelectedItem;
 
 		IPadWindow container;
-		NSTextField messageTextField;
+		
 		MacToolboxWidgetDataSource dataSource;
 
 		bool listMode;
@@ -91,19 +90,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 					return null;
 				}
 				return CategoryVisibilities [(int)selectedIndexPath.Section].Items [(int)selectedIndexPath.Item];
-			}
-		}
-
-		public string CustomMessage {
-			get => messageTextField.StringValue;
-			set {
-				if (string.IsNullOrEmpty (value)) {
-					messageTextField.StringValue = "";
-					messageTextField.Hidden = true;
-				} else {
-					messageTextField.StringValue = value;
-					messageTextField.Hidden = false;
-				}
 			}
 		}
 
@@ -189,16 +175,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			collectionViewDelegate.DragBegin += CollectionViewDelegate_DragBegin;
 			collectionViewDelegate.SelectionChanged += CollectionViewDelegate_SelectionChanged;
 
-			var fontSmall = NativeViewHelper.GetSystemFont (false, (int)NSFont.SmallSystemFontSize);
-			messageTextField = new NSLabel {
-				StringValue = String.Empty,
-				Alignment = NSTextAlignment.Center,
-				Font = fontSmall,
-				LineBreakMode = NSLineBreakMode.ByWordWrapping
-			};
-			messageTextField.SetContentCompressionResistancePriority (250, NSLayoutConstraintOrientation.Horizontal);
-			AddSubview (messageTextField);
-
 			BackgroundColors = new NSColor [] { Styles.ToolbarBackgroundColor };
 
 			RegisterClassForItem (typeof (HeaderCollectionViewItem), HeaderViewItemName);
@@ -237,8 +213,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		public override void SetFrameSize (CGSize newSize)
 		{
 			base.SetFrameSize (newSize);
-			var frame = messageTextField.Frame;
-			messageTextField.Frame = new CGRect (frame.Location, newSize);
+		
 			RedrawItems (true, false);
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -200,6 +200,10 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			AddSubview (messageTextField);
 
 			BackgroundColors = new NSColor [] { Styles.ToolbarBackgroundColor };
+
+			RegisterClassForItem (typeof (HeaderCollectionViewItem), HeaderViewItemName);
+			RegisterClassForItem (typeof (LabelCollectionViewItem), LabelViewItemName);
+			RegisterClassForItem (typeof (ImageCollectionViewItem), ImageViewItemName);
 		}
 
 		public override void KeyDown (NSEvent theEvent)
@@ -303,19 +307,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			dataSource.Clear ();
 		}
 
-		internal void OnContainerIsShown (object sender, EventArgs e)
-		{
-			RegisterClassForItem (typeof (HeaderCollectionViewItem), HeaderViewItemName);
-			RegisterClassForItem (typeof (LabelCollectionViewItem), LabelViewItemName);
-			RegisterClassForItem (typeof (ImageCollectionViewItem), ImageViewItemName);
-		}
-
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing) {
-				if (container != null) {
-					container.PadContentShown -= OnContainerIsShown;
-				}
 
 				collectionViewDelegate.DragBegin -= CollectionViewDelegate_DragBegin;
 				collectionViewDelegate.SelectionChanged -= CollectionViewDelegate_SelectionChanged;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -219,9 +219,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		NSIndexPath GetIndexPathFromItem (ToolboxWidgetItem item)
 		{
 			for (int i = 0; i < CategoryVisibilities.Count; i++) {
-				for (int j = 0; j < CategoryVisibilities[i].Items.Count; j++) {
-					if (item == CategoryVisibilities [i].Items[j])
-						return NSIndexPath.FromItemSection (j, i);
+				int index = CategoryVisibilities [i].Items.IndexOf (item);
+				if (index >= 0) {
+					return NSIndexPath.FromItemSection (index, i);
 				}
 			}
 			return null;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -180,12 +180,16 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			RegisterClassForItem (typeof (ImageCollectionViewItem), ImageViewItemName);
 		}
 
+	
+		public event EventHandler<NativeViews.NSEventArgs> KeyDownPressed;
+
 		public override void KeyDown (NSEvent theEvent)
 		{
-			if ((int)theEvent.ModifierFlags == (int)KeyModifierFlag.None && (theEvent.KeyCode == (int)KeyCodes.Enter)) {
-				PerformActivateSelectedItem ();
-			}
-			base.KeyDown (theEvent);
+			var args = new NativeViews.NSEventArgs (theEvent);
+			KeyDownPressed?.Invoke (this, args);
+
+			if (!args.Handled)
+				base.KeyDown (theEvent);
 		}
 
 		void DataSource_RegionCollapsed (object sender, NSIndexPath e)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidget.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		internal void PerformActivateSelectedItem () => ActivateSelectedItem?.Invoke (this, EventArgs.Empty);
 
 		public NSIndexPath SelectedIndexPath {
-			get => SelectionIndexPaths.FirstOrDefault () as NSIndexPath;
+			get => SelectionIndexPaths.AnyObject as NSIndexPath;
 			set {
 				if (value == null) {
 					SelectionIndexPaths = new NSSet ();
@@ -84,7 +84,8 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				if (MacToolboxWidgetDataSource.IsIndexOutOfSync (SelectedIndexPath, CategoryVisibilities)) {
 					return null;
 				}
-				return CategoryVisibilities [(int)SelectedIndexPath.Section].Items [(int)SelectedIndexPath.Item];
+				var indexPath = SelectedIndexPath;
+				return CategoryVisibilities [(int)indexPath.Section].Items [(int)indexPath.Item];
 			}
 		}
 
@@ -140,7 +141,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		void RedrawSelectedItem ()
 		{
 			if (SelectionIndexPaths.Count > 0) {
-				var collectionViewItem = GetItem ((NSIndexPath)SelectionIndexPaths.ElementAt (0));
+				var collectionViewItem = GetItem (SelectedIndexPath);
 				if (collectionViewItem != null && collectionViewItem.View is ContentCollectionViewItem contentCollectionView) {
 					contentCollectionView.RefreshLayer ();
 				}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidgetFlowLayoutDelegate.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolboxWidgetFlowLayoutDelegate.cs
@@ -49,8 +49,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 
 		public override CGSize SizeForItem (NSCollectionView collectionView, NSCollectionViewLayout collectionViewLayout, NSIndexPath indexPath)
 		{
-			var macToolboxWidget = (MacToolboxWidget)collectionView;
-			var dataSource = (MacToolboxWidgetDataSource)collectionView.DataSource;
 			var flowLayout = (NSCollectionViewFlowLayout)collectionViewLayout;
 			return flowLayout.ItemSize;
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ClickedButton.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ClickedButton.cs
@@ -36,6 +36,7 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 	class ClickedButton : NSButton
 	{
 		public event EventHandler Focused;
+		public event EventHandler<NSEventArgs> KeyDownPressed;
 
 		public override CGSize IntrinsicContentSize => Hidden ? CGSize.Empty : new CGSize (25, 25);
 
@@ -53,6 +54,19 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 		{
 			Focused?.Invoke (this, EventArgs.Empty);
 			return base.BecomeFirstResponder ();
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if ((int)theEvent.ModifierFlags == (int)KeyModifierFlag.None && (theEvent.KeyCode == (int)KeyCodes.Enter || theEvent.KeyCode == (int)KeyCodes.Space)) {
+				PerformClick (this);
+			}
+
+			var args = new NSEventArgs (theEvent);
+			KeyDownPressed?.Invoke (this, args);
+
+			if (!args.Handled)
+				base.KeyDown (theEvent);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/SearchTextField.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/SearchTextField.cs
@@ -46,7 +46,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 
 		public SearchTextField ()
 		{
-			TranslatesAutoresizingMaskIntoConstraints = false;
 			Delegate = this;
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/SearchTextField.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/SearchTextField.cs
@@ -29,22 +29,46 @@
 #if MAC
 using System;
 using AppKit;
+using Foundation;
 
 namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 {
-	class SearchTextField : NSSearchField
+	enum SearchTextFieldCommand
+	{
+		InsertTab,
+		InsertBacktab
+	}
+
+	class SearchTextField : NSSearchField, INSSearchFieldDelegate
 	{
 		public event EventHandler Focused;
+		public event EventHandler<SearchTextFieldCommand> CommandRaised;
 
 		public SearchTextField ()
 		{
 			TranslatesAutoresizingMaskIntoConstraints = false;
+			Delegate = this;
 		}
 
 		public override bool BecomeFirstResponder ()
 		{
 			Focused?.Invoke (this, EventArgs.Empty);
 			return base.BecomeFirstResponder ();
+		}
+
+		[Export ("control:textView:doCommandBySelector:")]
+		bool CommandBySelector (NSControl control, NSTextField field, ObjCRuntime.Selector sel)
+		{
+			switch (sel.Name) {
+			case "insertTab:": // down arrow
+				CommandRaised?.Invoke (this, SearchTextFieldCommand.InsertTab);
+				return true;
+
+			case "insertBacktab:": // up arrow
+				CommandRaised?.Invoke (this, SearchTextFieldCommand.InsertBacktab);
+				return true;
+			}
+			return false;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
@@ -58,7 +58,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 			BezelStyle = NSBezelStyle.RoundRect;
 			SetButtonType (NSButtonType.OnOff);
 			FocusRingType = NSFocusRingType.Default;
-			TranslatesAutoresizingMaskIntoConstraints = false;
 		}
 
 		public override bool BecomeFirstResponder ()

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
@@ -34,8 +34,20 @@ using MonoDevelop.Components.Mac;
 
 namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 {
+	class NSEventArgs : EventArgs
+	{
+		public NSEventArgs (NSEvent nsEvent)
+		{
+			Event = nsEvent;
+		}
+
+		public bool Handled { get; set; }
+		public NSEvent Event { get; set; }
+	}
+
 	class ToggleButton : NSButton
 	{
+		public event EventHandler<NSEventArgs> KeyDownPressed;
 		public event EventHandler Focused;
 
 		public override CGSize IntrinsicContentSize => Hidden ? CGSize.Empty : new CGSize (25, 25);
@@ -64,10 +76,15 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 
 		public override void KeyDown (NSEvent theEvent)
 		{
-			base.KeyDown (theEvent);
 			if ((int)theEvent.ModifierFlags == (int) KeyModifierFlag.None && (theEvent.KeyCode == (int)KeyCodes.Enter || theEvent.KeyCode == (int)KeyCodes.Space)) {
 				PerformClick (this);
 			}
+
+			var args = new NSEventArgs (theEvent);
+			KeyDownPressed?.Invoke (this, args);
+
+			if (!args.Handled)
+				base.KeyDown (theEvent);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
@@ -34,7 +34,7 @@ using MonoDevelop.Components.Mac;
 
 namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 {
-	class NSEventArgs : EventArgs
+	sealed class NSEventArgs : EventArgs
 	{
 		public NSEventArgs (NSEvent nsEvent)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/KeyCodes.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/KeyCodes.cs
@@ -39,7 +39,8 @@ namespace MonoDevelop.Components.Mac
 	[Flags]
 	internal enum KeyModifierFlag
 	{
-		None = 0x100
+		None = 0x100,
+		Shift = 0x20102
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/VerticalAlignmentTextCell.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/VerticalAlignmentTextCell.cs
@@ -1,0 +1,89 @@
+﻿//
+// VerticalAlignmentTextCell.cs
+//
+// Author:
+//       Jose Medrano <josmed@microsoft.com>
+//
+// Copyright (c) 2018 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+
+#if MAC
+using System;
+using AppKit;
+using CoreGraphics;
+using Foundation;
+
+namespace MonoDevelop.Components.Mac
+{
+	public class VerticalAlignmentTextCell : NSTextFieldCell
+	{
+		public NSTextBlockVerticalAlignment VerticalAligment { get; set; }
+
+		public VerticalAlignmentTextCell (NSTextBlockVerticalAlignment verticalAlignment = NSTextBlockVerticalAlignment.Top)
+		{
+			VerticalAligment = verticalAlignment;
+		}
+
+		public VerticalAlignmentTextCell (NSCoder coder) : base (coder)
+		{
+		}
+
+		public VerticalAlignmentTextCell (string aString) : base (aString)
+		{
+		}
+
+		public VerticalAlignmentTextCell (NSImage image) : base (image)
+		{
+		}
+
+		protected VerticalAlignmentTextCell (NSObjectFlag t) : base (t)
+		{
+		}
+
+		protected internal VerticalAlignmentTextCell (IntPtr handle) : base (handle)
+		{
+		}
+
+		public override CGRect DrawingRectForBounds (CGRect theRect)
+		{
+			var newRect = base.DrawingRectForBounds (theRect);
+			if (VerticalAligment == NSTextBlockVerticalAlignment.Top)
+				return newRect;
+			
+			var textSize = CellSizeForBounds (theRect);
+			//Center in the proposed rect
+			float heightDelta = (float)(newRect.Size.Height - textSize.Height);
+			float height = (float)newRect.Height;
+			float y = (float)newRect.Y;
+			if (heightDelta > 0) {
+				height -= heightDelta;
+				if (VerticalAligment == NSTextBlockVerticalAlignment.Bottom)
+					y += heightDelta;
+				else
+					y += heightDelta / 2f;
+			}
+			return new CGRect (newRect.X, y, newRect.Width, height);
+		}
+	}
+}
+
+#endif

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4297,6 +4297,7 @@
     <Compile Include="MonoDevelop.Ide.Projects.FileNesting\NestingRule.cs" />
     <Compile Include="MonoDevelop.Ide.Projects.FileNesting\NestingRulesProvider.cs" />
     <Compile Include="MonoDevelop.Ide\TranslationCatalog.cs" />
+    <Compile Include="MonoDevelop.Components\Mac\VerticalAlignmentTextCell.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />


### PR DESCRIPTION
This include some fixes and code clean for the Toolbox

* Fixes Bug #971161 - [Toolbox] Bad alignment in "There are no tools available for the current " label

![image](https://user-images.githubusercontent.com/1587480/63590018-eba3bf00-c5aa-11e9-8786-e39498602bb3.png)

* Fixes Bug #935560 - [Toolbox] Tab key to change between views seems to be broken
* Fixes Bug #752358: Accessibility: Toolbox Pad: Toolbox button is not accessible by keyboard as it is not receiving focus while tabbing and shift tabbing

![focus](https://user-images.githubusercontent.com/1587480/63590114-332a4b00-c5ab-11e9-84c0-a7539730bb1a.gif)

* Fixes Bug #972118 - [Toolbox] Selected item color it's not working when item has no focus

![focuscolor](https://user-images.githubusercontent.com/1587480/63590197-71c00580-c5ab-11e9-8ddc-4ae7c3118633.gif)

* Fixes Bug #972184 - [Toolbox] Filtering is not leaving the current selected item

![filter](https://user-images.githubusercontent.com/1587480/63590230-8ef4d400-c5ab-11e9-9308-c1ba8c741744.gif)

