### PR TITLE
[release-8.3] [Mac] Remove the code for changing application name

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/Carbon.cs
+++ b/main/src/addins/MacPlatform/MacInterop/Carbon.cs
@@ -207,32 +207,7 @@ namespace MonoDevelop.MacInterop
 		}
 		
 		#endregion
-		
-		#region Internal Mac API for setting process name
-		
-		[DllImport (CarbonLib)]
-		static extern int GetCurrentProcess (out ProcessSerialNumber psn);
-		
-		[DllImport (CarbonLib)]
-		static extern int CPSSetProcessName (ref ProcessSerialNumber psn, string name);
 
-		public static void SetProcessName (string name)
-		{
-			try {
-				if (GetCurrentProcess (out ProcessSerialNumber psn) == 0)
-					CPSSetProcessName (ref psn, name);
-			} catch (TypeLoadException) {} //EntryPointNotFoundException?
-		}
-
-		struct ProcessSerialNumber {
-#pragma warning disable 0169
-			uint highLongOfPSN;
-			uint lowLongOfPSN;
-#pragma warning restore 0169
-		}
-		
-		#endregion
-		
 		public static Dictionary<string,int> GetFileListFromEventRef (IntPtr eventRef)
 		{
 			AEDesc list = GetEventParameter<AEDesc> (eventRef, CarbonEventParameterName.DirectObject, CarbonEventParameterType.AEList);

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -83,7 +83,6 @@ namespace MonoDevelop.MacIntegration
 			set {
 				if (applicationMenuName != value) {
 					applicationMenuName = value;
-					OnApplicationMenuNameChanged ();
 				}
 			}
 		}
@@ -153,9 +152,6 @@ namespace MonoDevelop.MacIntegration
 				LoggingService.LogFatalError ("Unable to load libxammac");
 
 			mimemap = new Lazy<Dictionary<string, string>> (LoadMimeMapAsync);
-
-			//make sure the menu app name is correct even when running Mono 2.6 preview, or not running from the .app
-			Carbon.SetProcessName (BrandingService.ApplicationName);
 
 			CheckGtkVersion (2, 24, 14);
 
@@ -618,19 +614,6 @@ namespace MonoDevelop.MacIntegration
 		static string GetHideWindowCommandText ()
 		{
 			return GettextCatalog.GetString ("Hide {0}", ApplicationMenuName);
-		}
-
-		static void OnApplicationMenuNameChanged ()
-		{
-			Command aboutCommand = IdeApp.CommandService.GetCommand (HelpCommands.About);
-			if (aboutCommand != null)
-				aboutCommand.Text = GetAboutCommandText ();
-
-			Command hideCommand = IdeApp.CommandService.GetCommand (MacIntegrationCommands.HideWindow);
-			if (hideCommand != null)
-				hideCommand.Text = GetHideWindowCommandText ();
-
-			Carbon.SetProcessName (ApplicationMenuName);
 		}
 
 		// VV/VK: Disable tint based color generation

--- a/main/src/tools/mdmonitor/Main.cs
+++ b/main/src/tools/mdmonitor/Main.cs
@@ -67,8 +67,6 @@ namespace Mono.Instrumentation.Monitor
 			
 			if (MacIntegration.PlatformDetection.IsMac) {
 				try {
-					Carbon.SetProcessName ("MDMonitor");
-					
 					ApplicationEvents.Quit += delegate (object sender, ApplicationQuitEventArgs e) {
 						Application.Quit ();
 						e.Handled = true;

--- a/main/tests/MacPlatform.Tests/CarbonTests.cs
+++ b/main/tests/MacPlatform.Tests/CarbonTests.cs
@@ -33,17 +33,6 @@ namespace MacPlatform.Tests
 	public class CarbonTests
 	{
 		[Test]
-		[Ignore ("This test doesn't work on either 32 or 64bit")]
-		public void TestProcessName ()
-		{
-			string processName = "HelloWorld";
-			Carbon.SetProcessName (processName);
-
-			Process currentProcess = Process.GetCurrentProcess ();
-			Assert.AreEqual (processName, currentProcess.ProcessName);
-		}
-
-		[Test]
 		public void TestGestalt ()
 		{
 			int majorVersion = Carbon.Gestalt ("sys1");


### PR DESCRIPTION
The Carbon code for changing the application name is private and unsupported,
and fragile, and isn't really needed anymore as we just want to use the app
name from the app bundle.

The downside of this is that the app name displayed when debugging from inside
the IDE is "mono64" and when run from 'make run' it is MonoDevelop. Run from
an appbundle, it gets the correct name

Fixes vSTS #899321

Backport of #8510.

/cc @iainx 