### PR TITLE
[release-8.3] Fixes VSTS Bug 958249: System.InvalidOperationException exception in

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/LogTextWriter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/LogTextWriter.cs
@@ -76,7 +76,11 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		public override void Close ()
 		{
 			if (context != null)
-				context.Post ((o) => ((LogTextWriter)o).OnClosed (), this);
+				context.Post ((o) => {
+					if (((LogTextWriter)o).IsDisposed)
+						return;
+					((LogTextWriter)o).OnClosed ();
+				}, this);
 			else
 				OnClosed ();
 		}
@@ -89,7 +93,11 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		public override void Write (char[] buffer, int index, int count)
 		{
 			if (context != null)
-				context.Post ((o) => ((LogTextWriter)o).OnWrite (buffer, index, count), this);
+				context.Post ((o) => {
+					if (((LogTextWriter)o).IsDisposed)
+						return;
+					((LogTextWriter)o).OnWrite (buffer, index, count);
+				}, this);
 			else
 				OnWrite (buffer, index, count);
 		}
@@ -106,7 +114,11 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		public override void Write (char value)
 		{
 			if (context != null)
-				context.Post ((o) => ((LogTextWriter)o).OnWrite (value), this);
+				context.Post ((o) => {
+					if (((LogTextWriter)o).IsDisposed)
+						return;
+					((LogTextWriter)o).OnWrite (value);
+				}, this);
 			else
 				OnWrite (value);
 		}
@@ -123,7 +135,11 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		public override void Write (string value)
 		{
 			if (context != null)
-				context.Post ((o) => ((LogTextWriter)o).OnWrite (value), this);
+				context.Post ((o) => {
+					if (((LogTextWriter)o).IsDisposed)
+						return;
+					((LogTextWriter)o).OnWrite (value);
+				}, this);
 			else
 				OnWrite (value);
 		}
@@ -140,12 +156,26 @@ namespace MonoDevelop.Core.ProgressMonitoring
 		public override void Flush ()
 		{
 			if (context != null)
-				context.Post ((o) => base.Flush (), null);
+				context.Post ((o) => {
+					if (IsDisposed)
+						return;
+					base.Flush ();
+				}, null);
 			else
 				base.Flush ();
 		}
 
 		public event LogTextEventHandler TextWritten;
 		public event EventHandler Closed;
+
+		public bool IsDisposed { get; private set; }
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (disposing) {
+				IsDisposed = true;
+			}
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -981,6 +981,8 @@ namespace MonoDevelop.Ide.Gui.Components
 		protected override void OnDispose (bool disposing)
 		{
 			base.OnDispose (disposing);
+			internalLogger.TextWritten -= WriteConsoleLogText;
+
 			console.Dispose ();
 			Disposed?.Invoke (this, EventArgs.Empty);
 		}


### PR DESCRIPTION
MonoDevelop.Ide.Gui.Components.LogViewProgressMonitor.OnWriteLog()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958249

OnWriteLog is called on a disposed LogViewProgressMonitor. The removal
of the event handler would fix that exception. But it's better to
check for disposal on the context.Post calls. From the exception text
that is the cause and there are more cases where a disposal check
makes sense.

Backport of #8386.

/cc @mkrueger 