### PR TITLE
Fixes VSTS Bug 972229: [FATAL] System.ArgumentOutOfRangeException exc…

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
@@ -805,7 +805,11 @@ namespace MonoDevelop.VersionControl.Views
 			protected override bool OnButtonPressEvent (EventButton evnt)
 			{
 				if (!evnt.TriggersContextMenu () && evnt.Button == 1 && !selectedHunk.IsEmpty) {
-					widget.UndoChange (fromEditor, toEditor, selectedHunk);
+					try {
+						widget.UndoChange (fromEditor, toEditor, selectedHunk);
+					} catch (Exception e) {
+						LoggingService.LogInternalError ("Error while undoing widget change.", e);
+					}
 					return true;
 				}
 				return base.OnButtonPressEvent (evnt);


### PR DESCRIPTION
…eption in Gtk.Application.Run() "Index was out of range. Must be non-negative and less than the size of the collection. Parameter name: index"

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/972229

The old implementation bascially did a wrong thing all the time.