### PR TITLE
[release-8.3] Map JSON Property Name to type colors

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/ThemeToClassification.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/ThemeToClassification.cs
@@ -168,6 +168,7 @@ namespace MonoDevelop.TextEditor
 			("HTML Operator", "HTML Operator"),
 			("HTML Server-Side Script", "HTML Server-Side Script"),
 			("HTML Tag Delimiter", "HTML Tag Delimiter"),
+			("JSON Property Name", "User Types"),
 			("taskformat", "Comment Tags"),
 		};
 


### PR DESCRIPTION
Since MonoDevelop doesn't have JSON colors we map type, this color is always different from plain text color and its always meaningful color

Backport of #8506.

/cc @abock @DavidKarlas