### PR TITLE
[release-8.3] [F#] Fix parsing of long lines

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Shared/Lexer.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Shared/Lexer.fs
@@ -155,7 +155,7 @@ module Lexer =
       match tokenizer.ScanToken(state) with
       | Some tok, state ->
           parseLine tokenizer (tok::tokens) state
-      | None, state -> tokens, state
+      | None, state -> tokens |> List.rev, state
 
     let rec parseLines (sourceTok:FSharpSourceTokenizer) tokens state lines filename defines =
         [ match lines with

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/LexerTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/LexerTests.fs
@@ -1,0 +1,16 @@
+namespace MonoDevelopTests
+
+open System
+open NUnit.Framework
+open MonoDevelop.FSharp.Shared
+open FSharp.Compiler.SourceCodeServices
+
+[<TestFixture>]
+module LexerTests =
+    [<Test>]
+    let ``can parse long line``() =
+        let line = sprintf "let x = \"%s\"" (String('*', 10000000))
+        let sourceTok = FSharpSourceTokenizer([], None)
+        let tokenizer = sourceTok.CreateLineTokenizer line
+        let tokens, state = Lexer.parseLine tokenizer [] FSharpTokenizerLexState.Initial
+        Assert.AreNotEqual(state, FSharpTokenizerLexState.Initial)

--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
@@ -73,6 +73,21 @@
   </ItemGroup>
   <Import Project="$(CustomBeforeMicrosoftCommonTargets)" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
+  <Import Project="..\.paket\paket.targets" />
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy TabWidth="4" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabsToSpaces="True" scope="text/x-fsharp" />
+          <FSharpFormattingPolicy scope="text/x-fsharp">
+            <DefaultFormat IndentOnTryWith="False" ReorderOpenDeclaration="False" SpaceAfterComma="True" SpaceAfterSemicolon="True" SpaceAroundDelimiter="True" SpaceBeforeArgument="True" SpaceBeforeColon="True" __added="0" />
+          </FSharpFormattingPolicy>
+          <TextStylePolicy inheritsSet="null" scope="application/fsproject+xml" />
+          <XmlFormattingPolicy inheritsSet="null" scope="application/fsproject+xml" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
   <ItemGroup>
     <Compile Include="TestBase.fs" />
     <Compile Include="TestDocument.fs" />
@@ -105,49 +120,16 @@
       <Link>MonoDevelop.FSharpInteractive.Service.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.Debugger\MonoDevelop.Debugger.csproj">
-      <Project>{2357AABD-08C7-4808-A495-8FF2D3CDFDB0}</Project>
-      <Name>MonoDevelop.Debugger</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
-      <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
-      <Name>MonoDevelop.Ide</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\MonoDevelop.FSharpBinding\MonoDevelop.FSharp.fsproj">
-      <Project>{4C10F8F9-3816-4647-BA6E-85F5DE39883A}</Project>
-      <Name>MonoDevelop.FSharp</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.UnitTesting\MonoDevelop.UnitTesting.csproj">
-      <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>
-      <Name>MonoDevelop.UnitTesting</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
-      <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>
-      <Name>MonoDevelop.SourceEditor</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\MonoDevelop.FSharp.Shared\MonoDevelop.FSharp.Shared.fsproj">
-      <Project>{AF5FEAD5-B50E-4F07-A274-32F23D5C504D}</Project>
-      <Name>MonoDevelop.FSharp.Shared</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.csproj">
-      <Project>{F218643D-2E74-4309-820E-206A54B7133F}</Project>
-      <Name>MonoDevelop.PackageManagement</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.Tests\MonoDevelop.PackageManagement.Tests.csproj">
-      <Project>{2645C9F3-9ED5-4806-AB09-DAD9BE90C67B}</Project>
-      <Name>MonoDevelop.PackageManagement.Tests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
-      <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
-      <Name>MonoDevelop.Core</Name>
-      <Private>False</Private>
-    </ProjectReference>
+    <IncludeCopyLocal Include="System.Reactive.dll" />
+    <IncludeCopyLocal Include="Newtonsoft.Json.dll" />
+    <IncludeCopyLocal Include="ExtCore.dll" />
+    <IncludeCopyLocal Include="Fantomas.dll" />
+    <IncludeCopyLocal Include="FSharp.Compiler.CodeDom.dll" />
+    <IncludeCopyLocal Include="FSharp.Compiler.Service.dll" />
+    <IncludeCopyLocal Include="FSharp.Core.dll" />
+    <IncludeCopyLocal Include="MonoDevelop.FSharp.Shared.dll" />
+    <IncludeCopyLocal Include="FSharp.Compiler.Interactive.Settings.dll" />
+    <Compile Include="LexerTests.fs" />
     <ProjectReference Include="..\..\..\tests\UnitTests\UnitTests.csproj">
       <Project>{1497D0A8-AFF1-4938-BC22-BE79B358BA5B}</Project>
       <Name>UnitTests</Name>
@@ -158,32 +140,49 @@
       <Name>MonoDevelop.Refactoring</Name>
       <Private>False</Private>
     </ProjectReference>
-  </ItemGroup>
-  <Import Project="..\.paket\paket.targets" />
-  <ProjectExtensions>
-    <MonoDevelop>
-      <Properties>
-        <Policies>
-          <TextStylePolicy TabWidth="4" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabsToSpaces="True" scope="text/x-fsharp" />
-          <FSharpFormattingPolicy scope="text/x-fsharp">
-            <DefaultFormat IndentOnTryWith="False" ReorderOpenDeclaration="False" SpaceAfterComma="True" SpaceAfterSemicolon="True" SpaceAroundDelimiter="True" SpaceBeforeArgument="True" SpaceBeforeColon="True" __added="0" />
-          </FSharpFormattingPolicy>
-          <TextStylePolicy inheritsSet="null" scope="application/fsproject+xml" />
-          <XmlFormattingPolicy inheritsSet="null" scope="application/fsproject+xml" />
-        </Policies>
-      </Properties>
-    </MonoDevelop>
-  </ProjectExtensions>
-  <ItemGroup>
-    <IncludeCopyLocal Include="System.Reactive.dll" />
-    <IncludeCopyLocal Include="Newtonsoft.Json.dll" />
-    <IncludeCopyLocal Include="ExtCore.dll" />
-    <IncludeCopyLocal Include="Fantomas.dll" />
-    <IncludeCopyLocal Include="FSharp.Compiler.CodeDom.dll" />
-    <IncludeCopyLocal Include="FSharp.Compiler.Service.dll" />
-    <IncludeCopyLocal Include="FSharp.Core.dll" />
-    <IncludeCopyLocal Include="MonoDevelop.FSharp.Shared.dll" />
-    <IncludeCopyLocal Include="FSharp.Compiler.Interactive.Settings.dll" />
+    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.csproj">
+      <Project>{F218643D-2E74-4309-820E-206A54B7133F}</Project>
+      <Name>MonoDevelop.PackageManagement</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.PackageManagement\MonoDevelop.PackageManagement.Tests\MonoDevelop.PackageManagement.Tests.csproj">
+      <Project>{2645C9F3-9ED5-4806-AB09-DAD9BE90C67B}</Project>
+      <Name>MonoDevelop.PackageManagement.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.FSharp.Shared\MonoDevelop.FSharp.Shared.fsproj">
+      <Project>{AF5FEAD5-B50E-4F07-A274-32F23D5C504D}</Project>
+      <Name>MonoDevelop.FSharp.Shared</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
+      <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>
+      <Name>MonoDevelop.SourceEditor</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.UnitTesting\MonoDevelop.UnitTesting.csproj">
+      <Project>{A7A4246D-CEC4-42DF-A3C1-C31B9F51C4EC}</Project>
+      <Name>MonoDevelop.UnitTesting</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.FSharpBinding\MonoDevelop.FSharp.fsproj">
+      <Project>{4C10F8F9-3816-4647-BA6E-85F5DE39883A}</Project>
+      <Name>MonoDevelop.FSharp</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">
+      <Project>{27096E7F-C91C-4AC6-B289-6897A701DF21}</Project>
+      <Name>MonoDevelop.Ide</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\addins\MonoDevelop.Debugger\MonoDevelop.Debugger.csproj">
+      <Project>{2357AABD-08C7-4808-A495-8FF2D3CDFDB0}</Project>
+      <Name>MonoDevelop.Debugger</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">
+      <Project>{7525BB88-6142-4A26-93B9-A30C6983390A}</Project>
+      <Name>MonoDevelop.Core</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.7.2'">

--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpTokens.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpTokens.fs
@@ -22,12 +22,17 @@ module Tokens =
         match token with 
         | Some token -> MonoDevelop.FSharp.Shared.Lexer.isNonTipToken token
         | None -> false
-                
+
+
+    //(FSharpTokenInfo list * string) list option         
     let tryGetTokens source defines fileName =
         try
             LoggingService.logDebug "FSharpParser: Processing tokens for %s" (Path.GetFileName fileName)
             let readOnlyDoc = TextEditorFactory.CreateNewReadonlyDocument (source, fileName)
-            let lines = readOnlyDoc.GetLines() |> Seq.map readOnlyDoc.GetLineText
+            let lines = readOnlyDoc.GetLines() 
+                        |> Seq.map readOnlyDoc.GetLineText
+                        |> List.ofSeq
+
             let tokens = MonoDevelop.FSharp.Shared.Lexer.getTokensWithInitialState FSharpTokenizerLexState.Initial lines (Some fileName) defines
             Some(tokens)
         with ex ->


### PR DESCRIPTION
Fixes VSTS #963356

Make Lexer.parseLine tail recursive and remove mutable state

Backport of #8529.

/cc @nosami 