### PR TITLE
[release-8.3] [Toolbox] Fixes broken state dragging items when pad is closed

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -78,7 +78,12 @@ namespace MonoDevelop.DesignerSupport
 
 #if MAC
 
-		void Container_PadContentShown (object sender, EventArgs args) => toolbox.Hidden = false;
+		void Container_PadContentShown (object sender, EventArgs args)
+		{
+			//sanity check
+			isDragging = false;
+			toolbox.Hidden = false;
+		}
 		void Container_PadContentHidden (object sender, EventArgs args) => toolbox.Hidden = true;
 
 		private void Widget_DragEnd (object o, DragEndArgs args)


### PR DESCRIPTION
* Fixes Bug #943089 - [VS for Mac] Failed to drag new controls into designer after adding a control

![draganddrop3](https://user-images.githubusercontent.com/1587480/63589868-89e35500-c5aa-11e9-8eb7-5002d0e6780d.gif)
![draganddrop2](https://user-images.githubusercontent.com/1587480/63589872-8b148200-c5aa-11e9-8e0c-c17e0ffe4f1e.gif)
![draganddrop](https://user-images.githubusercontent.com/1587480/63589875-8d76dc00-c5aa-11e9-8e00-6116c826a8a2.gif)




Backport of #8526.

/cc @sevoku @netonjm