### PR TITLE
[Core] Fix null reference accessing target framework monikers

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -98,6 +98,17 @@ namespace MonoDevelop.Projects
 				languageName = MSBuildProjectService.GetLanguageFromGuid (TypeGuid);
 		}
 
+		protected override void OnItemReady ()
+		{
+			// This is done here not in OnInitialize since it needs the extension chain initialized to
+			// be able to access the TargetFramework if it is not set. OnItemReady is always called both
+			// when loading an existing project or creating a new one.
+			if (!HasMultipleTargetFrameworks)
+				targetFrameworkMonikers = ImmutableArray.Create (TargetFramework.Id);
+
+			base.OnItemReady ();
+		}
+
 		ImmutableArray<TargetFrameworkMoniker> targetFrameworkMonikers;
 
 		void EvaluateTargetFrameworkMonikers ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -446,8 +446,8 @@ namespace MonoDevelop.Projects
 					return;
 				bool updateReferences = targetFramework != null;
 				targetFramework = value;
-				if (targetFrameworkMonikers.IsDefaultOrEmpty)
-					targetFrameworkMonikers = ImmutableArray.Create<TargetFrameworkMoniker> (targetFramework.Id);
+				if (!HasMultipleTargetFrameworks)
+					targetFrameworkMonikers = ImmutableArray.Create (targetFramework.Id);
 				if (updateReferences)
 					UpdateSystemReferences ();
 				NotifyModified ("TargetFramework");

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -32,6 +32,7 @@ using System.IO;
 using NUnit.Framework;
 using UnitTests;
 using MonoDevelop.Core;
+using MonoDevelop.Core.Assemblies;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1263,6 +1264,14 @@ namespace MonoDevelop.Projects
 			using (DotNetProject p = Services.ProjectService.CreateDotNetProject ("C#")) {
 				var moniker = p.TargetFrameworkMonikers.Single ();
 				Assert.AreEqual (p.TargetFramework.Id, moniker);
+
+				// Ensure target framework moniker is updated if the project's target framework is changed.
+				var newTargetFramework = Runtime.SystemAssemblyService.GetTargetFramework (TargetFrameworkMoniker.NET_4_5);
+				Assert.AreNotEqual (p.TargetFramework.Id, newTargetFramework.Id);
+				p.TargetFramework = newTargetFramework;
+
+				moniker = p.TargetFrameworkMonikers.Single ();
+				Assert.AreEqual (newTargetFramework.Id, moniker);
 			}
 		}
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1252,6 +1252,20 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Adding a new project to an existing solution does not call the Project's TargetFramework setter
+		/// so the TargetFrameworkMonikers was not initialized. When the TargetFramework's getter sets the
+		/// TargetFramework we also initialize the TargetFrameworkMonikers.
+		/// </summary>
+		[Test]
+		public void TargetFrameworkMonikers_NewProject_DoesNotThrowNullReferenceException ()
+		{
+			using (DotNetProject p = Services.ProjectService.CreateDotNetProject ("C#")) {
+				var moniker = p.TargetFrameworkMonikers.Single ();
+				Assert.AreEqual (p.TargetFramework.Id, moniker);
+			}
+		}
+
 		class TestGetReferencesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override Task<List<AssemblyReference>> OnGetReferences (ConfigurationSelector configuration, CancellationToken token)


### PR DESCRIPTION
Creating a .NET Core console project, then adding a new non-SDK style
C# library project, it was not possible to open the Edit References
dialog for the library project. The IDE log would have a null
reference exception:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at System.Collections.Immutable.ImmutableArray`1[T].ThrowNullRefIfNotInitialized () [0x00000] in <6518d0e60ca84f6b915c07341a031a32>:0
  at System.Collections.Immutable.ImmutableArray`1[T].GetEnumerator () [0x00007] in <6518d0e60ca84f6b915c07341a031a32>:0
  at MonoDevelop.PackageManagement.PackageManagementCanReferenceProjectExtension.CanReferenceProject
```

The problem was that the project's TargetFramework setter is not
called when adding a new project to an existing solution so the
project's TargetFrameworkMonikers array was not initialized. This is
now handled.

Fixes VSTS #973344 - Unable to open Edit References dialog for new
project