### PR TITLE
[release-8.3] [Core] Fix null reference accessing target framework monikers

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -444,7 +444,13 @@ namespace MonoDevelop.Projects
 		}
 
 		public ImmutableArray<TargetFrameworkMoniker> TargetFrameworkMonikers {
-			get { return targetFrameworkMonikers; }
+			get {
+				// Adding a new project to an existing solution will not call the TargetFramework's setter which
+				// initializes this array, so handle this here if the array is not initialized.
+				if (targetFrameworkMonikers.IsDefaultOrEmpty)
+					targetFrameworkMonikers = ImmutableArray.Create<TargetFrameworkMoniker> (TargetFramework.Id);
+				return targetFrameworkMonikers;
+			}
 		}
 
 		public TargetRuntime TargetRuntime {

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1252,6 +1252,20 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Adding a new project to an existing solution does not call the Project's TargetFramework setter
+		/// so the TargetFrameworkMonikers was not initialized. When the TargetFramework's getter sets the
+		/// TargetFramework we also initialize the TargetFrameworkMonikers.
+		/// </summary>
+		[Test]
+		public void TargetFrameworkMonikers_NewProject_DoesNotThrowNullReferenceException ()
+		{
+			using (DotNetProject p = Services.ProjectService.CreateDotNetProject ("C#")) {
+				var moniker = p.TargetFrameworkMonikers.Single ();
+				Assert.AreEqual (p.TargetFramework.Id, moniker);
+			}
+		}
+
 		class TestGetReferencesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override Task<List<AssemblyReference>> OnGetReferences (ConfigurationSelector configuration, CancellationToken token)


### PR DESCRIPTION
Creating a .NET Core console project, then adding a new non-SDK style
C# library project, it was not possible to open the Edit References
dialog for the library project. The IDE log would have a null
reference exception:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at System.Collections.Immutable.ImmutableArray`1[T].ThrowNullRefIfNotInitialized () [0x00000] in <6518d0e60ca84f6b915c07341a031a32>:0
  at System.Collections.Immutable.ImmutableArray`1[T].GetEnumerator () [0x00007] in <6518d0e60ca84f6b915c07341a031a32>:0
  at MonoDevelop.PackageManagement.PackageManagementCanReferenceProjectExtension.CanReferenceProject
```

The problem was that the project's TargetFramework setter is not
called when adding a new project to an existing solution so the
project's TargetFrameworkMonikers array was not initialized. This is
now handled.

Fixes VSTS #973344 - Unable to open Edit References dialog for new
project

Backport of #8535.

/cc @mrward 