### PR TITLE
Fixes 940776: System.ArgumentOutOfRangeException on selection change in drop down

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/DropDownBoxListWindow.cs
@@ -30,6 +30,7 @@ using Gtk;
 using System.Text;
 using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.Fonts;
+using MonoDevelop.Core;
 
 namespace MonoDevelop.Components
 {
@@ -91,9 +92,14 @@ namespace MonoDevelop.Components
 			list.SelectItem += delegate {
 				var sel = list.Selection;
 				if (sel >= 0 && sel < DataProvider.IconCount) {
-					DataProvider.ActivateItem (sel);
-					// This is so parent window of dropdown regains focus
-					TransientFor?.Present ();
+					try {
+						DataProvider.ActivateItem (sel);
+						// This is so parent window of dropdown regains focus
+						TransientFor?.Present ();
+					} catch (Exception ex) {
+						LoggingService.LogInternalError ("Offset seems to be out of sync with the snapshot.", ex);
+					}
+
 					Destroy ();
 				}
 			};
@@ -298,8 +304,12 @@ namespace MonoDevelop.Components
 
 			void PerformPress (object sender, EventArgs args)
 			{
-				var element = (TextElement)sender;
-				win.DataProvider.ActivateItem (element.RowIndex);
+				try {
+					var element = (TextElement)sender;
+					win.DataProvider.ActivateItem (element.RowIndex);
+				} catch (Exception ex) {
+					LoggingService.LogInternalError ("Offset seems to be out of sync with the snapshot.", ex);
+				}
 			}
 
 			internal void CalcRowHeight ()


### PR DESCRIPTION
If appears that in some circumstances, the snapshot changes as we get to calling the ActivateItem method on the provider, causing an argument out of range exception. This attempts to fix it by (1) boxing the offset to the current length of the current (valid) snapshot, and (2) catching any exception that would still flow to (this particular) UI element.

Fixes: https://vsmac.dev/940776