### PR TITLE
[release-8.3] Fixes VSTS Bug 940635: Cloning project with submodules is stops with

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -693,7 +693,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 				var exception = e.InnerException;
 				// libgit2 < 0.26 will throw NotFoundException (result -3)
 				// libgit2 >= 0.26 will throw generic LibGit2SharpException (result -1), assert the expected message
-				Assert.That (exception, Is.InstanceOf<LibGit2Sharp.NotFoundException> ().Or.Message.EqualTo ("reference 'refs/heads/master' not found"));
+				Assert.That (exception, Is.InstanceOf<LibGit2Sharp.NotFoundException> ().Or.InstanceOf<LibGit2Sharp.NameConflictException> ().Or.Message.EqualTo ("reference 'refs/heads/master' not found"));
 				return;
 			} finally {
 				toCheckout.Dispose ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1419,8 +1419,13 @@ namespace MonoDevelop.VersionControl.Git
 							});
 						}
 					};
-					RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
 
+					try {
+						RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
+					} catch (AggregateException ae) {
+						ae.Flatten ().Handle (inner => inner is LibGit2Sharp.UserCancelledException);
+						return;
+					}
 					var updateOptions = new SubmoduleUpdateOptions {
 						Init = true,
 						CredentialsProvider = options.CredentialsProvider,

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1432,7 +1432,7 @@ namespace MonoDevelop.VersionControl.Git
 						if (!skipSubmodules)
 							RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
 					} catch (Exception e) {
-						LoggingService.LogError ("Error while cloning sub modules", e);
+						LoggingService.LogError ("Cloning submodules failed", e);
 						Directory.Delete (RootPath, true);
 						skipSubmodules = true;
 					}
@@ -1446,7 +1446,7 @@ namespace MonoDevelop.VersionControl.Git
 				RootRepository = new LibGit2Sharp.Repository (RootPath);
 				InitFileWatcher ();
 				if (skipSubmodules) {
-					MessageService.ShowError (GettextCatalog.GetString("Can't clone sub modules. Please use the command line client to init the sub modules."));
+					MessageService.ShowError (GettextCatalog.GetString("Cloning submodules failed"), GettextCatalog.GetString ("Please use the command line client to init the submodules manually."));
 				}
 				return Task.CompletedTask;
 			} catch (Exception e) {
@@ -1464,7 +1464,7 @@ namespace MonoDevelop.VersionControl.Git
 				// Iterate through the submodules (where the submodule is in the index),
 				// and clone them.
 				var submoduleArray = repo.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
-				monitor.BeginTask (GettextCatalog.GetString ("Cloning sub modules…"), submoduleArray.Length);
+				monitor.BeginTask (GettextCatalog.GetString ("Cloning submodules…"), submoduleArray.Length);
 				try {
 					foreach (var sm in submoduleArray) {
 						if (monitor.CancellationToken.IsCancellationRequested) {
@@ -1472,7 +1472,7 @@ namespace MonoDevelop.VersionControl.Git
 						}
 
 						Runtime.RunInMainThread (() => {
-							monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out submodule at '{0}'"), sm.Path);
+							monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out submodule at '{0}'…", sm.Path));
 							monitor.Step (1);
 						});
 						repo.Submodules.Update (sm.Name, updateOptions);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1397,45 +1397,47 @@ namespace MonoDevelop.VersionControl.Git
 			int checkoutProgress = 0;
 
 			try {
-				monitor.BeginTask ("Cloning...", 2);
-
+				monitor.BeginTask (GettextCatalog.GetString ("Cloning…"), 2);
 				RunOperation (() => RetryUntilSuccess (monitor, credType => {
-					try {
-						RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, new CloneOptions {
-							CredentialsProvider = (url, userFromUrl, types) => {
-								transferProgress = checkoutProgress = 0;
-								return GitCredentials.TryGet (url, userFromUrl, types, credType);
-							},
-							RepositoryOperationStarting = ctx => {
-								Runtime.RunInMainThread (() => {
-									monitor.Log.WriteLine ("Checking out repository at '{0}'", ctx.RepositoryPath);
-								});
-								return true;
-							},
-							OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
-							OnCheckoutProgress = (path, completedSteps, totalSteps) => {
-								OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
-								Runtime.RunInMainThread (() => {
-									monitor.Log.WriteLine ("Checking out file '{0}'", path);
-								});
-							},
-						});
-					} catch (Exception e) {
-						LoggingService.LogInternalError ("Error while cloning repository " + rev + " recuse: " + recurse, e);
-						throw e;
-					}
+				var options = new CloneOptions {
+						CredentialsProvider = (url, userFromUrl, types) => {
+							transferProgress = checkoutProgress = 0;
+							return GitCredentials.TryGet (url, userFromUrl, types, credType);
+						},
+						RepositoryOperationStarting = ctx => {
+							Runtime.RunInMainThread (() => {
+								monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out repository at '{0}'"), ctx.RepositoryPath);
+							});
+							return true;
+						},
+						OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
+						OnCheckoutProgress = (path, completedSteps, totalSteps) => {
+							OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
+							Runtime.RunInMainThread (() => {
+								monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out file '{0}'"), path);
+							});
+						},
+					};
+					RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
+
+					var updateOptions = new SubmoduleUpdateOptions {
+						Init = true,
+						CredentialsProvider = options.CredentialsProvider,
+						OnTransferProgress = options.OnTransferProgress,
+						OnCheckoutProgress = options.OnCheckoutProgress,
+					};
+					monitor.Step (1);
+
+					RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
 				}), true);
 
 				if (monitor.CancellationToken.IsCancellationRequested || RootPath.IsNull)
 					return Task.CompletedTask;
 
-				monitor.Step (1);
-
 				RootPath = RootPath.CanonicalPath.ParentDirectory;
+
 				RootRepository = new LibGit2Sharp.Repository (RootPath);
 				InitFileWatcher ();
-
-				RunOperation (() => RecursivelyCloneSubmodules (RootRepository, monitor), true);
 				return Task.CompletedTask;
 			} catch (Exception e) {
 				LoggingService.LogInternalError ("Error while cloning repository " + rev + " recuse: " + recurse, e);
@@ -1445,57 +1447,38 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		static void RecursivelyCloneSubmodules (LibGit2Sharp.Repository rootRepository, ProgressMonitor monitor)
+		static void RecursivelyCloneSubmodules (string repoPath, SubmoduleUpdateOptions updateOptions, ProgressMonitor monitor)
 		{
 			var submodules = new List<string> ();
-			RetryUntilSuccess (monitor, credType => {
+			using (var repo = new LibGit2Sharp.Repository (repoPath)) {
+				// Iterate through the submodules (where the submodule is in the index),
+				// and clone them.
+				var submoduleArray = repo.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
+				monitor.BeginTask (GettextCatalog.GetString ("Cloning sub modules…"), submoduleArray.Length);
 				try {
-					int transferProgress = 0, checkoutProgress = 0;
-					SubmoduleUpdateOptions updateOptions = new SubmoduleUpdateOptions () {
-						Init = true,
-						CredentialsProvider = (url, userFromUrl, types) => {
-							transferProgress = checkoutProgress = 0;
-							return GitCredentials.TryGet (url, userFromUrl, types, credType);
-						},
-						OnTransferProgress = (tp) => OnTransferProgress (tp, monitor, ref transferProgress),
-						OnCheckoutProgress = (file, completedSteps, totalSteps) => {
-							OnCheckoutProgress (completedSteps, totalSteps, monitor, ref checkoutProgress);
-							Runtime.RunInMainThread (() => {
-								monitor.Log.WriteLine ("Checking out file '{0}'", file);
-							});
-						},
-					};
-
-					// Iterate through the submodules (where the submodule is in the index),
-					// and clone them.
-					var submoduleArray = rootRepository.Submodules.Where (sm => sm.RetrieveStatus ().HasFlag (SubmoduleStatus.InIndex)).ToArray ();
-					monitor.BeginTask (submoduleArray.Length);
 					foreach (var sm in submoduleArray) {
 						if (monitor.CancellationToken.IsCancellationRequested) {
 							throw new UserCancelledException ("Recursive clone of submodules was cancelled.");
 						}
 
 						Runtime.RunInMainThread (() => {
-							monitor.Log.WriteLine ("Checking out submodule at '{0}'", sm.Path);
+							monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out submodule at '{0}'"), sm.Path);
+							monitor.Step (1);
 						});
-						rootRepository.Submodules.Update (sm.Name, updateOptions);
-						monitor.Step (1);
+						repo.Submodules.Update (sm.Name, updateOptions);
 
-						submodules.Add (Path.Combine (rootRepository.Info.WorkingDirectory, sm.Path));
+						submodules.Add (Path.Combine (repo.Info.WorkingDirectory, sm.Path));
 					}
+				} finally {
 					monitor.EndTask ();
-				} catch (Exception e) {
-					LoggingService.LogInternalError ("Error RecursivelyCloneSubmodules " + rootRepository, e);
-					throw e;
 				}
-			});
+			}
 
 			// If we are continuing the recursive operation, then
 			// recurse into nested submodules.
 			// Check submodules to see if they have their own submodules.
 			foreach (string path in submodules) {
-				using (var submodule = new LibGit2Sharp.Repository (path))
-					RecursivelyCloneSubmodules (submodule, monitor);
+				RecursivelyCloneSubmodules (path, updateOptions, monitor);
 			}
 		}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1422,8 +1422,7 @@ namespace MonoDevelop.VersionControl.Git
 
 					try {
 						RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
-					} catch (AggregateException ae) {
-						ae.Flatten ().Handle (inner => inner is LibGit2Sharp.UserCancelledException);
+					} catch (UserCancelledException) {
 						return;
 					}
 					var updateOptions = new SubmoduleUpdateOptions {
@@ -1438,7 +1437,7 @@ namespace MonoDevelop.VersionControl.Git
 							RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
 					} catch (Exception e) {
 						LoggingService.LogError ("Cloning submodules failed", e);
-						Directory.Delete (RootPath, true);
+						FileService.DeleteDirectory (RootPath);
 						skipSubmodules = true;
 						throw e;
 					}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1435,6 +1435,7 @@ namespace MonoDevelop.VersionControl.Git
 						LoggingService.LogError ("Cloning submodules failed", e);
 						Directory.Delete (RootPath, true);
 						skipSubmodules = true;
+						throw e;
 					}
 				}), true);
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1399,7 +1399,7 @@ namespace MonoDevelop.VersionControl.Git
 			try {
 				monitor.BeginTask (GettextCatalog.GetString ("Cloning…"), 2);
 				RunOperation (() => RetryUntilSuccess (monitor, credType => {
-				var options = new CloneOptions {
+					var options = new CloneOptions {
 						CredentialsProvider = (url, userFromUrl, types) => {
 							transferProgress = checkoutProgress = 0;
 							return GitCredentials.TryGet (url, userFromUrl, types, credType);
@@ -1416,7 +1416,7 @@ namespace MonoDevelop.VersionControl.Git
 							Runtime.RunInMainThread (() => {
 								monitor.Log.WriteLine (GettextCatalog.GetString ("Checking out file '{0}'"), path);
 							});
-						},
+						}
 					};
 					RootPath = LibGit2Sharp.Repository.Clone (Url, targetLocalPath, options);
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1398,6 +1398,7 @@ namespace MonoDevelop.VersionControl.Git
 
 			try {
 				monitor.BeginTask (GettextCatalog.GetString ("Cloning…"), 2);
+				bool skipSubmodules = false;
 				RunOperation (() => RetryUntilSuccess (monitor, credType => {
 					var options = new CloneOptions {
 						CredentialsProvider = (url, userFromUrl, types) => {
@@ -1427,8 +1428,14 @@ namespace MonoDevelop.VersionControl.Git
 						OnCheckoutProgress = options.OnCheckoutProgress,
 					};
 					monitor.Step (1);
-
-					RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
+					try {
+						if (!skipSubmodules)
+							RecursivelyCloneSubmodules (RootPath, updateOptions, monitor);
+					} catch (Exception e) {
+						LoggingService.LogError ("Error while cloning sub modules", e);
+						Directory.Delete (RootPath, true);
+						skipSubmodules = true;
+					}
 				}), true);
 
 				if (monitor.CancellationToken.IsCancellationRequested || RootPath.IsNull)
@@ -1438,6 +1445,9 @@ namespace MonoDevelop.VersionControl.Git
 
 				RootRepository = new LibGit2Sharp.Repository (RootPath);
 				InitFileWatcher ();
+				if (skipSubmodules) {
+					MessageService.ShowError (GettextCatalog.GetString("Can't clone sub modules. Please use the command line client to init the sub modules."));
+				}
 				return Task.CompletedTask;
 			} catch (Exception e) {
 				LoggingService.LogInternalError ("Error while cloning repository " + rev + " recuse: " + recurse, e);


### PR DESCRIPTION
error 'Version control operation filed'

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/940635

I think we're running into a libgit bug. Libgit2 works correctly if
the library itself does the submodule checkout - it's more reliable
for us to let do libgit2 the job as well.

Backport of #8199.

/cc @sevoku @mkrueger