### PR TITLE
[release-8.2] Fixes VSTS Bug 972866: [Feedback] Preferences are not saved when I

### DIFF
--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/AbstractOptionPreviewViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/AbstractOptionPreviewViewModel.cs
@@ -73,7 +73,10 @@ namespace MonoDevelop.Refactoring.Options
 		internal OptionSet ApplyChangedOptions (OptionSet optionSet)
 		{
 			foreach (var optionKey in this.Options.GetChangedOptions (_originalOptions)) {
-				optionSet = optionSet.WithChangedOption (optionKey, this.Options.GetOption (optionKey));
+				var value = this.Options.GetOption (optionKey);
+				if (value == null)
+					continue;
+				optionSet = optionSet.WithChangedOption (optionKey, value);
 			}
 
 			return optionSet;
@@ -82,11 +85,11 @@ namespace MonoDevelop.Refactoring.Options
 		public void SetOptionAndUpdatePreview<T> (T value, IOption option, string preview)
 		{
 			if (option is Option<CodeStyleOption<T>>) {
-				var opt = Options.GetOption ((Option<CodeStyleOption<T>>)option);
+				var opt = (CodeStyleOption<T>)BooleanCodeStyleOptionViewModel.GetOptionOrDefault (Options, option, Language);
 				opt.Value = value;
 				Options = Options.WithChangedOption ((Option<CodeStyleOption<T>>)option, opt);
 			} else if (option is PerLanguageOption<CodeStyleOption<T>>) {
-				var opt = Options.GetOption ((PerLanguageOption<CodeStyleOption<T>>)option, Language);
+				var opt = (CodeStyleOption<T>)BooleanCodeStyleOptionViewModel.GetOptionOrDefault (Options, option, Language); // PerLanguageOption in unwrapped.
 				opt.Value = value;
 				Options = Options.WithChangedOption ((PerLanguageOption<CodeStyleOption<T>>)option, Language, opt);
 			} else if (option is Option<T>) {

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/CheckBoxOptionViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/CheckBoxOptionViewModel.cs
@@ -37,7 +37,7 @@ namespace MonoDevelop.Refactoring.Options
 		public CheckBoxOptionViewModel (IOption option, string description, string truePreview, string falsePreview, AbstractOptionPreviewViewModel info, OptionSet options)
 			: base (option, description, truePreview, falsePreview, info)
 		{
-			SetProperty (ref _isChecked, (bool)options.GetOption (new OptionKey (option, option.IsPerLanguage ? info.Language : null)));
+			SetProperty (ref _isChecked, (bool)BooleanCodeStyleOptionViewModel.GetOptionOrDefault (options, option, info.Language));
 		}
 
 		public override bool IsChecked {

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/CheckBoxWithComboOptionViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/CheckBoxWithComboOptionViewModel.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Refactoring.Options
 		{
 			NotificationOptions = items;
 
-			var codeStyleOption = ((CodeStyleOption<bool>)options.GetOption (new OptionKey (option, option.IsPerLanguage ? info.Language : null)));
+			var codeStyleOption = ((CodeStyleOption<bool>)BooleanCodeStyleOptionViewModel.GetOptionOrDefault (options, option, info.Language));
 			SetProperty (ref _isChecked, codeStyleOption.Value);
 
 			var notificationViewModel = items.Where (i => i.Notification.Severity == codeStyleOption.Notification.Severity).Single ();

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/RadioButtonViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/RadioButtonViewModel.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.Refactoring.Options
 		private readonly TOption _value;
 
 		public RadioButtonViewModel (string description, string preview, string group, TOption value, Option<TOption> option, AbstractOptionPreviewViewModel info, OptionSet options)
-			: base (description, preview, info, options, isChecked: options.GetOption (option).Equals (value), group: group)
+			: base (description, preview, info, options, isChecked: BooleanCodeStyleOptionViewModel.GetOptionOrDefault (options, option, info.Language).Equals (value), group: group)
 		{
 			_value = value;
 			_option = option;

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/Style/BooleanCodeStyleOptionViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/Style/BooleanCodeStyleOptionViewModel.cs
@@ -59,7 +59,7 @@ namespace MonoDevelop.Refactoring.Options
 			_truePreview = truePreview;
 			_falsePreview = falsePreview;
 
-			var optionValue = options.GetOption (new OptionKey (option, option.IsPerLanguage ? info.Language : null));
+			var optionValue = GetOptionOrDefault (options, option, info.Language);
 			if (!(optionValue is CodeStyleOption<bool> codeStyleOption))
 				throw new InvalidOperationException (optionValue + " is no CodeStyleOption<bool>. Queried option: " + option);
 			_selectedPreference = Preferences.Single (c => c.IsChecked == codeStyleOption.Value);
@@ -69,6 +69,11 @@ namespace MonoDevelop.Refactoring.Options
 
 			NotifyPropertyChanged (nameof (SelectedPreference));
 			NotifyPropertyChanged (nameof (SelectedNotificationPreference));
+		}
+
+		internal static object GetOptionOrDefault (OptionSet options, IOption option, string language)
+		{
+			return options.GetOption (new OptionKey (option, option.IsPerLanguage ? language : null)) ?? option.DefaultValue;
 		}
 
 		public override CodeStylePreference SelectedPreference {

--- a/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/Style/EnumCodeStyleOptionViewModel.cs
+++ b/main/src/addins/MonoDevelop.Refactoring/MonoDevelop.Refactoring.Options/Style/EnumCodeStyleOptionViewModel.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Refactoring.Options
 			_enumValues = enumValues.ToImmutableArray ();
 			_previews = previews.ToImmutableArray ();
 
-			var codeStyleOption = (CodeStyleOption<T>)options.GetOption (new OptionKey (option, language));
+			var codeStyleOption = (CodeStyleOption<T>)BooleanCodeStyleOptionViewModel.GetOptionOrDefault (options, option, language);
 
 			var enumIndex = _enumValues.IndexOf (codeStyleOption.Value);
 			if (enumIndex < 0 || enumIndex >= Preferences.Count) {


### PR DESCRIPTION
click OK in the Preferences menu in Visual Studio for Mac.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/972866

Backport of #8522.

/cc @sevoku @mkrueger