### PR TITLE
[release-8.3] [CSharp] Don't hide formatting dialog in ctor

### DIFF
--- a/main/src/addins/CSharpBinding/Gui/MonoDevelop.CSharp.Formatting.CSharpFormattingProfileDialog.cs
+++ b/main/src/addins/CSharpBinding/Gui/MonoDevelop.CSharp.Formatting.CSharpFormattingProfileDialog.cs
@@ -281,7 +281,6 @@ namespace MonoDevelop.CSharp.Formatting
 			}
 			this.DefaultWidth = 880;
 			this.DefaultHeight = 555;
-			this.Hide ();
 		}
 	}
 }


### PR DESCRIPTION
The issue has already been fixed in MessageDialog, nevertheless
Hide, Show and ShowAll should never be called in the ctor
of a Gtk Dialog or Window. Even Hide will realize the window
and make it the key window on mac for the current UI iteration,
which will confuse MessageService and probably other logic
relying on a valid focused key window.

Fixes VSTS #943186

Backport of #8550.

/cc @sevoku 