### PR TITLE
[release-8.3] Check that SDK root path exists before versions

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreSDKResolverTests.cs
@@ -103,7 +103,9 @@ namespace MonoDevelop.DotNetCore.Tests
 			if (string.IsNullOrEmpty (DotNetCoreRuntime.FileName))
 				Assert.Inconclusive ($"'DotNetCoreRuntime.FileName' is empty. Unable to run the test. DotNetCore installed? {DotNetCoreRuntime.IsInstalled}");
 
-			var resolver = new DotNetCoreSdkPaths (dotnetCorePath);
+			// initializeSdkLocation: true resets the cached installed versions
+			var resolver = new DotNetCoreSdkPaths (dotnetCorePath, initializeSdkLocation: true);
+
 			if (mockSdkVersions)
 				resolver.SdkVersions = this.SdkVersions;
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -190,6 +190,9 @@ namespace MonoDevelop.DotNetCore
 
 		IEnumerable<DotNetCoreVersion> GetInstalledSdkVersions (string sdkRootPath)
 		{
+			if (!Directory.Exists (sdkRootPath))
+				return Enumerable.Empty<DotNetCoreVersion> ();
+
 			return Directory.EnumerateDirectories (sdkRootPath)
 				.Select (directory => {
 					if (!directory.Contains ("NuGetFallbackFolder"))

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -58,9 +58,6 @@ namespace MonoDevelop.DotNetCore
 			string rootDirectory = Path.GetDirectoryName (dotNetCorePath);
 			SdkRootPath = Path.Combine (rootDirectory, "sdk");
 
-			if (!Directory.Exists (SdkRootPath))
-				return;
-
 			SdkVersions = GetInstalledSdkVersions ()
 				.OrderByDescending (version => version)
 				.ToArray ();


### PR DESCRIPTION
Fixes VSTS #948292

Backport of #8546.

/cc @nosami 