### PR TITLE
[Ide] If MEF is queried before startup handlers are run, throw an exc…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Composition/CompositionManager.cs
@@ -56,14 +56,16 @@ namespace MonoDevelop.Ide.Composition
 			new AttributedPartDiscoveryV1 (StandardResolver),
 			new AttributedPartDiscovery (StandardResolver, true));
 
-		static Action HandleMefQueriedBeforeCompletion
-			= () => throw new InvalidOperationException ("MEF queried while it was still being built");
+		static Action HandleMefQueriedBeforeCompletion = UninitializedLogWarning;
 
-		internal static void SetMefSafeToQuery ()
-		{
-			HandleMefQueriedBeforeCompletion
-				= () => LoggingService.LogWarning ("UI thread queried MEF while it was still being built:{0}{1}", Environment.NewLine, Environment.StackTrace);
-		}
+		static void UninitializedLogWarning ()
+			=> LoggingService.LogWarning ("UI thread queried MEF while it was still being built:{0}{1}", Environment.NewLine, Environment.StackTrace);
+
+		static void UninitializedThrowException ()
+			=> throw new InvalidOperationException ("MEF queried while it was still being built");
+
+		internal static void ConfigureUninitializedMefHandling (bool throwException)
+			=> HandleMefQueriedBeforeCompletion = throwException ? new Action (UninitializedThrowException) : new Action (UninitializedLogWarning);
 
 		public static CompositionManager Instance {
 			get {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -315,10 +315,9 @@ namespace MonoDevelop.Ide
 			Counters.Initialization.Trace ("Running Startup Commands");
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/StartupHandlers", OnExtensionChanged);
 
+			// Let extensions now access CompositionManager.Instance and start asynchronously composing the catalog
 			CompositionManager.ConfigureUninitializedMefHandling (throwException: false);
-
-			// Make sure the composition manager started initializing
-			Runtime.GetService<CompositionManager> ();
+			Runtime.GetService<CompositionManager> ().Ignore ();
 		}
 
 		public static Task EnsureInitializedAsync ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -315,7 +315,7 @@ namespace MonoDevelop.Ide
 			Counters.Initialization.Trace ("Running Startup Commands");
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/StartupHandlers", OnExtensionChanged);
 
-			CompositionManager.SetMefSafeToQuery ();
+			CompositionManager.ConfigureUninitializedMefHandling (throwException: false);
 		}
 
 		public static Task EnsureInitializedAsync ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -314,6 +314,8 @@ namespace MonoDevelop.Ide
 			// Startup commands
 			Counters.Initialization.Trace ("Running Startup Commands");
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/StartupHandlers", OnExtensionChanged);
+
+			CompositionManager.SetMefSafeToQuery ();
 		}
 
 		public static Task EnsureInitializedAsync ()
@@ -423,7 +425,7 @@ namespace MonoDevelop.Ide
 							LoggingService.LogError ("Type " + args.ExtensionObject.GetType () + " must be a subclass of MonoDevelop.Components.Commands.CommandHandler");
 						}
 					} catch (Exception ex) {
-						LoggingService.LogError (ex.ToString ());
+						LoggingService.LogError ($"Error while running startup handler {args.ExtensionObject.GetType ()}", ex);
 					}
 				});
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -316,6 +316,9 @@ namespace MonoDevelop.Ide
 			AddinManager.AddExtensionNodeHandler ("/MonoDevelop/Ide/StartupHandlers", OnExtensionChanged);
 
 			CompositionManager.ConfigureUninitializedMefHandling (throwException: false);
+
+			// Make sure the composition manager started initializing
+			Runtime.GetService<CompositionManager> ();
 		}
 
 		public static Task EnsureInitializedAsync ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -76,6 +76,8 @@ namespace MonoDevelop.Ide
 
 		int Run (MonoDevelopOptions options)
 		{
+			CompositionManager.ConfigureUninitializedMefHandling (throwException: true);
+
 			LoggingService.LogInfo ("Starting {0} {1}", BrandingService.ApplicationLongName, IdeVersionInfo.MonoDevelopVersion);
 			LoggingService.LogInfo ("Build Information{0}{1}", Environment.NewLine, SystemInformation.GetBuildInformation ());
 			LoggingService.LogInfo ("Running on {0}", RuntimeVersionInfo.GetRuntimeInfo ());

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -438,9 +438,6 @@ namespace MonoDevelop.Ide
 
 		static bool OnIdle ()
 		{
-			// Make sure the composition manager started initializing
-			Runtime.GetService<CompositionManager> ();
-
 			// OpenDocuments appears when the app is idle.
 			if (!hideWelcomePage && !WelcomePage.WelcomePageService.HasWindowImplementation) {
 				WelcomePage.WelcomePageService.ShowWelcomePage ();


### PR DESCRIPTION
…eption

We should prevent extensions from slowing down the IDE startup if they request the composition before startup even occurs.
Mark anything after StartupHandlers as safe and only log a warning if queried too early

Fixes VSTS #973923 - Querying MEF in startup handlers should throw