### PR TITLE
[release-8.3] [Mac] Fix not being able to open a file with external application

### DIFF
--- a/main/src/addins/AspNet/Projects/AspNetAppProjectFlavor.cs
+++ b/main/src/addins/AspNet/Projects/AspNetAppProjectFlavor.cs
@@ -708,7 +708,7 @@ namespace MonoDevelop.AspNet.Projects
 		protected override IEnumerable<ExecutionTarget> OnGetExecutionTargets (ConfigurationSelector configuration)
 		{
 			var apps = new List<ExecutionTarget> ();
-			foreach (var browser in MonoDevelop.Ide.IdeServices.DesktopService.GetApplications ("test.html")) {
+			foreach (var browser in MonoDevelop.Ide.IdeServices.DesktopService.GetApplications ("https://localhost")) {
 				if (browser.IsDefault)
 					apps.Insert (0, new BrowserExecutionTarget (browser.Id,browser.DisplayName,browser));
 				else

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -963,11 +963,18 @@ namespace MonoDevelop.MacIntegration
 			checkUniqueName.Add ("MonoDevelop");
 			checkUniqueName.Add (BrandingService.ApplicationName);
 
-			var def = global::CoreServices.LaunchServices.GetDefaultApplicationUrlForUrl (NSUrl.FromString (filename));
+			NSUrl url = null;
+			if (Uri.TryCreate (filename, UriKind.Absolute, out Uri hyperlink) && !hyperlink.IsFile) {
+				url = NSUrl.FromString (filename);
+			} else {
+				url = NSUrl.FromFilename (filename);
+			}
+
+			var def = global::CoreServices.LaunchServices.GetDefaultApplicationUrlForUrl (url);
 
 			var apps = new List<DesktopApplication> ();
 
-			var retrievedApps = global::CoreServices.LaunchServices.GetApplicationUrlsForUrl (NSUrl.FromString (filename), global::CoreServices.LSRoles.All);
+			var retrievedApps = global::CoreServices.LaunchServices.GetApplicationUrlsForUrl (url, global::CoreServices.LSRoles.All);
 			if (retrievedApps != null) {
 				foreach (var app in retrievedApps) {
 					if (string.IsNullOrEmpty (app.Path) || !checkUniquePath.Add (app.Path))

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -963,12 +963,7 @@ namespace MonoDevelop.MacIntegration
 			checkUniqueName.Add ("MonoDevelop");
 			checkUniqueName.Add (BrandingService.ApplicationName);
 
-			NSUrl url = null;
-			if (Uri.TryCreate (filename, UriKind.Absolute, out Uri hyperlink) && !hyperlink.IsFile) {
-				url = NSUrl.FromString (filename);
-			} else {
-				url = NSUrl.FromFilename (filename);
-			}
+			NSUrl url = CreateNSUrl (filename);
 
 			var def = global::CoreServices.LaunchServices.GetDefaultApplicationUrlForUrl (url);
 
@@ -995,6 +990,14 @@ namespace MonoDevelop.MacIntegration
 			return apps;
 		}
 
+		static NSUrl CreateNSUrl (string filename)
+		{
+			if (Uri.TryCreate (filename, UriKind.Absolute, out Uri hyperlink) && !hyperlink.IsFile)
+				return NSUrl.FromString (filename);
+
+			return NSUrl.FromFilename (filename);
+		}
+
 		class MacDesktopApplication : DesktopApplication
 		{
 			public MacDesktopApplication (string app, string name, bool isDefault) : base (app, name, isDefault)
@@ -1004,7 +1007,7 @@ namespace MonoDevelop.MacIntegration
 			public override void Launch (params string[] files)
 			{
 				NSWorkspace.SharedWorkspace.OpenUrls (
-					Array.ConvertAll (files, file => NSUrl.FromString (file)),
+					Array.ConvertAll (files, file => CreateNSUrl (file)),
 					NSBundle.FromPath (Id).BundleIdentifier,
 					NSWorkspaceLaunchOptions.Default,
 					NSAppleEventDescriptor.DescriptorWithBoolean (true));

--- a/main/tests/MacPlatform.Tests/MacPlatformTest.cs
+++ b/main/tests/MacPlatform.Tests/MacPlatformTest.cs
@@ -218,6 +218,22 @@ namespace MacPlatform.Tests
 			if (Directory.Exists ("/Applications/Google Chrome.app"))
 				Assert.True (browsers.Any (x => x.DisplayName.Contains ("Google Chrome")), "Google Chrome is installed but wasn't returned by GetApplications()");
 		}
+
+		[Test]
+		public void GetApplications ()
+		{
+			if (!Directory.Exists ("/Applications/TextEdit.app")) {
+				Assert.Ignore ("TextEdit.app does not exist");
+				return;
+			}
+
+			FilePath directory = Util.CreateTmpDir ("GetApplicationsTest");
+			FilePath filename = directory.Combine ("test.txt");
+			File.WriteAllText (filename, "test");
+
+			var apps = IdeServices.DesktopService.GetApplications (filename);
+			Assert.True (apps.Any (x => x.DisplayName.Contains ("TextEdit")), "TextEdit is installed but wasn't returned by GetApplications()");
+		}
 	}
 }
 


### PR DESCRIPTION
[Mac] Handle filenames not just urls in GetApplications


MacPlatformService.GetApplications was using NSUrl.FromString which
works for hyperlinks but returns null for file that contains a space
character in its path. This was causing the open file dialog to
never close.

```
Parameter name: url
  at CoreServices.LaunchServices.GetDefaultApplicationUrlForUrl (Foundation.NSUrl url, CoreServices.LSRoles roles) [0x00030] in /Library/Frameworks/Xamarin.Mac.framework/Versions/5.16.1.17/src/Xamarin.Mac/CoreServices/LaunchServices.cs:97
  at MonoDevelop.MacIntegration.MacPlatformService.GetApplications (System.String filename) [0x00024] in /Users/vsts/agent/2.155.1/work/1/s/monodevelop/main/src/addins/MacPlatform/MacPlatform.cs:966
  at MonoDevelop.Ide.DesktopService.GetApplications (System.String filename) [0x00000] in /Users/vsts/agent/2.155.1/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs:139
  at MonoDevelop.Ide.Gui.DisplayBindingService.GetFileViewers (MonoDevelop.Core.FilePath filePath, MonoDevelop.Projects.Project ownerProject) [0x0017e] in /Users/vsts/agent/2.155.1/work/1/s/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DisplayBindingService.cs:131
```

Using NSUrl.FromString also meant that no applications were returned
for files when using the Open With context menu in the Solution pad.

To handle this a check is made to see if a url or a filename is
being passed then either NSUrl.FromString or NSUrl.FromFilename is
used.

[Mac] Fix not being able to open a file with external application

The Open With menu would launch the external application, such as
TextEdit.app, but not open the file. The problem was that the filename
was being converted using NSUrl.FromString which only works for
hyperlinks not files.

Fixes VSTS #970854 - GTC cannot open solutions via "open" button

Backport of #8565.

/cc @mrward 