### PR TITLE
Fix document focus issue

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -268,7 +268,9 @@ namespace MonoDevelop.Ide.Gui.Documents
 
 			await Task.Yield ();
 
-			if (disposed)
+			// Check again if the view is visible. Maybe it was hidden while processing the events in the previous call
+
+			if (disposed || !shown)
 				return;
 
 			if (SourceController != null)


### PR DESCRIPTION
When grabbing the focus of a view, the actual grab is done after
dispatching the event queue. It may happen that after the events are
executed, the view bacame hidden (for example, maybe an attached view
was set active). In that case, don't try to grab the focus since it
maye cause an unexpected re-activation of the view.

Fixes VSTS #963585 – Diff/View commands broken in SolutonPad