### PR TITLE
[release-8.3] Revert "[DotNetCore] Disable VB.NET test cases for 3.0"

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreProjectTemplateTests.cs
@@ -71,7 +71,7 @@ namespace MonoDevelop.DotNetCore.Tests
 
 			// Set environment variable to enable VB.NET support
 			// Disabled for now due to .NET Core 3.0 preview 8 bug - https://github.com/dotnet/corefx/issues/40012
-			//Environment.SetEnvironmentVariable ("MD_FEATURES_ENABLED", "VBNetDotnetCoreTemplates");
+			Environment.SetEnvironmentVariable ("MD_FEATURES_ENABLED", "VBNetDotnetCoreTemplates");
 
 			// Set $PATH to point to the .NET Core SDK we provision, as in VSTS bots are
 			// setup with lots of old and incompatible SDK versions under $HOME/.dotnet
@@ -231,15 +231,15 @@ namespace MonoDevelop.DotNetCore.Tests
 		[TestCase ("Microsoft.Test.xUnit.FSharp", "UseNetCore30=true")]
 		[TestCase ("Microsoft.Test.MSTest.FSharp", "UseNetCore30=true")]
 
-		//[TestCase ("Microsoft.Common.Console.VisualBasic", "UseNetCore30=true")]
-		//[TestCase ("Microsoft.Common.Library.VisualBasic-netcoreapp", "UseNetCore30=true;Framework=netcoreapp3.0")]
-		//[TestCase ("Microsoft.Test.xUnit.VisualBasic", "UseNetCore30=true")]
-		//[TestCase ("Microsoft.Test.MSTest.VisualBasic", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Common.Console.VisualBasic", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Common.Library.VisualBasic-netcoreapp", "UseNetCore30=true;Framework=netcoreapp3.0")]
+		[TestCase ("Microsoft.Test.xUnit.VisualBasic", "UseNetCore30=true")]
+		[TestCase ("Microsoft.Test.MSTest.VisualBasic", "UseNetCore30=true")]
 
 		// NUnit3 templates come with .NET Core 2.2, but they only support .NET Core 2.1 framework
 		[TestCase ("NUnit3.DotNetNew.Template.CSharp", "UseNetCore30=true")]
 		[TestCase ("NUnit3.DotNetNew.Template.FSharp", "UseNetCore30=true")]
-		//[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore30=true")]
+		[TestCase ("NUnit3.DotNetNew.Template.VisualBasic", "UseNetCore30=true")]
 		public async Task NetCore30 (string templateId, string parameters)
 		{
 			if (!IsDotNetCoreSdk30Installed ()) {


### PR DESCRIPTION
This reverts commit 70dcec9619bfcd1d15eb5b5ea0eee1130cb6041e.

.NET Core 3.0 preview 9 fixes the problem building VB.NET projects.

Fixes VSTS #964872 - VB.NET netcore project test failing

Backport of #8580.

/cc @mrward 