### PR TITLE
[release-8.3] Do not show "Include in Project" for empty folders

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -4756,6 +4756,12 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		public bool PathExistsInProject (FilePath path)
+		{
+			string basePath = path.ToRelative (BaseDirectory);
+			return files.GetFile(path) != null || files.GetFilesInVirtualPath (basePath).Any ();
+		}
+
 		public event EventHandler<ProjectItemEventArgs> ProjectItemAdded;
 
 		public event EventHandler<ProjectItemEventArgs> ProjectItemRemoved;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
@@ -383,8 +383,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		
 		internal static bool PathExistsInProject (Project project, FilePath path)
 		{
-			string basePath = path.ToRelative (project.BaseDirectory);
-			return project.Files.GetFile (path) != null || project.Files.GetFilesInVirtualPath (basePath).Any ();
+			return project.PathExistsInProject (path);
 		}
 
 		internal static bool ContainsDirectorySeparator (string name)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
@@ -384,7 +384,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		internal static bool PathExistsInProject (Project project, FilePath path)
 		{
 			string basePath = path.ToRelative (project.BaseDirectory);
-			return project.Files.GetFilesInVirtualPath (basePath).Any () || project.Files.GetFile (path) != null;
+			return project.Files.GetFile (path) != null || project.Files.GetFilesInVirtualPath (basePath).Any ();
 		}
 
 		internal static bool ContainsDirectorySeparator (string name)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolderNodeBuilder.cs
@@ -384,7 +384,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		internal static bool PathExistsInProject (Project project, FilePath path)
 		{
 			string basePath = path.ToRelative (project.BaseDirectory);
-			return project.Files.GetFilesInVirtualPath (basePath).Any ();
+			return project.Files.GetFilesInVirtualPath (basePath).Any () || project.Files.GetFile (path) != null;
 		}
 
 		internal static bool ContainsDirectorySeparator (string name)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1266,6 +1266,16 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		[Test]
+		public void EmptyFolderExistsInProject()
+		{
+			// Test case for bug #970095
+			var p = Services.ProjectService.CreateProject ("C#");
+			p.AddDirectory ("Model");
+			Assert.True(p.PathExistsInProject ("Model"));
+			p.Dispose ();
+		}
+
 		class TestGetReferencesProjectExtension : DotNetProjectExtension
 		{
 			protected internal override Task<List<AssemblyReference>> OnGetReferences (ConfigurationSelector configuration, CancellationToken token)


### PR DESCRIPTION
"Include in Project" command was only hidden if a folder contained items
that were inside the project

![image](https://user-images.githubusercontent.com/667194/63938675-4fbbfc80-ca5d-11e9-8d49-440b3d677cf3.png)


fixes VSTS #970095

Backport of #8572.

/cc @rodrmoya @nosami