### PR TITLE
[release-8.3] Icons: Map md-reference to KnownImageIds.Reference

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
@@ -235,7 +235,7 @@
 	<StockIcon stockid="md-reference-invalid" resource="reference-invalid-16.png" size="Menu" />
 	<StockIcon stockid="md-reference-warning" resource="reference-invalid-16.png" size="Menu" />
 	<StockIcon stockid="md-property" resource="element-property-16.png" size="Menu" imageid="2429;2431;2434;2435;2436;2437;{42f9e147-4a12-4cea-9c81-a155b6048de5}#102" />
-	<StockIcon stockid="md-reference" resource="reference-16.png" size="Menu" />
+	<StockIcon stockid="md-reference" resource="reference-16.png" size="Menu" imageid="2521" />
 	<StockIcon stockid="md-reference-package" resource="reference-16.png" size="Menu" />
 	<StockIcon stockid="md-region" resource="region-16.png" size="Menu" />
 	<StockIcon stockid="md-regular-file" resource="file-generic-16.png" size="Menu" />


### PR DESCRIPTION
On Windows:
![image](https://user-images.githubusercontent.com/638167/63980276-ef828600-ca6f-11e9-9cdb-f8a2c814d02c.png)

On Mac:
![image](https://user-images.githubusercontent.com/638167/63980119-8e5ab280-ca6f-11e9-8f2b-49d3bc2d1d02.png)

md-reference image:
![image](https://user-images.githubusercontent.com/638167/63980149-9ca8ce80-ca6f-11e9-8ddf-4155622f1d1f.png)

KnownImageId.Reference image:
![image](https://user-images.githubusercontent.com/638167/63980186-b5b17f80-ca6f-11e9-9d9b-cdb48be0fdef.png)

Id:
![image](https://user-images.githubusercontent.com/638167/63980222-ccf06d00-ca6f-11e9-91b4-3c7b3b1352d0.png)





Backport of #8583.

/cc @sandyarmstrong @sailro