### PR TITLE
[release-8.3] [VCS] VSEditor uses 0 based indices, so adjust for that

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
@@ -108,7 +108,7 @@ namespace MonoDevelop.VersionControl.Views
 		int GetLineInCenter (MonoTextEditor editor)
 		{
 			double midY = editor.VAdjustment.Value + editor.Allocation.Height / 2;
-			return editor.YToLine (midY);
+			return editor.YToLine (midY) - 1;
 		}
 
 		#endregion

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.VersionControl.Views
 		public int GetLineInCenter (Mono.TextEditor.MonoTextEditor editor)
 		{
 			double midY = editor.VAdjustment.Value + editor.Allocation.Height / 2;
-			return editor.YToLine (midY);
+			return editor.YToLine (midY) - 1;
 		}
 
 		protected override void OnContentShown ()


### PR DESCRIPTION


Backport of #8585.

/cc @Therzok 