### PR TITLE
[Ide] Fix ArgumentNullException when loading non-file documents

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentRegistry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentRegistry.cs
@@ -184,7 +184,7 @@ namespace MonoDevelop.Ide.Gui
 			void GetLastWriteTime ()
 			{
 				try {
-					LastSaveTimeUtc = !Document.IsNewDocument ? File.GetLastWriteTimeUtc (Document.FileName) : DateTime.MinValue;
+					LastSaveTimeUtc = (Document.IsFile && !Document.IsNewDocument) ? File.GetLastWriteTimeUtc (Document.FileName) : DateTime.MinValue;
 				} catch (Exception ex) {
 					LoggingService.LogError ("Error while getting last write time.", ex);
 					LastSaveTimeUtc = DateTime.UtcNow;


### PR DESCRIPTION
Like new usaved files, also documents without being a file have no
write time.

Fixes VSTS #976445