### PR TITLE
Fix launch settings always generated with https

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
@@ -205,6 +205,17 @@ namespace MonoDevelop.AspNetCore.Tests
 			Assert.False (project.RunConfigurations [1].StoreInUserFile);
 		}
 
+		[Test]
+		public async Task CreateProfile_creates_http_only ()
+		{
+			var solutionFileName = Util.GetSampleProject ("aspnetcore-empty-22", "aspnetcore-empty-22.sln");
+			solution = (Solution)await MonoDevelop.Projects.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
+			var project = (DotNetProject)solution.GetAllProjects ().Single ();
+			var launchProfileProvider = new LaunchProfileProvider (project);
+			var launchProfile = launchProfileProvider.CreateDefaultProfile ();
+			launchProfile.OtherSettings ["applicationUrl"] = "http://localhost:5000";
+		}
+
 		[TearDown]
 		public override void TearDown ()
 		{

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.AspNetCore.Tests
 			solution = (Solution)await MonoDevelop.Projects.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = (DotNetProject)solution.GetAllProjects ().Single ();
 
-			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
+			var launchProfileProvider = new LaunchProfileProvider (project);
 			launchProfileProvider.LoadLaunchSettings ();
 
 			Assert.That (launchProfileProvider.ProfilesObject, Is.Not.Null);
@@ -99,7 +99,7 @@ namespace MonoDevelop.AspNetCore.Tests
 
 			launchProfileProvider.SaveLaunchSettings ();
 
-			launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
+			launchProfileProvider = new LaunchProfileProvider (project);
 			launchProfileProvider.LoadLaunchSettings ();
 
 			Assert.That (launchProfileProvider.Profiles, Has.Count.EqualTo (3));
@@ -112,7 +112,7 @@ namespace MonoDevelop.AspNetCore.Tests
 			solution = (Solution)await MonoDevelop.Projects.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = (DotNetProject)solution.GetAllProjects ().Single ();
 
-			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
+			var launchProfileProvider = new LaunchProfileProvider (project);
 			launchProfileProvider.LoadLaunchSettings ();
 
 			Assert.That (launchProfileProvider.ProfilesObject, Is.Not.Null);
@@ -168,7 +168,7 @@ namespace MonoDevelop.AspNetCore.Tests
 			solution = (Solution)await MonoDevelop.Projects.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = (DotNetProject)solution.GetAllProjects ().Single ();
 
-			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
+			var launchProfileProvider = new LaunchProfileProvider (project);
 			launchProfileProvider.LoadLaunchSettings ();
 
 			Assert.That (launchProfileProvider.ProfilesObject, Is.Not.Null);
@@ -192,11 +192,11 @@ namespace MonoDevelop.AspNetCore.Tests
 
 			project.RunConfigurations.Clear ();
 			Assert.That (project.RunConfigurations, Is.Empty);
-			
-			var launchProfileProvider = new LaunchProfileProvider (project.BaseDirectory, project.DefaultNamespace);
+
+			var launchProfileProvider = new LaunchProfileProvider (project);
 			System.IO.File.WriteAllText (launchProfileProvider.LaunchSettingsJsonPath, LaunchSettings);
 			launchProfileProvider.LoadLaunchSettings ();
-			launchProfileProvider.SyncRunConfigurations (project);
+			launchProfileProvider.SyncRunConfigurations();
 
 			Assert.That (project.RunConfigurations, Has.Count.EqualTo (2));
 			Assert.That (project.RunConfigurations [0].Name, Is.EqualTo ("Kestrel Staging"));

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/LaunchSettingsTests.cs
@@ -208,7 +208,7 @@ namespace MonoDevelop.AspNetCore.Tests
 		[Test]
 		public async Task CreateProfile_creates_http_only ()
 		{
-			var solutionFileName = Util.GetSampleProject ("aspnetcore-empty-22", "aspnetcore-empty-22.sln");
+			var solutionFileName = Util.GetSampleProject ("aspnetcore-empty-30", "aspnetcore-empty-30.sln");
 			solution = (Solution)await MonoDevelop.Projects.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName);
 			var project = (DotNetProject)solution.GetAllProjects ().Single ();
 			var launchProfileProvider = new LaunchProfileProvider (project);

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreCertificateManager.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreCertificateManager.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.AspNetCore
 				UsingHttps (runConfiguration);
 		}
 
-		static bool UsingHttps (SolutionItemRunConfiguration runConfiguration)
+		internal static bool UsingHttps (SolutionItemRunConfiguration runConfiguration)
 		{
 			var aspNetCoreRunConfiguration = runConfiguration as AspNetCoreRunConfiguration;
 			return aspNetCoreRunConfiguration?.UsingHttps () == true;

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -78,7 +78,7 @@ namespace MonoDevelop.AspNetCore
 		void InitLaunchSettingsProvider ()
 		{
 			if (launchProfileProvider == null) {
-				launchProfileProvider = new LaunchProfileProvider (this.Project.BaseDirectory, this.Project.DefaultNamespace);
+				launchProfileProvider = new LaunchProfileProvider (this.Project);
 			}
 		}
 
@@ -191,7 +191,7 @@ namespace MonoDevelop.AspNetCore
 			updating = true;
 
 			launchProfileProvider.LoadLaunchSettings ();
-			launchProfileProvider.SyncRunConfigurations (Project);
+			launchProfileProvider.SyncRunConfigurations();
 
 			updating = false;
 		}
@@ -217,7 +217,7 @@ namespace MonoDevelop.AspNetCore
 			updating = true;
 
 			launchProfileProvider.LoadLaunchSettings ();
-			launchProfileProvider.SyncRunConfigurations (Project);
+			launchProfileProvider.SyncRunConfigurations();
 
 			await IdeApp.ProjectOperations.SaveAsync (Project);
 

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileProvider.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/LaunchProfileProvider.cs
@@ -196,7 +196,7 @@ namespace MonoDevelop.AspNetCore
 		/// Updates Project.RunConfigurations
 		/// </summary>
 		internal void SyncRunConfigurations()
-        {
+		{
 			foreach (var profile in this.Profiles) {
 
 				if (profile.Value.CommandName != "Project")

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -370,10 +370,10 @@ namespace MonoDevelop.Projects
 			// If the project doesn't have a Default run configuration, create one
 			if (!defaultRunConfigurationCreated) {
 				if (!runConfigurations.Any (c => c.IsDefaultConfiguration)) {
+					defaultRunConfigurationCreated = true;
 					var rc = CreateRunConfigurationInternal ("Default");
 					ImportDefaultRunConfiguration (rc);
 					runConfigurations.Insert (0, rc);
-					defaultRunConfigurationCreated = true;
 				}
 			}
 		}


### PR DESCRIPTION
When launching an existing project that didn't contain a
launchSettings.json file, one was generated that always created a https
profile even if https was not being used by any of the run
configurations.

Fixes VSTS #958951