### PR TITLE
[release-8.3] Icons: Design change to KnownImageIds.IntellisenseWarning icon

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/StockIcons.addin.xml
@@ -10,7 +10,7 @@
 		<StockIcon stockid="md-searchbox-search" resource="searchbox-search-macos-16.png" size="Menu" />
 		<StockIcon stockid="md-searchbox-clear" resource="searchbox-clear-macos-16.png" size="Menu" />
 	</Condition>
-	
+
 	<Condition id="Platform" value="windows">
 		<StockIcon stockid="md-searchbox-search" resource="searchbox-search-win-24.png" size="Menu" />
 		<StockIcon stockid="md-searchbox-clear" resource="searchbox-clear-win-24.png" size="Menu" />
@@ -304,13 +304,13 @@
 	<StockIcon stockid="md-workspace" resource="workspace-32.png" size="Dnd" />
 	<StockIcon stockid="md-solution" resource="solution-32.png" size="Dnd" />
 	<StockIcon stockid="md-project" resource="project-32.png" size="Dnd" />
-	
+
 	<StockIcon stockid="md-library-project" resource="project-library-32.png" size="Dnd" />
 	<StockIcon stockid="md-gui-project" resource="project-gui-32.png" size="Dnd" />
 	<StockIcon stockid="md-console-project" resource="project-console-32.png" size="Dnd" />
 	<StockIcon stockid="md-test-project" resource="project-test-32.png" size="Dnd" />
 	<StockIcon stockid="md-package-project" resource="project-package-32.png" size="Dnd" />
-	
+
 	<StockIcon stockid="md-crossplatform-pcl-project" resource="project-crossplatform-pcl-32.png" size="Dnd" />
 	<StockIcon stockid="md-crossplatform-shared-project" resource="project-crossplatform-shared-32.png" size="Dnd" />
 
@@ -364,7 +364,7 @@
 	<StockIcon stockid="md-package" resource="package-32.png" size="Dnd" />
 	<StockIcon stockid="md-package" resource="package-48.png" size="Dialog" />
 
-	<StockIcon stockid="md-warning" resource="warning-16.png" imageid="1591" />
+	<StockIcon stockid="md-warning" resource="warning-16.png" />
 	<StockIcon stockid="md-warning" resource="warning-16.png" size="Menu" />
 	<StockIcon stockid="md-warning" resource="warning-24.png" size="Button" />
 	<StockIcon stockid="md-warning" resource="warning-24.png" size="LargeToolbar" />
@@ -489,7 +489,7 @@
 	<StockIcon stockid="build-target" resource="build-target-16.png" size="Menu" />
 	<StockIcon stockid="build-task-failed" resource="build-task-failed-16.png" size="Menu" />
 	<StockIcon stockid="build-task-success" resource="build-task-success-16.png" size="Menu" />
-	<StockIcon stockid="build-warning" resource="build-warning-16.png" size="Menu" />
+	<StockIcon stockid="build-warning" resource="build-warning-16.png" size="Menu" imageid="1591" />
 	<StockIcon stockid="build-warning-small" resource="build-warning-small-16.png" size="Menu" />
 	<StockIcon stockid="build-expand" resource="tree-chevron-closed.png" size="Menu" />
 	<StockIcon stockid="build-collapse" resource="tree-chevron-open.png" size="Menu" />


### PR DESCRIPTION
<img width="448" alt="image" src="https://user-images.githubusercontent.com/155076/64195397-3983b700-ce36-11e9-97fa-2fbff8075cc0.png">

See https://github.com/mono/monodevelop/pull/8363 for the previous (temporary) icon mapping.

This change was requested by design (@vancura et al).

Backport of #8616.

/cc @sandyarmstrong 