### PR TITLE
Use a single-thread scheduler for all libgit2 operations 

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -315,7 +315,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 
 				await AddFileAsync ("file1", "text", true, true);
 
-				await Task.Run (() => repo2.CreateBranch ("branch1", null, null));
+				await repo2.CreateBranchAsync ("branch1", null, null);
 
 				await repo2.SwitchToBranchAsync (monitor, "branch1");
 				// Nothing could be stashed for master. Branch1 should be popped in any case if it exists.
@@ -326,7 +326,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 				Assert.IsTrue (File.Exists (LocalPath + "file1"), "Branch not inheriting from current.");
 
 				await AddFileAsync ("file2", "text", true, false);
-				repo2.CreateBranch ("branch2", null, null);
+				await repo2.CreateBranchAsync ("branch2", null, null);
 
 				await repo2.SwitchToBranchAsync (monitor, "branch2");
 				if (automaticStashCreation) {
@@ -355,11 +355,12 @@ namespace MonoDevelop.VersionControl.Git.Tests
 				}
 
 				await repo2.SwitchToBranchAsync (monitor, "master");
-				await Task.Run (() => repo2.RemoveBranch ("branch1"));
-				Assert.IsFalse (repo2.GetBranches ().Any (b => b.FriendlyName == "branch1"), "Failed to delete branch");
+				await repo2.RemoveBranchAsync ("branch1");
+				Assert.IsFalse ((await repo2.GetBranchesAsync ()).Any (b => b.FriendlyName == "branch1"), "Failed to delete branch");
 
-				repo2.RenameBranch ("branch2", "branch3");
-				Assert.IsTrue (repo2.GetBranches ().Any (b => b.FriendlyName == "branch3") && repo2.GetBranches ().All (b => b.FriendlyName != "branch2"), "Failed to rename branch");
+				await repo2.RenameBranchAsync ("branch2", "branch3");
+				var branches = await repo2.GetBranchesAsync ();
+				Assert.IsTrue (branches.Any (b => b.FriendlyName == "branch3") && branches.All (b => b.FriendlyName != "branch2"), "Failed to rename branch");
 			} finally {
 				GitService.StashUnstashWhenSwitchingBranches.Value = autoStashDefault;
 			}
@@ -376,14 +377,14 @@ namespace MonoDevelop.VersionControl.Git.Tests
 
 			var monitor = new ProgressMonitor ();
 
-			repo2.CreateBranch ("branch3", null, null);
+			await repo2.CreateBranchAsync ("branch3", null, null);
 			await repo2.SwitchToBranchAsync (monitor, "branch3");
 			await AddFileAsync ("file2", "asdf", true, true);
 			await Task.Run (() => repo2.Push (monitor, "origin", "branch3"));
 
 			await repo2.SwitchToBranchAsync (monitor, "master");
 
-			repo2.CreateBranch ("branch4", "origin/branch3", "refs/remotes/origin/branch3");
+			await repo2.CreateBranchAsync ("branch4", "origin/branch3", "refs/remotes/origin/branch3");
 			await repo2.SwitchToBranchAsync (monitor, "branch4");
 			Assert.IsTrue (File.Exists (LocalPath + "file2"), "Tracking remote is not grabbing correct commits");
 		}
@@ -479,17 +480,17 @@ namespace MonoDevelop.VersionControl.Git.Tests
 
 			await AddFileAsync ("file1", "text", true, true);
 			await PostCommit (repo2);
-			await Task.Run (() => repo2.CreateBranch ("branch1", null, null));
+			await repo2.CreateBranchAsync ("branch1", null, null);
 			await repo2.SwitchToBranchAsync (monitor, "branch1");
 			await AddFileAsync ("file2", "text", true, true);
 			await PostCommit (repo2);
-			Assert.AreEqual (2, repo2.GetBranches ().Count ());
+			Assert.AreEqual (2, (await repo2.GetBranchesAsync ()).Count ());
 			Assert.AreEqual (1, (await repo2.GetRemotesAsync ()).Count ());
 
-			await Task.Run (() => repo2.RenameRemote ("origin", "other"));
+			await repo2.RenameRemoteAsync ("origin", "other");
 			Assert.AreEqual ("other", await repo2.GetCurrentRemoteAsync ());
 
-			await Task.Run (() => repo2.RemoveRemote ("other"));
+			await repo2.RemoveRemoteAsync ("other");
 			Assert.IsFalse ((await repo2.GetRemotesAsync ()).Any ());
 		}
 
@@ -500,16 +501,16 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			var monitor = new ProgressMonitor ();
 			await AddFileAsync ("file1", "text", true, true);
 
-			Assert.IsTrue (repo2.IsBranchMerged ("master"));
+			Assert.IsTrue (await repo2.IsBranchMergedAsync ("master"));
 
-			await Task.Run (() => repo2.CreateBranch ("branch1", null, null));
+			await repo2.CreateBranchAsync ("branch1", null, null);
 			await repo2.SwitchToBranchAsync (monitor, "branch1");
 			await AddFileAsync ("file2", "text", true, true);
 
 			await repo2.SwitchToBranchAsync (monitor, "master");
-			Assert.IsFalse (repo2.IsBranchMerged ("branch1"));
-			await Task.Run (() => repo2.MergeAsync ("branch1", GitUpdateOptions.NormalUpdate, monitor));
-			Assert.IsTrue (repo2.IsBranchMerged ("branch1"));
+			Assert.IsFalse (await repo2.IsBranchMergedAsync ("branch1"));
+			await repo2.MergeAsync ("branch1", GitUpdateOptions.NormalUpdate, monitor);
+			Assert.IsTrue (await repo2.IsBranchMergedAsync ("branch1"));
 		}
 
 		[Test]
@@ -517,11 +518,12 @@ namespace MonoDevelop.VersionControl.Git.Tests
 		{
 			var repo2 = (GitRepository)Repo;
 			await AddFileAsync ("file1", "text", true, true);
-			repo2.AddTag ("tag1", GetHeadRevision (), "my-tag");
-			Assert.AreEqual (1, repo2.GetTags ().Count ());
-			Assert.AreEqual ("tag1", repo2.GetTags ().First ());
-			repo2.RemoveTag ("tag1");
-			Assert.AreEqual (0, repo2.GetTags ().Count ());
+			await repo2.AddTagAsync ("tag1", GetHeadRevision (), "my-tag");
+			var tags = await repo2.GetTagsAsync ();
+			Assert.AreEqual (1, tags.Count);
+			Assert.AreEqual ("tag1", tags.First ());
+			await repo2.RemoveTagAsync ("tag1");
+			Assert.AreEqual (0, (await repo2.GetTagsAsync ()).Count);
 		}
 
 		// TODO: Test rebase and merge - This is broken on Windows
@@ -580,7 +582,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			Assert.AreEqual (VersionStatus.Versioned | VersionStatus.ScheduledDelete, (await Repo.GetVersionInfoAsync (added, VersionInfoQueryFlags.IgnoreCache)).Status);
 
 			// Reset state.
-			await Task.Run (async () => await Repo.RevertAsync (added, false, monitor));
+			await Repo.RevertAsync (added, false, monitor);
 
 			// Test with Project Remove.
 			File.WriteAllText ("testfile", "t");
@@ -600,14 +602,19 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			var repo2 = (GitRepository)Repo;
 			await AddFileAsync ("init", "init", true, true);
 			await Task.Run (() => repo2.Push (new ProgressMonitor (), "origin", "master"));
-			repo2.CreateBranch ("testBranch", "origin/master", "refs/remotes/origin/master");
+			await repo2.CreateBranchAsync ("testBranch", "origin/master", "refs/remotes/origin/master");
 
-			if (exceptionType != null)
-				Assert.Throws (exceptionType, () => repo2.CreateBranch ("testBranch2", trackSource, trackRef));
-			else {
-				repo2.CreateBranch ("testBranch2", trackSource, trackRef);
-				Assert.True (repo2.GetBranches ().Any (b => b.FriendlyName == "testBranch2" && b.TrackedBranch.FriendlyName == trackSource));
+			if (exceptionType != null) {
+				try {
+					await repo2.CreateBranchAsync ("testBranch2", trackSource, trackRef);
+				} catch (Exception ex) {
+					Assert.IsInstanceOfType (exceptionType, ex);
+				}
+			} else {
+				await repo2.CreateBranchAsync ("testBranch2", trackSource, trackRef);
+				Assert.True ((await repo2.GetBranchesAsync ()).Any (b => b.FriendlyName == "testBranch2" && b.TrackedBranch.FriendlyName == trackSource));
 			}
+			repo2.Dispose ();
 		}
 
 		public async Task CanSetBranchTrackRef (string trackSource, string trackRef)
@@ -617,14 +624,15 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			await AddFileAsync ("init", "init", true, true);
 			repo2.Push (new ProgressMonitor (), "origin", "master");
 
-			repo2.SetBranchTrackRef ("testBranch", "origin/master", "refs/remotes/origin/master");
-			Assert.True (repo2.GetBranches ().Any (
+			await repo2.SetBranchTrackRefAsync ("testBranch", "origin/master", "refs/remotes/origin/master");
+			var branches = await repo2.GetBranchesAsync ();
+			Assert.True (branches.Any (
 				b => b.FriendlyName == "testBranch" &&
-				b.TrackedBranch == repo2.GetBranches ().Single (rb => rb.FriendlyName == "origin/master")
+				b.TrackedBranch == branches.Single (rb => rb.FriendlyName == "origin/master")
 			));
 
-			repo2.SetBranchTrackRef ("testBranch", null, null);
-			Assert.True (repo2.GetBranches ().Any (
+			await repo2.SetBranchTrackRefAsync ("testBranch", null, null);
+			Assert.True ((await repo2.GetBranchesAsync ()).Any (
 				b => b.FriendlyName == "testBranch" &&
 				b.TrackedBranch == null)
 			);
@@ -654,7 +662,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			await AddFileAsync ("init", "init", toVcs: true, commit: true);
 
 			// Create a branch from initial commit.
-			gitRepo.CreateBranch ("test", null, null);
+			await gitRepo.CreateBranchAsync ("test", null, null);
 
 			// Create two commits in master.
 			await AddFileAsync ("init2", "init", toVcs: true, commit: true);
@@ -665,7 +673,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			await AddFileAsync ("init4", "init", toVcs: true, commit: true);
 			await AddFileAsync ("init5", "init", toVcs: true, commit: true);
 
-			await Task.Run (async () => await gitRepo.RebaseAsync ("master", GitUpdateOptions.None, monitor));
+			await gitRepo.RebaseAsync ("master", GitUpdateOptions.None, monitor);
 
 			// Commits come in reverse (recent to old).
 			var history = (await gitRepo.GetHistoryAsync (LocalPath, null)).Reverse ().ToArray ();
@@ -688,7 +696,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 
 			var directory = FileService.CreateTempDirectory ();
 			try {
-				await Task.Run (async () => await toCheckout.CheckoutAsync (directory, true, monitor));
+				await toCheckout.CheckoutAsync (directory, true, monitor);
 			} catch (Exception e) {
 				var exception = e.InnerException;
 				// libgit2 < 0.26 will throw NotFoundException (result -3)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseRepositoryTests.cs
@@ -269,7 +269,7 @@ namespace MonoDevelop.VersionControl.Tests
 
 			await PostCommit (Repo2);
 
-			await Task.Run(async () => await Repo.UpdateAsync (Repo.RootPath, true, monitor));
+			await Repo.UpdateAsync (Repo.RootPath, true, monitor);
 			Assert.True (File.Exists (LocalPath + "testfile2"));
 
 			Repo2.Dispose ();
@@ -337,7 +337,7 @@ namespace MonoDevelop.VersionControl.Tests
 
 			// Revert to head.
 			File.WriteAllText (added, content);
-			await Task.Run (async () => await Repo.RevertAsync (added, false, monitor));
+			await Repo.RevertAsync (added, false, monitor);
 			Assert.AreEqual (await Repo.GetBaseTextAsync (added), File.ReadAllText (added));
 		}
 
@@ -355,7 +355,7 @@ namespace MonoDevelop.VersionControl.Tests
 			// Force cache evaluation.
 			await Repo.GetVersionInfoAsync (added, VersionInfoQueryFlags.IgnoreCache);
 
-			await Task.Run (() => Repo.RevertAsync (added, false, monitor));
+			await Repo.RevertAsync (added, false, monitor);
 			Assert.AreEqual (VersionStatus.Unversioned, (await Repo.GetVersionInfoAsync (added, VersionInfoQueryFlags.IgnoreCache)).Status);
 		}
 
@@ -383,7 +383,7 @@ namespace MonoDevelop.VersionControl.Tests
 			string added = LocalPath + "testfile2";
 			await AddFileAsync ("testfile", "text", true, true);
 			await AddFileAsync ("testfile2", "text2", true, true);
-			Task.Run (async () => await Repo.RevertRevisionAsync (added, GetHeadRevision (), monitor)).Wait ();
+			await Repo.RevertRevisionAsync (added, GetHeadRevision (), monitor);
 			Assert.IsFalse (File.Exists (added));
 		}
 
@@ -650,8 +650,8 @@ namespace MonoDevelop.VersionControl.Tests
 			string dirFile = Path.Combine (dir, "testfile");
 			await AddFileAsync ("testfile", "test", true, true);
 			await AddDirectoryAsync ("testdir", true, false);
-			await Task.Run (() => Repo.MoveFileAsync (added, dirFile, true, monitor));
-			await Task.Run (() => Repo.MoveFileAsync (dirFile, added, true, monitor));
+			await Repo.MoveFileAsync (added, dirFile, true, monitor);
+			await Repo.MoveFileAsync (dirFile, added, true, monitor);
 
 			Assert.AreEqual (VersionStatus.Unversioned, (await Repo.GetVersionInfoAsync (dirFile, VersionInfoQueryFlags.IgnoreCache)).Status);
 			Assert.AreEqual (VersionStatus.Versioned, (await Repo.GetVersionInfoAsync (added, VersionInfoQueryFlags.IgnoreCache)).Status);
@@ -667,8 +667,8 @@ namespace MonoDevelop.VersionControl.Tests
 			// Force cache update.
 			await Repo.GetVersionInfoAsync (added, VersionInfoQueryFlags.IgnoreCache);
 
-			await Task.Run (() => Repo.DeleteFileAsync (added, true, monitor, false));
-			await Task.Run (() => Repo.RevertAsync (added, false, monitor));
+			await Repo.DeleteFileAsync (added, true, monitor, false);
+			await Repo.RevertAsync (added, false, monitor);
 
 			Assert.AreEqual (VersionStatus.Versioned, (await Repo.GetVersionInfoAsync (added, VersionInfoQueryFlags.IgnoreCache)).Status);
 		}
@@ -681,11 +681,11 @@ namespace MonoDevelop.VersionControl.Tests
 			string dstFile = LocalPath.Combine ("TESTFILE");
 			await AddFileAsync ("testfile", "test", true, true);
 
-			await Task.Run (() => Repo.MoveFileAsync (srcFile, dstFile, true, monitor));
+			await Repo.MoveFileAsync (srcFile, dstFile, true, monitor);
 			Assert.AreEqual (VersionStatus.ScheduledAdd, (await Repo.GetVersionInfoAsync (dstFile, VersionInfoQueryFlags.IgnoreCache)).Status & VersionStatus.ScheduledAdd);
 			Assert.AreEqual (VersionStatus.ScheduledDelete, (await Repo.GetVersionInfoAsync (srcFile, VersionInfoQueryFlags.IgnoreCache)).Status & VersionStatus.ScheduledDelete);
 
-			await Task.Run (() => Repo.MoveFileAsync (dstFile, srcFile, true, monitor));
+			await Repo.MoveFileAsync (dstFile, srcFile, true, monitor);
 			Assert.AreEqual (VersionStatus.Unversioned, (await Repo.GetVersionInfoAsync (dstFile, VersionInfoQueryFlags.IgnoreCache)).Status);
 			Assert.AreEqual (VersionStatus.Versioned, (await Repo.GetVersionInfoAsync (srcFile, VersionInfoQueryFlags.IgnoreCache)).Status);
 			
@@ -763,9 +763,7 @@ namespace MonoDevelop.VersionControl.Tests
 			var monitor = new ProgressMonitor ();
 			using (var mockRepo = (UrlBasedRepository)GetRepo ()) {
 				mockRepo.Url = url;
-				await Task.Run (async () => {
-					await mockRepo.CheckoutAsync (path, true, monitor);
-				});
+				await mockRepo.CheckoutAsync (path, true, monitor);
 			}
 
 			var _repo = GetRepo (path, url);

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
@@ -58,6 +58,9 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <IncludeCopyLocal Include="LibGit2Sharp.dll" />
+  </ItemGroup>
   <Choose>
     <When Condition=" '$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac' ">
       <ItemGroup>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/MonoDevelop.VersionControl.Git.Tests.csproj
@@ -51,8 +51,6 @@
     <ProjectReference Include="..\..\..\..\external\libgit2sharp\LibGit2Sharp\LibGit2Sharp.csproj">
       <Project>{EE6ED99F-CB12-4683-B055-D28FC7357A34}</Project>
       <Name>LibGit2Sharp</Name>
-      <IncludeInPackage>true</IncludeInPackage>
-      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\MonoDevelop.SourceEditor2\MonoDevelop.SourceEditor.csproj">
       <Project>{F8F92AA4-A376-4679-A9D4-60E7B7FBF477}</Project>

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -107,9 +107,13 @@ namespace MonoDevelop.VersionControl.Git
 			if (wob == null)
 				return;
 			if (((wob is WorkspaceItem) && ((WorkspaceItem)wob).ParentWorkspace == null) ||
-			    (wob.BaseDirectory.CanonicalPath == repo.RootPath.CanonicalPath))
-			{
-				string currentBranch = repo.GetCurrentBranch ();
+			    (wob.BaseDirectory.CanonicalPath == repo.RootPath.CanonicalPath)) {
+
+				string currentBranch = GitRepository.DefaultNoBranchName;
+				var getBranch = repo.GetCurrentBranchAsync ();
+				if (getBranch.Wait (250))
+					currentBranch = getBranch.Result;
+
 				foreach (Branch branch in repo.GetBranches ()) {
 					CommandInfo ci = info.Add (branch.FriendlyName, branch.FriendlyName);
 					if (branch.FriendlyName == currentBranch)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -114,9 +114,9 @@ namespace MonoDevelop.VersionControl.Git
 				if (getBranch.Wait (250))
 					currentBranch = getBranch.Result;
 
-				foreach (Branch branch in repo.GetBranches ()) {
-					CommandInfo ci = info.Add (branch.FriendlyName, branch.FriendlyName);
-					if (branch.FriendlyName == currentBranch)
+				foreach (var branch in repo.GetLocalBranchNamesAsync ().Result) {
+					CommandInfo ci = info.Add (branch, branch);
+					if (branch == currentBranch)
 						ci.Checked = true;
 				}
 			}
@@ -219,11 +219,11 @@ namespace MonoDevelop.VersionControl.Git
 			});
 		}
 
-		protected override void Update (CommandInfo info)
+		protected override async Task UpdateAsync (CommandInfo info, CancellationToken cancelToken)
 		{
 			var repo = UpdateVisibility (info);
 			if (repo != null)
-				info.Enabled = repo.GetStashes ().Any ();
+				info.Enabled = (await repo.GetStashesAsync (cancelToken)).Any ();
 		}
 	}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -130,13 +130,18 @@ namespace MonoDevelop.VersionControl.Git
 			FillTags ();
 		}
 
-		void FillBranches ()
+		async void FillBranches ()
 		{
 			var state = new TreeViewState (listBranches, 3);
 			state.Save ();
 			storeBranches.Clear ();
-			string currentBranch = repo.GetCurrentBranch ();
-			foreach (Branch branch in repo.GetBranches ()) {
+			var token = destroyTokenSource.Token;
+			string currentBranch = await repo.GetCurrentBranchAsync (token);
+			if (token.IsCancellationRequested)
+				return;
+			foreach (var branch in await repo.GetBranchesAsync (token)) {
+				if (token.IsCancellationRequested)
+					return;
 				string text = branch.FriendlyName == currentBranch ? "<b>" + branch.FriendlyName + "</b>" : branch.FriendlyName;
 				storeBranches.AppendValues (branch, text, branch.IsTracking ? branch.TrackedBranch.FriendlyName : String.Empty, branch.FriendlyName);
 			}
@@ -160,7 +165,11 @@ namespace MonoDevelop.VersionControl.Git
 					string text = remote.Name == currentRemote ? "<b>" + remote.Name + "</b>" : remote.Name;
 					string url = remote.Url;
 					TreeIter it = storeRemotes.AppendValues (remote, text, url, null, remote.Name);
-					foreach (string branch in repo.GetRemoteBranches (remote.Name))
+
+					var remoteBranches = await repo.GetRemoteBranchesAsync (remote.Name, token);
+					if (token.IsCancellationRequested)
+						return;
+					foreach (string branch in remoteBranches)
 						storeRemotes.AppendValues (it, null, branch, null, branch, remote.Name + "/" + branch);
 				}
 				state.Load ();
@@ -169,10 +178,14 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		void FillTags ()
+		async void FillTags ()
 		{
 			storeTags.Clear ();
-			foreach (string tag in repo.GetTags ()) {
+			var token = destroyTokenSource.Token;
+			var tags = await repo.GetTagsAsync (token);
+			if (token.IsCancellationRequested)
+				return;
+			foreach (string tag in tags) {
 				storeTags.AppendValues (tag);
 			}
 		}
@@ -190,13 +203,15 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected virtual void OnButtonAddBranchClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonAddBranchClicked (object sender, EventArgs e)
 		{
 			var dlg = new EditBranchDialog (repo);
 			try {
 				if (MessageService.RunCustomDialog (dlg) == (int)ResponseType.Ok) {
-					repo.CreateBranch (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
-					FillBranches ();
+					var token = destroyTokenSource.Token;
+					await repo.CreateBranchAsync (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
+					if (!token.IsCancellationRequested)
+						FillBranches ();
 				}
 			} catch (Exception ex) {
 				MessageService.ShowError (GettextCatalog.GetString ("The branch could not be created"), ex);
@@ -206,7 +221,7 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected virtual void OnButtonEditBranchClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonEditBranchClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!listBranches.Selection.GetSelected (out it))
@@ -214,16 +229,18 @@ namespace MonoDevelop.VersionControl.Git
 			var b = (Branch) storeBranches.GetValue (it, 0);
 			var dlg = new EditBranchDialog (repo, b.FriendlyName, b.IsTracking ? b.TrackedBranch.FriendlyName : String.Empty);
 			try {
+				var token = destroyTokenSource.Token;
 				if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
 					if (dlg.BranchName != b.FriendlyName) {
 						try {
-							repo.RenameBranch (b.FriendlyName, dlg.BranchName);
+							await repo.RenameBranchAsync (b.FriendlyName, dlg.BranchName);
 						} catch (Exception ex) {
 							MessageService.ShowError (GettextCatalog.GetString ("The branch could not be renamed"), ex);
 						}
 					}
-					repo.SetBranchTrackRef (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
-					FillBranches ();
+					await repo.SetBranchTrackRefAsync (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
+					if (!token.IsCancellationRequested)
+						FillBranches ();
 				}
 			} finally {
 				dlg.Destroy ();
@@ -231,19 +248,21 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected virtual void OnButtonRemoveBranchClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonRemoveBranchClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!listBranches.Selection.GetSelected (out it))
 				return;
 			var b = (Branch) storeBranches.GetValue (it, 0);
 			string txt = null;
-			if (!repo.IsBranchMerged (b.FriendlyName))
+			if (!await repo.IsBranchMergedAsync (b.FriendlyName))
 				txt = GettextCatalog.GetString ("WARNING: The branch has not yet been merged to HEAD");
 			if (MessageService.Confirm (GettextCatalog.GetString ("Are you sure you want to delete the branch '{0}'?", b.FriendlyName), txt, AlertButton.Delete)) {
 				try {
-					repo.RemoveBranch (b.FriendlyName);
-					FillBranches ();
+					var token = destroyTokenSource.Token;
+					await repo.RemoveBranchAsync (b.FriendlyName);
+					if (!token.IsCancellationRequested)
+						FillBranches ();
 				} catch (Exception ex) {
 					MessageService.ShowError (GettextCatalog.GetString ("The branch could not be deleted"), ex);
 				}
@@ -256,17 +275,20 @@ namespace MonoDevelop.VersionControl.Git
 			if (!listBranches.Selection.GetSelected (out it))
 				return;
 			var b = (Branch) storeBranches.GetValue (it, 0);
-			if (await GitService.SwitchToBranchAsync (repo, b.FriendlyName))
+			var token = destroyTokenSource.Token;
+			if (await GitService.SwitchToBranchAsync (repo, b.FriendlyName) && !token.IsCancellationRequested)
 				FillBranches ();
 		}
 
-		protected virtual void OnButtonAddRemoteClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonAddRemoteClicked (object sender, EventArgs e)
 		{
 			var dlg = new EditRemoteDialog (repo, null);
 			try {
 				if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
-					repo.AddRemote (dlg.RemoteName, dlg.RemoteUrl, dlg.ImportTags);
-					FillRemotes ();
+					var token = destroyTokenSource.Token;
+					await repo.AddRemoteAsync (dlg.RemoteName, dlg.RemoteUrl, dlg.ImportTags);
+					if (!token.IsCancellationRequested)
+						FillRemotes ();
 				}
 			} finally {
 				dlg.Destroy ();
@@ -274,7 +296,7 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected virtual void OnButtonEditRemoteClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonEditRemoteClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!treeRemotes.Selection.GetSelected (out it))
@@ -287,15 +309,17 @@ namespace MonoDevelop.VersionControl.Git
 			var dlg = new EditRemoteDialog (repo, remote);
 			try {
 				if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
+					var token = destroyTokenSource.Token;
 					if (remote.Url != dlg.RemoteUrl)
-						repo.ChangeRemoteUrl (remote.Name, dlg.RemoteUrl);
+						await repo.ChangeRemoteUrlAsync (remote.Name, dlg.RemoteUrl);
 					if (remote.PushUrl != dlg.RemotePushUrl)
-						repo.ChangeRemotePushUrl (remote.Name, dlg.RemotePushUrl);
+						await repo.ChangeRemotePushUrlAsync (remote.Name, dlg.RemotePushUrl);
 
 					// Only do rename after we've done previous changes.
 					if (remote.Name != dlg.RemoteName)
-						repo.RenameRemote (remote.Name, dlg.RemoteName);
-					FillRemotes ();
+						await repo.RenameRemoteAsync (remote.Name, dlg.RemoteName);
+					if (!token.IsCancellationRequested)
+						FillRemotes ();
 				}
 			} finally {
 				dlg.Destroy ();
@@ -303,7 +327,7 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected virtual void OnButtonRemoveRemoteClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonRemoveRemoteClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!treeRemotes.Selection.GetSelected (out it))
@@ -314,8 +338,10 @@ namespace MonoDevelop.VersionControl.Git
 				return;
 
 			if (MessageService.Confirm (GettextCatalog.GetString ("Are you sure you want to delete the remote '{0}'?", remote.Name), AlertButton.Delete)) {
-				repo.RemoveRemote (remote.Name);
-				FillRemotes ();
+				var token = destroyTokenSource.Token;
+				await repo.RemoveRemoteAsync (remote.Name);
+				if (!token.IsCancellationRequested)
+					FillRemotes ();
 			}
 		}
 
@@ -331,7 +357,7 @@ namespace MonoDevelop.VersionControl.Git
 			buttonAddRemote.Sensitive = buttonEditRemote.Sensitive = buttonRemoveRemote.Sensitive = remote != null;
 		}
 
-		protected virtual void OnButtonTrackRemoteClicked (object sender, EventArgs e)
+		protected virtual async void OnButtonTrackRemoteClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!treeRemotes.Selection.GetSelected (out it))
@@ -346,8 +372,10 @@ namespace MonoDevelop.VersionControl.Git
 			var dlg = new EditBranchDialog (repo, branchName, remote.Name + "/" + branchName);
 			try {
 				if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
-					repo.CreateBranch (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
-					FillBranches ();
+					var token = destroyTokenSource.Token;
+					await repo.CreateBranchAsync (dlg.BranchName, dlg.TrackSource, dlg.TrackRef);
+					if (!token.IsCancellationRequested)
+						FillBranches ();
 				}
 			} finally {
 				dlg.Destroy ();
@@ -355,27 +383,31 @@ namespace MonoDevelop.VersionControl.Git
 			}
 		}
 
-		protected void OnButtonNewTagClicked (object sender, EventArgs e)
+		protected async void OnButtonNewTagClicked (object sender, EventArgs e)
 		{
 			using (var dlg = new GitSelectRevisionDialog (repo)) {
 				Xwt.WindowFrame parent = Xwt.Toolkit.CurrentEngine.WrapWindow (this);
 				if (dlg.Run (parent) != Xwt.Command.Ok)
 					return;
 
-				repo.AddTag (dlg.TagName, dlg.SelectedRevision, dlg.TagMessage);
-				FillTags ();
+				var token = destroyTokenSource.Token;
+				await repo.AddTagAsync (dlg.TagName, dlg.SelectedRevision, dlg.TagMessage, token);
+				if (!token.IsCancellationRequested)
+					FillTags ();
 			}
 		}
 
-		protected void OnButtonRemoveTagClicked (object sender, EventArgs e)
+		protected async void OnButtonRemoveTagClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!listTags.Selection.GetSelected (out it))
 				return;
 
 			string tagName = (string) storeTags.GetValue (it, 0);
-			repo.RemoveTag (tagName);
-			FillTags ();
+			var token = destroyTokenSource.Token;
+			await repo.RemoveTagAsync (tagName, token);
+			if (!token.IsCancellationRequested)
+				FillTags ();
 		}
 
 		protected virtual void OnButtonPushTagClicked (object sender, EventArgs e)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitNodeBuilderExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitNodeBuilderExtension.cs
@@ -30,6 +30,7 @@ using MonoDevelop.Projects;
 using System.Collections.Generic;
 using MonoDevelop.Ide;
 using MonoDevelop.Core;
+using System.Threading;
 
 namespace MonoDevelop.VersionControl.Git
 {
@@ -64,8 +65,17 @@ namespace MonoDevelop.VersionControl.Git
 				WorkspaceObject rob;
 				if (repos.TryGetValue (rep.RootPath, out rob)) {
 					if (ob == rob) {
-						string branch = rep.GetCurrentBranch ();
-						if (branch == "(no branch)") {
+						string branch = rep.CachedCurrentBranch;
+						//FIXME: we need to find a better way to get this sync
+						using (var cts = new CancellationTokenSource ()) {
+							var getBranch = rep.GetCurrentBranchAsync (cts.Token);
+							if (!getBranch.Wait (250)) {
+								cts.Cancel ();
+								LoggingService.LogError ("Getting current Git branch timed out");
+							}
+						}
+
+						if (branch == GitRepository.DefaultNoBranchName) {
 							using (var RootRepository = new LibGit2Sharp.Repository (rep.RootPath))
 								branch = RootRepository.ObjectDatabase.ShortenObjectId (RootRepository.Head.Tip);
 						}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitNodeBuilderExtension.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitNodeBuilderExtension.cs
@@ -72,7 +72,8 @@ namespace MonoDevelop.VersionControl.Git
 							if (!getBranch.Wait (250)) {
 								cts.Cancel ();
 								LoggingService.LogError ("Getting current Git branch timed out");
-							}
+							} else if (!getBranch.IsFaulted)
+								branch = getBranch.Result;
 						}
 
 						if (branch == GitRepository.DefaultNoBranchName) {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -556,11 +556,9 @@ namespace MonoDevelop.VersionControl.Git
 				DedicatedOperationFactory.StartNew (action).RunWaitAndCapture ();
 		}
 
-		internal Task RunOperationAsync (Action action, bool hasUICallbacks = false)
+		internal Task RunOperationAsync (Action action)
 		{
 			EnsureInitialized ();
-			if (hasUICallbacks)
-				EnsureBackgroundThread ();
 			if (IsGitThread) {
 				action ();
 				return Task.CompletedTask;
@@ -578,11 +576,9 @@ namespace MonoDevelop.VersionControl.Git
 			return DedicatedOperationFactory.StartNew (action).RunWaitAndCapture ();
 		}
 
-		internal Task<T> RunOperationAsync<T> (Func<T> action, bool hasUICallbacks = false, CancellationToken cancellationToken = default)
+		internal Task<T> RunOperationAsync<T> (Func<T> action, CancellationToken cancellationToken = default)
 		{
 			EnsureInitialized ();
-			if (hasUICallbacks)
-				EnsureBackgroundThread ();
 			if (IsGitThread)
 				return Task.FromResult (action ());
 			return DedicatedOperationFactory.StartNew (action, cancellationToken);
@@ -598,11 +594,9 @@ namespace MonoDevelop.VersionControl.Git
 			return DedicatedOperationFactory.StartNew (() => action (GetRepository (localPath))).RunWaitAndCapture ();
 		}
 
-		internal Task<T> RunOperationAsync<T> (FilePath localPath, Func<LibGit2Sharp.Repository, T> action, bool hasUICallbacks = false, CancellationToken cancellationToken = default)
+		internal Task<T> RunOperationAsync<T> (FilePath localPath, Func<LibGit2Sharp.Repository, T> action, CancellationToken cancellationToken = default)
 		{
 			EnsureInitialized ();
-			if (hasUICallbacks)
-				EnsureBackgroundThread ();
 			if (IsGitThread)
 				return Task.FromResult (action (GetRepository (localPath)));
 			return DedicatedOperationFactory.StartNew (() => action (GetRepository (localPath)), cancellationToken);
@@ -1976,7 +1970,7 @@ namespace MonoDevelop.VersionControl.Git
 				OnCheckoutProgress = (path, completedSteps, totalSteps) => OnCheckoutProgress (completedSteps, totalSteps, monitor, ref progress),
 				OnCheckoutNotify = (string path, CheckoutNotifyFlags flags) => RefreshFile (path, flags),
 				CheckoutNotifyFlags = refreshFlags,
-			}), true, monitor.CancellationToken);
+			}), monitor.CancellationToken);
 
 			if (GitService.StashUnstashWhenSwitchingBranches) {
 				try {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -140,12 +140,12 @@ namespace MonoDevelop.VersionControl.Git
 				throw new InvalidOperationException ($"{nameof (RootPath)} is not a valid Git repository, FileSystemWantcher can not be initialized");
 			}
 
-			if (watcher?.Path == dotGitPath.CanonicalPath.ParentDirectory)
+			if (watcher?.Path == dotGitPath.CanonicalPath)
 				return;
 
 			ShutdownFileWatcher ();
 
-			watcher = new FileSystemWatcher (dotGitPath.CanonicalPath.ParentDirectory, Path.Combine (dotGitPath.FileName, "*"));
+			watcher = new FileSystemWatcher (dotGitPath.CanonicalPath, "*");
 			watcher.Created += HandleGitLockCreated;
 			watcher.Deleted += HandleGitLockDeleted;
 			watcher.Renamed += HandleGitLockRenamed;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/PushDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/PushDialog.cs
@@ -79,10 +79,15 @@ namespace MonoDevelop.VersionControl.Git
 				return;
 			}
 			branchCombo.Sensitive = true;
-			var list = new List<string> (repo.GetRemoteBranches (remoteCombo.ActiveText));
-			foreach (string s in list)
-				branchCombo.AppendText (s);
-			branchCombo.Active = list.IndexOf (repo.GetCurrentBranch ());
+			var token = destroyTokenSource.Token;
+			repo.GetRemoteBranchesAsync (remoteCombo.ActiveText).ContinueWith (t => {
+				if (token.IsCancellationRequested)
+					return;
+				var list = t.Result;
+				foreach (string s in list)
+					branchCombo.AppendText (s);
+				branchCombo.Active = list.IndexOf (repo.GetCurrentBranch ());
+			}, token, TaskContinuationOptions.NotOnCanceled, Runtime.MainTaskScheduler).Ignore ();
 		}
 
 		void UpdateChangeSet ()

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/StashManagerDialog.cs
@@ -140,7 +140,7 @@ namespace MonoDevelop.VersionControl.Git
 				var dlg = new EditBranchDialog (repository);
 				try {
 					if (MessageService.RunCustomDialog (dlg) == (int) ResponseType.Ok) {
-						repository.CreateBranchFromCommit (dlg.BranchName, s.Base);
+						await repository.CreateBranchFromCommitAsync (dlg.BranchName, s.Base);
 						if (await GitService.SwitchToBranchAsync (repository, dlg.BranchName))
 							await ApplyStashAndRemove (stashIndex);
 					}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -742,6 +742,7 @@
     <Compile Include="MonoDevelop.Projects\DotNetProjectFrameworkConfigurationSelector.cs" />
     <Compile Include="MonoDevelop.Core.Execution\TargetFrameworkExecutionTarget.cs" />
     <Compile Include="MonoDevelop.Projects\FrameworkReference.cs" />
+    <Compile Include="MonoDevelop.Core\DedicatedThreadScheduler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="BuildVariables.cs.in" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/DedicatedThreadScheduler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/DedicatedThreadScheduler.cs
@@ -1,0 +1,144 @@
+//
+// DedicatedThreadScheduler.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2019 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MonoDevelop.Core
+{
+	public class DedicatedThreadScheduler : TaskScheduler, IDisposable
+	{
+		readonly BlockingCollection<Task> taskQueue = new BlockingCollection<Task> ();
+		readonly string threadName;
+		readonly CancellationTokenSource cancellation = new CancellationTokenSource ();
+		CancellationToken cancellationToken;
+		volatile bool isDisposed;
+		Thread dedicatedThread;
+
+		public Thread DedicatedThread {
+			get {
+				EnsureThread ();
+				return dedicatedThread;
+			}
+		}
+
+		public override int MaximumConcurrencyLevel => 1;
+
+		public DedicatedThreadScheduler ()
+		{
+		}
+
+		public DedicatedThreadScheduler (string dedicatedThreadName)
+		{
+			threadName = dedicatedThreadName;
+		}
+
+		void EnsureThread ()
+		{
+			AssertDisposed (false);
+			if (dedicatedThread == null) {
+				cancellationToken = cancellation.Token;
+				dedicatedThread = new Thread (Run);
+				if (!string.IsNullOrEmpty (threadName))
+					dedicatedThread.Name = threadName;
+				dedicatedThread.Start ();
+			}
+		}
+
+		void AssertDisposed (bool shouldBeDisposed)
+		{
+			if (shouldBeDisposed != isDisposed) {
+				if (!shouldBeDisposed)
+					throw new ObjectDisposedException (nameof (DedicatedThreadScheduler));
+				else
+					throw new InvalidOperationException ($"{nameof (DedicatedThreadScheduler)} not disposed as expected");
+			}
+		}
+
+		void Run ()
+		{
+			AssertDisposed (false);
+			try {
+				while (!isDisposed) {
+					try {
+						var task = taskQueue.Take (cancellationToken);
+						TryExecuteTask (task);
+					} catch (OperationCanceledException) {
+						AssertDisposed (true);
+					}
+				}
+			} catch (Exception ex) {
+				LoggingService.LogInternalError ("Scheduler loop failed unexpectedly", ex);
+			} finally {
+				taskQueue.Dispose ();
+			}
+		}
+
+		protected override IEnumerable<Task> GetScheduledTasks ()
+		{
+			AssertDisposed (false);
+			return taskQueue;
+		}
+
+		protected override void QueueTask (Task task)
+		{
+			EnsureThread ();
+			taskQueue.Add (task);
+		}
+
+		protected override bool TryExecuteTaskInline (Task task, bool taskWasPreviouslyQueued)
+		{
+			if (Thread.CurrentThread == dedicatedThread) {
+				return TryExecuteTask (task);
+			}
+			return false;
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (!isDisposed) {
+				isDisposed = true;
+				if (disposing) {
+					cancellation.Cancel ();
+					cancellation.Dispose ();
+				}
+			}
+		}
+
+		~DedicatedThreadScheduler ()
+		{
+			Dispose (false);
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/DedicatedThreadScheduler.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/DedicatedThreadScheduler.cs
@@ -63,7 +63,7 @@ namespace MonoDevelop.Core
 			AssertDisposed (false);
 			if (dedicatedThread == null) {
 				cancellationToken = cancellation.Token;
-				dedicatedThread = new Thread (Run);
+				dedicatedThread = new Thread (Run) { IsBackground = true };
 				if (!string.IsNullOrEmpty (threadName))
 					dedicatedThread.Name = threadName;
 				dedicatedThread.Start ();

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="MonoDevelop.Projects\MultiTargetProjectTests.cs" />
     <Compile Include="MonoDevelop.Projects\FileWatcherServiceTests.cs" />
     <Compile Include="MonoDevelop.Projects\FileWatcherTestBase.cs" />
+    <Compile Include="MonoDevelop.Core\DedicatedThreadSchedulerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/DedicatedThreadSchedulerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/DedicatedThreadSchedulerTests.cs
@@ -1,0 +1,137 @@
+//
+// DedicatedThreadSchedulerTests.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2019 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace MonoDevelop.Core
+{
+	[TestFixture]
+	public class DedicatedThreadSchedulerTests
+	{
+		const string DedicatedThreadName = "Test Scheduler Thread";
+
+		DedicatedThreadScheduler TestScheduler;
+		TaskFactory TestFactory;
+
+		[SetUp]
+		public void Setup ()
+		{
+			TestScheduler = new DedicatedThreadScheduler (DedicatedThreadName);
+			TestFactory = new TaskFactory (TestScheduler);
+		}
+
+		[Test]
+		public void ConcurrencyLevel ()
+		{
+			Assert.AreEqual (1, TestScheduler.MaximumConcurrencyLevel);
+		}
+
+		static void AssertQueuedOnScheduler (DedicatedThreadScheduler scheduler)
+		{
+			Assert.AreSame (TaskScheduler.Current, scheduler);
+			Assert.AreSame (Thread.CurrentThread, scheduler.DedicatedThread);
+		}
+
+		[Test]
+		[Timeout (5000)]
+		public void DedicatedThreadStartStop ()
+		{
+			var mainThread = Thread.CurrentThread;
+
+			var tcs = new TaskCompletionSource<bool> ();
+			var task = TestFactory.StartNew (() => {
+				AssertQueuedOnScheduler (TestScheduler);
+				Assert.AreEqual (DedicatedThreadName, Thread.CurrentThread.Name);
+				Assert.AreNotSame (mainThread, TestScheduler.DedicatedThread);
+				Assert.DoesNotThrow (tcs.Task.Wait);
+			});
+
+			var testThread = TestScheduler.DedicatedThread;
+
+			Assert.IsTrue (testThread.IsAlive);
+			Assert.IsFalse (testThread.IsThreadPoolThread);
+			Assert.AreEqual (DedicatedThreadName, testThread.Name);
+
+			Assert.IsTrue (tcs.TrySetResult (true));
+
+			Assert.DoesNotThrow (task.Wait);
+			Assert.IsTrue (task.IsCompleted);
+
+			TestScheduler.Dispose ();
+
+			Assert.IsTrue (testThread.Join (50)); // wait a bit for the thread to dispose of the queue
+			Assert.Throws<ObjectDisposedException> (() => TestScheduler.DedicatedThread.Join (0));
+			Assert.IsFalse (testThread.IsAlive);
+			Assert.AreEqual (ThreadState.Stopped, testThread.ThreadState);
+		}
+
+		[Test]
+		[Timeout (5000)]
+		public async Task TestTasksExecuteSequentially ()
+		{
+			int runTasks = 50;
+			int mdelay = 2;
+			var results = new List<int> (runTasks);
+			var tasks = new Task [runTasks];
+
+			for (int i = 0; i < runTasks; i++) {
+				var task = TestFactory.StartNew ((counter) => {
+					AssertQueuedOnScheduler (TestScheduler);
+					// decrease the delay of scheduled tasks
+					var result = runTasks - (int)counter - 1;
+					Thread.Sleep (result * mdelay);
+					results.Add (result);
+				}, i);
+				tasks [i] = task;
+			}
+
+			await Task.WhenAll (tasks);
+
+			Assert.AreEqual (runTasks, results.Count);
+			foreach (var result in results) {
+				Assert.AreEqual (--runTasks, result);
+			}
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (TestScheduler != null) {
+				try {
+					if (TestScheduler.DedicatedThread.IsAlive)
+						TestScheduler.DedicatedThread.Abort ();
+					TestScheduler.Dispose ();
+				} catch (ObjectDisposedException) {
+				} finally {
+					TestScheduler = null;
+				}
+			}
+		}
+	}
+}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/DedicatedThreadSchedulerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/DedicatedThreadSchedulerTests.cs
@@ -74,6 +74,7 @@ namespace MonoDevelop.Core
 
 			var testThread = TestScheduler.DedicatedThread;
 
+			Assert.IsTrue (testThread.IsBackground);
 			Assert.IsTrue (testThread.IsAlive);
 			Assert.IsFalse (testThread.IsThreadPoolThread);
 			Assert.AreEqual (DedicatedThreadName, testThread.Name);


### PR DESCRIPTION
This should solve most of the threading issues with libgit2.

Fixes VSTS #972329
Fixes VSTS #974907
Fixes VSTS #975668

**PR Review assistance:**

- Single Thread Scheduler: 2eaaf0c21d487cef4f936f983fdd0e65317ae9be
  - Tests: 4c4a19ccbd2f3a24dcd35569db09f315e853721e
  - BG thread: 1a303d5593e8b25b51693a835ad37cf0625f423c
- Git using single thread: e09e9d3450921b9d994c0ca541d21e8bb1c7bfb1, 0a2a352b7530797d70437a600651a836a1685fc5, 194d6f40e030d217d101dd0d0333be258e9b92f9
- FSW / Git lockfiles related fixes: 9cb3134bf5d70c93698cb5cee8e236d7ce0f731d, 260396f3fd0f8e7b789e0c271953d4228251745f and the **most important**: 2ca7910f0d5487899036628a0b3ca2d828ed6775
- GIT API mostly async to avoid UI deadlocks with the single thread scheduler: 90537534481b007be5d8c22d133a0265ef983345

**Important note:** not all UIs are really async right now (see 90537534481b007be5d8c22d133a0265ef983345), to make it kind of work properly I just replaced the sync calls with async.Wait at several places. We need to get this in ASAP, since 8.3 is crashin all over the place. the sync calls were crashing too, so if async.Wait() doesn't work (likely blocks rather than crashes), it'd not be a merge blocker, because other fixes here a real.