### PR TITLE
[Ide] Rework GetWorkspaceAsync to cancel requests on any solution dispose

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
@@ -177,7 +177,7 @@ namespace MonoDevelop.AssemblyBrowser
 			} else {
 				var token = cts.Token;
 
-				var workspace = IdeApp.TypeSystemService.GetWorkspaceAsync (IdeApp.ProjectOperations.CurrentSelectedSolution)
+				var workspace = IdeApp.TypeSystemService.GetWorkspaceAsync (IdeApp.ProjectOperations.CurrentSelectedSolution, token)
 					.ContinueWith (t => {
 						if (token.IsCancellationRequested)
 							return;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -362,7 +362,8 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			TypeSystemService.EnableSourceAnalysis.Changed -= OnEnableSourceAnalysisChanged;
 			TypeSystemService.Preferences.FullSolutionAnalysisRuntimeEnabledChanged -= OnEnableFullSourceAnalysisChanged;
-			desktopService.MemoryMonitor.StatusChanged -= OnMemoryStatusChanged;
+			if (desktopService !=null)
+				desktopService.MemoryMonitor.StatusChanged -= OnMemoryStatusChanged;
 
 			if (workspace != null) {
 				workspace.ActiveConfigurationChanged -= HandleActiveConfigurationChanged;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -362,7 +362,7 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			TypeSystemService.EnableSourceAnalysis.Changed -= OnEnableSourceAnalysisChanged;
 			TypeSystemService.Preferences.FullSolutionAnalysisRuntimeEnabledChanged -= OnEnableFullSourceAnalysisChanged;
-			if (desktopService !=null)
+			if (desktopService != null)
 				desktopService.MemoryMonitor.StatusChanged -= OnMemoryStatusChanged;
 
 			if (workspace != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -193,8 +193,10 @@ namespace MonoDevelop.Ide.TypeSystem
 						result.Dispose ();
 					}
 
-					if (solution.ExtendedProperties [typeof (WorkspaceRequestRegistration)] is WorkspaceRequestRegistration registration) {
-						registration.Dispose ();
+					lock (solution.ExtendedProperties.SyncRoot) {
+						if (solution.ExtendedProperties [typeof (WorkspaceRequestRegistration)] is WorkspaceRequestRegistration registration) {
+							registration.Dispose ();
+						}
 					}
 
 					solution.SolutionItemAdded -= OnSolutionItemAdded;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceRequestRegistration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceRequestRegistration.cs
@@ -41,14 +41,13 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			internal async Task<MonoDevelopWorkspace> GetWorkspaceAsync (CancellationToken token)
 			{
-				using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource (src.Token, token);
-
 				var tcs = new TaskCompletionSource<MonoDevelopWorkspace> ();
 				lock (requests) {
 					requests.Add (tcs);
 				}
 
 				try {
+					using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource (src.Token, token);
 					using (linkedTokenSource.Token.Register (() => tcs.TrySetCanceled (linkedTokenSource.Token))) {
 						var workspace = await tcs.Task;
 						return workspace;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceRequestRegistration.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceRequestRegistration.cs
@@ -1,0 +1,85 @@
+//
+// TypeSystemService_WorkspaceRequestRegistration.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide.TypeSystem
+{
+	public partial class TypeSystemService
+	{
+		internal sealed class WorkspaceRequestRegistration : IDisposable
+		{
+			readonly List<TaskCompletionSource<MonoDevelopWorkspace>> requests = new List<TaskCompletionSource<MonoDevelopWorkspace>> ();
+			CancellationTokenSource src = new CancellationTokenSource ();
+
+			internal async Task<MonoDevelopWorkspace> GetWorkspaceAsync (CancellationToken token)
+			{
+				using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource (src.Token, token);
+
+				var tcs = new TaskCompletionSource<MonoDevelopWorkspace> ();
+				lock (requests) {
+					requests.Add (tcs);
+				}
+
+				try {
+					using (linkedTokenSource.Token.Register (() => tcs.TrySetCanceled (linkedTokenSource.Token))) {
+						var workspace = await tcs.Task;
+						return workspace;
+					}
+				} finally {
+					lock (requests) {
+						requests.Remove (tcs);
+					}
+				}
+			}
+
+			internal void Complete (MonoDevelopWorkspace workspace)
+			{
+				if (workspace == null)
+					throw new ArgumentNullException (nameof (workspace));
+
+				lock (requests) {
+					foreach (var request in requests.ToList ()) {
+						// Requests are removed when completed.
+						request.TrySetResult (workspace);
+					}
+				}
+			}
+
+			public void Dispose ()
+			{
+				// Requests are removed when canceled.
+				src.Cancel ();
+				src.Dispose ();
+				src = new CancellationTokenSource ();
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="..\..\..\MonoDevelop.props" />
   <Import Project="$(ReferencesGtk)" />
   <Import Project="$(ReferencesVSEditor)" />
@@ -4298,6 +4298,7 @@
     <Compile Include="MonoDevelop.Ide.Projects.FileNesting\NestingRulesProvider.cs" />
     <Compile Include="MonoDevelop.Ide\TranslationCatalog.cs" />
     <Compile Include="MonoDevelop.Components\Mac\VerticalAlignmentTextCell.cs" />
+    <Compile Include="MonoDevelop.Ide.TypeSystem\TypeSystemService_WorkspaceRequestRegistration.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -1254,15 +1254,14 @@ namespace MonoDevelop.Ide
 					LastWorkspaceItemClosed (this, EventArgs.Empty);
 			}
 
-			UnloadWorkspaceTypeSystem (item).Ignore ();
+			UnloadWorkspaceTypeSystem (item);
 
 			NotifyDescendantItemRemoved (this, args);
 		}
 
-		async Task UnloadWorkspaceTypeSystem (WorkspaceItem item)
+		void UnloadWorkspaceTypeSystem (WorkspaceItem item)
 		{
-			var typeSystem = await serviceProvider.GetService<TypeSystemService> ();
-			typeSystem.Unload (item);
+			serviceProvider.PeekService<TypeSystemService> ()?.Unload (item);
 		}
 
 		void SubscribeSolution (Solution sol)

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
@@ -53,7 +53,9 @@ namespace MonoDevelop.Ide.TypeSystem
 			var symlinkFileSource = Path.GetFullPath (Path.Combine (solutionDirectory, data [1]));
 
 			File.Delete (symlinkFileName);
-			Process.Start ("ln", $"-s '{symlinkFileSource}' '{symlinkFileName}'").WaitForExit ();
+			Process.Start (new ProcessStartInfo ("ln", $"-s '{symlinkFileSource}' '{symlinkFileName}'") {
+				UseShellExecute = false,
+			}).WaitForExit ();
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
@@ -77,7 +77,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			FilePath solFile = Util.GetSampleProject ("multi-target-netframework", "multi-target.sln");
 
 			CreateNuGetConfigFile (solFile.ParentDirectory);
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
@@ -159,7 +159,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			FilePath solFile = Util.GetSampleProject ("multi-target-project-ref", "multi-target.sln");
 
 			CreateNuGetConfigFile (solFile.ParentDirectory);
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
@@ -204,7 +204,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			FilePath solFile = Util.GetSampleProject ("multi-target-netframework", "multi-target.sln");
 
 			CreateNuGetConfigFile (solFile.ParentDirectory);
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
@@ -244,7 +244,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			FilePath solFile = Util.GetSampleProject ("multi-target", "multi-target.sln");
 
 			CreateNuGetConfigFile (solFile.ParentDirectory);
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
@@ -328,7 +328,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			FilePath solFile = Util.GetSampleProject ("netstandard-project", "NetStandardTest.sln");
 
 			CreateNuGetConfigFile (solFile.ParentDirectory);
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
 			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
@@ -364,13 +364,6 @@ namespace MonoDevelop.Ide.TypeSystem
 				"</configuration>";
 
 			File.WriteAllText (fileName, xml);
-		}
-
-		void RunMSBuild (string arguments)
-		{
-			var process = Process.Start ("msbuild", arguments);
-			Assert.IsTrue (process.WaitForExit (240000), "Timed out waiting for MSBuild.");
-			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed");
 		}
 	}
 }

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/WorkspaceFilesCacheTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/WorkspaceFilesCacheTests.cs
@@ -127,7 +127,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			FilePath solFile = Util.GetSampleProject ("multi-target-netframework", "multi-target.sln");
 
 			CreateNuGetConfigFile (solFile.ParentDirectory);
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			await IdeServices.Workspace.OpenWorkspaceItem (solFile);
 			await IdeServices.TypeSystemService.ProcessPendingLoadOperations ();
@@ -439,13 +439,6 @@ namespace MonoDevelop.Ide.TypeSystem
 				"</configuration>";
 
 			File.WriteAllText (fileName, xml);
-		}
-
-		void RunMSBuild (string arguments)
-		{
-			var process = Process.Start ("msbuild", arguments);
-			Assert.IsTrue (process.WaitForExit (240000), "Timed out waiting for MSBuild.");
-			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed");
 		}
 
 		class CustomItemNode<T> : SolutionItemExtensionNode where T : new()

--- a/main/tests/Ide.Tests/MonoDevelop.Ide/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide/TypeSystemServiceTests.cs
@@ -670,7 +670,7 @@ namespace MonoDevelop.Ide
 
 					// A newly requested task is already completed on request, as the mapping is done
 					Assert.That (workspaceTasks.Select (x => x.IsCompleted), Is.All.EqualTo (true));
-					Assert.That (await Task.WhenAll (workspaceTasks), Is.All.EqualTo (ws));
+					Assert.That (await Task.WhenAll (workspaceTasks), Is.All.SameAs (ws));
 				}
 
 				cancelledOnDispose = typeSystemService.GetWorkspaceAsync (sol);

--- a/main/tests/IdeUnitTests/ProjectTemplateTest.cs
+++ b/main/tests/IdeUnitTests/ProjectTemplateTest.cs
@@ -91,25 +91,10 @@ namespace IdeUnitTests
 
 			// RestoreDisableParallel prevents parallel restores which sometimes cause
 			// the restore to fail on Mono.
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{Solution.FileName}\"");
-			RunMSBuild ($"/t:Build \"{Solution.FileName}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{Solution.FileName}\"");
+			Util.RunMSBuild ($"/t:Build \"{Solution.FileName}\"");
 
 			return template;
-		}
-
-		void RunMSBuild (string arguments)
-		{
-			var process = new Process ();
-			process.StartInfo = new ProcessStartInfo ("msbuild", arguments) {
-				RedirectStandardOutput = true,
-				RedirectStandardError = true,
-				UseShellExecute = false
-			};
-			process.Start ();
-			var standardError = $"Error: {process.StandardOutput.ReadToEnd ()}";
-
-			Assert.IsTrue (process.WaitForExit (240000), "Timed out waiting for MSBuild.");
-			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed. Exit code: {process.ExitCode}. {standardError}");
 		}
 
 		protected virtual string GetExtraNuGetSources () => string.Empty;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreFileWatcherTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreFileWatcherTests.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Projects
 
 			Assert.AreEqual (0, project.Files.Count);
 
-			RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solution.FileName}\"");
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solution.FileName}\"");
 
 			await FileWatcherService.Add (solution);
 
@@ -94,13 +94,6 @@ namespace MonoDevelop.Projects
 				"</configuration>";
 
 			File.WriteAllText (fileName, xml);
-		}
-
-		void RunMSBuild (string arguments)
-		{
-			var process = Process.Start ("msbuild", arguments);
-			Assert.IsTrue (process.WaitForExit (240000), "Timed out waiting for MSBuild.");
-			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed");
 		}
 
 		Task<ProjectFile> WaitForSingleFileAdded (Project project)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -318,9 +318,7 @@ namespace MonoDevelop.Projects
 		{
 			FilePath solFile = Util.GetSampleProject ("NetStandardXamarinForms", "NetStandardXamarinForms.sln");
 
-			var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
-			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-			Assert.AreEqual (0, process.ExitCode);
+			Util.RunMSBuild ($"/t:Restore \"{solFile}\"");
 
 			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var p = (Project)sol.Items [0];
@@ -345,9 +343,7 @@ namespace MonoDevelop.Projects
 		{
 			FilePath solFile = Util.GetSampleProject ("NetStandardXamarinForms", "NetStandardXamarinForms.sln");
 
-			var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
-			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-			Assert.AreEqual (0, process.ExitCode);
+			Util.RunMSBuild ($"/t:Restore \"{solFile}\"");
 
 			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var p = (Project)sol.Items [0];
@@ -395,9 +391,7 @@ namespace MonoDevelop.Projects
 		{
 			FilePath solFile = Util.GetSampleProject ("NetStandardXamarinForms", "NetStandardXamarinForms.sln");
 
-			var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
-			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-			Assert.AreEqual (0, process.ExitCode);
+			Util.RunMSBuild ($"/t:Restore \"{solFile}\"");
 
 			var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile);
 			var p = (Project)sol.Items [0];
@@ -450,9 +444,7 @@ namespace MonoDevelop.Projects
 				// No DependsOn set until NuGet restore and re-evaluation.
 				Assert.AreEqual (string.Empty, xamlCSharpFile.DependsOn);
 
-				var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
-				Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-				Assert.AreEqual (0, process.ExitCode);
+				Util.RunMSBuild ($"/t:Restore \"{solFile}\"");
 
 				await p.ReevaluateProject (Util.GetMonitor ());
 
@@ -496,9 +488,7 @@ namespace MonoDevelop.Projects
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
 				var p = (Project)sol.Items [0];
 
-				var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
-				Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-				Assert.AreEqual (0, process.ExitCode);
+				Util.RunMSBuild ($"/t:Restore \"{solFile}\"");
 
 				await p.ReevaluateProject (Util.GetMonitor ());
 
@@ -523,9 +513,7 @@ namespace MonoDevelop.Projects
 				var p = (Project)sol.Items [0];
 				Assert.AreEqual ("DotNetCoreNoMainPropertyGroup", p.Name);
 
-				var process = Process.Start ("msbuild", $"/t:Restore \"{solFile}\"");
-				Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-				Assert.AreEqual (0, process.ExitCode);
+				Util.RunMSBuild ($"/t:Restore \"{solFile}\"");
 
 				await p.ReevaluateProject (Util.GetMonitor ());
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -786,9 +786,7 @@ namespace MonoDevelop.Projects
 		{
 			CreateNuGetConfigFile (fileName.ParentDirectory);
 
-			var process = Process.Start ("msbuild", $"/t:Restore \"{fileName}\"");
-			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-			Assert.AreEqual (0, process.ExitCode);
+			Util.RunMSBuild ($"/t:Restore \"{fileName}\"");
 		}
 
 		/// <summary>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MultiTargetProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MultiTargetProjectTests.cs
@@ -67,9 +67,7 @@ namespace MonoDevelop.Projects
 
 		static void NuGetRestore (FilePath file)
 		{
-			var process = Process.Start ("msbuild", $"/t:Restore /p:RestoreDisableParallel=true \"{file}\"");
-			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-			Assert.AreEqual (0, process.ExitCode);
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{file}\"");
 		}
 
 		/// <summary>

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1021,9 +1021,7 @@ namespace MonoDevelop.Projects
 			FilePath solFile = Util.GetSampleProject ("iOSImmutableCollections", "iOSImmutableCollections.sln");
 			CreateNuGetConfigFile (solFile.ParentDirectory);
 
-			var process = Process.Start ("msbuild", $"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
-			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
-			Assert.AreEqual (0, process.ExitCode);
+			Util.RunMSBuild ($"/t:Restore /p:RestoreDisableParallel=true \"{solFile}\"");
 
 			using (var sol = (Solution) await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
 				var p = (DotNetProject) sol.Items [0];

--- a/main/tests/UnitTests/Util.cs
+++ b/main/tests/UnitTests/Util.cs
@@ -31,6 +31,8 @@ using System.Collections;
 using System.Text;
 using MonoDevelop.Core;
 using MonoDevelop.Core.ProgressMonitoring;
+using System.Diagnostics;
+using NUnit.Framework;
 
 namespace UnitTests
 {
@@ -195,6 +197,19 @@ namespace UnitTests
 			for (int n=1; n<paths.Length; n++)
 				p = Path.Combine (p, paths [n]);
 			return p;
+		}
+
+		public static void RunMSBuild (string arguments)
+		{
+			using var process = Process.Start (new ProcessStartInfo ("msbuild", arguments) {
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				UseShellExecute = false
+			});
+			var standardError = $"Error: {process.StandardOutput.ReadToEnd ()}";
+
+			Assert.IsTrue (process.WaitForExit (240000), $"Timed out waiting for 'msbuild {arguments}'.");
+			Assert.AreEqual (0, process.ExitCode, $"msbuild {arguments} failed. Exit code: {process.ExitCode}. {standardError}");
 		}
 	}
 }

--- a/main/tests/UnitTests/Util.cs
+++ b/main/tests/UnitTests/Util.cs
@@ -81,9 +81,26 @@ namespace UnitTests
 			DeleteSubDirectory (srcDir, ".vs");
 			DeleteSubDirectory (srcDir, ".svn");
 
+			CreateDirectoryBuildMSBuildFiles ();
+
 			string tmpDir = CreateTmpDir (Path.GetFileName (projDir));
 			CopyDir (srcDir, tmpDir);
 			return Path.Combine (tmpDir, Path.GetFileName (projDir));
+		}
+
+		static void CreateDirectoryBuildMSBuildFiles ()
+		{
+			Directory.CreateDirectory (TmpDir);
+
+			WriteEmptyProjectFile (Path.Combine (TmpDir, "Directory.Build.props"));
+			WriteEmptyProjectFile (Path.Combine (TmpDir, "Directory.Build.targets"));
+
+			static void WriteEmptyProjectFile (string fileName)
+			{
+				// This is needed so we don't inherit properties from the monodevelop source tree.
+				if (!File.Exists (fileName))
+					File.WriteAllText (fileName, "<Project></Project>");
+			}
 		}
 
 		static void DeleteSubDirectory (string directory, string subDirectory)


### PR DESCRIPTION
Refactor the current code to move the workspace registrations from TypeSystemService
into Solution.ExtendedProperties.

This way, we can keep track of all the registrations done for a solution, and cancel
all of them whenever a solution is disposed.

The second part of the PR is splitting each request into its own TaskCompletionSource.
Reusing the same task has unintended side effects due to the cancellation token being
passed as a parameter.

Using the same task meant that if some CancellationTokenSource decided to cancel its
request, it would cancel all the current active requests on the solution

Fixes VSTS #977144 - Leak detected on cleanup iteration in MonoDevelop.Projects.Solution class
Fixes VSTS #977335 - Quality of local testing