### PR TITLE
[DotNetCore] Only attach FileChanged handler if we have a globalJsonPath

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -283,7 +283,6 @@ namespace MonoDevelop.DotNetCore
 		protected override void OnItemReady ()
 		{
 			base.OnItemReady ();
-			FileService.FileChanged += FileService_FileChanged;
 
 			if (!IdeApp.IsInitialized)
 				return;
@@ -304,6 +303,7 @@ namespace MonoDevelop.DotNetCore
 				return;
 
 			Project.ParentSolution.ExtendedProperties [GlobalJsonPathExtendedPropertyName] = globalJsonPath;
+			FileService.FileChanged += FileService_FileChanged;
 			DetectSDK ();
 		}
 


### PR DESCRIPTION
Nothing else sets this value so it's safe to assume that we need it set to non-null for the handler to have any purpose.

This should speed up headless test runs for dotnetcore projects when building