### PR TITLE
Remove document from `GetOpenDocumentIds` when removed from project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1509,6 +1509,11 @@ namespace MonoDevelop.Ide.TypeSystem
 										ProjectInfo newProjectContents = t.Result;
 										newProjectContents = AddVirtualDocuments (newProjectContents);
 										OnProjectReloaded (newProjectContents);
+										foreach (var docId in GetOpenDocumentIds (newProjectContents.Id)) {
+											if (CurrentSolution.GetDocument (docId) == null) {
+												ClearOpenDocument (docId);
+											}
+										}
 										Runtime.RunInMainThread (() => IdeServices.TypeSystemService.UpdateRegisteredOpenDocuments ()).Ignore();
 									}
 								} catch (Exception e) {


### PR DESCRIPTION
`GetOpenDocumentIds` returned invalid documentId, this can happened if user removed open document by clicking on `Solution pad` and removed document, when asked to `Delete` or `Remove from Project` if user chose `Remove from Project` document remained opened in editor but Roslyn workspace still considered it as open in project, hence wrongly returning it via `GetOpenDocumentIds`, with this change every time project is reloaded we ensure there is no invalid documents in list