### PR TITLE
[release-8.3] [Core] Prefer Compile items over None items

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -532,8 +532,10 @@ namespace MonoDevelop.Projects
 			var coreCompileResult = await compileEvaluator.GetItemsFromCoreCompileDependenciesAsync (this, monitor, configuration);
 			var evaluatedCompileItems = coreCompileResult.SourceFiles;
 
-			var results = new HashSet<ProjectFile> (evaluatedItems, ProjectFileFilePathComparer.Instance);
+			// Add Compile items first to avoid using potential duplicate None items which would break code completion.
+			var results = new HashSet<ProjectFile> (evaluatedItems.Length, ProjectFileFilePathComparer.Instance);
 			results.UnionWith (evaluatedCompileItems);
+			results.UnionWith (evaluatedItems);
 
 			return results.ToImmutableArray ();
 		}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/DotNetCoreProjectTests.cs
@@ -696,6 +696,26 @@ namespace MonoDevelop.Projects
 			}
 		}
 
+		/// <summary>
+		/// Compile items preferred over None items.
+		/// </summary>
+		[Test]
+		public async Task GetSourceFilesAsync_SdkProjectWithCSharpFileDefindAsNoneThenCompileItem_FileHasCompileBuildAction ()
+		{
+			FilePath solFile = Util.GetSampleProject ("duplicate-none-compile-items", "duplicate-none-compile-items.sln");
+
+			RunMSBuildRestore (solFile);
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (Project)sol.Items [0];
+
+				var files = await p.GetSourceFilesAsync (ConfigurationSelector.Default);
+				var class1File = files.Single (f => f.FilePath.FileName == "Class1.cs");
+
+				Assert.AreEqual (BuildAction.Compile, class1File.BuildAction);
+			}
+		}
+
 		[Test]
 		public async Task AddNewFileToProjectAndSave_ProjectHas1500CSharpFiles_SavingIsFast ()
 		{

--- a/main/tests/test-projects/duplicate-none-compile-items/duplicate-none-compile-items.csproj
+++ b/main/tests/test-projects/duplicate-none-compile-items/duplicate-none-compile-items.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="**\*.cs" />
+    <None Include="src\**\*.cs" />
+    <Compile Include="src\Class1.cs" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/duplicate-none-compile-items/duplicate-none-compile-items.sln
+++ b/main/tests/test-projects/duplicate-none-compile-items/duplicate-none-compile-items.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "duplicate-none-compile-items", "duplicate-none-compile-items.csproj", "{5B443F8D-6C84-443F-A395-5429E8F4A47D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/duplicate-none-compile-items/src/Class1.cs
+++ b/main/tests/test-projects/duplicate-none-compile-items/src/Class1.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace DuplicateNoneCompileItems
+{
+	public class Class1
+	{
+	}
+}


### PR DESCRIPTION
Project.GetSourceFilesAsync will add the Compile items it gets from
CoreCompileDependsOn to the HashSet before adding the evaluated items.
This prevents None items being used instead of Compile items where
an SDK project does not remove duplicate None items. A project that
does the equivalent of the following would result in code completion
not showing target frameworks in the text editor's navigation bar
for a multi-target project.

    <Compile Remove="**\*.cs" />
    <None Include="src\**\*.cs" />
    <Compile Include="src\Class1.cs" />

The None item was added to the HashSet first. The Compile item added
afterwards would be ignored.

Fixes VSTS #974214 - Multi-targeting: No target framework selector
shown in editor
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/974214

Other ideas here might be:

1. Always add None items last to the HashSet.
2. Provide a way for callers of Project.GetSourceFilesAsync to pass in a filter so the files can be filtered before the HashSet is used.
3. Provide a custom type system specific method (e.g. GetCompileSourceFilesAsync) that returns the files it needs and move all the filtering logic to this method. Problem here might be how to handle Projections.
4. Change the hash key to be build action + filename.

Backport of #8606.

/cc @mrward 