### PR TITLE
[AspNet*] Filter HTTP handlers to viewer role

### DIFF
--- a/main/src/addins/AspNet/Projects/AspNetAppProjectFlavor.cs
+++ b/main/src/addins/AspNet/Projects/AspNetAppProjectFlavor.cs
@@ -708,7 +708,7 @@ namespace MonoDevelop.AspNet.Projects
 		protected override IEnumerable<ExecutionTarget> OnGetExecutionTargets (ConfigurationSelector configuration)
 		{
 			var apps = new List<ExecutionTarget> ();
-			foreach (var browser in MonoDevelop.Ide.IdeServices.DesktopService.GetApplications ("https://localhost")) {
+			foreach (var browser in MonoDevelop.Ide.IdeServices.DesktopService.GetApplications ("https://localhost", DesktopApplicationRole.Viewer)) {
 				if (browser.IsDefault)
 					apps.Insert (0, new BrowserExecutionTarget (browser.Id,browser.DisplayName,browser));
 				else

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -942,6 +942,28 @@ namespace MonoDevelop.MacIntegration
 
 		public override IEnumerable<DesktopApplication> GetApplications (string filename)
 		{
+			return GetApplications (filename, DesktopApplicationRole.All);
+		}
+
+		public override IEnumerable<DesktopApplication> GetApplications (string filename, DesktopApplicationRole role)
+		{
+			static global::CoreServices.LSRoles ToLSRoles (DesktopApplicationRole role)
+			{
+				var lsRole = global::CoreServices.LSRoles.None;
+
+				if (role == DesktopApplicationRole.All)
+					return global::CoreServices.LSRoles.All;
+
+				if (role.HasFlag (DesktopApplicationRole.Viewer))
+					lsRole |= global::CoreServices.LSRoles.Viewer;
+				if (role.HasFlag (DesktopApplicationRole.Editor))
+					lsRole |= global::CoreServices.LSRoles.Editor;
+				if (role.HasFlag (DesktopApplicationRole.Shell))
+					lsRole |= global::CoreServices.LSRoles.Shell;
+
+				return lsRole;
+			}
+
 			//FIXME: we should disambiguate dupliacte apps in different locations and display both
 			//for now, just filter out the duplicates
 			var checkUniqueName = new HashSet<string> ();
@@ -960,7 +982,7 @@ namespace MonoDevelop.MacIntegration
 
 			var apps = new List<DesktopApplication> ();
 
-			var retrievedApps = global::CoreServices.LaunchServices.GetApplicationUrlsForUrl (url, global::CoreServices.LSRoles.All);
+			var retrievedApps = global::CoreServices.LaunchServices.GetApplicationUrlsForUrl (url, ToLSRoles (role));
 			if (retrievedApps != null) {
 				foreach (var app in retrievedApps) {
 					if (string.IsNullOrEmpty (app.Path) || !checkUniquePath.Add (app.Path))

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -149,7 +149,7 @@ namespace MonoDevelop.AspNetCore
 		protected override IEnumerable<ExecutionTarget> OnGetExecutionTargets (ConfigurationSelector configuration)
 		{
 			var result = new List<ExecutionTarget> ();
-			foreach (var browser in IdeServices.DesktopService.GetApplications ("https://localhost")) {
+			foreach (var browser in IdeServices.DesktopService.GetApplications ("https://localhost", Ide.Desktop.DesktopApplicationRole.Viewer)) {
 				if (browser.IsDefault) {
 					result.Insert (0, new AspNetCoreExecutionTarget (browser));
 				} else {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/DesktopApplication.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/DesktopApplication.cs
@@ -35,6 +35,16 @@ using System.Diagnostics;
 
 namespace MonoDevelop.Ide.Desktop
 {
+	[Flags]
+	public enum DesktopApplicationRole
+	{
+		None   = 0,
+		Viewer = 1,
+		Editor = 2,
+		Shell  = 4,
+		All    = Viewer | Editor | Shell
+	}
+
 	public abstract class DesktopApplication
 	{
 		public DesktopApplication (string id, string displayName, bool isDefault)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -348,6 +348,11 @@ namespace MonoDevelop.Ide.Desktop
 			return new DesktopApplication[0];
 		}
 
+		public virtual IEnumerable<DesktopApplication> GetApplications (string filename, DesktopApplicationRole role)
+		{
+			return GetApplications (filename);
+		}
+
 		public virtual Xwt.Rectangle GetUsableMonitorGeometry (int screenNumber, int monitorNumber)
 		{
 			var screen = Gdk.Display.Default.GetScreen (screenNumber);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -139,6 +139,11 @@ namespace MonoDevelop.Ide
 			return PlatformService.GetApplications (filename);
 		}
 
+		public IEnumerable<DesktopApplication> GetApplications (string filename, DesktopApplicationRole role)
+		{
+			return PlatformService.GetApplications (filename, role);
+		}
+
 		internal string DefaultMonospaceFont {
 			get { return PlatformService.DefaultMonospaceFont; }
 		}

--- a/main/tests/MacPlatform.Tests/MacPlatformTest.cs
+++ b/main/tests/MacPlatform.Tests/MacPlatformTest.cs
@@ -210,7 +210,7 @@ namespace MacPlatform.Tests
 		[Test]
 		public void GetBrowsers ()
 		{
-			var browsers = IdeServices.DesktopService.GetApplications ("https://localhost");
+			var browsers = IdeServices.DesktopService.GetApplications ("https://localhost", MonoDevelop.Ide.Desktop.DesktopApplicationRole.Viewer);
 			Assert.NotNull (browsers);
 			Assert.That (browsers.Count (), Is.AtLeast (1));
 			if (Directory.Exists ("/Applications/Safari.app"))


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/970420

This still shows iTerm as a browser, but this is the same the OS shows:

<img width="664" alt="image" src="https://user-images.githubusercontent.com/1873039/64424020-40b1fb80-d0a8-11e9-93bd-28f6b6d5abc6.png">

So, as discussed on the bug, provided this is what the OS shows, do the same on our side.