### PR TITLE
[release-8.3] Workspace: Prevent DocumentIds from changing on configuration change

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectData.cs
@@ -46,11 +46,17 @@ namespace MonoDevelop.Ide.TypeSystem
 				this.projectId = projectId;
 				workspaceRef = new WeakReference<MonoDevelopWorkspace> (ws);
 				DocumentData = new DocumentMap (projectId);
-				this.metadataReferences = new List<MonoDevelopMetadataReference> (metadataReferences.Length);
+				this.metadataReferences = new List<MonoDevelopMetadataReference> (metadataReferences);
+			}
 
-				lock (this.metadataReferences) {
+			internal void Connect ()
+			{
+				if (!workspaceRef.TryGetTarget (out var ws))
+					return;
+
+				lock (metadataReferences) {
 					foreach (var metadataReference in metadataReferences) {
-						AddMetadataReference_NoLock (metadataReference, ws);
+						metadataReference.SnapshotUpdated += OnMetadataReferenceUpdated;
 					}
 				}
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectDataMap.cs
@@ -202,14 +202,33 @@ namespace MonoDevelop.Ide.TypeSystem
 				}
 			}
 
-			internal ProjectData CreateData (ProjectId id, ImmutableArray<MonoDevelopMetadataReference> metadataReferences)
+			/// <summary>
+			/// Construct, connect to, and return a new <see cref="ProjectData"/> based on
+			/// <paramref name="metadataReferences"/>. This replaces any old <see cref="ProjectData"/> for
+			/// <paramref name="id"/>.
+			/// </summary>
+			internal ProjectData ReplaceData (ProjectId id, ImmutableArray<MonoDevelopMetadataReference> metadataReferences, out ProjectData oldData)
+			{
+				var result = new ProjectData (id, metadataReferences, Workspace);
+				ReplaceData (id, result, out oldData);
+				return result;
+			}
+
+			/// <summary>
+			/// Remove the old <see cref="ProjectData"/> for <paramref name="id"/>, replace it with
+			/// <paramref name="newData"/>, and and connect to <paramref name="newData"/>.
+			/// </summary>
+			internal void ReplaceData (ProjectId id, ProjectData newData, out ProjectData oldData)
 			{
 				lock (updatingProjectDataLock) {
-					var result = new ProjectData (id, metadataReferences, Workspace);
-					projectDataMap [id] = result;
-					return result;
+					oldData = RemoveData (id);
+					if (newData != null) {
+						newData.Connect ();
+						projectDataMap [id] = newData;
+					}
 				}
 			}
+
 			internal ProjectId[] GetProjectIds ()
 			{
 				lock (updatingProjectDataLock) {

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataMapTests.cs
@@ -136,17 +136,23 @@ namespace MonoDevelop.Ide.TypeSystem
 				Assert.IsNull (data);
 				Assert.IsFalse (map.Contains (pid));
 
-				data = map.CreateData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty);
+				data = map.ReplaceData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty, out var oldData);
 
 				Assert.IsNotNull (data);
 				Assert.IsTrue (map.Contains (pid));
+				Assert.IsNull (oldData);
 
 				map.RemoveData (pid);
 
-				data = map.GetData (pid);
+				oldData = map.GetData (pid);
 
-				Assert.IsNull (data);
+				Assert.IsNull (oldData);
 				Assert.IsFalse (map.Contains (pid));
+				
+				map.ReplaceData (pid, data, out oldData);
+				
+				Assert.IsNull (oldData);
+				Assert.AreSame (data, map.GetData (pid));
 			}
 		}
 
@@ -170,15 +176,17 @@ namespace MonoDevelop.Ide.TypeSystem
 				Assert.IsNull (data2);
 				Assert.IsFalse (map.Contains (pid2));
 
-				data = map.CreateData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty);
+				data = map.ReplaceData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty, out var oldData);
 
 				Assert.IsNotNull (data);
 				Assert.IsTrue (map.Contains (pid));
+				Assert.IsNull (oldData);
 
-				data2 = map.CreateData (pid2, ImmutableArray<MonoDevelopMetadataReference>.Empty);
+				data2 = map.ReplaceData (pid2, ImmutableArray<MonoDevelopMetadataReference>.Empty, out var oldData2);
 
 				Assert.IsNotNull (data2);
 				Assert.IsTrue (map.Contains (pid2));
+				Assert.IsNull (oldData2);
 
 				map.RemoveData (pid);
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspaceProjectDataTests.cs
@@ -41,6 +41,7 @@ namespace MonoDevelop.Ide.TypeSystem
 
 			using (var workspace = await IdeApp.TypeSystemService.CreateEmptyWorkspace ()) {
 				var data = new MonoDevelopWorkspace.ProjectData (pid, ImmutableArray<MonoDevelopMetadataReference>.Empty, workspace);
+				data.Connect ();
 				data.Disconnect ();
 				// Do nothing, we just want to see it construct and dispose properly.
 			}


### PR DESCRIPTION
It's possible for events like device (dis)connect to make several quick
calls to `ActiveConfigurationChanged`, some of which would be canceled,
ultimately causing old `DocumentId` data to get lost during project
reload.

Creating new `DocumentId`s could break multiple Roslyn services such as
intellisense. This change makes the whole process more robust so that
`DocumentId` data does not get lost.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/915494

Backport of #8647.

/cc @sandyarmstrong @Therzok