### PR TITLE
Map `ShowCompletionWindow` to `CommitUniqueCompletionListItem`

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/Properties/MonoDevelop.TextEditor.addin.xml
@@ -136,7 +136,7 @@
 		<Map id="MonoDevelop.Ide.Commands.EditCommands.Delete" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.DeleteKeyCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.DeleteRightChar" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.DeleteKeyCommandArgs" />
 
-		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCompletionWindow" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InvokeCompletionListCommandArgs" />
+		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.ShowCompletionWindow" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.CommitUniqueCompletionListItemCommandArgs" />
 		<Map id="MonoDevelop.Ide.Commands.TextEditorCommands.ShowParameterCompletionWindow" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InvokeSignatureHelpCommandArgs" />
 
 		<Map id="MonoDevelop.Refactoring.RefactoryCommands.QuickFix" argsType="Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InvokeQuickFixCommandArgs" />


### PR DESCRIPTION
Visual Studio Editor has 2 commands to show code completion `CommitUniqueCompletionListItemCommandArgs` and `InvokeCompletionListCommandArgs` there are 2 differences between two..
1) If there is unique item(only 1) in list just complete it without showing code completion
2) At least for web-tools difference is also, filter or not list of items

Since Cmd/Ctrl+Space on Windows but also in old editor behaved as `CommitUniqueCompletionListItemCommandArgs` this mapping is much more correct.