### PR TITLE
[release-8.3] Bump Roslyn to 3.3.1-beta3-19454-05

### DIFF
--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.3.1-beta3-19426-02</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.3.1-beta3-19454-05</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes since [c82648d](https://www.github.com/dotnet/roslyn/commit/c82648d):
- [Increase Editor Completion Timeout for tests (#38413)](https://www.github.com/dotnet/roslyn/pull/38413)
- [Merge pull request #38441 from mavasani/Issue38330](https://www.github.com/dotnet/roslyn/pull/38441)
- [Merge pull request #38425 from 333fred/source-build-workspaces](https://www.github.com/dotnet/roslyn/pull/38425)
- [Consider nullability when comparing IReference instances during emit (#38249) (#38396)](https://www.github.com/dotnet/roslyn/pull/38396)
- [Merge pull request #38412 from heejaechang/experimentService2](https://www.github.com/dotnet/roslyn/pull/38412)
- [Merge pull request #38356 from heejaechang/experimentService](https://www.github.com/dotnet/roslyn/pull/38356)
- [Merge pull request #38220 from mavasani/Issue38180](https://www.github.com/dotnet/roslyn/pull/38220)
- [Merge pull request #38225 from jasonmalinowski/wire-up-to-documents-even-without-docdata-change](https://www.github.com/dotnet/roslyn/pull/38225)
- [Avoid a race around initialization of TypeWithAnnotations structure and IsDefault check. (#38230)](https://www.github.com/dotnet/roslyn/pull/38230)

(https://github.com/dotnet/roslyn/compare/c82648d...3b423bd)

Backport of #8660.

/cc @sandyarmstrong 