### PR TITLE
[release-8.3] Fixes current WindowList command handler to show correctly opened windows

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -777,11 +777,11 @@ namespace MonoDevelop.Components.Commands
 			// before doing any change to the topLevelWindows list
 			EndWaitingForUserInteraction ();
 
-			var node = topLevelWindows.Find (win);
+			var node = topLevelWindows.FirstOrDefault (s => s.nativeWidget.Equals (win.nativeWidget));
 			if (node != null) {
 				if (win.HasFocus) {
 					topLevelWindows.Remove (node);
-					topLevelWindows.AddFirst (node);
+					topLevelWindows.AddFirst (win);
 				}
 			} else {
 				topLevelWindows.AddFirst (win);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkMacInterop.cs
@@ -164,6 +164,14 @@ namespace MonoDevelop.Components.Mac
 			image.AddRepresentation (imageRep);
 			return image;
 		}
+
+		public static bool IsGdkQuartzWindow (Window window)
+		{
+			if (window.nativeWidget is AppKit.NSWindow nsWindow) {
+				return GetGtkWindow (nsWindow) != null;
+			}
+			return false;
+		}
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
@@ -55,6 +55,18 @@ namespace MonoDevelop.Components
 			}
 		}
 
+		public bool IsVisible {
+			get {
+				if (nativeWidget is Gtk.Window)
+					return ((Gtk.Window)nativeWidget).Visible;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow)
+					return ((AppKit.NSWindow)nativeWidget).IsVisible;
+#endif
+				return false;
+			}
+		}
+
 		public override bool HasFocus {
 			get {
 				if (nativeWidget is Gtk.Window)
@@ -65,6 +77,57 @@ namespace MonoDevelop.Components
 #endif
 				return false;
 			}
+		}
+
+		public string Title {
+			get {
+				if (nativeWidget is Gtk.Window gtkWindow)
+					return gtkWindow.Title;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow nsWindow)
+					return nsWindow.Title;
+#endif
+				return string.Empty;
+			}
+			set {
+
+				if (value == null)
+					return;
+
+				if (nativeWidget is Gtk.Window gtkWindow) {
+					gtkWindow.Title = value;
+					return;
+				}
+#if MAC
+				if (nativeWidget is AppKit.NSWindow nsWindow) {
+					nsWindow.Title = value;
+					return;
+				}
+#endif
+			}
+		}
+
+		public bool HasTopLevelFocus {
+			get {
+				if (nativeWidget is Gtk.Window gtkWindow)
+					return gtkWindow.HasToplevelFocus;
+#if MAC
+				if (nativeWidget is AppKit.NSWindow nsWindow)
+					return AppKit.NSApplication.SharedApplication.KeyWindow == nsWindow;
+#endif
+
+				return false;
+			}
+		}
+
+		public void Present ()
+		{
+			if (nativeWidget is Gtk.Window gtkWindow)
+				gtkWindow.Present ();
+#if MAC
+			if (nativeWidget is AppKit.NSWindow nsWindow)
+				nsWindow.MakeKeyAndOrderFront (nsWindow);
+#endif
 		}
 
 		public static implicit operator Gtk.Window (Window d)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
@@ -249,9 +249,13 @@ namespace MonoDevelop.Ide.Commands
 
 	internal class OpenWindowListHandler : CommandHandler
 	{
+	
 		protected override void Update (CommandArrayInfo info)
 		{
 			foreach (Components.Window window in IdeApp.CommandService.TopLevelWindowStack) {
+				//we don't want include hidden windows
+				if (!window.IsRealized || !window.IsVisible || Components.Mac.GtkMacInterop.IsGdkQuartzWindow (window))
+					continue;
 
 				//Create CommandInfo object
 				var commandInfo = new CommandInfo ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/WindowCommands.cs
@@ -251,30 +251,32 @@ namespace MonoDevelop.Ide.Commands
 	{
 		protected override void Update (CommandArrayInfo info)
 		{
-			var windows = IdeApp.CommandService.TopLevelWindowStack.ToArray (); // enumerate only once
-			if (windows.Length <= 1)
-				return;
-			int i = 0;
-			foreach (Gtk.Window window in windows) {
+			foreach (Components.Window window in IdeApp.CommandService.TopLevelWindowStack) {
 
 				//Create CommandInfo object
-				CommandInfo commandInfo = new CommandInfo ();
-				commandInfo.Text = window.Title.Replace ("_", "__").Replace("-","\u2013").Replace(" \u2013 " + BrandingService.ApplicationName, "");
-				if (window.HasToplevelFocus)
+				var commandInfo = new CommandInfo ();
+				commandInfo.Text = window.Title.Replace ("_", "__").Replace ("-", "\u2013").Replace (" \u2013 " + BrandingService.ApplicationName, "");
+
+				if (string.IsNullOrEmpty (commandInfo.Text)) {
+					commandInfo.Text = GettextCatalog.GetString ("No description");
+				}
+
+				if (window.HasTopLevelFocus) 
 					commandInfo.Checked = true;
 				commandInfo.Description = GettextCatalog.GetString ("Activate window '{0}'", commandInfo.Text);
 
 				//Add menu item
-				info.Add (commandInfo, window);
-
-				i++;
+				info.Add (commandInfo, window.Title);
 			}
 		}
 
 		protected override void Run (object dataItem)
 		{
-			Window window = (Window)dataItem;
-			window.Present ();
+			//the window could be disposed/closed for some reason in between this 2 menu statements
+			//it's safe to ask again
+			var window = IdeApp.CommandService.TopLevelWindowStack
+				.FirstOrDefault (s => s.Title == (string)dataItem);
+			window?.Present ();
 		}
 	}
 


### PR DESCRIPTION
This PR fixes current WindowList command handler, where it was raising an exception trying to cast a NSWindow (WelcomeScreen) into a GtkWindow.

To fix this I did changes to use our current component.window abstraction instead the specific (adding some missing properties to reuse), also a small fix to ensure the the window exists (not  disposed or closed)  between this 2 menu statements (show menu and clicked)

Additionally included the fix to ensure we don't show duplicated items

To show correctly the WelcomeScreen title this PR needs https://github.com/xamarin/md-addins/pull/5346


Fixes VSTS #960819 - Exception in MacPlatformService.GetNSWindow

<img width="795" alt="Screenshot 2019-09-04 at 11 38 16" src="https://user-images.githubusercontent.com/1587480/64245468-41615b00-cf0b-11e9-9c06-a8666ca0d1ef.png">

Fixes VSTS #976240 - Recent Windows list shows the same pad multiple times

<img width="1146" alt="Screenshot 2019-09-04 at 11 39 11" src="https://user-images.githubusercontent.com/1587480/64245528-5b02a280-cf0b-11e9-9883-4d229159229f.png">



Backport of #8623.

/cc @slluis @netonjm