### PR TITLE
Increase timeout of TestTasksExecuteSequentially

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/DedicatedThreadSchedulerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/DedicatedThreadSchedulerTests.cs
@@ -93,7 +93,7 @@ namespace MonoDevelop.Core
 		}
 
 		[Test]
-		[Timeout (5000)]
+		[Timeout (20000)]
 		public async Task TestTasksExecuteSequentially ()
 		{
 			int runTasks = 50;


### PR DESCRIPTION
The tests is timing out sometimes. It might happen in slow machines,
or there might be a legitimate bug that is causing tasks to never be
dispatched. Let's find out.