### PR TITLE
[release-8.3] Fix 980541: Switching themes in Preferences corrupts colors in editor 

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/ThemeToClassification.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/ThemeToClassification.cs
@@ -182,6 +182,15 @@ namespace MonoDevelop.TextEditor
 		{
 			var editorFormat = editorFormatMapService.GetEditorFormatMap (appearanceCategory);
 			editorFormat.BeginBatchUpdate ();
+
+			// Reason we do it this way to purge existing values is because there is many possible
+			// value that can be already in ResourceDictionary, Bold, Color, Font... So we would have to explicitly
+			// clear all this values and set them to default before setting new theme, since theme might depend on default
+			// Handling all this is very complicated and error prone, since this whole file should be removed at some point
+			// and replaced with new theming system better adjusted to ITextView
+			// See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/980541 for more details
+			(editorFormat as IEditorFormatMap2)?.ClearProperties ();
+
 			var theme = SyntaxHighlightingService.GetEditorTheme (IdeApp.Preferences.ColorScheme.Value);
 			var settingsMap = new Dictionary<string, ThemeSetting> ();
 			var defaultSettings = theme.Settings[0];


### PR DESCRIPTION
Using reflection is never pretty way to fix a bug, but themeing/coloring API of VS is just too old and ugly...
So for now this is solution, because alternative is so much code and potential bugs I would rather not do that...

Backport of #8661.

/cc @abock @DavidKarlas