### PR TITLE
[release-8.3] [Git] Fix blame command on mixed hunks

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -127,9 +127,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 		{
 			var repo2 = (GitRepository)repo;
 			var monitor = new ProgressMonitor ();
-			await Task.Run (async () => {
-				repo2.Push (monitor, await repo2.GetCurrentRemoteAsync (), repo2.GetCurrentBranch ());
-			});
+			await repo2.PushAsync (monitor, await repo2.GetCurrentRemoteAsync (), repo2.GetCurrentBranch ());
 		}
 
 		protected override void BlameExtraInternals (Annotation [] annotations)
@@ -380,7 +378,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			await repo2.CreateBranchAsync ("branch3", null, null);
 			await repo2.SwitchToBranchAsync (monitor, "branch3");
 			await AddFileAsync ("file2", "asdf", true, true);
-			await Task.Run (() => repo2.Push (monitor, "origin", "branch3"));
+			await repo2.PushAsync (monitor, "origin", "branch3");
 
 			await repo2.SwitchToBranchAsync (monitor, "master");
 
@@ -601,7 +599,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			var monitor = new ProgressMonitor ();
 			var repo2 = (GitRepository)Repo;
 			await AddFileAsync ("init", "init", true, true);
-			await Task.Run (() => repo2.Push (new ProgressMonitor (), "origin", "master"));
+			await repo2.PushAsync (new ProgressMonitor (), "origin", "master");
 			await repo2.CreateBranchAsync ("testBranch", "origin/master", "refs/remotes/origin/master");
 
 			if (exceptionType != null) {
@@ -622,7 +620,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			var monitor = new ProgressMonitor ();
 			var repo2 = (GitRepository)Repo;
 			await AddFileAsync ("init", "init", true, true);
-			repo2.Push (new ProgressMonitor (), "origin", "master");
+			await repo2.PushAsync (new ProgressMonitor (), "origin", "master");
 
 			await repo2.SetBranchTrackRefAsync ("testBranch", "origin/master", "refs/remotes/origin/master");
 			var branches = await repo2.GetBranchesAsync ();

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -452,15 +452,15 @@ namespace MonoDevelop.VersionControl.Git
 				return;
 
 			var monitor = VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Fetching remote..."));
-			await System.Threading.Tasks.Task.Run (() => {
+			await System.Threading.Tasks.Task.Run ((Func<System.Threading.Tasks.Task>)(async () => {
 				try {
-					repo.Fetch (monitor, remoteName);
+					await repo.FetchAsync ((ProgressMonitor)monitor, (string)remoteName);
 				} catch (Exception ex) {
 					monitor.ReportError (GettextCatalog.GetString ("Fetching remote failed"), ex);
 				} finally {
 					monitor.Dispose ();
 				}
-			});
+			}));
 			FillRemotes ();
 		}
 	}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -410,7 +410,7 @@ namespace MonoDevelop.VersionControl.Git
 				FillTags ();
 		}
 
-		protected virtual void OnButtonPushTagClicked (object sender, EventArgs e)
+		protected async void OnButtonPushTagClicked (object sender, EventArgs e)
 		{
 			TreeIter it;
 			if (!listTags.Selection.GetSelected (out it))
@@ -418,19 +418,17 @@ namespace MonoDevelop.VersionControl.Git
 
 			string tagName = (string)storeTags.GetValue (it, 0);
 			var monitor = new Ide.ProgressMonitoring.MessageDialogProgressMonitor (true, false, false, true);
-			System.Threading.Tasks.Task.Run (async () => {
-				try {
-					monitor.BeginTask (GettextCatalog.GetString ("Pushing Tag"), 1);
-					monitor.Log.WriteLine (GettextCatalog.GetString ("Pushing Tag '{0}' to '{1}'", tagName, repo.Url));
-					await repo.PushTagAsync (tagName);
-					monitor.Step (1);
-					monitor.EndTask ();
-				} catch (Exception ex) {
-					monitor.ReportError (GettextCatalog.GetString ("Pushing tag failed"), ex);
-				} finally {
-					monitor.Dispose ();
-				}
-			});
+			try {
+				monitor.BeginTask (GettextCatalog.GetString ("Pushing Tag"), 1);
+				monitor.Log.WriteLine (GettextCatalog.GetString ("Pushing Tag '{0}' to '{1}'", tagName, repo.Url));
+				await repo.PushTagAsync (tagName);
+				monitor.Step (1);
+				monitor.EndTask ();
+			} catch (Exception ex) {
+				monitor.ReportError (GettextCatalog.GetString ("Pushing tag failed"), ex);
+			} finally {
+				monitor.Dispose ();
+			}
 		}
 
 		protected async void OnButtonFetchClicked (object sender, EventArgs e)
@@ -452,15 +450,13 @@ namespace MonoDevelop.VersionControl.Git
 				return;
 
 			var monitor = VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Fetching remote..."));
-			await System.Threading.Tasks.Task.Run ((Func<System.Threading.Tasks.Task>)(async () => {
-				try {
-					await repo.FetchAsync ((ProgressMonitor)monitor, (string)remoteName);
-				} catch (Exception ex) {
-					monitor.ReportError (GettextCatalog.GetString ("Fetching remote failed"), ex);
-				} finally {
-					monitor.Dispose ();
-				}
-			}));
+			try {
+				await repo.FetchAsync (monitor, remoteName);
+			} catch (Exception ex) {
+				monitor.ReportError (GettextCatalog.GetString ("Fetching remote failed"), ex);
+			} finally {
+				monitor.Dispose ();
+			}
 			FillRemotes ();
 		}
 	}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -2406,7 +2406,7 @@ namespace MonoDevelop.VersionControl.Git
 			get; private set;
 		}
 
-		public GitRevision (Repository repo, string gitRepository, Commit commit) : base(repo, commit.Author.When.DateTime, commit.Author.Name, commit.Message)
+		public GitRevision (Repository repo, string gitRepository, Commit commit) : base(repo, commit?.Author.When.DateTime ?? DateTime.Now, commit?.Author.Name, commit?.Message)
 		{
 			GitRepository = gitRepository;
 			rev = commit != null ? commit.Id.Sha : "";

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -2330,13 +2330,16 @@ namespace MonoDevelop.VersionControl.Git
 						var baseDocument = Mono.TextEditor.TextDocument.CreateImmutableDocument (baseText);
 						var workingDocument = Mono.TextEditor.TextDocument.CreateImmutableDocument (TextFileUtility.GetText (repositoryPath));
 						var nextRev = new Annotation (null, GettextCatalog.GetString ("<uncommitted>"), DateTime.MinValue, null, GettextCatalog.GetString ("working copy"));
+						int offsetStart = 0;
 						foreach (var hunk in baseDocument.Diff (workingDocument, includeEol: false)) {
-							list.RemoveRange (hunk.RemoveStart - 1, hunk.Removed);
+							list.RemoveRange (offsetStart + hunk.RemoveStart - 1, hunk.Removed);
+							offsetStart -= hunk.Removed;
 							for (int i = 0; i < hunk.Inserted; ++i) {
 								if (hunk.InsertStart + i >= list.Count)
 									list.Add (nextRev);
 								else
-									list.Insert (hunk.InsertStart - 1, nextRev);
+									list.Insert (offsetStart + hunk.InsertStart - 1, nextRev);
+								offsetStart++;
 							}
 						}
 					});
@@ -2403,7 +2406,7 @@ namespace MonoDevelop.VersionControl.Git
 			get; private set;
 		}
 
-		public GitRevision (Repository repo, string gitRepository, Commit commit) : base(repo)
+		public GitRevision (Repository repo, string gitRepository, Commit commit) : base(repo, commit.Author.When.DateTime, commit.Author.Name, commit.Message)
 		{
 			GitRepository = gitRepository;
 			rev = commit != null ? commit.Id.Sha : "";

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/MonoDevelop.VersionControl.Subversion/SubversionRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/MonoDevelop.VersionControl.Subversion/SubversionRepository.cs
@@ -258,7 +258,7 @@ namespace MonoDevelop.VersionControl.Subversion
 				if (await IsVersionedAsync (path, monitor.CancellationToken).ConfigureAwait (false) && File.Exists (path) && !Directory.Exists (path)) {
 					if (RootPath.IsNull)
 						throw new UserException (GettextCatalog.GetString ("Project publishing failed. There is a stale .svn folder in the path '{0}'", path.ParentDirectory));
-					VersionInfo srcInfo = await GetVersionInfoAsync (path, VersionInfoQueryFlags.IgnoreCache);
+					VersionInfo srcInfo = await GetVersionInfoAsync (path, VersionInfoQueryFlags.IgnoreCache).ConfigureAwait (false));
 					if (srcInfo.HasLocalChange (VersionStatus.ScheduledDelete)) {
 						// It is a file that was deleted. It can be restored now since it's going
 						// to be added again.

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/MonoDevelop.VersionControl.Subversion/SubversionRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Subversion/MonoDevelop.VersionControl.Subversion/SubversionRepository.cs
@@ -258,7 +258,7 @@ namespace MonoDevelop.VersionControl.Subversion
 				if (await IsVersionedAsync (path, monitor.CancellationToken).ConfigureAwait (false) && File.Exists (path) && !Directory.Exists (path)) {
 					if (RootPath.IsNull)
 						throw new UserException (GettextCatalog.GetString ("Project publishing failed. There is a stale .svn folder in the path '{0}'", path.ParentDirectory));
-					VersionInfo srcInfo = await GetVersionInfoAsync (path, VersionInfoQueryFlags.IgnoreCache).ConfigureAwait (false));
+					VersionInfo srcInfo = await GetVersionInfoAsync (path, VersionInfoQueryFlags.IgnoreCache).ConfigureAwait (false);
 					if (srcInfo.HasLocalChange (VersionStatus.ScheduledDelete)) {
 						// It is a file that was deleted. It can be restored now since it's going
 						// to be added again.

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameView.cs
@@ -99,7 +99,7 @@ namespace MonoDevelop.VersionControl.Views
 				textView.Caret.MoveTo (point);
 
 				int line = GetLineInCenter (widget.Editor);
-				line = Math.Min (line, snapshot.LineCount);
+				line = Math.Min (line, snapshot.LineCount - 1);
 				var middleLine = snapshot.GetLineFromLineNumber (line);
 				textView.ViewScroller.EnsureSpanVisible (new SnapshotSpan (textView.TextSnapshot, middleLine.Start, 0), EnsureSpanVisibleOptions.AlwaysCenter);
 			}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/BlameWidget.cs
@@ -576,8 +576,10 @@ namespace MonoDevelop.VersionControl.Views
 						//							Annotation varname = annotations[i];
 						//							System.Console.WriteLine (i + ":" + varname);
 						//						}
-						minDate = annotations.Min (a => a.Date);
-						maxDate = annotations.Max (a => a.Date);
+						if (annotations.Count > 0) {
+							minDate = annotations.Min (a => a.Date);
+							maxDate = annotations.Max (a => a.Date);
+						}
 					} catch (Exception ex) {
 						LoggingService.LogError ("Error retrieving history", ex);
 					}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/DiffView.cs
@@ -139,7 +139,7 @@ namespace MonoDevelop.VersionControl.Views
 					textView.Caret.MoveTo (point);
 
 					int line = GetLineInCenter (ComparisonWidget.OriginalEditor);
-					line = Math.Min (line, snapshot.LineCount);
+					line = Math.Min (line, snapshot.LineCount - 1);
 					var middleLine = snapshot.GetLineFromLineNumber (line);
 					textView.ViewScroller.EnsureSpanVisible (new SnapshotSpan (textView.TextSnapshot, middleLine.Start, 0), EnsureSpanVisibleOptions.AlwaysCenter);
 				}

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -245,7 +245,7 @@ namespace MonoDevelop.VersionControl
 		// Returns the versioning status of a file or directory
 		public async Task<VersionInfo> GetVersionInfoAsync (FilePath localPath, VersionInfoQueryFlags queryFlags = VersionInfoQueryFlags.None, CancellationToken cancellationToken = default)
 		{
-			var infos = await GetVersionInfoAsync (new FilePath [] { localPath }, queryFlags, cancellationToken);
+			var infos = await GetVersionInfoAsync (new FilePath [] { localPath }, queryFlags, cancellationToken).ConfigureAwait (false);
 			if (infos.Count != 1) {
 				LoggingService.LogError ("VersionControl returned {0} items for {1}", infos.Count, localPath);
 				LoggingService.LogError ("The infos were: {0}", string.Join (" ::: ", infos.Select (i => i.LocalPath)));
@@ -293,15 +293,16 @@ namespace MonoDevelop.VersionControl
 		public async Task<IReadOnlyList<VersionInfo>> GetVersionInfoAsync (IEnumerable<FilePath> paths, VersionInfoQueryFlags queryFlags = VersionInfoQueryFlags.None, CancellationToken cancellationToken = default)
 		{
 			if ((queryFlags & VersionInfoQueryFlags.IgnoreCache) != 0) {
-				var res = await ExclusiveOperationFactory.StartNew (async delegate {
+				var task = await ExclusiveOperationFactory.StartNew (delegate {
 					// We shouldn't use IEnumerable because elements don't save property modifications.
-					var res = await OnGetVersionInfoAsync (paths, (queryFlags & VersionInfoQueryFlags.IncludeRemoteStatus) != 0, cancellationToken);
-					foreach (var vi in res)
-						if (!vi.IsInitialized) await vi.InitAsync (this, cancellationToken);
-					await infoCache.SetStatusAsync (res, cancellationToken: cancellationToken);
-					return res;
-				});
-				return await res;
+					return OnGetVersionInfoAsync (paths, (queryFlags & VersionInfoQueryFlags.IncludeRemoteStatus) != 0, cancellationToken);
+				}).ConfigureAwait (false);
+
+				var res = await task.ConfigureAwait (false);
+				foreach (var vi in res)
+					if (!vi.IsInitialized) await vi.InitAsync (this, cancellationToken).ConfigureAwait (false);
+				await infoCache.SetStatusAsync (res, cancellationToken: cancellationToken).ConfigureAwait (false);
+				return res;
 			}
 			var pathsToQuery = new List<FilePath> ();
 			var result = new List<VersionInfo> ();
@@ -316,7 +317,7 @@ namespace MonoDevelop.VersionControl
 				else {
 					// If there is no cached status, query it asynchronously
 					vi = new VersionInfo (path, "", Directory.Exists (path), VersionStatus.Versioned, null, VersionStatus.Versioned, null);
-					await infoCache.SetStatusAsync (vi, false);
+					await infoCache.SetStatusAsync (vi, false).ConfigureAwait (false);
 					result.Add (vi);
 					pathsToQuery.Add (path);
 				}
@@ -381,7 +382,7 @@ namespace MonoDevelop.VersionControl
 		{
 			try {
 				if (recursive) {
-					return await OnGetDirectoryVersionInfoAsync (localDirectory, getRemoteStatus, true, cancellationToken);
+					return await OnGetDirectoryVersionInfoAsync (localDirectory, getRemoteStatus, true, cancellationToken).ConfigureAwait (false);
 				}
 
 				var status = infoCache.GetDirectoryStatus (localDirectory);
@@ -390,8 +391,8 @@ namespace MonoDevelop.VersionControl
 
 				var directoryVersionInfo = await OnGetDirectoryVersionInfoAsync (localDirectory, getRemoteStatus, false, cancellationToken).ConfigureAwait (false);
 				foreach (var vi in directoryVersionInfo)
-					if (!vi.IsInitialized) await vi.InitAsync (this, cancellationToken);
-				await infoCache.SetDirectoryStatusAsync (localDirectory, directoryVersionInfo, getRemoteStatus, cancellationToken);
+					if (!vi.IsInitialized) await vi.InitAsync (this, cancellationToken).ConfigureAwait (false);
+				await infoCache.SetDirectoryStatusAsync (localDirectory, directoryVersionInfo, getRemoteStatus, cancellationToken).ConfigureAwait (false);
 
 				// If we have a status value but the value was invalidated (RequiresRefresh == true)
 				// then we return the invalidated value while we start an async query to get the new one
@@ -440,7 +441,7 @@ namespace MonoDevelop.VersionControl
 		{
 			using (var tracker = Instrumentation.GetRevisionChangesCounter.BeginTiming (new RepositoryMetadata (VersionControlSystem))) {
 				try {
-					return await OnGetRevisionChangesAsync (revision, cancellationToken);
+					return await OnGetRevisionChangesAsync (revision, cancellationToken).ConfigureAwait (false);
 				} catch {
 					tracker.Metadata.SetFailure ();
 					throw;
@@ -453,11 +454,11 @@ namespace MonoDevelop.VersionControl
 		public abstract Task<string> GetBaseTextAsync (FilePath localFile, CancellationToken cancellationToken = default);
 
 		// Returns the revision history of a file
-		public Task<Revision[]> GetHistoryAsync (FilePath localFile, Revision since, CancellationToken cancellationToken = default)
+		public async Task<Revision[]> GetHistoryAsync (FilePath localFile, Revision since, CancellationToken cancellationToken = default)
 		{
 			using (var tracker = Instrumentation.GetHistoryCounter.BeginTiming (new RepositoryMetadata (VersionControlSystem))) {
 				try {
-					return OnGetHistoryAsync (localFile, since, cancellationToken);
+					return await OnGetHistoryAsync (localFile, since, cancellationToken).ConfigureAwait (false);
 				} catch {
 					tracker.Metadata.SetFailure ();
 					throw;
@@ -492,7 +493,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new PublishMetadata (VersionControlSystem) { PathsCount = files.Length, SubFolder = !RootPath.IsNullOrEmpty && localPath.IsChildPathOf(RootPath) };
 			using (var tracker = Instrumentation.PublishCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					var res = await OnPublishAsync (serverPath, localPath, files, message, monitor);
+					var res = await OnPublishAsync (serverPath, localPath, files, message, monitor).ConfigureAwait (false);
 					ClearCachedVersionInfo (localPath);
 					return res;
 				} catch {
@@ -516,7 +517,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new MultipathOperationMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Recursive = recurse };
 			using (var tracker = Instrumentation.UpdateCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnUpdateAsync (localPaths, recurse, monitor);
+					await OnUpdateAsync (localPaths, recurse, monitor).ConfigureAwait (false);
 					ClearCachedVersionInfo (localPaths);
 				} catch {
 					metadata.SetFailure ();
@@ -557,7 +558,7 @@ namespace MonoDevelop.VersionControl
 			using (var tracker = Instrumentation.CommitCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
 					ClearCachedVersionInfo (changeSet.BaseLocalPath);
-					await OnCommitAsync (changeSet, monitor);
+					await OnCommitAsync (changeSet, monitor).ConfigureAwait (false);
 				} catch {
 					metadata.SetFailure ();
 					throw;
@@ -579,7 +580,7 @@ namespace MonoDevelop.VersionControl
 			using (var tracker = Instrumentation.CheckoutCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
 					ClearCachedVersionInfo (targetLocalPath);
-					await OnCheckoutAsync (targetLocalPath, rev, recurse, monitor);
+					await OnCheckoutAsync (targetLocalPath, rev, recurse, monitor).ConfigureAwait (false);
 
 					if (!Directory.Exists (targetLocalPath))
 						metadata.SetFailure ();
@@ -599,7 +600,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new RevertMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Recursive = recurse, OperationType = RevertMetadata.RevertType.LocalChanges };
 			using (var tracker = Instrumentation.RevertCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnRevertAsync (localPaths, recurse, monitor);
+					await OnRevertAsync (localPaths, recurse, monitor).ConfigureAwait (false);
 					ClearCachedVersionInfo (localPaths);
 				} catch {
 					metadata.SetFailure ();
@@ -621,7 +622,7 @@ namespace MonoDevelop.VersionControl
 			using (var tracker = Instrumentation.RevertCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
 					ClearCachedVersionInfo (localPath);
-					await OnRevertRevisionAsync (localPath, revision, monitor);
+					await OnRevertRevisionAsync (localPath, revision, monitor).ConfigureAwait (false);
 				} catch {
 					metadata.SetFailure ();
 					throw;
@@ -637,7 +638,7 @@ namespace MonoDevelop.VersionControl
 			using (var tracker = Instrumentation.RevertCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
 					ClearCachedVersionInfo (localPath);
-					await OnRevertToRevisionAsync (localPath, revision, monitor);
+					await OnRevertToRevisionAsync (localPath, revision, monitor).ConfigureAwait (false);
 				} catch {
 					metadata.SetFailure ();
 					throw;
@@ -663,7 +664,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new MultipathOperationMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Recursive = recurse };
 			using (var tracker = Instrumentation.AddCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnAddAsync (localPaths, recurse, monitor);
+					await OnAddAsync (localPaths, recurse, monitor).ConfigureAwait (false);
 				} catch (Exception e) {
 					LoggingService.LogError ("Failed to add file", e);
 					metadata.SetFailure ();
@@ -693,7 +694,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new MoveMetadata (VersionControlSystem) { Force = force, OperationType = MoveMetadata.MoveType.File };
 			using (var tracker = Instrumentation.MoveCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnMoveFileAsync (localSrcPath, localDestPath, force, monitor);
+					await OnMoveFileAsync (localSrcPath, localDestPath, force, monitor).ConfigureAwait (false);
 				} catch (Exception e) {
 					LoggingService.LogError ("Failed to move file", e);
 					metadata.SetFailure ();
@@ -716,7 +717,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new MoveMetadata (VersionControlSystem) { Force = force, OperationType = MoveMetadata.MoveType.Directory };
 			using (var tracker = Instrumentation.MoveCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnMoveDirectoryAsync (localSrcPath, localDestPath, force, monitor);
+					await OnMoveDirectoryAsync (localSrcPath, localDestPath, force, monitor).ConfigureAwait (false);
 				} catch (Exception e) {
 					LoggingService.LogError ("Failed to move directory", e);
 					metadata.SetFailure ();
@@ -744,7 +745,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new DeleteMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Force = force, KeepLocal = keepLocal };
 			using (var tracker = Instrumentation.DeleteCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnDeleteFilesAsync (localPaths, force, monitor, keepLocal);
+					await OnDeleteFilesAsync (localPaths, force, monitor, keepLocal).ConfigureAwait (false);
 					foreach (var path in localPaths)
 						args.Add (new FileUpdateEventInfo (this, path, false));
 				} catch (Exception e) {
@@ -764,7 +765,7 @@ namespace MonoDevelop.VersionControl
 
 		public void DeleteDirectory (FilePath localPath, bool force, ProgressMonitor monitor, bool keepLocal = true)
 		{
-			DeleteDirectoriesAsync (new FilePath[] { localPath }, force, monitor, keepLocal).Ignore ();
+			DeleteDirectoriesAsync (new FilePath[] { localPath }, force, monitor, keepLocal).Wait ();
 		}
 
 		public async Task DeleteDirectoriesAsync (FilePath[] localPaths, bool force, ProgressMonitor monitor, bool keepLocal = true)
@@ -773,7 +774,7 @@ namespace MonoDevelop.VersionControl
 			var metadata = new DeleteMetadata (VersionControlSystem) { PathsCount = localPaths.Length, Force = force, KeepLocal = keepLocal };
 			using (var tracker = Instrumentation.DeleteCounter.BeginTiming (metadata, monitor.CancellationToken)) {
 				try {
-					await OnDeleteDirectoriesAsync (localPaths, force, monitor, keepLocal);
+					await OnDeleteDirectoriesAsync (localPaths, force, monitor, keepLocal).ConfigureAwait (false);
 					foreach (var path in localPaths)
 						args.Add (new FileUpdateEventInfo (this, path, true));
 				} catch (Exception e) {
@@ -991,7 +992,7 @@ namespace MonoDevelop.VersionControl
 			using (var tracker = Instrumentation.IgnoreCounter.BeginTiming (metadata)) {
 				try {
 					ClearCachedVersionInfo (localPath);
-					await OnIgnoreAsync (localPath, cancellationToken);
+					await OnIgnoreAsync (localPath, cancellationToken).ConfigureAwait (false);
 				} catch {
 					metadata.SetFailure ();
 					throw;
@@ -1008,7 +1009,7 @@ namespace MonoDevelop.VersionControl
 			using (var tracker = Instrumentation.UnignoreCounter.BeginTiming (metadata)) {
 				try {
 					ClearCachedVersionInfo (localPath);
-					await OnUnignoreAsync (localPath, cancellationToken);
+					await OnUnignoreAsync (localPath, cancellationToken).ConfigureAwait (false);
 				} catch {
 					metadata.SetFailure ();
 					throw;

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -651,7 +651,7 @@ namespace MonoDevelop.VersionControl
 		// Adds a file or directory to the repository
 		public void Add (FilePath localPath, bool recurse, ProgressMonitor monitor)
 		{
-			AddAsync (new FilePath [] { localPath }, recurse, monitor).Ignore ();
+			AddAsync (new FilePath [] { localPath }, recurse, monitor).Wait ();
 		}
 
 		public Task AddAsync (FilePath localPath, bool recurse, ProgressMonitor monitor)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfo.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfo.cs
@@ -40,7 +40,7 @@ namespace MonoDevelop.VersionControl
 		{
 			ownerRepository = repo;
 			RequiresRefresh = false;
-			operations = await ownerRepository.GetSupportedOperationsAsync (this, cancellationToken);
+			operations = await ownerRepository.GetSupportedOperationsAsync (this, cancellationToken).ConfigureAwait (false);
 		}
 		
 		public static VersionInfo CreateUnversioned (FilePath path, bool isDirectory)

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionInfoCache.cs
@@ -87,7 +87,7 @@ namespace MonoDevelop.VersionControl
 		public async Task SetStatusAsync (VersionInfo versionInfo, bool notify = true, CancellationToken cancellationToken = default)
 		{
 			if (!versionInfo.IsInitialized)
-				await versionInfo.InitAsync (repo, cancellationToken);
+				await versionInfo.InitAsync (repo, cancellationToken).ConfigureAwait (false);
 
 			if (fileStatus.TryGetValue (versionInfo.LocalPath, out var vi) && vi.Equals (versionInfo)) {
 				vi.RequiresRefresh = false;


### PR DESCRIPTION
We need to offset based on hunk inserted/removed lengths

Fixes VSTS 978853 - [VersionControl] GitRepository: Error retrieving history System.ArgumentException: Offset and length were out of bounds
Fixes VSTS #977874 - Renaming file makes intellisense disapear when project has .git
Fixes VSTS #787121 - [Watson] Git commands are run on the UI thread, causing the UI to hang

Backport of #8682.

/cc @Therzok 