### PR TITLE
[release-8.3] [IDE] Check that events passed to the keypress handler are key events

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -310,6 +310,13 @@ namespace MonoDevelop.Components.Commands
 #if MAC
 		AppKit.NSEvent OnNSEventKeyPress (AppKit.NSEvent ev)
 		{
+			// Protect against non-keyevents being passed here. See VSTS #935180. It seems that certain
+			// keyboard remapper applications such as Ukuele can cause non-keyevents to be sent to key event handlers.
+			if (ev.Type != AppKit.NSEventType.KeyDown && ev.Type != AppKit.NSEventType.KeyUp) {
+				LoggingService.LogInternalError (new Exception ($"Event is type {ev.Type} and not a KeyEvent"));
+				return null;
+			}
+
 			// If we have a native window that can handle this command, let it process
 			// the keys itself and do not go through the command manager.
 			// Events in Gtk windows do not pass through here except when they're done

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -317,6 +317,11 @@ namespace MonoDevelop.Components.Commands
 				return null;
 			}
 
+			if (string.IsNullOrEmpty (ev.Characters)) {
+				LoggingService.LogInternalError (new Exception ($"Keyevent has no characters"));
+				return null;
+			}
+
 			// If we have a native window that can handle this command, let it process
 			// the keys itself and do not go through the command manager.
 			// Events in Gtk windows do not pass through here except when they're done


### PR DESCRIPTION
Keyboard remapper applications can cause invalid events to be
sent to the key event handlers. Check that events passed to the keypress
handler are actually key events

Fixes VSTS #935180

Backport of #8664.

/cc @slluis @iainx