### PR TITLE
[release-8.3] [Ide] Don't log an error if getting last write time for new documents fails

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentRegistry.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/DocumentRegistry.cs
@@ -184,7 +184,7 @@ namespace MonoDevelop.Ide.Gui
 			void GetLastWriteTime ()
 			{
 				try {
-					LastSaveTimeUtc = File.GetLastWriteTimeUtc (Document.FileName);
+					LastSaveTimeUtc = !Document.IsNewDocument ? File.GetLastWriteTimeUtc (Document.FileName) : DateTime.MinValue;
 				} catch (Exception ex) {
 					LoggingService.LogError ("Error while getting last write time.", ex);
 					LastSaveTimeUtc = DateTime.UtcNow;


### PR DESCRIPTION
A new - not yet saved - document can't have a last write time. Although it's not a crasher, we should not even try to get the write time if we know that the file doesn't exist.

Backport of #8380.

/cc @slluis @sevoku