### PR TITLE
[release-8.3][DotNetCore] Do not show update count label on Frameworks folde

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/FrameworkReferencesNode.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/FrameworkReferencesNode.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 
 		public string GetSecondaryLabel ()
 		{
-			return ParentNode.GetSecondaryLabel ();
+			return string.Empty;
 		}
 
 		public IconId Icon {

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/FrameworkReferencesNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/FrameworkReferencesNodeBuilder.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections;
 using MonoDevelop.Ide.Gui.Components;
 
 namespace MonoDevelop.DotNetCore.NodeBuilders
@@ -57,7 +58,12 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 		public override void BuildChildNodes (ITreeBuilder treeBuilder, object dataObject)
 		{
 			var node = (FrameworkReferencesNode)dataObject;
-			treeBuilder.AddChildren (node.GetChildNodes ());
+			AddChildren (treeBuilder, node.GetChildNodes ());
+		}
+
+		protected virtual void AddChildren (ITreeBuilder treeBuilder, IEnumerable dataObjects)
+		{
+			treeBuilder.AddChildren (dataObjects);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestableSdkDependenciesNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestablePackageDependenciesNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestableTargetFrameworkNodeBuilder.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Tests\TestableFrameworkReferencesNodeBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestablePackageDependenciesNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestableTargetFrameworkNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestableFrameworkReferencesNodeBuilder.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Tests\FakeUpdatedPackagesInWorkspace.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DependencyNodeTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DependencyNodeTests.cs
@@ -33,7 +33,9 @@ using MonoDevelop.Core;
 using MonoDevelop.Core.Assemblies;
 using MonoDevelop.DotNetCore.NodeBuilders;
 using MonoDevelop.Ide.Tasks;
+using MonoDevelop.PackageManagement;
 using MonoDevelop.Projects;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NUnit.Framework;
 using UnitTests;
@@ -72,10 +74,10 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.AreEqual (0, process.ExitCode);
 		}
 
-		async Task CreateDependenciesNode ()
+		async Task CreateDependenciesNode (IUpdatedNuGetPackagesInWorkspace updatedNuGetPackages = null)
 		{
 			dependenciesNodeBuilder = new TestableDependenciesNodeBuilder ();
-			dependenciesNode = new DependenciesNode (project);
+			dependenciesNode = new DependenciesNode (project, updatedNuGetPackages ?? PackageManagementServices.UpdatedPackagesInWorkspace);
 			dependenciesNode.PackageDependencyCache.PackageDependenciesChanged += PackageDependenciesChanged;
 			packageDependenciesChanged = new TaskCompletionSource<bool> ();
 
@@ -470,6 +472,40 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.IsTrue (newtonsoftNode.IsTopLevel);
 			Assert.IsTrue (newtonsoftNode.IsReleaseVersion ());
 			Assert.IsTrue (newtonsoftNode.HasDependencies ());
+		}
+
+		[Test]
+		public async Task NetStandard21Library_NewtonsoftJsonNuGetPackageReferenceHasUpdates ()
+		{
+			if (!IsDotNetCoreSdk30OrLaterInstalled ()) {
+				Assert.Ignore (".NET Core 3 SDK is not installed.");
+			}
+
+			FilePath projectFileName = Util.GetSampleProject ("DotNetCoreDependenciesFolder", "NetStandard21JsonNet.csproj");
+			Restore (projectFileName);
+			project = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFileName);
+
+			var updatedPackages = new FakeUpdatedPackagesInWorkspace ();
+			updatedPackages.AddUpdatedPackages (new PackageIdentity ("Newtonsoft.Json", NuGetVersion.Parse ("11.0.1")));
+			await CreateDependenciesNode (updatedPackages);
+
+			// Should be no sdk folder node.
+			Assert.IsNull (sdkFolderNode);
+
+			Assert.AreEqual ("(1 update)", dependenciesNode.GetSecondaryLabel ());
+
+			var newtonsoftNode = GetNuGetFolderChildDependencies ().Single ();
+			Assert.AreEqual ("Newtonsoft.Json", newtonsoftNode.GetLabel ());
+			Assert.AreEqual ("(10.0.3)", newtonsoftNode.GetSecondaryLabel ());
+			Assert.AreEqual ("md-package-update", newtonsoftNode.GetStatusIconId ().ToString ());
+
+			Assert.AreEqual ("(1 update)", nugetFolderNode.GetSecondaryLabel ());
+
+			var frameworkNode = GetFrameworksFolderChildDependencies ().Single ();
+			Assert.AreEqual ("NETStandard.Library", frameworkNode.GetLabel ());
+
+			// No updates label.
+			Assert.AreEqual (string.Empty, frameworksFolderNode.GetSecondaryLabel ());
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/FakeUpdatedPackagesInWorkspace.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/FakeUpdatedPackagesInWorkspace.cs
@@ -1,0 +1,76 @@
+//
+// FakeUpdatedPackagesInWorkspace.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using MonoDevelop.PackageManagement;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+
+namespace MonoDevelop.DotNetCore.Tests
+{
+	class FakeUpdatedPackagesInWorkspace : IUpdatedNuGetPackagesInWorkspace
+	{
+		public List<UpdatedNuGetPackagesInProject> ProjectsWithUpdatedPackages = new List<UpdatedNuGetPackagesInProject> ();
+
+		public void AddUpdatedPackages (params PackageIdentity [] packages)
+		{
+			var updatedPackages = new UpdatedNuGetPackagesInProject (null, packages);
+			ProjectsWithUpdatedPackages.Add (updatedPackages);
+		}
+
+		public void Clear ()
+		{
+			ProjectsWithUpdatedPackages.Clear ();
+		}
+
+		public void CheckForUpdates ()
+		{
+		}
+
+		public UpdatedNuGetPackagesInProject GetUpdatedPackages (IDotNetProject project)
+		{
+			return ProjectsWithUpdatedPackages.FirstOrDefault () ?? new UpdatedNuGetPackagesInProject (project);
+		}
+
+		public bool AnyUpdates ()
+		{
+			return ProjectsWithUpdatedPackages.Any ();
+		}
+
+		public void Clear (ISolution solution)
+		{
+		}
+
+		public void CheckForUpdates (ISolution solution)
+		{
+		}
+
+		public void CheckForUpdates (ISolution solution, ISourceRepositoryProvider sourceRepositoryProvider)
+		{
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/TestableFrameworkReferencesNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/TestableFrameworkReferencesNodeBuilder.cs
@@ -1,5 +1,5 @@
 //
-// TestableDependenciesNodeBuilder.cs
+// TestableFrameworkReferencesNodeBuilder.cs
 //
 // Author:
 //       Matt Ward <matt.ward@microsoft.com>
@@ -26,45 +26,25 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using MonoDevelop.DotNetCore.NodeBuilders;
 using MonoDevelop.Ide.Gui.Components;
 
 namespace MonoDevelop.DotNetCore.Tests
 {
-	class TestableDependenciesNodeBuilder : DependenciesNodeBuilder
+	class TestableFrameworkReferencesNodeBuilder : FrameworkReferencesNodeBuilder
 	{
 		public List<object> ChildNodes = new List<object> ();
 
-		public PackageDependenciesNode PackageDependencies;
-		public SdkDependenciesNode SdkDependencies;
-		public ProjectDependenciesNode ProjectDependencies;
-		public AssemblyDependenciesNode AssemblyDependencies;
-		public FrameworkReferencesNode FrameworkReferences;
-		public List<TargetFrameworkNode> TargetFrameworks = new List<TargetFrameworkNode> ();
-
-		void AddChild (ITreeBuilder treeBuilder, object dataObject)
+		public IEnumerable<FrameworkReferenceNode> ChildNodesAsFrameworkReferenceNode ()
 		{
-			ChildNodes.Add (dataObject);
-
-			if (dataObject is AssemblyDependenciesNode assemblyDependencies) {
-				AssemblyDependencies = assemblyDependencies;
-			} else if (dataObject is PackageDependenciesNode packageDependencies) {
-				PackageDependencies = packageDependencies;
-			} else if (dataObject is ProjectDependenciesNode projectDependencies) {
-				ProjectDependencies = projectDependencies;
-			} else if (dataObject is SdkDependenciesNode sdkDependencies) {
-				SdkDependencies = sdkDependencies;
-			} else if (dataObject is TargetFrameworkNode targetFramework) {
-				TargetFrameworks.Add (targetFramework);
-			} else if (dataObject is FrameworkReferencesNode frameworkReferences) {
-				FrameworkReferences = frameworkReferences;
-			}
+			return ChildNodes.OfType<FrameworkReferenceNode> ();
 		}
 
 		protected override void AddChildren (ITreeBuilder treeBuilder, IEnumerable dataObjects)
 		{
-			foreach (object dataObject in dataObjects) {
-				AddChild (treeBuilder, dataObject);
+			foreach (var dataObject in dataObjects) {
+				ChildNodes.Add (dataObject);
 			}
 		}
 	}

--- a/main/tests/test-projects/DotNetCoreDependenciesFolder/NetCore30JsonNet.csproj
+++ b/main/tests/test-projects/DotNetCoreDependenciesFolder/NetCore30JsonNet.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp30</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/DotNetCoreDependenciesFolder/NetStandard21JsonNet.csproj
+++ b/main/tests/test-projects/DotNetCoreDependenciesFolder/NetStandard21JsonNet.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #8691

The Frameworks folder for .NET Core 3.0 and .NET Standard 2.1
projects would show an update count label if the project had package
updates. Framework references cannot be updated in the IDE, and also
are not typically defined in the project itself, so the update count
should not be shown.

Fixes VSTS #980887 - Frameworks node under dependencies has a message
about updates next to it

<img width="343" alt="Frameworks" src="https://user-images.githubusercontent.com/372361/64713381-a9d4ad00-d4b4-11e9-9b7d-21577a2dec44.png">
