### PR TITLE
[release-8.3] [Core] Fix adding derived Control items to the weak map

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpPathedDocumentExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/CSharpPathedDocumentExtension.cs
@@ -154,7 +154,7 @@ namespace MonoDevelop.CSharp
 				MaxVisibleRows = 14
 			};
 			window.SelectItem (path [index].Tag);
-			return window;
+			return (Window)window;
 		}
 
 		PathEntry [] currentPath;

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp/PathedDocumentTextEditorExtension.cs
@@ -653,7 +653,7 @@ namespace MonoDevelop.CSharp
 			window.FixedRowHeight = 22;
 			window.MaxVisibleRows = 14;
 			window.SelectItem (path [index].Tag);
-			return window;
+			return (Window)window;
 		}
 
 		PathEntry[] currentPath;

--- a/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
+++ b/main/src/addins/Xml/Editor/BaseXmlEditorExtension.cs
@@ -872,7 +872,7 @@ namespace MonoDevelop.Xml.Editor
 				window.FixedRowHeight = 22;
 				window.MaxVisibleRows = 14;
 				window.SelectItem (currentPath [index].Tag);
-				return window;
+				return (MonoDevelop.Components.Window)window;
 			} else {
 				if (ownerProjects.Count > 1)
 					index--;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.BuildOutputView/BuildOutputWidget.cs
@@ -713,7 +713,7 @@ namespace MonoDevelop.Ide.BuildOutputView
 			window.MaxVisibleRows = 14;
 			if (path [index].Tag != null)
 				window.SelectItem (path [index].Tag);
-			return window;
+			return (Components.Window)window;
 		}
 
 		protected override void Dispose (bool disposing)


### PR DESCRIPTION
DropDownListBox is actually a Window, so use that as the type when adding to the table, not plain Control.
This prevents duplicates from being added to the map, and ensures the right type is added for this widget.

Fixes VSTS #976424 - Unhandled argument exception adding to ConditionalWeakTable in Components.Control

Backport of #8693.

/cc @Therzok 