### PR TITLE
[release-8.3] Sets Xwt translation catalog on Ide initialization

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj
@@ -4281,6 +4281,7 @@
     <Compile Include="MonoDevelop.Ide.Projects.FileNesting\FileNestingService.cs" />
     <Compile Include="MonoDevelop.Ide.Projects.FileNesting\NestingRule.cs" />
     <Compile Include="MonoDevelop.Ide.Projects.FileNesting\NestingRulesProvider.cs" />
+    <Compile Include="MonoDevelop.Ide\TranslationCatalog.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMac' OR '$(Configuration)' == 'ReleaseMac'">
     <Compile Include="MonoDevelop.Components\Mac\KeyCodes.cs" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -214,6 +214,8 @@ namespace MonoDevelop.Ide
 
 			IdeApp.IsRunning = true;
 
+			Xwt.Application.TranslationCatalog = new XwtTranslationCatalog ();
+
 			// Load the main menu before running the main loop
 			var commandService = Runtime.GetService<CommandManager> ().Result;
 			var desktopService = Runtime.GetService<DesktopService> ().Result;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/TranslationCatalog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/TranslationCatalog.cs
@@ -1,0 +1,17 @@
+﻿using MonoDevelop.Core;
+
+namespace MonoDevelop.Ide
+{
+	sealed class XwtTranslationCatalog : Xwt.ITranslationCatalog
+	{
+		public string GetString (string str)
+		{
+			return GettextCatalog.GetString (str);
+		}
+
+		public string GetPluralString (string singular, string plural, int number)
+		{
+			return GettextCatalog.GetPluralString (singular, plural, number);
+		}
+	}
+}


### PR DESCRIPTION
This PR routes from VS4Mac to Xwt the current translation mechanism implementing ITranslationCatalog

![image](https://user-images.githubusercontent.com/1587480/64630670-df669100-d3f5-11e9-81e1-ff5a6b40acd1.png)

Fixes Bug #975047 - New folder missing translation [Italian]

Backport of #8678.

/cc @slluis @netonjm