### PR TITLE
Fix version control view initialization issue

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/VersionControlDocumentInfo.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/VersionControlDocumentInfo.cs
@@ -37,10 +37,11 @@ namespace MonoDevelop.VersionControl.Views
 	public class VersionControlDocumentInfo
 	{
 		bool alreadyStarted = false;
+		Document document;
 
 		public Document Document {
-			get;
-			set;
+			get => document ?? Controller?.Document;
+			set => document = value;
 		}
 
 		public VersionControlDocumentController VersionControlExtension {

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlDocumentController.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/VersionControlDocumentController.cs
@@ -43,12 +43,14 @@ namespace MonoDevelop.VersionControl
 	{
 		WorkspaceObject project;
 		Repository repo;
-		VersionControlDocumentInfo vcInfo;
 
 		DocumentView diffView;
 		DocumentView blameView;
 		DocumentView logView;
 		DocumentView mergeView;
+
+		DocumentView mainView;
+		VersionControlDocumentInfo vcInfo;
 
 		public override async Task<bool> SupportsController (DocumentController controller)
 		{
@@ -70,22 +72,85 @@ namespace MonoDevelop.VersionControl
 			repo = VersionControlService.GetRepository (project);
 			if (repo == null)
 				return false;
-			return repo.TryGetVersionInfo (fileController.FilePath, out var info) && info.IsVersioned;
+
+			return true;
 		}
 
 		protected internal override async Task<DocumentView> OnInitializeView ()
 		{
-			var mainView = await base.OnInitializeView ();
+			mainView = await base.OnInitializeView ();
 			var controller = (FileDocumentController)Controller;
 			var item = new VersionControlItem (repo, project, controller.FilePath, false, null);
 			vcInfo = new VersionControlDocumentInfo (this, Controller, item, item.Repository);
-			vcInfo.Document = Controller.Document;
-
-			diffView = await TryAttachView (mainView, vcInfo, DiffCommand.DiffViewHandlers, GettextCatalog.GetString ("Changes"), GettextCatalog.GetString ("Shows the differences in the code between the current code and the version in the repository"));
-			blameView = await TryAttachView (mainView, vcInfo, BlameCommand.BlameViewHandlers, GettextCatalog.GetString ("Authors"), GettextCatalog.GetString ("Shows the authors of the current file"));
-			logView = await TryAttachView (mainView, vcInfo, LogCommand.LogViewHandlers, GettextCatalog.GetString ("Log"), GettextCatalog.GetString ("Shows the source control log for the current file"));
-			mergeView = await TryAttachView (mainView, vcInfo, MergeCommand.MergeViewHandlers, GettextCatalog.GetString ("Merge"), GettextCatalog.GetString ("Shows the merge view for the current file"));
+			await UpdateSubviewsAsync ();
+			VersionControlService.FileStatusChanged += VersionControlService_FileStatusChanged;
 			return mainView;
+		}
+
+		public override void Dispose ()
+		{
+			VersionControlService.FileStatusChanged -= VersionControlService_FileStatusChanged;
+			base.Dispose ();
+			mainView = null;
+			vcInfo = null;
+		}
+
+		void VersionControlService_FileStatusChanged (object sender, FileUpdateEventArgs args)
+		{
+			var controller = (FileDocumentController)Controller;
+			foreach (var file in args) {
+				if (!controller.FilePath.IsNullOrEmpty && controller.FilePath.Equals (file.FilePath)) {
+					Runtime.RunInMainThread (async () => {
+						await UpdateSubviewsAsync ();
+					}).Ignore();
+				}
+			}
+		}
+
+		bool showSubviews;
+		async Task UpdateSubviewsAsync ()
+		{
+			var controller = (FileDocumentController)Controller;
+			var hasVersionInfo = repo.TryGetVersionInfo (controller.FilePath, out var info);
+			if (hasVersionInfo)
+				vcInfo.Item.VersionInfo = info;
+
+			if (!hasVersionInfo || !info.IsVersioned) {
+				if (!showSubviews)
+					return;
+				showSubviews = false;
+				if (diffView != null) {
+					mainView.AttachedViews.Remove (diffView);
+					diffView.Dispose ();
+					diffView = null;
+				}
+
+				if (blameView != null) {
+					mainView.AttachedViews.Remove (blameView);
+					blameView.Dispose ();
+					blameView = null;
+				}
+
+				if (logView != null) {
+					mainView.AttachedViews.Remove (logView);
+					logView.Dispose ();
+					logView = null;
+				}
+
+				if (mergeView != null) {
+					mainView.AttachedViews.Remove (mergeView);
+					mergeView.Dispose ();
+					mergeView = null;
+				}
+			} else {
+				if (showSubviews)
+					return;
+				showSubviews = true;
+				diffView = await TryAttachView (mainView, vcInfo, DiffCommand.DiffViewHandlers, GettextCatalog.GetString ("Changes"), GettextCatalog.GetString ("Shows the differences in the code between the current code and the version in the repository"));
+				blameView = await TryAttachView (mainView, vcInfo, BlameCommand.BlameViewHandlers, GettextCatalog.GetString ("Authors"), GettextCatalog.GetString ("Shows the authors of the current file"));
+				logView = await TryAttachView (mainView, vcInfo, LogCommand.LogViewHandlers, GettextCatalog.GetString ("Log"), GettextCatalog.GetString ("Shows the source control log for the current file"));
+				mergeView = await TryAttachView (mainView, vcInfo, MergeCommand.MergeViewHandlers, GettextCatalog.GetString ("Merge"), GettextCatalog.GetString ("Shows the merge view for the current file"));
+			}
 		}
 
 		async Task<DocumentView> TryAttachView (DocumentView mainView, VersionControlDocumentInfo info, string type, string title, string description)
@@ -108,35 +173,41 @@ namespace MonoDevelop.VersionControl
 
 		internal void ShowDiffView (Revision originalRevision = null, Revision diffRevision = null, int line = -1)
 		{
-			if (originalRevision != null && diffRevision != null && diffView?.SourceController is DiffView content) {
-				content.ComparisonWidget.info.RunAfterUpdate (delegate {
-					content.ComparisonWidget.SetRevision (content.ComparisonWidget.DiffEditor, diffRevision);
-					content.ComparisonWidget.SetRevision (content.ComparisonWidget.OriginalEditor, originalRevision);
-					if (line != -1) {
-						content.ComparisonWidget.DiffEditor.Caret.Location = new Ide.Editor.DocumentLocation (line, 1);
-						content.ComparisonWidget.DiffEditor.CenterToCaret ();
-					}
-				});
+			if (diffView != null) {
+				if (originalRevision != null && diffRevision != null && diffView.SourceController is DiffView content) {
+					content.ComparisonWidget.info.RunAfterUpdate (delegate {
+						content.ComparisonWidget.SetRevision (content.ComparisonWidget.DiffEditor, diffRevision);
+						content.ComparisonWidget.SetRevision (content.ComparisonWidget.OriginalEditor, originalRevision);
+						if (line != -1) {
+							content.ComparisonWidget.DiffEditor.Caret.Location = new Ide.Editor.DocumentLocation (line, 1);
+							content.ComparisonWidget.DiffEditor.CenterToCaret ();
+						}
+					});
+				}
+				diffView.SetActive ();
 			}
-			diffView?.SetActive ();
 		}
 
 		internal void ShowBlameView ()
 		{
-			blameView?.SetActive ();
+			if (blameView != null)
+				blameView.SetActive ();
 		}
 
 		internal void ShowLogView (Revision revision = null)
 		{
-			if (revision != null && diffView?.SourceController is LogView content)
-				content.LogWidget.SelectedRevision = revision;
+			if (logView != null) {
+				if (revision != null && logView.SourceController is LogView content)
+					content.LogWidget.SelectedRevision = revision;
 
-			logView?.SetActive ();
+				logView.SetActive ();
+			}
 		}
 
 		internal void ShowMergeView ()
 		{
-			mergeView?.SetActive ();
+			if (mergeView != null)
+				mergeView.SetActive ();
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -363,6 +363,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 			mainShellView.LostFocus += ShellContentView_LostFocus;
 			if (IsRoot && AttachedViews.Count > 0) {
 				CreateAttachmentsContainer ();
+				InitializeAttachmentsContainer ();
 			} else
 				shellView = mainShellView;
 
@@ -382,12 +383,16 @@ namespace MonoDevelop.Ide.Gui.Documents
 			int pos = 1;
 			foreach (var attachedView in AttachedViews)
 				attachmentsContainer.InsertView (pos++, attachedView.CreateShellView (window));
+			shellView = attachmentsContainer;
+		}
+
+		private void InitializeAttachmentsContainer ()
+		{
 			if (activeAttachedView == this)
 				attachmentsContainer.ActiveView = mainShellView;
 			else
 				attachmentsContainer.ActiveView = activeAttachedView?.ShellView;
 			attachmentsContainer.ActiveViewChanged += AttachmentsContainer_ActiveViewChanged;
-			shellView = attachmentsContainer;
 		}
 
 		private void ShellContentView_GotFocus (object sender, EventArgs e)
@@ -448,6 +453,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 					CreateAttachmentsContainer ();
 					UpdateTitle ();
 					ReplaceViewInParent ();
+					InitializeAttachmentsContainer ();
 				}
 			} else {
 				if (attachmentsContainer != null) {


### PR DESCRIPTION
Merged back the code that updates the version control tabs when the status of a
file changes.  That code was reverted because it caused VSTS 977977, but this PR
fixes the bug that the old PR introduced.

When a controller is being initialized, the Document property may not yet be
set. This happens for example, when a designer view creates an editor view on
its own to be added to a container together with the designer. In that scenario,
the editor view is created and fully initialized before it is added to the
document. The old implementation of VersionControlDocumentController relied on
the Document property to initialize VersionControlDocumentInfo.Document, and
that was used later to get the file name. Instead, now it gets the file name
directly from the controller.

There are other classes that use the VersionControlDocumentInfo.Document
property, but they do it after the view is initialized and added to a document.
To make sure that property returns a valid document, it now returns the document
directly from the controller.

Also removed the use of weak references for the attached views. The references
should go away together with the extension object.

Fixes VSTS #978932

Backport of https://github.com/mono/monodevelop/pull/8698