### PR TITLE
[GlobalSearch] Fixes flickering catching results from providers in UI thread

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -467,7 +467,7 @@ namespace MonoDevelop.Components.MainToolbar
 					processingTasks++;
 
 					//this is the
-					var currentThreadId = current++;
+					var localCurrent = current++;
 
 					//if cancellation is requested nothing more to do
 					if (token.IsCancellationRequested || colTask.IsCanceled) {
@@ -503,7 +503,7 @@ namespace MonoDevelop.Components.MainToolbar
 						}
 					}
 
-					if (currentThreadId == total) {
+					if (localCurrent == total) {
 						isInSearch = false;
 					}
 
@@ -515,7 +515,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 						newResults.Remove (newResults.FirstOrDefault (s => s.Item1 == searchProvidersCategory));
 
-						if (currentThreadId < total) {
+						if (localCurrent < total) {
 							indexToInsert = GetIndexFromCategory (newResults, searchProvidersCategory);
 							newResults.Insert (indexToInsert, new Tuple<SearchCategory, IReadOnlyList<SearchResult>> (searchProvidersCategory, searchProvidersCategory.Values));
 						}


### PR DESCRIPTION
It seems the GlobalSearch was giving some unexpected behaviour obtaining the results from current search providers and also giving some issues modifying collections on quick typing.

To fix this, I needed to change some logic of the current code when each provider has finished before draw the results. Now  all of this is handled from the UIThread and we draw all the records we receive at once, so we fix the flickering problem.

Fixes #972204 - Too much flickering while typing in searchbar 
Fixes #982384 - [Shell] Silent Index was out of range in log, writing fast in the global search

![flick](https://user-images.githubusercontent.com/1587480/64825327-2e125780-d5bd-11e9-9433-530ad97bea1a.gif)
