### PR TITLE
Enable FileNesting support on Razor Class Library projects

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/AspNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/AspNetCoreProjectTests.cs
@@ -115,6 +115,15 @@ namespace MonoDevelop.AspNetCore.Tests
 		}
 
 		[Test]
+		public async Task RazorClassLib_Supports_FileNesting ()
+		{
+			string projectFileName = Util.GetSampleProject ("aspnetcore-razor-class-lib", "aspnetcore-razor-class-lib.csproj");
+			using (var project = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFileName)) {
+				Assert.True (FileNestingService.IsEnabledForProject (project));
+			}
+		}
+
+		[Test]
 		public async Task MultiTargetFrameworks_ExecutionTargets ()
 		{
 			string solutionFileName = Util.GetSampleProject ("aspnetcore-multi-target-execution", "aspnetcore-multi-target.sln");

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreNestingRulesProvider.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreNestingRulesProvider.cs
@@ -42,7 +42,9 @@ namespace MonoDevelop.AspNetCore
 		public override bool AppliesToProject (Project project)
 		{
 			var dotnetProj = project as DotNetProject;
-			return dotnetProj != null && dotnetProj.ProjectProperties.HasProperty ("UsingMicrosoftNETSdkWeb");
+			return dotnetProj != null &&
+				(dotnetProj.ProjectProperties.HasProperty ("UsingMicrosoftNETSdkWeb") ||
+				 dotnetProj.ProjectProperties.HasProperty ("RazorTargetName"));
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/977852

The current logic which determines whether FileNesting is enabled checks for the existence of the UsingMicrosoftNETSdkWeb project property.
This isn't set in a Razor Class Library project, so we also look for the RazorTargetName property which is always set in this project type (see https://docs.microsoft.com/en-us/aspnet/core/razor-pages/sdk?view=aspnetcore-2.2)