### PR TITLE
[release-8.3] Parse revision number out of .NET Core SDK preview version

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreVersionTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreVersionTests.cs
@@ -299,5 +299,26 @@ namespace MonoDevelop.DotNetCore.Tests
 			var result = DotNetCoreVersion.IsSdkSupported (dotnetCoreVersion);
 			Assert.True (result == isSupported);
 		}
+
+		[TestCase ("3.0.100", 0)]
+		[TestCase ("3.0.100-preview-010184", 10184)]
+		[TestCase ("3.0.100-preview3-010431", 10431)]
+		[TestCase ("3.0.100-preview3-010431-22", 10431)]
+		public void ParseRevisionNumber(string version, long expected)
+		{
+			var dotNetCoreVersion = DotNetCoreVersion.Parse (version);
+			Assert.That (dotNetCoreVersion.Revision, Is.EqualTo (expected));
+		}
+
+		[TestCase ("3.0.100", 300100999999)]
+		[TestCase ("3.0.100-preview-010184", 300100010184)]
+		[TestCase ("3.0.100-preview3-010431", 300100010431)]
+		[TestCase ("3.0.100-preview3-010431-22", 300100010431)]
+		public void GetVersionId (string version, long expected)
+		{
+			var dotNetCoreVersion = DotNetCoreVersion.Parse (version);
+			var versionId = DotNetCoreSystemInformation.GenerateVersionId (dotNetCoreVersion);
+			Assert.That (versionId, Is.EqualTo (expected));
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
@@ -106,7 +106,7 @@ namespace MonoDevelop.DotNetCore
 				versionString = input.Substring (0, prereleaseLabelStart);
 				releaseLabel = input.Substring (prereleaseLabelStart + 1);
 				int revisionLabelStart = input.IndexOf ('-', prereleaseLabelStart + 1) + 1;
-				if(revisionLabelStart >= 0) {
+				if (revisionLabelStart > 0) {
 					int revisionLabelEnd = input.IndexOf ('-', revisionLabelStart);
 					string revisionString;
 					if (revisionLabelEnd < 0) {
@@ -114,7 +114,7 @@ namespace MonoDevelop.DotNetCore
 					} else {
 						revisionString = input.Substring (revisionLabelStart, revisionLabelEnd - revisionLabelStart);
 					}
-					if(!int.TryParse (revisionString , out revision)) {
+					if (!int.TryParse (revisionString , out revision)) {
 						throw new FormatException (string.Format ("Invalid .NET Core version: '{0}'", input));
 					}
 				}

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
@@ -59,6 +59,9 @@ namespace MonoDevelop.DotNetCore
 
 		public int Patch => Version.Build;
 
+		// Used by UpdaterService to generate VersionId
+		public int Revision { get; private set; }
+
 		public string OriginalString { get; private set; }
 
 		public bool IsPrerelease { get; private set; }
@@ -97,11 +100,24 @@ namespace MonoDevelop.DotNetCore
 
 			string versionString = input;
 			string releaseLabel = string.Empty;
-
+			int revision = 0;
 			int prereleaseLabelStart = input.IndexOf ('-');
 			if (prereleaseLabelStart >= 0) {
 				versionString = input.Substring (0, prereleaseLabelStart);
 				releaseLabel = input.Substring (prereleaseLabelStart + 1);
+				int revisionLabelStart = input.IndexOf ('-', prereleaseLabelStart + 1) + 1;
+				if(revisionLabelStart >= 0) {
+					int revisionLabelEnd = input.IndexOf ('-', revisionLabelStart);
+					string revisionString;
+					if (revisionLabelEnd < 0) {
+						revisionString = input.Substring (revisionLabelStart);
+					} else {
+						revisionString = input.Substring (revisionLabelStart, revisionLabelEnd - revisionLabelStart);
+					}
+					if(!int.TryParse (revisionString , out revision)) {
+						throw new FormatException (string.Format ("Invalid .NET Core version: '{0}'", input));
+					}
+				}
 			}
 
 			if (!Version.TryParse (versionString, out var version))
@@ -110,6 +126,7 @@ namespace MonoDevelop.DotNetCore
 			result = new DotNetCoreVersion (version) {
 				OriginalString = input,
 				IsPrerelease = prereleaseLabelStart >= 0,
+				Revision = revision,
 				ReleaseLabel = releaseLabel
 			};
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/981132

Backport of #8705.

/cc @nosami 