### PR TITLE
[release-8.3] Editor: Remove bold from CSS elements for most themes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/FallbackStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/FallbackStyle.json
@@ -232,12 +232,12 @@
 		{ "name": "Preview Diff Removed Line", "fore": "#a14d4d", "back": "#fcf8f8" },
 		{ "name": "Preview Diff Added Line", "fore": "#419b41", "back": "#edf8ed" },
 
-		{ "name": "Css Comment", "fore": "comment-gray", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "text-black", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "literal-orange", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "comment-gray", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "literal-orange", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "keyword-teal", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "comment-gray" },
+		{ "name": "Css Property Name", "fore": "text-black" },
+		{ "name": "Css Property Value", "fore": "literal-orange" },
+		{ "name": "Css Selector", "fore": "comment-gray" },
+		{ "name": "Css String Value", "fore": "literal-orange" },
+		{ "name": "Css Keyword", "fore": "keyword-teal" },
 
 		{ "name": "Script Comment", "fore": "comment-gray" },
 		{ "name": "Script Identifier" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/GruvboxStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/GruvboxStyle.json
@@ -219,12 +219,12 @@
 		{ "name": "Preview Diff Removed Line", "fore": "#5c2c2c", "back": "#dcb4b4" },
 		{ "name": "Preview Diff Added Line", "fore": "#235423", "back": "#a4d9a4" },
 
-		{ "name": "Css Comment", "fore": "comment", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "foreground", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "bright-green", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "comment", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "literal-orange", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "bright-red", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "comment" },
+		{ "name": "Css Property Name", "fore": "foreground" },
+		{ "name": "Css Property Value", "fore": "bright-green" },
+		{ "name": "Css Selector", "fore": "comment" },
+		{ "name": "Css String Value", "fore": "literal-orange" },
+		{ "name": "Css Keyword", "fore": "bright-red" },
 
 		{ "name": "Script Comment", "fore": "comment" },
 		{ "name": "Script Keyword", "fore": "bright-red" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/MonokaiStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/MonokaiStyle.json
@@ -231,11 +231,11 @@
 		{ "name": "Preview Diff Removed Line", "fore": "#5c2c2c", "back": "#dcb4b4" },
 		{ "name": "Preview Diff Added Line", "fore": "#235423", "back": "#a4d9a4" },
 
-		{ "name": "Css Comment", "fore": "monokai-comment", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "monokai-white", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "monokai-string", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "monokai-comment", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "monokai-keyword", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "monokai-comment" },
+		{ "name": "Css Property Name", "fore": "monokai-white" },
+		{ "name": "Css Property Value", "fore": "monokai-string" },
+		{ "name": "Css Selector", "fore": "monokai-comment" },
+		{ "name": "Css Keyword", "fore": "monokai-keyword" },
 
 		{ "name": "Script Comment", "fore": "monokai-comment" },
 		{ "name": "Script Keyword", "fore": "monokai-keyword" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/NightshadeStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/NightshadeStyle.json
@@ -244,12 +244,12 @@
 		{ "name": "Preview Diff Removed Line", "fore": "#5c2c2c", "back": "#dcb4b4" },
 		{ "name": "Preview Diff Added Line", "fore": "#235423", "back": "#a4d9a4" },
 
-		{ "name": "Css Comment", "fore": "CommentVim", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "NormalVim", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "StringVim", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "CommentVim", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "StringVim", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "StatementVim", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "CommentVim" },
+		{ "name": "Css Property Name", "fore": "NormalVim" },
+		{ "name": "Css Property Value", "fore": "StringVim" },
+		{ "name": "Css Selector", "fore": "CommentVim" },
+		{ "name": "Css String Value", "fore": "StringVim" },
+		{ "name": "Css Keyword", "fore": "StatementVim" },
 
 		{ "name": "Script Comment", "fore": "CommentVim" },
 		{ "name": "Script Keyword", "fore": "StatementVim" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/OblivionStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/OblivionStyle.json
@@ -235,12 +235,12 @@
 		{ "name": "Preview Diff Removed Line", "fore": "#5c2c2c", "back": "#dcb4b4" },
 		{ "name": "Preview Diff Added Line", "fore": "#235423", "back": "#a4d9a4" },
 
-		{ "name": "Css Comment", "fore": "aluminium4", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "aluminium2", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "butter2", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "aluminium2", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "butter2", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "plum1", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "aluminium4" },
+		{ "name": "Css Property Name", "fore": "aluminium2" },
+		{ "name": "Css Property Value", "fore": "butter2" },
+		{ "name": "Css Selector", "fore": "aluminium2" },
+		{ "name": "Css String Value", "fore": "butter2" },
+		{ "name": "Css Keyword", "fore": "plum1" },
 
 		{ "name": "Script Comment", "fore": "aluminium4" },
 		{ "name": "Script Keyword", "fore": "plum1" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedDarkStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedDarkStyle.json
@@ -226,12 +226,12 @@
 		{ "name": "Diff Header(New)", "fore": "Blue", "weight": "bold" },
 		{ "name": "Diff Location", "fore": "Magenta", "weight": "bold" },
 
-		{ "name": "Css Comment", "fore": "base01", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "base00", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "cyan", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "base01", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "cyan", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "keyword-teal", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "base01" },
+		{ "name": "Css Property Name", "fore": "base00" },
+		{ "name": "Css Property Value", "fore": "cyan" },
+		{ "name": "Css Selector", "fore": "base01" },
+		{ "name": "Css String Value", "fore": "cyan" },
+		{ "name": "Css Keyword", "fore": "keyword-teal" },
 
 		{ "name": "Script Comment", "fore": "base01" },
 		{ "name": "Script Keyword", "fore": "green" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedLightStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/SolarizedLightStyle.json
@@ -72,7 +72,7 @@
 		{ "name": "Primary Link(Highlighted)", "color": "base02", "secondcolor": "base02" },
 		{ "name": "Secondary Link", "color": "base2", "secondcolor": "base2" },
 		{ "name": "Secondary Link(Highlighted)", "color": "base2", "secondcolor": "base2" },
-		
+
 		{ "name": "Message Bubble Error Marker", "color": "#b28d37" },
 		{ "name": "Message Bubble Error Tag", "color": "#e3a6a1", "secondcolor": "black" },
 		{ "name": "Message Bubble Error Counter", "color": "black", "secondcolor": "#e3a6a1" },
@@ -204,11 +204,11 @@
 		{ "name": "Diff Header(New)", "fore": "Blue", "weight": "bold" },
 		{ "name": "Diff Location", "fore": "Magenta", "weight": "bold" },
 
-		{ "name": "Css Comment", "fore": "base01", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "black", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "cyan", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "base01", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "cyan", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "base01" },
+		{ "name": "Css Property Name", "fore": "black" },
+		{ "name": "Css Property Value", "fore": "cyan" },
+		{ "name": "Css Selector", "fore": "base01" },
+		{ "name": "Css String Value", "fore": "cyan" },
 
 		{ "name": "Script Comment", "fore": "base01" },
 		{ "name": "Script Keyword", "fore": "green" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/TangoStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/TangoStyle.json
@@ -119,8 +119,8 @@
 
 		{ "name": "String Format Items", "fore": "chocolate2" },
 
-		{ "name": "Css Comment", "fore": "aluminium3", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "chameleon3", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "aluminium3" },
+		{ "name": "Css Selector", "fore": "chameleon3" },
 
 		{ "name": "Script Comment", "fore": "aluminium3" },
 		{ "name": "Script Keyword", "fore": "skyblue2" },

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
@@ -102,12 +102,12 @@
 
 		{ "name": "Debugger Current Statement", "fore": "#000000", "back": "#FFEE61" },
 
-		{ "name": "Css Comment", "fore": "#006400", "weight": "bold" },
-		{ "name": "Css Property Name", "fore": "#FF0000", "weight": "bold" },
-		{ "name": "Css Property Value", "fore": "keyword-blue", "weight": "bold" },
-		{ "name": "Css Selector", "fore": "#800000", "weight": "bold" },
-		{ "name": "Css String Value", "fore": "keyword-blue", "weight": "bold" },
-		{ "name": "Css Keyword", "fore": "keyword-blue", "weight": "bold" },
+		{ "name": "Css Comment", "fore": "#006400" },
+		{ "name": "Css Property Name", "fore": "#FF0000" },
+		{ "name": "Css Property Value", "fore": "keyword-blue" },
+		{ "name": "Css Selector", "fore": "#800000" },
+		{ "name": "Css String Value", "fore": "keyword-blue" },
+		{ "name": "Css Keyword", "fore": "keyword-blue" },
 
 		{ "name": "Script Comment", "fore": "comment-green" },
 		{ "name": "Script Keyword", "fore": "keyword-blue" },


### PR DESCRIPTION
Leave high contrast themes alone.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/982109

Backport of #8713.

/cc @sandyarmstrong 