### PR TITLE
[release-8.3] Fixes a System.AggregateException trying opening HexEditor document

### DIFF
--- a/main/src/addins/MonoDevelop.HexEditor/Mono.MHex.Data/ByteBufferModel.cs
+++ b/main/src/addins/MonoDevelop.HexEditor/Mono.MHex.Data/ByteBufferModel.cs
@@ -60,7 +60,7 @@ namespace Mono.MHex.Data
 			{
 				byteBuffer = new ByteBuffer ();
 				byteBuffer.Replaced += ByteBuffer_Replaced;
-				using (var stream = File.OpenRead (FilePath)) {
+				using (var stream = new FileStream (FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 1024, true)) {
 					byteBuffer.Buffer = await ArrayBuffer.LoadAsync (stream);
 				}
 			}


### PR DESCRIPTION
This fix introduces a change in our implementation to get a file stream for the HexEditor, because mono has an issue in FileStream implementation with the SynchronizationContext

![flick](https://user-images.githubusercontent.com/1587480/64827082-3c637200-d5c3-11e9-8eb3-efaed24937d2.gif)

This does not solve the mono problem, but with the Hexadecimal Editor

Fixes VSTS #978857 - [HexEditor] View failed to load. System.AggregateException:EnsureUIThread


Backport of #8715.

/cc @slluis @netonjm