### PR TITLE
[release-8.3] Enable Browser Selection on Publish Part 1

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreExecutionTarget.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreExecutionTarget.cs
@@ -30,7 +30,7 @@ using MonoDevelop.Ide.Gui;
 
 namespace MonoDevelop.AspNetCore
 {
-	class AspNetCoreExecutionTarget : ExecutionTarget
+	public class AspNetCoreExecutionTarget : ExecutionTarget
 	{
 		internal AspNetCoreExecutionTarget (DesktopApplication desktopApplication)
 		{


### PR DESCRIPTION
Make AspNetCoreExecutionTarget public so that we can determine the active execution target and hence preferred browser from external code

Backport of #8725.

/cc @iantoalms 