### PR TITLE
[release-8.3] [AspNetCore] Fix Razor Class Lib file nesting test

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/AspNetCoreProjectTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/AspNetCoreProjectTests.cs
@@ -119,7 +119,7 @@ namespace MonoDevelop.AspNetCore.Tests
 		{
 			string projectFileName = Util.GetSampleProject ("aspnetcore-razor-class-lib", "aspnetcore-razor-class-lib.csproj");
 			using (var project = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFileName)) {
-				Assert.True (FileNestingService.IsEnabledForProject (project));
+				Assert.True (FileNestingService.AppliesToProject (project));
 			}
 		}
 


### PR DESCRIPTION
It should be testing if file nesting applies to a Razor Class library
project, not if it is enabled, which is always true unless explicitly
disabled.

Backport of #8729.

/cc @rodrmoya 