### PR TITLE
TextViewContent: Add ShouldHandleTextViewCommands

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
@@ -236,6 +236,9 @@ namespace MonoDevelop.TextEditor
 			}
 		}
 
+		protected override bool ShouldHandleTextViewCommands ()
+			=> textViewHost != null && !textViewHost.MarginViewElementHasInputFocus;
+
 		protected override void InstallAdditionalEditorOperationsCommands ()
 		{
 			base.InstallAdditionalEditorOperationsCommands ();

--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
@@ -198,6 +198,8 @@ namespace MonoDevelop.TextEditor
 			"MonoDevelop.Ide.Commands.TextEditorCommands.RotatePrimaryCaretPrevious"
 		};
 
+		protected virtual bool ShouldHandleTextViewCommands () => true;
+
 		bool CanHandleCommand (object commandId)
 		{
 			// check TextView for null because of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/890051
@@ -208,7 +210,7 @@ namespace MonoDevelop.TextEditor
 				}
 			}
 
-			return true;
+			return ShouldHandleTextViewCommands ();
 		}
 
 		ICommandHandler ICustomCommandTarget.GetCommandHandler (object commandId)


### PR DESCRIPTION
Provides a way to indicate that due to some other view component having
input focus, the text view should not be handling commands.