### PR TITLE
TextViewContent: Only handle commands if text view has keyboard focus

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor/TextViewContent.Commands.cs
@@ -207,6 +207,10 @@ namespace MonoDevelop.TextEditor
 					return commandsSupportedWhenFindPresenterIsFocused.Contains (commandId);
 				}
 			}
+#if !WINDOWS
+			if (TextView is ITextView3 textView3)
+				return textView3.IsKeyboardFocused;
+#endif
 
 			return true;
 		}


### PR DESCRIPTION
Allows various keyboard commands to continue working if, for example,
an editor margin contains a view that accepts input.