### PR TITLE
[AutoTest] NSObjectResult: Check for null runtimeName is added

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -378,9 +378,11 @@ namespace MonoDevelop.Components.AutoTest.Results
 				if (string.IsNullOrEmpty (runtimeName))
 					return false;
 
-				if (mutableModel.FullDisplayString.Contains (runtimeName) || mutableModel.DisplayString.Contains (runtimeName))
+				if (!string.IsNullOrWhiteSpace(mutableModel.FullDisplayString) && mutableModel.FullDisplayString.Contains (runtimeName))
 					return true;
-			
+				if (!string.IsNullOrWhiteSpace(mutableModel.DisplayString) && mutableModel.DisplayString.Contains (runtimeName))
+					return true;
+
 				var execTargetPInfo = r.GetType().GetProperty ("ExecutionTarget");
 				if(execTargetPInfo != null) {
 					if (execTargetPInfo.GetValue (r) is Core.Execution.ExecutionTarget execTarget) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.AutoTest.Results/NSObjectResult.cs
@@ -374,10 +374,13 @@ namespace MonoDevelop.Components.AutoTest.Results
 			var runtime = model.FirstOrDefault (r => {
 				var mutableModel = r.GetMutableModel ();
 				LoggingService.LogDebug ($"[IRuntimeModel.IRuntimeMutableModel] FullDisplayString: '{mutableModel.FullDisplayString}' | DisplayString: '{mutableModel.DisplayString}'");
-				if (mutableModel.FullDisplayString.Contains (runtimeName))
+
+				if (string.IsNullOrEmpty (runtimeName))
+					return false;
+
+				if (mutableModel.FullDisplayString.Contains (runtimeName) || mutableModel.DisplayString.Contains (runtimeName))
 					return true;
-				if (mutableModel.DisplayString.Contains (runtimeName))
-					return true;
+			
 				var execTargetPInfo = r.GetType().GetProperty ("ExecutionTarget");
 				if(execTargetPInfo != null) {
 					if (execTargetPInfo.GetValue (r) is Core.Execution.ExecutionTarget execTarget) {


### PR DESCRIPTION
[Bug 983495:](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/983495) ArgumentNullException is triggered in NSObjectResult on Active Runtime selection in Autotest