### PR TITLE
Break back compat of version control add-in

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/AddinInfo.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/AddinInfo.cs
@@ -6,6 +6,7 @@ using Mono.Addins.Description;
 [assembly:Addin ("VersionControl", 
 	Namespace = "MonoDevelop",
 	Version = MonoDevelop.BuildInfo.Version,
+	CompatVersion = "8.3",
 	Category = "Version Control")]
 
 [assembly:AddinName ("Version Control Support")]


### PR DESCRIPTION
Version control api has changed. This will prevent the load of version control extensions targeting old versions of the IDE.