### PR TITLE
[Git] Fix FileService discarding events due to imbalanced freeze/thaw

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1509,7 +1509,7 @@ namespace MonoDevelop.Ide.TypeSystem
 										ProjectInfo newProjectContents = t.Result;
 										newProjectContents = AddVirtualDocuments (newProjectContents);
 										OnProjectReloaded (newProjectContents);
-										foreach (var docId in GetOpenDocumentIds (newProjectContents.Id)) {
+										foreach (var docId in GetOpenDocumentIds (newProjectContents.Id).ToArray ()) {
 											if (CurrentSolution.GetDocument (docId) == null) {
 												ClearOpenDocument (docId);
 											}


### PR DESCRIPTION
Fixes VSTS #983894 - Switching branches doesn't respect target framework changes
Fixes VSTS #984213 - FileWatcher sometimes stops raising events, causing files to stop reloading when external changes occur