### PR TITLE
Fixes redundant string copying in msbuild evaluation

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -743,6 +743,7 @@
     <Compile Include="MonoDevelop.Core.Execution\TargetFrameworkExecutionTarget.cs" />
     <Compile Include="MonoDevelop.Projects\FrameworkReference.cs" />
     <Compile Include="MonoDevelop.Core\DedicatedThreadScheduler.cs" />
+    <Compile Include="MonoDevelop.Projects.MSBuild\IntrinsicFunctions.Extensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="BuildVariables.cs.in" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IntrinsicFunctions.Extensions.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IntrinsicFunctions.Extensions.cs
@@ -1,0 +1,35 @@
+//
+// IntrinsicFunctions.Extensions.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace Microsoft.Build.Evaluation
+{
+	internal static partial class IntrinsicFunctions
+	{
+		// Similar to https://github.com/microsoft/msbuild/pull/4731
+		// This avoids creating a string copy for the purpose of evaluation in metadata items.
+		internal static string Copy (string value) => value;
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IntrinsicFunctions.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IntrinsicFunctions.cs
@@ -29,14 +29,6 @@ namespace Microsoft.Build.Evaluation
 	/// </summary>
 	internal static partial class IntrinsicFunctions
 	{
-		private static Lazy<string> _validOsPlatforms = new Lazy<string> (
-			() => typeof (OSPlatform).GetTypeInfo ()
-				.GetProperties (BindingFlags.Static | BindingFlags.Public)
-				.Where (pi => pi.PropertyType == typeof (OSPlatform))
-				.Select (pi => pi.Name)
-				.Aggregate ("", (a, b) => string.IsNullOrEmpty (a) ? b : $"{a}, {b}"),
-			true);
-
 		/// <summary>
 		/// Add two doubles
 		/// </summary>

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IntrinsicFunctions.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/IntrinsicFunctions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Evaluation
 	/// The Intrinsic class provides static methods that can be accessed from MSBuild's
 	/// property functions using $([MSBuild]::Function(x,y))
 	/// </summary>
-	internal static class IntrinsicFunctions
+	internal static partial class IntrinsicFunctions
 	{
 		private static Lazy<string> _validOsPlatforms = new Lazy<string> (
 			() => typeof (OSPlatform).GetTypeInfo ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -1016,10 +1016,16 @@ namespace MonoDevelop.Projects.MSBuild
 
 		MemberInfo[] ResolveMember (Type type, string memberName, bool isStatic, MemberTypes memberTypes)
 		{
-			if (type == typeof (string) && memberName == "new")
-				memberName = "Copy";
-			if (type.IsArray)
-				type = typeof (Array);
+			if (type == typeof (string)) {
+				if (memberName == "new" || memberName == "Copy") {
+					type = typeof (IntrinsicFunctions);
+					memberName = "Copy";
+				}
+			} else {
+				if (type.IsArray)
+					type = typeof (Array);
+			}
+
 			var flags = isStatic ? BindingFlags.Static : BindingFlags.Instance;
 			if (type != typeof (Microsoft.Build.Evaluation.IntrinsicFunctions)) {
 				if (!supportedTypeMembers.TryGetValue (type, out var list))

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="MonoDevelop.Projects\FileWatcherServiceTests.cs" />
     <Compile Include="MonoDevelop.Projects\FileWatcherTestBase.cs" />
     <Compile Include="MonoDevelop.Core\DedicatedThreadSchedulerTests.cs" />
+    <Compile Include="MonoDevelop.Projects\IntrinsicFunctionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/IntrinsicFunctionsTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/IntrinsicFunctionsTests.cs
@@ -1,0 +1,50 @@
+//
+// IntrinsicFunctionsTests.cs
+//
+// Author:
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Evaluation;
+using NUnit.Framework;
+
+namespace MonoDevelop.Projects
+{
+	[TestFixture]
+	public class IntrinsicFunctionsTests
+	{
+		[Test]
+		public void TypeContainsOnlyMethods()
+		{
+			// MSBuildEvaluationContext.cachedIntrinsicFunctions only caches methods and code path only takes that into account
+			foreach (var member in typeof(IntrinsicFunctions).GetMembers(BindingFlags.NonPublic | BindingFlags.Static)) {
+				// Skip compiler generated code, such as lambda classes
+				if (member.IsDefined (typeof (CompilerGeneratedAttribute)))
+					continue;
+
+				Assert.AreEqual (MemberTypes.Method, member.MemberType);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes VSTS #984689 - String::Copy creates a string copy, while msbuild doesn't

Also add a cache for IntrinsicFunctions so we don't fall-back to the slow reflection based mechanism.