### PR TITLE
[F#] Fix LanguageService exception

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/FileService.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/Services/FileService.fs
@@ -16,8 +16,11 @@ type FileSystem (defaultFileSystem : IFileSystem, openDocuments: unit -> Documen
     let getOpenDocContent (filename: string) =
         match getOpenDoc filename with
         | Some d ->
-           let bytes = System.Text.Encoding.UTF8.GetBytes (d.Editor.Text)
-           Some bytes
+           match d.Editor with
+           | null -> None
+           | editor ->
+               let bytes = System.Text.Encoding.UTF8.GetBytes (editor.Text)
+               Some bytes
         | _ -> None
 
     static member IsAScript fileName =


### PR DESCRIPTION
Sometimes the Document.Editor property was null which caused
the whole project to not get parsed

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/984699