### PR TITLE
Fix attachment view display issue

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentView.cs
@@ -379,11 +379,22 @@ namespace MonoDevelop.Ide.Gui.Documents
 			attachmentsContainer = window.CreateViewContainer ();
 			attachmentsContainer.SetSupportedModes (DocumentViewContainerMode.Tabs);
 			attachmentsContainer.CurrentMode = DocumentViewContainerMode.Tabs;
+
+			bool mainViewVisible = shellView == mainShellView;
+			shellView = attachmentsContainer;
+
+			if (mainViewVisible) {
+				// If the shell view is already set it is likely it has already been added to a container
+				// In that case we need the attachemnts container to replace it, so that the view can
+				// be added to the attachments container
+				ReplaceViewInParent ();
+			}
+
 			attachmentsContainer.InsertView (0, mainShellView);
+
 			int pos = 1;
 			foreach (var attachedView in AttachedViews)
 				attachmentsContainer.InsertView (pos++, attachedView.CreateShellView (window));
-			shellView = attachmentsContainer;
 		}
 
 		private void InitializeAttachmentsContainer ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewItem.cs
@@ -44,6 +44,7 @@ namespace MonoDevelop.Ide.Gui.Shell
 		object delegatedCommandTarget;
 		Task loadTask;
 		bool subscribedWindowsEvents;
+		bool destroyed;
 
 		public GtkShellDocumentViewItem ()
 		{
@@ -78,13 +79,16 @@ namespace MonoDevelop.Ide.Gui.Shell
 			Application.Invoke ((s,a) => {
 				// Don't execute Load inside the OnRealized handler, since Load can trigger events or async continuations that
 				// can end having an effect on the current widget, and that may cause weird behaviors of GTK.
-				Load ().Ignore ();
-				SubscribeWindowEvents ();
+				if (!destroyed) {
+					Load ().Ignore ();
+					SubscribeWindowEvents ();
+				}
 			});
 		}
 
 		protected override void OnDestroyed ()
 		{
+			destroyed = true;
 			cancellationTokenSource.Cancel ();
 
 			focusLostTimeout?.Dispose ();
@@ -179,7 +183,8 @@ namespace MonoDevelop.Ide.Gui.Shell
 
 				if (focusLostTimeout == null) {
 					focusLostTimeout = Xwt.Application.TimeoutInvoke (100, () => {
-						NotifyLostFocus ();
+						if (!destroyed)
+							NotifyLostFocus ();
 						return false;
 					});
 				}


### PR DESCRIPTION
When attachments are added to a view, a new attachments container is
added, which has the main view as first item and the attachments as
additional items. Before inserting the main view as first item of the
attachments container we need to make sure it is detached from the
parent container, otherwise it can't be added to the new container.

Also fixed exception that may happen when a view is realized and then
quickly disposed.

Fixes VSTS #983862 - Editor goes blank if solution pad is used to move
an unsaved file to another folder