### PR TITLE
[release-8.3-rtw] Fixes VSTS Bug 984467: SIGABRT when attempting to fetch a branch from

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitRepository.cs
@@ -1234,7 +1234,7 @@ namespace MonoDevelop.VersionControl.Git
 			monitor.Log.WriteLine (GettextCatalog.GetString ("Fetching from '{0}'", remote));
 			int progress = 0;
 
-			var innerTask = await RunOperationAsync (() => {
+			var innerTask = await RunBlockingOperationAsync (() => {
 				var refSpec = RootRepository.Network.Remotes [remote]?.FetchRefSpecs.Select (spec => spec.Specification);
 				return RetryUntilSuccessAsync (monitor, credType => {
 					LibGit2Sharp.Commands.Fetch (RootRepository, remote, refSpec, new FetchOptions {


### PR DESCRIPTION
Azure DevOps Git

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/984467

I couldn't reproduce the issue but running the fetch operation on an
exclusive threat should prevent other operations from interfering.

Backport of #8764.

/cc @slluis @mkrueger