### PR TITLE
[Unit Tests] avoid running old tests in VsTestProjectTestSuite

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
@@ -89,6 +89,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 
 		protected override async void OnCreateTests ()
 		{
+			AddOldTests ();
 			if (testDiscoveryTask == null) {
 				testDiscoveryTask = DiscoverTestsAsync ();
 			}
@@ -164,7 +165,6 @@ namespace MonoDevelop.UnitTesting.VsTest
 	
 		public async override Task Refresh (CancellationToken ct)
 		{
-			AddOldTests ();
 			if (testDiscoveryTask == null) {
 				testDiscoveryTask = DiscoverTestsAsync ();
 			}

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
@@ -142,13 +142,11 @@ namespace MonoDevelop.UnitTesting.VsTest
 
 		void AfterBuild (object sender, BuildEventArgs args)
 		{
-			testDiscoveryTask = null;
 			DateTime? buildTime = GetAssemblyLastWriteTime ();
 			if (RefreshRequired (buildTime)) {
 				lastBuildTime = buildTime;
-
+				testDiscoveryTask = null;
 				SaveOldTests ();
-
 				UpdateTests ();
 			}
 		}

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestProjectTestSuite.cs
@@ -98,7 +98,6 @@ namespace MonoDevelop.UnitTesting.VsTest
 		protected async Task DiscoverTestsAsync ()
 		{
 			try {
-				AddOldTests ();
 				Status = TestStatus.Loading;
 
 				var discoveredTests = await VsTestDiscoveryAdapter.Instance.DiscoverTestsAsync (Project);
@@ -127,7 +126,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 
 		void AddOldTests ()
 		{
-			if (oldTests != null && Tests.Count == 0) {
+			if (oldTests != null) {
 				foreach (var test in oldTests) {
 					Tests.Add (test);
 				}
@@ -165,8 +164,10 @@ namespace MonoDevelop.UnitTesting.VsTest
 	
 		public async override Task Refresh (CancellationToken ct)
 		{
-			if (testDiscoveryTask == null)
+			AddOldTests ();
+			if (testDiscoveryTask == null) {
 				testDiscoveryTask = DiscoverTestsAsync ();
+			}
 			await testDiscoveryTask;
 		}
 


### PR DESCRIPTION
When UnitTestService is running the tests, for VsTest, it is using the old tests before all test information is refreshed.
In UnitTestGroup.Refresh(), Tests collection is accessed which triggered VsTestProjectTestSuite’s `OnCreateTests()`. However it will return the control to the calling thread once `VsTestDiscoveryAdapter.Instance.DiscoverTestsAsync (Project);` is called. This causes the tests not properly refreshed.
For the fix, a new method `DiscoverTestAsync()`is created, which does the same thing as old `OnCreateTests()` does, but returns a Task. Local variable `testDiscoveryTask` is created and shared by `OnCreateTests()` and `Refresh()`. We use it to know when `Refresh()` can return.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/967657/