### PR TITLE
[release-8.3] Fixes current navigation history and takes care about closed documents

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/DocumentNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/DocumentNavigationPoint.cs
@@ -48,8 +48,11 @@ namespace MonoDevelop.Ide.Navigation
 		FilePath fileName;
 		string project;
 		
+		bool isDocument;
+
 		public DocumentNavigationPoint (Document doc)
 		{
+			isDocument = true;
 			SetDocument (doc);
 		}
 
@@ -113,7 +116,14 @@ namespace MonoDevelop.Ide.Navigation
 					break;
 				}
 			}
-			return await IdeApp.Workbench.OpenDocument (new FileOpenInformation (fileName, p, true));
+
+			//in case the document was reopened we want to set again
+			var document = await IdeApp.Workbench.OpenDocument (new FileOpenInformation (fileName, p, true));
+			if (isDocument) {
+				SetDocument (document);
+			}
+
+			return document;
 		}
 		
 		public override string DisplayName {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
@@ -53,6 +53,16 @@ namespace MonoDevelop.Ide.Navigation
 			: base (doc)
 		{
 			offset = textView.Caret.Position.BufferPosition;
+			RefreshWithCurrentOffset (textView);
+		}
+
+		void RefreshWithCurrentOffset (ITextView textView)
+		{
+			if (textView != null && offset.HasValue) {
+				var currentLine = textView.TextBuffer.CurrentSnapshot.GetLineFromPosition (offset.Value);
+				line = currentLine.LineNumber;
+				column = offset.Value.Position - currentLine.Start.Position;
+			}
 		}
 
 		protected override void OnDocumentClosing ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
@@ -138,7 +138,7 @@ namespace MonoDevelop.Ide.Navigation
 
 		protected void JumpToCurrentLocation (ITextView textView)
 		{
-			textView.NavigateToLineAndColumn (Math.Max (0, Line - 1), Math.Max (0, Column - 1));
+			textView.NavigateToLineAndColumn (Math.Max (0, Line), Math.Max (0, Column));
 		}
 
 		public override bool Equals (object o)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskStore.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Tasks/TaskStore.cs
@@ -419,8 +419,11 @@ namespace MonoDevelop.Ide.Tasks
 		class TaskNavigationPoint : TextFileNavigationPoint
 		{
 			TaskListEntry task;
-			
-			public TaskNavigationPoint (TaskListEntry task) : base (task.FileName, task.Line, task.Column)
+
+			// Due to changes in the editor, the offsets of how we count lines seem to be different
+			// so it makes sense that we try to do translation at this point, where it doesn't change
+			// the logic in either <see cref="TextFileNavigationPoint"/> or in the TaskStore.
+			public TaskNavigationPoint (TaskListEntry task) : base (task.FileName, task.Line - 1, task.Column - 1)
 			{
 				this.task = task;
 			}


### PR DESCRIPTION
Our navigation history seems to be broken because we are not refreshing current Line and Column of all TextFileNavigationPoint.cs items (is stays at 0).

This PR also fixes a case when the document is closed but has a TextFileNavigationPoint. We empty the doc variable for a good clean, but in case of go history of a closed document we need to re-set this property to set the cursor correctly in the line

![someeyes](https://user-images.githubusercontent.com/1587480/65167033-136b3300-da42-11e9-886d-12427a2a7dd1.gif)

Fixes VSTS #984818 - "Navigate Back" shorcut it's not working correctly

Backport of #8768.

/cc @sevoku @netonjm