### PR TITLE
Fixes VSTS #611793 - quit re-defaulting to case sensitive search #4727

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SearchAndReplaceWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SearchAndReplaceWidget.cs
@@ -353,7 +353,7 @@ namespace MonoDevelop.SourceEditor
 		
 		internal void CheckSearchPatternCasing (string searchPattern)
 		{
-			if (!DisableAutomaticSearchPatternCaseMatch && PropertyService.Get ("AutoSetPatternCasing", true)) {
+			if (!DisableAutomaticSearchPatternCaseMatch && PropertyService.Get ("AutoSetPatternCasing", false)) {
 				IsCaseSensitive = searchPattern.Any (ch => Char.IsUpper (ch));
 				SetSearchOptions ();
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
@@ -92,7 +92,7 @@ namespace MonoDevelop.Components.MainToolbar
 			public override void Activate ()
 			{
 				var options = new FilterOptions ();
-				if (PropertyService.Get ("AutoSetPatternCasing", true))
+				if (PropertyService.Get ("AutoSetPatternCasing", false))
 					options.CaseSensitive = pattern.Pattern.Any (char.IsUpper);
 				FindInFilesDialog.SearchReplace (pattern.Pattern, null, new WholeSolutionScope (), options, null, null);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Components/LogView.cs
@@ -384,7 +384,7 @@ namespace MonoDevelop.Ide.Gui.Components
 
 		static StringComparison GetComparer ()
 		{
-			if (PropertyService.Get ("AutoSetPatternCasing", true)) {
+			if (PropertyService.Get ("AutoSetPatternCasing", false)) {
 				if (currentSearchPattern != null && currentSearchPattern.Any (Char.IsUpper))
 					return StringComparison.Ordinal;
 			}


### PR DESCRIPTION
Fixes VSTS #611793 - quit re-defaulting to case sensitive search #4727

By default, in MonoDevelop preferences, the "Automatically Set Pattern Casing" setting is off. However, in the product code when retrieving this setting it's defaulting to enable it. This change modifies the default value (when retrieving this setting from the PropertyService) to match the default setting show in preferences. As I confirmed this worked in the legacy editor, I also found that the Search in Solution feature from the search box also displayed this bug, likewise for the Find for log views.

I've tested and confirmed that search is now case insensitive until Automatically Set Pattern Casing is enabled in preferences by the user. This also matches the behavior in the new editor.