### PR TITLE
[Ide] Mark NSViewExtensions as obsolete and remove it in future versions

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NSViewExtensions.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NSViewExtensions.cs
@@ -30,6 +30,7 @@ using ObjCRuntime;
 
 namespace AppKit
 {
+	[Obsolete("Will be removed in future versions, as Xamarin.Mac 5.16.1+ has SortSubviews bound", error: true)]
 	public static class NSViewExtensions
 	{
 		delegate nint view_compare_func (IntPtr view1, IntPtr view2, IntPtr context);
@@ -55,6 +56,7 @@ namespace AppKit
 			}
 		}
 
+		[Obsolete ("Will be removed in future versions, use NSView.SortSubviews instead, Xamarin.Mac 5.16.1+", error: true)]
 		public static void SortSubviews (this NSView view, Func<NSView, NSView, NSComparisonResult> comparer)
 		{
 			if (comparer == null)


### PR DESCRIPTION
The method is implemented in XamMac, no need to duplicate the implementation
Fixes VSTS #973862 - Type forward NSViewExtensions.SortSubviews to Xamarin.Mac