### PR TITLE
Fixes VSTS Bug 988755: [Feedback] iOS project will not build

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -925,6 +925,10 @@ namespace MonoDevelop.Ide.Gui
 			foreach (ExtensionNode node in padCodons)
 				ShowPadNode (node);
 
+			if (!this.padContentCollection.Exists (codon => codon.Id == "MonoDevelop.Ide.Gui.Pads.ErrorListPad")) {
+				LoggingService.LogWarning ("ErrorListPad not loaded.");
+			}
+
 			try {
 				if (System.IO.File.Exists (configFile)) {
 					dock.LoadLayouts (configFile);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/ProgressMonitors.cs
@@ -74,11 +74,16 @@ namespace MonoDevelop.Ide.Gui
 		ProgressMonitor GetBuildProgressMonitor (string statusText)
 		{
 			return Runtime.RunInMainThread (() => {
-				Pad pad = IdeApp.Workbench.GetPad<ErrorListPad> ();
-				ErrorListPad errorPad = (ErrorListPad)pad.Content;
-				AggregatedProgressMonitor mon = new AggregatedProgressMonitor (errorPad.GetBuildProgressMonitor ());
-				mon.AddFollowerMonitor (GetStatusProgressMonitor (statusText, Stock.StatusBuild, false, true, false, pad, true));
-				return mon;
+				try {
+					var pad = IdeApp.Workbench.GetPad<ErrorListPad> ();
+					var errorPad = (ErrorListPad)pad.Content;
+					var mon = new AggregatedProgressMonitor (errorPad.GetBuildProgressMonitor ());
+					mon.AddFollowerMonitor (GetStatusProgressMonitor (statusText, Stock.StatusBuild, false, true, false, pad, true));
+					return mon;
+				} catch (Exception e) {
+					LoggingService.LogInternalError ("Error while getting build progress monitor", e);
+					return new ProgressMonitor ();
+				}
 			}).Result;
 		}
 


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/988755

ErrorListPad is mandatory for the IDE to work. A null progress monitor
will prevent the crash here, but that needs to be logged. The earliest
point to look for the ErrorListPad is the initialization.
It may be that the pad gets removed after the initialization - the
logging will tell us if it's never loaded.