### PR TITLE
[NuGet] Handle NuGet addin API used when project disposed

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/ProjectPackageReferenceTests.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Xml;
 using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
 using MonoDevelop.Projects.MSBuild;
 using NUnit.Framework;
 
@@ -97,6 +98,27 @@ namespace MonoDevelop.PackageManagement.Tests
 			Assert.IsFalse (packageReference.PackageIdentity.HasVersion);
 			Assert.IsFalse (packageReference.HasAllowedVersions);
 			Assert.IsFalse (projectPackageReference.IsAtLeastVersion (new Version (3, 1)));
+		}
+
+		/// <summary>
+		/// Ensure that a null MSBuildProject does not break getting a PackageReference.
+		/// Previously this would throw a null reference exception when an attempt was made
+		/// to determine the frameworks defined by the project.
+		/// </summary>
+		[Test]
+		public void DisposedProject ()
+		{
+			var project = Services.ProjectService.CreateDotNetProject ("C#");
+			var projectPackageReference = ProjectPackageReference.Create ("Test", "1.2.3");
+			project.Items.Add (projectPackageReference);
+
+			project.Dispose ();
+
+			var packageReference = projectPackageReference.CreatePackageReference ();
+
+			Assert.IsNull (project.MSBuildProject);
+			Assert.AreEqual ("Test", packageReference.PackageIdentity.Id);
+			Assert.AreEqual ("1.2.3", packageReference.PackageIdentity.Version.ToString ());
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/DotNetProjectExtensions.cs
@@ -156,7 +156,8 @@ namespace MonoDevelop.PackageManagement
 
 		public static IEnumerable<string> GetDotNetCoreTargetFrameworks (this Project project)
 		{
-			foreach (MSBuildPropertyGroup propertyGroup in project.MSBuildProject.PropertyGroups) {
+			var groups = project.MSBuildProject?.PropertyGroups ?? Enumerable.Empty<MSBuildPropertyGroup> ();
+			foreach (MSBuildPropertyGroup propertyGroup in groups) {
 				string framework = propertyGroup.GetValue ("TargetFramework", null);
 				if (framework != null)
 					return new [] { framework };


### PR DESCRIPTION
Handle a null Project.MSBuildProject when the NuGet addin's
GetInstalledPackages API is called.

```
System.NullReferenceException
Object reference not set to an instance of an object
MonoDevelop.PackageManagement.DotNetProjectExtensions.GetDotNetCoreTargetFrameworks(Project)
MonoDevelop.PackageManagement.ProjectPackageReference.GetFramework()
MonoDevelop.PackageManagement.ProjectPackageReference.CreatePackageReference()
MonoDevelop.PackageManagement.PackageReferenceNuGetProject.<>c.<GetPackageReferences>b__XXX(ProjectPackageReference)
System.Linq.Enumerable.SelectEnumerableIterator`2[[MonoDevelop.PackageManagement.ProjectPackageReference, MonoDevelop.PackageManagement, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ead7498f347467b],[NuGet.Packaging.PackageReference, NuGet.Packaging, Version=5.2.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35]].ToList()
System.Linq.Enumerable.ToList[PackageReference](IEnumerable`1)
MonoDevelop.PackageManagement.PackageReferenceNuGetProject.GetPackageReferences()
MonoDevelop.PackageManagement.PackageReferenceNuGetProject.GetInstalledPackagesAsync(CancellationToken)
MonoDevelop.PackageManagement.PackageManagementProjectOperations.<>c__XXX.<GetInstalledPackages>b__XXX()
System.Threading.Tasks.Task`1[[System.Threading.Tasks.Task`1[[System.Collections.Generic.IEnumerable`1[[NuGet.Packaging.PackageReference, NuGet.Packaging, Version=5.2.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].InnerInvoke()
System.Threading.Tasks.Task.Execute()
Gtk.Application.Run()
MonoDevelop.Ide.IdeStartup.Run(MonoDevelopOptions)
MonoDevelop.Ide.IdeStartup.Main(String[],IdeCustomizer)
```

Fixes VSTS #987260 - System.NullReferenceException exception in
MonoDevelop.PackageManagement.DotNetProjectExtensions.GetDotNetCoreTargetFrameworks()