### PR TITLE
[A11y] Make GtkNSViewHost accessible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -29,6 +29,8 @@ using CoreGraphics;
 using ObjCRuntime;
 using Foundation;
 
+using MonoDevelop.Components.AtkCocoaHelper;
+
 namespace Gtk
 {
 	/// <summary>
@@ -85,6 +87,12 @@ namespace Gtk
 			this.view = view ?? throw new ArgumentNullException (nameof (view));
 
 			WidgetFlags |= WidgetFlags.NoWindow;
+
+			Accessible.SetRole (AtkCocoa.Roles.AXGroup);
+
+			var accessibility = AtkCocoaMacExtensions.GetNSAccessibilityElement (Accessible);
+			accessibility.AccessibilityElement = true;
+			accessibility.AccessibilityChildren = new NSObject [] { view };
 		}
 
 		void UpdateViewFrame ()
@@ -177,11 +185,15 @@ namespace Gtk
 					var superviewHandle = gdk_quartz_window_get_nsview (GdkWindow.Handle);
 					if (superviewHandle != IntPtr.Zero)
 						superview = Runtime.GetNSObject<NSView> (superviewHandle);
-					}
+						//we don't want accessibility exploring this view
+						superview.AccessibilityElement = false;
+				}
 
 				if (superview != null && view != null) {
 					superview.AddSubview (view);
 					superview.SortSubviews (CompareViews);
+					//we don't want include gdk_quartz children in accessibility navigation hierarchy
+					superview.AccessibilityChildren = Array.Empty<NSObject>();
 				}
 				base.OnRealized ();
 


### PR DESCRIPTION
Advertise the NSView accessible children to the Cocoa accessibilty subsystem so that Cocoa widgets embedded inside GtkNSViewHosts will be accessible.

This is the `GtkNSViewHost` part from #8502 by @netonjm 

Fixes VSTS #977183 - [DockSystem] Accessibility VoiceOver hierarchy seems to be broken for Embedded native views