### PR TITLE
[release-8.3] [Ide] Improve global search result reporting even more

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FakeSearchCategory.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FakeSearchCategory.fs
@@ -48,7 +48,7 @@ type FakeSearchCategory() =
 
     override x.get_Tags() = [|"fake"|]
 
-    override x.IsValidTag _tag = true
+    override x.IsValidTag _tag = _tag = "fake"
 
     override x.GetResults(searchCallback, pattern, token) =
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
@@ -83,18 +83,19 @@ namespace MonoDevelop.Components.MainToolbar
 				return Task.CompletedTask;
 			var route = new CommandTargetRoute (IdeApp.CommandService.LastCommandTarget);
 			var matcher = StringMatcher.GetMatcher (pattern.Pattern, false);
-			foreach (var cmd in GetAllCommands ()) {
-				if (token.IsCancellationRequested)
-					break;
-				var matchString = cmd.DisplayName;
+			return Runtime.RunInMainThread (() => {
+				foreach (var cmd in GetAllCommands ()) {
+					if (token.IsCancellationRequested)
+						break;
+					var matchString = cmd.DisplayName;
 
-				if (matcher.CalcMatchRank (matchString, out var rank)) {
-					if ((cmd as ActionCommand)?.RuntimeAddin == currentRuntimeAddin)
-						rank += 1; // we prefer commands comming from the addin
-					searchResultCallback.ReportResult (new CommandResult (cmd, null, route, pattern.Pattern, matchString, rank));
+					if (matcher.CalcMatchRank (matchString, out var rank)) {
+						if ((cmd as ActionCommand)?.RuntimeAddin == currentRuntimeAddin)
+							rank += 1; // we prefer commands comming from the addin
+						searchResultCallback.ReportResult (new CommandResult (cmd, null, route, pattern.Pattern, matchString, rank));
+					}
 				}
-			}
-			return Task.CompletedTask;
+			});
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Gtk;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -716,7 +717,8 @@ namespace MonoDevelop.Components.MainToolbar
 				PositionPopup ();
 				popup.Show ();
 			}
-			popup.Update (pattern);
+			// popup.Update () is thread safe, so run it on a bg thread for faster results
+			Task.Run (() => popup.Update (pattern)).Ignore ();
 		}
 
 		void HandleSearchEntryActivated (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -553,7 +553,7 @@ namespace MonoDevelop.Components.MainToolbar
 			for (int i = 0; i < newResults.Count; i++) {
 				var tuple = newResults [i];
 				try {
-					if (tuple.Item2.Count == 0)
+					if (tuple.Item2.Count == 0 || tuple.Item1 is LoadingSearchProvidersCategory)
 						continue;
 					if (topResult == null || topResult.DataSource [topResult.Item].Weight < tuple.Item2 [0].Weight)
 						topResult = new ItemIdentifier (tuple.Item1, tuple.Item2, 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 		public void Update (SearchPopupSearchPattern pattern)
 		{
-			Content.Update (pattern);
+			Task.Run (() => Content.Update (pattern)).Ignore ();
 		}
 
 		internal void OpenFile ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -428,7 +428,7 @@ namespace MonoDevelop.Components.MainToolbar
 			this.pattern = pattern;
 			if (src != null)
 				src.Cancel ();
-			HideTooltip ();
+
 			src = new CancellationTokenSource ();
 			isInSearch = true;
 			if (results.Count == 0) {
@@ -460,15 +460,13 @@ namespace MonoDevelop.Components.MainToolbar
 				col.Task = cat.GetResults (col, pattern, token);
 
 				//we append on finished  to process and show the results
-				col.Task.ContinueWith (async (colTask) => {
+				col.Task.ContinueWith ((colTask) => {
 
 					//cancel last provider continueWith task
 					lastProvSrc?.Cancel ();
-					
+
 					if (token.IsCancellationRequested || colTask.IsCanceled)
 						return;
-
-					await nextUpdate;
 
 					lock (lockObject) {
 
@@ -514,7 +512,7 @@ namespace MonoDevelop.Components.MainToolbar
 							return;
 
 						//refresh panel and show results 
-						InvokeAsync (() => {
+						Runtime.RunInMainThread (() => {
 							lock (lockObject) // We have to lock here because newResults can mutate
 								ShowResults (newResults, calculatedResult.topResult);
 
@@ -527,16 +525,12 @@ namespace MonoDevelop.Components.MainToolbar
 								return;
 
 							OnPreferredSizeChanged ();
-
-							nextUpdate = Task.Delay (250);
 						}).Ignore ();
 					}
 				}, token, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Default)
 					.Ignore ();
 			}
 		}
-
-		Task nextUpdate = Task.CompletedTask;
 
 		readonly object lockObject = new object ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -452,15 +452,15 @@ namespace MonoDevelop.Components.MainToolbar
 			int total = categories.Count;
 			int current = 0;
 
+			var activeCategories = string.IsNullOrEmpty (pattern.Tag) ? categories : categories.Where (cat => cat.IsValidTag (pattern.Tag));
+
 			if (!token.IsCancellationRequested) {
 				searchProvidersCategory.Clear ();
-				searchProvidersCategory.AddRange (categories);
+				searchProvidersCategory.AddRange (activeCategories);
 			}
 
-			foreach (var _cat in categories) {
+			foreach (var _cat in activeCategories) {
 				var cat = _cat;
-				if (!string.IsNullOrEmpty (pattern.Tag) && !cat.IsValidTag (pattern.Tag))
-					continue;
 				var col = new SearchResultCollector (_cat);
 				collectors.Add (col);
 				col.Task = cat.GetResults (col, pattern, token);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -73,7 +73,7 @@ namespace MonoDevelop.Components.MainToolbar
 
 		public void Update (SearchPopupSearchPattern pattern)
 		{
-			Task.Run (() => Content.Update (pattern)).Ignore ();
+			Content.Update (pattern);
 		}
 
 		internal void OpenFile ()


### PR DESCRIPTION
This avoids unneeded global search hiding and redrawing
so that we actually don't need to throttle the incoming results
to avoid flickering.

This reverts 731915e557e92dfe7333a1fab6cd37335aae1583 introduced in https://github.com/mono/monodevelop/pull/8719

Fixes VSTS #972204
Fixes VSTS #982384
Fixes VSTS #984594
Fixes VSTS #985811

Backport of #8786.

/cc @sevoku 