### PR TITLE
[release-8.3] [F#] Fix recursion stack overflow when parsing big files

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/LexerTests.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharp.Tests/LexerTests.fs
@@ -14,3 +14,12 @@ module LexerTests =
         let tokenizer = sourceTok.CreateLineTokenizer line
         let tokens, state = Lexer.parseLine tokenizer [] FSharpTokenizerLexState.Initial
         Assert.AreNotEqual(state, FSharpTokenizerLexState.Initial)
+
+
+    [<Test>]
+    let ``can parse long file``() =
+        let lines = [ for i in 1..100000 do
+                        yield sprintf "let x = %i" i ]
+        let sourceTok = FSharpSourceTokenizer([], None)
+        let res = Lexer.getTokensWithInitialState FSharpTokenizerLexState.Initial lines (Some "test.fsx") []
+        ()


### PR DESCRIPTION
Before this fix, the stack could overflow with ~12000 lines on my
machine.

Unit test is using 100000 lines without a crash
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/988934

Backport of #8811.

/cc @nosami 