### PR TITLE
[release-8.3] Don't throw exception for invalid dotnet core version

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreVersionTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DotNetCoreVersionTests.cs
@@ -103,6 +103,15 @@ namespace MonoDevelop.DotNetCore.Tests
 			Assert.IsFalse (result);
 		}
 
+		[Test]
+		public void TryParse_InvalidVersion()
+		{
+			DotNetCoreVersion version = null;
+			bool result = DotNetCoreVersion.TryParse ("INVALID", out version);
+
+			Assert.IsFalse (result);
+		}
+
 		[TestCase ("1.0.2", "1.0.2", true)]
 		[TestCase ("1.2.3", "1.0.2", false)]
 		[TestCase ("1.0.2", "1.0.2-preview1-002912-00", false)]

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreVersion.cs
@@ -1,4 +1,4 @@
-﻿﻿//
+﻿//
 // DotNetCoreVersion.cs
 //
 // Author:
@@ -115,7 +115,7 @@ namespace MonoDevelop.DotNetCore
 						revisionString = input.Substring (revisionLabelStart, revisionLabelEnd - revisionLabelStart);
 					}
 					if (!int.TryParse (revisionString , out revision)) {
-						throw new FormatException (string.Format ("Invalid .NET Core version: '{0}'", input));
+						return false;
 					}
 				}
 			}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/987887

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/986987

Backport of #8797.

/cc @nosami 