### PR TITLE
[Roslyn] Fix support for non-roslyn language name

### DIFF
--- a/main/tests/Ide.Tests/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferencesTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.RoslynServices.Options/RoslynPreferencesTests.cs
@@ -58,6 +58,21 @@ namespace MonoDevelop.Ide.RoslynServices.Options
 		}
 
 		[Test]
+		public void UnknownLanguageNameDoesNotCrash ()
+		{
+			var preferences = new RoslynPreferences ();
+
+			Assert.IsNotNull (preferences.CSharp);
+			Assert.AreSame (preferences.CSharp, preferences.For (LanguageNames.CSharp));
+
+			var xaml = preferences.For ("XAML");
+
+			Assert.IsNotNull (xaml);
+			Assert.AreSame (xaml, preferences.For ("XAML"));
+
+		}
+
+		[Test]
 		public void TestRoslynPropertyWithMultipleKeys ()
 		{
 			var (preferences, persister) = Setup ();


### PR DESCRIPTION
```
The given key 'XAML' was not present in the dictionary.
["System.ThrowHelper.GetKeyNotFoundException(Object)","System.ThrowHelper.ThrowKeyNotFoundException(Object)","System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[MonoDevelop.Ide.RoslynServices.Options.RoslynPreferences.PerLanguagePreferences, MonoDevelop.Ide, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3ead7498f347467b]].get_Item(String)","MonoDevelop.Ide.RoslynServices.Options.RoslynPreferences.For(String)","MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace.IsUserOptionOn()","MonoDevelop.Ide.TypeSystem.MonoDevelopWorkspace.OnMemoryStatusChanged(Object,PlatformMemoryStatusEventArgs)","System.CoreExtensions.SafeInvoke[PlatformMemoryStatusEventArgs](EventHandler`1,Object,PlatformMemoryStatusEventArgs)"]
```

Found via https://devdiv.visualstudio.com/DevDiv/_workitems/edit/985671