### PR TITLE
[release-8.3] Fixes VSTS Bug 983399: [VersionControl] Credential dialog is on top of

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Window.cs
@@ -24,6 +24,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using MonoDevelop.Core;
+#if MAC
+using AppKit;
+#endif
 
 namespace MonoDevelop.Components
 {
@@ -207,5 +211,26 @@ namespace MonoDevelop.Components
 			throw new NotSupportedException ();
 		}
 	}
-}
 
+	public static class WindowExt
+	{
+		public static void SetParentToWindow (this Gtk.Window window, MonoDevelop.Components.Window parent)
+		{
+			try {
+#if MAC
+				var nsWindow = parent.GetNativeWidget<NSWindow> ();
+				if (nsWindow != null) {
+					var myNSWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetNSWindow (window);
+					myNSWindow.ParentWindow = nsWindow;
+				} else {
+					window.TransientFor = parent;
+				}
+#else
+				window.TransientFor = parent;
+#endif
+			} catch (Exception e) {
+				LoggingService.LogInternalError ("Error while setting parent.", e);
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ProgressDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/ProgressDialog.cs
@@ -30,6 +30,9 @@ using Gtk;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 using System.Threading;
+#if MAC
+using AppKit;
+#endif
 
 namespace MonoDevelop.Ide.Gui.Dialogs
 {
@@ -43,6 +46,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		List<TextTag> tags = new List<TextTag> ();
 		Stack<string> indents = new Stack<string> ();
 		CancellationTokenSource cancellationTokenSource;
+		private MonoDevelop.Components.Window componentsWindowParent;
 
 		public ProgressDialog (bool allowCancel, bool showDetails): this (null, allowCancel, showDetails)
 		{
@@ -53,6 +57,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			MonoDevelop.Components.IdeTheme.ApplyTheme (this);
 			this.Build ();
 			this.Title = BrandingService.ApplicationName;
+			this.componentsWindowParent = parent; 
 			HasSeparator = false;
 			ActionArea.Hide ();
 			DefaultHeight = 5;
@@ -189,6 +194,11 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 		{
 			Destroy ();
 		}
+
+		protected override void OnShown ()
+		{
+			base.OnShown ();
+			this.SetParentToWindow (componentsWindowParent);
+		}
 	}
 }
-


### PR DESCRIPTION
all applications

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/983399

ProgressDialog didn't had the parent set. In VS4Mac the parent is a
NSWindow so it's needed to set the parent in that case after the gtk
window has been created.

Backport of #8779.

/cc @sevoku @mkrueger