### PR TITLE
[release-8.3] Fix 985131: Unable to pull up the emoji selector

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -317,11 +317,6 @@ namespace MonoDevelop.Components.Commands
 				return null;
 			}
 
-			if (string.IsNullOrEmpty (ev.Characters)) {
-				LoggingService.LogInternalError (new Exception ($"Keyevent has no characters"));
-				return null;
-			}
-
 			// If we have a native window that can handle this command, let it process
 			// the keys itself and do not go through the command manager.
 			// Events in Gtk windows do not pass through here except when they're done


### PR DESCRIPTION
The check for an empty `NSEvent.Characters` is too exhaustive for attempting to validate an event. The explicit check for Key Up/Down should be enough.

Apple documentation states that dead keys will result in an empty string for `NSEvent.Characters`, but these keys should be allowed to be processed as well by commanding.

This fixes a regression introduced in #8664.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/985131

Backport of #8832.

/cc @abock 