### PR TITLE
Fixes VSTS Bug 810270: Accessibility: Version Control - Changes: Voice

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/EditorCompareWidgetBase.cs
@@ -41,6 +41,7 @@ using MonoDevelop.Core.Text;
 using MonoDevelop.Ide.Editor;
 using Microsoft.VisualStudio.Text;
 using MonoDevelop.Ide.TextEditing;
+using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace MonoDevelop.VersionControl.Views
 {
@@ -231,8 +232,15 @@ namespace MonoDevelop.VersionControl.Views
 				Add (middleAreas[1]);
 			}
 			this.MainEditor.EditorOptionsChanged += HandleMainEditorhandleEditorOptionsChanged;
+			SetupAccessibility ();
 		}
-		
+
+		void SetupAccessibility ()
+		{
+			leftDiffScrollBar.Accessible.SetShouldIgnore (true);
+			rightDiffScrollBar.Accessible.SetShouldIgnore (true);
+		}
+
 		void ShowPopup (MonoTextEditor editor, EventButton evt)
 		{
 			CommandEntrySet cset = IdeApp.CommandService.CreateCommandEntrySet ("/MonoDevelop/VersionControl/DiffView/ContextMenu");


### PR DESCRIPTION
Over was not reading anything when the focus moves to the vertical
scroll bars in the "Changes" window and the central section which
shows differences.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/810270

Removed scroll bars from the list.