### PR TITLE
SaveJson - Serialize "protected List<CounterValue> values" in Counter

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -472,15 +472,16 @@ namespace MonoDevelop.Core.Instrumentation
 		Line
 	}
 
-	public class CounterContractResolver : DefaultContractResolver
+	internal class CounterContractResolver : DefaultContractResolver
 	{
 		protected override List<MemberInfo> GetSerializableMembers (Type objectType)
 		{
 			var serializableMembers = base.GetSerializableMembers (objectType);
-			if (objectType.IsAssignableFrom(typeof(Counter))) {
-				var protectedNameMember = objectType.GetProperty ("values", BindingFlags.NonPublic | BindingFlags.Default | BindingFlags.Instance);
-				if (protectedNameMember != null)
+			if (typeof (Counter).IsAssignableFrom (objectType)) {
+				var protectedNameMember = objectType.GetMember ("values", BindingFlags.NonPublic | BindingFlags.Default | BindingFlags.Instance).FirstOrDefault();
+				if (protectedNameMember != null) {
 					serializableMembers.Add (protectedNameMember);
+				}
 			}
 			return serializableMembers;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/InstrumentationService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/InstrumentationService.cs
@@ -180,9 +180,11 @@ namespace MonoDevelop.Core.Instrumentation
 			Save (filePath, (fs, data) => {
 				using var writer = new StreamWriter (fs);
 				var serializer = JsonSerializer.Create (new JsonSerializerSettings {
+					Formatting = Formatting.Indented,
 					ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
 					DefaultValueHandling = DefaultValueHandling.Ignore,
 					NullValueHandling = NullValueHandling.Ignore,
+					ContractResolver = new CounterContractResolver()
 				});
 				serializer.Serialize (writer, data);
 			});


### PR DESCRIPTION
Fixes #992546

We wish to save all the counter data on the disk, but since `Counter.values` is protected, it can't be serialized. Create a custom `ContractResolver` named `CounterContractResolver` as per @Therzok suggestion.

This only helps in serialization and not deserialization (which should use JObject).