### PR TITLE
SaveJson - Serialize "protected List<CounterValue> values" in Counter,TimerCounter using ISerializer

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -30,11 +30,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace MonoDevelop.Core.Instrumentation
 {
 	[Serializable]
-	public class Counter: MarshalByRefObject
+	public class Counter: MarshalByRefObject, ISerializable
 	{
 		internal int count;
 		internal int totalCount;
@@ -353,6 +354,25 @@ namespace MonoDevelop.Core.Instrumentation
 			return null;
 		}
 
+		public void GetObjectData (SerializationInfo info, StreamingContext context)
+			=> PopulateSerializableMembers (info, context);
+
+		protected void PopulateSerializableMembers (SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue (nameof (this.StoreValues), this.StoreValues);
+			info.AddValue (nameof (this.Resolution), this.Resolution);
+			info.AddValue (nameof (this.values), this.values);
+			info.AddValue (nameof (this.TotalCount), this.TotalCount);
+			info.AddValue (nameof (this.Name), this.Name);
+			info.AddValue (nameof (this.LogMessages), this.LogMessages);
+			info.AddValue (nameof (this.LastValue), this.LastValue);
+			info.AddValue (nameof (this.Id), this.Id);
+			info.AddValue (nameof (this.Handlers), this.Handlers);
+			info.AddValue (nameof (this.Category), this.Category);
+			info.AddValue (nameof (this.Count), this.Count);
+			info.AddValue (nameof (this.DisplayMode), this.DisplayMode);
+			info.AddValue (nameof (this.Enabled), this.Enabled);
+		}
 	}
 
 	public class Counter<T>: Counter where T : CounterMetadata, new()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -354,7 +354,7 @@ namespace MonoDevelop.Core.Instrumentation
 			return null;
 		}
 
-		public void GetObjectData (SerializationInfo info, StreamingContext context)
+		public virtual void GetObjectData (SerializationInfo info, StreamingContext context)
 			=> PopulateSerializableMembers (info, context);
 
 		protected void PopulateSerializableMembers (SerializationInfo info, StreamingContext context)

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/InstrumentationService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/InstrumentationService.cs
@@ -183,6 +183,7 @@ namespace MonoDevelop.Core.Instrumentation
 					ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
 					DefaultValueHandling = DefaultValueHandling.Ignore,
 					NullValueHandling = NullValueHandling.Ignore,
+					Formatting = Formatting.Indented
 				});
 				serializer.Serialize (writer, data);
 			});

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -143,7 +143,7 @@ namespace MonoDevelop.Core.Instrumentation
 			return c;
 		}
 
-		public new void GetObjectData (SerializationInfo info, StreamingContext context)
+		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
 			base.PopulateSerializableMembers (info, context);
 			info.AddValue (nameof (this.MinSeconds), this.MinSeconds);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -33,11 +33,12 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace MonoDevelop.Core.Instrumentation
 {
 	[Serializable]
-	public class TimerCounter : Counter
+	public class TimerCounter : Counter , ISerializable
 	{
 		double minSeconds;
 		TimeSpan totalTime;
@@ -140,6 +141,17 @@ namespace MonoDevelop.Core.Instrumentation
 					InstrumentationService.LogMessage ("START: " + Name);
 			}
 			return c;
+		}
+
+		public new void GetObjectData (SerializationInfo info, StreamingContext context)
+		{
+			base.PopulateSerializableMembers (info, context);
+			info.AddValue (nameof (this.MinSeconds), this.MinSeconds);
+			info.AddValue (nameof (this.TotalTime), this.TotalTime);
+			info.AddValue (nameof (this.AverageTime), this.AverageTime);
+			info.AddValue (nameof (this.MinTime), this.MinTime);
+			info.AddValue (nameof (this.MaxTime), this.MaxTime);
+			info.AddValue (nameof (this.CountWithDuration), this.CountWithDuration);
 		}
 	}
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
@@ -230,31 +230,62 @@ namespace MonoDevelop.Core
 			using (var textReader = new StreamReader("serialize_counters.json")) {
 				using (var jsonTextReader = new JsonTextReader (textReader)) {
 					var jsonRootObj = JObject.Load (jsonTextReader);
-					Assert.IsNotNull (jsonRootObj ["StartTime"]);
+
+					var startTimeToken = jsonRootObj ["StartTime"];
+					Assert.IsNotNull (startTimeToken);
+					Assert.That (startTimeToken.ToString (), Is.EqualTo (InstrumentationService.StartTime.ToString()));
 					Assert.IsNotNull (jsonRootObj ["EndTime"]);
+
 					var counters = jsonRootObj ["Counters"];
 					Assert.IsNotNull (counters);
 					var runtimeCounter = counters ["Runtime initialization"];
+					var actualRuntimeInitializationCounter = InstrumentationService.GetCounter ("Runtime initialization");
 					Assert.IsNotNull (runtimeCounter);
-					Assert.IsNotNull (runtimeCounter ["StoreValues"]);
-					Assert.IsNotNull (runtimeCounter ["Resolution"]);
-					Assert.IsNotNull (runtimeCounter ["values"]);
-					Assert.IsNotNull (runtimeCounter ["TotalCount"]);
-					Assert.IsNotNull (runtimeCounter ["Name"]);
-					Assert.IsNotNull (runtimeCounter ["LogMessages"]);
-					Assert.IsNotNull (runtimeCounter ["LastValue"]);
-					Assert.IsNotNull (runtimeCounter ["Id"]);
-					Assert.IsNotNull (runtimeCounter ["Handlers"]);
+
+					var storeValuesToken = runtimeCounter ["StoreValues"];
+					Assert.IsNotNull (storeValuesToken);
+					Assert.That (bool.Parse(storeValuesToken.ToString ()), Is.EqualTo (actualRuntimeInitializationCounter.StoreValues));
+
+					var resolutionToken = runtimeCounter ["Resolution"];
+					Assert.IsNotNull (resolutionToken);
+					Assert.That (resolutionToken.ToString (), Is.EqualTo (actualRuntimeInitializationCounter.Resolution.ToString()));
+
+					var totalCountToken = runtimeCounter ["TotalCount"];
+					Assert.IsNotNull (totalCountToken);
+					Assert.That (int.Parse (totalCountToken.ToString ()), Is.EqualTo (actualRuntimeInitializationCounter.TotalCount));
+
+					var nameToken = runtimeCounter ["Name"];
+					Assert.IsNotNull (nameToken);
+					Assert.That (nameToken.ToString(), Is.EqualTo (actualRuntimeInitializationCounter.Name));
+
+					var idToken = runtimeCounter ["Id"];
+					Assert.IsNotNull (idToken);
+					Assert.That (idToken.ToString (), Is.EqualTo (actualRuntimeInitializationCounter.Id));
+
+					var countToken = runtimeCounter ["Count"];
+					Assert.IsNotNull (countToken);
+					Assert.That (int.Parse (countToken.ToString ()), Is.EqualTo (actualRuntimeInitializationCounter.Count));
+
+					var displayModeToken = runtimeCounter ["DisplayMode"];
+					Assert.IsNotNull (displayModeToken);
+					Assert.That ((CounterDisplayMode)Enum.Parse (typeof(CounterDisplayMode), displayModeToken.ToString ()), Is.EqualTo (actualRuntimeInitializationCounter.DisplayMode));
+
+					var enabledToken = runtimeCounter ["Enabled"];
+					Assert.IsNotNull (enabledToken);
+					Assert.That (bool.Parse (enabledToken.ToString ()), Is.EqualTo (actualRuntimeInitializationCounter.Enabled));
+
 					Assert.IsNotNull (runtimeCounter ["Category"]);
-					Assert.IsNotNull (runtimeCounter ["Count"]);
-					Assert.IsNotNull (runtimeCounter ["DisplayMode"]);
-					Assert.IsNotNull (runtimeCounter ["Enabled"]);
 					Assert.IsNotNull (runtimeCounter ["MinSeconds"]);
 					Assert.IsNotNull (runtimeCounter ["TotalTime"]);
 					Assert.IsNotNull (runtimeCounter ["AverageTime"]);
 					Assert.IsNotNull (runtimeCounter ["MinTime"]);
 					Assert.IsNotNull (runtimeCounter ["MaxTime"]);
 					Assert.IsNotNull (runtimeCounter ["CountWithDuration"]);
+
+					Assert.IsNotNull (runtimeCounter ["values"]);
+					Assert.IsNotNull (runtimeCounter ["LastValue"]);
+					Assert.IsNotNull (runtimeCounter ["LogMessages"]);
+					Assert.IsNotNull (runtimeCounter ["Handlers"]);
 				}
 			}
 		}

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Core/InstrumentationTests.cs
@@ -28,6 +28,9 @@ using System.Collections.Generic;
 using MonoDevelop.Core.Instrumentation;
 using NUnit.Framework;
 using System.Threading;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace MonoDevelop.Core
 {
@@ -218,6 +221,42 @@ namespace MonoDevelop.Core
 			var metadata = new CustomCounterMetadata ();
 
 			Assert.AreEqual (default (int), metadata.SomeMeasure);
+		}
+
+		[Test]
+		public void SerializeCounters ()
+		{
+			InstrumentationService.SaveJson ("serialize_counters.json");
+			using (var textReader = new StreamReader("serialize_counters.json")) {
+				using (var jsonTextReader = new JsonTextReader (textReader)) {
+					var jsonRootObj = JObject.Load (jsonTextReader);
+					Assert.IsNotNull (jsonRootObj ["StartTime"]);
+					Assert.IsNotNull (jsonRootObj ["EndTime"]);
+					var counters = jsonRootObj ["Counters"];
+					Assert.IsNotNull (counters);
+					var runtimeCounter = counters ["Runtime initialization"];
+					Assert.IsNotNull (runtimeCounter);
+					Assert.IsNotNull (runtimeCounter ["StoreValues"]);
+					Assert.IsNotNull (runtimeCounter ["Resolution"]);
+					Assert.IsNotNull (runtimeCounter ["values"]);
+					Assert.IsNotNull (runtimeCounter ["TotalCount"]);
+					Assert.IsNotNull (runtimeCounter ["Name"]);
+					Assert.IsNotNull (runtimeCounter ["LogMessages"]);
+					Assert.IsNotNull (runtimeCounter ["LastValue"]);
+					Assert.IsNotNull (runtimeCounter ["Id"]);
+					Assert.IsNotNull (runtimeCounter ["Handlers"]);
+					Assert.IsNotNull (runtimeCounter ["Category"]);
+					Assert.IsNotNull (runtimeCounter ["Count"]);
+					Assert.IsNotNull (runtimeCounter ["DisplayMode"]);
+					Assert.IsNotNull (runtimeCounter ["Enabled"]);
+					Assert.IsNotNull (runtimeCounter ["MinSeconds"]);
+					Assert.IsNotNull (runtimeCounter ["TotalTime"]);
+					Assert.IsNotNull (runtimeCounter ["AverageTime"]);
+					Assert.IsNotNull (runtimeCounter ["MinTime"]);
+					Assert.IsNotNull (runtimeCounter ["MaxTime"]);
+					Assert.IsNotNull (runtimeCounter ["CountWithDuration"]);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Supersedes #8841

Fixes #992546

We wish to save all the counter data on the disk, but since Counter.values is protected, it can't be serialized. Implement `ISerializable` over `Counter` and `TimerCounter`

This only helps in serialization and not deserialization (which should use JObject). Deserialization would be cumbersome and error prone since many fields are `read` only and we are also saving some state, which not not be valid if we deserialize.