### PR TITLE
[release-8.4] [Core] Fix test to work with new gtk-sharp.dll.pdb

### DIFF
--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/LocalCopyTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/LocalCopyTests.cs
@@ -250,7 +250,7 @@ namespace MonoDevelop.Projects
 				"System.Data.dll",
 				"gtk-sharp.dll",
 				"gtk-sharp.dll.config",
-				"gtk-sharp.dll.mdb",
+				"gtk-sharp.dll.pdb",
 			});
 
 			string projectXml1 = Util.GetXmlFileInfoset (p.FileName.ParentDirectory.Combine ("ConsoleProject.csproj.saved"));

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/LocalCopyTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/LocalCopyTests.cs
@@ -250,7 +250,7 @@ namespace MonoDevelop.Projects
 				"System.Data.dll",
 				"gtk-sharp.dll",
 				"gtk-sharp.dll.config",
-				"gtk-sharp.dll.pdb",
+				"gtk-sharp.pdb",
 			});
 
 			string projectXml1 = Util.GetXmlFileInfoset (p.FileName.ParentDirectory.Combine ("ConsoleProject.csproj.saved"));


### PR DESCRIPTION
Mono 2019-08 v6.6.0.104 changed the compiler used to build gtk-sharp from `mcs` to `csc`.
As a result, we do not have .mdb files anymore, rather the normal .pdb.

This fixes the test to look for the right file.

Backport of #8845.

/cc @kdubau 