### PR TITLE
[PerfTests] Add create new solution tests

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs
@@ -40,10 +40,10 @@ using System.Text;
 using Mono.Addins;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.Templates;
+using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.Projects;
 using Xwt.Drawing;
 using System.Threading.Tasks;
-using System.Threading;
 
 namespace MonoDevelop.Ide.Projects
 {
@@ -52,6 +52,11 @@ namespace MonoDevelop.Ide.Projects
 	/// </summary>
 	class NewProjectDialogController : INewProjectDialogController
 	{
+		static TimerCounter NewProjectCreatedTimer = InstrumentationService.CreateTimerCounter (
+			"New Project Created",
+			"IDE",
+			id: "Ide.NewProjectDialog.ProjectCreated");
+
 		public event EventHandler ProjectCreationFailed;
 		public event EventHandler ProjectCreated;
 
@@ -612,6 +617,13 @@ namespace MonoDevelop.Ide.Projects
 		}
 
 		public async Task Create ()
+		{
+			using (var timer = NewProjectCreatedTimer.BeginTiming ()) {
+				await CreateInternal ();
+			}
+		}
+
+		async Task CreateInternal ()
 		{
 			projectCreated = new TaskCompletionSource<bool> ();
 

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/MonoDevelop.Ide.PerfTests.csproj
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/MonoDevelop.Ide.PerfTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="TestSolutionBuild.cs" />
     <Compile Include="TestFileWatcherHandlers.cs" />
     <Compile Include="TestTypeSystemServiceLoad.cs" />
+    <Compile Include="TestNewSolution.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
@@ -24,6 +24,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
+using System.Linq;
+using MonoDevelop.Components.AutoTest;
 using MonoDevelop.Core;
 using MonoDevelop.Core.Instrumentation;
 using MonoDevelop.PerformanceTesting;
@@ -44,7 +47,7 @@ namespace MonoDevelop.Ide.PerfTests
 		}
 
 		[Test]
-		[Benchmark (Tolerance = 0.50)]
+		[Benchmark (Tolerance = 2)]
 		public void TestNewConsoleProject ()
 		{
 			OpenApplicationAndWait ();
@@ -70,13 +73,69 @@ namespace MonoDevelop.Ide.PerfTests
 			Benchmark.SetTime (t.TotalSeconds);
 		}
 
-		void CreateNewSolutionAndWait (TemplateSelectionOptions templateOptions)
+		[Test]
+		[Benchmark (Tolerance = 5)]
+		public void TestNewXamarinFormsProject ()
+		{
+			OpenApplicationAndWait ();
+
+			var templateOptions = new TemplateSelectionOptions {
+				CategoryRoot = "Multiplatform",
+				Category = "App",
+				TemplateKindRoot = "Xamarin.Forms",
+				TemplateKind = "Blank Forms App"
+			};
+
+			CreateNewXamarinFormsSolutionAndWait (templateOptions);
+
+			Session.RunAndWaitForTimer (() => {
+				// Do nothing. Cannot call this with CreateNewSolutionAndWait since the timer is not available
+				// at that point but is available after it has been called. Using RunAndWaitForTimer here
+				// ensures we wait for the timer to change. Otherwise we would get the timer with no duration
+				// since the project is still being created.
+			}, "Ide.NewProjectDialog.ProjectCreated", 60000);
+
+			var t = Session.GetTimerDuration ("Ide.NewProjectDialog.ProjectCreated");
+
+			Benchmark.SetTime (t.TotalSeconds);
+		}
+
+		void CreateNewSolutionAndWait (TemplateSelectionOptions template, Action<NewProjectController> wizardPageAction = null)
 		{
 			var newProject = new NewProjectController ();
 			newProject.Open ();
 
-			newProject.Select (templateOptions);
+			AppQuery categoryUIQuery (AppQuery c) => templateCategoriesQuery (c)
+				.Contains (template.CategoryRoot)
+				.Children ()
+				.Text (template.Category);
+
+			Session.SelectElement (templateCategoriesWidgetQuery);
+			Session.SelectElement (categoryUIQuery);
+			bool result = Session.WaitForElement (c => categoryUIQuery (c).Selected ()).Any ();
+
+			Assert.IsTrue (result, "Project template category not selected {0}/{1}", template.CategoryRoot, template.Category);
+
+			AppQuery templateUIQuery (AppQuery c) => templatesQuery (c)
+				.Contains (template.TemplateKindRoot)
+				.Children ()
+				.Text (template.TemplateKind);
+
+			Session.SelectElement (templatesWidgetQuery);
+			Session.SelectElement (templateUIQuery);
+			result = Session.WaitForElement (c => templateUIQuery (c).Selected ()).Any ();
+
+			Assert.IsTrue (result, "Project template not selected {0}/{1}", template.TemplateKindRoot, template.TemplateKind);
+
+			// Does not work.
+			//result = newProject.SelectTemplateType (template.CategoryRoot, template.Category);
+
+			// Does not work.
+			//result = newProject.SelectTemplate (template.TemplateKindRoot, template.TemplateKind);
+
 			newProject.Next ();
+
+			wizardPageAction?.Invoke (newProject);
 
 			newProject.SetProjectName ("NewProjectTest", false);
 
@@ -94,5 +153,29 @@ namespace MonoDevelop.Ide.PerfTests
 
 			newProject.Create ();
 		}
+
+		void CreateNewXamarinFormsSolutionAndWait (TemplateSelectionOptions templateOptions)
+		{
+			CreateNewSolutionAndWait (templateOptions, FillInXamarinFormsTemplateWizardPage);
+		}
+
+		void FillInXamarinFormsTemplateWizardPage (NewProjectController newProject)
+		{
+			Session.EnterText (c => c.Marked ("appNameTextBox"), "formstest");
+			Session.EnterText (c => c.Marked ("organizationTextBox"), "com.test");
+
+			Session.ToggleElement (c => c.CheckButton ().Text ("Android"), true);
+			Session.WaitForElement (c => c.CheckButton ().Text ("iOS").Property ("Active", true));
+
+			Session.ToggleElement (c => c.CheckButton ().Text ("Use .NET Standard").Visibility (true), true);
+			Session.WaitForElement (c => c.CheckButton ().Text ("Use .NET Standard").Visibility (true).Property ("Active", true));
+
+			newProject.Next	();
+		}
+
+		readonly Func<AppQuery, AppQuery> templateCategoriesWidgetQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView");
+		readonly Func<AppQuery, AppQuery> templatesWidgetQuery = c => c.TreeView ().Marked ("templatesTreeView");
+		readonly Func<AppQuery, AppQuery> templateCategoriesQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView").Model ("templateCategoriesListStore__Name");
+		readonly Func<AppQuery, AppQuery> templatesQuery = c => c.TreeView ().Marked ("templatesTreeView").Model ("templateListStore__Name");
 	}
 }

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
@@ -1,0 +1,98 @@
+//
+// TestNewSolution.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.Core;
+using MonoDevelop.Core.Instrumentation;
+using MonoDevelop.PerformanceTesting;
+using MonoDevelop.UserInterfaceTesting;
+using MonoDevelop.UserInterfaceTesting.Controllers;
+using NUnit.Framework;
+
+namespace MonoDevelop.Ide.PerfTests
+{
+	[TestFixture]
+	[BenchmarkCategory]
+	public class TestNewSolution : UITestBase
+	{
+		public override void SetUp ()
+		{
+			InstrumentationService.Enabled = true;
+			PreStart ();
+		}
+
+		[Test]
+		[Benchmark (Tolerance = 0.50)]
+		public void TestNewConsoleProject ()
+		{
+			OpenApplicationAndWait ();
+
+			var templateOptions = new TemplateSelectionOptions {
+				CategoryRoot = "Other",
+				Category = ".NET",
+				TemplateKindRoot = "General",
+				TemplateKind = "Console Project"
+			};
+
+			CreateNewSolutionAndWait (templateOptions);
+
+			Session.RunAndWaitForTimer (() => {
+				// Do nothing. Cannot call this with CreateNewSolutionAndWait since the timer is not available
+				// at that point but is available after it has been called. Using RunAndWaitForTimer here
+				// ensures we wait for the timer to change. Otherwise we would get the timer with no duration
+				// since the project is still being created.
+			}, "Ide.NewProjectDialog.ProjectCreated");
+
+			var t = Session.GetTimerDuration ("Ide.NewProjectDialog.ProjectCreated");
+
+			Benchmark.SetTime (t.TotalSeconds);
+		}
+
+		void CreateNewSolutionAndWait (TemplateSelectionOptions templateOptions)
+		{
+			var newProject = new NewProjectController ();
+			newProject.Open ();
+
+			newProject.Select (templateOptions);
+			newProject.Next ();
+
+			newProject.SetProjectName ("NewProjectTest", false);
+
+			FilePath solutionDirectory = Util.CreateTmpDir ()
+				.Combine ("NewSolutionRoot");
+			newProject.SetSolutionLocation (solutionDirectory);
+
+			newProject.CreateProjectInSolutionDirectory (true);
+
+			var gitOptions = new GitOptions {
+				UseGit = true,
+				UseGitIgnore = true
+			};
+			newProject.UseGit (gitOptions);
+
+			newProject.Create ();
+		}
+	}
+}

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
@@ -105,11 +105,8 @@ namespace MonoDevelop.Ide.PerfTests
 			var newProject = new NewProjectController ();
 			newProject.Open ();
 
-			bool result = newProject.SelectTemplateType (template.CategoryRoot, template.Category);
-			Assert.IsTrue (result, "Project template category not selected {0}/{1}", template.CategoryRoot, template.Category);
-
-			result = newProject.SelectTemplate (template.TemplateKindRoot, template.TemplateKind);
-			Assert.IsTrue (result, "Project template not selected {0}/{1}", template.TemplateKindRoot, template.TemplateKind);
+			newProject.SelectTemplateType (template.CategoryRoot, template.Category);
+			newProject.SelectTemplate (template.TemplateKindRoot, template.TemplateKind);
 
 			newProject.Next ();
 

--- a/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
+++ b/main/tests/performance/MonoDevelop.Ide.PerfTests/TestNewSolution.cs
@@ -105,33 +105,11 @@ namespace MonoDevelop.Ide.PerfTests
 			var newProject = new NewProjectController ();
 			newProject.Open ();
 
-			AppQuery categoryUIQuery (AppQuery c) => templateCategoriesQuery (c)
-				.Contains (template.CategoryRoot)
-				.Children ()
-				.Text (template.Category);
-
-			Session.SelectElement (templateCategoriesWidgetQuery);
-			Session.SelectElement (categoryUIQuery);
-			bool result = Session.WaitForElement (c => categoryUIQuery (c).Selected ()).Any ();
-
+			bool result = newProject.SelectTemplateType (template.CategoryRoot, template.Category);
 			Assert.IsTrue (result, "Project template category not selected {0}/{1}", template.CategoryRoot, template.Category);
 
-			AppQuery templateUIQuery (AppQuery c) => templatesQuery (c)
-				.Contains (template.TemplateKindRoot)
-				.Children ()
-				.Text (template.TemplateKind);
-
-			Session.SelectElement (templatesWidgetQuery);
-			Session.SelectElement (templateUIQuery);
-			result = Session.WaitForElement (c => templateUIQuery (c).Selected ()).Any ();
-
+			result = newProject.SelectTemplate (template.TemplateKindRoot, template.TemplateKind);
 			Assert.IsTrue (result, "Project template not selected {0}/{1}", template.TemplateKindRoot, template.TemplateKind);
-
-			// Does not work.
-			//result = newProject.SelectTemplateType (template.CategoryRoot, template.Category);
-
-			// Does not work.
-			//result = newProject.SelectTemplate (template.TemplateKindRoot, template.TemplateKind);
 
 			newProject.Next ();
 
@@ -172,10 +150,5 @@ namespace MonoDevelop.Ide.PerfTests
 
 			newProject.Next	();
 		}
-
-		readonly Func<AppQuery, AppQuery> templateCategoriesWidgetQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView");
-		readonly Func<AppQuery, AppQuery> templatesWidgetQuery = c => c.TreeView ().Marked ("templatesTreeView");
-		readonly Func<AppQuery, AppQuery> templateCategoriesQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView").Model ("templateCategoriesListStore__Name");
-		readonly Func<AppQuery, AppQuery> templatesQuery = c => c.TreeView ().Marked ("templatesTreeView").Model ("templateListStore__Name");
 	}
 }

--- a/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting.Controllers/NewProjectController.cs
+++ b/main/tests/ui/MonoDevelop.UserInterfaceTesting/MonoDevelop.UserInterfaceTesting.Controllers/NewProjectController.cs
@@ -38,9 +38,11 @@ namespace MonoDevelop.UserInterfaceTesting.Controllers
 			get { return TestService.Session; }
 		}
 
-		Func<AppQuery, AppQuery> previewTree = c => c.TreeView ().Marked ("folderTreeView").Model ("folderTreeStore__NodeName");
-		Func<AppQuery, AppQuery> templateCategoriesQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView").Model ("templateCategoriesListStore__Name");
-		Func<AppQuery, AppQuery> templatesQuery = c => c.TreeView ().Marked ("templatesTreeView").Model ("templateListStore__Name");
+		readonly Func<AppQuery, AppQuery> previewTree = c => c.TreeView ().Marked ("folderTreeView").Model ("folderTreeStore__NodeName");
+		readonly Func<AppQuery, AppQuery> templateCategoriesWidgetQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView");
+		readonly Func<AppQuery, AppQuery> templatesWidgetQuery = c => c.TreeView ().Marked ("templatesTreeView");
+		readonly Func<AppQuery, AppQuery> templateCategoriesQuery = c => c.TreeView ().Marked ("templateCategoriesTreeView").Model ("templateCategoriesListStore__Name");
+		readonly Func<AppQuery, AppQuery> templatesQuery = c => c.TreeView ().Marked ("templatesTreeView").Model ("templateListStore__Name");
 
 		public void Open ()
 		{
@@ -75,24 +77,26 @@ namespace MonoDevelop.UserInterfaceTesting.Controllers
 
 		public bool SelectTemplateType (string categoryRoot, string category)
 		{
-			return Session.SelectElement (c => templateCategoriesQuery (c).Contains (categoryRoot).NextSiblings ().Text (category))
-				&& IsTemplateTypeSelected (categoryRoot, category);
+			AppQuery categoryUIQuery (AppQuery c) => templateCategoriesQuery (c)
+				.Contains (categoryRoot)
+				.Children ()
+				.Text (category);
+
+			Session.SelectElement (templateCategoriesWidgetQuery);
+			Session.SelectElement (categoryUIQuery);
+			return Session.WaitForElement (c => categoryUIQuery (c).Selected ()).Any ();
 		}
 
 		public bool SelectTemplate (string kindRoot, string kind)
 		{
-			return Session.SelectElement (c => templatesQuery (c).Contains (kindRoot).NextSiblings ().Text (kind))
-				&& IsTemplateSelected (kindRoot, kind);
-		}
+			AppQuery templateUIQuery (AppQuery c) => templatesQuery (c)
+				.Contains (kindRoot)
+				.Children ()
+				.Text (kind);
 
-		public bool IsTemplateTypeSelected (string categoryRoot, string category)
-		{
-			return Session.WaitForElement (c => templateCategoriesQuery (c).Contains (categoryRoot).NextSiblings ().Text (category).Selected ()).Any ();
-		}
-
-		public bool IsTemplateSelected (string kindRoot, string kind)
-		{
-			return Session.WaitForElement (c => templatesQuery (c).Contains (kindRoot).NextSiblings ().Text (kind).Selected ()).Any ();
+			Session.SelectElement (templatesWidgetQuery);
+			Session.SelectElement (templateUIQuery);
+			return Session.WaitForElement (c => templateUIQuery (c).Selected ()).Any ();
 		}
 
 		public bool Next ()


### PR DESCRIPTION
 - Add a test that creates a new console project.
 - Add a test that creates a Xamarin.Forms solution.
 - Fixed the NewProjectController UITest helper - was not selecting the template categories in the New Project dialog.

Need to get some timings and update the baseline xml before this can be merged.