### PR TITLE
[release-8.3] [Core] Fix ReferencePath items being ignored by the type system

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1126,8 +1126,7 @@ namespace MonoDevelop.Projects
 				var monitor = new ProgressMonitor ();
 
 				var context = new TargetEvaluationContext ();
-				context.ItemsToEvaluate.Add ("_ReferencesFromRAR");
-				context.ItemsToEvaluate.Add ("_ProjectReferencesFromRAR");
+				context.ItemsToEvaluate.Add ("ReferencePath");
 				context.BuilderQueue = BuilderQueue.ShortOperations;
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;

--- a/main/tests/test-projects/ReferencePathTest/Directory.Build.targets
+++ b/main/tests/test-projects/ReferencePathTest/Directory.Build.targets
@@ -1,0 +1,18 @@
+<Project>
+
+  <Target Name="TestGeneratingReferencePathItems" BeforeTargets="BeforeBuild;BeforeResolveReferences;ResolveAssemblyReferences">
+    <ItemGroup>
+      <_ExtraReferenceItem Include="$(MonoPath)\System.ComponentModel.Composition.dll">
+        <CopyLocal>false</CopyLocal>
+        <Test>test-value</Test>
+      </_ExtraReferenceItem>
+    </ItemGroup>
+
+   <RemoveDuplicates
+      Inputs="@(_ExtraReferenceItem)">
+      <Output
+        TaskParameter="Filtered"
+        ItemName="ReferencePath" />
+    </RemoveDuplicates>
+  </Target>
+</Project>

--- a/main/tests/test-projects/ReferencePathTest/ReferencePathTest.sln
+++ b/main/tests/test-projects/ReferencePathTest/ReferencePathTest.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferencePathTest", "ReferencePathTest\ReferencePathTest.csproj", "{AAEFD239-BCA1-40A8-A8F2-57E313B22186}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AAEFD239-BCA1-40A8-A8F2-57E313B22186}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAEFD239-BCA1-40A8-A8F2-57E313B22186}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAEFD239-BCA1-40A8-A8F2-57E313B22186}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAEFD239-BCA1-40A8-A8F2-57E313B22186}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ReferencePathTest/ReferencePathTest/MyClass.cs
+++ b/main/tests/test-projects/ReferencePathTest/ReferencePathTest/MyClass.cs
@@ -1,0 +1,15 @@
+﻿
+using System;
+using System.ComponentModel.Composition;
+
+namespace ReferencePathTest
+{
+	public class MyClass
+	{
+		CreationPolicy policy;
+
+		public MyClass ()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/ReferencePathTest/ReferencePathTest/ReferencePathTest.csproj
+++ b/main/tests/test-projects/ReferencePathTest/ReferencePathTest/ReferencePathTest.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AAEFD239-BCA1-40A8-A8F2-57E313B22186}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ReferencePathTest</RootNamespace>
+    <AssemblyName>ReferencePathTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
The DotNetProject's GetReferencedAssemblies method was not returning
all references used by a project. A project may define extra
assemblies by adding ReferencePath items. These were being
filtered out since only the output parameters defined by the targets
ResolveAssemblyReferencesDesignTime and ResolveProjectReferencesDesignTime
which missed some references.

Fixes VSTS #991961 - Project model reports wrong references for
WebTools projects

Backport of #8861.

/cc @mrward 