### PR TITLE
Fix 997787 and Fix 992438

### DIFF
--- a/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
+++ b/main/src/addins/MonoDevelop.TextEditor/MonoDevelop.TextEditor.Cocoa/CocoaTextViewContent.cs
@@ -93,7 +93,10 @@ namespace MonoDevelop.TextEditor
 				if (textViewHost == null)
 					throw new ArgumentNullException (nameof (textViewHost));
 
-				GtkView = new Gtk.GtkNSViewHost (textViewHost.HostControl);
+				GtkView = new Gtk.GtkNSViewHost (
+					textViewHost.HostControl,
+					disposeViewOnGtkDestroy: true);
+
 				GtkView.Show ();
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -151,6 +151,7 @@ namespace Gtk
 			LogEnter ();
 			try {
 				view?.RemoveFromSuperview ();
+				view?.Dispose ();
 				view = null;
 				superview = null;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -77,11 +77,18 @@ namespace Gtk
 
 		NSView view;
 		NSView superview;
+		bool disposeViewOnGtkDestroy;
 		bool sizeAllocated;
 
 		public GtkNSViewHost (NSView view)
+			: this (view, disposeViewOnGtkDestroy: false)
+		{
+		}
+
+		public GtkNSViewHost (NSView view, bool disposeViewOnGtkDestroy)
 		{
 			this.view = view ?? throw new ArgumentNullException (nameof (view));
+			this.disposeViewOnGtkDestroy = disposeViewOnGtkDestroy;
 
 			WidgetFlags |= WidgetFlags.NoWindow;
 
@@ -151,7 +158,10 @@ namespace Gtk
 			LogEnter ();
 			try {
 				view?.RemoveFromSuperview ();
-				view?.Dispose ();
+
+				if (disposeViewOnGtkDestroy)
+					view?.Dispose ();
+
 				view = null;
 				superview = null;
 


### PR DESCRIPTION
`ObjectDisposedException` when closing TextEditor
Problem was with recent work to garbage collect memory of new editor, .Dispose were called from TextView.Close method, which disposed controls too early so now, when GtkHost is destroyed we also call NSView.Dispose so native controls are disposed a little later then before so accesses shouldn't happen after this point.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/997787
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/992438