### PR TITLE
[8.3][Mac] Use static NSSavePanel.SavePanel to avoid crashes on Catalina

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
@@ -41,10 +41,10 @@ namespace MonoDevelop.MacIntegration
 	{
 		protected override NSSavePanel OnCreatePanel (AddFileDialogData data)
 		{
-			return new NSOpenPanel {
-				CanChooseDirectories = false,
-				CanChooseFiles = true,
-			};
+			var panel = NSOpenPanel.OpenPanel;
+			panel.CanChooseDirectories = false;
+			panel.CanChooseFiles = true;
+			return panel;
 		}
 
 		public bool Run (AddFileDialogData data)

--- a/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
@@ -47,14 +47,14 @@ namespace MonoDevelop.MacIntegration
 		protected override NSSavePanel OnCreatePanel (SelectFileDialogData data)
 		{
 			if (data.Action == FileChooserAction.Save)
-				return new NSSavePanel ();
+				return NSSavePanel.SavePanel;
 
-			return new NSOpenPanel {
-				CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
-				CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
-				CanCreateDirectories = (data.Action & FileChooserAction.CreateFolder) != 0,
-				ResolvesAliases = false,
-			};
+			var openPanel = NSOpenPanel.OpenPanel;
+			openPanel.CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0;
+			openPanel.CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0;
+			openPanel.CanCreateDirectories = (data.Action & FileChooserAction.CreateFolder) != 0;
+			openPanel.ResolvesAliases = false;
+			return openPanel;
 		}
 
 		public bool Run (SelectFileDialogData data)


### PR DESCRIPTION
See for details: xamarin/xamarin-macios#6474

This reverts 508796b
Reopening VSTS #859111
Fixes VSTS #989519
Backport of #8877