### PR TITLE
Don't allow Reset current property pad in case of item focused changed

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPadVisitor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPadVisitor.cs
@@ -73,7 +73,6 @@ namespace MonoDevelop.DesignerSupport
 						return;
 					}
 				}
-				DesignerSupport.Service.ReSetPad ();
 			}
 		}
 
@@ -85,7 +84,7 @@ namespace MonoDevelop.DesignerSupport
 			if (ob == ((DefaultWorkbench)IdeApp.Workbench.RootWindow).ActiveWorkbenchWindow)
 				visitedCurrentDoc = true;
 
-			if (ob is MonoDevelop.Components.Docking.AutoHideBox) {
+			if (ob is Components.Docking.AutoHideBox) {
 				found = true;
 				return true;
 			}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPadVisitor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPadVisitor.cs
@@ -88,7 +88,8 @@ namespace MonoDevelop.DesignerSupport
 				found = true;
 				return true;
 			}
-			if (ob is IPropertyPad) {
+
+			if (ob is PropertyPad) {
 				// Don't change the property grid selection when the focus is inside the property grid itself
 				found = true;
 				return true;


### PR DESCRIPTION
Fixes #999288 - Native Property Pad switches context when it loses focus