### PR TITLE
[release-8.3][Core] Continue on errors when resolving assembly references

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestableTargetFrameworkNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\TestableFrameworkReferencesNodeBuilder.cs" />
     <Compile Include="MonoDevelop.DotNetCore.Tests\FakeUpdatedPackagesInWorkspace.cs" />
+    <Compile Include="MonoDevelop.DotNetCore.Tests\FrameworkReferenceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/FrameworkReferenceTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/FrameworkReferenceTests.cs
@@ -1,0 +1,69 @@
+//
+// FrameworkReferenceTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.DotNetCore.Tests
+{
+	[TestFixture]
+	class FrameworkReferenceTests : DotNetCoreTestBase
+	{
+		static bool IsDotNetCoreSdk30OrLaterInstalled ()
+		{
+			return DotNetCoreSdk.Versions.Any (version => version.Major >= 3);
+		}
+
+		[Test]
+		public async Task UnknownNuGetPackageReferenceId_DesignTimeBuilds ()
+		{
+			if (!IsDotNetCoreSdk30OrLaterInstalled ()) {
+				Assert.Ignore (".NET Core 3 SDK is not installed.");
+			}
+
+			FilePath solutionFileName = Util.GetSampleProject ("UnknownPackageReference", "NetStandard21.sln");
+			CreateNuGetConfigFile (solutionFileName.ParentDirectory);
+
+			// Run restore but do not check result since this will fail.
+			var process = Process.Start ("msbuild", $"/t:Restore /p:RestoreDisableParallel=true \"{solutionFileName}\"");
+			Assert.IsTrue (process.WaitForExit (120000), "Timeout restoring NuGet packages.");
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName)) {
+				var project = sol.GetAllProjects ().Single () as DotNetProject;
+				var references = (await project.GetFrameworkReferences (ConfigurationSelector.Default, CancellationToken.None)).ToArray ();
+
+				Assert.IsTrue (references.Any ());
+				Assert.IsTrue (references.Any (r => r.Include == "NETStandard.Library"));
+			}
+		}
+	}
+}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1197,6 +1197,9 @@ namespace MonoDevelop.Projects
 				context.BuilderQueue = BuilderQueue.ShortOperations;
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
+				// Even though some targets may fail it may still be possible for the main resolve target to return
+				// information so we set ContinueOnError. This matches VS on Windows behaviour.
+				context.GlobalProperties.SetValue ("ContinueOnError", "ErrorAndContinue");
 
 				var result = await RunTargetInternal (monitor, "ResolvePackageDependenciesDesignTime", configuration, context);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1269,6 +1269,9 @@ namespace MonoDevelop.Projects
 				context.BuilderQueue = BuilderQueue.ShortOperations;
 				context.LoadReferencedProjects = false;
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
+				// Even though some targets may fail it may still be possible for the main resolve target to return
+				// information so we set ContinueOnError. This matches VS on Windows behaviour.
+				context.GlobalProperties.SetValue ("ContinueOnError", "ErrorAndContinue");
 
 				var result = await RunTargetInternal (monitor, "ResolveFrameworkReferences", configuration, context);
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1133,6 +1133,9 @@ namespace MonoDevelop.Projects
 				context.LogVerbosity = MSBuildVerbosity.Quiet;
 				context.GlobalProperties.SetValue ("Silent", true);
 				context.GlobalProperties.SetValue ("DesignTimeBuild", true);
+				// Even though some targets may fail it may still be possible for the main resolve targets to return
+				// information so we set ContinueOnError. This matches VS on Windows behaviour.
+				context.GlobalProperties.SetValue ("ContinueOnError", "ErrorAndContinue");
 
 				var result = await RunTargetInternal (monitor, "ResolveAssemblyReferencesDesignTime;ResolveProjectReferencesDesignTime", configuration, context);
 				refs = result.Items.Select (i => new AssemblyReference (i.Include, i.Metadata)).ToList ();

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -1097,10 +1097,13 @@ namespace MonoDevelop.Projects
 
 			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
 				var project = sol.GetAllProjects ().Single () as DotNetProject;
-				var refs = (await project.GetReferencedAssemblies (ConfigurationSelector.Default)).ToArray ();
+				var references = (await project.GetReferencedAssemblies (ConfigurationSelector.Default)).ToArray ();
+				var packageDependencies = (await project.GetPackageDependencies (ConfigurationSelector.Default, CancellationToken.None)).ToArray ();
 
-				Assert.IsTrue (refs.Any ());
-				Assert.IsTrue (refs.Any (r => r.FilePath.FileName == "Newtonsoft.Json.dll"));
+				Assert.IsTrue (references.Any ());
+				Assert.IsTrue (references.Any (r => r.FilePath.FileName == "Newtonsoft.Json.dll"));
+				Assert.IsTrue (packageDependencies.Any ());
+				Assert.IsTrue (packageDependencies.Any (p => p.Name == "Newtonsoft.Json"));
 			}
 		}
 

--- a/main/tests/test-projects/UnknownPackageReference/NetStandard21.csproj
+++ b/main/tests/test-projects/UnknownPackageReference/NetStandard21.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="UnknownPackageIdThatDoesNotExistAnywhere" Version="1.0.3" />
+   </ItemGroup>
+</Project>

--- a/main/tests/test-projects/UnknownPackageReference/NetStandard21.sln
+++ b/main/tests/test-projects/UnknownPackageReference/NetStandard21.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard21", "NetStandard21.csproj", "{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/UnknownPackageReference/UnknownPackageReference.csproj
+++ b/main/tests/test-projects/UnknownPackageReference/UnknownPackageReference.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="UnknownPackageIdThatDoesNotExistAnywhere" Version="1.0.3" />
+   </ItemGroup>
+</Project>

--- a/main/tests/test-projects/UnknownPackageReference/UnknownPackageReference.sln
+++ b/main/tests/test-projects/UnknownPackageReference/UnknownPackageReference.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnknownPackageReference", "UnknownPackageReference.csproj", "{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEC2E74C-F54E-4E9E-B0A6-4E7A0D71A9A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Backport of #8896

If a PackageReference could not be resolved then no assembly
references would be given to the type system from the DotNetProject's
GetReferencedAssemblies. Whilst the NuGet restore may fail the
project.assets.json file is created and reference information is
available. The ResolvePackageAssets target was failing which then
stopped the ResolveAssemblyReferencesDesignTime target from being run.
Visual Studio on Windows avoids this problem by setting the
ContinueOnError property to ErrorAndContinue. This allows all the
targets to run even if some of them fail. It also allows references
to be returned and provided to the type system service for the
PackageReferences that can be determined.

Also set ContinueOnError for:
 - Resolving package dependencies.
 - Resolving framework references

Could not get a test working with the CoreCompileDependsOn run target - so did not add ContinueOnError there.

Fixes VSTS #998324 - NuGet Package Restore causes BCLs to not be
defined/imported

Backport of #8897.

/cc @mrward 