### PR TITLE
[release-8.4] [NuGet] Update multiple packages together in a batch

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -757,8 +757,16 @@ namespace MonoDevelop.PackageManagement
 		{
 			int count = packageActions.Count;
 			if (count == 1) {
-				string packageId = packageActions.Cast<INuGetPackageAction> ().First ().PackageId;
-				return ProgressMonitorStatusMessageFactory.CreateUpdatingSinglePackageMessage (packageId);
+				if (packageActions [0] is UpdateMultipleNuGetPackagesAction updateMultiplePackagesAction) {
+					count = updateMultiplePackagesAction.PackagesToUpdate.Count ();
+					if (count == 1) {
+						return ProgressMonitorStatusMessageFactory.CreateUpdatingSinglePackageMessage (
+							updateMultiplePackagesAction.PackagesToUpdate.First ().Id);
+					}
+				} else {
+					string packageId = packageActions.Cast<INuGetPackageAction> ().First ().PackageId;
+					return ProgressMonitorStatusMessageFactory.CreateUpdatingSinglePackageMessage (packageId);
+				}
 			}
 
 			return new ProgressMonitorStatusMessage (

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetPackageManager.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		public NuGetProject ExecutedNuGetProject;
 		public List<NuGetProjectAction> ExecutedActions;
 		public INuGetProjectContext ExecutedProjectContext;
+		public SourceCacheContext ExecutedSourceCacheContext;
 		public CancellationToken ExecutedCancellationToken;
 
 		public Action BeforeExecuteAction = () => { };
@@ -74,6 +75,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			ExecutedNuGetProject = nuGetProject;
 			ExecutedActions = nuGetProjectActions.ToList ();
 			ExecutedProjectContext = nuGetProjectContext;
+			ExecutedSourceCacheContext = sourceCacheContext;
 			ExecutedCancellationToken = token;
 
 			BeforeExecuteAction ();
@@ -82,6 +84,25 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 				return BeforeExecuteActionTask.Invoke ();
 
 			return Task.FromResult (0);
+		}
+
+		public List<NuGetProject> ExecutedNuGetProjects;
+
+		public Task ExecuteNuGetProjectActionsAsync (
+			IEnumerable<NuGetProject> nuGetProjects,
+			IEnumerable<NuGetProjectAction> nuGetProjectActions,
+			INuGetProjectContext nuGetProjectContext,
+			SourceCacheContext sourceCacheContext,
+			CancellationToken token)
+		{
+			ExecutedNuGetProjects = nuGetProjects.ToList ();
+
+			return ExecuteNuGetProjectActionsAsync (
+				(NuGetProject)null,
+				nuGetProjectActions,
+				nuGetProjectContext,
+				sourceCacheContext,
+				token);
 		}
 
 		public NuGetVersion LatestVersion = new NuGetVersion ("1.2.3");
@@ -203,6 +224,30 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			);
 		}
 
+		public List<PackageIdentity> PreviewUpdatePackages;
+		public List<NuGetProject> PreviewUpdateProjects;
+
+		public Task<IEnumerable<NuGetProjectAction>> PreviewUpdatePackagesAsync (
+			List<PackageIdentity> packageIdentities,
+			IEnumerable<NuGetProject> nuGetProjects,
+			ResolutionContext resolutionContext,
+			INuGetProjectContext nuGetProjectContext,
+			IEnumerable<SourceRepository> primarySources,
+			IEnumerable<SourceRepository> secondarySources,
+			CancellationToken token)
+		{
+			PreviewUpdatePackages = packageIdentities;
+			PreviewUpdateProjects = nuGetProjects.ToList ();
+
+			return PreviewUpdatePackagesAsync (
+				null,
+				resolutionContext,
+				nuGetProjectContext,
+				primarySources,
+				secondarySources,
+				token);
+		}
+
 		public void AddPackageToPackagesFolder (string packageId, string version)
 		{
 			var package = new PackageIdentity (packageId, new NuGetVersion (version));
@@ -239,6 +284,7 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 		}
 
 		public NuGetProject OpenReadmeFilesForProject;
+		public List<NuGetProject> OpenReadmeFilesForProjects;
 		public List<PackageIdentity> OpenReadmeFilesForPackages;
 		public INuGetProjectContext OpenReadmeFilesWithProjectContext;
 		public CancellationToken OpenReadmeFilesWithCancellationToken;
@@ -250,6 +296,20 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			CancellationToken token)
 		{
 			OpenReadmeFilesForProject = project;
+			OpenReadmeFilesForPackages = packages.ToList ();
+			OpenReadmeFilesWithProjectContext = nuGetProjectContext;
+			OpenReadmeFilesWithCancellationToken = token;
+
+			return Task.FromResult (0);
+		}
+
+		public Task OpenReadmeFiles (
+			IEnumerable<NuGetProject> projects,
+			IEnumerable<PackageIdentity> packages,
+			INuGetProjectContext nuGetProjectContext,
+			CancellationToken token)
+		{
+			OpenReadmeFilesForProjects = projects.ToList ();
 			OpenReadmeFilesForPackages = packages.ToList ();
 			OpenReadmeFilesWithProjectContext = nuGetProjectContext;
 			OpenReadmeFilesWithCancellationToken = token;
@@ -277,6 +337,20 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			BeforePreviewUninstallPackagesAsync ();
 
 			return Task.FromResult (BuildIntegratedProjectAction);
+		}
+
+		public INuGetProjectContext RunPostProcessAsyncProjectContext;
+		public List<NuGetProject> RunPostProcessAsyncProjects;
+
+		public Task RunPostProcessAsync (
+			List<NuGetProject> nuGetProjects,
+			INuGetProjectContext nuGetProjectContext,
+			CancellationToken token)
+		{
+			RunPostProcessAsyncProjectContext = nuGetProjectContext;
+			RunPostProcessAsyncProjects = nuGetProjects;
+
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProjectContext.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakeNuGetProjectContext.cs
@@ -72,6 +72,8 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public void Log (ILogMessage message)
 		{
+			if (LogToConsole)
+				Console.WriteLine (message.Message);
 		}
 
 		public void ReportError (ILogMessage message)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakePackageRestoreManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/FakePackageRestoreManager.cs
@@ -78,6 +78,16 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 
 		public void AddUnrestoredPackageForProject (string projectName, string solutionDirectory)
 		{
+			AddPackageForProject (projectName, solutionDirectory, isMissing: true);
+		}
+
+		public void AddRestoredPackageForProject (string projectName, string solutionDirectory)
+		{
+			AddPackageForProject (projectName, solutionDirectory, isMissing: false);
+		}
+
+		public void AddPackageForProject (string projectName, string solutionDirectory, bool isMissing)
+		{
 			var packageReference = new PackageReference (
 				new PackageIdentity ("Test", new NuGetVersion ("1.0")),
 				new NuGetFramework ("any"));
@@ -85,11 +95,11 @@ namespace MonoDevelop.PackageManagement.Tests.Helpers
 			var restoreData = new PackageRestoreData (
 				packageReference,
 				new [] { projectName },
-				isMissing: true);
+				isMissing);
 
 			var restoreDataList = new List<PackageRestoreData> ();
 			restoreDataList.Add (restoreData);
-			PackagesInSolution[solutionDirectory] = restoreDataList;
+			PackagesInSolution [solutionDirectory] = restoreDataList;
 		}
 
 		public Task<IEnumerable<PackageRestoreData>> GetPackagesInSolutionAsync (

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableUpdateMultipleNuGetPackagesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.Helpers/TestableUpdateMultipleNuGetPackagesAction.cs
@@ -1,0 +1,86 @@
+//
+// TestableUpdateMultipleNuGetPackagesAction.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+using NuGet.Protocol.Core.Types;
+
+namespace MonoDevelop.PackageManagement.Tests.Helpers
+{
+	class TestableUpdateMultipleNuGetPackagesAction : UpdateMultipleNuGetPackagesAction
+	{
+		public FakeNuGetProjectContext ProjectContext;
+		public FakeNuGetPackageManager PackageManager;
+		public FakePackageRestoreManager RestoreManager;
+		public PackageManagementEvents PackageManagementEvents;
+		public FakeLicenseAcceptanceService LicenseAcceptanceService = new FakeLicenseAcceptanceService ();
+		public FakeFileRemover FileRemover = new FakeFileRemover ();
+
+		public TestableUpdateMultipleNuGetPackagesAction (
+			IEnumerable<SourceRepository> primarySources,
+			FakeSolutionManager solutionManager)
+			: this (
+				primarySources,
+				solutionManager,
+				new FakeNuGetProjectContext (),
+				new FakeNuGetPackageManager (),
+				new FakePackageRestoreManager (),
+				new PackageManagementEvents ())
+		{
+		}
+
+		public TestableUpdateMultipleNuGetPackagesAction (
+			IEnumerable<SourceRepository> primarySources,
+			FakeSolutionManager solutionManager,
+			FakeNuGetProjectContext projectContext,
+			FakeNuGetPackageManager packageManager,
+			FakePackageRestoreManager restoreManager,
+			PackageManagementEvents packageManagementEvents)
+			: base (
+				primarySources,
+				solutionManager,
+				projectContext,
+				packageManager,
+				restoreManager,
+				packageManagementEvents)
+		{
+			ProjectContext = projectContext;
+			PackageManager = packageManager;
+			RestoreManager = restoreManager;
+
+			PackageManagementEvents = packageManagementEvents;
+		}
+
+		protected override ILicenseAcceptanceService GetLicenseAcceptanceService ()
+		{
+			return LicenseAcceptanceService;
+		}
+
+		protected override IFileRemover GetFileRemover ()
+		{
+			return FileRemover;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests.csproj
@@ -156,6 +156,9 @@
     <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableManagePackagesViewModel.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\PackageManagementCanReferenceProjectExtensionTests.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Tests\PackageLoadContextTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\UpdateStrictPackageDependenciesTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests\UpdateMultipleNuGetPackagesActionTests.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Tests.Helpers\TestableUpdateMultipleNuGetPackagesAction.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\MonoDevelop.Core\MonoDevelop.Core.csproj">

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateStrictPackageDependenciesTests.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Tests/MonoDevelop.PackageManagement.Tests/UpdateStrictPackageDependenciesTests.cs
@@ -1,0 +1,88 @@
+//
+// UpdateStrictPackageDependenciesTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.PackageManagement.Tests.Helpers;
+using MonoDevelop.Projects;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.PackageManagement.Tests
+{
+	[TestFixture]
+	public class UpdateStrictPackageDependenciesTests : RestoreTestBase
+	{
+		[Test]
+		public async Task UpdatePackage_ReferenceInsideItemGroupWithCondition_ReferenceRemainsInsideItemGroupAfterUpdate ()
+		{
+			string solutionFileName = Util.GetSampleProject ("StrictNuGetDependency", "StrictNuGetDependency.sln");
+			using (solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName)) {
+				CreateNuGetConfigFile (solution.BaseDirectory);
+				var project = (DotNetProject)solution.FindProjectByName ("StrictNuGetDependency");
+
+				await RestoreNuGetPackages (solution);
+
+				// Update NuGet packages
+				var packages = new List<PackageIdentity> ();
+				packages.Add (new PackageIdentity ("Test.Xam.Strict.Dependency.A", NuGetVersion.Parse ("1.1.0")));
+				packages.Add (new PackageIdentity ("Test.Xam.Strict.Dependency.B", NuGetVersion.Parse ("1.1.0")));
+				await UpdateNuGetPackages (project, packages);
+
+				string expectedXml = Util.ToSystemEndings (File.ReadAllText (project.FileName.ChangeExtension (".csproj-saved")));
+				string actualXml = Util.ToSystemEndings (File.ReadAllText (project.FileName));
+				Assert.AreEqual (expectedXml, actualXml);
+			}
+		}
+
+		Task UpdateNuGetPackages (DotNetProject project, IEnumerable<PackageIdentity> packages)
+		{
+			var solutionManager = new MonoDevelopSolutionManager (project.ParentSolution);
+			var context = CreateNuGetProjectContext (solutionManager.Settings);
+
+			var sources = solutionManager.CreateSourceRepositoryProvider ().GetRepositories ().ToList ();
+
+			var action = new UpdateMultipleNuGetPackagesAction (
+				sources,
+				solutionManager,
+				context);
+
+			action.AddProject (new DotNetProjectProxy (project));
+
+			foreach (var package in packages) {
+				action.AddPackageToUpdate (package);
+			}
+
+			return Task.Run (() => {
+				action.Execute ();
+			});
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -366,6 +366,8 @@
     <Compile Include="MonoDevelop.PackageManagement\RecentManagedNuGetPackagesRepository.cs" />
     <Compile Include="MonoDevelop.PackageManagement\ManageProjectViewModel.cs" />
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementCanReferenceProjectExtension.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\UpdateMultipleNuGetPackagesAction.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\ProjectReferenceMaintainerCollection.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/INuGetPackageManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/INuGetPackageManager.cs
@@ -63,6 +63,15 @@ namespace MonoDevelop.PackageManagement
 			IEnumerable<SourceRepository> secondarySources,
 			CancellationToken token);
 
+		Task<IEnumerable<NuGetProjectAction>> PreviewUpdatePackagesAsync (
+			List<PackageIdentity> packageIdentities,
+			IEnumerable<NuGetProject> nuGetProjects,
+			ResolutionContext resolutionContext,
+			INuGetProjectContext nuGetProjectContext,
+			IEnumerable<SourceRepository> primarySources,
+			IEnumerable<SourceRepository> secondarySources,
+			CancellationToken token);
+
 		Task<IEnumerable<NuGetProjectAction>> PreviewUninstallPackageAsync(
 			NuGetProject nuGetProject,
 			string packageId,
@@ -91,6 +100,13 @@ namespace MonoDevelop.PackageManagement
 			SourceCacheContext sourceCacheContext,
 			CancellationToken token);
 
+		Task ExecuteNuGetProjectActionsAsync (
+			IEnumerable<NuGetProject> nuGetProjects,
+			IEnumerable<NuGetProjectAction> nuGetProjectActions,
+			INuGetProjectContext nuGetProjectContext,
+			SourceCacheContext sourceCacheContext,
+			CancellationToken token);
+
 		void SetDirectInstall (PackageIdentity directInstall, INuGetProjectContext nuGetProjectContext);
 		void ClearDirectInstall (INuGetProjectContext nuGetProjectContext);
 
@@ -99,6 +115,17 @@ namespace MonoDevelop.PackageManagement
 		Task OpenReadmeFiles (
 			NuGetProject project,
 			IEnumerable<PackageIdentity> packages,
+			INuGetProjectContext nuGetProjectContext,
+			CancellationToken token);
+
+		Task OpenReadmeFiles (
+			IEnumerable<NuGetProject> projects,
+			IEnumerable<PackageIdentity> packages,
+			INuGetProjectContext nuGetProjectContext,
+			CancellationToken token);
+
+		Task RunPostProcessAsync (
+			List<NuGetProject> nuGetProjects,
 			INuGetProjectContext nuGetProjectContext,
 			CancellationToken token);
 	}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopBuildIntegratedRestorer.cs
@@ -250,6 +250,10 @@ namespace MonoDevelop.PackageManagement
 			if (dotNetCoreNuGetProject?.ProjectRequiresReloadAfterRestore () == true)
 				return dotNetCoreNuGetProject.DotNetProject;
 
+			var packageReferenceNuGetProject = project as PackageReferenceNuGetProject;
+			if (packageReferenceNuGetProject?.ProjectRequiresReloadAfterRestore () == true)
+				return packageReferenceNuGetProject.DotNetProject;
+
 			return null;
 		}
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopNuGetPackageManager.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopNuGetPackageManager.cs
@@ -351,8 +351,12 @@ namespace MonoDevelop.PackageManagement
 				dotNetProject.DotNetProject.ShutdownProjectBuilder ();
 
 				if (!packageRestorer.LockFileChanged) {
+					// Need to re-evaluate. When updating multiple projects the restore done at the end
+					// may be a no-op. This results in no re-evaluation being done so we re-evaluate here.
+					//
 					// Need to refresh the references since the restore did not.
-					await Runtime.RunInMainThread (() => {
+					await Runtime.RunInMainThread (async () => {
+						await dotNetProject.DotNetProject.ReevaluateProject (new ProgressMonitor ());
 						dotNetProject.DotNetProject.DotNetCoreNotifyReferencesChanged ();
 					});
 				}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectReferenceMaintainerCollection.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ProjectReferenceMaintainerCollection.cs
@@ -1,10 +1,10 @@
-﻿//
-// FakeNuGetProjectAction.cs
+//
+// ProjectReferenceMaintainerCollection.cs
 //
 // Author:
-//       Matt Ward <matt.ward@xamarin.com>
+//       Matt Ward <matt.ward@microsoft.com>
 //
-// Copyright (c) 2016 Xamarin Inc. (http://xamarin.com)
+// Copyright (c) 2019 Microsoft Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,45 +24,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using NuGet.PackageManagement;
-using NuGet.Packaging.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using NuGet.ProjectManagement;
-using NuGet.Versioning;
 
-namespace MonoDevelop.PackageManagement.Tests.Helpers
+namespace MonoDevelop.PackageManagement
 {
-	class FakeNuGetProjectAction : NuGetProjectAction
+	sealed class ProjectReferenceMaintainerCollection : IDisposable
 	{
-		public FakeNuGetProjectAction (
-			string packageId,
-			string packageVersion,
-			NuGetProjectActionType actionType)
-			: base (
-				CreatePackageIdentity (packageId, packageVersion),
-				actionType,
-				null)
+		List<ProjectReferenceMaintainer> referenceMaintainers;
+
+		public ProjectReferenceMaintainerCollection (IEnumerable<NuGetProject> projects)
 		{
+			referenceMaintainers = projects
+				.Select (project => new ProjectReferenceMaintainer (project))
+				.ToList ();
 		}
 
-		public FakeNuGetProjectAction (
-			NuGetProject project,
-			string packageId,
-			string packageVersion,
-			NuGetProjectActionType actionType)
-			: base (
-				CreatePackageIdentity (packageId, packageVersion),
-				actionType,
-				project)
+		public void Dispose ()
 		{
-		}
-
-		static PackageIdentity CreatePackageIdentity (string packageId, string packageVersion)
-		{
-			NuGetVersion nuGetVersion = null;
-			if (packageVersion != null) {
-				nuGetVersion = new NuGetVersion (packageVersion);
+			foreach (ProjectReferenceMaintainer referenceMaintainer in referenceMaintainers) {
+				referenceMaintainer.Dispose ();
 			}
-			return new PackageIdentity (packageId, nuGetVersion);
+		}
+
+		public async Task ApplyChangesAsync ()
+		{
+			foreach (ProjectReferenceMaintainer referenceMaintainer in referenceMaintainers) {
+				await referenceMaintainer.ApplyChanges ();
+			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateAllNuGetPackagesInProjectAction.cs
@@ -172,8 +172,7 @@ namespace MonoDevelop.PackageManagement
 				solutionManager.SolutionDirectory,
 				cancellationToken);
 
-			var missingPackages = packages.Select (IsMissingForCurrentProject).ToList ();
-			if (missingPackages.Any ()) {
+			if (packages.Any (package => IsMissingForCurrentProject (package))) {
 				using (var monitor = new PackageRestoreMonitor (restoreManager, packageManagementEvents)) {
 					using (var cacheContext = new SourceCacheContext ()) {
 						var downloadContext = new PackageDownloadContext (cacheContext);
@@ -244,7 +243,8 @@ namespace MonoDevelop.PackageManagement
 		{
 			return actions
 				.Where (action => action.NuGetProjectActionType == NuGetProjectActionType.Install)
-				.Select (action => action.PackageIdentity);
+				.Select (action => action.PackageIdentity)
+				.Distinct ();
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateMultipleNuGetPackagesAction.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/UpdateMultipleNuGetPackagesAction.cs
@@ -1,0 +1,297 @@
+//
+// UpdateMultipleNuGetPackagesAction.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using NuGet.PackageManagement;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+
+namespace MonoDevelop.PackageManagement
+{
+	class UpdateMultipleNuGetPackagesAction : IPackageAction, INuGetProjectActionsProvider
+	{
+		INuGetProjectContext context;
+		IMonoDevelopSolutionManager solutionManager;
+		INuGetPackageManager packageManager;
+		IPackageRestoreManager restoreManager;
+		IEnumerable<NuGetProjectAction> actions;
+		List<IDotNetProject> dotNetProjects = new List<IDotNetProject> ();
+		List<NuGetProject> projects = new List<NuGetProject> ();
+		List<PackageIdentity> packagesToUpdate = new List<PackageIdentity> ();
+		List<SourceRepository> primarySources;
+		List<SourceRepository> secondarySources;
+		IPackageManagementEvents packageManagementEvents;
+
+		public UpdateMultipleNuGetPackagesAction (
+			IEnumerable<SourceRepository> primarySources,
+			IMonoDevelopSolutionManager solutionManager,
+			INuGetProjectContext context)
+			: this (
+				primarySources,
+				solutionManager,
+				context,
+				new MonoDevelopNuGetPackageManager (solutionManager),
+				new MonoDevelopPackageRestoreManager (solutionManager),
+				PackageManagementServices.PackageManagementEvents)
+		{
+		}
+
+		public UpdateMultipleNuGetPackagesAction (
+			IEnumerable<SourceRepository> primarySources,
+			IMonoDevelopSolutionManager solutionManager,
+			INuGetProjectContext context,
+			INuGetPackageManager packageManager,
+			IPackageRestoreManager restoreManager,
+			IPackageManagementEvents packageManagementEvents)
+		{
+			this.solutionManager = solutionManager;
+			this.context = context;
+			this.packageManager = packageManager;
+			this.restoreManager = restoreManager;
+			this.packageManagementEvents = packageManagementEvents;
+
+			this.primarySources = primarySources.ToList ();
+			secondarySources = solutionManager.CreateSourceRepositoryProvider ().GetRepositories ().ToList ();
+		}
+
+		public PackageActionType ActionType => PackageActionType.Install;
+
+		/// <summary>
+		/// Used for testing to disable the license service check.
+		/// </summary>
+		internal bool LicensesMustBeAccepted { get; set; } = true;
+
+		public void AddProject (IDotNetProject project)
+		{
+			dotNetProjects.Add (project);
+			projects.Add (solutionManager.GetNuGetProject (project));
+		}
+
+		public void AddPackageToUpdate (PackageIdentity package)
+		{
+			packagesToUpdate.Add (package);
+		}
+
+		internal IList<IDotNetProject> DotNetProjects => dotNetProjects;
+		internal IList<PackageIdentity> PackagesToUpdate => packagesToUpdate;
+
+		public void Execute ()
+		{
+			Execute (CancellationToken.None);
+		}
+
+		public void Execute (CancellationToken cancellationToken)
+		{
+			ExecuteAsync (cancellationToken).Wait ();
+		}
+
+		public IEnumerable<NuGetProjectAction> GetNuGetProjectActions ()
+		{
+			return actions;
+		}
+
+		public bool HasPackageScriptsToRun ()
+		{
+			return false;
+		}
+
+		async Task ExecuteAsync (CancellationToken cancellationToken)
+		{
+			using (var sourceCacheContext = new SourceCacheContext ()) {
+				await RestoreAnyMissingPackagesAsync (sourceCacheContext, cancellationToken);
+
+				var resolutionContext = CreateResolutionContext (sourceCacheContext);
+
+				actions = await packageManager.PreviewUpdatePackagesAsync (
+					packagesToUpdate,
+					projects,
+					resolutionContext,
+					context,
+					primarySources,
+					secondarySources,
+					cancellationToken);
+
+				if (!actions.Any ()) {
+					foreach (IDotNetProject project in dotNetProjects) {
+						packageManagementEvents.OnNoUpdateFound (project);
+					}
+					return;
+				}
+
+				if (LicensesMustBeAccepted) {
+					await CheckLicensesAsync (cancellationToken);
+				}
+
+				using (IDisposable fileMonitor = CreateFileMonitor ()) {
+					using (var referenceMaintainer = new ProjectReferenceMaintainerCollection (projects)) {
+						await packageManager.ExecuteNuGetProjectActionsAsync (
+							projects,
+							actions,
+							context,
+							sourceCacheContext,
+							cancellationToken);
+
+						await referenceMaintainer.ApplyChangesAsync ();
+					}
+				}
+
+				OnAfterExecutionActions ();
+
+				await RunPostProcessAsync (cancellationToken);
+
+				await OpenReadmeFilesAsync (cancellationToken);
+			}
+		}
+
+		async Task RestoreAnyMissingPackagesAsync (SourceCacheContext sourceCacheContext, CancellationToken cancellationToken)
+		{
+			var packages = await restoreManager.GetPackagesInSolutionAsync (
+				solutionManager.SolutionDirectory,
+				cancellationToken);
+
+			if (!packages.Any (package => IsMissingForProject (package)))
+				return;
+
+			using (var monitor = new PackageRestoreMonitor (restoreManager, packageManagementEvents)) {
+				var downloadContext = new PackageDownloadContext (sourceCacheContext);
+				await restoreManager.RestoreMissingPackagesAsync (
+					solutionManager.SolutionDirectory,
+					packages,
+					context,
+					downloadContext,
+					cancellationToken);
+			}
+
+			await Runtime.RunInMainThread (() => {
+				foreach (IDotNetProject dotNetProject in dotNetProjects) {
+					dotNetProject.RefreshReferenceStatus ();
+				}
+			});
+
+			packageManagementEvents.OnPackagesRestored ();
+		}
+
+		bool IsMissingForProject (PackageRestoreData package)
+		{
+			if (!package.IsMissing)
+				return false;
+
+			foreach (string projectName in package.ProjectNames) {
+				foreach (IDotNetProject dotNetProject in dotNetProjects) {
+					if (dotNetProject.Name == projectName) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		ResolutionContext CreateResolutionContext (SourceCacheContext sourceCacheContext)
+		{
+			bool includePrerelease = packagesToUpdate
+				.Where (package => package.Version.IsPrerelease)
+				.Any ();
+
+			return new ResolutionContext (
+				DependencyBehavior.Lowest,
+				includePrerelease,
+				true, // includeUnlisted. Visual Studio on Windows sets this to true.
+				VersionConstraints.None,
+				new GatherCache (),
+				sourceCacheContext);
+		}
+
+		IDisposable CreateFileMonitor ()
+		{
+			return new PreventPackagesConfigFileBeingRemovedOnUpdateMonitor (
+				packageManagementEvents,
+				GetFileRemover ());
+		}
+
+		protected virtual IFileRemover GetFileRemover ()
+		{
+			return new FileRemover ();
+		}
+
+		Task CheckLicensesAsync (CancellationToken cancellationToken)
+		{
+			return NuGetPackageLicenseAuditor.AcceptLicenses (
+				primarySources,
+				actions,
+				packageManager,
+				GetLicenseAcceptanceService (),
+				cancellationToken);
+		}
+
+		protected virtual ILicenseAcceptanceService GetLicenseAcceptanceService ()
+		{
+			return new LicenseAcceptanceService ();
+		}
+
+		void OnAfterExecutionActions ()
+		{
+			if (projects.Count == 1) {
+				projects [0].OnAfterExecuteActions (actions);
+				return;
+			}
+
+			foreach (NuGetProject project in projects) {
+				var projectActions = actions
+					.Where (action => action.Project == project)
+					.ToArray ();
+				if (projectActions.Any ()) {
+					project.OnAfterExecuteActions (projectActions);
+				}
+			}
+		}
+
+		Task RunPostProcessAsync (CancellationToken cancellationToken)
+		{
+			return packageManager.RunPostProcessAsync (projects, context, cancellationToken);
+		}
+
+		Task OpenReadmeFilesAsync (CancellationToken cancellationToken)
+		{
+			var packages = GetPackagesUpdated ();
+			return packageManager.OpenReadmeFiles (projects, packages, context, cancellationToken);
+		}
+
+		IEnumerable<PackageIdentity> GetPackagesUpdated ()
+		{
+			return actions
+				.Where (action => action.NuGetProjectActionType == NuGetProjectActionType.Install)
+				.Select (action => action.PackageIdentity)
+				.Distinct ();
+		}
+	}
+}

--- a/main/tests/test-projects/NuGetUpdateAvailableItems/NuGetUpdateAvailableItems.sln
+++ b/main/tests/test-projects/NuGetUpdateAvailableItems/NuGetUpdateAvailableItems.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferenceProject", "PackageReferenceProject\PackageReferenceProject.csproj", "{7F63CBE6-2FE7-47A7-8930-EA078DA05062}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SdkStyleProject", "SdkStyleProject\SdkStyleProject.csproj", "{5B443F8D-6C84-443F-A395-5429E8F4A47D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F63CBE6-2FE7-47A7-8930-EA078DA05062}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/NuGetUpdateAvailableItems/PackageReferenceProject/PackageReferenceProject.csproj
+++ b/main/tests/test-projects/NuGetUpdateAvailableItems/PackageReferenceProject/PackageReferenceProject.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>RestoreStylePackageReference</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Test.Xam.AvailableItemName" Version="0.1.0" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/NuGetUpdateAvailableItems/SdkStyleProject/SdkStyleProject.csproj
+++ b/main/tests/test-projects/NuGetUpdateAvailableItems/SdkStyleProject/SdkStyleProject.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Test.Xam.AvailableItemName" Version="0.1.0" />
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/StrictNuGetDependency/StrictNuGetDependency.csproj
+++ b/main/tests/test-projects/StrictNuGetDependency/StrictNuGetDependency.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>StrictNuGetDependency</RootNamespace>
+    <AssemblyName>StrictNuGetDependency</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Test.Xam.Strict.Dependency.A" Version="1.0.0" />
+    <PackageReference Include="Test.Xam.Strict.Dependency.B" Version="1.0.0" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/StrictNuGetDependency/StrictNuGetDependency.csproj-saved
+++ b/main/tests/test-projects/StrictNuGetDependency/StrictNuGetDependency.csproj-saved
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>StrictNuGetDependency</RootNamespace>
+    <AssemblyName>StrictNuGetDependency</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Test.Xam.Strict.Dependency.A" Version="1.1.0" />
+    <PackageReference Include="Test.Xam.Strict.Dependency.B" Version="1.1.0" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/StrictNuGetDependency/StrictNuGetDependency.sln
+++ b/main/tests/test-projects/StrictNuGetDependency/StrictNuGetDependency.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrictNuGetDependency", "StrictNuGetDependency.csproj", "{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B42BCDC-B50D-4529-85D8-D7FDEFB3447F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Updating two NuGet package references that have a strict dependency
on a single version of another NuGet package not explicitly added
to the project would fail in the Manage NuGet Packages dialog. This
was because the update would be done one package at a time. Doing
the update of the two NuGet packages together allows NuGet to
update both so they then use the new strict dependency.

Note that updating all packages in the project from the Solution
window does not have this problem since there the packages are
updated together in a batch.

Fixes VSTS #986960 - Solution nuget updater fails to update a set of
packages that all have a related dependency update

Backport of #8818.

/cc @mrward 