### PR TITLE
[release-8.4] [Core] Fix project modified fired for refs when they have not changed

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1922,8 +1922,11 @@ namespace MonoDevelop.Projects
 
 		protected override void OnItemsAdded (IEnumerable<ProjectItem> objs)
 		{
-			foreach (var pref in objs.OfType<ProjectReference> ())
+			bool referencedAdded = false;
+			foreach (var pref in objs.OfType<ProjectReference> ()) {
+				referencedAdded = true;
 				pref.SetOwnerProject (this);
+			}
 
 			base.OnItemsAdded (objs);
 
@@ -1934,13 +1937,17 @@ namespace MonoDevelop.Projects
 			foreach (var pref in objs.OfType<ProjectReference> ())
 				ProjectExtension.OnReferenceAddedToProject (new ProjectReferenceEventArgs (this, pref));
 			
-			NotifyReferencedAssembliesChanged ();
+			if (referencedAdded)
+				NotifyReferencedAssembliesChanged ();
 		}
 
 		protected override void OnItemsRemoved (IEnumerable<ProjectItem> objs)
 		{
-			foreach (var pref in objs.OfType<ProjectReference> ())
+			bool referencedRemoved = false;
+			foreach (var pref in objs.OfType<ProjectReference> ()) {
+				referencedRemoved = true;
 				pref.SetOwnerProject (null);
+			}
 
 			base.OnItemsRemoved (objs);
 
@@ -1951,7 +1958,8 @@ namespace MonoDevelop.Projects
 			foreach (var pref in objs.OfType<ProjectReference> ())
 				ProjectExtension.OnReferenceRemovedFromProject (new ProjectReferenceEventArgs (this, pref));
 			
-			NotifyReferencedAssembliesChanged ();
+			if (referencedRemoved)
+				NotifyReferencedAssembliesChanged ();
 		}
 
 		internal void NotifyReferencedAssembliesChanged ()


### PR DESCRIPTION
Originally the Project.Modified event was fired with a Hint set to
References when a ProjectReference was added to or removed from the
project. This was changed in commit 90d690e56f2e100d8dea11bf3ad690f9eefaeb4f
and now the event is fired for any ProjectItem being added/removed.
This can cause the type system to try to update its type information
when it should not. One example is updating a NuGet PackageReference
which would trigger this event before the updated reference information
will be available for the type system.

Fixes VSTS #992017 - Modified event fires for References when non
reference added/removed from project

Backport of #8840.

/cc @mrward 