### PR TITLE
[IN Progress] Cleans current loaded editors when project is unloaded for any reason

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/DesignerSupportService.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/DesignerSupportService.cs
@@ -249,6 +249,20 @@ namespace MonoDevelop.DesignerSupport
 		{
 			IdeApp.CommandService.RegisterCommandTargetVisitor (new PropertyPadVisitor ());
 			AddinManager.ExtensionChanged += OnExtensionChanged;
+
+			IdeApp.Initialized += (s, args) => {
+				IdeApp.Workspace.LastWorkspaceItemClosed += delegate {
+					if (!IdeApp.IsExiting && !IdeApp.Workspace.WorkspaceItemIsOpening) {
+						ReSetPad ();
+					}
+				};
+				
+				IdeApp.Workbench.DocumentClosed += delegate {
+					if (!IdeApp.IsExiting && IdeApp.Workbench.Documents.Count == 0 && !IdeApp.Workspace.IsOpen) {
+						ReSetPad ();
+					}
+				};
+			};
 		}
 		
 		void OnExtensionChanged (object s, ExtensionEventArgs args)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/DesignerSupportService.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/DesignerSupportService.cs
@@ -250,17 +250,10 @@ namespace MonoDevelop.DesignerSupport
 			IdeApp.CommandService.RegisterCommandTargetVisitor (new PropertyPadVisitor ());
 			AddinManager.ExtensionChanged += OnExtensionChanged;
 
-			IdeApp.Initialized += (s, args) => {
-				IdeApp.Workspace.LastWorkspaceItemClosed += delegate {
-					if (!IdeApp.IsExiting && !IdeApp.Workspace.WorkspaceItemIsOpening) {
+			IdeApp.Initialized += (s, args) => {				
+				IdeApp.Workbench.DocumentClosed += (o, args) => {
+					if (lastPadProvider != null && lastPadProvider == args.Document.DocumentContext.GetContent<IPropertyPadProvider>())
 						ReSetPad ();
-					}
-				};
-				
-				IdeApp.Workbench.DocumentClosed += delegate {
-					if (!IdeApp.IsExiting && IdeApp.Workbench.Documents.Count == 0 && !IdeApp.Workspace.IsOpen) {
-						ReSetPad ();
-					}
 				};
 			};
 		}


### PR DESCRIPTION
Basically this PR cleans property panel stored objects on workspace ended.

Fixes VSTS #1000899 - PropertyPad creates leak of editor instance