### PR TITLE
Fixes overlapping in custom native property pad on PadContentShown/Hidden

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
@@ -230,7 +230,10 @@ namespace MonoDevelop.DesignerSupport
 			customWidget = true;
 			frame.Remove (frame.Child);
 			frame.Add (widget);
-			widget.Show ();			
+			widget.Show ();
+			if (container != null) {
+				widget.Visible = container.ContentVisible;
+			}
 		}
 		
 		void ClearToolbar ()

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
@@ -104,10 +104,14 @@ namespace MonoDevelop.DesignerSupport
 
 			propertyGrid.SetToolbarProvider (toolbarProvider);
 
+#if MAC
 			//native cocoa needs content shown to initialize stuff
 			if (isNative) {
 				container.PadContentShown += Window_PadContentShown;
+				container.PadContentHidden += Window_PadContentHidden;
 			}
+#endif
+
 			this.container = container;
 			DesignerSupport.Service.SetPad (this);
 		}
@@ -127,6 +131,7 @@ namespace MonoDevelop.DesignerSupport
 #if MAC
 			if (isNative) {
 				container.PadContentShown -= Window_PadContentShown;
+				container.PadContentHidden -= Window_PadContentHidden;
 				nativeGrid.PropertyGridChanged -= Grid_Changed;
 			} else {
 #endif
@@ -181,10 +186,23 @@ namespace MonoDevelop.DesignerSupport
 			CommandRouteOrigin = null;
 		}
 
+#if MAC
 		void Window_PadContentShown (object sender, EventArgs e)
 		{
 			propertyGrid.OnPadContentShown ();
+
+			if (customWidget && frame.Child is GtkNSViewHost viewHost) {
+				viewHost.Visible = true;
+			}
 		}
+
+		void Window_PadContentHidden (object sender, EventArgs e)
+		{
+			if (customWidget && frame.Child is GtkNSViewHost viewHost) {
+				viewHost.Visible = false;
+			}
+		}
+#endif
 
 		void AttachToolbarIfCustomWidget ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -80,6 +80,18 @@ namespace Gtk
 		bool disposeViewOnGtkDestroy;
 		bool sizeAllocated;
 
+		protected override void OnShown ()
+		{
+			view.Hidden = false;
+			base.OnShown ();
+		}
+
+		protected override void OnHidden ()
+		{
+			view.Hidden = true;
+			base.OnHidden ();
+		}
+
 		public GtkNSViewHost (NSView view)
 			: this (view, disposeViewOnGtkDestroy: false)
 		{


### PR DESCRIPTION
Basically the problem was we didn't have a mechanism to hide **custom property panels** in case of DockSystem needs hide a Pad for some reason (like relayout or unexpected tab change). Now with the native embeded views we need not only hide the GtkViewHost but also the contained native view.

Fixes VSTS #1001720 - Property Panel overlays Document Outline pane when opening new Xaml files

### Before

![ge11MKCB7D](https://user-images.githubusercontent.com/1587480/66792818-b5bfee80-eefa-11e9-8ca4-76fd5eed4db2.gif)

### After

![8QDzvMqtAo](https://user-images.githubusercontent.com/1587480/66792799-a8a2ff80-eefa-11e9-9004-d48abe7e6a64.gif)


### To Test the issue

1) Open a Xaml Forms Project, close all Xaml Files.
2) Select the Properties Tab
3) Open a Xaml File
4) Select the Document Outline Tab
5) Open a second Xaml File
