### PR TITLE
[release-8.3] [Catalina] Fixes broken accessory view in any NSSavePanel based panels (Cocoa bug)

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacCommonFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacCommonFileDialogHandler.cs
@@ -92,10 +92,14 @@ namespace MonoDevelop.MacIntegration
 			if (!string.IsNullOrEmpty (data.CurrentFolder))
 				panel.DirectoryUrl = new NSUrl (data.CurrentFolder, true);
 
-			var parent = IdeServices.DesktopService.GetFocusedTopLevelWindow ();
-			if (parent != null)
-				panel.ParentWindow = parent;
-
+			if (MacSystemInformation.OsVersion < MacSystemInformation.Catalina) {
+				//set ParentWindow in NSSavePanel is broken in Catalina, we need a fix in cocoa
+				var parentWindow = (NSWindow)IdeServices.DesktopService.GetFocusedTopLevelWindow ();
+				if (parentWindow != null) {
+					panel.ParentWindow = parentWindow;
+				}
+			}
+			
 			if (panel is NSOpenPanel openPanel) {
 				openPanel.AllowsMultipleSelection = data.SelectMultiple;
 				openPanel.ShowsHiddenFiles = data.ShowHidden;


### PR DESCRIPTION
This problem happens only in Catalina, in a first try I thought it was something about bindings or new behaviour but investigating I tested in a real xcode swift application and I can reproduce the issue. 

The problem only happens when we set the parent in any NSSavePanel. This breaks the accessory view (no matter the complexity). I think we'll need wait a fix in cocoa. 

switft code: https://gist.github.com/netonjm/c2f526e6df8143281448ccf461a64221

To try speed up this I also opened an issue in Apple Feedback : 

https://feedbackassistant.apple.com/feedback/7380159

That's how it feels now.

Open Dialog

<img width="1013" alt="Screenshot 2019-10-15 at 04 35 12" src="https://user-images.githubusercontent.com/1587480/66798438-43f1a000-ef0e-11e9-937c-cb9783ac8020.png">

![image](https://user-images.githubusercontent.com/1587480/66798586-c24e4200-ef0e-11e9-9e0d-aa7f1292183c.png)


![image](https://user-images.githubusercontent.com/1587480/66798178-7a7aeb00-ef0d-11e9-835d-db759a2ea0e7.png)

Fixes VSTS #1000498 - Open/Save File dialog accessory views not visible on Catalina



Backport of #8923.

/cc @sevoku @netonjm