### PR TITLE
[Debugger] Handle case when the text snapshot has less lines than the breakpoint location

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Debugger/DebuggerCompletionController.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Debugger/DebuggerCompletionController.cs
@@ -123,6 +123,10 @@ namespace MonoDevelop.CSharp.Debugger
 				return null;
 			var solution = document.Project.Solution;
 			var textSnapshot = textBuffer.CurrentSnapshot;
+
+			if (location.EndLine > textSnapshot.LineCount)
+				return null;
+
 			var text = textSnapshot.GetText (new Span (0, textSnapshot.Length));
 			var insertOffset = await GetAdjustedContextPointAsync (textSnapshot.GetLineFromLineNumber (location.EndLine - 1).Start.Position + location.EndColumn - 1, document, token).ConfigureAwait(false);
 			text = text.Insert (insertOffset, ";" + exp + ";");


### PR DESCRIPTION
Fixes VSTS 958245
System.ArgumentOutOfRangeException exception in Microsoft.VisualStudio.Text.Implementation.BinaryStringRebuilder.GetLineFromLineNumber()
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958245

---

I think the location end line is '1' based from where we subtract 1 from it to GetLineFromLineNumber but I might be wrong there.