### PR TITLE
[Ide] Hide .NET Runtimes selection behind feature switch

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntimeFactory.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/MonoTargetRuntimeFactory.cs
@@ -28,6 +28,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using MonoDevelop.Core.AddIns;
+using MonoDevelop.Core.FeatureConfiguration;
 using MonoDevelop.Core.Serialization;
 
 namespace MonoDevelop.Core.Assemblies
@@ -51,6 +52,11 @@ namespace MonoDevelop.Core.Assemblies
 			if (currentRuntime != null) {
 				yield return new MonoTargetRuntime (currentRuntime);
 			}
+
+			if (!FeatureSwitchService.IsFeatureEnabled ("RUNTIME_SELECTOR").GetValueOrDefault ()) {
+				yield break;
+			}
+
 			if (Platform.IsWindows) {
 				string progs = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles);
 				foreach (string dir in Directory.EnumerateDirectories (progs, "Mono*")) {

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/GlobalOptionsDialog.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/GlobalOptionsDialog.addin.xml
@@ -21,7 +21,9 @@
 		<Section id = "Build" _label = "Build" class = "MonoDevelop.Ide.Gui.OptionPanels.BuildPanel" icon="md-prefs-build">
 			<Panel id = "BuildMessages" _label = "Errors and Warnings" class = "MonoDevelop.Ide.Gui.OptionPanels.BuildMessagePanel" />
 		</Section>
-		<Section id = "MonoRuntime" _label = ".NET Runtimes" fill="true" class = "MonoDevelop.Ide.Gui.OptionPanels.MonoRuntimePanel" />
+		<Condition id="FeatureSwitch" name="RUNTIME_SELECTOR" optIn="true">
+			<Section id = "MonoRuntime" _label = ".NET Runtimes" fill="true" class = "MonoDevelop.Ide.Gui.OptionPanels.MonoRuntimePanel" />
+		</Condition>
 		<Section id = "SdkLocations" _label = "SDK Locations" icon = "md-prefs-sdk-locations" />
 	</Section>
 


### PR DESCRIPTION
The .NET Runtimes page in Preferences - Projects is now not displayed
unless the RUNTIME_SELECTOR feature switch is enabled.

Other Mono runtimes, apart from the current runtime being used to run
the IDE, are ignored if the RUNTIME_SELECTOR feature switch is not set.
This prevents older Mono versions being run to check their version in
the MonoRuntimeInfo class which can trigger the mono-sgen32 is not
optimized dialog to be displayed on the Mac for Mono versions that do
not have 64 bit support.

If another runtime was configured to be used instead of the default
and the RUNTIME_SELECTOR is not set it will not be used since it will
not be returned from the MonoTargetRuntimeFactory. Instead the runtime
used by the IDE will be used.

Fixes VSTS #997928 - Disable support for multiple Mono runtimes
behind feature switch