### PR TITLE
[752629] [RunConfigurationsOptionsPanel] Fix keyboard focus after configuration selection

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/RunConfigurationsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/RunConfigurationsPanel.cs
@@ -131,6 +131,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			var rc = configs.First (ci => ci.EditedConfig == editedConfig);
 			var section = sections [rc];
 			ParentDialog.ShowPage (section);
+			ParentDialog.Child.GrabFocus ();
 		}
 
 		public override Control CreatePanelWidget ()

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/RunConfigurationsPanel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/RunConfigurationsPanel.cs
@@ -131,7 +131,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			var rc = configs.First (ci => ci.EditedConfig == editedConfig);
 			var section = sections [rc];
 			ParentDialog.ShowPage (section);
-			ParentDialog.Child.GrabFocus ();
+			ParentDialog.Child?.GrabFocus ();
 		}
 
 		public override Control CreatePanelWidget ()


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/752629

After pressing Enter on configuration selection, focus now goes to the first control of the Panel.

![image](https://user-images.githubusercontent.com/43088712/66914763-2f053180-f020-11e9-9493-92bcf54acf90.png)
![image](https://user-images.githubusercontent.com/43088712/66914782-388e9980-f020-11e9-80ec-d630a6c38ec9.png)
