### PR TITLE
[release-8.4] [Ide] Fix document tabs container disposing widgets on mode change

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerTabs.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/GtkShellDocumentViewContainerTabs.cs
@@ -102,14 +102,6 @@ namespace MonoDevelop.Ide.Gui.Shell
 			public GtkShellDocumentTab (Tabstrip parent, string label) : base (parent, label)
 			{
 			}
-
-			protected override void OnDispose ()
-			{
-				if (Tag is IShellDocumentViewItem disposable)
-					disposable.Dispose ();
-
-				base.OnDispose ();
-			}
 		}
 
 		internal static void UpdateTab (Tab tab, string label, Xwt.Drawing.Image icon, string accessibilityDescription)


### PR DESCRIPTION
Fixes VSTS #1002168 - [VS for Mac]The split tab is empty in Xamarin.Forms project

Backport of #8950.

/cc @Therzok 