### PR TITLE
[DotNetCore] Fix focus in SDK locations options page

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Gui/DotNetCoreSdkLocationWidget.UI.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Components.Extensions;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 using Xwt;
 
 namespace MonoDevelop.DotNetCore.Gui
@@ -253,6 +254,9 @@ namespace MonoDevelop.DotNetCore.Gui
 						dialog.Title = title;
 					if (dialog.Run (ParentWindow))
 						FileName = dialog.FileName;
+
+					// Ensure the parent window has focus after the OpenFileDialog is closed.
+					IdeServices.DesktopService.FocusWindow (ParentWindow);
 				} finally {
 					dialog.Dispose ();
 					dialog = null;


### PR DESCRIPTION
In Preferences - Projects - SDK Locations - .NET Core, opening
the open file dialog and then closing it would end up with the
Preferences dialog not having focus. This only happens when the IDE
window is open. When the Start Window is open then the focus goes
back to the Preferences dialog. To reproduce this tab to the browse
button, press space to open the open file dialog, then press
escape. The focus should be on the browse button, but the dialog
does not have the focus so tabbing does not move around the dialog.

To fix this the dialog is explicitly focussed after the select file
dialog is closed. Note that the SDK locations dialog uses the XWT
OpenFileDialog which does not set the focus back to its parent. The
MonoDevelop.Components.SelectFileDialog will set focus back to its
TransientFor using the DesktopService.FocusWindow method. The .NET
Core SDK locations page now does the same.

Fixes VSTS #752768 - Accessibility: After closing the Choose Location
window focus is not there on Choose Location button.