### PR TITLE
[release-8.4] [Debugger] Fixed tracking of current expressions in Watch Pad

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -206,6 +206,7 @@
     <Compile Include="MonoDevelop.Debugger\ObjectValue\Mac\MacDebuggerObjectValueView.cs" />
     <Compile Include="MonoDevelop.Debugger\ObjectValue\Mac\MacDebuggerObjectTypeView.cs" />
     <Compile Include="MonoDevelop.Debugger\ObjectValue\Mac\MacDebuggerObjectPinView.cs" />
+    <Compile Include="MonoDevelop.Debugger\ObjectValue\ExpressionEventArgs.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(OS) != 'Windows_NT'">
     <Compile Include="MonoDevelop.Debugger.VSTextView\ExceptionCaught\ExceptionCaughtProvider.cs" />

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ExpressionEventArgs.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ExpressionEventArgs.cs
@@ -1,0 +1,59 @@
+//
+// ExpressionEventArgs.cs
+//
+// Author:
+//       Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace MonoDevelop.Debugger
+{
+	public class ExpressionEventArgs : EventArgs
+	{
+		public ExpressionEventArgs (string expression)
+		{
+			Expression = expression;
+		}
+
+		public string Expression {
+			get; private set;
+		}
+	}
+
+	public class ExpressionChangedEventArgs : EventArgs
+	{
+		public ExpressionChangedEventArgs (string oldExpression, string newExpression)
+		{
+			OldExpression = oldExpression;
+			NewExpression = newExpression;
+		}
+
+		public string OldExpression {
+			get; private set;
+		}
+
+		public string NewExpression {
+			get; private set;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -818,7 +818,7 @@ namespace MonoDevelop.Debugger
 
 			var selectedRows = SelectedRows;
 			foreach (var row in selectedRows) {
-				var item = (MacObjectValueNode)ItemAtRow ((nint)row);
+				var item = (MacObjectValueNode) ItemAtRow ((nint) row);
 
 				if (!(item.Target.Parent is RootObjectValueNode)) {
 					enabled = false;


### PR DESCRIPTION
This avoids scenarios where we clear the expressions list thereby
losing all known expressions.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1002638/

Backport of #8967.

/cc @jstedfast 