### PR TITLE
[release-8.4] [Debugger] Use the ~sel icon variants when the row is selected

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
@@ -100,10 +100,13 @@ namespace MonoDevelop.Debugger
 			get { return Node is LoadingObjectValueNode; }
 		}
 
-		protected static NSImage GetImage (string name, Gtk.IconSize size)
+		protected static NSImage GetImage (string name, Gtk.IconSize size, bool selected = false)
 		{
 			var icon = ImageService.GetIcon (name, size);
 
+			if (selected)
+				icon = icon.WithStyles ("sel");
+
 			try {
 				return icon.ToNSImage ();
 			} catch (Exception ex) {
@@ -112,10 +115,13 @@ namespace MonoDevelop.Debugger
 			}
 		}
 
-		protected static NSImage GetImage (string name, Gtk.IconSize size, double alpha)
+		protected static NSImage GetImage (string name, Gtk.IconSize size, double alpha, bool selected = false)
 		{
 			var icon = ImageService.GetIcon (name, size).WithAlpha (alpha);
 
+			if (selected)
+				icon = icon.WithStyles ("sel");
+
 			try {
 				return icon.ToNSImage ();
 			} catch (Exception ex) {
@@ -124,9 +130,12 @@ namespace MonoDevelop.Debugger
 			}
 		}
 
-		protected static NSImage GetImage (string name, int width, int height)
+		protected static NSImage GetImage (string name, int width, int height, bool selected = false)
 		{
 			var icon = ImageService.GetIcon (name).WithSize (width, height);
+
+			if (selected)
+				icon = icon.WithStyles ("sel");
 
 			try {
 				return icon.ToNSImage ();

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectNameView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectNameView.cs
@@ -171,8 +171,9 @@ namespace MonoDevelop.Debugger
 
 			OptimalWidth = MarginSize;
 
+			bool selected = Superview is NSTableRowView rowView && rowView.Selected;
 			var iconName = ObjectValueTreeViewController.GetIcon (Node.Flags);
-			ImageView.Image = GetImage (iconName, Gtk.IconSize.Menu);
+			ImageView.Image = GetImage (iconName, Gtk.IconSize.Menu, selected);
 			constraints.Add (ImageView.CenterYAnchor.ConstraintEqualToAnchor (CenterYAnchor));
 			constraints.Add (ImageView.LeadingAnchor.ConstraintEqualToAnchor (LeadingAnchor, MarginSize));
 			constraints.Add (ImageView.WidthAnchor.ConstraintEqualToConstant (ImageSize));

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
@@ -188,6 +188,7 @@ namespace MonoDevelop.Debugger
 			}
 			constraints.Clear ();
 
+			bool selected = Superview is NSTableRowView rowView && rowView.Selected;
 			var editable = TreeView.GetCanEditNode (Node);
 			var textColor = NSColor.ControlText;
 			string evaluateStatusIcon = null;
@@ -255,7 +256,7 @@ namespace MonoDevelop.Debugger
 
 			// First item: Status Icon -or- Spinner
 			if (evaluateStatusIcon != null) {
-				statusIcon.Image = GetImage (evaluateStatusIcon, Gtk.IconSize.Menu);
+				statusIcon.Image = GetImage (evaluateStatusIcon, Gtk.IconSize.Menu, selected);
 
 				if (!statusIconVisible) {
 					AddSubview (statusIcon);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999602/

Backport of #8970.

/cc @jstedfast 