### PR TITLE
[NuGet] Fix dialog loss of focus on adding new package source

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackageSourceDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/AddPackageSourceDialog.cs
@@ -26,6 +26,7 @@
 
 using System;
 using MonoDevelop.Core;
+using MonoDevelop.Ide;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -146,6 +147,9 @@ namespace MonoDevelop.PackageManagement
 			if (viewModel.BrowsePackageFolder ()) {
 				UpdateAfterFolderSelected ();
 			}
+
+			// Ensure dialog has focus after browsing for a folder.
+			IdeServices.DesktopService.FocusWindow (this);
 		}
 
 		void UpdateAfterFolderSelected ()

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageSourcesWidget.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/PackageSourcesWidget.cs
@@ -8,6 +8,7 @@ using MonoDevelop.PackageManagement;
 using MonoDevelop.Core;
 using MonoDevelop.Components;
 using MonoDevelop.Components.AutoTest;
+using MonoDevelop.Ide;
 using System.ComponentModel;
 
 namespace MonoDevelop.PackageManagement
@@ -238,7 +239,12 @@ namespace MonoDevelop.PackageManagement
 		Xwt.Command ShowDialogWithParent (AddPackageSourceDialog dialog)
 		{
 			Xwt.WindowFrame parent = Xwt.Toolkit.CurrentEngine.WrapWindow (Toplevel);
-			return dialog.Run (parent);
+			Xwt.Command result = dialog.Run (parent);
+
+			// Ensure dialog has focus after browsing for a folder.
+			IdeServices.DesktopService.FocusWindow (parent);
+
+			return result;
 		}
 
 		void UpdateSelectedPackageSource ()


### PR DESCRIPTION
In Preferences - NuGet - Sources, the Add Package Source dialog
would lose focus when the Browse button was used. A way to reproduce
this is to tab to the Add button, press space, then tab to the
Browse button in the Add Package Source dialog, press space, then
press escape. The Add Package Source dialog then no longer has focus
and tabbing does not work.

Fixed this by explicitly setting focus back to the parent dialog
when a child dialog is closed.

Fixes VSTS #1003430 - Accessibility: NuGet add package source dialog
browse button loses dialog focus