### PR TITLE
[release-8.4] [Ide] Pass AdditionalFiles and EditorConfigFiles to Roslyn

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectExtension.cs
@@ -175,9 +175,19 @@ namespace MonoDevelop.Projects
 			return next.OnReevaluateProject (monitor);
 		}
 
+		internal protected virtual Task<ImmutableArray<FilePath>> OnGetAdditionalFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
+		{
+			return next.OnGetAdditionalFiles (monitor, configuration);
+		}
+
 		internal protected virtual Task<ImmutableArray<FilePath>> OnGetAnalyzerFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
 		{
 			return next.OnGetAnalyzerFiles (monitor, configuration);
+		}
+
+		internal protected virtual Task<ImmutableArray<FilePath>> OnGetEditorConfigFiles (ProgressMonitor monitor, ConfigurationSelector configuration)
+		{
+			return next.OnGetEditorConfigFiles (monitor, configuration);
 		}
 
 		internal protected virtual Task<ImmutableArray<ProjectFile>> OnGetSourceFiles (ProgressMonitor monitor, ConfigurationSelector configuration)

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
@@ -349,6 +349,31 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
+		[Test]
+		public async Task AdditionalFiles_EditorConfigFiles ()
+		{
+			FilePath solFile = Util.GetSampleProject ("additional-files", "additional-files.sln");
+
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))
+			using (var ws = await TypeSystemServiceTestExtensions.LoadSolution (sol)) {
+				try {
+					var project = sol.GetAllProjects ().Single ();
+
+					var projectInfo = ws.CurrentSolution.Projects.Single ();
+					var additionalDocs = projectInfo.AdditionalDocuments.ToArray ();
+					var editorConfigDocs = projectInfo.AnalyzerConfigDocuments.ToArray ();
+
+					FilePath expectedAdditionalFileName = project.BaseDirectory.Combine ("additional-file.txt");
+					FilePath expectedEditorConfigFileName = solFile.ParentDirectory.Combine (".editorconfig");
+
+					Assert.IsTrue (additionalDocs.Any (d => d.FilePath == expectedAdditionalFileName));
+					Assert.IsTrue (editorConfigDocs.Any (d => d.FilePath == expectedEditorConfigFileName));
+				} finally {
+					TypeSystemServiceTestExtensions.UnloadSolution (sol);
+				}
+			}
+		}
+
 		/// <summary>
 		/// Clear all other package sources and just use the main NuGet package source when
 		/// restoring the packages for the project tests.

--- a/main/tests/test-projects/additional-files/.editorconfig
+++ b/main/tests/test-projects/additional-files/.editorconfig
@@ -1,0 +1,11 @@
+# Top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+end_of_line = crlf
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/main/tests/test-projects/additional-files/additional-files.sln
+++ b/main/tests/test-projects/additional-files/additional-files.sln
@@ -1,0 +1,20 @@
+
+Microsoft Visual Studio Solution File, Format Version 9.00
+# Visual Studio 2005
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "library", "library\library.csproj", "{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A9E3523-48F0-4BDF-A0F4-49DAD4431FAB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/additional-files/library/MyClass.cs
+++ b/main/tests/test-projects/additional-files/library/MyClass.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Library
+{
+
+	public class MyClass
+	{
+
+		public MyClass()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/additional-files/library/additional-file.txt
+++ b/main/tests/test-projects/additional-files/library/additional-file.txt
@@ -1,0 +1,1 @@
+additional file test

--- a/main/tests/test-projects/additional-files/library/library.csproj
+++ b/main/tests/test-projects/additional-files/library/library.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F63CBE6-2FE7-47A7-8930-EA078DA05062}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>library</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="MyClass.cs" />
+    <AdditionalFiles Include="additional-file.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Use MSBuild to find AdditionalFiles and EditorConfigFiles and pass
these to Roslyn when creating the documents for the Roslyn project.

Fixes VSTS #963753 - Migrate editorconfig support to use new
workspace-based approach

[Ide] Fix analyzers not retriggered on editorconfig changes

If an editorconfig file was changed externally, or edited in the text
editor, the changes would not affect the open solution until it was
closed and re-opened again. To support this the Roslyn workspace
needs to know when the editor config file has changed externally
by calling OnAnalyzerConfigDocumentTextChanged. When the editorconfig
file is open in the text editor the Roslyn workspace needs to be
told the file has opened via OnAnalyzerConfigDocumentOpened and
when it has closed via OnAnalyzerConfigDocumentClosed. Then all changes
made in the editor are handled by Roslyn and the analyzers are re-run.

Fixes VSTS #706520 - Analyzers not retriggered on editorconfig change

Backport of #8872.

/cc @mrward 