### PR TITLE
Added machine hardware model to telemetry details

### DIFF
--- a/main/src/addins/MacPlatform/MacTelemetryDetails.cs
+++ b/main/src/addins/MacPlatform/MacTelemetryDetails.cs
@@ -46,6 +46,7 @@ namespace MacPlatform
 		int coreCount;
 		long freq;
 		string arch;
+		string model;
 		ulong size;
 		ulong freeSize;
 
@@ -67,6 +68,7 @@ namespace MacPlatform
 			Interop.SysCtl ("hw.cpufamily", out result.family);
 			Interop.SysCtl ("hw.cpufrequency", out result.freq);
 			Interop.SysCtl ("hw.physicalcpu", out result.coreCount);
+			Interop.SysCtl ("hw.model", out result.model);
 
 			var attrs = NSFileManager.DefaultManager.GetFileSystemAttributes ("/");
 			result.size = attrs.Size;
@@ -119,6 +121,8 @@ namespace MacPlatform
 		public TimeSpan UserTime => TimeSpan.Zero;
 
 		public string CpuArchitecture => arch;
+
+		public string Model => model;
 
 		public int CpuCount => (int)NSProcessInfo.ProcessInfo.ActiveProcessorCount;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/IPlatformTelemetryDetails.cs
@@ -59,6 +59,7 @@ namespace MonoDevelop.Ide.Desktop
 		GraphicsDetails[] GPU { get; }
 
 		string CpuArchitecture { get; }
+		string Model { get; }
 		int PhysicalCpuCount { get; }
 		int CpuCount { get; }
 		int CpuFamily { get; }


### PR DESCRIPTION
creating new pull request to backport https://github.com/mono/monodevelop/pull/8960 to 8.4 since the monodevelop and mdaddins branches have to have same names 