### PR TITLE
[release-8.4] Bump Roslyn to 3.4.0-beta3-19518-02

### DIFF
--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.4.0-beta2-19476-01</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.4.0-beta3-19518-02</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>

--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/StyleViewModel.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.OptionProvider/StyleViewModel.cs
@@ -1255,11 +1255,11 @@ class C
 			AddExpressionBodyOptions (optionSet, expressionPreferencesGroupTitle);
 
 			// Variable preferences
-			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CodeStyleOptions.PreferInlinedVariableDeclaration, GettextCatalog.GetString("Prefer inlined variable declaration"), s_preferInlinedVariableDeclaration, s_preferInlinedVariableDeclaration, this, optionSet, variablePreferencesGroupTitle));
-			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CodeStyleOptions.PreferDeconstructedVariableDeclaration, GettextCatalog.GetString("Prefer deconstructed variable declaration"), s_preferDeconstructedVariableDeclaration, s_preferDeconstructedVariableDeclaration, this, optionSet, variablePreferencesGroupTitle));
+			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CSharpCodeStyleOptions.PreferInlinedVariableDeclaration, GettextCatalog.GetString("Prefer inlined variable declaration"), s_preferInlinedVariableDeclaration, s_preferInlinedVariableDeclaration, this, optionSet, variablePreferencesGroupTitle));
+			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CSharpCodeStyleOptions.PreferDeconstructedVariableDeclaration, GettextCatalog.GetString("Prefer deconstructed variable declaration"), s_preferDeconstructedVariableDeclaration, s_preferDeconstructedVariableDeclaration, this, optionSet, variablePreferencesGroupTitle));
 
 			// Null preferences.
-			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CodeStyleOptions.PreferThrowExpression, GettextCatalog.GetString("Prefer throw-expression"), s_preferThrowExpression, s_preferThrowExpression, this, optionSet, nullCheckingGroupTitle));
+			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CSharpCodeStyleOptions.PreferThrowExpression, GettextCatalog.GetString("Prefer throw-expression"), s_preferThrowExpression, s_preferThrowExpression, this, optionSet, nullCheckingGroupTitle));
 			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CSharpCodeStyleOptions.PreferConditionalDelegateCall, GettextCatalog.GetString("Prefer conditional delegate call"), s_preferConditionalDelegateCall, s_preferConditionalDelegateCall, this, optionSet, nullCheckingGroupTitle));
 			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CodeStyleOptions.PreferCoalesceExpression, GettextCatalog.GetString("Prefer coalesce expression"), s_preferCoalesceExpression, s_preferCoalesceExpression, this, optionSet, nullCheckingGroupTitle));
 			CodeStyleItems.Add (new BooleanCodeStyleOptionViewModel (CodeStyleOptions.PreferNullPropagation, GettextCatalog.GetString("Prefer null propagation"), s_preferNullPropagation, s_preferNullPropagation, this, optionSet, nullCheckingGroupTitle));


### PR DESCRIPTION
Updating Roslyn to 20191018.2 (7c7708e)
Changes since [5ca9538](https://www.github.com/dotnet/roslyn/commit/5ca9538):
- [Add test for #34921 (#39365)](https://www.github.com/dotnet/roslyn/pull/39365)
- [Merge pull request #39127 from mavasani/SolutionItemEditorConfig](https://www.github.com/dotnet/roslyn/pull/39127)
- [Use ConstructWithNullability in InferTypeInAwaitExpression since the inferred type may include nullable information (#39335)](https://www.github.com/dotnet/roslyn/pull/39335)
- [Ensure synthesized closure method is static for static local function (#38147)](https://www.github.com/dotnet/roslyn/pull/38147)
- [Skip RenamingEscapedIdentifiers (#39330)](https://www.github.com/dotnet/roslyn/pull/39330)
- [Do not wait for output writer thread to complete when aborting execution in IW (#39322)](https://www.github.com/dotnet/roslyn/pull/39322)
- [Merge pull request #39316 from NextTurn/keyword](https://www.github.com/dotnet/roslyn/pull/39316)
- [Using declaration ioperation (#39125)](https://www.github.com/dotnet/roslyn/pull/39125)
- [Require MSBuild 16.3 in compiler NuGet packages (#39137)](https://www.github.com/dotnet/roslyn/pull/39137)
- [Merge pull request #39105 from CyrusNajmabadi/sqliteBenchmark](https://www.github.com/dotnet/roslyn/pull/39105)
- [Use default parameter values in flow analysis (#38788)](https://www.github.com/dotnet/roslyn/pull/38788)
- [Merge pull request #39251 from castholm/move-code-style-options](https://www.github.com/dotnet/roslyn/pull/39251)
- [Merge pull request #39184 from sharwell/symbol-annotations-2](https://www.github.com/dotnet/roslyn/pull/39184)
- [Merge pull request #39228 from allisonchou/FalsePositiveLocalFunc](https://www.github.com/dotnet/roslyn/pull/39228)
- [Rely on PDB document table for identification of design-time-only source files (#39295)](https://www.github.com/dotnet/roslyn/pull/39295)
- [Merge pull request #39281 from CyrusNajmabadi/interpolations](https://www.github.com/dotnet/roslyn/pull/39281)
- [Merge pull request #39063 from zlatanov/make-field-readonly-fix](https://www.github.com/dotnet/roslyn/pull/39063)
- [EnC: Recover from unexpected exceptions in Emit, ReadChecksum (#39223)](https://www.github.com/dotnet/roslyn/pull/39223)
- [Merge pull request #39077 from CyrusNajmabadi/simplifyGeneratedCode](https://www.github.com/dotnet/roslyn/pull/39077)
- [Merge pull request #39237 from sharwell/text-annotations-1](https://www.github.com/dotnet/roslyn/pull/39237)
- [Refactor merging types (dynamic, tuple names, nullability) into a single pass (#39069)](https://www.github.com/dotnet/roslyn/pull/39069)
- [Add nullable annotations to EnC impl (#39195)](https://www.github.com/dotnet/roslyn/pull/39195)
- [Handle a missing case in bad conversion error reporting. (#39104)](https://www.github.com/dotnet/roslyn/pull/39104)
- [Merge pull request #39273 from dotnet/dev/dibarbet/disable_flow_opt_prof](https://www.github.com/dotnet/roslyn/pull/39273)
- [Include source files w/o method bodies in the PDB documents (#39136)](https://www.github.com/dotnet/roslyn/pull/39136)
- [Fix converted nullability on extract method (#39134)](https://www.github.com/dotnet/roslyn/pull/39134)
- [Merge pull request #39254 from castholm/invariant-culture-number-parsing](https://www.github.com/dotnet/roslyn/pull/39254)
- [Merge pull request #39180 from sharwell/symbol-annotations-1](https://www.github.com/dotnet/roslyn/pull/39180)
- [Merge pull request #39185 from sharwell/symbol-annotations-3](https://www.github.com/dotnet/roslyn/pull/39185)
- [Merge pull request #39216 from dibarbet/disable_opt_flow](https://www.github.com/dotnet/roslyn/pull/39216)
- [Merge pull request #39055 from ivanbasov/GoToBase](https://www.github.com/dotnet/roslyn/pull/39055)
- [Fix EnC for multi-targeted projects that emit embedded PDBs (#39178)](https://www.github.com/dotnet/roslyn/pull/39178)
- [Merge pull request #39061 from nnpcYvIVl/spelling-19](https://www.github.com/dotnet/roslyn/pull/39061)
- [Merge pull request #39053 from sharwell/compiler-annotations-2](https://www.github.com/dotnet/roslyn/pull/39053)
- [Merge pull request #39014 from JoeRobich/enable-warnaserror](https://www.github.com/dotnet/roslyn/pull/39014)
- [Merge pull request #39156 from sharwell/rm-typeswitch-gen](https://www.github.com/dotnet/roslyn/pull/39156)
- [Merge pull request #39091 from petrroll/underselectionTestBug](https://www.github.com/dotnet/roslyn/pull/39091)
- [Pool analyzer diagnostic reporters (#39034)](https://www.github.com/dotnet/roslyn/pull/39034)
- [Better array pattern index codegen (#38988)](https://www.github.com/dotnet/roslyn/pull/38988)
- [Merge pull request #39097 from mavasani/Issue39092](https://www.github.com/dotnet/roslyn/pull/39097)
- [Merge pull request #38793 from mavasani/AnalyzerPerfOptimization](https://www.github.com/dotnet/roslyn/pull/38793)
- [Merge pull request #39015 from dibarbet/update_lsp_telemetry](https://www.github.com/dotnet/roslyn/pull/39015)
- [Add note about testing updated assembly versions (#39119)](https://www.github.com/dotnet/roslyn/pull/39119)
- [Clean up FIPS settings in Interactive (#38611)](https://www.github.com/dotnet/roslyn/pull/38611)
- [Allow conversion of GetAwaiter extension method this arg (#38960)](https://www.github.com/dotnet/roslyn/pull/38960)
- [Merge pull request #38868 from jnm2/use_overridden_value_type_GetHashCode_directly](https://www.github.com/dotnet/roslyn/pull/38868)
- [Use SHA256 (default source hash) for hashing privateimplementationdefails and MVID (#38693)](https://www.github.com/dotnet/roslyn/pull/38693)
- [Merge pull request #37758 from sharwell/nullable-syntax](https://www.github.com/dotnet/roslyn/pull/37758)
- [Merge pull request #39035 from dotnet/RikkiGibson-patch-2](https://www.github.com/dotnet/roslyn/pull/39035)
- [Merge pull request #39005 from jasonmalinowski/delete-github-tools](https://www.github.com/dotnet/roslyn/pull/39005)
- [Merge pull request #39089 from svick/groupby-range-variable-quickinfo](https://www.github.com/dotnet/roslyn/pull/39089)
- [Merge pull request #38341 from Therzok/runtime-loader-hack](https://www.github.com/dotnet/roslyn/pull/38341)
- [Merge pull request #38992 from allisonchou/EditorConfig](https://www.github.com/dotnet/roslyn/pull/38992)
- [Fix Issue #9658 (#39085)](https://www.github.com/dotnet/roslyn/pull/39085)
- [Merge pull request #39029 from mavasani/MoveTo295](https://www.github.com/dotnet/roslyn/pull/39029)
- [Merge pull request #39071 from dotnet/RikkiGibson-patch-3](https://www.github.com/dotnet/roslyn/pull/39071)
- [Merge pull request #38769 from 333fred/lambdas](https://www.github.com/dotnet/roslyn/pull/38769)
- [EnC: Track documents that do not match the debuggee (#38905)](https://www.github.com/dotnet/roslyn/pull/38905)
- [Merge pull request #38999 from jasonmalinowski/make-cancellationtoken-parameter-optional](https://www.github.com/dotnet/roslyn/pull/38999)
- [Spelling fixes (#39056)](https://www.github.com/dotnet/roslyn/pull/39056)
- [Merge pull request #38981 from dibarbet/duplicate_diagnostics](https://www.github.com/dotnet/roslyn/pull/38981)
- [Fix crash in flow analysis (#38929)](https://www.github.com/dotnet/roslyn/pull/38929)
- [Update dependencies from https://github.com/dotnet/arcade build 20191002.11 (#39023)](https://www.github.com/dotnet/roslyn/pull/39023)
- [Merge pull request #38718 from CyrusNajmabadi/nugetCancellation](https://www.github.com/dotnet/roslyn/pull/38718)
- [Merge pull request #39013 from JoeRobich/nowarn-nu5128](https://www.github.com/dotnet/roslyn/pull/39013)
- [Merge pull request #39031 from genlu/FixInteractiveWindow](https://www.github.com/dotnet/roslyn/pull/39031)
- [Merge pull request #38855 from CyrusNajmabadi/initializeSigHelp](https://www.github.com/dotnet/roslyn/pull/38855)
- [Merge pull request #38882 from sharwell/new-compiler-annotations](https://www.github.com/dotnet/roslyn/pull/38882)
- [Disable assert tracked by https://github.com/dotnet/roslyn/issΓÇª (#39018)](https://www.github.com/dotnet/roslyn/pull/39018)
- [Spelling fixes (#38977)](https://www.github.com/dotnet/roslyn/pull/38977)
- [Merge pull request #38841 from CyrusNajmabadi/renameFSharp](https://www.github.com/dotnet/roslyn/pull/38841)
- [Merge pull request #38007 from alrz/fix-0066](https://www.github.com/dotnet/roslyn/pull/38007)
- [Merge pull request #39016 from RikkiGibson/update-config](https://www.github.com/dotnet/roslyn/pull/39016)
- [Merge pull request #38980 from alrz/fix-38486](https://www.github.com/dotnet/roslyn/pull/38980)
- [Fix favorites for expansions of nullables (#39004)](https://www.github.com/dotnet/roslyn/pull/39004)
- [Update dependencies from https://github.com/dotnet/arcade build 20191001.4 (#38996)](https://www.github.com/dotnet/roslyn/pull/38996)
- [Merge pull request #38998 from jasonmalinowski/delete-dead-code](https://www.github.com/dotnet/roslyn/pull/38998)
- [Merge pull request #37228 from YairHalberstadt/feature/add-import-annotation](https://www.github.com/dotnet/roslyn/pull/37228)
- [Fix docker caching by resetting cache only when mono changes (#38972)](https://www.github.com/dotnet/roslyn/pull/38972)
- [Ensure target-typed constructs are bound during initial binding in error scenarios. (#38750)](https://www.github.com/dotnet/roslyn/pull/38750)
- [Merge pull request #38987 from mavasani/FixUnusedValueFalsePositive](https://www.github.com/dotnet/roslyn/pull/38987)
- [Merge pull request #38985 from mavasani/DisableDisposeAnalyzers](https://www.github.com/dotnet/roslyn/pull/38985)
- [Merge pull request #38825 from dibarbet/cleanup_syntactic_lsp](https://www.github.com/dotnet/roslyn/pull/38825)
- [Merge pull request #38920 from ryzngard/feature/remove_inline_rename_experiment](https://www.github.com/dotnet/roslyn/pull/38920)
- [Merge pull request #38974 from dotnet/dev/ryzn/dev16_4_p1_test_rps_fix](https://www.github.com/dotnet/roslyn/pull/38974)
- [Fix language check for netcoreapp3.1 (#38967)](https://www.github.com/dotnet/roslyn/pull/38967)
- [Add API Review notes (#38969)](https://www.github.com/dotnet/roslyn/pull/38969)
- [Update dependencies from https://github.com/dotnet/arcade build 20190930.3 (#38976)](https://www.github.com/dotnet/roslyn/pull/38976)
- [Merge pull request #38792 from mavasani/AnalyzerDriverFix](https://www.github.com/dotnet/roslyn/pull/38792)
- [Merge pull request #38951 from nnpcYvIVl/spelling-15](https://www.github.com/dotnet/roslyn/pull/38951)
- [Skip flaky tests (#38955)](https://www.github.com/dotnet/roslyn/pull/38955)
- [Merge pull request #38935 from CyrusNajmabadi/parsingSimplification](https://www.github.com/dotnet/roslyn/pull/38935)
- [Fix typos (#38948)](https://www.github.com/dotnet/roslyn/pull/38948)
- [Merge pull request #38952 from nnpcYvIVl/spelling-16](https://www.github.com/dotnet/roslyn/pull/38952)
- [Merge pull request #38911 from reaction1989/ref/progressStatus](https://www.github.com/dotnet/roslyn/pull/38911)
- [Merge pull request #38894 from mavasani/FAR_Kind_Column_2](https://www.github.com/dotnet/roslyn/pull/38894)
- [Merge pull request #38861 from nnpcYvIVl/spelling-11](https://www.github.com/dotnet/roslyn/pull/38861)
- [Update dependencies from https://github.com/dotnet/arcade build 20190927.2 (#38938)](https://www.github.com/dotnet/roslyn/pull/38938)
- [Completion: refactor FilterResult (#38904)](https://www.github.com/dotnet/roslyn/pull/38904)
- [Merge pull request #38917 from sharwell/elastic-attributes](https://www.github.com/dotnet/roslyn/pull/38917)
- [Fix expected test output for TestPragmaWarningDirectiveWithDocumentationComment2 (#38930)](https://www.github.com/dotnet/roslyn/pull/38930)
- [support local functions inside static in signature help (#38811)](https://www.github.com/dotnet/roslyn/pull/38811)
- [Refactoring: remove CompltetionItemFilter (#38759)](https://www.github.com/dotnet/roslyn/pull/38759)
- [Merge pull request #32623 from jasonmalinowski/delete-legacy-commanding-infrastructure](https://www.github.com/dotnet/roslyn/pull/32623)
- [Merge pull request #38627 from sharwell/suppress-format](https://www.github.com/dotnet/roslyn/pull/38627)
- [Merge pull request #38907 from sharwell/test-tabs-master](https://www.github.com/dotnet/roslyn/pull/38907)
- [Merge pull request #34762 from Therzok/allocation-diagnostics](https://www.github.com/dotnet/roslyn/pull/34762)
- [Merge pull request #38915 from Youssef1313/patch-1](https://www.github.com/dotnet/roslyn/pull/38915)
- [Merge pull request #38906 from sharwell/comment-format](https://www.github.com/dotnet/roslyn/pull/38906)
- [Optimize GetSolutionUpdateStatusAsync for stepping in absence of changes (#38892)](https://www.github.com/dotnet/roslyn/pull/38892)
- [Update dependencies from https://github.com/dotnet/arcade build 20190926.6 (#38912)](https://www.github.com/dotnet/roslyn/pull/38912)
- [[master] Update dependencies from dotnet/arcade (#38764)](https://www.github.com/dotnet/roslyn/pull/38764)
- [Merge pull request #37795 from mavasani/SetSeverityCommandHandler](https://www.github.com/dotnet/roslyn/pull/37795)
- [Add missing parsing test for TypeOf expr IsNot type (#38870)](https://www.github.com/dotnet/roslyn/pull/38870)
- [completion leaking cancellation exception (#38526)](https://www.github.com/dotnet/roslyn/pull/38526)
- [Avoid crash on concat on structs with ToString member (#38860)](https://www.github.com/dotnet/roslyn/pull/38860)
- [Merge pull request #38833 from dibarbet/code_action_span_lsp](https://www.github.com/dotnet/roslyn/pull/38833)
- [Use new Span/Memory APIs on System.Collections.Immutable (#38809)](https://www.github.com/dotnet/roslyn/pull/38809)
- [Merge pull request #38887 from genlu/FixBadMerge](https://www.github.com/dotnet/roslyn/pull/38887)
- [Merge pull request #38880 from nnpcYvIVl/spelling-13](https://www.github.com/dotnet/roslyn/pull/38880)
- [Merge pull request #38883 from JoeRobich/bump-format-version](https://www.github.com/dotnet/roslyn/pull/38883)
- [Merge pull request #38877 from nnpcYvIVl/spelling-12](https://www.github.com/dotnet/roslyn/pull/38877)
- [Merge pull request #38881 from nnpcYvIVl/spelling-14](https://www.github.com/dotnet/roslyn/pull/38881)
- [Update IOperationTests_IDelegateCreationExpression.vb (#38849)](https://www.github.com/dotnet/roslyn/pull/38849)
- [x == default is valid object equality for reference types (#38853)](https://www.github.com/dotnet/roslyn/pull/38853)
- [Update Binder_Lookup.vb (#38828)](https://www.github.com/dotnet/roslyn/pull/38828)
- [Update AnalysisContextInfoTests.cs (#38829)](https://www.github.com/dotnet/roslyn/pull/38829)
- [Update DecisionDagBuilder.cs (#38847)](https://www.github.com/dotnet/roslyn/pull/38847)
- [Add nullable-annotated Debug.Assert (#38646)](https://www.github.com/dotnet/roslyn/pull/38646)
- [Adjust tuple and nullability checks on duplicate implementations and type constraints (#38563)](https://www.github.com/dotnet/roslyn/pull/38563)
- [Merge pull request #38824 from nnpcYvIVl/spelling-2](https://www.github.com/dotnet/roslyn/pull/38824)
- [Update Language Feature Status (#38818)](https://www.github.com/dotnet/roslyn/pull/38818)
- [Merge pull request #38845 from nnpcYvIVl/spelling-6](https://www.github.com/dotnet/roslyn/pull/38845)
- [Merge pull request #38846 from nnpcYvIVl/spelling-7](https://www.github.com/dotnet/roslyn/pull/38846)
- [Merge pull request #38848 from nnpcYvIVl/spelling-9](https://www.github.com/dotnet/roslyn/pull/38848)
- [Cache AnalyzerConfigOptionsResult instances (#38760)](https://www.github.com/dotnet/roslyn/pull/38760)
- [Merge pull request #38823 from nnpcYvIVl/spelling-1](https://www.github.com/dotnet/roslyn/pull/38823)
- [Merge pull request #38834 from dotnet/release/dev16.4-preview1-vs-deps](https://www.github.com/dotnet/roslyn/pull/38834)
- [Merge pull request #38800 from dotnet/release/dev16.3-vs-deps](https://www.github.com/dotnet/roslyn/pull/38800)

Backport of #8994.

/cc @sandyarmstrong @dibarbet