### PR TITLE
[Ide] Fixed possible null reference exception.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Tabstrip.cs
@@ -489,7 +489,7 @@ namespace MonoDevelop.Components
 
 		void UpdateAccessibility ()
 		{
-			Accessible.SetRole (AtkCocoa.Roles.AXRadioButton, active ? "active tab" : "tab");
+			Accessible?.SetRole (AtkCocoa.Roles.AXRadioButton, active ? "active tab" : "tab");
 		}
 
 		public bool IsSeparator {


### PR DESCRIPTION
See: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/810343

https://github.com/mono/monodevelop/pull/8925

Didn't know that Accessibility can be == null.

Fixes VSTS #1005254 - File content isn't displayed after opening