### PR TITLE
Fixes VSTS Bug 958242: System.NullReferenceException exception in

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -1634,12 +1634,12 @@ namespace MonoDevelop.SourceEditor
 
 		public void RunWhenLoaded (System.Action action)
 		{
-			Document.RunWhenLoaded (action);
+			Document?.RunWhenLoaded (action);
 		}
 
 		public void RunWhenRealized (System.Action action)
 		{
-			Document.RunWhenRealized (action);
+			Document?.RunWhenRealized (action);
 		}
 		#endregion
 


### PR DESCRIPTION
MonoDevelop.SourceEditor.SourceEditorView.RunWhenRealized()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958242