### PR TITLE
[release-8.3] Fixes VSTS Bug 958249: System.InvalidOperationException exception in

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/AggregatedProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.ProgressMonitoring/AggregatedProgressMonitor.cs
@@ -201,6 +201,7 @@ namespace MonoDevelop.Core.ProgressMonitoring
 				if ((info.ActionMask & MonitorAction.FollowerCancel) != 0)
 					info.CancellationTokenRegistration.Dispose ();
 			}
+			monitors.Clear ();
 		}
 
 		void OnFollowerCancelRequested ()

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
@@ -144,6 +144,17 @@ namespace MonoDevelop.Core
 			if (disposed)
 				return;
 			disposed = true;
+			if (logWriter != null) {
+				logWriter.TextWritten -= DoWriteLog;
+				logWriter.Dispose ();
+				logWriter = null;
+			}
+
+			if (errorLogWriter != null) {
+				errorLogWriter.TextWritten -= DoWriteErrorLog;
+				errorLogWriter.Dispose ();
+				errorLogWriter = null;
+			}
 
 			if (parentMonitor != null && firstCachedLogChunk != null) {
 				parentMonitor.DumpLog (firstCachedLogChunk);

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core/ProgressMonitor.cs
@@ -144,17 +144,6 @@ namespace MonoDevelop.Core
 			if (disposed)
 				return;
 			disposed = true;
-			if (logWriter != null) {
-				logWriter.TextWritten -= DoWriteLog;
-				logWriter.Dispose ();
-				logWriter = null;
-			}
-
-			if (errorLogWriter != null) {
-				errorLogWriter.TextWritten -= DoWriteErrorLog;
-				errorLogWriter.Dispose ();
-				errorLogWriter = null;
-			}
 
 			if (parentMonitor != null && firstCachedLogChunk != null) {
 				parentMonitor.DumpLog (firstCachedLogChunk);


### PR DESCRIPTION
MonoDevelop.Ide.Gui.Components.LogViewProgressMonitor.OnWriteLog()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/958249

Found some event handlers that were not unregistered on dispose which
may explain that issue.

Backport of #9030.

/cc @mkrueger 