### PR TITLE
[release-8.4] Fixes NRE focusing main toolbar in early initializations when the window is not yet attached to the view

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/MainToolbar.cs
@@ -103,7 +103,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		void Focus(Gtk.DirectionType direction)
 		{
-			awesomeBar.Window.MakeFirstResponder (direction == Gtk.DirectionType.TabForward ? (NSView)awesomeBar.RunButton : (NSView)awesomeBar.SearchBar);
+			awesomeBar.Window?.MakeFirstResponder (direction == Gtk.DirectionType.TabForward ? (NSView)awesomeBar.RunButton : (NSView)awesomeBar.SearchBar);
 		}
 
 		Action<Gtk.DirectionType> exitAction;


### PR DESCRIPTION
Fixes NRE focusing main toolbar in early initializations when the window is not yet attached to the view


Fixes VSTS #1002143 - [FATAL] System.NullReferenceException exception in MonoDevelop.MacIntegration.MainToolbar.MainToolbar.Focus()

Backport of #9023.

/cc @netonjm 