### PR TITLE
[release-8.4] [AspNetCore] Avoid exception when saving run configurations

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -64,10 +64,16 @@ namespace MonoDevelop.AspNetCore
 				profile = launchProfileProvider.Profiles [key];
 			}
 
-			var aspnetconf = new AspNetCoreRunConfiguration (name, profile);
-			aspnetconf.LaunchProfileProvider = launchProfileProvider;
+			var aspnetconf = new AspNetCoreRunConfiguration (name, profile) {
+				LaunchProfileProvider = launchProfileProvider
+			};
+			if (aspNetCoreRunConfs.TryGetValue (name, out var existingConf)) {
+				// This can be called a few times with the same config at load time,
+				// so make sure we clean up the previous version
+				existingConf.SaveRequested -= Aspnetconf_Save;
+			}
 			aspnetconf.SaveRequested += Aspnetconf_Save;
-			aspNetCoreRunConfs.Add (name, aspnetconf);
+			aspNetCoreRunConfs [name] = aspnetconf;
 			return aspnetconf;
 		}
 


### PR DESCRIPTION
When loading a ASP.NET Core project, OnCreateRunConfiguration is called
for the "Default" config, and the ASP.NET Core implementation does the
syncing of the launchSettings.json file, in which case it enumerates
the existing RunConfigurations in the Project, which in turn calls
again OnCreateRunConfiguration to create the "Default" again.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1005086

Backport of #9038.

/cc @rodrmoya 