### PR TITLE
[release-8.4] [Debugger] Make sure tooltip request wasn't cancelled before showing

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/DebuggerQuickInfoSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/DebuggerQuickInfoSource.cs
@@ -146,6 +146,10 @@ namespace MonoDevelop.Debugger.VSTextView.QuickInfo
 			// and do our own thing, notice VS does same thing
 			await session.DismissAsync ();
 			await provider.joinableTaskContext.Factory.SwitchToMainThreadAsync ();
+
+			if (cancellationToken.IsCancellationRequested)
+				return;
+
 			lastView = view;
 
 			val.Name = debugInfo.Text;
@@ -176,6 +180,11 @@ namespace MonoDevelop.Debugger.VSTextView.QuickInfo
 			var cocoaView = (ICocoaTextView) view;
 			var bounds = view.TextViewLines.GetCharacterBounds (point);
 			var rect = new CoreGraphics.CGRect (bounds.Left - view.ViewportLeft, bounds.Top - view.ViewportTop, bounds.Width, bounds.Height);
+
+			if (cocoaView.IsClosed) {
+				LoggingService.LogWarning ("Editor window has been closed before debugger tooltip was shown. How did this happen?");
+				return;
+			}
 
 			window.Show (rect, cocoaView.VisualElement, AppKit.NSRectEdge.MaxXEdge);
 #else


### PR DESCRIPTION
After the context switch to the main thread in order to show the tooltip,
check that the request hasn't been cancelled due to the editor window
being closed in the meantime (for example).

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1002160/

Backport of #9042.

/cc @jstedfast 