### PR TITLE
[release-8.4] [Ide] Fix incorrect language read by voice over in New Project dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -58,11 +58,18 @@ namespace MonoDevelop.Ide.Projects
 		TreeStore templateCategoriesTreeStore =
 			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(TemplateCategory));
 		TreeView templatesTreeView;
+		// DO NOT REMOVE
+		// This column is not used here, but is required for
+		// external UI tests which need a plain string name inside the model
+		// This is a reminder to not remove or abuse this column for other purposes
+		const int TemplateNameColumn = 0;
+		// DO NOT REMOVE
 		const int TemplateIconColumn = 1;
 		const int TemplateColumn = 2;
-		const int TemplateA11yLanguageName = 3;
+		const int TemplateOwnCategoryNameColumn = 3;
+		const int TemplateA11yLanguageNameColumn = 4;
 		TreeStore templatesTreeStore =
-			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(SolutionTemplate), typeof (string));
+			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(SolutionTemplate), typeof (string), typeof (string));
 		VBox templateVBox;
 		ImageView templateImage;
 		Label templateNameLabel;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -59,7 +59,6 @@ namespace MonoDevelop.Ide.Projects
 		TreeStore templateCategoriesTreeStore =
 			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(TemplateCategory));
 		TreeView templatesTreeView;
-		const int TemplateNameColumn = 0;
 		const int TemplateIconColumn = 1;
 		const int TemplateColumn = 2;
 		TreeStore templatesTreeStore =

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -55,12 +55,12 @@ namespace MonoDevelop.Ide.Projects
 		const int TemplateCategoryNameColumn = 0;
 		const int TemplateCategoryIconColumn = 1;
 		const int TemplateCategoryColumn = 2;
-		const int TemplateA11yLanguageName = 3;
 		TreeStore templateCategoriesTreeStore =
 			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(TemplateCategory));
 		TreeView templatesTreeView;
 		const int TemplateIconColumn = 1;
 		const int TemplateColumn = 2;
+		const int TemplateA11yLanguageName = 3;
 		TreeStore templatesTreeStore =
 			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(SolutionTemplate), typeof (string));
 		VBox templateVBox;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.UI.cs
@@ -55,6 +55,7 @@ namespace MonoDevelop.Ide.Projects
 		const int TemplateCategoryNameColumn = 0;
 		const int TemplateCategoryIconColumn = 1;
 		const int TemplateCategoryColumn = 2;
+		const int TemplateA11yLanguageName = 3;
 		TreeStore templateCategoriesTreeStore =
 			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(TemplateCategory));
 		TreeView templatesTreeView;
@@ -62,7 +63,7 @@ namespace MonoDevelop.Ide.Projects
 		const int TemplateIconColumn = 1;
 		const int TemplateColumn = 2;
 		TreeStore templatesTreeStore =
-			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(SolutionTemplate));
+			new TreeStore(typeof (string), typeof (Xwt.Drawing.Image), typeof(SolutionTemplate), typeof (string));
 		VBox templateVBox;
 		ImageView templateImage;
 		Label templateNameLabel;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -138,7 +138,7 @@ namespace MonoDevelop.Ide.Projects
 			var templateTextRenderer = (GtkTemplateCellRenderer)renderer;
 			templateTextRenderer.Template = template;
 			templateTextRenderer.TemplateIcon = model.GetValue (it, TemplateIconColumn) as Xwt.Drawing.Image;
-			templateTextRenderer.TemplateCategory = model.GetValue (it, TemplateNameColumn) as string;
+			templateTextRenderer.TemplateCategory = model.GetValue (it, TemplateCategoryNameColumn) as string;
 		}
 
 		static void SetLanguageCellData (TreeViewColumn col, CellRenderer renderer, TreeModel model, TreeIter it)
@@ -403,7 +403,7 @@ namespace MonoDevelop.Ide.Projects
 					if (template.HasProjects || controller.IsNewSolution) {
 						templatesTreeStore.AppendValues (
 							iter,
-							template.Name,
+							subCategory.Name,
 							GetIcon (template.IconId, IconSize.Dnd),
 							template,
 							template.AvailableLanguages?.OrderBy (item => item).FirstOrDefault () ?? template.Language);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -401,16 +401,27 @@ namespace MonoDevelop.Ide.Projects
 
 				foreach (SolutionTemplate template in subCategory.Templates) {
 					if (template.HasProjects || controller.IsNewSolution) {
+						string language = GetLanguageForTemplate (template);
 						templatesTreeStore.AppendValues (
 							iter,
 							subCategory.Name,
 							GetIcon (template.IconId, IconSize.Dnd),
 							template,
-							template.AvailableLanguages?.OrderBy (item => item).FirstOrDefault () ?? template.Language);
+							language);
 					}
 				}
 			}
 			templatesTreeView.ExpandAll ();
+		}
+
+		string GetLanguageForTemplate (SolutionTemplate template)
+		{
+			string language = controller.SelectedLanguage;
+			if (template.AvailableLanguages.Contains (language)) {
+				return language;
+			}
+
+			return template.AvailableLanguages.OrderBy (item => item).FirstOrDefault ();
 		}
 
 		void ShowRecentTemplates ()
@@ -468,6 +479,13 @@ namespace MonoDevelop.Ide.Projects
 
 		void ShowTemplate (SolutionTemplate template)
 		{
+			string language = GetLanguageForTemplate (controller.SelectedTemplate);
+
+			TreeIter item;
+			if (templatesTreeView.Selection.GetSelected (out item)) {
+				templatesTreeStore.SetValue (item, TemplateA11yLanguageName, language);
+			}
+
 			templateNameLabel.Markup = MarkupTemplateName (template.Name);
 			templateDescriptionLabel.Text = template.Description;
 			templateImage.Image = controller.GetImage (template);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -147,7 +147,7 @@ namespace MonoDevelop.Ide.Projects
 			var language = (string)model.GetValue (it, TemplateA11yLanguageName);
 			var languageRenderer = (LanguageCellRenderer)renderer;
 			languageRenderer.Template = template;
-			languageRenderer.SelectedLanguage = language ?? template.Language;
+			languageRenderer.SelectedLanguage = language ?? template?.Language ?? string.Empty;
 		}
 
 		void HandlePopup (SolutionTemplate template, uint eventTime)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkTemplateCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkTemplateCellRenderer.cs
@@ -73,11 +73,11 @@ namespace MonoDevelop.Ide.Projects
 
 		void SetAccessibilityText ()
 		{
-			if (template != null) {
-				var text = template.Name;
-				if (!string.IsNullOrEmpty (templateCategory))
-					text += ", " + templateCategory.Replace ("→", "–"); // we don't want narrators to read "right arrow"
-				Text = text;
+			Text = template?.Name ?? string.Empty;
+			if (!string.IsNullOrEmpty (templateCategory)) {
+				if (!string.IsNullOrEmpty (Text))
+					Text += ", ";
+				Text += templateCategory.Replace ("→", "–"); // we don't want narrators to read "right arrow"
 			}
 		}
 
@@ -133,7 +133,7 @@ namespace MonoDevelop.Ide.Projects
 				int textPixelWidth = widget.Allocation.Width - ((int)Xpad * 2);
 				layout.Width = (int)(textPixelWidth * Pango.Scale.PangoScale);
 
-				layout.SetMarkup (TemplateCategory);
+				layout.SetMarkup (MarkupTopLevelCategoryName (TemplateCategory));
 
 				int w, h;
 				layout.GetPixelSize (out w, out h);
@@ -212,6 +212,11 @@ namespace MonoDevelop.Ide.Projects
 			if ((flags & CellRendererState.Selected) != 0)
 				stateType = widget.HasFocus ? StateType.Selected : StateType.Active;
 			return stateType;
+		}
+
+		static string MarkupTopLevelCategoryName (string name)
+		{
+			return "<span font_weight='bold'>" + GLib.Markup.EscapeText (name) + "</span>";
 		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkTemplateCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkTemplateCellRenderer.cs
@@ -41,14 +41,45 @@ namespace MonoDevelop.Ide.Projects
 		const int iconTextPadding = 9;
 		int groupTemplateHeadingTotalYPadding = 24;
 		int recentTemplateHeadingTotalYPadding = 30;
+		private SolutionTemplate template;
+		private string templateCategory;
+		private string selectedLanguage;
 		const int groupTemplateHeadingYOffset = 4;
 		const int categoryTextPaddingX = 4;
 
-		public SolutionTemplate Template { get; set; }
-		public string SelectedLanguage { get; set; }
+		public SolutionTemplate Template {
+			get { return template; }
+			set {
+				template = value;
+				SetAccessibilityText ();
+			}
+		}
+		public string SelectedLanguage {
+			get { return selectedLanguage; }
+			set {
+				selectedLanguage = value;
+				SetAccessibilityText ();
+			}
+		}
 		public Xwt.Drawing.Image TemplateIcon { get; set; }
-		public string TemplateCategory { get; set; }
+		public string TemplateCategory {
+			get { return templateCategory; }
+			set {
+				templateCategory = value;
+				SetAccessibilityText ();
+			}
+		}
 		public bool RenderRecentTemplate { get; set; }
+
+		void SetAccessibilityText ()
+		{
+			if (template != null) {
+				var text = template.Name;
+				if (!string.IsNullOrEmpty (templateCategory))
+					text += ", " + templateCategory.Replace ("→", "–"); // we don't want narrators to read "right arrow"
+				Text = text;
+			}
+		}
 
 		public GtkTemplateCellRenderer ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
@@ -62,7 +62,7 @@ namespace MonoDevelop.Ide.Projects
 			}
 			set {
 				selectedLanguage = value;
-				Text = GetAccessibleLanguageName ();
+				Text = GetAccessibleLanguageName (selectedLanguage);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/LanguageCellRenderer.cs
@@ -45,7 +45,16 @@ namespace MonoDevelop.Ide.Projects
 
 		int minLanguageRectWidth;
 
-		public SolutionTemplate Template { get; set; }
+		SolutionTemplate template;
+
+		public SolutionTemplate Template {
+			get { return template; }
+			set {
+				template = value;
+				Text = GetAccessibleLanguageName ();
+			}
+		}
+
 		string selectedLanguage;
 		public string SelectedLanguage { 
 			get {
@@ -53,8 +62,15 @@ namespace MonoDevelop.Ide.Projects
 			}
 			set {
 				selectedLanguage = value;
-				Text = GetAccessibleLanguageName (value);
+				Text = GetAccessibleLanguageName ();
 			}
+		}
+
+		string GetAccessibleLanguageName ()
+		{
+			if (template == null)
+				return string.Empty;
+			return GetAccessibleLanguageName (GetSelectedLanguage ());
 		}
 
 		internal static string GetAccessibleLanguageName (string language)


### PR DESCRIPTION
If F# was selected for one template in the New Project dialog but
the other templates did not support F# then moving to the other
templates F Sharp would be announced by Voice Over. The problem was
that the wrong language was being set for the Text associated with
the language selector.

Fixes VSTS #752317 - Accessibility: In Project description Voice over
is reading  letter C as F (C#(C number) as F#(F number))
Fixes VSTS #751297 - Accessibility: Voice over is not reading the  whole project details in recently used templates page

Backport of #8991.

/cc @mrward 