### PR TITLE
[UI] Remove trailing period from exception caught dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -401,7 +401,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			}
 			var actionArea = new HBox (false, 0) { BorderWidth = 14 };
 
-			onlyShowMyCodeCheckbox = new CheckButton (GettextCatalog.GetString ("_Only show my code."));
+			onlyShowMyCodeCheckbox = new CheckButton (GettextCatalog.GetString ("_Only show my code"));
 			onlyShowMyCodeCheckbox.Toggled += OnlyShowMyCodeToggled;
 			onlyShowMyCodeCheckbox.Show ();
 			onlyShowMyCodeCheckbox.Active = DebuggingService.GetUserOptions ().ProjectAssembliesOnly;


### PR DESCRIPTION
Fixes https://github.com/mono/monodevelop/issues/8204