### PR TITLE
Use the right pasteboard type values for rtf/html atoms

### DIFF
--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Actions/ClipboardActions.cs
@@ -162,9 +162,8 @@ namespace Mono.TextEditor
 			static CopyOperation ()
 			{
 				if (Platform.IsMac) {
-					RTF_ATOM = Gdk.Atom.Intern ("NSRTFPboardType", false); //TODO: use public.rtf when dep on MacOS 10.6
-					const string NSHTMLPboardType = "Apple HTML pasteboard type";
-					HTML_ATOM = Gdk.Atom.Intern (NSHTMLPboardType, false);
+					RTF_ATOM = Gdk.Atom.Intern ("public.rtf", false);
+					HTML_ATOM = Gdk.Atom.Intern ("public.html", false);
 				} else if (Platform.IsWindows) {
 					RTF_ATOM = Gdk.Atom.Intern ("Rich Text Format", false);
 					HTML_ATOM = Gdk.Atom.Intern ("HTML Format", false);


### PR DESCRIPTION
NOTE: This patch by itself does not fix anything.

There are outdated pboard type values being used in gtk which may need updating.