### PR TITLE
[release-8.4] [Debugger] When a CellView gets moved to a null Superview, don't Upda…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.Debugger
 		public override NSObject ObjectValue {
 			get { return base.ObjectValue; }
 			set {
-				var target = ((MacObjectValueNode)value)?.Target;
+				var target = ((MacObjectValueNode) value)?.Target;
 
 				if (Node != target) {
 					if (target != null)
@@ -172,7 +172,9 @@ namespace MonoDevelop.Debugger
 		public override void ViewDidMoveToSuperview ()
 		{
 			base.ViewDidMoveToSuperview ();
-			UpdateContents ();
+
+			if (Superview != null)
+				UpdateContents ();
 		}
 
 		public override NSBackgroundStyle BackgroundStyle {


### PR DESCRIPTION
…teContents()

When the Superview is null, it means that we are being removed from view
so it is unnecessary to UpdateContents(). It can also mean we are in the
process of being disposed. Either way, don't UpdateContents().

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1006517/

Backport of #9077.

/cc @jstedfast 