### PR TITLE
[Debugger] null-protect nameView.SetPreviewIcon() in case nameView is…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -636,7 +636,7 @@ namespace MonoDevelop.Debugger
 			if (rowView != null) {
 				var nameView = (MacDebuggerObjectNameView) rowView.ViewAtColumn (0);
 
-				nameView.SetPreviewButtonIcon (icon);
+				nameView?.SetPreviewButtonIcon (icon);
 			}
 		}
 


### PR DESCRIPTION
… null?

I'm not sure how this is possible... but yay Catalina?

Everything else is null-protected so the only way to get an NRE in this
tiny method is if nameView is null.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1006515/