### PR TITLE
[NuGet]  Show license metadata

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseAcceptanceDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseAcceptanceDialog.cs
@@ -196,7 +196,7 @@ namespace MonoDevelop.PackageManagement
 		static void AddFileLicenseLinkLabel (LicenseFileText licenseFileText, VBox parentVBox)
 		{
 			var licenseLabel = new LinkLabel (GettextCatalog.GetString ("View License"));
-			licenseLabel.Uri = licenseFileText.CreateLicenseFileUri (1);
+			licenseLabel.Uri = licenseFileText.CreateLicenseFileUri ();
 			licenseLabel.Tag = licenseFileText;
 			licenseLabel.NavigateToUrl += (sender, e) => ShowFileDialog ((LinkLabel)sender);
 			parentVBox.PackStart (licenseLabel);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileDialog.cs
@@ -24,14 +24,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using NuGet.PackageManagement.UI;
 using Xwt;
 using Xwt.Formats;
 
-namespace MonoDevelop.PackageManagement.Gui
+namespace MonoDevelop.PackageManagement
 {
-	class LicenseFileDialog : Dialog
+	sealed class LicenseFileDialog : Dialog
 	{
 		RichTextView textView;
 		LicenseFileText licenseFileText;
@@ -76,6 +78,43 @@ namespace MonoDevelop.PackageManagement.Gui
 			if (disposing) {
 				licenseFileText.PropertyChanged -= LicenseFileTextPropertyChanged;
 			}
+		}
+
+		public static bool ShowDialog (Uri uri, IReadOnlyList<IText> licenseLinks, Dialog parent)
+		{
+			if (!uri.IsFile)
+				return false;
+
+			if (uri.Fragment?.Length > 0) {
+				if (int.TryParse (uri.Fragment.Substring (1), out int fileNumber)) {
+					ShowLicenseFile (fileNumber, licenseLinks, parent);
+					return true;
+				}
+			}
+			return false;
+		}
+
+		static void ShowLicenseFile (int fileNumber, IReadOnlyList<IText> licenseLinks, Dialog parent)
+		{
+			LicenseFileText licenseFileText = GetLicenseFile (fileNumber, licenseLinks);
+			if (licenseFileText != null) {
+				var dialog = new LicenseFileDialog (licenseFileText);
+				dialog.Run (parent);
+			}
+		}
+
+		static LicenseFileText GetLicenseFile (int fileNumber, IReadOnlyList<IText> licenseLinks)
+		{
+			int currentFileNumber = 0;
+			foreach (IText text in licenseLinks) {
+				if (text is LicenseFileText licenseFileText) {
+					currentFileNumber++;
+					if (currentFileNumber == fileNumber) {
+						return licenseFileText;
+					}
+				}
+			}
+			return null;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileDialog.cs
@@ -1,0 +1,81 @@
+//
+// LicenseFileDialog.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.ComponentModel;
+using NuGet.PackageManagement.UI;
+using Xwt;
+using Xwt.Formats;
+
+namespace MonoDevelop.PackageManagement.Gui
+{
+	class LicenseFileDialog : Dialog
+	{
+		RichTextView textView;
+		LicenseFileText licenseFileText;
+
+		public LicenseFileDialog (LicenseFileText licenseFileText)
+		{
+			this.licenseFileText = licenseFileText;
+
+			Build ();
+			LoadText ();
+
+			licenseFileText.PropertyChanged += LicenseFileTextPropertyChanged;
+			licenseFileText.LoadLicenseFile ();
+		}
+
+		void Build ()
+		{
+			Height = 450;
+			Width = 450;
+			Title = licenseFileText.LicenseHeader;
+
+			textView = new RichTextView ();
+			Content = textView;
+
+			Buttons.Add (Command.Ok);
+			DefaultCommand = Command.Ok;
+		}
+
+		void LicenseFileTextPropertyChanged (object sender, PropertyChangedEventArgs e)
+		{
+			LoadText ();
+		}
+
+		void LoadText ()
+		{
+			textView.LoadText (licenseFileText.LicenseText, TextFormat.Plain);
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (disposing) {
+				licenseFileText.PropertyChanged -= LicenseFileTextPropertyChanged;
+			}
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileDialog.cs
@@ -79,42 +79,5 @@ namespace MonoDevelop.PackageManagement
 				licenseFileText.PropertyChanged -= LicenseFileTextPropertyChanged;
 			}
 		}
-
-		public static bool ShowDialog (Uri uri, IReadOnlyList<IText> licenseLinks, Dialog parent)
-		{
-			if (!uri.IsFile)
-				return false;
-
-			if (uri.Fragment?.Length > 0) {
-				if (int.TryParse (uri.Fragment.Substring (1), out int fileNumber)) {
-					ShowLicenseFile (fileNumber, licenseLinks, parent);
-					return true;
-				}
-			}
-			return false;
-		}
-
-		static void ShowLicenseFile (int fileNumber, IReadOnlyList<IText> licenseLinks, Dialog parent)
-		{
-			LicenseFileText licenseFileText = GetLicenseFile (fileNumber, licenseLinks);
-			if (licenseFileText != null) {
-				var dialog = new LicenseFileDialog (licenseFileText);
-				dialog.Run (parent);
-			}
-		}
-
-		static LicenseFileText GetLicenseFile (int fileNumber, IReadOnlyList<IText> licenseLinks)
-		{
-			int currentFileNumber = 0;
-			foreach (IText text in licenseLinks) {
-				if (text is LicenseFileText licenseFileText) {
-					currentFileNumber++;
-					if (currentFileNumber == fileNumber) {
-						return licenseFileText;
-					}
-				}
-			}
-			return null;
-		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileTextExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileTextExtensions.cs
@@ -31,9 +31,9 @@ namespace MonoDevelop.PackageManagement
 {
 	static class LicenseFileTextExtensions
 	{
-		public static Uri CreateLicenseFileUri  (this LicenseFileText licenseFileText, int licenseCount)
+		public static Uri CreateLicenseFileUri  (this LicenseFileText licenseFileText)
 		{
-			return new Uri ($"file:///{licenseFileText.Text}#{licenseCount}");
+			return new Uri ($"file:///{licenseFileText.Text}");
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileTextExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseFileTextExtensions.cs
@@ -1,0 +1,39 @@
+//
+// LicenseFileTextExtensions.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NuGet.PackageManagement.UI;
+
+namespace MonoDevelop.PackageManagement
+{
+	static class LicenseFileTextExtensions
+	{
+		public static Uri CreateLicenseFileUri  (this LicenseFileText licenseFileText, int licenseCount)
+		{
+			return new Uri ($"file:///{licenseFileText.Text}#{licenseCount}");
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseLinkMarkupBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseLinkMarkupBuilder.cs
@@ -1,0 +1,74 @@
+//
+// LicenseLinkMarkupBuilder.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using MonoDevelop.Core;
+using NuGet.PackageManagement.UI;
+
+namespace MonoDevelop.PackageManagement
+{
+	sealed class LicenseLinkMarkupBuilder
+	{
+		List<WarningText> warnings;
+
+		public string GetMarkup (IReadOnlyList<IText> textLinks)
+		{
+			var markupBuilder = StringBuilderCache.Allocate ();
+
+			int fileLicenseCount = 0; // Should be one but handle multiple.
+			foreach (IText textLink in textLinks) {
+				if (textLink is LicenseText licenseText) {
+					markupBuilder.Append (GetUriMarkup (licenseText.Link, licenseText.Text));
+				} else if (textLink is LicenseFileText licenseFileText) {
+					fileLicenseCount++;
+					markupBuilder.Append (GetUriMarkup (licenseFileText.CreateLicenseFileUri (fileLicenseCount), licenseFileText.Text));
+				} else if (textLink is WarningText warning) {
+					warnings ??= new List<WarningText> ();
+					warnings.Add (warning);
+				} else {
+					markupBuilder.Append (textLink.Text);
+				}
+			}
+
+			return StringBuilderCache.ReturnAndFree (markupBuilder);
+		}
+
+		public IEnumerable<WarningText> Warnings {
+			get { return warnings ?? Enumerable.Empty<WarningText> (); }
+		}
+
+		static string GetUriMarkup (Uri uri, string text)
+		{
+			return string.Format (
+				"<a href=\"{0}\">{1}</a>",
+				uri != null ? SecurityElement.Escape (uri.ToString ()) : string.Empty,
+				SecurityElement.Escape (text));
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseLinkMarkupBuilder.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/LicenseLinkMarkupBuilder.cs
@@ -41,13 +41,12 @@ namespace MonoDevelop.PackageManagement
 		{
 			var markupBuilder = StringBuilderCache.Allocate ();
 
-			int fileLicenseCount = 0; // Should be one but handle multiple.
 			foreach (IText textLink in textLinks) {
 				if (textLink is LicenseText licenseText) {
 					markupBuilder.Append (GetUriMarkup (licenseText.Link, licenseText.Text));
 				} else if (textLink is LicenseFileText licenseFileText) {
-					fileLicenseCount++;
-					markupBuilder.Append (GetUriMarkup (licenseFileText.CreateLicenseFileUri (fileLicenseCount), licenseFileText.Text));
+					// Should not happen. Building an expression should not contain a license file.
+					LoggingService.LogError ("Unexpected LicenseFileText when building markup {0}", licenseFileText.Text);
 				} else if (textLink is WarningText warning) {
 					warnings ??= new List<WarningText> ();
 					warnings.Add (warning);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
@@ -47,7 +47,11 @@ namespace MonoDevelop.PackageManagement
 		Label packageAuthor;
 		Label packagePublishedDate;
 		Label packageDownloads;
+		Label packageLicenseLabel;
 		LinkLabel packageLicenseLink;
+		VBox packageLicenseMetadataWarningsVBox;
+		HBox packageLicenseMetadataHBox;
+		Label packageLicenseMetadataLabel;
 		LinkLabel packageProjectPageLink;
 		Label packageDependenciesList;
 		HBox packageDependenciesHBox;
@@ -322,7 +326,7 @@ namespace MonoDevelop.PackageManagement
 			var packageLicenseHBox = new HBox ();
 			packageInfoVBox.PackStart (packageLicenseHBox);
 
-			var packageLicenseLabel = new Label ();
+			packageLicenseLabel = new Label ();
 			packageLicenseLabel.Text = GettextCatalog.GetString ("License");
 			packageLicenseLabel.Font = packageInfoBoldFont;
 			packageLicenseHBox.PackStart (packageLicenseLabel);
@@ -331,6 +335,21 @@ namespace MonoDevelop.PackageManagement
 			packageLicenseLink.Text = GettextCatalog.GetString ("View License");
 			packageLicenseLink.Font = packageInfoSmallFont;
 			packageLicenseHBox.PackEnd (packageLicenseLink);
+
+			packageLicenseMetadataWarningsVBox = new VBox ();
+			packageLicenseMetadataWarningsVBox.Visible = false;
+			packageInfoVBox.PackStart (packageLicenseMetadataWarningsVBox);
+
+			packageLicenseMetadataHBox = new HBox ();
+			packageLicenseMetadataHBox.Visible = false;
+			packageInfoVBox.PackStart (packageLicenseMetadataHBox);
+
+			packageLicenseMetadataLabel = new Label ();
+			packageLicenseMetadataLabel.Wrap = WrapMode.Word;
+			packageLicenseMetadataLabel.MarginLeft = 5;
+			packageLicenseMetadataLabel.Font = packageInfoSmallFont;
+			packageLicenseMetadataLabel.Accessible.LabelWidget = packageLicenseLabel;
+			packageLicenseMetadataHBox.PackStart (packageLicenseMetadataLabel, true);
 
 			// Package project page.
 			var packageProjectPageHBox = new HBox ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -27,9 +27,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
+using MonoDevelop.PackageManagement.Gui;
 using MonoDevelop.Projects;
+using NuGet.PackageManagement.UI;
 using NuGet.Versioning;
 using Xwt;
 using Xwt.Drawing;
@@ -97,6 +100,8 @@ namespace MonoDevelop.PackageManagement
 			LoadViewModel (initialSearch);
 
 			closeButton.Clicked += CloseButtonClicked;
+			packageLicenseLink.NavigateToUrl += PackageLicenseNavigateToUrl;
+			packageLicenseMetadataLabel.LinkClicked += PackageLicenseLinkClicked;
 			this.showPrereleaseCheckBox.Clicked += ShowPrereleaseCheckBoxClicked;
 			this.packageSourceComboBox.SelectionChanged += PackageSourceChanged;
 			this.addPackagesButton.Clicked += AddPackagesButtonClicked;
@@ -115,6 +120,8 @@ namespace MonoDevelop.PackageManagement
 		protected override void Dispose (bool disposing)
 		{
 			closeButton.Clicked -= CloseButtonClicked;
+			packageLicenseLink.NavigateToUrl -= PackageLicenseNavigateToUrl;
+			packageLicenseMetadataLabel.LinkClicked -= PackageLicenseLinkClicked;
 			currentPackageVersionLabel.BoundsChanged -= PackageVersionLabelBoundsChanged;
 
 			imageLoader.Loaded -= ImageLoaded;
@@ -408,6 +415,10 @@ namespace MonoDevelop.PackageManagement
 		{
 			bool consolidate = viewModel.IsConsolidatePageSelected;
 
+			foreach (Widget child in packageInfoVBox.Children) {
+				child.Visible = !consolidate;
+			}
+
 			if (consolidate) {
 				projectsListViewLabel.Text = GettextCatalog.GetString ("Select projects and a version for a consolidation.");
 			} else {
@@ -422,7 +433,7 @@ namespace MonoDevelop.PackageManagement
 				this.packageId.Visible = packageViewModel.HasNoGalleryUrl;
 				ShowUri (this.packageIdLink, packageViewModel.GalleryUrl, packageViewModel.Id);
 				ShowUri (this.packageProjectPageLink, packageViewModel.ProjectUrl);
-				ShowUri (this.packageLicenseLink, packageViewModel.LicenseUrl);
+				ShowLicense (packageViewModel);
 
 				PopulatePackageDependencies (packageViewModel);
 			}
@@ -440,10 +451,6 @@ namespace MonoDevelop.PackageManagement
 				currentPackageVersionHBox.Visible = false;
 				PopulatePackageVersions (packageViewModel);
 				packageVersionsHBox.Visible = true;
-			}
-
-			foreach (Widget child in packageInfoVBox.Children) {
-				child.Visible = !consolidate;
 			}
 
 			if (consolidate) {
@@ -971,6 +978,7 @@ namespace MonoDevelop.PackageManagement
 				} else {
 					if (!viewModel.IsConsolidatePageSelected) {
 						packagePublishedDate.Text = viewModel.SelectedPackage.GetLastPublishedDisplayText ();
+						ShowLicense (viewModel.SelectedPackage);
 						PopulatePackageDependencies (viewModel.SelectedPackage);
 					}
 				}
@@ -1160,6 +1168,160 @@ namespace MonoDevelop.PackageManagement
 			selectedProject.IsChecked = !selectedProject.IsChecked;
 
 			UpdateAddPackagesButton ();
+		}
+
+		void ShowLicense (ManagePackagesSearchResultViewModel packageViewModel)
+		{
+			if (packageViewModel.HasLicenseMetadata) {
+				ShowLicenseMetadata (packageViewModel);
+			} else {
+				packageLicenseMetadataHBox.Visible = false;
+				packageLicenseMetadataWarningsVBox.Visible = false;
+				ShowUri (packageLicenseLink, packageViewModel.LicenseUrl, GettextCatalog.GetString ("View License"));
+			}
+		}
+
+		static string GetUriMarkup (Uri uri, string text)
+		{
+			return string.Format (
+				"<a href=\"{0}\">{1}</a>",
+				uri != null ? SecurityElement.Escape (uri.ToString ()) : string.Empty,
+				SecurityElement.Escape (text));
+		}
+
+		void PackageLicenseNavigateToUrl (object sender, NavigateToUrlEventArgs e)
+		{
+			if (ShowLicenseFile (e.Uri)) {
+				e.SetHandled ();
+			}
+		}
+
+		bool ShowLicenseFile (Uri uri)
+		{
+			if (!uri.IsFile)
+				return false;
+
+			if (uri.Fragment?.Length > 0) {
+				if (int.TryParse (uri.Fragment.Substring (1), out int fileNumber)) {
+					ShowLicenseFile (fileNumber);
+					return true;
+				}
+			}
+			return false;
+		}
+
+		void PackageLicenseLinkClicked (object sender, LinkEventArgs e)
+		{
+			if (ShowLicenseFile (e.Target)) {
+				e.SetHandled ();
+			}
+		}
+
+		void ShowLicenseMetadata (ManagePackagesSearchResultViewModel packageViewModel)
+		{
+			List<WarningText> warnings = null;
+			var textLinks = packageViewModel.GetLicenseLinks ();
+
+			if (textLinks.Count == 0) {
+				packageLicenseLink.Visible = false;
+				packageLicenseMetadataHBox.Visible = false;
+				packageLicenseMetadataWarningsVBox.Visible = false;
+				return;
+			}
+
+			// Single link - show this on the same line as the License label.
+			if (textLinks.Count == 1) {
+				packageLicenseLink.Visible = true;
+				packageLicenseMetadataHBox.Visible = false;
+				packageLicenseMetadataWarningsVBox.Visible = false;
+
+				IText textLink = textLinks [0];
+				if (textLink is LicenseText licenseText) {
+					packageLicenseLink.Text = licenseText.Text;
+					packageLicenseLink.Uri = licenseText.Link;
+					return;
+				} else if (textLink is LicenseFileText licenseFileText) {
+					packageLicenseLink.Text = GettextCatalog.GetString ("View License");
+					packageLicenseLink.Uri = CreateLicenseFileUri (licenseFileText, 1);
+					return;
+				} else {
+					// Warning or plain text - handled below.
+				}
+			}
+
+			// Multiple text links. We need to allow these to wrap so show these below the license label.
+			var markupBuilder = StringBuilderCache.Allocate ();
+
+			int fileLicenseCount = 0; // Should be one but handle multiple.
+			foreach (IText textLink in textLinks) {
+				if (textLink is LicenseText licenseText) {
+					markupBuilder.Append (GetUriMarkup (licenseText.Link, licenseText.Text));
+				} else if (textLink is LicenseFileText licenseFileText) {
+					fileLicenseCount++;
+					markupBuilder.Append (GetUriMarkup (CreateLicenseFileUri (licenseFileText, fileLicenseCount), licenseFileText.Text));
+				} else if (textLink is WarningText warning) {
+					warnings ??= new List<WarningText> ();
+					warnings.Add (warning);
+				} else {
+					markupBuilder.Append (textLink.Text);
+				}
+			}
+
+			packageLicenseLink.Visible = false;
+			packageLicenseMetadataHBox.Visible = true;
+			packageLicenseMetadataLabel.Markup = StringBuilderCache.ReturnAndFree (markupBuilder);
+
+			if (warnings != null) {
+				AddWarnings (warnings);
+			} else {
+				packageLicenseMetadataWarningsVBox.Visible = false;
+			}
+		}
+
+		Uri CreateLicenseFileUri (LicenseFileText licenseFileText, int licenseCount)
+		{
+			return new Uri ($"file:///{licenseFileText.Text}#{licenseCount}");
+		}
+
+		void AddWarnings (List<WarningText> warnings)
+		{
+			foreach (Widget child in packageLicenseMetadataWarningsVBox.Children.ToArray ()) {
+				packageLicenseMetadataWarningsVBox.Remove (child);
+				child.Dispose ();
+			}
+
+			foreach (WarningText warning in warnings) {
+				var hbox = new HBox ();
+				var image = new ImageView {
+					Image = ImageService.GetIcon ("md-warning", Gtk.IconSize.Menu),
+					MarginLeft = packageLicenseMetadataLabel.MarginLeft,
+					VerticalPlacement = WidgetPlacement.Start,
+				};
+				image.Accessible.RoleDescription = GettextCatalog.GetString ("Warning Icon");
+				hbox.PackStart (image);
+
+				var label = new Label {
+					Text = warning.Text,
+					Font = packageLicenseMetadataLabel.Font,
+					Wrap = WrapMode.Word
+				};
+				image.Accessible.LabelWidget = label;
+				label.Accessible.LabelWidget = packageLicenseLabel;
+				hbox.PackStart (label, true, true);
+
+				packageLicenseMetadataWarningsVBox.PackStart (hbox);
+			}
+
+			packageLicenseMetadataWarningsVBox.Visible = true;
+		}
+
+		void ShowLicenseFile (int fileNumber)
+		{
+			LicenseFileText licenseFileText = viewModel.SelectedPackage.GetLicenseFile (fileNumber);
+			if (licenseFileText != null) {
+				var dialog = new LicenseFileDialog (licenseFileText);
+				dialog.Run (this);
+			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -27,10 +27,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
-using MonoDevelop.PackageManagement.Gui;
 using MonoDevelop.Projects;
 using NuGet.PackageManagement.UI;
 using NuGet.Versioning;
@@ -1181,33 +1179,11 @@ namespace MonoDevelop.PackageManagement
 			}
 		}
 
-		static string GetUriMarkup (Uri uri, string text)
-		{
-			return string.Format (
-				"<a href=\"{0}\">{1}</a>",
-				uri != null ? SecurityElement.Escape (uri.ToString ()) : string.Empty,
-				SecurityElement.Escape (text));
-		}
-
 		void PackageLicenseNavigateToUrl (object sender, NavigateToUrlEventArgs e)
 		{
 			if (ShowLicenseFile (e.Uri)) {
 				e.SetHandled ();
 			}
-		}
-
-		bool ShowLicenseFile (Uri uri)
-		{
-			if (!uri.IsFile)
-				return false;
-
-			if (uri.Fragment?.Length > 0) {
-				if (int.TryParse (uri.Fragment.Substring (1), out int fileNumber)) {
-					ShowLicenseFile (fileNumber);
-					return true;
-				}
-			}
-			return false;
 		}
 
 		void PackageLicenseLinkClicked (object sender, LinkEventArgs e)
@@ -1217,9 +1193,16 @@ namespace MonoDevelop.PackageManagement
 			}
 		}
 
+		bool ShowLicenseFile (Uri uri)
+		{
+			return LicenseFileDialog.ShowDialog (
+				uri,
+				viewModel.SelectedPackage.GetLicenseLinks (),
+				this);
+		}
+
 		void ShowLicenseMetadata (ManagePackagesSearchResultViewModel packageViewModel)
 		{
-			List<WarningText> warnings = null;
 			var textLinks = packageViewModel.GetLicenseLinks ();
 
 			if (textLinks.Count == 0) {
@@ -1242,7 +1225,7 @@ namespace MonoDevelop.PackageManagement
 					return;
 				} else if (textLink is LicenseFileText licenseFileText) {
 					packageLicenseLink.Text = GettextCatalog.GetString ("View License");
-					packageLicenseLink.Uri = CreateLicenseFileUri (licenseFileText, 1);
+					packageLicenseLink.Uri = licenseFileText.CreateLicenseFileUri (1);
 					return;
 				} else {
 					// Warning or plain text - handled below.
@@ -1250,40 +1233,20 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			// Multiple text links. We need to allow these to wrap so show these below the license label.
-			var markupBuilder = StringBuilderCache.Allocate ();
-
-			int fileLicenseCount = 0; // Should be one but handle multiple.
-			foreach (IText textLink in textLinks) {
-				if (textLink is LicenseText licenseText) {
-					markupBuilder.Append (GetUriMarkup (licenseText.Link, licenseText.Text));
-				} else if (textLink is LicenseFileText licenseFileText) {
-					fileLicenseCount++;
-					markupBuilder.Append (GetUriMarkup (CreateLicenseFileUri (licenseFileText, fileLicenseCount), licenseFileText.Text));
-				} else if (textLink is WarningText warning) {
-					warnings ??= new List<WarningText> ();
-					warnings.Add (warning);
-				} else {
-					markupBuilder.Append (textLink.Text);
-				}
-			}
+			var markupBuilder = new LicenseLinkMarkupBuilder ();
+			packageLicenseMetadataLabel.Markup = markupBuilder.GetMarkup (textLinks);
 
 			packageLicenseLink.Visible = false;
 			packageLicenseMetadataHBox.Visible = true;
-			packageLicenseMetadataLabel.Markup = StringBuilderCache.ReturnAndFree (markupBuilder);
 
-			if (warnings != null) {
-				AddWarnings (warnings);
+			if (markupBuilder.Warnings.Any ()) {
+				AddWarnings (markupBuilder.Warnings);
 			} else {
 				packageLicenseMetadataWarningsVBox.Visible = false;
 			}
 		}
 
-		Uri CreateLicenseFileUri (LicenseFileText licenseFileText, int licenseCount)
-		{
-			return new Uri ($"file:///{licenseFileText.Text}#{licenseCount}");
-		}
-
-		void AddWarnings (List<WarningText> warnings)
+		void AddWarnings (IEnumerable<WarningText> warnings)
 		{
 			foreach (Widget child in packageLicenseMetadataWarningsVBox.Children.ToArray ()) {
 				packageLicenseMetadataWarningsVBox.Remove (child);
@@ -1313,15 +1276,6 @@ namespace MonoDevelop.PackageManagement
 			}
 
 			packageLicenseMetadataWarningsVBox.Visible = true;
-		}
-
-		void ShowLicenseFile (int fileNumber)
-		{
-			LicenseFileText licenseFileText = viewModel.SelectedPackage.GetLicenseFile (fileNumber);
-			if (licenseFileText != null) {
-				var dialog = new LicenseFileDialog (licenseFileText);
-				dialog.Run (this);
-			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -99,7 +99,6 @@ namespace MonoDevelop.PackageManagement
 
 			closeButton.Clicked += CloseButtonClicked;
 			packageLicenseLink.NavigateToUrl += PackageLicenseNavigateToUrl;
-			packageLicenseMetadataLabel.LinkClicked += PackageLicenseLinkClicked;
 			this.showPrereleaseCheckBox.Clicked += ShowPrereleaseCheckBoxClicked;
 			this.packageSourceComboBox.SelectionChanged += PackageSourceChanged;
 			this.addPackagesButton.Clicked += AddPackagesButtonClicked;
@@ -119,7 +118,6 @@ namespace MonoDevelop.PackageManagement
 		{
 			closeButton.Clicked -= CloseButtonClicked;
 			packageLicenseLink.NavigateToUrl -= PackageLicenseNavigateToUrl;
-			packageLicenseMetadataLabel.LinkClicked -= PackageLicenseLinkClicked;
 			currentPackageVersionLabel.BoundsChanged -= PackageVersionLabelBoundsChanged;
 
 			imageLoader.Loaded -= ImageLoaded;
@@ -1170,6 +1168,7 @@ namespace MonoDevelop.PackageManagement
 
 		void ShowLicense (ManagePackagesSearchResultViewModel packageViewModel)
 		{
+			packageLicenseLink.Tag = null;
 			if (packageViewModel.HasLicenseMetadata) {
 				ShowLicenseMetadata (packageViewModel);
 			} else {
@@ -1181,24 +1180,12 @@ namespace MonoDevelop.PackageManagement
 
 		void PackageLicenseNavigateToUrl (object sender, NavigateToUrlEventArgs e)
 		{
-			if (ShowLicenseFile (e.Uri)) {
+			var licenseFileText = packageLicenseLink.Tag as LicenseFileText;
+			if (licenseFileText != null) {
 				e.SetHandled ();
+				var dialog = new LicenseFileDialog (licenseFileText);
+				dialog.Run (this);
 			}
-		}
-
-		void PackageLicenseLinkClicked (object sender, LinkEventArgs e)
-		{
-			if (ShowLicenseFile (e.Target)) {
-				e.SetHandled ();
-			}
-		}
-
-		bool ShowLicenseFile (Uri uri)
-		{
-			return LicenseFileDialog.ShowDialog (
-				uri,
-				viewModel.SelectedPackage.GetLicenseLinks (),
-				this);
 		}
 
 		void ShowLicenseMetadata (ManagePackagesSearchResultViewModel packageViewModel)
@@ -1225,7 +1212,8 @@ namespace MonoDevelop.PackageManagement
 					return;
 				} else if (textLink is LicenseFileText licenseFileText) {
 					packageLicenseLink.Text = GettextCatalog.GetString ("View License");
-					packageLicenseLink.Uri = licenseFileText.CreateLicenseFileUri (1);
+					packageLicenseLink.Uri = licenseFileText.CreateLicenseFileUri ();
+					packageLicenseLink.Tag = licenseFileText;
 					return;
 				} else {
 					// Warning or plain text - handled below.

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -368,6 +368,13 @@
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementCanReferenceProjectExtension.cs" />
     <Compile Include="MonoDevelop.PackageManagement\UpdateMultipleNuGetPackagesAction.cs" />
     <Compile Include="MonoDevelop.PackageManagement\ProjectReferenceMaintainerCollection.cs" />
+    <Compile Include="NuGet.PackageManagement.UI\Models\FreeText.cs" />
+    <Compile Include="NuGet.PackageManagement.UI\Models\IText.cs" />
+    <Compile Include="NuGet.PackageManagement.UI\Models\LicenseFileText.cs" />
+    <Compile Include="NuGet.PackageManagement.UI\Models\LicenseText.cs" />
+    <Compile Include="NuGet.PackageManagement.UI\Models\WarningText.cs" />
+    <Compile Include="NuGet.PackageManagement.UI\PackageLicenseUtilities.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Gui\LicenseFileDialog.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -375,6 +375,8 @@
     <Compile Include="NuGet.PackageManagement.UI\Models\WarningText.cs" />
     <Compile Include="NuGet.PackageManagement.UI\PackageLicenseUtilities.cs" />
     <Compile Include="MonoDevelop.PackageManagement.Gui\LicenseFileDialog.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Gui\LicenseLinkMarkupBuilder.cs" />
+    <Compile Include="MonoDevelop.PackageManagement.Gui\LicenseFileTextExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
@@ -47,11 +47,13 @@ namespace MonoDevelop.PackageManagement
 		{
 			var res = new TaskCompletionSource<bool> ();
 			IdeApp.RunWhenIdle (() => {
-				Xwt.Toolkit.NativeEngine.Invoke (delegate {
+				// Disable use of native toolkit since hyperlinks cannot be clicked with the Xamarin.Mac LabelBackend
+				// Also scrollbars are always visible even when they are not needed.
+				//Xwt.Toolkit.NativeEngine.Invoke (delegate {
 					using (LicenseAcceptanceDialog dialog = CreateLicenseAcceptanceDialog (licenses)) {
 						res.SetResult (dialog.Run (Xwt.MessageDialog.RootWindow));
 					}
-				});
+				//});
 			});
 			return res.Task;
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesSearchResultViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesSearchResultViewModel.cs
@@ -479,20 +479,6 @@ namespace MonoDevelop.PackageManagement
 			licenseLinks ??= new List<IText> ();
 			return licenseLinks;
 		}
-
-		public LicenseFileText GetLicenseFile (int fileNumber)
-		{
-			int currentFileNumber = 0;
-			foreach (IText text in GetLicenseLinks ()) {
-				if (text is LicenseFileText licenseFileText) {
-					currentFileNumber++;
-					if (currentFileNumber == fileNumber) {
-						return licenseFileText;
-					}
-				}
-			}
-			return null;
-		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesSearchResultViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/ManagePackagesSearchResultViewModel.cs
@@ -47,6 +47,7 @@ namespace MonoDevelop.PackageManagement
 		PackageItemListViewModel viewModel;
 		PackageDetailControlModel packageDetailModel;
 		PackageDependencyMetadata[] dependencies;
+		IReadOnlyList<IText> licenseLinks;
 		string summary;
 		bool isChecked;
 
@@ -383,6 +384,7 @@ namespace MonoDevelop.PackageManagement
 					if (metadata != null) {
 						viewModel.Published = metadata.Published;
 						dependencies = GetCompatibleDependencies ().ToArray ();
+						licenseLinks = PackageLicenseUtilities.GenerateLicenseLinks (metadata);
 						OnPropertyChanged ("Dependencies");
 					}
 				}
@@ -466,6 +468,30 @@ namespace MonoDevelop.PackageManagement
 		public string GetCurrentPackageVersionAdditionalText ()
 		{
 			return parent.GetCurrentPackageVersionAdditionalText (Id);
+		}
+
+		public bool HasLicenseMetadata {
+			get { return packageDetailModel?.PackageMetadata?.LicenseMetadata != null; }
+		}
+
+		public IReadOnlyList<IText> GetLicenseLinks ()
+		{
+			licenseLinks ??= new List<IText> ();
+			return licenseLinks;
+		}
+
+		public LicenseFileText GetLicenseFile (int fileNumber)
+		{
+			int currentFileNumber = 0;
+			foreach (IText text in GetLicenseLinks ()) {
+				if (text is LicenseFileText licenseFileText) {
+					currentFileNumber++;
+					if (currentFileNumber == fileNumber) {
+						return licenseFileText;
+					}
+				}
+			}
+			return null;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageLicense.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageLicense.cs
@@ -25,6 +25,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
+using NuGet.PackageManagement.UI;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -40,6 +42,7 @@ namespace MonoDevelop.PackageManagement
 			PackageAuthor = metadata.Authors;
 			LicenseUrl = metadata.LicenseUrl;
 			IconUrl = metadata.IconUrl;
+			LicenseLinks = PackageLicenseUtilities.GenerateLicenseLinks (metadata);
 		}
 
 		public PackageIdentity PackageIdentity { get; private set; }
@@ -48,6 +51,7 @@ namespace MonoDevelop.PackageManagement
 		public string PackageAuthor { get; private set; }
 		public Uri LicenseUrl { get; private set; }
 		public Uri IconUrl { get; private set; }
+		public IReadOnlyList<IText> LicenseLinks { get; }
 	}
 }
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageLicenseViewModel.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageLicenseViewModel.cs
@@ -27,6 +27,9 @@
 //
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.PackageManagement.UI;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -53,6 +56,10 @@ namespace MonoDevelop.PackageManagement
 
 		public Uri IconUrl {
 			get { return packageLicense.IconUrl; }
+		}
+
+		public IReadOnlyList<IText> LicenseLinks {
+			get { return packageLicense.LicenseLinks; }
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/DetailedPackageMetadata.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/DetailedPackageMetadata.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Packaging;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -17,6 +19,7 @@ namespace NuGet.PackageManagement.UI
 
 		public DetailedPackageMetadata(IPackageSearchMetadata serverData, long? downloadCount)
 		{
+			Id = serverData.Identity.Id;
 			Version = serverData.Identity.Version;
 			Summary = serverData.Summary;
 			Description = serverData.Description;
@@ -34,9 +37,16 @@ namespace NuGet.PackageManagement.UI
 				?? new PackageDependencySetMetadata[] { };
 			HasDependencies = DependencySets.Any(
 				dependencySet => dependencySet.Dependencies != null && dependencySet.Dependencies.Count > 0);
+			LicenseMetadata = serverData.LicenseMetadata;
+			localMetadata = serverData as LocalPackageSearchMetadata;
 		}
 
+		readonly LocalPackageSearchMetadata localMetadata;
+
+		public string Id { get; set; }
+
 		public NuGetVersion Version { get; set; }
+
 		public string Summary { get; set; }
 
 		public string Description { get; set; }
@@ -63,5 +73,17 @@ namespace NuGet.PackageManagement.UI
 
 		// This property is used by data binding to display text "No dependencies"
 		public bool HasDependencies { get; set; }
+
+		public LicenseMetadata LicenseMetadata { get; set; }
+
+		public IReadOnlyList<IText> LicenseLinks => PackageLicenseUtilities.GenerateLicenseLinks (this);
+
+		public string LoadFileAsText (string path)
+		{
+			if (localMetadata != null) {
+				return localMetadata.LoadFileAsText (path);
+			}
+			return null;
+		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/FreeText.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/FreeText.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.UI
+{
+	internal class FreeText : IText
+	{
+		public FreeText (string text)
+		{
+			Text = text;
+		}
+
+		public string Text { get; }
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/IText.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/IText.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.UI
+{
+	public interface IText
+	{
+		string Text { get; }
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/LicenseFileText.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/LicenseFileText.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+
+namespace NuGet.PackageManagement.UI
+{
+	internal class LicenseFileText : IText, INotifyPropertyChanged
+	{
+		string _text;
+		string _licenseText;
+		string _licenseHeader;
+		readonly string _licenseFileLocation;
+		private Func<string, string> _loadFileFromPackage;
+
+		int _initialized;
+
+		internal LicenseFileText (string text, string licenseFileHeader, Func<string, string> loadFileFromPackage, string licenseFileLocation)
+		{
+			_text = text;
+			_licenseHeader = licenseFileHeader;
+			_licenseText = GettextCatalog.GetString ("Loading license file…");
+			_loadFileFromPackage = loadFileFromPackage;
+			_licenseFileLocation = licenseFileLocation;
+		}
+
+		internal void LoadLicenseFile ()
+		{
+			if (Interlocked.CompareExchange (ref _initialized, 1, 0) == 0) {
+				if (_loadFileFromPackage != null) {
+					Task.Run (async () => {
+						string content = _loadFileFromPackage (_licenseFileLocation);
+						await Runtime.RunInMainThread (() => {
+							LicenseText = content;
+						});
+					}).Ignore ();
+				}
+			}
+		}
+
+		public string LicenseHeader {
+			get => _licenseHeader;
+			set {
+				_licenseHeader = value;
+				OnPropertyChanged ("LicenseHeader");
+			}
+		}
+
+		public string Text {
+			get => _text;
+			set {
+				_text = value;
+				OnPropertyChanged ("Text");
+			}
+		}
+
+		public string LicenseFileLocation => _licenseFileLocation;
+
+		public string LicenseText {
+			get => _licenseText;
+			set {
+				_licenseText = value;
+				OnPropertyChanged ("LicenseText");
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged (string name)
+		{
+			PropertyChanged?.Invoke (this, new System.ComponentModel.PropertyChangedEventArgs (name));
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/LicenseText.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/LicenseText.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement.UI
+{
+	internal class LicenseText : IText
+	{
+		public LicenseText (string text, Uri link)
+		{
+			Text = text;
+			Link = link;
+		}
+
+		public string Text { get; set; }
+		public Uri Link { get; set; }
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/WarningText.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/Models/WarningText.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.UI
+{
+	internal class WarningText : IText
+	{
+		public WarningText (string text)
+		{
+			Text = text;
+		}
+
+		public string Text { get; }
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.PackageManagement.UI/PackageLicenseUtilities.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using MonoDevelop.Core;
+using NuGet.Packaging;
+using NuGet.Packaging.Licenses;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.PackageManagement.UI
+{
+	internal class PackageLicenseUtilities
+	{
+		internal static IReadOnlyList<IText> GenerateLicenseLinks (DetailedPackageMetadata metadata)
+		{
+			return GenerateLicenseLinks (metadata.LicenseMetadata, metadata.LicenseUrl, GettextCatalog.GetString ("{0} License", metadata.Id), metadata.LoadFileAsText);
+		}
+
+		internal static IReadOnlyList<IText> GenerateLicenseLinks (IPackageSearchMetadata metadata)
+		{
+			if (metadata is LocalPackageSearchMetadata localMetadata) {
+				return GenerateLicenseLinks (metadata.LicenseMetadata, metadata.LicenseUrl, GettextCatalog.GetString ("{0} License", metadata.Identity.Id), localMetadata.LoadFileAsText);
+			}
+			return GenerateLicenseLinks (metadata.LicenseMetadata, metadata.LicenseUrl, metadata.Identity.Id, null);
+		}
+
+		internal static IReadOnlyList<IText> GenerateLicenseLinks (LicenseMetadata licenseMetadata, Uri licenseUrl, string licenseFileHeader, Func<string, string> loadFile)
+		{
+			if (licenseMetadata != null) {
+				return GenerateLicenseLinks (licenseMetadata, licenseFileHeader, loadFile);
+			} else if (licenseUrl != null) {
+				return new List<IText> () { new LicenseText (GettextCatalog.GetString ("View License"), licenseUrl) };
+			}
+			return new List<IText> ();
+		}
+
+		//internal static Paragraph[] GenerateParagraphs (string licenseContent)
+		//{
+		//	var textParagraphs = licenseContent.Split (
+		//		new[] { "\n\n", "\r\n\r\n" }, // Take care of paragraphs regardless of the name ending. It's a best effort, so weird line ending combinations might not work too well.
+		//		StringSplitOptions.None);
+
+		//	var paragraphs = new Paragraph[textParagraphs.Length];
+		//	for (var i = 0; i < textParagraphs.Length; i++) {
+		//		paragraphs[i] = new Paragraph (new Run (textParagraphs[i]));
+		//	}
+		//	return paragraphs;
+		//}
+
+		// Internal for testing purposes.
+		internal static IReadOnlyList<IText> GenerateLicenseLinks (LicenseMetadata metadata, string licenseFileHeader, Func<string, string> loadFile)
+		{
+			var list = new List<IText> ();
+
+			if (metadata.WarningsAndErrors != null) {
+				list.Add (new WarningText (string.Join (Environment.NewLine, metadata.WarningsAndErrors)));
+			}
+
+			switch (metadata.Type) {
+				case LicenseType.Expression:
+
+					if (metadata.LicenseExpression != null && !metadata.LicenseExpression.IsUnlicensed ()) {
+						var identifiers = new List<string> ();
+						PopulateLicenseIdentifiers (metadata.LicenseExpression, identifiers);
+
+						var licenseToBeProcessed = metadata.License;
+
+						foreach (var identifier in identifiers) {
+							var licenseStart = licenseToBeProcessed.IndexOf (identifier);
+							if (licenseStart != 0) {
+								list.Add (new FreeText (licenseToBeProcessed.Substring (0, licenseStart)));
+							}
+							var license = licenseToBeProcessed.Substring (licenseStart, identifier.Length);
+							list.Add (new LicenseText (license, new Uri (string.Format (LicenseMetadata.LicenseServiceLinkTemplate, license))));
+							licenseToBeProcessed = licenseToBeProcessed.Substring (licenseStart + identifier.Length);
+						}
+
+						if (licenseToBeProcessed.Length != 0) {
+							list.Add (new FreeText (licenseToBeProcessed));
+						}
+					} else {
+						list.Add (new FreeText (metadata.License));
+					}
+
+					break;
+
+				case LicenseType.File:
+					list.Add (new LicenseFileText (metadata.License, licenseFileHeader, loadFile, metadata.License));
+					break;
+
+				default:
+					break;
+			}
+
+			return list;
+		}
+
+		private static void PopulateLicenseIdentifiers (NuGetLicenseExpression expression, IList<string> identifiers)
+		{
+			switch (expression.Type) {
+				case LicenseExpressionType.License:
+					var license = (NuGetLicense)expression;
+					identifiers.Add (license.Identifier);
+					break;
+
+				case LicenseExpressionType.Operator:
+					var licenseOperator = (LicenseOperator)expression;
+					switch (licenseOperator.OperatorType) {
+						case LicenseOperatorType.LogicalOperator:
+							var logicalOperator = (LogicalOperator)licenseOperator;
+							PopulateLicenseIdentifiers (logicalOperator.Left, identifiers);
+							PopulateLicenseIdentifiers (logicalOperator.Right, identifiers);
+							break;
+
+						case LicenseOperatorType.WithOperator:
+							var withOperator = (WithOperator)licenseOperator;
+							identifiers.Add (withOperator.License.Identifier);
+							identifiers.Add (withOperator.Exception.Identifier);
+							break;
+
+						default:
+							break;
+					}
+					break;
+
+				default:
+					break;
+			}
+		}
+	}
+}


### PR DESCRIPTION
 - Show license metadata in Manage Packages dialog  …

If the NuGet package source has license metadata then show this
information instead of the View License link. License metadata
can either be an license expression or a file.

If the license is a file then clicking View License will open a separate
dialog with the license read from the file.

Fixes VSTS #1005394 - Support the new "license" properties in the NuGet
package manager UI

 - Show license metadata in License Acceptance dialog

If the NuGet package has associated license metadata then show this
in the dialog. License metadata can be an expression or a file.
A license file will now be displayed in a dialog if the View License
link is clicked. Warning icons and associated message will also be
displayed for deprecated licenses.

There are problems here. Could not get the text to wrap so ended up
making the dialog resizable and always showing the scrollbars. Not wrapping should be OK in the majority of cases since the text should fit unless a complex license expression is used. Scrollbars show with a whitebackground unlike the scrollbars when using the GTK# backend.

Hyperlinks in license expressions do not open the url in a browser
since the Xwt Xamarin.Mac's LabelBackend does not implement support
for this. Worked around this by using the gtk# backend instead.

Dialog no longer shrinks to fit. Using the GTK# backend the dialog is displayed before you can resize so you can see it shrink, unlike when Xamarin.Mac backend is used. The resize code has been removed.

 - Screenshots

<img width="837" alt="MITLicense" src="https://user-images.githubusercontent.com/372361/67568225-86dc2080-f723-11e9-9a41-43b0e9623016.png">

<img width="836" alt="LicenseExpression" src="https://user-images.githubusercontent.com/372361/67568250-90658880-f723-11e9-8c15-a16dfa43c439.png">

<img width="834" alt="LicenseWarnings" src="https://user-images.githubusercontent.com/372361/67568254-922f4c00-f723-11e9-886c-aff1e37ba266.png">

<img width="839" alt="LicenseFileDialog" src="https://user-images.githubusercontent.com/372361/67568262-965b6980-f723-11e9-9cc4-fb63856b8bd2.png">

<img width="539" alt="LicenseAcceptanceDialog" src="https://user-images.githubusercontent.com/372361/67568266-99565a00-f723-11e9-882c-aad79601898a.png">



