### PR TITLE
[Ide] Handle unauthorized access exception on startup

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -187,9 +187,14 @@ namespace MonoDevelop.Ide
 
 			if (!options.NewWindow && startupInfo.HasFiles) {
 				foreach (var file in startupInfo.RequestedFileList) {
-					if (MonoDevelop.Projects.Services.ProjectService.IsWorkspaceItemFile (file.FileName)) {
-						options.NewWindow = true;
-						break;
+					try {
+						if (MonoDevelop.Projects.Services.ProjectService.IsWorkspaceItemFile (file.FileName)) {
+							options.NewWindow = true;
+							break;
+						}
+					} catch (UnauthorizedAccessException ex) {
+						LoggingService.LogError (string.Format ("Unable to check startup file is a workspace item '{0}'", file.FileName), ex);
+						return 1;
 					}
 				}
 			}


### PR DESCRIPTION
Handle an UnauthorizedAccessException when trying to determine if
the filename passed as a startup argument is a workspace item. The
exception is caught and logged and return a non-zero exit code.
Previously this would generate a fatal exception.

```
System.IO.FileStream..ctor(String,FileMode,FileAccess,FileShare,Int32,Boolean,FileOptions)
System.IO.FileStream..ctor(String,FileMode,FileAccess,FileShare,Int32,FileOptions)
System.IO.StreamReader..ctor(String,Encoding,Boolean,Int32)
System.IO.StreamReader..ctor(String,Boolean)
System.IO.StreamReader..ctor(String)
MonoDevelop.Projects.MSBuild.SlnFile.GetFileVersion(String)
MonoDevelop.Projects.MSBuild.SlnFileFormat.CanReadFile(String,MSBuildFileFormat)
MonoDevelop.Projects.MSBuild.MSBuildFileFormat.CanReadFile(FilePath,Type)
MonoDevelop.Projects.MSBuildSerializationExtension.CanRead(FilePath,Type)
MonoDevelop.Projects.ProjectService.GetObjectReaderForFile(FilePath,Type)
MonoDevelop.Projects.ProjectService.FileIsObjectOfType(FilePath,Type)
MonoDevelop.Projects.ProjectService.IsWorkspaceItemFile(FilePath)
MonoDevelop.Ide.IdeStartup.Run(MonoDevelopOptions)
MonoDevelop.Ide.IdeStartup.Main(String[],IdeCustomizer)
```

Fixes VSTS #1005197 - [FATAL] System.UnauthorizedAccessException
exception in System.IO.FileStream..ctor()