### PR TITLE
[release-8.4] [Project] Make Run Configurations accessible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EnvironmentVariableCollectionEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EnvironmentVariableCollectionEditor.cs
@@ -28,6 +28,8 @@ using System.Collections.Generic;
 using MonoDevelop.Core;
 using Xwt;
 using System.Linq;
+using MonoDevelop.Components.AtkCocoaHelper;
+
 namespace MonoDevelop.Components
 {
 	public class EnvironmentVariableCollectionEditor: VBox
@@ -62,6 +64,7 @@ namespace MonoDevelop.Components
 			var box = new HBox ();
 
 			var btn = new Button (GettextCatalog.GetString ("Add"));
+			btn.Accessible.Description = GettextCatalog.GetString ("Add an environment variable");
 			btn.Clicked += delegate {
 				var row = store.AddRow ();
 				list.SelectRow (row);
@@ -72,6 +75,7 @@ namespace MonoDevelop.Components
 			box.PackStart (btn);
 
 			deleteButton = new Button (GettextCatalog.GetString ("Remove"));
+			deleteButton.Accessible.Description = GettextCatalog.GetString ("Remove the selected environment variable");
 			deleteButton.Clicked += delegate {
 				var row = list.SelectedRow;
 				if (row != -1) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
@@ -105,18 +105,26 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 			table = new Table ();
 
-			table.Add (new Label (GettextCatalog.GetString ("Arguments:")), 0, 0);
+			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
+			table.Add (argumentsLabel, 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
+			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
 
-			table.Add (new Label (GettextCatalog.GetString ("Run in directory:")), 0, 1);
+			var runInDirectoryLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
+			table.Add (runInDirectoryLabel, 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
-		
+			workingDir.Accessible.LabelWidget = runInDirectoryLabel;
+
+
+
 			mainBox.PackStart (table);
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 
-			mainBox.PackStart (new Label (GettextCatalog.GetString ("Environment Variables")));
+			var environmentVariablesLabel = new Label (GettextCatalog.GetString ("Environment Variables"));
+			mainBox.PackStart (environmentVariablesLabel);
 			envVars = new EnvironmentVariableCollectionEditor ();
+			envVars.Accessible.LabelWidget = environmentVariablesLabel;
 
 			mainBox.PackStart (envVars, true);
 
@@ -133,18 +141,23 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			adBox.Margin = 12;
 
 			table = new Table ();
-			table.Add (new Label (GettextCatalog.GetString ("Execute in .NET Runtime:")), 0, 0);
+			var executeNetRuntimeLabel = new Label (GettextCatalog.GetString ("Execute in .NET Runtime:"));
+			table.Add (executeNetRuntimeLabel, 0, 0);
 			table.Add (runtimesCombo = new ComboBox (), 1, 0, hexpand:true);
+			runtimesCombo.Accessible.LabelWidget = executeNetRuntimeLabel;
 
-			table.Add (new Label (GettextCatalog.GetString ("Mono runtime settings:")), 0, 1);
+			var runtimeSettingsLabel = new Label (GettextCatalog.GetString ("Mono runtime settings:"));
+			table.Add (runtimeSettingsLabel, 0, 1);
 
 			var box = new HBox ();
-			Button monoSettingsButton = new Button (GettextCatalog.GetString ("..."));
+			Button monoSettingsButton = new Button (GettextCatalog.GetString ("\u2026"));
 			box.PackStart (monoSettingsEntry = new TextEntry { PlaceholderText = GettextCatalog.GetString ("Default settings")}, true);
 			box.PackStart (monoSettingsButton);
 			monoSettingsEntry.ReadOnly = true;
 			table.Add (box, 1, 1, hexpand: true);
 			adBox.PackStart (table);
+			monoSettingsEntry.Accessible.LabelWidget = runtimeSettingsLabel;
+			monoSettingsButton.Accessible.LabelWidget = runtimeSettingsLabel;
 
 			if (includeAdvancedTab)
 				Add (adBox, GettextCatalog.GetString ("Advanced"));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
@@ -102,31 +102,30 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table.MarginLeft = 12;
 			mainBox.PackStart (table);
 
-			appEntry.Accessible.LabelWidget = radioStartApp;
+			appEntry.Accessible.Label = GettextCatalog.GetString ("external program");
+			appEntry.Accessible.Description = GettextCatalog.GetString ("choose the external program to start the project");
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 			table = new Table ();
 
-			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
-			table.Add (argumentsLabel, 0, 0);
+			table.Add (new Label (GettextCatalog.GetString ("Arguments:")), 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
-			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
+			argumentsEntry.Accessible.Label = GettextCatalog.GetString ("arguments");
+			argumentsEntry.Accessible.Description = GettextCatalog.GetString ("set any additional arguments to pass");
 
-			var runInDirectoryLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
-			table.Add (runInDirectoryLabel, 0, 1);
+			table.Add (new Label (GettextCatalog.GetString ("Run in directory:")), 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
-			workingDir.Accessible.LabelWidget = runInDirectoryLabel;
-
-
+			workingDir.Accessible.Label = GettextCatalog.GetString ("run in directory");
+			workingDir.Accessible.Description = GettextCatalog.GetString ("choose the directory to run the project in");
 
 			mainBox.PackStart (table);
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 
-			var environmentVariablesLabel = new Label (GettextCatalog.GetString ("Environment Variables"));
-			mainBox.PackStart (environmentVariablesLabel);
+			mainBox.PackStart (new Label (GettextCatalog.GetString ("Environment Variables")));
 			envVars = new EnvironmentVariableCollectionEditor ();
-			envVars.Accessible.LabelWidget = environmentVariablesLabel;
+			envVars.Accessible.Label = GettextCatalog.GetString ("environment variables");
+			envVars.Accessible.Description = GettextCatalog.GetString ("set additional environment variables for the project");
 
 			mainBox.PackStart (envVars, true);
 
@@ -143,13 +142,12 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			adBox.Margin = 12;
 
 			table = new Table ();
-			var executeNetRuntimeLabel = new Label (GettextCatalog.GetString ("Execute in .NET Runtime:"));
-			table.Add (executeNetRuntimeLabel, 0, 0);
+			table.Add (new Label (GettextCatalog.GetString ("Execute in .NET Runtime:")), 0, 0);
 			table.Add (runtimesCombo = new ComboBox (), 1, 0, hexpand:true);
-			runtimesCombo.Accessible.LabelWidget = executeNetRuntimeLabel;
+			runtimesCombo.Accessible.Label = GettextCatalog.GetString (".NET Runtime");
+			runtimesCombo.Accessible.Description = GettextCatalog.GetString ("choose the .NET Runtime to execute the project with");
 
-			var runtimeSettingsLabel = new Label (GettextCatalog.GetString ("Mono runtime settings:"));
-			table.Add (runtimeSettingsLabel, 0, 1);
+			table.Add (new Label (GettextCatalog.GetString ("Mono runtime settings:")), 0, 1);
 
 			var box = new HBox ();
 			Button monoSettingsButton = new Button (GettextCatalog.GetString ("\u2026"));
@@ -158,8 +156,9 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			monoSettingsEntry.ReadOnly = true;
 			table.Add (box, 1, 1, hexpand: true);
 			adBox.PackStart (table);
-			monoSettingsEntry.Accessible.LabelWidget = runtimeSettingsLabel;
-			monoSettingsButton.Accessible.LabelWidget = runtimeSettingsLabel;
+			monoSettingsEntry.Accessible.Role = Xwt.Accessibility.Role.Label;
+			monoSettingsButton.Accessible.Label = GettextCatalog.GetString ("Mono runtime settings");
+			monoSettingsButton.Accessible.Description = GettextCatalog.GetString ("Set the Mono runtime settings");
 
 			if (includeAdvancedTab)
 				Add (adBox, GettextCatalog.GetString ("Advanced"));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
@@ -102,6 +102,8 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table.MarginLeft = 12;
 			mainBox.PackStart (table);
 
+			appEntry.Accessible.LabelWidget = radioStartApp;
+
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 			table = new Table ();
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
@@ -77,7 +77,7 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
 			table.Add (argumentsLabel, 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
-			argumentsEntry.Accessible.LabelWidget = argumentsEntry;
+			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
 
 			var runInDirectoryLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
 			table.Add (runInDirectoryLabel, 0, 1);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
@@ -74,18 +74,24 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			mainBox.Margin = 12;
 			var table = new Table ();
 
-			table.Add (new Label (GettextCatalog.GetString ("Arguments:")), 0, 0);
+			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
+			table.Add (argumentsLabel, 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
+			argumentsEntry.Accessible.LabelWidget = argumentsEntry;
 
-			table.Add (new Label (GettextCatalog.GetString ("Run in directory:")), 0, 1);
+			var runInDirectoryLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
+			table.Add (runInDirectoryLabel, 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
-		
+			workingDir.Accessible.LabelWidget = runInDirectoryLabel;
+
 			mainBox.PackStart (table);
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 
-			mainBox.PackStart (new Label (GettextCatalog.GetString ("Environment Variables")));
+			var environmentVarsLabel = new Label (GettextCatalog.GetString ("Environment Variables"));
+			mainBox.PackStart (environmentVarsLabel);
 			envVars = new EnvironmentVariableCollectionEditor ();
+			envVars.Accessible.LabelWidget = environmentVarsLabel;
 
 			mainBox.PackStart (envVars, true);
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
@@ -74,24 +74,24 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			mainBox.Margin = 12;
 			var table = new Table ();
 
-			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
-			table.Add (argumentsLabel, 0, 0);
+			table.Add (new Label (GettextCatalog.GetString ("Arguments:")), 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
-			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
+			argumentsEntry.Accessible.Label = GettextCatalog.GetString ("arguments");
+			argumentsEntry.Accessible.Description = GettextCatalog.GetString ("set any additional arguments to pass");
 
-			var runInDirectoryLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
-			table.Add (runInDirectoryLabel, 0, 1);
+			table.Add (new Label (GettextCatalog.GetString ("Run in directory:")), 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
-			workingDir.Accessible.LabelWidget = runInDirectoryLabel;
+			workingDir.Accessible.Label = GettextCatalog.GetString ("run in directory");
+			workingDir.Accessible.Description = GettextCatalog.GetString ("choose the directory to run the project in");
 
 			mainBox.PackStart (table);
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 
-			var environmentVarsLabel = new Label (GettextCatalog.GetString ("Environment Variables"));
-			mainBox.PackStart (environmentVarsLabel);
+			mainBox.PackStart (new Label (GettextCatalog.GetString ("Environment Variables")));
 			envVars = new EnvironmentVariableCollectionEditor ();
-			envVars.Accessible.LabelWidget = environmentVarsLabel;
+			envVars.Accessible.Label = GettextCatalog.GetString ("environment variables");
+			envVars.Accessible.Description = GettextCatalog.GetString ("set additional environment variables for the project");
 
 			mainBox.PackStart (envVars, true);
 


### PR DESCRIPTION
Fixes VSTS 752769 in conjunction with https://github.com/mono/xwt/pull/987
Accessibility: Project Options - Run Configuration: No on-screen or programmatically associated label provided for the edit fields.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/752769

Backport of #8965.

/cc @sgmunn 