### PR TITLE
[Core] Fix project options showing all frameworks for sdk project

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -438,7 +438,9 @@ namespace MonoDevelop.Projects
 				return targetFramework;
 			}
 			set {
-				if (!SupportsFramework (value))
+				// Allow all SDK style projects to be loaded even if the framework is unknown.
+				// A PackageReference may define the target framework with an imported MSBuild file (e.g. Tizen.NET projects).
+				if (!SupportsFramework (value) && !HasFlavor<SdkProjectExtension> ())
 					throw new ArgumentException ("Project does not support framework '" + value.Id.ToString () +"'");
 				if (value == null)
 					value = Runtime.SystemAssemblyService.GetTargetFramework (GetDefaultTargetFrameworkForFormat (ToolsVersion));

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectExtension.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectExtension.cs
@@ -68,19 +68,6 @@ namespace MonoDevelop.Projects
 			return base.SupportsObject (item) && IsSdkProject ((DotNetProject)item);
 		}
 
-		internal protected override bool OnGetSupportsFramework (TargetFramework framework)
-		{
-			// Allow all SDK style projects to be loaded even if the framework is unknown.
-			// A PackageReference may define the target framework with an imported MSBuild file.
-			return true;
-		}
-
-		/// <summary>
-		/// Currently this project extension is enabled for all SDK style projects and
-		/// not just for .NET Core and .NET Standard projects. SDK project support
-		/// should be separated out from this extension so it can be enabled only for
-		/// .NET Core and .NET Standard projects.
-		/// </summary>
 		bool IsSdkProject (DotNetProject project)
 		{
 			return project.MSBuildProject.GetReferencedSDKs ().Length > 0;


### PR DESCRIPTION
If a SDK style project targeted net472 then Project Options - Build -
General would list all target frameworks, not just the .NET Framework.
The problem was that the SdkProjectExtension overrode the
OnGetSupportsFramework and returns true so it can support any target
framework. This prevents the RuntimeOptionsPanel from listing only
the related target frameworks for the project.

To fix this the SdkProjectExtension no longer indicates it supports
all target frameworks and instead the DotNetProject checks if the
project has a SdkProjectExtension enabled when setting the
TargetFramework property. If there an associated SdkProjectExtension
then an exception is not thrown when the target framework is not known.

Fixes VSTS #992631 - net472 sdk style project allows any target
framework to be selected in project options