### PR TITLE
[Core] Fix MSBuild functions not being evaluated

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -1017,7 +1017,7 @@ namespace MonoDevelop.Projects.MSBuild
 		static readonly Dictionary<string, MethodInfo[]> cachedIntrinsicFunctions = typeof (IntrinsicFunctions)
 			.GetMethods (BindingFlags.NonPublic | BindingFlags.IgnoreCase | BindingFlags.Static)
 			.ToLookup (x => x.Name)
-			.ToDictionary(x => x.Key, x => x.ToArray ());
+			.ToDictionary(x => x.Key, x => x.ToArray (), StringComparer.OrdinalIgnoreCase);
 
 		MemberInfo[] ResolveMember (Type type, string memberName, bool isStatic, MemberTypes memberTypes)
 		{

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/MSBuildProjectTests.cs
@@ -572,6 +572,20 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public void InstrinsicProperties_IsOSPlatform_IsCaseInsensitive ()
+		{
+			if (!Platform.IsMac)
+				Assert.Ignore ();
+
+			using (var p = LoadAndEvaluate ("msbuild-tests", "osplatform.csproj")) {
+				Assert.IsTrue (p.EvaluatedProperties.GetValue<bool> ("IsMac"));
+				Assert.IsTrue (p.EvaluatedProperties.GetValue<bool> ("IsMac2"));
+				Assert.IsTrue (p.EvaluatedProperties.GetValue<bool> ("IsMac3"));
+				Assert.AreEqual ("MAC", p.EvaluatedProperties.GetValue ("DefineConstants"));
+			}
+		}
+
+		[Test]
 		public void ItemDefinitionGroup ()
 		{
 			using (var p = LoadAndEvaluate ("project-with-item-def-group", "item-definition-group.csproj")) {

--- a/main/tests/test-projects/msbuild-tests/osplatform.csproj
+++ b/main/tests/test-projects/msbuild-tests/osplatform.csproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsMac>$([MSBuild]::IsOsPlatform('OSX'))</IsMac>
+    <IsMac2>$([MSBuild]::IsOSPlatform('OSX'))</IsMac2>
+    <IsMac3>$([MSBuild]::isosplatform('OSX'))</IsMac3>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants Condition="$(IsMac)">MAC</DefineConstants>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Defining a property that used an MSBuild instrinsic function would
not evaluate if the case did not match. For example:

    <PropertyGroup>
      <IsMac>$([MSBuild]::IsOsPlatform('OSX'))</IsMac>
    </PropertyGroup>

This would not evaluate to true since the instrinsic function's
case is IsOSPlatform. However MSBuild on the command line would
evaluate this correctly.

Fixed this by making the method cache lookup case insensitive so it
matches MSBuild's behaviour.

Fixes VSTS #1008396 - DefineConstants not working right if they are
set in imported projects