### PR TITLE
[release-8.4] [Debugger] Make sure SelectedRow isn't -1 when renaming an expression

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -914,7 +914,7 @@ namespace MonoDevelop.Debugger
 		{
 			enabled = SelectedRowCount > 0;
 
-			return true; 
+			return true;
 		}
 
 		[CommandUpdateHandler (DebugCommands.AddWatch)]
@@ -927,6 +927,9 @@ namespace MonoDevelop.Debugger
 		[CommandHandler (EditCommands.Rename)]
 		protected void OnRename ()
 		{
+			if (SelectedRow == -1)
+				return;
+
 			var nameView = (MacDebuggerObjectNameView) GetView (0, SelectedRow, false);
 
 			nameView.TextField.BecomeFirstResponder ();
@@ -939,7 +942,7 @@ namespace MonoDevelop.Debugger
 
 		bool CanRename (out bool enabled)
 		{
-			enabled = SelectedRowCount == 1;
+			enabled = SelectedRowCount == 1 && SelectedRow != -1;
 
 			return AllowWatchExpressions;
 		}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1008367/

Backport of #9112.

/cc @jstedfast 