### PR TITLE
Don't start Drag in cases of no currentEvent from Gtk

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -130,10 +130,12 @@ namespace MonoDevelop.DesignerSupport
 				// Gtk.Application.CurrentEvent and other copied gdk_events seem to have a problem
 				// when used as they use gdk_event_copy which seems to crash on de-allocating the private slice.
 				IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
-				Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent, false));
+				if (currentEvent != IntPtr.Zero) {
+					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent, false));
 
-				// gtk_drag_begin does not store the event, so we're okay
-				GtkWorkarounds.FreeEvent (currentEvent);
+					// gtk_drag_begin does not store the event, so we're okay
+					GtkWorkarounds.FreeEvent (currentEvent);
+				}
 			}
 		}
 


### PR DESCRIPTION
Don't start Drag in cases of no currentEvent from Gtk
Fixes VSTS #998490 - [FATAL] SigAbrt exception in gtk-sharp.dll!mdtoken:6000ae2+4c