### PR TITLE
[release-8.4] [Debugger] Don't dereference statusIcon.Image for its size, just use …

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
@@ -194,7 +194,7 @@ namespace MonoDevelop.Debugger
 				constraints.Add (statusIcon.HeightAnchor.ConstraintEqualToConstant (ImageSize));
 				views.Add (statusIcon);
 
-				OptimalWidth += statusIcon.Image.Size.Width;
+				OptimalWidth += ImageSize;
 				OptimalWidth += RowCellSpacing;
 			} else if (statusIconVisible) {
 				statusIcon.RemoveFromSuperview ();


### PR DESCRIPTION
…ImageSize

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1004949/

Backport of #9115.

/cc @jstedfast 