### PR TITLE
Prevents OpenFile dialog set a disposable parent window setting to IDE or GTC instead the last focused top level

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
@@ -82,7 +82,7 @@ namespace MonoDevelop.Ide.Commands
 		protected override void Run ()
 		{
 			var dlg = new OpenFileDialog (GettextCatalog.GetString ("File to Open"), MonoDevelop.Components.FileChooserAction.Open) {
-				TransientFor = IdeServices.DesktopService.GetFocusedTopLevelWindow (),
+				TransientFor = MessageService.RootWindow,
 				ShowEncodingSelector = true,
 				ShowViewerSelector = true,
 			};


### PR DESCRIPTION
 GetFocusedTopLevelWindow gets the most top level window, but in some contexts this could be transients windows which could be closed unexpectly for a reason.

I changed to use IDE or GTC as parent to get a consistent not disposable windowlike parent of OpenFile dialog

Fixes VSTS #998575 - [FATAL] System.ObjectDisposedException exception in Foundation.NSObject.get_SuperHandle()