### PR TITLE
Prevents not disposable parent window in nuget license dialog setting to IDE or GTC instead use XwtRootWindow

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.PackageManagement
 			IdeApp.RunWhenIdle (() => {
 				Xwt.Toolkit.NativeEngine.Invoke (delegate {
 					using (LicenseAcceptanceDialog dialog = CreateLicenseAcceptanceDialog (licenses)) {
-						res.SetResult (dialog.Run (Xwt.MessageDialog.RootWindow));
+						res.SetResult (dialog.Run (MessageService.RootWindow));
 					}
 				});
 			});


### PR DESCRIPTION
I changed in nuget license dialog to use IDE or GTC as parent to get a consistent not disposable window like parent

Fixes VSTS #961624 - "System.ObjectDisposedException: Cannot access a disposed object" error when trying to access nuget license dialog