### PR TITLE
Only brings ErrorListPad to front in case of be loaded in Workbench

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -242,7 +242,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 
 		public override void MouseDown (NSEvent theEvent)
 		{
-			IdeApp.Workbench.GetPad<MonoDevelop.Ide.Gui.Pads.ErrorListPad> ().BringToFront ();
+			IdeApp.Workbench.GetPad<MonoDevelop.Ide.Gui.Pads.ErrorListPad> ()?.BringToFront ();
 		}
 
 		string INSAccessibilityStaticText.AccessibilityValue {


### PR DESCRIPTION
Only brings ErrorListPad to front in case of be loaded in Workbench

Fixes #941969 - [FATAL] System.NullReferenceException exception in MonoDevelop.MacIntegration.MainToolbar.BuildResultsView.MouseDown()