### PR TITLE
[release-8.4] [Project] Make Run Configurations accessible

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EnvironmentVariableCollectionEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EnvironmentVariableCollectionEditor.cs
@@ -45,6 +45,7 @@ namespace MonoDevelop.Components
 		{
 			store = new ListStore (keyField, valueField);
 			list = new ListView (store);
+			list.Accessible.Label = GettextCatalog.GetString ("Environment Variables");
 			PackStart (list, true);
 
 			TextCellView crt = new TextCellView ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EnvironmentVariableCollectionEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/EnvironmentVariableCollectionEditor.cs
@@ -28,6 +28,8 @@ using System.Collections.Generic;
 using MonoDevelop.Core;
 using Xwt;
 using System.Linq;
+using MonoDevelop.Components.AtkCocoaHelper;
+
 namespace MonoDevelop.Components
 {
 	public class EnvironmentVariableCollectionEditor: VBox
@@ -62,6 +64,7 @@ namespace MonoDevelop.Components
 			var box = new HBox ();
 
 			var btn = new Button (GettextCatalog.GetString ("Add"));
+			btn.Accessible.Description = GettextCatalog.GetString ("Add an environment variable");
 			btn.Clicked += delegate {
 				var row = store.AddRow ();
 				list.SelectRow (row);
@@ -72,6 +75,7 @@ namespace MonoDevelop.Components
 			box.PackStart (btn);
 
 			deleteButton = new Button (GettextCatalog.GetString ("Remove"));
+			deleteButton.Accessible.Description = GettextCatalog.GetString ("Remove the selected environment variable");
 			deleteButton.Clicked += delegate {
 				var row = list.SelectedRow;
 				if (row != -1) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
@@ -90,7 +90,8 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			VBox mainBox = new VBox ();
 
 			mainBox.Margin = 12;
-			mainBox.PackStart (new Label { Markup = GettextCatalog.GetString ("Start Action") });
+			var startActionlabel = new Label { Markup = GettextCatalog.GetString ("Start Action") };
+			mainBox.PackStart (startActionlabel);
 			var table = new Table ();
 			
 			table.Add (radioStartProject = new RadioButton (GettextCatalog.GetString ("Start project")), 0, 0);
@@ -102,8 +103,10 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table.MarginLeft = 12;
 			mainBox.PackStart (table);
 
+			radioStartProject.Accessible.LabelWidget = startActionlabel;
+			radioStartApp.Accessible.LabelWidget = startActionlabel;
+
 			appEntry.Accessible.Label = GettextCatalog.GetString ("External Program");
-			appEntry.Accessible.Description = GettextCatalog.GetString ("Choose the external program to start the project.");
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 			table = new Table ();
@@ -112,13 +115,11 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table.Add (argumentsLabel, 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
 			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
-			argumentsEntry.Accessible.Description = GettextCatalog.GetString ("Set any additional arguments to pass.");
 
 			var workingDirLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
 			table.Add (workingDirLabel, 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
 			workingDir.Accessible.LabelWidget = workingDirLabel;
-			workingDir.Accessible.Description = GettextCatalog.GetString ("Choose the directory to run the project in.");
 
 			mainBox.PackStart (table);
 
@@ -128,7 +129,6 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			mainBox.PackStart (envVarsLabel);
 			envVars = new EnvironmentVariableCollectionEditor ();
 			envVars.Accessible.LabelWidget = envVarsLabel;
-			envVars.Accessible.Description = GettextCatalog.GetString ("Set additional environment variables for the project.");
 
 			mainBox.PackStart (envVars, true);
 
@@ -148,7 +148,6 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table.Add (new Label (GettextCatalog.GetString ("Execute in .NET Runtime:")), 0, 0);
 			table.Add (runtimesCombo = new ComboBox (), 1, 0, hexpand:true);
 			runtimesCombo.Accessible.Label = GettextCatalog.GetString (".NET Runtime");
-			runtimesCombo.Accessible.Description = GettextCatalog.GetString ("Choose the .NET Runtime to execute the project with.");
 
 			var monoLabel = new Label (GettextCatalog.GetString ("Mono runtime settings:"));
 			table.Add (monoLabel, 0, 1);
@@ -162,7 +161,6 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			adBox.PackStart (table);
 
 			monoSettingsButton.Accessible.LabelWidget = monoLabel;
-			monoSettingsButton.Accessible.Description = GettextCatalog.GetString ("Set the Mono runtime settings.");
 
 			if (includeAdvancedTab)
 				Add (adBox, GettextCatalog.GetString ("Advanced"));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/AssemblyRunConfigurationEditor.cs
@@ -102,21 +102,33 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table.MarginLeft = 12;
 			mainBox.PackStart (table);
 
+			appEntry.Accessible.Label = GettextCatalog.GetString ("External Program");
+			appEntry.Accessible.Description = GettextCatalog.GetString ("Choose the external program to start the project.");
+
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 			table = new Table ();
 
-			table.Add (new Label (GettextCatalog.GetString ("Arguments:")), 0, 0);
+			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
+			table.Add (argumentsLabel, 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
+			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
+			argumentsEntry.Accessible.Description = GettextCatalog.GetString ("Set any additional arguments to pass.");
 
-			table.Add (new Label (GettextCatalog.GetString ("Run in directory:")), 0, 1);
+			var workingDirLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
+			table.Add (workingDirLabel, 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
-		
+			workingDir.Accessible.LabelWidget = workingDirLabel;
+			workingDir.Accessible.Description = GettextCatalog.GetString ("Choose the directory to run the project in.");
+
 			mainBox.PackStart (table);
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 
-			mainBox.PackStart (new Label (GettextCatalog.GetString ("Environment Variables")));
+			var envVarsLabel = new Label (GettextCatalog.GetString ("Environment Variables"));
+			mainBox.PackStart (envVarsLabel);
 			envVars = new EnvironmentVariableCollectionEditor ();
+			envVars.Accessible.LabelWidget = envVarsLabel;
+			envVars.Accessible.Description = GettextCatalog.GetString ("Set additional environment variables for the project.");
 
 			mainBox.PackStart (envVars, true);
 
@@ -135,16 +147,22 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			table = new Table ();
 			table.Add (new Label (GettextCatalog.GetString ("Execute in .NET Runtime:")), 0, 0);
 			table.Add (runtimesCombo = new ComboBox (), 1, 0, hexpand:true);
+			runtimesCombo.Accessible.Label = GettextCatalog.GetString (".NET Runtime");
+			runtimesCombo.Accessible.Description = GettextCatalog.GetString ("Choose the .NET Runtime to execute the project with.");
 
-			table.Add (new Label (GettextCatalog.GetString ("Mono runtime settings:")), 0, 1);
+			var monoLabel = new Label (GettextCatalog.GetString ("Mono runtime settings:"));
+			table.Add (monoLabel, 0, 1);
 
 			var box = new HBox ();
-			Button monoSettingsButton = new Button (GettextCatalog.GetString ("..."));
+			Button monoSettingsButton = new Button (GettextCatalog.GetString ("\u2026"));
 			box.PackStart (monoSettingsEntry = new TextEntry { PlaceholderText = GettextCatalog.GetString ("Default settings")}, true);
 			box.PackStart (monoSettingsButton);
 			monoSettingsEntry.ReadOnly = true;
 			table.Add (box, 1, 1, hexpand: true);
 			adBox.PackStart (table);
+
+			monoSettingsButton.Accessible.LabelWidget = monoLabel;
+			monoSettingsButton.Accessible.Description = GettextCatalog.GetString ("Set the Mono runtime settings.");
 
 			if (includeAdvancedTab)
 				Add (adBox, GettextCatalog.GetString ("Advanced"));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.OptionPanels/ProcessRunConfigurationEditor.cs
@@ -74,18 +74,27 @@ namespace MonoDevelop.Ide.Projects.OptionPanels
 			mainBox.Margin = 12;
 			var table = new Table ();
 
-			table.Add (new Label (GettextCatalog.GetString ("Arguments:")), 0, 0);
+			var argumentsLabel = new Label (GettextCatalog.GetString ("Arguments:"));
+			table.Add (argumentsLabel, 0, 0);
 			table.Add (argumentsEntry = new TextEntry (), 1, 0, hexpand:true);
+			argumentsEntry.Accessible.LabelWidget = argumentsLabel;
+			argumentsEntry.Accessible.Description = GettextCatalog.GetString ("Set any additional arguments to pass to the project.");
 
-			table.Add (new Label (GettextCatalog.GetString ("Run in directory:")), 0, 1);
+			var workingDirLabel = new Label (GettextCatalog.GetString ("Run in directory:"));
+			table.Add (workingDirLabel, 0, 1);
 			table.Add (workingDir = new FolderSelector (), 1, 1, hexpand: true);
-		
+			workingDir.Accessible.LabelWidget = workingDirLabel;
+			workingDir.Accessible.Description = GettextCatalog.GetString ("Choose the directory to run the project in.");
+
 			mainBox.PackStart (table);
 
 			mainBox.PackStart (new HSeparator () { MarginTop = 8, MarginBottom = 8 });
 
-			mainBox.PackStart (new Label (GettextCatalog.GetString ("Environment Variables")));
+			var envVarsLabel = new Label (GettextCatalog.GetString ("Environment Variables"));
+			mainBox.PackStart (envVarsLabel);
 			envVars = new EnvironmentVariableCollectionEditor ();
+			envVars.Accessible.LabelWidget = envVarsLabel;
+			envVars.Accessible.Description = GettextCatalog.GetString ("Set additional environment variables for the project.");
 
 			mainBox.PackStart (envVars, true);
 


### PR DESCRIPTION
Fixes VSTS 752769 in conjunction with https://github.com/mono/xwt/pull/987
Accessibility: Project Options - Run Configuration: No on-screen or programmatically associated label provided for the edit fields.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/752769

Backport of #8965.

/cc @sevoku @sgmunn