### PR TITLE
[Mac] Use static NSSavePanel.SavePanel to avoid crashes on Catalina

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacAddFileDialogHandler.cs
@@ -41,10 +41,10 @@ namespace MonoDevelop.MacIntegration
 	{
 		protected override NSSavePanel OnCreatePanel (AddFileDialogData data)
 		{
-			return new NSOpenPanel {
-				CanChooseDirectories = false,
-				CanChooseFiles = true,
-			};
+			var panel = NSOpenPanel.OpenPanel;
+			panel.CanChooseDirectories = false;
+			panel.CanChooseFiles = true;
+			return panel;
 		}
 
 		public bool Run (AddFileDialogData data)

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -41,34 +41,6 @@ using MonoDevelop.Projects.Text;
 
 namespace MonoDevelop.MacIntegration
 {
-	interface ICentrablePanel
-	{
-		bool CenterToParent { get; set; }
-	}
-
-	sealed class OpenPanel : NSOpenPanel, ICentrablePanel
-	{
-	    public bool CenterToParent { get; set; }
-
-		public OpenPanel ()
-		{
-		}
-
-		internal OpenPanel (IntPtr handle) : base (handle)
-		{
-		}
-
-		public override void Center ()
-		{
-			if (ParentWindow != null && CenterToParent) {
-				MessageService.CenterWindow (this, ParentWindow);
-			} else {
-				//default behaviour
-				base.Center ();
-			}
-		}
-	}
-
 	class MacOpenFileDialogHandler : MacCommonFileDialogHandler<OpenFileDialogData, MacOpenFileDialogHandler.SaveState>, IOpenFileDialogHandler
 	{
 		internal class SaveState
@@ -90,13 +62,13 @@ namespace MonoDevelop.MacIntegration
 		protected override NSSavePanel OnCreatePanel (OpenFileDialogData data)
 		{
 			if (data.Action == FileChooserAction.Save) {
-				return new NSSavePanel ();
+				return NSSavePanel.SavePanel;
 			}
 
-			return new OpenPanel {
-				CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
-				CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
-			};
+			var openPanel = NSOpenPanel.OpenPanel;
+			openPanel.CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0;
+			openPanel.CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0;
+			return openPanel;
 		}
 
 		public bool Run (OpenFileDialogData data)
@@ -136,11 +108,8 @@ namespace MonoDevelop.MacIntegration
 					};
 
 					var parent = data.TransientFor ?? MessageService.RootWindow;
-					
-					if (panel is ICentrablePanel centrablePanel) {
-						centrablePanel.CenterToParent = data.CenterToParent;
-					}
 
+					// TODO: support for data.CenterToParent, we could use sheeting.
 					if (panel.RunModal () == 0 && !pathAlreadySet) {
 						IdeServices.DesktopService.FocusWindow (parent);
 						return false;

--- a/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacSelectFileDialogHandler.cs
@@ -47,14 +47,14 @@ namespace MonoDevelop.MacIntegration
 		protected override NSSavePanel OnCreatePanel (SelectFileDialogData data)
 		{
 			if (data.Action == FileChooserAction.Save)
-				return new NSSavePanel ();
+				return NSSavePanel.SavePanel;
 
-			return new NSOpenPanel {
-				CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0,
-				CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0,
-				CanCreateDirectories = (data.Action & FileChooserAction.CreateFolder) != 0,
-				ResolvesAliases = false,
-			};
+			var openPanel = NSOpenPanel.OpenPanel;
+			openPanel.CanChooseDirectories = (data.Action & FileChooserAction.FolderFlags) != 0;
+			openPanel.CanChooseFiles = (data.Action & FileChooserAction.FileFlags) != 0;
+			openPanel.CanCreateDirectories = (data.Action & FileChooserAction.CreateFolder) != 0;
+			openPanel.ResolvesAliases = false;
+			return openPanel;
 		}
 
 		public bool Run (SelectFileDialogData data)


### PR DESCRIPTION
See for details: https://github.com/xamarin/xamarin-macios/issues/6474

This reverts 508796b31408db1ea6682ba8f38586550711fe1c
Reopening VSTS #859111
Fixes VSTS #989519
Backport of #8877