### PR TITLE
[release-8.4] [Debugger] Fix color contrast of secondary labels in breakpoint props dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
@@ -106,11 +106,11 @@ namespace MonoDevelop.Debugger
 
 		// Tips labels.
 		readonly Label printMessageTip = new Label (GettextCatalog.GetString ("Place simple C# expressions within {} to interpolate them.")) {
-			Sensitive = false,
+			TextColor = Styles.BreakpointPropertiesSecondaryTextColor,
 			TextAlignment = Alignment.End
 		};
 		readonly Label conditionalExpressionTip = new Label (GettextCatalog.GetString ("A C# boolean expression. Scope is local to the breakpoint.")) {
-			Sensitive = false,
+			TextColor = Styles.BreakpointPropertiesSecondaryTextColor,
 			TextAlignment = Alignment.End
 		};
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Styles.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Styles.cs
@@ -42,6 +42,7 @@ namespace MonoDevelop.Debugger
 		public static Color PreviewVisualizerBackgroundColor { get; internal set; }
 		public static Color PreviewVisualizerTextColor { get; internal set; }
 		public static Color PreviewVisualizerHeaderTextColor { get; internal set; }
+		public static Color BreakpointPropertiesSecondaryTextColor { get; internal set; }
 
 		public static ExceptionCaughtDialogStyle ExceptionCaughtDialog { get; internal set; }
 
@@ -85,6 +86,8 @@ namespace MonoDevelop.Debugger
 				ExceptionCaughtDialog.LineNumberTextColor = Color.FromName ("#707070");
 				ExceptionCaughtDialog.ExternalCodeTextColor = Color.FromName ("#707070");
 				ExceptionCaughtDialog.ValueTreeBackgroundColor = Color.FromName ("#ffffff");
+
+				BreakpointPropertiesSecondaryTextColor = Color.FromName ("#707070");
 			} else {
 				ObjectValueTreeValuesButtonBackground = Color.FromName ("#555b65");
 				ObjectValueTreeValuesButtonText = Color.FromName ("#ace2ff");
@@ -96,6 +99,8 @@ namespace MonoDevelop.Debugger
 				ExceptionCaughtDialog.LineNumberTextColor = Color.FromName ("#b4b4b4");
 				ExceptionCaughtDialog.ExternalCodeTextColor = Color.FromName ("#b4b4b4");
 				ExceptionCaughtDialog.ValueTreeBackgroundColor = Color.FromName ("#525252");
+
+				BreakpointPropertiesSecondaryTextColor = Color.FromName ("#b4b4b4");
 			}
 
 			//Disabled state


### PR DESCRIPTION
Fixes VSTS #754224

![grafik](https://user-images.githubusercontent.com/951587/67786143-ab5f3200-fa6e-11e9-9cc0-04fbc701dc38.png)


Backport of #9142.

/cc @sevoku 