### PR TITLE
[DotNetCore] Fix incorrect folders displayed for multi-target projects

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DependenciesNode.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/DependenciesNode.cs
@@ -119,10 +119,12 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 		{
 			bool addedFrameworkReferencesNode = false;
 			if (frameworkNode != null) {
-				var frameworkReferencesNode = new FrameworkReferencesNode (this);
-				if (frameworkReferencesNode.HasChildNodes ()) {
-					addedFrameworkReferencesNode = true;
-					yield return frameworkReferencesNode;
+				if (frameworkNode.CanGetFrameworkReferences ()) {
+					var frameworkReferencesNode = new FrameworkReferencesNode (frameworkNode);
+					if (frameworkReferencesNode.HasChildNodes ()) {
+						addedFrameworkReferencesNode = true;
+						yield return frameworkReferencesNode;
+					}
 				}
 
 				var packagesNode = new PackageDependenciesNode (frameworkNode);
@@ -135,10 +137,12 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 						yield return sdkNode;
 				}
 			} else {
-				var frameworkReferencesNode = new FrameworkReferencesNode (this);
-				if (frameworkReferencesNode.HasChildNodes ()) {
-					addedFrameworkReferencesNode = true;
-					yield return frameworkReferencesNode;
+				if (FrameworkReferenceNodeCache.CanGetFrameworkReferences (Project)) {
+					var frameworkReferencesNode = new FrameworkReferencesNode (this);
+					if (frameworkReferencesNode.HasChildNodes ()) {
+						addedFrameworkReferencesNode = true;
+						yield return frameworkReferencesNode;
+					}
 				}
 
 				var packagesNode = new PackageDependenciesNode (this);

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/TargetFrameworkNode.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.NodeBuilders/TargetFrameworkNode.cs
@@ -24,8 +24,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using MonoDevelop.Core;
+using MonoDevelop.Core.Assemblies;
 using MonoDevelop.Projects;
 
 namespace MonoDevelop.DotNetCore.NodeBuilders
@@ -79,6 +81,16 @@ namespace MonoDevelop.DotNetCore.NodeBuilders
 		public IEnumerable<object> GetChildNodes ()
 		{
 			return DependenciesNode.GetChildNodes (this);
+		}
+
+		public bool CanGetFrameworkReferences ()
+		{
+			return FrameworkReferenceNodeCache.CanGetFrameworkReferences (GetTargetFrameworkMoniker ());
+		}
+
+		internal TargetFrameworkMoniker GetTargetFrameworkMoniker ()
+		{
+			return new TargetFrameworkMoniker (dependency.Name, dependency.Version);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DependencyNodeTests.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/DependencyNodeTests.cs
@@ -51,6 +51,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		PackageDependenciesNode nugetFolderNode;
 		FrameworkReferencesNode frameworksFolderNode;
 		TaskCompletionSource<bool> packageDependenciesChanged;
+		TaskCompletionSource<bool> frameworkReferencesChanged;
 		TestableDependenciesNodeBuilder dependenciesNodeBuilder;
 		// Ensure NuGet.Versioning assembly is loaded by the tests otherwise they fail
 		// when run from the command line with mdtool.
@@ -79,7 +80,9 @@ namespace MonoDevelop.DotNetCore.Tests
 			dependenciesNodeBuilder = new TestableDependenciesNodeBuilder ();
 			dependenciesNode = new DependenciesNode (project, updatedNuGetPackages ?? PackageManagementServices.UpdatedPackagesInWorkspace);
 			dependenciesNode.PackageDependencyCache.PackageDependenciesChanged += PackageDependenciesChanged;
+			dependenciesNode.FrameworkReferencesCache.FrameworkReferencesChanged += FrameworkReferencesChanged;
 			packageDependenciesChanged = new TaskCompletionSource<bool> ();
+			frameworkReferencesChanged = new TaskCompletionSource<bool> ();
 
 			dependenciesNode.PackageDependencyCache.Refresh ();
 			dependenciesNode.FrameworkReferencesCache.Refresh ();
@@ -97,12 +100,25 @@ namespace MonoDevelop.DotNetCore.Tests
 			packageDependenciesChanged.TrySetResult (true);
 		}
 
+		void FrameworkReferencesChanged (object sender, EventArgs e)
+		{
+			frameworkReferencesChanged.TrySetResult (true);
+		}
+
 		async Task WaitForPackageDependenciesChanged (int millisecondsTimeout = 60000)
 		{
 			var timeoutTask = Task.Delay (millisecondsTimeout);
 			var result = await Task.WhenAny (timeoutTask, packageDependenciesChanged.Task);
 			if (result == timeoutTask)
 				Assert.Fail ("Timed out waiting for package dependencies to be updated.");
+		}
+
+		async Task WaitForFrameworkReferencesChanged (int millisecondsTimeout = 60000)
+		{
+			var timeoutTask = Task.Delay (millisecondsTimeout);
+			var result = await Task.WhenAny (timeoutTask, frameworkReferencesChanged.Task);
+			if (result == timeoutTask)
+				Assert.Fail ("Timed out waiting for framework references to be updated.");
 		}
 
 		static SdkDependenciesNode GetSdkFolder (TargetFrameworkNode frameworkNode)
@@ -158,6 +174,13 @@ namespace MonoDevelop.DotNetCore.Tests
 			var nodeBuilder = new TestableFrameworkReferencesNodeBuilder ();
 			nodeBuilder.BuildChildNodes (null, node);
 			return nodeBuilder.ChildNodesAsFrameworkReferenceNode ().ToList ();
+		}
+
+		static FrameworkReferencesNode GetFrameworkReferencesFolder (TargetFrameworkNode node)
+		{
+			var nodeBuilder = new TestableTargetFrameworkNodeBuilder ();
+			nodeBuilder.BuildChildNodes (null, node);
+			return nodeBuilder.FrameworkReferences;
 		}
 
 		static bool IsDotNetCoreSdk30OrLaterInstalled ()
@@ -506,6 +529,73 @@ namespace MonoDevelop.DotNetCore.Tests
 
 			// No updates label.
 			Assert.AreEqual (string.Empty, frameworksFolderNode.GetSecondaryLabel ());
+		}
+
+		[Test]
+		public async Task MultiTarget_NetStandard21_NetStandard20_NetCoreApp30_NetCoreApp21 ()
+		{
+			if (!IsDotNetCoreSdk30OrLaterInstalled ()) {
+				Assert.Ignore (".NET Core 3 SDK is not installed.");
+			}
+
+			FilePath projectFileName = Util.GetSampleProject ("DotNetCoreDependenciesFolder", "NetStandard21NetStandard20NetCore30NetCore21.csproj");
+			Restore (projectFileName);
+			project = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFileName);
+			await CreateDependenciesNode ();
+			await WaitForFrameworkReferencesChanged ();
+
+			var frameworkNodes = GetTargetFrameworkChildDependencies ();
+			var netstandard21FrameworkNode = frameworkNodes.Single (node => node.Name == ".NETStandard" && node.GetSecondaryLabel () == "(2.1.0.0)");
+			var netstandard20FrameworkNode = frameworkNodes.Single (node => node.Name == ".NETStandard" && node.GetSecondaryLabel () == "(2.0.0.0)");
+			var netCoreApp30FrameworkNode = frameworkNodes.Single (node => node.Name == ".NETCoreApp" && node.GetSecondaryLabel () == "(3.0.0.0)");
+			var netCoreApp21FrameworkNode = frameworkNodes.Single (node => node.Name == ".NETCoreApp" && node.GetSecondaryLabel () == "(2.1.0.0)");
+
+			// .NET Standard 2.1 nodes
+			var frameworksFolder = GetFrameworkReferencesFolder (netstandard21FrameworkNode);
+			var frameworkNode = GetFrameworksFolderChildDependencies (frameworksFolder).Single ();
+			Assert.AreEqual ("NETStandard.Library", frameworkNode.Name);
+			Assert.AreEqual ("NETStandard.Library", frameworkNode.GetLabel ());
+			Assert.IsTrue (
+				frameworkNode.GetSecondaryLabel ().StartsWith ("(2.1."),
+				"Unexpected secondary label '{0}'", frameworkNode.GetSecondaryLabel ());
+
+			var defaultNode = frameworksFolder.GetDefaultNodes ().Single ();
+			Assert.AreEqual ("NETStandard.Library", defaultNode.Name);
+			Assert.AreEqual ("NETStandard.Library", defaultNode.GetLabel ());
+
+			// .NET Standard 2.0 nodes.
+			var sdkFolder = GetSdkFolder (netstandard20FrameworkNode);
+			var packageDependency = GetSdkFolderChildDependencies (sdkFolder).Single ();
+			Assert.AreEqual ("NETStandard.Library", packageDependency.Name);
+			Assert.AreEqual ("NETStandard.Library", packageDependency.GetLabel ());
+			Assert.IsTrue (
+				packageDependency.GetSecondaryLabel ().StartsWith ("(2.0."),
+				"Unexpected secondary label '{0}'", packageDependency.GetSecondaryLabel ());
+
+			// .NET Core 3.0 nodes.
+			frameworksFolder = GetFrameworkReferencesFolder (netCoreApp30FrameworkNode);
+			frameworkNode = GetFrameworksFolderChildDependencies (frameworksFolder).Single ();
+			Assert.AreEqual ("Microsoft.NETCore.App", frameworkNode.Name);
+			Assert.AreEqual ("Microsoft.NETCore.App", frameworkNode.GetLabel ());
+			Assert.IsTrue (
+				frameworkNode.GetSecondaryLabel ().StartsWith ("(3.0."),
+				"Unexpected secondary label '{0}'", frameworkNode.GetSecondaryLabel ());
+
+			defaultNode = frameworksFolder.GetDefaultNodes ().Single ();
+			Assert.AreEqual ("Microsoft.NETCore.App", defaultNode.Name);
+			Assert.AreEqual ("Microsoft.NETCore.App", defaultNode.GetLabel ());
+
+			// .NET Core 2.1 nodes.
+			// Note that for some reason in a multi-target project a .NET Core 2.1 project also gets
+			// a .NET Standard dependency if .net standard is one of the frameworks. With a non-multi-target
+			// project this does not happen.
+			sdkFolder = GetSdkFolder (netCoreApp21FrameworkNode);
+			var packageDependencies = GetSdkFolderChildDependencies (sdkFolder);
+			packageDependency = packageDependencies.Single (p => p.Name == "Microsoft.NETCore.App");
+			Assert.AreEqual ("Microsoft.NETCore.App", packageDependency.GetLabel ());
+			Assert.IsTrue (
+				packageDependency.GetSecondaryLabel ().StartsWith ("(2.1."),
+				"Unexpected secondary label '{0}'", packageDependency.GetSecondaryLabel ());
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/TestableTargetFrameworkNodeBuilder.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore.Tests/MonoDevelop.DotNetCore.Tests/TestableTargetFrameworkNodeBuilder.cs
@@ -39,6 +39,7 @@ namespace MonoDevelop.DotNetCore.Tests
 		public SdkDependenciesNode SdkDependencies;
 		public ProjectDependenciesNode ProjectDependencies;
 		public AssemblyDependenciesNode AssemblyDependencies;
+		public FrameworkReferencesNode FrameworkReferences;
 
 		void AddChild (ITreeBuilder treeBuilder, object dataObject)
 		{
@@ -52,6 +53,8 @@ namespace MonoDevelop.DotNetCore.Tests
 				ProjectDependencies = projectDependencies;
 			} else if (dataObject is SdkDependenciesNode sdkDependencies) {
 				SdkDependencies = sdkDependencies;
+			} else if (dataObject is FrameworkReferencesNode frameworkReferences) {
+				FrameworkReferences = frameworkReferences;
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkExtensions.cs
@@ -82,20 +82,12 @@ namespace MonoDevelop.DotNetCore
 
 		public static bool IsNetCoreAppOrHigher (this TargetFramework framework, DotNetCoreVersion version)
 		{
-			DotNetCoreVersion.TryParse (framework.Id.Version, out var dotNetCoreVersion);
-			if (dotNetCoreVersion == null)
-				return false;
-
-			return framework.Id.IsNetCoreApp () && dotNetCoreVersion >= version;
+			return framework.Id.IsNetCoreAppOrHigher (version);
 		}
 
 		public static bool IsNetStandardOrHigher (this TargetFramework framework, DotNetCoreVersion version)
 		{
-			DotNetCoreVersion.TryParse (framework.Id.Version, out var dotNetCoreVersion);
-			if (dotNetCoreVersion == null)
-				return false;
-
-			return framework.Id.IsNetStandard () && dotNetCoreVersion >= version;
+			return framework.Id.IsNetStandardOrHigher (version);
 		}
 
 		public static bool IsNetFramework (this TargetFramework framework) => framework.Id.IsNetFramework ();

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkMonikerExtensions.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/TargetFrameworkMonikerExtensions.cs
@@ -49,5 +49,23 @@ namespace MonoDevelop.DotNetCore
 		{
 			return framework.IsNetStandard () || framework.IsNetCoreApp ();
 		}
+
+		public static bool IsNetCoreAppOrHigher (this TargetFrameworkMoniker framework, DotNetCoreVersion version)
+		{
+			DotNetCoreVersion.TryParse (framework.Version, out var dotNetCoreVersion);
+			if (dotNetCoreVersion == null)
+				return false;
+
+			return framework.IsNetCoreApp () && dotNetCoreVersion >= version;
+		}
+
+		public static bool IsNetStandardOrHigher (this TargetFrameworkMoniker framework, DotNetCoreVersion version)
+		{
+			DotNetCoreVersion.TryParse (framework.Version, out var dotNetCoreVersion);
+			if (dotNetCoreVersion == null)
+				return false;
+
+			return framework.IsNetStandard () && dotNetCoreVersion >= version;
+		}
 	}
 }

--- a/main/tests/test-projects/DotNetCoreDependenciesFolder/NetStandard21NetStandard20NetCore30NetCore21.csproj
+++ b/main/tests/test-projects/DotNetCoreDependenciesFolder/NetStandard21NetStandard20NetCore30NetCore21.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
If a multi-target project used .NET Standard 2.1, or .NET Core 3.0, and
an older framework such as .NET Standard 2.0, or .NET Core 2.1, then
the Solution window would not show the correct folders under the
Dependencies folder. If the first target framework was .NET Standard
2.0 then an SDK folder would be displayed for all frameworks. If the
first target framework was .NET Standard 2.1 then a Frameworks folder
would be displayed for all frameworks.

The problem was that there was no multi-target support for
FrameworkReferences. Each framework that supports FrameworkReferences
needs to have the ResolveFrameworkReferences MSBuild target called
separately. Also all project target frameworks are checked individually
when building the Solution window tree nodes. Previously the first
target framework was being considered when building the Frameworks
folder.

<img width="313" alt="NuGetFrameworks2" src="https://user-images.githubusercontent.com/372361/67794745-13b11200-fa75-11e9-896a-47c259a8eb54.png">

Fixes VSTS #1001442 - [Multitargeting] Incorrect Framework version