### PR TITLE
Ignore MSBuild.Workspaces

### DIFF
--- a/main/build/MacOSX/BinaryCheckerConfig.txt
+++ b/main/build/MacOSX/BinaryCheckerConfig.txt
@@ -13,5 +13,6 @@
 !Contents/Resources/lib/monodevelop/AddIns/Xamarin.Interactive.XS/Xamarin Inspector.app
 !Contents/Resources/lib/monodevelop/bin/Microsoft.VisualStudio.Imaging.dll
 !Contents/Resources/lib/monodevelop/bin/ServiceHub
+!Contents/Resources/lib/monodevelop/AddIns/MonoDevelop.MonoDroid/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll
 Contents/Resources/lib/monodevelop/AddIns/FSharpBinding/MonoDevelop.FSharpInteractive.Service.exe.config
 Contents/Resources/lib/monodevelop/bin/VisualStudio.exe.config


### PR DESCRIPTION
Monodroid includes MSBuild.Workspace, which is confusing the checker. Ignore it to be able to build.