### PR TITLE
[release-8.4] Bump Roslyn to 3.4.0-beta3-19525-13

### DIFF
--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.4.0-beta3-19518-02</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.4.0-beta3-19525-13</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>

--- a/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
+++ b/main/src/core/Mono.TextEditor.Shared/Mono.TextEditor/Document/TextDocument.cs
@@ -343,7 +343,7 @@ namespace Mono.TextEditor
 			this.mimeType = mimeType;
 			var doc = PlatformCatalog.Instance.TextDocumentFactoryService.CreateTextDocument (
 				PlatformCatalog.Instance.TextBufferFactoryService.CreateTextBuffer (
-					text ?? string.Empty,
+					new StringReader(text ?? string.Empty),
 					GetContentTypeFromMimeType (fileName, mimeType)
 				),
 				fileName ?? string.Empty

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/TextBufferFileModel.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/TextBufferFileModel.cs
@@ -80,7 +80,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 						ThawChangeEvent ();
 					}
 				} else {
-					var buffer = PlatformCatalog.Instance.TextBufferFactoryService.CreateTextBuffer (text.Text, contentType);
+					var buffer = PlatformCatalog.Instance.TextBufferFactoryService.CreateTextBuffer (new System.IO.StringReader (text.Text), contentType);
 					var doc = PlatformCatalog.Instance.TextDocumentFactoryService.CreateTextDocument (buffer, FilePath);
 					doc.Encoding = text.Encoding;
 					SetTextDocument (doc);


### PR DESCRIPTION
Updating Roslyn to 20191025.13 ([b8a5611](https://www.github.com/dotnet/roslyn/commit/b8a5611))

[Changes](https://github.com/dotnet/roslyn/compare/7c7708e...b8a5611?w=1) since [7c7708e](https://www.github.com/dotnet/roslyn/commit/7c7708e):
- [Merge pull request #39450 from mavasani/TelemetryLogging](https://www.github.com/dotnet/roslyn/pull/39450)
- [Merge pull request #39159 from jasonmalinowski/support-inferred-indentation](https://www.github.com/dotnet/roslyn/pull/39159)
- [Variable suggestions show duplicated filter buttons on completion window (#39499)](https://www.github.com/dotnet/roslyn/pull/39499)
- [Merge pull request #39487 from dibarbet/port_editorconfig](https://www.github.com/dotnet/roslyn/pull/39487)
- [Merge pull request #39473 from mavasani/FixEditorConfigGoldBar](https://www.github.com/dotnet/roslyn/pull/39473)
- [Merge pull request #39463 from jasonmalinowski/core-changes-to-support-inferred-indentation](https://www.github.com/dotnet/roslyn/pull/39463)
- [Ignore await in completion when triggers completion between two dots (#39302)](https://www.github.com/dotnet/roslyn/pull/39302)
- [Change inline rename dialog to be more uniquely identifiable (#39428)](https://www.github.com/dotnet/roslyn/pull/39428)
- [Remove the workspace IVT of SourceBasedTestDiscovery and LiveUnitTesting (#38466)](https://www.github.com/dotnet/roslyn/pull/38466)
- [Adjust syntax equivalence to account for nullable directives (#39227)](https://www.github.com/dotnet/roslyn/pull/39227)
- [Merge pull request #39224 from AdamYoblick/winforms_designer_loader](https://www.github.com/dotnet/roslyn/pull/39224)
- [Merge pull request #39455 from uniqueiniquity/preferredCompletionItem](https://www.github.com/dotnet/roslyn/pull/39455)
- [Fix IDE test (#2)](https://www.github.com/dotnet/roslyn/pull/2)
- [Async-streams: Call AsyncIteratorMethodBuilder.Complete (#39436)](https://www.github.com/dotnet/roslyn/pull/39436)
- [Semantic model assert (#39432)](https://www.github.com/dotnet/roslyn/pull/39432)
- [Merge pull request #39431 from dotnet/KirillOsenkov-patch-1](https://www.github.com/dotnet/roslyn/pull/39431)
- [Avoid leave.s opcode jumping out of a finally block (#39300)](https://www.github.com/dotnet/roslyn/pull/39300)
- [Merge pull request #39395 from mavasani/FixCachingCFG](https://www.github.com/dotnet/roslyn/pull/39395)
- [Use LangVersion 8 in tests rather than Preview (#39421)](https://www.github.com/dotnet/roslyn/pull/39421)
- [Merge pull request #39394 from mavasani/ReuseSemanticModel](https://www.github.com/dotnet/roslyn/pull/39394)
- [Merge pull request #39419 from JoeRobich/fix-command-text](https://www.github.com/dotnet/roslyn/pull/39419)
- [follow up for Go to base: support metadata references and bug fixes (#39334)](https://www.github.com/dotnet/roslyn/pull/39334)
- [Merge pull request #38013 from sharwell/annotations2](https://www.github.com/dotnet/roslyn/pull/38013)
- [Merge pull request #39258 from ashmind/sourcetext-getchanges-merge-fix](https://www.github.com/dotnet/roslyn/pull/39258)
- [ProjectExternalErrorReporter: Avoid subscribing to solution build events multiple times and leaking the object (#39389)](https://www.github.com/dotnet/roslyn/pull/39389)
- [Merge pull request #39242 from jnm2/equals_with_lifted_operator](https://www.github.com/dotnet/roslyn/pull/39242)
- [Minor using decl fixes (#39373)](https://www.github.com/dotnet/roslyn/pull/39373)
- [Fix 'ref' parsing crash (#39233)](https://www.github.com/dotnet/roslyn/pull/39233)
- [EnC: Compare document content before performing IO while stepping (#39341)](https://www.github.com/dotnet/roslyn/pull/39341)

Backport of #9151.

/cc @sandyarmstrong 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1013363