### PR TITLE
[release-8.4] Updated Visual Studio theme

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
@@ -1,15 +1,16 @@
 {
 	"name": "Visual Studio",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "Reminiscent of Microsoft Visual Studio's default colors",
 	"originator": "Jeffrey Stedfast <fejj@novell.com>",
 
-	"palette": [
+"palette": [
 		{ "name": "text-black", "value": "#222222" },
 		{ "name": "comment-green", "value": "#008000" },
 		{ "name": "keyword-blue", "value": "#0000ff" },
-		{ "name": "semantic-type", "value": "#2B90AF" }
-	],
+		{ "name": "semantic-type", "value": "#508FAE" },
+    { "name": "selection-bg", "value": "#94CAED" }
+    ],
 
 	"colors": [
 		{ "name": "Background(Read Only)", "color": "#FFFFFF" },
@@ -25,13 +26,19 @@
 
 		{ "name": "Message Bubble Warning IconMargin", "color": "#e68100", "bordercolor": "#e68100" },
 
-		{ "name": "Brace Matching(Rectangle)", "color": "#e2e6d6", "secondcolor": "#e2e6d6" }
+    { "name": "Brace Matching(Rectangle)", "color": "#e2e6d6", "secondcolor": "#e2e6d6" },
+
+    { "name": "Usages(Rectangle)", "color": "#E2E6E6", "secondcolor": "#E2E6E6", "bordercolor": "#E2E6E6" },
+		{ "name": "Search result background", "color": "#F6B94D" },
+		
+		{ "name": "Link Color", "color": "keyword-blue" },
+		{ "name": "Link Color(Active)", "color": "keyword-blue" }
 	],
 
 	"text": [
 		{ "name": "Plain Text", "fore": "text-black", "back": "#FFFFFF" },
-		{ "name": "Selected Text", "fore": "white", "back": "#94CAED" },
-		{ "name": "Selected Text(Inactive)", "fore": "white", "back": "#BFCDDB" },
+		{ "name": "Selected Text", "back": "selection-bg" },
+		{ "name": "Selected Text(Inactive)", "fore": "white", "back": "selection-bg" },
 
 		{ "name": "Collapsed Text", "fore": "comment-green", "back": "white" },
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/themes/VisualStudioStyle.json
@@ -30,7 +30,7 @@
 
 	"text": [
 		{ "name": "Plain Text", "fore": "text-black", "back": "#FFFFFF" },
-		{ "name": "Selected Text", "fore": "white", "back": "#3298FF" },
+		{ "name": "Selected Text", "fore": "white", "back": "#94CAED" },
 		{ "name": "Selected Text(Inactive)", "fore": "white", "back": "#BFCDDB" },
 
 		{ "name": "Collapsed Text", "fore": "comment-green", "back": "white" },


### PR DESCRIPTION
Updated the Visual Studio theme to fix the text selection color, which was too dark and made text hard to read when selected.

![image](https://user-images.githubusercontent.com/1333029/67788709-12a9c180-fa30-11e9-8e7a-bf04f90a5452.png)


While making the change, I also updated a few other colors to match Windows:
* Usages (i.e. identifier highighting)
![image](https://user-images.githubusercontent.com/1333029/67788754-205f4700-fa30-11e9-8378-33a82ca05f06.png)

* Find results
![image](https://user-images.githubusercontent.com/1333029/67788793-2d7c3600-fa30-11e9-9424-cf93e65bec59.png)

* Link colors
![image](https://user-images.githubusercontent.com/1333029/67788842-41279c80-fa30-11e9-8220-de63d559c29b.png)



Fixes VSTS #1009498.

Backport of #9131.

/cc @jmatthiesen 