### PR TITLE
[release-8.4] Abstracts IPropertyGrid and uses in Preferences to fix a11c issues

### DIFF
--- a/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpFormattingPanelWidget.fs
+++ b/main/external/fsharpbinding/MonoDevelop.FSharpBinding/FSharpFormattingPanelWidget.fs
@@ -2,7 +2,7 @@
 
 open Gtk
 open MonoDevelop.Core
-open MonoDevelop.Components.PropertyGrid
+open MonoDevelop.DesignerSupport
 
 // Handwritten GUI, feel free to edit
 
@@ -21,7 +21,7 @@ type FSharpFormattingPolicyPanelWidget() =
     let mutable hbox2 : Gtk.HBox = null
     let mutable vbox4 : Gtk.VBox = null
     let mutable tableScopes : Gtk.Table = null
-    let mutable propertyGrid : PropertyGrid = null
+    let mutable propertyGrid : PropertyGridWrapper = null
 
     let getName format =
         if format = policy.DefaultFormat then
@@ -125,12 +125,12 @@ type FSharpFormattingPolicyPanelWidget() =
         w8.Expand <- false
         w8.Fill <- false
         // Container child vbox4.Gtk.Box+BoxChild
-        propertyGrid <- new PropertyGrid()
+        propertyGrid <- new PropertyGridWrapper ()
         propertyGrid.Name <- "propertyGrid"
         propertyGrid.ShowToolbar <- false
         propertyGrid.ShowHelp <- false
-        vbox4.Add (propertyGrid)
-        let w9 = vbox4.[propertyGrid] :?> Gtk.Box.BoxChild
+        vbox4.Add (propertyGrid.Widget)
+        let w9 = vbox4.[propertyGrid.Widget] :?> Gtk.Box.BoxChild
         w9.Position <- 2
         hbox1.Add(vbox4)
         let w10 = hbox1.[vbox4] :?> Gtk.Box.BoxChild

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/SearchTextField.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/SearchTextField.cs
@@ -33,41 +33,19 @@ using Foundation;
 
 namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 {
-	enum SearchTextFieldCommand
-	{
-		InsertTab,
-		InsertBacktab
-	}
-
-	class SearchTextField : NSSearchField, INSSearchFieldDelegate
+	class SearchTextField : NSSearchField
 	{
 		public event EventHandler Focused;
-		public event EventHandler<SearchTextFieldCommand> CommandRaised;
 
 		public SearchTextField ()
 		{
-			Delegate = this;
+		
 		}
 
 		public override bool BecomeFirstResponder ()
 		{
 			Focused?.Invoke (this, EventArgs.Empty);
 			return base.BecomeFirstResponder ();
-		}
-
-		[Export ("control:textView:doCommandBySelector:")]
-		bool CommandBySelector (NSControl control, NSTextField field, ObjCRuntime.Selector sel)
-		{
-			switch (sel.Name) {
-			case "insertTab:": // down arrow
-				CommandRaised?.Invoke (this, SearchTextFieldCommand.InsertTab);
-				return true;
-
-			case "insertBacktab:": // up arrow
-				CommandRaised?.Invoke (this, SearchTextFieldCommand.InsertBacktab);
-				return true;
-			}
-			return false;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/NativeViews/ToggleButton.cs
@@ -47,7 +47,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 
 	class ToggleButton : NSButton
 	{
-		public event EventHandler<NSEventArgs> KeyDownPressed;
 		public event EventHandler Focused;
 
 		public override CGSize IntrinsicContentSize => Hidden ? CGSize.Empty : new CGSize (25, 25);
@@ -78,12 +77,6 @@ namespace MonoDevelop.DesignerSupport.Toolbox.NativeViews
 			if ((int)theEvent.ModifierFlags == (int) KeyModifierFlag.None && (theEvent.KeyCode == (int)KeyCodes.Enter || theEvent.KeyCode == (int)KeyCodes.Space)) {
 				PerformClick (this);
 			}
-
-			var args = new NSEventArgs (theEvent);
-			KeyDownPressed?.Invoke (this, args);
-
-			if (!args.Handled)
-				base.KeyDown (theEvent);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/IPropertyPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/IPropertyPad.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace MonoDevelop.DesignerSupport
 {
-	public interface IPropertyPad
+	public interface IPropertyPad : IDisposable
 	{
 		bool IsGridEditing { get; }
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -51,7 +51,7 @@ namespace MonoDevelop.DesignerSupport
 		public bool IsEditing => false;
 
 		//Small hack to cover the missing Proppy feature
-		public bool Sensitive { get; set; }
+		public bool Sensitive { get; set; } = true;
 		public override NSView HitTest (CGPoint aPoint)
 		{
 			if (!Sensitive) return null;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -39,7 +39,7 @@ using CoreGraphics;
 
 namespace MonoDevelop.DesignerSupport
 {
-	class MacPropertyGrid : NSView, IPropertyGrid
+	class MacPropertyGrid : NSView
 	{
 		readonly MacPropertyEditorPanel propertyEditorPanel;
 		ComponentModelEditorProvider editorProvider;
@@ -95,21 +95,6 @@ namespace MonoDevelop.DesignerSupport
 			} else {
 				BlankPad ();
 			}
-		}
-
-		public void Populate (bool saveEditSession)
-		{
-			//not implemented
-		}
-
-		public void SetToolbarProvider (Components.PropertyGrid.PropertyGrid.IToolbarProvider toolbarProvider)
-		{
-			//not implemented
-		}
-
-		public void OnPadContentShown ()
-		{
-			//not implemented
 		}
 
 		protected override void Dispose (bool disposing)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -120,7 +120,7 @@ namespace MonoDevelop.DesignerSupport
 		NSTableView internalTableView;
 		NSView border;
 
-		void ShowToolbar (bool enabled)
+		void ShowHeader (bool enabled)
 		{
 			var topConstraint = propertyEditorPanel.Constraints.FirstOrDefault (s => s.FirstItem == propertyList && s.FirstAttribute == NSLayoutAttribute.Top);
 			propertyEditorPanel.RemoveConstraint (topConstraint);
@@ -141,7 +141,7 @@ namespace MonoDevelop.DesignerSupport
 			get => !header.Hidden;
 			set {
 				//we ensure remove current constraints from proppy
-				ShowToolbar (value);
+				ShowHeader (value);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -83,6 +83,10 @@ namespace MonoDevelop.DesignerSupport
 			editorProvider.Clear ();
 		}
 
+		public object CurrentObject {
+			get => currentSelectedObject.Target;
+		}
+
 		public void SetCurrentObject (object lastComponent, object [] propertyProviders)
 		{
 			if (lastComponent != null) {

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -95,6 +95,22 @@ namespace MonoDevelop.DesignerSupport
 			get => currentSelectedObject.Target;
 		}
 
+		//HACK: this 
+		bool showToolbar = true;
+		public bool ShowToolbar {
+			get => showToolbar;
+			set {
+				//we ensure remove current constraints from proppy
+
+
+				if (showToolbar) {
+
+				} else {
+					//we only want include 
+				}
+			}
+		}
+
 		public void SetCurrentObject (object lastComponent, object [] propertyProviders)
 		{
 			if (lastComponent != null) {

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -49,6 +49,14 @@ namespace MonoDevelop.DesignerSupport
 
 		public bool IsEditing => false;
 
+		//Small hack to cover the missing Proppy feature
+		public bool Sensitive { get; set; }
+		public override NSView HitTest (CGPoint aPoint)
+		{
+			if (!Sensitive) return null;
+			return base.HitTest (aPoint);
+		}
+
 		public event EventHandler PropertyGridChanged;
 
 		public MacPropertyGrid () 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -120,25 +120,20 @@ namespace MonoDevelop.DesignerSupport
 		NSTableView internalTableView;
 		NSView border;
 
-		void ShowHeader ()
+		void ShowToolbar (bool enabled)
 		{
-			internalTableView.BackgroundColor = hostResourceProvider.GetNamedColor (NamedResources.PadBackgroundColor);
-
 			var topConstraint = propertyEditorPanel.Constraints.FirstOrDefault (s => s.FirstItem == propertyList && s.FirstAttribute == NSLayoutAttribute.Top);
 			propertyEditorPanel.RemoveConstraint (topConstraint);
-			propertyEditorPanel.AddConstraint (NSLayoutConstraint.Create (this.propertyList, NSLayoutAttribute.Top, NSLayoutRelation.Equal, border, NSLayoutAttribute.Bottom, 1, 0));
 
-			header.Hidden = false;
-		}
-
-		void HideHeader ()
-		{
-			internalTableView.BackgroundColor = NSColor.Clear;
-			header.Hidden = true;
-
-			var topConstraint = propertyEditorPanel.Constraints.FirstOrDefault (s => s.FirstItem == propertyList && s.FirstAttribute == NSLayoutAttribute.Top);
-			propertyEditorPanel.RemoveConstraint (topConstraint);
-			propertyEditorPanel.AddConstraint (NSLayoutConstraint.Create (this.propertyList, NSLayoutAttribute.Top, NSLayoutRelation.Equal, propertyEditorPanel, NSLayoutAttribute.Top, 1, 0));
+			if (enabled) {
+				internalTableView.BackgroundColor = hostResourceProvider.GetNamedColor (NamedResources.PadBackgroundColor);
+				header.Hidden = false;
+				propertyEditorPanel.AddConstraint (NSLayoutConstraint.Create (this.propertyList, NSLayoutAttribute.Top, NSLayoutRelation.Equal, border, NSLayoutAttribute.Bottom, 1, 0));
+			} else {
+				internalTableView.BackgroundColor = NSColor.Clear;
+				header.Hidden = true;
+				propertyEditorPanel.AddConstraint (NSLayoutConstraint.Create (this.propertyList, NSLayoutAttribute.Top, NSLayoutRelation.Equal, propertyEditorPanel, NSLayoutAttribute.Top, 1, 0));
+			}
 		}
 
 		//HACK: this 
@@ -146,11 +141,7 @@ namespace MonoDevelop.DesignerSupport
 			get => !header.Hidden;
 			set {
 				//we ensure remove current constraints from proppy
-				if (value) {
-					ShowHeader ();
-				} else {
-					HideHeader ();
-				}
+				ShowToolbar (value);
 			}
 		}
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -73,9 +73,10 @@ namespace MonoDevelop.DesignerSupport
 
 			#region Header Proppy Hack
 
-			header = propertyEditorPanel.Subviews [0];
-			propertyList = propertyEditorPanel.Subviews [1];
-			internalTableView = propertyList.Subviews.OfType<NSScrollView> ()
+			var subviews = propertyEditorPanel.Subviews;
+			header = subviews [0];
+			propertyList = subviews [1];
+			internalTableView = subviews.OfType<NSScrollView> ()
 				.FirstOrDefault ().DocumentView as NSTableView;
 
 			//we need the second item constrained with the property list

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -76,7 +76,7 @@ namespace MonoDevelop.DesignerSupport
 			var subviews = propertyEditorPanel.Subviews;
 			header = subviews [0];
 			propertyList = subviews [1];
-			internalTableView = subviews.OfType<NSScrollView> ()
+			internalTableView = propertyList.Subviews.OfType<NSScrollView> ()
 				.FirstOrDefault ().DocumentView as NSTableView;
 
 			//we need the second item constrained with the property list

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelEditorProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelEditorProvider.cs
@@ -116,7 +116,7 @@ namespace MonoDevelop.DesignerSupport
 		{
 			var typeDescriptorContext = new TypeDescriptorContext (propertyProvider, propertyDescriptor);
 
-			var valueSources = ValueSources.Local | ValueSources.Default;
+			var valueSources = ValueSources.Default;
 			if (propertyDescriptor.PropertyType.IsEnum) {
 				if (propertyDescriptor.PropertyType.IsDefined (typeof (FlagsAttribute), inherit: false))
 					return new FlagDescriptorPropertyInfo (typeDescriptorContext, valueSources);

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
@@ -35,12 +35,11 @@ using Xamarin.PropertyEditing;
 namespace MonoDevelop.DesignerSupport
 {
 	class ComponentModelObjectEditor
-		: IObjectEditor, INameableObject, IDisposable
+		: IObjectEditor, IDisposable
 	{
 		internal const string ComboSeparatorString = "--";
 
 		private readonly ComponentModelTarget propertyItem;
-		public string Name { get; private set; }
 
 		static IReadOnlyList<string> defaultHandlerList = new List<string> ().AsReadOnly ();
 		static AssignableTypesResult defaultAssignableTypeResult = new AssignableTypesResult (new List<ITypeInfo> ().AsReadOnly ());
@@ -84,7 +83,7 @@ namespace MonoDevelop.DesignerSupport
 
 		public Task<IReadOnlyList<string>> GetHandlersAsync (IEventInfo ev) => Task.FromResult(defaultHandlerList);
 
-		public Task<string> GetNameAsync () => Task.FromResult (Name);
+		public Task<string> GetNameAsync () => Task.FromResult ((string) null);
 
 		public Task<IReadOnlyCollection<PropertyVariation>> GetPropertyVariantsAsync (IPropertyInfo property)
 			=> Task.FromResult<IReadOnlyCollection<PropertyVariation>> (Array.Empty<PropertyVariation> ());
@@ -107,12 +106,6 @@ namespace MonoDevelop.DesignerSupport
 		}
 
 		public Task RemovePropertyVariantAsync (IPropertyInfo property, PropertyVariation variant) => Task.CompletedTask;
-
-		public Task SetNameAsync (string name)
-		{
-			Name = name;
-			return Task.CompletedTask;
-		}
 
 		public Task SetValueAsync<T> (IPropertyInfo propertyInfo, ValueInfo<T> value, PropertyVariation variations = null)
 		{

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
@@ -83,7 +83,7 @@ namespace MonoDevelop.DesignerSupport
 
 		public Task<IReadOnlyList<string>> GetHandlersAsync (IEventInfo ev) => Task.FromResult(defaultHandlerList);
 
-		public Task<string> GetNameAsync () => Task.FromResult ((string) null);
+		public Task<string> GetNameAsync () => Task.FromResult<string> (null);
 
 		public Task<IReadOnlyCollection<PropertyVariation>> GetPropertyVariantsAsync (IPropertyInfo property)
 			=> Task.FromResult<IReadOnlyCollection<PropertyVariation>> (Array.Empty<PropertyVariation> ());

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
@@ -101,7 +101,7 @@ namespace MonoDevelop.DesignerSupport
 			T value = propertyInfo.GetValue<T> (this.Target);
 			var valueInfo = new ValueInfo<T> {
 				Value = value,
-				Source = ValueSource.Local,
+				Source = ValueSource.Default,
 			};
 			return Task.FromResult (valueInfo);
 		}

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
@@ -98,7 +98,7 @@ namespace MonoDevelop.DesignerSupport
 				return Task.FromException<ValueInfo<T>> (new ArgumentException ($"Property should be a {nameof (DescriptorPropertyInfo)}", nameof (property)));
 			}
 
-			T value = propertyInfo.GetValue<T> (this);
+			T value = propertyInfo.GetValue<T> (this.Target);
 			var valueInfo = new ValueInfo<T> {
 				Value = value,
 				Source = ValueSource.Local,
@@ -121,7 +121,7 @@ namespace MonoDevelop.DesignerSupport
 					return Task.FromException (new ArgumentNullException (nameof (propertyInfo)));
 
 				if (propertyInfo is DescriptorPropertyInfo info && info.CanWrite) {
-					info.SetValue (this, value.Value);
+					info.SetValue (this.Target, value.Value);
 					RaisePropertyChanged (info);
 				} else {
 					return Task.FromException<T> (new ArgumentException ($"Property should be a writeable {nameof (DescriptorPropertyInfo)}.", nameof (propertyInfo)));

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelObjectEditor.cs
@@ -114,6 +114,16 @@ namespace MonoDevelop.DesignerSupport
 					return Task.FromException (new ArgumentNullException (nameof (propertyInfo)));
 
 				if (propertyInfo is DescriptorPropertyInfo info && info.CanWrite) {
+
+					var actualValue = info.GetValue<T> (this.Target);
+					if (info.GetValue<T> (this.Target).Equals (value.Value)) {
+						return Task.CompletedTask;
+					}
+
+					//this is an exception for null/empty cases of string
+					if (typeof (T) == typeof(string) && string.IsNullOrEmpty (actualValue as string) && string.IsNullOrEmpty (value.Value as string)) {
+						return Task.CompletedTask;
+					}
 					info.SetValue (this.Target, value.Value);
 					RaisePropertyChanged (info);
 				} else {

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
@@ -46,16 +46,29 @@ namespace MonoDevelop.DesignerSupport
 {
 	class PropertyMacHostWidget : IPropertyGrid
 	{
+		public event EventHandler PropertyGridChanged;
+
 		readonly GtkNSViewHost host;
+
 		MacPropertyGrid view;
 
 		public string Name { get; set; }
+		public bool ShowHelp { get; set; } //not implemented
+		
+		public ShadowType ShadowType { get; set; } //not implemented
+		public Widget Widget => host;
 
 		public bool IsGridEditing => view.IsEditing;
 
-		public event EventHandler PropertyGridChanged;
+		public bool ShowToolbar {
+			get => view.ShowToolbar;
+			set => view.ShowToolbar = value;
+		}
 
-		public Widget Widget => host;
+		public bool Sensitive {
+			get => view.Sensitive;
+			set => view.Sensitive = value;
+		}
 
 		public object CurrentObject {
 			get => view.CurrentObject;
@@ -72,23 +85,13 @@ namespace MonoDevelop.DesignerSupport
 			view.PropertyGridChanged += View_PropertyGridChanged;
 		}
 
-		private void View_PropertyGridChanged (object sender, EventArgs e) => PropertyGridChanged?.Invoke (this, e);
+		void View_PropertyGridChanged (object sender, EventArgs e)
+			=> PropertyGridChanged?.Invoke (this, e);
 
 		public void SetCurrentObject (object obj, object [] propertyProviders)
 			=> view.SetCurrentObject (obj, propertyProviders);
 
-		public void BlankPad ()
-			=> view.BlankPad ();
-
-		public void Dispose ()
-		{
-			if (view != null) {
-				view.PropertyGridChanged -= View_PropertyGridChanged;
-				view.Dispose ();
-				view = null;
-			}
-		}
-
+		public void BlankPad () => view.BlankPad ();
 		public void Hide () => view.Hidden = true;
 		public void Show () => view.Hidden = false;
 
@@ -111,22 +114,33 @@ namespace MonoDevelop.DesignerSupport
 		{
 			//not implemented;
 		}
+
+		public void Dispose ()
+		{
+			if (view != null) {
+				view.PropertyGridChanged -= View_PropertyGridChanged;
+				view.Dispose ();
+				view = null;
+			}
+		}
 	}
 
 	public interface IPropertyGrid : IPropertyPad
 	{
-		public string Name { get; set; }
-
+		bool ShowToolbar { get; set; }
+		bool ShowHelp { get; set; }
+		bool Sensitive { get; set; }
+		string Name { get; set; }
 		object CurrentObject { get; set; }
+
+		Gtk.Widget Widget { get; }
+		ShadowType ShadowType { get; set; }
 
 		void Hide ();
 		void Show ();
 
 		void SetToolbarProvider (object toolbarProvider);
-
 		void CommitPendingChanges ();
-
-		Gtk.Widget Widget { get; }
 	}
 
 	public class PropertyGridWrapper : IPropertyGrid
@@ -136,22 +150,36 @@ namespace MonoDevelop.DesignerSupport
 			set => nativeWidget.Name = value;
 		}
 
-		public bool IsGridEditing => nativeWidget.IsGridEditing;
-
 		public event EventHandler PropertyGridChanged;
 
 		public Gtk.Widget Widget => nativeWidget.Widget;
 
-		public bool ShowToolbar { get; set; }
-		public ShadowType ShadowType { get; set; }
-		public bool ShowHelp { get; set; }
+		public bool ShowToolbar {
+			get => nativeWidget.ShowToolbar;
+			set => nativeWidget.ShowToolbar = value;
+		}
+
+		public ShadowType ShadowType {
+			get => nativeWidget.ShadowType;
+			set => nativeWidget.ShadowType = value;
+		}
+
+		public bool ShowHelp {
+			get => nativeWidget.ShowHelp;
+			set => nativeWidget.ShowHelp = value;
+		}
+
+		public bool Sensitive {
+			get => nativeWidget.Sensitive;
+			set => nativeWidget.Sensitive = value;
+		}
+
+		public bool IsGridEditing => nativeWidget.IsGridEditing;
 
 		public object CurrentObject {
 			get => nativeWidget.CurrentObject;
 			set => nativeWidget.CurrentObject = value;
 		}
-
-		public bool Sensitive { get; set; }
 
 		IPropertyGrid nativeWidget;
 
@@ -171,8 +199,8 @@ namespace MonoDevelop.DesignerSupport
 		public void BlankPad ()
 			=> nativeWidget.BlankPad ();
 
-		public void PopulateGrid (bool saveEditSession) =>
-			nativeWidget.PopulateGrid (saveEditSession);
+		public void PopulateGrid (bool saveEditSession)
+			=> nativeWidget.PopulateGrid (saveEditSession);
 
 		public void SetCurrentObject (object lastComponent, object [] propertyProviders)
 			=> nativeWidget.SetCurrentObject (lastComponent, propertyProviders);
@@ -196,14 +224,11 @@ namespace MonoDevelop.DesignerSupport
 
 		public void OnPadContentShown ()
 		{
-			//nativeWidget.SetToolbarProvider (toolbarProvider);
+			//not implemented
 		}
 
-		public void CommitPendingChanges ()
-		{
+		public void CommitPendingChanges () =>
 			nativeWidget.CommitPendingChanges ();
-			//to implement
-		}
 	}
 
 	public class PropertyPad : PadContent, ICommandDelegator, IPropertyPad

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
@@ -49,6 +49,8 @@ namespace MonoDevelop.DesignerSupport
 		readonly GtkNSViewHost host;
 		MacPropertyGrid view;
 
+		public string Name { get; set; }
+
 		public bool IsGridEditing => view.IsEditing;
 
 		public event EventHandler PropertyGridChanged;
@@ -113,6 +115,8 @@ namespace MonoDevelop.DesignerSupport
 
 	public interface IPropertyGrid : IPropertyPad
 	{
+		public string Name { get; set; }
+
 		object CurrentObject { get; set; }
 
 		void Hide ();
@@ -127,6 +131,11 @@ namespace MonoDevelop.DesignerSupport
 
 	public class PropertyGridWrapper : IPropertyGrid
 	{
+		public string Name {
+			get => nativeWidget.Name;
+			set => nativeWidget.Name = value;
+		}
+
 		public bool IsGridEditing => nativeWidget.IsGridEditing;
 
 		public event EventHandler PropertyGridChanged;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/PropertyPad.cs
@@ -61,8 +61,8 @@ namespace MonoDevelop.DesignerSupport
 		public bool IsGridEditing => view.IsEditing;
 
 		public bool ShowToolbar {
-			get => view.ShowToolbar;
-			set => view.ShowToolbar = value;
+			get => view.ToolbarVisible;
+			set => view.ToolbarVisible = value;
 		}
 
 		public bool Sensitive {

--- a/main/src/addins/Xml/Formatting/XmlFormattingPolicyPanelWidget.cs
+++ b/main/src/addins/Xml/Formatting/XmlFormattingPolicyPanelWidget.cs
@@ -59,7 +59,7 @@ namespace MonoDevelop.Xml.Formatting
 		Button buttonRemove;
 		Label labelScopes;
 		Table tableScopes;
-		MonoDevelop.Components.PropertyGrid.PropertyGrid propertyGrid;
+		DesignerSupport.PropertyGridWrapper propertyGrid;
 		Button buttonAdvanced;
 
 		void Build ()
@@ -85,7 +85,7 @@ namespace MonoDevelop.Xml.Formatting
 				ColumnSpacing = 6
 			};
 
-			propertyGrid = new MonoDevelop.Components.PropertyGrid.PropertyGrid {
+			propertyGrid = new DesignerSupport.PropertyGridWrapper {
 				ShowToolbar = false,
 				ShowHelp = false
 			};
@@ -107,7 +107,7 @@ namespace MonoDevelop.Xml.Formatting
 			var rightVBox = new VBox (false, 6);
 			rightVBox.PackStart (labelScopes, false, false, 0);
 			rightVBox.PackStart (tableScopes, false, false, 0);
-			rightVBox.PackStart (propertyGrid, true, true, 0);
+			rightVBox.PackStart (propertyGrid.Widget, true, true, 0);
 
 			var mainBox = new HBox (false, 6);
 			mainBox.PackStart (boxScopes, false, false, 0);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -511,14 +511,19 @@ namespace MonoDevelop.Components.Commands
 				view != window.ContentView) {
 
 				if (currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
-					view = FindValidKeyView (view);
+
+					var expectedKeyView = FindValidKeyView (view);
 					AppKit.NSView next = null;
 					if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
-						next = view.PreviousValidKeyView;
+						next = expectedKeyView.PreviousValidKeyView;
 					} else {
-						next = view.NextValidKeyView;
+						next = expectedKeyView.NextValidKeyView;
 					}
-					window.MakeFirstResponder (next);
+
+					view.KeyDown (currentEvent);
+					if (next != null && window?.FirstResponder != next) {
+						window.MakeFirstResponder (next);
+					}
 				} else {
 					view.KeyDown (currentEvent);
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -453,6 +453,8 @@ namespace MonoDevelop.Components.Commands
 			var window = currentEvent?.Window;
 			var firstResponder = window?.FirstResponder;
 
+			bool retVal = false;
+
 			// GTK eats FlagsChanged events and this is just to inform
 			// modifier keys changed state, hence always send it to
 			// focused view
@@ -467,10 +469,22 @@ namespace MonoDevelop.Components.Commands
 			// KeyboardShortcut[] accels = 
 			KeyBindingManager.AccelsFromKey (e.Event, out complete);
 
+			if (currentEvent != null &&
+				currentEvent.Type == AppKit.NSEventType.KeyUp &&
+				firstResponder is AppKit.NSView view &&
+				view != window.ContentView) {
+
+				view.KeyUp (currentEvent);
+
+				retVal = true;
+			}
+
 			if (!complete) {
 				// incomplete accel
 				NotifyIncompleteKeyReleased (e.Event);
 			}
+
+			e.RetVal = retVal;
 		}
 
 		internal bool ProcessKeyEvent (Gdk.EventKey ev)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -524,29 +524,33 @@ namespace MonoDevelop.Components.Commands
 				firstResponder is AppKit.NSView view &&
 				view != window.ContentView) {
 
-				if (currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
-
-					var expectedKeyView = FindValidKeyView (view);
-					AppKit.NSView next = null;
-					if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
-						next = expectedKeyView.PreviousValidKeyView;
-					} else {
-						next = expectedKeyView.NextValidKeyView;
-					}
-
-					view.KeyDown (currentEvent);
-					if (next != null && window?.FirstResponder != next) {
-						window.MakeFirstResponder (next);
-					}
-				} else {
-					view.KeyDown (currentEvent);
-				}
+				SimulateKeyDownInView (view, currentEvent, window);
+				
 				return true;
 			}
 #endif
 			return false;
 		}
 
+		void SimulateKeyDownInView (AppKit.NSView view, AppKit.NSEvent currentEvent, AppKit.NSWindow window)
+		{
+			if (currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
+				var expectedKeyView = FindValidKeyView (view);
+				AppKit.NSView next = null;
+				if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
+					next = expectedKeyView.PreviousValidKeyView;
+				} else {
+					next = expectedKeyView.NextValidKeyView;
+				}
+
+				view.KeyDown (currentEvent);
+				if (next != null && window?.FirstResponder != next) {
+					window.MakeFirstResponder (next);
+				}
+			} else {
+				view.KeyDown (currentEvent);
+			}
+		}
 
 		static AppKit.NSView FindValidKeyView (AppKit.NSView view)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -437,6 +437,13 @@ namespace MonoDevelop.Components.Commands
 			}
 			return false;
 		}
+
+		private void SimulateViewKeyActionBehaviour (AppKit.NSView view, AppKit.NSEvent currentEvent)
+		{
+			if (view is AppKit.NSButton btn && (currentEvent.KeyCode == (ushort)AppKit.NSKey.Space || currentEvent.KeyCode == (ushort)AppKit.NSKey.Return)) {
+				btn.PerformClick (btn);
+			}
+		}
 #endif
 
 		[GLib.ConnectBefore]
@@ -475,7 +482,7 @@ namespace MonoDevelop.Components.Commands
 				view != window.ContentView) {
 
 				view.KeyUp (currentEvent);
-
+				SimulateViewKeyActionBehaviour (view, currentEvent);
 				retVal = true;
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/IPropertyGrid.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/IPropertyGrid.cs
@@ -45,5 +45,7 @@ namespace MonoDevelop.Components
 		void BlankPad ();
 		void OnPadContentShown ();
 		void Populate (bool saveEditSession);
+
+		public Gtk.Widget Widget { get; }
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.PropertyGrid/PropertyGrid.cs
@@ -75,7 +75,9 @@ namespace MonoDevelop.Components.PropertyGrid
 		PropertySort propertySort = PropertySort.Categorized;
 		
 		const string PROP_HELP_KEY = "MonoDevelop.PropertyPad.ShowHelp";
-		
+
+		public Widget Widget => this;
+
 		public PropertyGrid (): this (new EditorManager ())
 		{
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -379,31 +379,6 @@ namespace Gtk
 			return baseCall (evnt);
 		}
 
-		protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
-		{
-			LogEnter ();
-			try {
-				return ForwardEvent (
-					evnt,
-					(v, e) => v.KeyDown (e),
-					base.OnKeyReleaseEvent);
-			} finally {
-				LogExit ();
-			}
-		}
-
-		protected override bool OnKeyReleaseEvent (Gdk.EventKey evnt)
-		{
-			LogEnter ();
-			try {
-				return ForwardEvent (
-					evnt,
-					(v, e) => v.KeyUp (e),
-					base.OnKeyReleaseEvent);
-			} finally {
-				LogExit ();
-			}
-		}
 
 		#region Tracing
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -53,9 +53,6 @@ namespace Gtk
 		static extern IntPtr gdk_quartz_window_get_nsview (IntPtr window);
 
 		[DllImport (LIBGTKQUARTZ)]
-		static extern IntPtr gdk_quartz_event_get_nsevent (IntPtr evnt);
-
-		[DllImport (LIBGTKQUARTZ)]
 		static extern void gdk_window_coords_to_parent (
 			IntPtr window,
 			double x,
@@ -65,15 +62,6 @@ namespace Gtk
 
 		[DllImport (LIBGTKQUARTZ)]
 		static extern bool gdk_window_has_native (IntPtr window);
-
-		static NSEvent GetNSEvent (Gdk.Event evnt)
-		{
-			if (evnt == null || evnt.Handle == IntPtr.Zero)
-				return null;
-
-			var nsEventHandle = gdk_quartz_event_get_nsevent (evnt.Handle);
-			return Runtime.GetNSObject<NSEvent> (nsEventHandle);
-		}
 
 		NSView view;
 		NSView superview;
@@ -360,25 +348,6 @@ namespace Gtk
 				LogExit ();
 			}
 		}
-
-		bool ForwardEvent<TEvent> (
-			TEvent evnt,
-			Action<NSView, NSEvent> forwardCall,
-			Func<TEvent, bool> baseCall) where TEvent : Gdk.Event
-		{
-			var acceptsFirstResponderView = GetAcceptsFirstResponderView ();
-			if (acceptsFirstResponderView == null)
-				return false;
-
-			var nsEvent = GetNSEvent (evnt);
-			if (nsEvent == null)
-				return false;
-
-			forwardCall (acceptsFirstResponderView, nsEvent);
-
-			return baseCall (evnt);
-		}
-
 
 		#region Tracing
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NativeViewHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NativeViewHelper.cs
@@ -32,9 +32,22 @@ using Foundation;
 
 namespace MonoDevelop.Components.Mac
 {
+	internal class UnfocusableScrollview : NSScrollView
+	{
+		public override bool AcceptsFirstResponder () => false;
+	}
+
+	internal class UnfocusableStackView : NSStackView
+	{
+		public override bool AcceptsFirstResponder ()
+		{
+			return false;
+		}
+	}
+
 	static class NativeViewHelper
 	{
-		public static NSStackView CreateVerticalStackView (int spacing = 10, bool translatesAutoresizingMaskIntoConstraints = false) => new NSStackView () {
+		public static NSStackView CreateVerticalStackView (int spacing = 10, bool translatesAutoresizingMaskIntoConstraints = false) => new UnfocusableStackView () {
 			Orientation = NSUserInterfaceLayoutOrientation.Vertical,
 			Alignment = NSLayoutAttribute.Leading,
 			Spacing = spacing,
@@ -42,7 +55,7 @@ namespace MonoDevelop.Components.Mac
 			TranslatesAutoresizingMaskIntoConstraints = translatesAutoresizingMaskIntoConstraints
 		};
 
-		public static NSStackView CreateHorizontalStackView (int spacing = 10) => new NSStackView () {
+		public static NSStackView CreateHorizontalStackView (int spacing = 10) => new UnfocusableStackView () {
 			Orientation = NSUserInterfaceLayoutOrientation.Horizontal,
 			Alignment = NSLayoutAttribute.CenterY,
 			Spacing = spacing,

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/MessageService.cs
@@ -394,6 +394,7 @@ namespace MonoDevelop.Ide
 			try {
 				Xwt.MessageDialog.RootWindow = Xwt.Toolkit.CurrentEngine.WrapWindow (dialog);
 				IdeApp.DisableIdleActions ();
+				IdeApp.CommandService.RegisterTopWindow (dialog);
 				int result = GtkWorkarounds.RunDialogWithNotification (dialog);
 				// Focus parent window once the dialog is ran, as focus gets lost
 				if (parent != null) {


### PR DESCRIPTION
NOTES: Proppy doesn't expose any API to allow us remove the toolbar
https://github.com/xamarin/Xamarin.PropertyEditing/issues/663

Also there is an issue in numeric decimal editors in Culture separator symbol non ENGLISH based
https://github.com/xamarin/Xamarin.PropertyEditing/issues/662

Fixes VSTS #1003417 - Replace current F# format preference panel to use native Proppy
Fixes VSTS #1003416 - Replace current XML format preference panel to use native Proppy
Fixes VSTS #1002622 - Add a mechanism outside proppy to hide toolbar
Fixes VSTS #637121 - Accessibility: Preferences - Code Formatting: Unable to access Layout,Refracting,Spacing categorized formattings using keyboard.
Fixes VSTS #637246 - Accessibility: Preferences - Code Formatting F#: Not able to access Attributes,Document,Elements and it’s inside elements under 'Source code -> XML document'.
Fixes VSTS #1001600 - A11Y_Xamarin Designers_Property pane_keyboard : Keyboard is getting trapped at “Automatic tree” check box
Fixes VSTS #1001627 -  A11Y_Xamarin Designers_Property pane_keyboard : User is unable to open the “Edit” button by using space/enter keys### Preferences CodeFormating XML
Fixes VSTS #1001625 - A11Y_Xamarin Designers_Property pane_keyboard : User is unable to check/uncheck the “Automatic tree” check box by using space key

![image](https://user-images.githubusercontent.com/1587480/67010290-a5bc3080-f0ed-11e9-883d-6e09ff488bd5.png)


### Preferences CodeFormating F#

![image](https://user-images.githubusercontent.com/1587480/67010323-b66ca680-f0ed-11e9-851d-3dd73a440170.png)




Backport of #8937.

/cc @netonjm 