### PR TITLE
Set `DesignTimeBuild` when evaluating SourceFiles

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -782,6 +782,7 @@ namespace MonoDevelop.Projects
 						ctx.LoadReferencedProjects = false;
 						ctx.BuilderQueue = BuilderQueue.ShortOperations;
 						ctx.LogVerbosity = MSBuildVerbosity.Quiet;
+						ctx.GlobalProperties.SetValue ("DesignTimeBuild", "true");
 
 						var evalResult = await project.RunTargetInternal (monitor, dependsList, config.Selector, ctx);
 						if (evalResult != null && evalResult.Items != null) {


### PR DESCRIPTION
Fixes problem with Razor projects including obj/*.razor.g.cs files

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1010676