### PR TITLE
[release-8.4][Mac] Disable memory monitor due to broken xammac binding

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1371,7 +1371,8 @@ namespace MonoDevelop.MacIntegration
 			return MacTelemetryDetails.CreateTelemetryDetails ();
 		}
 
-		internal override MemoryMonitor CreateMemoryMonitor () => new MacMemoryMonitor ();
+		// Disabled due to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1008370
+		//internal override MemoryMonitor CreateMemoryMonitor () => new MacMemoryMonitor ();
 
 		internal class MacMemoryMonitor : MemoryMonitor, IDisposable
 		{


### PR DESCRIPTION
Causes crashes in the wild under high memory pressure conditions

Fixes VSTS #1008370 - [FATAL] SigSegv signal in Xamarin.Mac.dll!ObjCRuntime.Trampolines.SDAction::Invoke+0