### PR TITLE
[release-8.3] [Mac] Disable memory monitor due to broken xammac binding

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1380,7 +1380,8 @@ namespace MonoDevelop.MacIntegration
 			return MacTelemetryDetails.CreateTelemetryDetails ();
 		}
 
-		internal override MemoryMonitor CreateMemoryMonitor () => new MacMemoryMonitor ();
+		// Disabled due to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1008370
+		//internal override MemoryMonitor CreateMemoryMonitor () => new MacMemoryMonitor ();
 
 		internal class MacMemoryMonitor : MemoryMonitor, IDisposable
 		{

--- a/main/tests/MacPlatform.Tests/MacPlatformTest.cs
+++ b/main/tests/MacPlatform.Tests/MacPlatformTest.cs
@@ -94,6 +94,7 @@ namespace MacPlatform.Tests
 		}
 
 		[Test]
+		[Ignore("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1008370")]
 		public void MacHasProperMonitor ()
 		{
 			Assert.That (IdeServices.DesktopService.MemoryMonitor, Is.TypeOf<MacPlatformService.MacMemoryMonitor> ());


### PR DESCRIPTION
Causes crashes in the wild under high memory pressure conditions

Fixes VSTS #1008370 - [FATAL] SigSegv signal in Xamarin.Mac.dll!ObjCRuntime.Trampolines.SDAction::Invoke+0

Backport of #9182.

/cc @Therzok 