### PR TITLE
[release-8.4] [Ide] Update dotnet templating engine

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,6 +10,7 @@
 		<add key="NuGetizer3000" value="https://ci.appveyor.com/nuget/nugetizer3000" />
 		<add key="VSTest" value="https://dotnet.myget.org/F/vstest/" />
 		<add key="Templating" value="https://dotnet.myget.org/F/templating/" />
+		<add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
 		<add key="Azure AppService" value="https://www.myget.org/F/azure-appservice/api/v3/index.json" />
 		<add key="MSBuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
 		<add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />

--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -13,7 +13,7 @@
     <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
     <NuGetVersionCecil>0.10.1</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
-    <NuGetVersionMicrosoftTemplateEngine>1.0.0-beta3-20171117-314</NuGetVersionMicrosoftTemplateEngine>
+    <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>
     <NuGetVersionMicrosoftTestPlatform>15.5.0-preview-20170919-04</NuGetVersionMicrosoftTestPlatform>
     <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>
     <NuGetVersionNewtonsoftJson>12.0.2</NuGetVersionNewtonsoftJson>


### PR DESCRIPTION
Update to version 3.0.0-rc1.19464.2

Fixes VSTS #999874 - New Blazor project has template sections which
haven't been processed

Backport of #9185.

/cc @mrward 