### PR TITLE
New command called "Quick New File"

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -401,6 +401,13 @@
 			macShortcut = "Meta|N"
 			_description = "Create a new file"
 			icon = "md-regular-file" />
+	<Command id = "MonoDevelop.Ide.Commands.FileCommands.QuickNewFile"
+			defaultHandler = "MonoDevelop.Ide.Commands.QuickNewFileHandler"
+			_label = "Quick New File..."
+			shortcut = "Control|Alt|N"
+			macShortcut = "Meta|Alt|N"
+			_description = "Create a new file without dialog"
+			icon = "md-regular-file" />
 	<Command id = "MonoDevelop.Ide.Commands.FileCommands.Save"
 			icon = "gtk-save"
 			shortcut = "Control|S"

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -403,7 +403,7 @@
 			icon = "md-regular-file" />
 	<Command id = "MonoDevelop.Ide.Commands.FileCommands.QuickNewFile"
 			defaultHandler = "MonoDevelop.Ide.Commands.QuickNewFileHandler"
-			_label = "Quick New File..."
+			_label = "Quick New File"
 			shortcut = "Control|Alt|N"
 			macShortcut = "Meta|Alt|N"
 			_description = "Create a new file without dialog"

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -406,7 +406,7 @@
 			_label = "Quick New File"
 			shortcut = "Control|Alt|N"
 			macShortcut = "Meta|Alt|N"
-			_description = "Create a new file without dialog"
+			_description = "Create a new empty Text File"
 			icon = "md-regular-file" />
 	<Command id = "MonoDevelop.Ide.Commands.FileCommands.Save"
 			icon = "gtk-save"

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Commands/FileCommands.cs
@@ -40,6 +40,7 @@ using MonoDevelop.Ide.Desktop;
 using System.Linq;
 using MonoDevelop.Components;
 using MonoDevelop.Components.Extensions;
+using System.Collections.Generic;
 
 namespace MonoDevelop.Ide.Commands
 {
@@ -73,7 +74,8 @@ namespace MonoDevelop.Ide.Commands
 		OpenContainingFolder,
 		SetBuildAction,
 		ShowProperties,
-		CopyToOutputDirectory
+		CopyToOutputDirectory,
+		QuickNewFile
 	}
 
 	// MonoDevelop.Ide.Commands.FileCommands.OpenFile
@@ -123,6 +125,22 @@ namespace MonoDevelop.Ide.Commands
 		{
 			using (var dlg = new NewFileDialog (null, null)) // new file seems to fail if I pass the project IdeApp.ProjectOperations.CurrentSelectedProject
 				MessageService.ShowCustomDialog (dlg, IdeServices.DesktopService.GetFocusedTopLevelWindow ());
+		}
+	}
+
+	// MonoDevelop.Ide.Commands.FileCommands.QuickNewFile
+	sealed class QuickNewFileHandler : CommandHandler
+	{
+		protected override void Run ()
+		{
+			const string namePrefix = "Untitled-";
+			var names = new HashSet<string> (IdeApp.Workbench.Documents.Select (d => d.Name).Where (d => d.StartsWith (namePrefix, StringComparison.Ordinal)));
+			for (int i = 1; i < int.MaxValue; i++) {
+				if (!names.Contains (namePrefix + i)) {
+					IdeApp.Workbench.NewDocument (namePrefix + i, "text/plain", "").Ignore ();
+					return;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Behaviour is same as VSCode Cmd+N which creates "Untitled-#" file I used Cmd+Option+N shortcut that was available, this is super useful when I want to inspect some log file that I copied from web or terminal output, that I want to search/read in editor...

Fixes https://github.com/mono/monodevelop/issues/9243