### PR TITLE
[Debugger] Fixed deleting/changing of expressions in Watch Pad

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ExpressionEventArgs.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ExpressionEventArgs.cs
@@ -28,9 +28,9 @@ using System;
 
 namespace MonoDevelop.Debugger
 {
-	public class ExpressionEventArgs : EventArgs
+	public class ExpressionAddedEventArgs : EventArgs
 	{
-		public ExpressionEventArgs (string expression)
+		public ExpressionAddedEventArgs (string expression)
 		{
 			Expression = expression;
 		}
@@ -40,12 +40,34 @@ namespace MonoDevelop.Debugger
 		}
 	}
 
+	public class ExpressionRemovedEventArgs : EventArgs
+	{
+		public ExpressionRemovedEventArgs (int index, string expression)
+		{
+			Expression = expression;
+			Index = index;
+		}
+
+		public string Expression {
+			get; private set;
+		}
+
+		public int Index {
+			get; private set;
+		}
+	}
+
 	public class ExpressionChangedEventArgs : EventArgs
 	{
-		public ExpressionChangedEventArgs (string oldExpression, string newExpression)
+		public ExpressionChangedEventArgs (int index, string oldExpression, string newExpression)
 		{
 			OldExpression = oldExpression;
 			NewExpression = newExpression;
+			Index = index;
+		}
+
+		public int Index {
+			get; private set;
 		}
 
 		public string OldExpression {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/WatchPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/WatchPad.cs
@@ -75,7 +75,7 @@ namespace MonoDevelop.Debugger
 
 		public void AddWatch (string expression)
 		{
-			LoggingService.LogInfo ("Adding expression '{0}'", expression);
+			//LoggingService.LogInfo ("Adding expression '{0}'", expression);
 
 			if (UseNewTreeView) {
 				controller.AddExpression (expression);
@@ -118,30 +118,32 @@ namespace MonoDevelop.Debugger
 			}
 		}
 
-		void OnExpressionAdded (object sender, ExpressionEventArgs e)
+		void OnExpressionAdded (object sender, ExpressionAddedEventArgs e)
 		{
-			LoggingService.LogInfo ("Expression added: {0}", e.Expression);
+			//LoggingService.LogInfo ("Expression added: '{0}'", e.Expression);
 			expressions.Add (e.Expression);
 		}
 
 		void OnExpressionChanged (object sender, ExpressionChangedEventArgs e)
 		{
-			LoggingService.LogInfo ("Expression changed: '{0}' -> '{1}'", e.OldExpression, e.NewExpression);
-			int index = expressions.IndexOf (e.OldExpression);
+			//LoggingService.LogInfo ("Expression changed @ index {0}: '{1}' -> '{2}'", e.Index, e.OldExpression, e.NewExpression);
 
-			if (index != -1) {
-				expressions[index] = e.NewExpression;
+			if (e.Index != -1) {
+				expressions[e.Index] = e.NewExpression;
 			} else {
-				LoggingService.LogWarning ("Failed to find old expression: {0}", e.OldExpression);
+				//LoggingService.LogWarning ("Failed to find old expression: '{0}'", e.OldExpression);
 				expressions.Add (e.NewExpression);
 			}
 		}
 
-		void OnExpressionRemoved (object sender, ExpressionEventArgs e)
+		void OnExpressionRemoved (object sender, ExpressionRemovedEventArgs e)
 		{
-			LoggingService.LogInfo ("Expression removed: {0}", e.Expression);
-			if (!expressions.Remove (e.Expression))
-				LoggingService.LogWarning ("Failed to remove expression: {0}", e.Expression);
+			//LoggingService.LogInfo ("Expression removed @ index {0}: '{1}'", e.Index, e.Expression);
+			if (e.Index < 0 || e.Index >= expressions.Count) {
+				//LoggingService.LogWarning ("Failed to remove expression: '{0}'", e.Expression);
+				return;
+			}
+			expressions.RemoveAt (e.Index);
 		}
 
 		public override void Dispose ()


### PR DESCRIPTION
For deleting, 2 bugs are fixed:

1. Deleting an expression now works between sessions (failed before because
   removing the node sets the Parent to null and thus 'is RootObjectValueNode'
   failed, causing no ExpressionRemoved event to fire.
2. If the user has multiple of the same expression, the old logic would remove
   the first instance even if the user was deleting the last instance.

A similar bug existed for editing an existing expression if the user had
identical expressions in the list.