### PR TITLE
When opening files without solution open maximized(closed pads)

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -1053,7 +1053,7 @@ namespace MonoDevelop.Ide.Gui
 		public event EventHandler<WindowReorderedEventArgs> WindowReordered;
 
 
-		bool IsInFullViewMode {
+		internal bool IsInFullViewMode {
 			get {
 				return dock?.CurrentLayout?.EndsWith(fullViewModeTag, StringComparison.Ordinal) ?? false;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -643,6 +643,47 @@ namespace MonoDevelop.Ide.Gui
 
 		public void ToggleMaximize ()
 		{
+			if (workbench.IsInFullViewMode) {
+				Normalize ();
+			} else {
+				Maximize ();
+			}
+		}
+
+		bool normalizeAutomatically = false;
+		/// <summary>
+		/// Maximizes editor area by hiding all other pads, e.g. Solution pad, Errors pad...
+		/// </summary>
+		/// <param name="normalizeAutomatically">When set to true, Workbench will reverse effect of maximazing whenever suitable, e.g. when solution loads</param>
+		public void Maximize (bool normalizeAutomatically = false)
+		{
+			this.normalizeAutomatically = normalizeAutomatically;
+			if (workbench.IsInFullViewMode)
+				return;
+
+			if (normalizeAutomatically) {
+				IdeApp.Workspace.SolutionLoaded += Workspace_SolutionLoaded;
+			}
+			workbench.ToggleFullViewMode ();
+		}
+
+		private void Workspace_SolutionLoaded (object sender, SolutionEventArgs e)
+		{
+			IdeApp.Workspace.SolutionLoaded -= Workspace_SolutionLoaded;
+			if (!normalizeAutomatically)
+				return;
+			normalizeAutomatically = false;
+			Normalize ();
+		}
+
+		/// <summary>
+		/// If workbench is maximized it resets back to normal state. <seealso cref="Maximize(bool)"/> and <seealso cref="ToggleMaximize"/>
+		/// </summary>
+		public void Normalize ()
+		{
+			if (!workbench.IsInFullViewMode)
+				return;
+
 			workbench.ToggleFullViewMode ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -655,7 +655,7 @@ namespace MonoDevelop.Ide.Gui
 		/// Maximizes editor area by hiding all other pads, e.g. Solution pad, Errors pad...
 		/// </summary>
 		/// <param name="normalizeAutomatically">When set to true, Workbench will reverse effect of maximazing whenever suitable, e.g. when solution loads</param>
-		public void Maximize (bool normalizeAutomatically = false)
+		public void Maximize (bool normalizeAutomatically)
 		{
 			this.normalizeAutomatically = normalizeAutomatically;
 			if (workbench.IsInFullViewMode)
@@ -665,6 +665,14 @@ namespace MonoDevelop.Ide.Gui
 				IdeApp.Workspace.SolutionLoaded += Workspace_SolutionLoaded;
 			}
 			workbench.ToggleFullViewMode ();
+		}
+
+		/// <summary>
+		/// Maximizes editor area by hiding all other pads, e.g. Solution pad, Errors pad...
+		/// </summary>
+		public void Maximize ()
+		{
+			Maximize (false);
 		}
 
 		private void Workspace_SolutionLoaded (object sender, SolutionEventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -339,7 +339,13 @@ namespace MonoDevelop.Ide
 					IdeApp.OpenFilesAsync (startupInfo.RequestedFileList, GetOpenWorkspaceOnStartupMetadata ()).Ignore ();
 					startupInfo.OpenedFiles = startupInfo.HasFiles;
 				}
-				
+				if (!startupInfo.HasSolutionFile && startupInfo.HasFiles) {
+					//If we are opening files but no solution, start in Maximized mode
+					//so only editor is visible, without Solution, Error and other pads
+					//that are not very useful when opening files
+					IdeApp.Workbench.Maximize (true);
+				}
+
 				monitor.Step (1);
 			
 			} catch (Exception e) {


### PR DESCRIPTION
Main reason behind this change is to make IDE more friendly to open single files and behave more like editor. Since default open pads are useless(empty solution and error pad).
If user later opens solution, we automatically revert this.

This fixes https://github.com/mono/monodevelop/issues/9242
Fixes VSTS #1017488