### PR TITLE
[Error Pad] Optimize rendering and remove manual loop pumping

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl.Views/LogWidget.cs
@@ -798,7 +798,7 @@ namespace MonoDevelop.VersionControl.Views
 						actionIcon = ImageService.GetIcon ("gtk-edit", Gtk.IconSize.Menu);
 					} else {
 						action = rp.ActionDescription;
-						actionIcon = ImageService.GetIcon (MonoDevelop.Ide.Gui.Stock.Empty, Gtk.IconSize.Menu);
+						actionIcon = CellRendererImage.NullImage;
 					}
 					Xwt.Drawing.Image fileIcon = IdeServices.DesktopService.GetIconForFile (rp.Path, Gtk.IconSize.Menu);
 					var iter = changedpathstore.AppendValues (actionIcon, action, fileIcon, System.IO.Path.GetFileName (rp.Path), System.IO.Path.GetDirectoryName (rp.Path), rp.Path, null);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/CellRendererImage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/CellRendererImage.cs
@@ -138,6 +138,10 @@ namespace MonoDevelop.Components
 			//
 			// Except in the solution treeview, because the Mac's default unfocused selection background is too light for the
 			// custom treeview background
+			var img = GetImage ();
+			if (img == null)
+				return;
+
 			if (!ignoreSelection.HasValue) {
 				if (Platform.IsMac) {
 					if (IdeTheme.UserInterfaceTheme == Theme.Light) {
@@ -150,10 +154,6 @@ namespace MonoDevelop.Components
 					ignoreSelection = false;
 				}
 			}
-
-			var img = GetImage ();
-			if (img == null)
-				return;
 
 			var shouldIgnoreSelection = ignoreSelection.GetValueOrDefault () && !widget.HasFocus;
 			if (!shouldIgnoreSelection && ((flags & Gtk.CellRendererState.Selected) != 0))

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -767,7 +767,8 @@ namespace MonoDevelop.Ide.Gui.Pads
 		{
 			OnTaskJumpto (null, null);
 		}
-		
+
+		[Obsolete("This will be removed in future versions")]
 		public CompilerResults CompilerResults = null;
 		
 		void FilterChanged (object sender, EventArgs e)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -893,20 +893,18 @@ namespace MonoDevelop.Ide.Gui.Pads
 		
 		public void AddTasks (IEnumerable<TaskListEntry> tasks)
 		{
-			int n = 1;
+			Runtime.CheckMainThread ();
+
 			foreach (TaskListEntry t in tasks) {
 				AddTaskInternal (t);
-				if ((n++ % 100) == 0) {
-					// Adding many tasks is a bit slow, so refresh the
-					// ui at every block of 100.
-					DispatchService.RunPendingEvents ();
-				}
 			}
 			filter.Refilter ();
 		}
 		
 		public void AddTask (TaskListEntry t)
 		{
+			Runtime.CheckMainThread ();
+
 			AddTaskInternal (t);
 			filter.Refilter ();
 		}
@@ -939,10 +937,10 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 			var indexOfNewLine = t.Description.IndexOfAny (new [] { '\n', '\r' });
 			if (indexOfNewLine != -1) {
-				var iter = store.AppendValues (stock, false, t, t.Description.Remove (indexOfNewLine));
-				store.AppendValues (iter, iconEmpty, false, null, t.Description);
+				var iter = store.InsertWithValues (-1, stock, false, t, t.Description.Remove (indexOfNewLine));
+				store.InsertWithValues (iter, -1, iconEmpty, false, null, t.Description);
 			} else {
-				store.AppendValues (stock, false, t, t.Description);
+				store.InsertWithValues (-1, stock, false, t, t.Description);
 			}
 
 			UpdatePadIcon ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -88,7 +88,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 		Xwt.Drawing.Image iconWarning;
 		Xwt.Drawing.Image iconError;
 		Xwt.Drawing.Image iconInfo;
-		Xwt.Drawing.Image iconEmpty;
 
 		static readonly string restoreID = "Monodevelop.ErrorListColumns";
 		public readonly ConfigurationProperty<bool> ShowErrors = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowErrors", true);
@@ -308,7 +307,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			iconWarning = ImageService.GetIcon (Ide.Gui.Stock.Warning, Gtk.IconSize.Menu);
 			iconError = ImageService.GetIcon (Ide.Gui.Stock.Error, Gtk.IconSize.Menu);
 			iconInfo = ImageService.GetIcon (Ide.Gui.Stock.Information, Gtk.IconSize.Menu);
-			iconEmpty = ImageService.GetIcon (Ide.Gui.Stock.Empty, Gtk.IconSize.Menu);
 
 			control.Add1 (sw);
 
@@ -918,7 +916,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			var indexOfNewLine = t.Description.IndexOfAny (newlineCharacters);
 			if (indexOfNewLine != -1) {
 				var iter = store.InsertWithValues (-1, stock, false, t, t.Description.Remove (indexOfNewLine));
-				store.InsertWithValues (iter, -1, iconEmpty, false, null, t.Description);
+				store.InsertWithValues (iter, -1, CellRendererImage.NullImage, false, null, t.Description);
 			} else {
 				store.InsertWithValues (-1, stock, false, t, t.Description);
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -927,38 +927,29 @@ namespace MonoDevelop.Ide.Gui.Pads
 		void UpdateLabels()
 		{
 			UpdatePadIcon ();
-			UpdateErrorsNum ();
-			UpdateWarningsNum ();
-			UpdateMessagesNum ();
+			UpdateButtonLabel (errorBtnLbl, errorBtn, GettextCatalog.GetPluralString ("{0} Error", "{0} Errors", errorCount, errorCount));
+			UpdateButtonLabel (warnBtnLbl, warnBtn, GettextCatalog.GetPluralString ("{0} Warning", "{0} Warnings", warningCount, warningCount));
+			UpdateButtonLabel (msgBtnLbl, msgBtn, GettextCatalog.GetPluralString ("{0} Message", "{0} Messages", infoCount, infoCount));
+
+			static void UpdateButtonLabel (Label label, ToggleButton button, string text)
+			{
+				text = " " + text;
+				label.Text = text;
+				button.Accessible.SetTitle (text);
+			}
+
+			void UpdatePadIcon ()
+			{
+				if (errorCount > 0)
+					Window.Icon = "md-errors-list-has-errors";
+				else if (warningCount > 0)
+					Window.Icon = "md-errors-list-has-warnings";
+				else
+					Window.Icon = "md-errors-list";
+			}
 		}
 
-		void UpdateErrorsNum () 
-		{
-			errorBtnLbl.Text = " " + string.Format(GettextCatalog.GetPluralString("{0} Error", "{0} Errors", errorCount), errorCount);
-			errorBtn.Accessible.SetTitle (errorBtnLbl.Text);
-		}
 
-		void UpdateWarningsNum ()
-		{
-			warnBtnLbl.Text = " " + string.Format(GettextCatalog.GetPluralString("{0} Warning", "{0} Warnings", warningCount), warningCount);
-			warnBtn.Accessible.SetTitle (warnBtnLbl.Text);
-		}
-
-		void UpdateMessagesNum ()
-		{
-			msgBtnLbl.Text = " " + string.Format(GettextCatalog.GetPluralString("{0} Message", "{0} Messages", infoCount), infoCount);
-			msgBtn.Accessible.SetTitle (msgBtnLbl.Text);
-		}
-
-		void UpdatePadIcon ()
-		{
-			if (errorCount > 0)
-				Window.Icon = "md-errors-list-has-errors";
-			else if (warningCount > 0)
-				Window.Icon = "md-errors-list-has-warnings";
-			else
-				Window.Icon = "md-errors-list";
-		}
 		
 		private void ItemToggled (object o, ToggledArgs args)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -185,7 +185,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			errorBtn.Toggled += FilterChanged;
 			errorBtn.TooltipText = GettextCatalog.GetString ("Show Errors");
 			errorBtn.Accessible.Description = GettextCatalog.GetString ("Show Errors");
-			UpdateErrorsNum ();
 			toolbar.Add (errorBtn);
 
 			warnBtn = MakeButton (Stock.Warning, "toggleWarnings", ShowWarnings, out warnBtnLbl);
@@ -193,7 +192,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			warnBtn.Toggled += FilterChanged;
 			warnBtn.TooltipText = GettextCatalog.GetString ("Show Warnings");
 			warnBtn.Accessible.Description = GettextCatalog.GetString ("Show Warnings");
-			UpdateWarningsNum ();
 			toolbar.Add (warnBtn);
 
 			msgBtn = MakeButton (Stock.Information, "toggleMessages", ShowMessages, out msgBtnLbl);
@@ -201,7 +199,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			msgBtn.Toggled += FilterChanged;
 			msgBtn.TooltipText = GettextCatalog.GetString ("Show Messages");
 			msgBtn.Accessible.Description = GettextCatalog.GetString ("Show Messages");
-			UpdateMessagesNum ();
 			toolbar.Add (msgBtn);
 
 			var sep = new SeparatorToolItem ();
@@ -248,7 +245,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 
 			toolbar.ShowAll ();
 
-			UpdatePadIcon ();
+			UpdateLabels ();
 
 			IdeApp.ProjectOperations.StartBuild += OnBuildStarted;
 			IdeApp.ProjectOperations.StartClean += OnBuildStarted;
@@ -858,10 +855,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				view.ScrollToPoint (0, 0);
 			store.Clear ();
 			tasks.Clear ();
-			UpdateErrorsNum ();
-			UpdateWarningsNum ();
-			UpdateMessagesNum ();
-			UpdatePadIcon ();
+			UpdateLabels ();
 		}
 		
 		void TaskChanged (object sender, TaskEventArgs e)
@@ -887,10 +881,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				view.Model = sort;
 			}
 
-			UpdatePadIcon ();
-			UpdateErrorsNum ();
-			UpdateWarningsNum ();
-			UpdateMessagesNum ();
+			UpdateLabels ();
 		}
 		
 		public void AddTask (TaskListEntry t)
@@ -898,11 +889,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			Runtime.CheckMainThread ();
 
 			AddTaskInternal (t);
-
-			UpdatePadIcon ();
-			UpdateErrorsNum ();
-			UpdateWarningsNum ();
-			UpdateMessagesNum ();
+			UpdateLabels ();
 		}
 
 		static readonly char [] newlineCharacters = { '\n', '\r' };
@@ -935,6 +922,14 @@ namespace MonoDevelop.Ide.Gui.Pads
 			} else {
 				store.InsertWithValues (-1, stock, false, t, t.Description);
 			}
+		}
+
+		void UpdateLabels()
+		{
+			UpdatePadIcon ();
+			UpdateErrorsNum ();
+			UpdateWarningsNum ();
+			UpdateMessagesNum ();
 		}
 
 		void UpdateErrorsNum () 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -90,11 +90,11 @@ namespace MonoDevelop.Ide.Gui.Pads
 		Xwt.Drawing.Image iconInfo;
 
 		static readonly string restoreID = "Monodevelop.ErrorListColumns";
-		public readonly ConfigurationProperty<bool> ShowErrors = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowErrors", true);
-		public readonly ConfigurationProperty<bool> ShowWarnings = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowWarnings", true);
-		public readonly ConfigurationProperty<bool> ShowMessages = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowMessages", true);
-		public readonly ConfigurationProperty<double> LogSeparatorPosition = ConfigurationProperty.Create ("SharpDevelop.TaskList.LogSeparatorPosition", 0.5d);
-		public readonly ConfigurationProperty<bool> OutputViewVisible = ConfigurationProperty.Create ("SharpDevelop.TaskList.OutputViewVisible", false);
+		static readonly ConfigurationProperty<bool> ShowErrors = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowErrors", true);
+		static readonly ConfigurationProperty<bool> ShowWarnings = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowWarnings", true);
+		static readonly ConfigurationProperty<bool> ShowMessages = ConfigurationProperty.Create ("SharpDevelop.TaskList.ShowMessages", true);
+		static readonly ConfigurationProperty<double> LogSeparatorPosition = ConfigurationProperty.Create ("SharpDevelop.TaskList.LogSeparatorPosition", 0.5d);
+		static readonly ConfigurationProperty<bool> OutputViewVisible = ConfigurationProperty.Create ("SharpDevelop.TaskList.OutputViewVisible", false);
 
 		static class DataColumns
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -878,15 +878,19 @@ namespace MonoDevelop.Ide.Gui.Pads
 		{
 			Runtime.CheckMainThread ();
 
-			foreach (TaskListEntry t in tasks) {
-				AddTaskInternal (t);
+			view.Model = null;
+			try {
+				foreach (TaskListEntry t in tasks) {
+					AddTaskInternal (t);
+				}
+			} finally {
+				view.Model = sort;
 			}
+
 			UpdatePadIcon ();
 			UpdateErrorsNum ();
 			UpdateWarningsNum ();
 			UpdateMessagesNum ();
-
-			filter.Refilter ();
 		}
 		
 		public void AddTask (TaskListEntry t)
@@ -899,8 +903,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			UpdateErrorsNum ();
 			UpdateWarningsNum ();
 			UpdateMessagesNum ();
-
-			filter.Refilter ();
 		}
 
 		static readonly char [] newlineCharacters = { '\n', '\r' };

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -77,13 +77,11 @@ namespace MonoDevelop.Ide.Gui.Pads
 		Label errorBtnLbl, warnBtnLbl, msgBtnLbl, logBtnLbl;
 		SearchEntry searchEntry;
 		string currentSearchPattern = null;
-		HashSet<TaskListEntry> tasks = new HashSet<TaskListEntry> ();
+		readonly HashSet<TaskListEntry> tasks = new HashSet<TaskListEntry> ();
 		int errorCount;
 		int warningCount;
 		int infoCount;
 		bool initialLogShow = true;
-
-		Clipboard clipboard;
 
 		Xwt.Drawing.Image iconWarning;
 		Xwt.Drawing.Image iconError;
@@ -583,7 +581,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				}
 			}
 
-			clipboard = Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
+			var clipboard = Clipboard.Get (Gdk.Atom.Intern ("CLIPBOARD", false));
 			clipboard.Text = text.ToString ();
 			clipboard = Clipboard.Get (Gdk.Atom.Intern ("PRIMARY", false));
 			clipboard.Text = text.ToString ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -898,6 +898,11 @@ namespace MonoDevelop.Ide.Gui.Pads
 			foreach (TaskListEntry t in tasks) {
 				AddTaskInternal (t);
 			}
+			UpdatePadIcon ();
+			UpdateErrorsNum ();
+			UpdateWarningsNum ();
+			UpdateMessagesNum ();
+
 			filter.Refilter ();
 		}
 		
@@ -906,6 +911,12 @@ namespace MonoDevelop.Ide.Gui.Pads
 			Runtime.CheckMainThread ();
 
 			AddTaskInternal (t);
+
+			UpdatePadIcon ();
+			UpdateErrorsNum ();
+			UpdateWarningsNum ();
+			UpdateMessagesNum ();
+
 			filter.Refilter ();
 		}
 
@@ -919,17 +930,14 @@ namespace MonoDevelop.Ide.Gui.Pads
 				case TaskSeverity.Error:
 					stock = iconError;
 					errorCount++;
-					UpdateErrorsNum ();
 					break; 
 				case TaskSeverity.Warning:
 					stock = iconWarning;
 					warningCount++;
-					UpdateWarningsNum ();	
 					break;
 				default:
 					stock = iconInfo;
 					infoCount++;
-					UpdateMessagesNum ();
 					break;
 			}
 			
@@ -942,8 +950,6 @@ namespace MonoDevelop.Ide.Gui.Pads
 			} else {
 				store.InsertWithValues (-1, stock, false, t, t.Description);
 			}
-
-			UpdatePadIcon ();
 		}
 
 		void UpdateErrorsNum () 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -322,9 +322,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			logBtn.Active = OutputViewVisible;
 
 			// Load existing tasks
-			foreach (TaskListEntry t in IdeServices.TaskService.Errors) {
-				AddTask (t);
-			}
+			AddTasks (IdeServices.TaskService.Errors);
 		}
 
 		public override void Dispose ()


### PR DESCRIPTION
Removing manual loop pumping introduces an UI hang, which is why this is still a draft. Need to figure out how to optimize rendering, sorting, filtering for a scenario where 28000 warnings are added at once

Fixes VSTS #1006554 - Potential crash due to manual UI loop pumping when adding tasks