### PR TITLE
[Mac][985660] Fix NSSavePanel crash on Catalina

### DIFF
--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // MacSelectFileDialogHandler.cs
 //  
 // Author:
@@ -77,29 +77,29 @@ namespace MonoDevelop.MacIntegration
 			try {
 				using (var panel = CreatePanel (data, out var state)) {
 					bool pathAlreadySet = false;
-					//TODO: DidChangeToDirectory is broken on Catalina
-					if (MacSystemInformation.OsVersion < MacSystemInformation.Catalina) {
-						var panelClosedToken = panelClosedSource.Token;
-						panel.DidChangeToDirectory += (sender, e) => {
-							var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
-							if (string.IsNullOrEmpty (directoryPath))
-								return;
-							var selectedPath = data.OnDirectoryChanged (this, directoryPath);
-							if (selectedPath.IsNull)
-								return;
-							data.SelectedFiles = new FilePath [] { selectedPath };
-							pathAlreadySet = true;
+					var panelClosedToken = panelClosedSource.Token;
+					panel.DidChangeToDirectory += (sender, e) => {
+						// HACK: On Catalina e.NewDirectoryUrl might be NSNull instead of null
+						if (e.NewDirectoryUrl == null || ((NSObject)e.NewDirectoryUrl) is NSNull)
+							return;
+						var directoryPath = e.NewDirectoryUrl.AbsoluteString;
+						if (string.IsNullOrEmpty (directoryPath))
+							return;
+						var selectedPath = data.OnDirectoryChanged (this, directoryPath);
+						if (selectedPath.IsNull)
+							return;
+						data.SelectedFiles = new FilePath [] { selectedPath };
+						pathAlreadySet = true;
 
-							// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
-							// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
-							// in that case calling .Cancel() leaves dialog in weird state...
-							// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
-							System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate {
-								if (!panelClosedToken.IsCancellationRequested)
-									panel.Cancel (panel);
-							}, panelClosedToken, System.Threading.Tasks.TaskContinuationOptions.None, Runtime.MainTaskScheduler);
-						};
-					}
+						// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
+						// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
+						// in that case calling .Cancel() leaves dialog in weird state...
+						// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
+						System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate {
+							if (!panelClosedToken.IsCancellationRequested)
+								panel.Cancel (panel);
+						}, panelClosedToken, System.Threading.Tasks.TaskContinuationOptions.None, Runtime.MainTaskScheduler);
+					};
 
 					panel.SelectionDidChange += delegate {
 						var selection = MacSelectFileDialogHandler.GetSelectedFiles (panel);

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -28,7 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-
+using System.Threading;
 using AppKit;
 using Foundation;
 using MonoDevelop.Components;
@@ -74,8 +74,10 @@ namespace MonoDevelop.MacIntegration
 		public bool Run (OpenFileDialogData data)
 		{
 			try {
-				using (var panel = CreatePanel (data, out var state)) {
+				using (var panel = CreatePanel (data, out var state))
+				using (var panelClosedSource = new CancellationTokenSource ()) {
 					bool pathAlreadySet = false;
+					var panelClosedToken = panelClosedSource.Token;
 					panel.DidChangeToDirectory += (sender, e) => {
 						var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
 						if (string.IsNullOrEmpty (directoryPath))
@@ -90,7 +92,10 @@ namespace MonoDevelop.MacIntegration
 						// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
 						// in that case calling .Cancel() leaves dialog in weird state...
 						// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
-						System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate { panel.Cancel (panel); }, Runtime.MainTaskScheduler);
+						System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate {
+							if (!panelClosedToken.IsCancellationRequested)
+								panel.Cancel (panel);
+						}, panelClosedToken, System.Threading.Tasks.TaskContinuationOptions.None, Runtime.MainTaskScheduler);
 					};
 
 					panel.SelectionDidChange += delegate {
@@ -111,9 +116,11 @@ namespace MonoDevelop.MacIntegration
 
 					// TODO: support for data.CenterToParent, we could use sheeting.
 					if (panel.RunModal () == 0 && !pathAlreadySet) {
+						panelClosedSource.Cancel ();
 						IdeServices.DesktopService.FocusWindow (parent);
 						return false;
 					}
+					panelClosedSource.Cancel ();
 					if (!pathAlreadySet)
 						data.SelectedFiles = MacSelectFileDialogHandler.GetSelectedFiles (panel);
 

--- a/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
+++ b/main/src/addins/MacPlatform/Dialogs/MacOpenFileDialogHandler.cs
@@ -73,30 +73,33 @@ namespace MonoDevelop.MacIntegration
 
 		public bool Run (OpenFileDialogData data)
 		{
+			var panelClosedSource = MacSystemInformation.OsVersion < MacSystemInformation.Catalina ? new CancellationTokenSource () : null;
 			try {
-				using (var panel = CreatePanel (data, out var state))
-				using (var panelClosedSource = new CancellationTokenSource ()) {
+				using (var panel = CreatePanel (data, out var state)) {
 					bool pathAlreadySet = false;
-					var panelClosedToken = panelClosedSource.Token;
-					panel.DidChangeToDirectory += (sender, e) => {
-						var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
-						if (string.IsNullOrEmpty (directoryPath))
-							return;
-						var selectedPath = data.OnDirectoryChanged (this, directoryPath);
-						if (selectedPath.IsNull)
-							return;
-						data.SelectedFiles = new FilePath [] { selectedPath };
-						pathAlreadySet = true;
+					//TODO: DidChangeToDirectory is broken on Catalina
+					if (MacSystemInformation.OsVersion < MacSystemInformation.Catalina) {
+						var panelClosedToken = panelClosedSource.Token;
+						panel.DidChangeToDirectory += (sender, e) => {
+							var directoryPath = e.NewDirectoryUrl?.AbsoluteString;
+							if (string.IsNullOrEmpty (directoryPath))
+								return;
+							var selectedPath = data.OnDirectoryChanged (this, directoryPath);
+							if (selectedPath.IsNull)
+								return;
+							data.SelectedFiles = new FilePath [] { selectedPath };
+							pathAlreadySet = true;
 
-						// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
-						// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
-						// in that case calling .Cancel() leaves dialog in weird state...
-						// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
-						System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate {
-							if (!panelClosedToken.IsCancellationRequested)
-								panel.Cancel (panel);
-						}, panelClosedToken, System.Threading.Tasks.TaskContinuationOptions.None, Runtime.MainTaskScheduler);
-					};
+							// We need to call Cancel on 1ms delay so it's executed after DidChangeToDirectory event handler is finished
+							// this is needed because it's possible that DidChangeToDirectory event is executed while dialog is opening
+							// in that case calling .Cancel() leaves dialog in weird state...
+							// Fun fact: DidChangeToDirectory event is called from Open on 10.12 but not on 10.13
+							System.Threading.Tasks.Task.Delay (1).ContinueWith (delegate {
+								if (!panelClosedToken.IsCancellationRequested)
+									panel.Cancel (panel);
+							}, panelClosedToken, System.Threading.Tasks.TaskContinuationOptions.None, Runtime.MainTaskScheduler);
+						};
+					}
 
 					panel.SelectionDidChange += delegate {
 						var selection = MacSelectFileDialogHandler.GetSelectedFiles (panel);
@@ -116,11 +119,11 @@ namespace MonoDevelop.MacIntegration
 
 					// TODO: support for data.CenterToParent, we could use sheeting.
 					if (panel.RunModal () == 0 && !pathAlreadySet) {
-						panelClosedSource.Cancel ();
+						panelClosedSource?.Cancel ();
 						IdeServices.DesktopService.FocusWindow (parent);
 						return false;
 					}
-					panelClosedSource.Cancel ();
+					panelClosedSource?.Cancel ();
 					if (!pathAlreadySet)
 						data.SelectedFiles = MacSelectFileDialogHandler.GetSelectedFiles (panel);
 
@@ -138,6 +141,8 @@ namespace MonoDevelop.MacIntegration
 				}
 			} catch (Exception ex) {
 				LoggingService.LogInternalError ("Error in Open File dialog", ex);
+			} finally {
+				panelClosedSource?.Dispose ();
 			}
 			return true;
 		}


### PR DESCRIPTION
The NSSavePanel.DidChangeToDirectory event is broken on Catalina and using a custom delegate doesn't seem to be supported by Xamarin.Mac (although we don't know if that'd actually fix the crash).

This fixes a potential race with the `NSSavePanel.DidChangeToDirectory` delayed continuation and adds an additional check for `NSOpenSavePanelUrlEventArgs.NewDirectoryUrl` being NSNull, which can happen on Catalina for some unknown reason.

~and disables `NSSavePanel.DidChangeToDirectory` handling on Catalina (introduced in 5a2894490ba43c9e1056d09f39255c794facbe8d for https://github.com/mono/monodevelop/pull/3119)~.

Fixes VSTS #985660
Fixes VSTS #1015827