### PR TITLE
[Mac] Fix binding for task_info

### DIFF
--- a/main/src/addins/MacPlatform/KernelInterop.cs
+++ b/main/src/addins/MacPlatform/KernelInterop.cs
@@ -76,7 +76,7 @@ namespace MacPlatform
 			vm_info = new task_vm_info ();
 			int size;
 			unsafe {
-				// task_vm_info is the size in natural_t units
+				// task_vm_info's size in natural_t units
 				size = sizeof (task_vm_info) / 4;
 			}
 

--- a/main/src/addins/MacPlatform/KernelInterop.cs
+++ b/main/src/addins/MacPlatform/KernelInterop.cs
@@ -76,7 +76,8 @@ namespace MacPlatform
 			vm_info = new task_vm_info ();
 			int size;
 			unsafe {
-				size = sizeof (task_vm_info);
+				// task_vm_info is the size in natural_t units
+				size = sizeof (task_vm_info) / 4;
 			}
 
 			int ret = task_info (mach_task_self (), TASK_VM_INFO, ref vm_info, ref size);


### PR DESCRIPTION
It seems that the API requires the count in natural_t units, not in bytes. Fixing this, fixes the crasher in Catalina
the reason it crashes in Catalina is that in Catalina task_info tries to write more data to the output struct (for Mojave the size of the struct and the maximum size written by Mojave was the same, so it didn't matter that the size argument was too big, because Mojave would never write more than the size of the buffer anyway)

Thanks to @rolfbjarne for the investigative work