### PR TITLE
[release-8.4] Fix 988924: Some commands (save, undo) do not work if editor is detat…

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -2426,7 +2426,8 @@ namespace MonoDevelop.Components.Commands
 		Gtk.Widget GetFocusedChild (Control widget)
 		{
 			Gtk.Container container;
-
+			if (widget?.nativeWidget is AppKit.NSWindow window)
+				widget = Mac.GtkMacInterop.GetGtkWindow (window)?.Child;
 			do {
 				container = widget?.nativeWidget is Gtk.Container ? widget.GetNativeWidget<Gtk.Container> () : null;
 				if (container != null) {


### PR DESCRIPTION
…ched from IDE into its own window

Problem is that when command comes in, it first goes to CocoaTextViewControl and then up NSView treeview, problem starts when migrating to GTK treeview because GtkNSViewHost is not set as it should be, after debugging why this happens it appears that `GetFocusedChild` method wasn't returning `GtkNSViewHost` as expected, upon further debugging it turns out thats because logic of drilling down GTK treeview doesn't work because `GetFocusedChild` parameter is `NSWindow` instead of `GtkWindow`. So fix is to convert `NSWindow` to `GtkWindow` and now everything works as expected. Reason we are getting `NSWindow` instead of `GtkWindow` is somewhere in `GetActiveWindow` method, but I'm not sure if its bug or not....

Backport of #9218.

/cc @DavidKarlas 