### PR TITLE
[release-8.4] [Debugger] Explicitly check cocoaView.VisualElement.Windows != null

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/DebuggerQuickInfoSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/DebuggerQuickInfoSource.cs
@@ -177,7 +177,7 @@ namespace MonoDevelop.Debugger.VSTextView.QuickInfo
 			var bounds = view.TextViewLines.GetCharacterBounds (point);
 			var rect = new CoreGraphics.CGRect (bounds.Left - view.ViewportLeft, bounds.Top - view.ViewportTop, bounds.Width, bounds.Height);
 
-			if (cocoaView.IsClosed) {
+			if (cocoaView.IsClosed || cocoaView.VisualElement.Window == null) {
 				LoggingService.LogWarning ("Editor window has been closed before debugger tooltip was shown. How did this happen?");
 				return;
 			}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1002160/
(I hope)

Backport of #9221.

/cc @jstedfast 