### PR TITLE
[release-8.4] Fixes 1007912: Keyboard focus isn't given to Solution pad

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -331,7 +331,7 @@ namespace Gtk
 			try {
 				if (view?.Window?.FirstResponder is NSView firstResponder &&
 					view?.AncestorSharedWithView (firstResponder) == view)
-					firstResponder.Window?.MakeFirstResponder (null);
+					firstResponder.Window?.MakeFirstResponder (firstResponder.Window.ContentView);
 				return base.OnFocusOutEvent (evnt);
 			} finally {
 				LogExit ();


### PR DESCRIPTION
Focus wasn't given back to the Solution pad when the `View | Pads | Solution` command was invoked. 

Backport of #9216.

/cc @sandyarmstrong @avodovnik