### PR TITLE
[release-8.4] Fixes VSTS Bug 991658: Crashes from "Critical Gtk Errors" in log

### DIFF
--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserNavigationPoint.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserNavigationPoint.cs
@@ -23,6 +23,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#nullable enable
+
 using System;
 using System.Linq;
 using MonoDevelop.Core;
@@ -37,9 +39,9 @@ namespace MonoDevelop.AssemblyBrowser
 	class AssemblyBrowserNavigationPoint : DocumentNavigationPoint
 	{
 		List<string> definitions = new List<string> ();
-		string idString;
+		string? idString;
 
-		public AssemblyBrowserNavigationPoint (ImmutableList<AssemblyLoader> definitions, AssemblyLoader assembly, string idString) : base (assembly?.FileName)
+		public AssemblyBrowserNavigationPoint (ImmutableList<AssemblyLoader> definitions, AssemblyLoader assembly, string? idString) : base (assembly?.FileName)
 		{
 			foreach (var def in definitions) {
 				if (def != null)
@@ -89,7 +91,7 @@ namespace MonoDevelop.AssemblyBrowser
 				if (!string.IsNullOrEmpty (idString)) {
 					if (!string.IsNullOrEmpty (FileName))
 						return String.Format ("{0} : {1}", base.DisplayName, idString);
-					return idString;
+					return idString ?? "";
 				}
 				return base.DisplayName;
 			}

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserNavigationPoint.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserNavigationPoint.cs
@@ -36,12 +36,15 @@ namespace MonoDevelop.AssemblyBrowser
 {
 	class AssemblyBrowserNavigationPoint : DocumentNavigationPoint
 	{
-		ImmutableList<AssemblyLoader> definitions;
+		List<string> definitions = new List<string> ();
 		string idString;
 
 		public AssemblyBrowserNavigationPoint (ImmutableList<AssemblyLoader> definitions, AssemblyLoader assembly, string idString) : base (assembly?.FileName)
 		{
-			this.definitions = definitions;
+			foreach (var def in definitions) {
+				if (def != null)
+					this.definitions.Add (def.FileName);
+			}
 			this.idString = idString;
 		}
 
@@ -52,12 +55,13 @@ namespace MonoDevelop.AssemblyBrowser
 			if (idString != null) {
 				var view = result.GetContent<AssemblyBrowserViewContent> ();
 				view.Widget.suspendNavigation = true;
-				view.EnsureDefinitionsLoaded (definitions);
+				foreach (var def in definitions) {
+					view.Widget.AddReferenceByFileName (def);
+				}
 				view.Open (idString, expandNode: false);
 			} else if (FileName != null) {
 				var view = result.GetContent<AssemblyBrowserViewContent> ();
 				view.Widget.suspendNavigation = true;
-				view.EnsureDefinitionsLoaded (definitions);
 				view.Load (FileName);
 			}
 			return result;

--- a/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
+++ b/main/src/addins/MonoDevelop.AssemblyBrowser/MonoDevelop.AssemblyBrowser/AssemblyBrowserViewContent.cs
@@ -102,11 +102,6 @@ namespace MonoDevelop.AssemblyBrowser
 			}
 		}
 
-		internal void EnsureDefinitionsLoaded (ImmutableList<AssemblyLoader> definitions)
-		{
-			widget.EnsureDefinitionsLoaded (definitions);
-		}
-
 		protected override void OnDispose ()
 		{
 			if (cts != null) {


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/991658

AssemblyBrowser navigation points were broken. The assembly
definitions are disposed on close so the definitions need to be
reloaded using file names.

Backport of #9072.

/cc @sevoku @mkrueger