### PR TITLE
[release-8.4] Bump Roslyn to 3.4.0-beta4-19556-02

### DIFF
--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.4.0-beta3-19525-13</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.4.0-beta4-19556-02</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating Roslyn to 20191106.2 ([24c9587](https://www.github.com/dotnet/roslyn/commit/24c9587))

[Changes](https://github.com/dotnet/roslyn/compare/b8a5611...24c9587?w=1) since [b8a5611](https://www.github.com/dotnet/roslyn/commit/b8a5611):
- [Merge pull request #39680 from JoeRobich/fix-uithread-check](https://www.github.com/dotnet/roslyn/pull/39680)
- [Merge pull request #39675 from dotnet/move-16.4-to-beta4](https://www.github.com/dotnet/roslyn/pull/39675)
- [Merge pull request #39639 from dotnet/revert-39587-use-vs-core-sdk](https://www.github.com/dotnet/roslyn/pull/39639)
- [Merge pull request #39638 from JoeRobich/fix-test-strings](https://www.github.com/dotnet/roslyn/pull/39638)
- [Merge pull request #39642 from JoeRobich/skip-int-tests](https://www.github.com/dotnet/roslyn/pull/39642)
- [Merge pull request #39607 from jasonmalinowski/fix-null-textsnapshot-crashes](https://www.github.com/dotnet/roslyn/pull/39607)
- [Merge pull request #39594 from mavasani/FixRPSIssue](https://www.github.com/dotnet/roslyn/pull/39594)
- [Subscribe to OnModuleInstanceLoad/OnModuleInstanceUnload events only when managed debugging is being used. (#39568)](https://www.github.com/dotnet/roslyn/pull/39568)
- [Merge pull request #39576 from 333fred/iusingdeclarationoperation](https://www.github.com/dotnet/roslyn/pull/39576)
- [Merge pull request #39573 from dustincoleman/release/dev16.4-vs-deps](https://www.github.com/dotnet/roslyn/pull/39573)
- [Merge pull request #39587 from JoeRobich/use-vs-core-sdk](https://www.github.com/dotnet/roslyn/pull/39587)
- [Merge pull request #39532 from JoeRobich/is-packageservice-enabled](https://www.github.com/dotnet/roslyn/pull/39532)
- [Make sure to consume MaxLanguageVersion in legacy style projects as well (#39486)](https://www.github.com/dotnet/roslyn/pull/39486)

Backport of #9253.

/cc @sandyarmstrong 