### PR TITLE
[Core] Support generating a binlog for any MSBuild target

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProcessService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProcessService.cs
@@ -34,6 +34,12 @@ namespace MonoDevelop.Projects.MSBuild
 {
 	public static class MSBuildProcessService
 	{
+		/// <summary>
+		/// Allows the MSBuild process start to be intercepted and monitored.
+		/// </summary>
+		public static Func<string, string, string, TextWriter, TextWriter, EventHandler, ProcessWrapper>
+			StartProcessHandler { get; set; } = Runtime.ProcessService.StartProcess;
+
 		public static ProcessWrapper StartMSBuild (string arguments, string workingDirectory, TextWriter outWriter, TextWriter errorWriter, EventHandler exited)
 		{
 			FilePath msbuildBinPath = GetMSBuildBinPath ();
@@ -49,7 +55,7 @@ namespace MonoDevelop.Projects.MSBuild
 				arguments = argumentsBuilder.ToString ();
 			}
 
-			return Runtime.ProcessService.StartProcess (
+			return StartProcessHandler (
 				command,
 				arguments,
 				workingDirectory,

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProcessService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildProcessService.cs
@@ -34,11 +34,12 @@ namespace MonoDevelop.Projects.MSBuild
 {
 	public static class MSBuildProcessService
 	{
+		public delegate ProcessWrapper StartProcessCallback (string command, string arguments, string workingDirectory, TextWriter outWriter, TextWriter errorWriter, EventHandler exited);
+
 		/// <summary>
 		/// Allows the MSBuild process start to be intercepted and monitored.
 		/// </summary>
-		public static Func<string, string, string, TextWriter, TextWriter, EventHandler, ProcessWrapper>
-			StartProcessHandler { get; set; } = Runtime.ProcessService.StartProcess;
+		public static StartProcessCallback StartProcessHandler { get; set; } = Runtime.ProcessService.StartProcess;
 
 		public static ProcessWrapper StartMSBuild (string arguments, string workingDirectory, TextWriter outWriter, TextWriter errorWriter, EventHandler exited)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -91,6 +91,7 @@ namespace MonoDevelop.Projects.MSBuild
 			TextWriter logWriter,
 			MSBuildLogger logger,
 			MSBuildVerbosity verbosity,
+			string binLogFilePath,
 			string[] runTargets,
 			string[] evaluateItems,
 			string[] evaluateProperties,
@@ -105,7 +106,7 @@ namespace MonoDevelop.Projects.MSBuild
 
 			try {
 				BeginOperation ();
-				var res = await SendRun (configurations, loggerId, logger.EnabledEvents, verbosity, runTargets, evaluateItems, evaluateProperties, globalProperties, taskId).ConfigureAwait (false);
+				var res = await SendRun (configurations, loggerId, logger.EnabledEvents, verbosity, binLogFilePath, runTargets, evaluateItems, evaluateProperties, globalProperties, taskId).ConfigureAwait (false);
 				if (res == null && cancellationToken.IsCancellationRequested) {
 					MSBuildTargetResult err = new MSBuildTargetResult (file, false, "", "", file, 1, 1, 1, 1, "Build cancelled", "");
 					return new MSBuildResult (new [] { err });
@@ -170,7 +171,7 @@ namespace MonoDevelop.Projects.MSBuild
 			return connection.SendMessage (new RefreshWithContentRequest { ProjectId = projectId, Content = projectContent });
 		}
 
-		async Task<MSBuildResult> SendRun (ProjectConfigurationInfo [] configurations, int loggerId, MSBuildEvent enabledLogEvents, MSBuildVerbosity verbosity, string [] runTargets, string [] evaluateItems, string [] evaluateProperties, Dictionary<string, string> globalProperties, int taskId)
+		async Task<MSBuildResult> SendRun (ProjectConfigurationInfo [] configurations, int loggerId, MSBuildEvent enabledLogEvents, MSBuildVerbosity verbosity, string binLogFilePath, string [] runTargets, string [] evaluateItems, string [] evaluateProperties, Dictionary<string, string> globalProperties, int taskId)
 		{
 			var msg = new RunProjectRequest {
 				ProjectId = projectId,
@@ -182,7 +183,8 @@ namespace MonoDevelop.Projects.MSBuild
 				EvaluateItems = evaluateItems,
 				EvaluateProperties = evaluateProperties,
 				GlobalProperties = globalProperties,
-				TaskId = taskId
+				TaskId = taskId,
+				BinLogFilePath = binLogFilePath
 			};
 
 			var res = await connection.SendMessage (msg);
@@ -293,13 +295,14 @@ namespace MonoDevelop.Projects.MSBuild
 			TextWriter logWriter,
 			MSBuildLogger logger,
 			MSBuildVerbosity verbosity,
+			string binLogFilePath,
 			string [] runTargets,
 			string [] evaluateItems,
 			string [] evaluateProperties,
 			Dictionary<string, string> globalProperties,
 			CancellationToken cancellationToken
 		) {
-			return builder.Run (configurations, logWriter, logger, verbosity, runTargets, evaluateItems, evaluateProperties, globalProperties, cancellationToken);
+			return builder.Run (configurations, logWriter, logger, verbosity, binLogFilePath, runTargets, evaluateItems, evaluateProperties, globalProperties, cancellationToken);
 		}
 
 		public void Dispose ()
@@ -317,6 +320,7 @@ namespace MonoDevelop.Projects.MSBuild
 			TextWriter logWriter,
 			MSBuildLogger logger,
 			MSBuildVerbosity verbosity,
+			string binLogFilePath,
 			string [] runTargets,
 			string [] evaluateItems,
 			string [] evaluateProperties,

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/Project.cs
@@ -1509,7 +1509,7 @@ namespace MonoDevelop.Projects
 				var logger = context.Loggers.Count != 1 ? new ProxyLogger (this, context.Loggers) : context.Loggers.First ();
 
 				try {
-					result = await builder.Run (configs, monitor.Log, logger, context.LogVerbosity, targets, evaluateItems, evaluateProperties, globalProperties, monitor.CancellationToken).ConfigureAwait (false);
+					result = await builder.Run (configs, monitor.Log, logger, context.LogVerbosity, context.BinLogFilePath, targets, evaluateItems, evaluateProperties, globalProperties, monitor.CancellationToken).ConfigureAwait (false);
 				} finally {
 					builder.Dispose ();
 					t1.End ();

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/TargetEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/TargetEvaluationContext.cs
@@ -56,6 +56,8 @@ namespace MonoDevelop.Projects
 			get { return loggers; }
 		}
 
+		public string BinLogFilePath { get; set; }
+
 		/// <summary>
 		/// Gets or sets the builder queue to be used to execute the target
 		/// </summary>

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.Shared.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/BuildEngine.Shared.cs
@@ -200,7 +200,7 @@ namespace MonoDevelop.Projects.MSBuild
 			var pb = GetProject (msg.ProjectId);
 			if (pb != null) {
 				var logger = msg.LogWriterId != -1 ? (IEngineLogWriter) new LogWriter (msg.LogWriterId, msg.EnabledLogEvents) : (IEngineLogWriter) new NullLogWriter ();
-				var res = pb.Run (msg.Configurations, logger, msg.Verbosity, msg.RunTargets, msg.EvaluateItems, msg.EvaluateProperties, msg.GlobalProperties, msg.TaskId);
+				var res = pb.Run (msg.Configurations, logger, msg.Verbosity, msg.BinLogFilePath, msg.RunTargets, msg.EvaluateItems, msg.EvaluateProperties, msg.GlobalProperties, msg.TaskId);
 				return new RunProjectResponse { Result = res };
 			}
 			return msg.CreateResponse ();

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/MSBuildLoggerAdapter.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/MSBuildLoggerAdapter.cs
@@ -93,6 +93,14 @@ namespace MonoDevelop.Projects.MSBuild
 			get { return results; }
 		}
 
+		public void AddLogger (ILogger logger)
+		{
+			var newLoggers = new ILogger [loggers.Length + 1];
+			Array.Copy (loggers, newLoggers, loggers.Length);
+			newLoggers [loggers.Length] = logger;
+			loggers = newLoggers;
+		}
+
 		void Initialize (IEventSource eventSource)
 		{
 			this.eventSource = eventSource;

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/ProjectBuilder.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Projects.MSBuild
 		}
 
 		public MSBuildResult Run (
-			ProjectConfigurationInfo[] configurations, IEngineLogWriter logWriter, MSBuildVerbosity verbosity,
+			ProjectConfigurationInfo[] configurations, IEngineLogWriter logWriter, MSBuildVerbosity verbosity, string binLogFilePath,
 			string[] runTargets, string[] evaluateItems, string[] evaluateProperties, Dictionary<string,string> globalProperties, int taskId)
 		{
 			if (runTargets == null || runTargets.Length == 0)
@@ -71,8 +71,16 @@ namespace MonoDevelop.Projects.MSBuild
 				if (buildEngine.BuildOperationStarted) {
 					loggerAdapter = buildEngine.StartProjectSessionBuild (logWriter);
 				}
-				else
+				else {
 					loggerAdapter = new MSBuildLoggerAdapter (logWriter, verbosity);
+					if (!string.IsNullOrEmpty (binLogFilePath)) {
+						var binaryLogger = new BinaryLogger {
+							Parameters = binLogFilePath,
+							Verbosity = LoggerVerbosity.Diagnostic
+						};
+						loggerAdapter.AddLogger (binaryLogger);
+					}
+				}
 
 				try {
 					project = SetupProject (configurations);

--- a/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/RemoteBuildEngineMessages.cs
+++ b/main/src/core/MonoDevelop.Projects.Formats.MSBuild/MonoDevelop.Projects.MSBuild/RemoteBuildEngineMessages.cs
@@ -144,6 +144,9 @@ namespace MonoDevelop.Projects.MSBuild
 
 		[MessageDataProperty]
 		public int TaskId { get; set; }
+
+		[MessageDataProperty]
+		public string BinLogFilePath { get; set; }
 	}
 
 	[MessageDataTypeAttribute]

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
@@ -418,6 +418,7 @@ namespace MonoDevelop.Projects
 								new StringWriter (),
 								new MSBuildLogger (),
 								MSBuildVerbosity.Quiet,
+								null,
 								new [] { "ResolveAssemblyReferences" },
 								new string [0],
 								new string [0],


### PR DESCRIPTION
Previously a binlog file would only be generated if a Build was run.
Now it is possible to have a binlog generated for any MSBuild target.
The filename for the bin log can be specified when running an MSBuild
target by setting the TargetEvaluationContext's BinLogFilePath.

Note that setting the BinLogFilePath if a build session is in progress
will not have any affect, the build session's binlog overrides this
setting.

Also support advanced scenarios where the running of MSBuild directly
can be intercepted and monitored. This is done by adding a handler
to the MSBuildProcessService which by default will call the
Runtime.ProcessService's StartProcess. This allows binlogs to be generated when MSBuild is run directly not in the build host.

Allows the Project System Tools addin (similar to that available for Visual Studio on Windows) to support showing a binlog for all MSBuild targets:

<img width="1055" alt="BuildLogging2" src="https://user-images.githubusercontent.com/372361/68482229-fcbaae80-0230-11ea-9001-745e5627d714.png">