### PR TITLE
[Debugger] Optimize debugger tooltip resizing

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/PinnedWatches/PinnedWatchView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/PinnedWatches/PinnedWatchView.cs
@@ -126,8 +126,8 @@ namespace MonoDevelop.Debugger.VSTextView.PinnedWatches
 
 			var origin = textView.ConvertPointFromView (Frame.Location, this);
 			var maxHeight = NMath.Max (textView.Frame.Bottom - origin.Y, treeView.RowHeight * 2);
-			var height = treeView.FittingSize.Height;
-			var width = treeView.Frame.Width;
+			var height = (treeView.RowHeight + treeView.IntercellSpacing.Height) * treeView.RowCount;
+			var width = treeView.OptimalTooltipWidth;
 
 			height = NMath.Min (height, maxHeight);
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.Debugger
 				View = scrollView
 			};
 
-			widthConstraint = scrollView.WidthAnchor.ConstraintEqualToAnchor (treeView.WidthAnchor);
+			widthConstraint = scrollView.WidthAnchor.ConstraintEqualToConstant (treeView.Frame.Width);
 			widthConstraint.Active = true;
 
 			heightConstraint = scrollView.HeightAnchor.ConstraintEqualToConstant (treeView.Frame.Height);
@@ -108,12 +108,16 @@ namespace MonoDevelop.Debugger
 
 		void OnTreeViewResized (object sender, EventArgs e)
 		{
-			Console.WriteLine ("OnTreeViewResized: treeView.Frame.Width = {0}", treeView.Frame.Width);
+			var height = (treeView.RowHeight + treeView.IntercellSpacing.Height) * treeView.RowCount;
 			var maxHeight = GetMaxHeight (treeView.Window);
-			var height = treeView.FittingSize.Height;
 
 			height = NMath.Min (height, maxHeight);
 
+			Console.WriteLine ("OnTreeViewResized()");
+			Console.WriteLine ("\told size = {0}x{1}", widthConstraint.Constant, heightConstraint.Constant);
+			Console.WriteLine ("\tnew size = {0}x{1}", treeView.OptimalTooltipWidth, height);
+
+			widthConstraint.Constant = treeView.OptimalTooltipWidth;
 			heightConstraint.Constant = height;
 		}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
@@ -113,10 +113,6 @@ namespace MonoDevelop.Debugger
 
 			height = NMath.Min (height, maxHeight);
 
-			Console.WriteLine ("OnTreeViewResized()");
-			Console.WriteLine ("\told size = {0}x{1}", widthConstraint.Constant, heightConstraint.Constant);
-			Console.WriteLine ("\tnew size = {0}x{1}", treeView.OptimalTooltipWidth, height);
-
 			widthConstraint.Constant = treeView.OptimalTooltipWidth;
 			heightConstraint.Constant = height;
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
@@ -108,6 +108,7 @@ namespace MonoDevelop.Debugger
 
 		void OnTreeViewResized (object sender, EventArgs e)
 		{
+			Console.WriteLine ("OnTreeViewResized: treeView.Frame.Width = {0}", treeView.Frame.Width);
 			var maxHeight = GetMaxHeight (treeView.Window);
 			var height = treeView.FittingSize.Height;
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
@@ -158,6 +158,22 @@ namespace MonoDevelop.Debugger
 			return new NSAttributedString (text ?? string.Empty, strokeColor: NSColor.PlaceholderTextColor);
 		}
 
+		protected static nfloat GetWidthForString (NSFont font, string text, int sizeDelta = 0)
+		{
+			NSFont modified = null;
+			nfloat width;
+
+			if (sizeDelta != 0)
+				modified = NSFont.FromDescription (font.FontDescriptor, font.PointSize + sizeDelta);
+
+			using (var str = new NSAttributedString (text, font: modified ?? font))
+				width = str.Size.Width;
+
+			modified?.Dispose ();
+
+			return width;
+		}
+
 		protected void UpdateFont (NSControl control, int sizeDelta = 0)
 		{
 			var font = TreeView.CustomFont;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectCellViewBase.cs
@@ -171,7 +171,7 @@ namespace MonoDevelop.Debugger
 
 			modified?.Dispose ();
 
-			return width;
+			return NMath.Ceiling (width + 2);
 		}
 
 		protected void UpdateFont (NSControl control, int sizeDelta = 0)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectTypeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectTypeView.cs
@@ -58,11 +58,12 @@ namespace MonoDevelop.Debugger
 
 		protected override void UpdateContents ()
 		{
-			TextField.StringValue = Node?.TypeName ?? string.Empty;
-			UpdateFont (TextField);
-			TextField.SizeToFit ();
+			var value = Node?.TypeName ?? string.Empty;
 
-			OptimalWidth = MarginSize + TextField.Frame.Width + MarginSize;
+			TextField.StringValue = value;
+			UpdateFont (TextField);
+
+			OptimalWidth = MarginSize + GetWidthForString (TextField.Font, value) + MarginSize;
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
@@ -319,7 +319,6 @@ namespace MonoDevelop.Debugger
 		public static nfloat GetOptimalWidth (MacObjectValueTreeView treeView, ObjectValueNode node, bool hideValueButton)
 		{
 			nfloat optimalWidth = MarginSize;
-
 			string evaluateStatusIcon = null;
 			string valueButtonText = null;
 			var showViewerButton = false;
@@ -390,8 +389,8 @@ namespace MonoDevelop.Debugger
 
 			// Third Item: Value Button
 			if (valueButtonText != null && !hideValueButton) {
-				// FIXME: what left/right padding do we need to add for the button around the button label? 6px?
-				optimalWidth += GetWidthForString (treeView.CustomFont, valueButtonText, -3) + 6;
+				// FIXME: what left/right padding do we need to add for the button around the button label? 4px?
+				optimalWidth += GetWidthForString (treeView.CustomFont, valueButtonText, -3) + 4;
 				optimalWidth += RowCellSpacing;
 			}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
@@ -116,6 +116,7 @@ namespace MonoDevelop.Debugger
 			constraints.Clear ();
 
 			bool selected = Superview is NSTableRowView rowView && rowView.Selected;
+			var wrapper = (MacObjectValueNode) ObjectValue;
 			var editable = TreeView.GetCanEditNode (Node);
 			var textColor = NSColor.ControlText;
 			string evaluateStatusIcon = null;
@@ -236,7 +237,7 @@ namespace MonoDevelop.Debugger
 				constraints.Add (colorPreview.HeightAnchor.ConstraintEqualToConstant (ImageSize));
 				views.Add (colorPreview);
 
-				OptimalWidth += colorPreview.Frame.Width;
+				OptimalWidth += ImageSize;
 				OptimalWidth += RowCellSpacing;
 			} else if (colorPreviewVisible) {
 				colorPreview.RemoveFromSuperview ();
@@ -288,7 +289,8 @@ namespace MonoDevelop.Debugger
 			TextField.TextColor = textColor;
 			TextField.Editable = editable;
 			UpdateFont (TextField);
-			TextField.SizeToFit ();
+
+			OptimalWidth += GetWidthForString (TextField.Font, strval);
 
 			constraints.Add (TextField.CenterYAnchor.ConstraintEqualToAnchor (CenterYAnchor));
 			views.Add (TextField);
@@ -308,8 +310,103 @@ namespace MonoDevelop.Debugger
 			foreach (var constraint in constraints)
 				constraint.Active = true;
 
-			OptimalWidth += TextField.Frame.Width;
 			OptimalWidth += MarginSize;
+
+			wrapper.OptimalValueFont = TreeView.CustomFont;
+			wrapper.OptimalValueWidth = OptimalWidth;
+		}
+
+		public static nfloat GetOptimalWidth (MacObjectValueTreeView treeView, ObjectValueNode node, bool hideValueButton)
+		{
+			nfloat optimalWidth = MarginSize;
+
+			string evaluateStatusIcon = null;
+			string valueButtonText = null;
+			var showViewerButton = false;
+			Color? previewColor = null;
+			bool showSpinner = false;
+			string strval;
+
+			if (node.IsUnknown) {
+				if (treeView.DebuggerService.Frame != null) {
+					strval = GettextCatalog.GetString ("The name '{0}' does not exist in the current context.", node.Name);
+				} else {
+					strval = string.Empty;
+				}
+				evaluateStatusIcon = Ide.Gui.Stock.Warning;
+			} else if (node.IsError || node.IsNotSupported) {
+				evaluateStatusIcon = Ide.Gui.Stock.Warning;
+				strval = node.Value ?? string.Empty;
+				int i = strval.IndexOf ('\n');
+				if (i != -1)
+					strval = strval.Substring (0, i);
+			} else if (node.IsImplicitNotSupported) {
+				strval = string.Empty;//val.Value; with new "Show Value" button we don't want to display message "Implicit evaluation is disabled"
+				if (node.CanRefresh)
+					valueButtonText = GettextCatalog.GetString ("Show Value");
+			} else if (node.IsEvaluating) {
+				strval = GettextCatalog.GetString ("Evaluating\u2026");
+				showSpinner = true;
+			} else if (node.IsEnumerable) {
+				if (node is ShowMoreValuesObjectValueNode) {
+					valueButtonText = GettextCatalog.GetString ("Show More");
+				} else {
+					valueButtonText = GettextCatalog.GetString ("Show Values");
+				}
+				strval = string.Empty;
+			} else if (node is AddNewExpressionObjectValueNode) {
+				strval = string.Empty;
+			} else {
+				strval = treeView.Controller.GetDisplayValueWithVisualisers (node, out showViewerButton);
+
+				var val = node.GetDebuggerObjectValue ();
+				if (val != null && !val.IsNull && DebuggingService.HasGetConverter<Color> (val)) {
+					try {
+						previewColor = DebuggingService.GetGetConverter<Color> (val).GetValue (val);
+					} catch {
+						previewColor = null;
+					}
+				}
+			}
+
+			strval = strval.Replace ("\r\n", " ").Replace ("\n", " ");
+
+			// First item: Status Icon -or- Spinner
+			if (evaluateStatusIcon != null) {
+				optimalWidth += ImageSize;
+				optimalWidth += RowCellSpacing;
+			}
+
+			if (showSpinner) {
+				optimalWidth += ImageSize;
+				optimalWidth += RowCellSpacing;
+			}
+
+			// Second Item: Color Preview
+			if (previewColor.HasValue) {
+				optimalWidth += ImageSize;
+				optimalWidth += RowCellSpacing;
+			}
+
+			// Third Item: Value Button
+			if (valueButtonText != null && !hideValueButton) {
+				// FIXME: what left/right padding do we need to add for the button around the button label? 6px?
+				optimalWidth += GetWidthForString (treeView.CustomFont, valueButtonText, -3) + 6;
+				optimalWidth += RowCellSpacing;
+			}
+
+			// Fourth Item: Viewer Button
+			if (showViewerButton) {
+				optimalWidth += treeView.CompactView ? CompactImageSize : ImageSize;
+				optimalWidth += RowCellSpacing;
+			}
+
+			// Fifth Item: Text Value
+			optimalWidth += GetWidthForString (treeView.CustomFont, strval);
+
+			optimalWidth += MarginSize;
+
+			return optimalWidth;
 		}
 
 		void OnValueButtonActivated (object sender, EventArgs e)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueNode.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueNode.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 
+using AppKit;
 using Foundation;
 
 namespace MonoDevelop.Debugger
@@ -39,12 +40,47 @@ namespace MonoDevelop.Debugger
 		public readonly List<MacObjectValueNode> Children = new List<MacObjectValueNode> ();
 		public readonly MacObjectValueNode Parent;
 		public readonly ObjectValueNode Target;
+		public nfloat OptimalValueWidth;
+		public NSFont OptimalValueFont;
+		public nfloat OptimalNameWidth;
+		public NSFont OptimalNameFont;
+		public nfloat OptimalXOffset;
 		public bool HideValueButton;
 
 		public MacObjectValueNode (MacObjectValueNode parent, ObjectValueNode target)
 		{
+			OptimalValueWidth = -1.0f;
+			OptimalNameWidth = -1.0f;
+			OptimalValueFont = null;
+			OptimalNameFont = null;
+			OptimalXOffset = -1.0f;
 			Parent = parent;
 			Target = target;
+		}
+
+		public void Measure (MacObjectValueTreeView treeView)
+		{
+			if (OptimalXOffset < 0) {
+				nfloat offset = 17.0f;
+				var node = Target;
+
+				while (!(node.Parent is RootObjectValueNode)) {
+					node = node.Parent;
+					offset += 16.0f;
+				}
+
+				OptimalXOffset = offset;
+			}
+
+			if (OptimalNameFont != treeView.CustomFont || OptimalNameWidth < 0) {
+				OptimalNameWidth = MacDebuggerObjectNameView.GetOptimalWidth (treeView, Target);
+				OptimalNameFont = treeView.CustomFont;
+			}
+
+			if (OptimalValueFont != treeView.CustomFont || OptimalValueWidth < 0) {
+				OptimalValueWidth = MacDebuggerObjectValueView.GetOptimalWidth (treeView, Target, HideValueButton);
+				OptimalValueFont = treeView.CustomFont;
+			}
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -213,11 +213,20 @@ namespace MonoDevelop.Debugger
 			}
 		}
 
+		/// <summary>
+		/// Gets the optimal tooltip window width in order to display the name/value/pin columns w/o truncation.
+		/// </summary>
+		public nfloat OptimalTooltipWidth {
+			get; private set;
+		}
+
 		// Note: this resizing method is the one used by debugger tooltips and pinned watches in the editor
 		void OptimizeColumnSizes (bool emitResized = true)
 		{
 			if (!compactView || Superview == null || RowCount == 0)
 				return;
+
+			Console.WriteLine ("OptimizeColumnSizes({0})", emitResized);
 
 			nfloat nameWidth = MinimumNameColumnWidth;
 			nfloat valueWidth = MinimumValueColumnWidth;
@@ -237,31 +246,32 @@ namespace MonoDevelop.Debugger
 
 			bool changed = false;
 
-			if (nameColumn.Width != nameWidth) {
+			if ((int) nameColumn.Width != (int) nameWidth) {
 				nameColumn.MinWidth = nameColumn.Width = nameWidth;
 				changed = true;
 			}
 
-			if (valueColumn.Width != valueWidth) {
+			if ((int) valueColumn.Width != (int) valueWidth) {
 				valueColumn.MinWidth = valueColumn.Width = valueWidth;
 				changed = true;
 			}
 
+			Console.WriteLine ("\tchanged = {0}", changed);
+
 			if (changed) {
-				var optimalWidth = nameColumn.Width + valueColumn.Width + pinColumn.Width;
-				Console.WriteLine ("OptimizeColumnWidths: optimal width = {0}", optimalWidth);
+				var optimalTooltipWidth = nameWidth + valueWidth + pinColumn.Width + IntercellSpacing.Width * 2;
 
-				var size = Frame.Size;
-				size.Width = optimalWidth;
-				SetFrameSize (size);
+				Console.WriteLine ("\tOptimalTooltipWidth: old = {0}, new = {1}", OptimalTooltipWidth, optimalTooltipWidth);
 
-				//SizeToFit ();
+				OptimalTooltipWidth = optimalTooltipWidth;
 
 				if (emitResized)
 					OnResized ();
+
+				SizeToFit ();
 			}
 
-			ReloadData ();
+			//ReloadData ();
 			SetNeedsDisplayInRect (Frame);
 		}
 
@@ -321,24 +331,28 @@ namespace MonoDevelop.Debugger
 		public override void ViewDidMoveToSuperview ()
 		{
 			base.ViewDidMoveToSuperview ();
+			Console.WriteLine ("ViewDidMoveToSuperview()");
 			OptimizeColumnSizes ();
 		}
 
 		public override void ViewDidMoveToWindow ()
 		{
 			base.ViewDidMoveToWindow ();
+			Console.WriteLine ("ViewDidMoveToWindow()");
 			OptimizeColumnSizes ();
 		}
 
 		public override void ViewDidEndLiveResize ()
 		{
 			base.ViewDidEndLiveResize ();
+			Console.WriteLine ("ViewDidEndLiveResize()");
 			OptimizeColumnSizes ();
 		}
 
 		public override void ViewDidUnhide ()
 		{
 			base.ViewDidHide ();
+			Console.WriteLine ("ViewDidUnhide()");
 			OptimizeColumnSizes ();
 		}
 
@@ -355,6 +369,7 @@ namespace MonoDevelop.Debugger
 
 		public override void ExpandItem (NSObject item, bool expandChildren)
 		{
+			Console.WriteLine ("ExpandItem(item, expandChildren = {0})", expandChildren);
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item, expandChildren);
@@ -365,6 +380,7 @@ namespace MonoDevelop.Debugger
 
 		public override void ExpandItem (NSObject item)
 		{
+			Console.WriteLine ("ExpandItem(item)");
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item);
@@ -385,6 +401,7 @@ namespace MonoDevelop.Debugger
 
 		public override void CollapseItem (NSObject item, bool collapseChildren)
 		{
+			Console.WriteLine ("CollapseItem(item, collapseChildren = {0})", collapseChildren);
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item, collapseChildren);
@@ -395,6 +412,7 @@ namespace MonoDevelop.Debugger
 
 		public override void CollapseItem (NSObject item)
 		{
+			Console.WriteLine ("CollapseItem(item)");
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item);
@@ -549,6 +567,7 @@ namespace MonoDevelop.Debugger
 				return;
 
 			dataSource.Replace (node, replacementNodes);
+			Console.WriteLine ("OnEvaluationCompleted()");
 			OptimizeColumnSizes (false);
 			OnResized ();
 		}
@@ -564,6 +583,7 @@ namespace MonoDevelop.Debugger
 				return;
 
 			dataSource.ReloadChildren (node);
+			Console.WriteLine ("OnChildrenLoaded()");
 			OptimizeColumnSizes (false);
 			OnResized ();
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -247,12 +247,12 @@ namespace MonoDevelop.Debugger
 			bool changed = false;
 
 			if ((int) nameColumn.Width != (int) nameWidth) {
-				nameColumn.MinWidth = nameColumn.Width = nameWidth;
+				nameColumn.Width = nameWidth;
 				changed = true;
 			}
 
 			if ((int) valueColumn.Width != (int) valueWidth) {
-				valueColumn.MinWidth = valueColumn.Width = valueWidth;
+				valueColumn.Width = valueWidth;
 				changed = true;
 			}
 
@@ -267,8 +267,6 @@ namespace MonoDevelop.Debugger
 
 				if (emitResized)
 					OnResized ();
-
-				SizeToFit ();
 			}
 
 			//ReloadData ();

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -223,30 +223,16 @@ namespace MonoDevelop.Debugger
 			nfloat valueWidth = MinimumValueColumnWidth;
 
 			for (nint row = 0; row < RowCount; row++) {
-				var rowView = GetRowView (row, true);
+				var item = (MacObjectValueNode) ItemAtRow (row);
 
-				if (rowView == null)
-					continue;
+				item.Measure (this);
 
-				var nameView = (MacDebuggerObjectNameView) rowView.ViewAtColumn (0);
+				var totalNameWidth = item.OptimalXOffset + item.OptimalNameWidth;
+				if (totalNameWidth > nameWidth)
+					nameWidth = NMath.Min (totalNameWidth, nameColumn.MaxWidth);
 
-				if (nameView != null) {
-					// Note: the Name column's X-offset is the width of the expander which we need to take that into account
-					// when calculating the Name column's width.
-					var width = nameView.Frame.X + nameView.OptimalWidth;
-
-					if (width > nameWidth)
-						nameWidth = NMath.Min (width, nameColumn.MaxWidth);
-				}
-
-				var valueView = (MacDebuggerObjectValueView) rowView.ViewAtColumn (1);
-
-				if (valueView != null) {
-					var width = valueView.OptimalWidth;
-
-					if (width > valueWidth)
-						valueWidth = NMath.Min (width, valueColumn.MaxWidth);
-				}
+				if (item.OptimalValueWidth > valueWidth)
+					valueWidth = NMath.Min (item.OptimalValueWidth, valueColumn.MaxWidth);
 			}
 
 			bool changed = false;
@@ -262,7 +248,14 @@ namespace MonoDevelop.Debugger
 			}
 
 			if (changed) {
-				SizeToFit ();
+				var optimalWidth = nameColumn.Width + valueColumn.Width + pinColumn.Width;
+				Console.WriteLine ("OptimizeColumnWidths: optimal width = {0}", optimalWidth);
+
+				var size = Frame.Size;
+				size.Width = optimalWidth;
+				SetFrameSize (size);
+
+				//SizeToFit ();
 
 				if (emitResized)
 					OnResized ();

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -221,7 +221,7 @@ namespace MonoDevelop.Debugger
 		}
 
 		// Note: this resizing method is the one used by debugger tooltips and pinned watches in the editor
-		void OptimizeColumnSizes (bool emitResized = true)
+		void OptimizeColumnSizes ()
 		{
 			if (!compactView || Superview == null || RowCount == 0)
 				return;
@@ -257,11 +257,11 @@ namespace MonoDevelop.Debugger
 			if (changed) {
 				var optimalTooltipWidth = nameWidth + valueWidth + pinColumn.Width + IntercellSpacing.Width * 2;
 				OptimalTooltipWidth = optimalTooltipWidth;
-
-				if (emitResized)
-					OnResized ();
 			}
 
+			// we almost always need to recalculate the size - particularly if the widths don't
+			// change but the row count did.
+			OnResized ();
 			SetNeedsDisplayInRect (Frame);
 		}
 
@@ -318,21 +318,9 @@ namespace MonoDevelop.Debugger
 		{
 		}
 
-		public override void ViewDidMoveToSuperview ()
-		{
-			base.ViewDidMoveToSuperview ();
-			OptimizeColumnSizes ();
-		}
-
 		public override void ViewDidMoveToWindow ()
 		{
 			base.ViewDidMoveToWindow ();
-			OptimizeColumnSizes ();
-		}
-
-		public override void ViewDidEndLiveResize ()
-		{
-			base.ViewDidEndLiveResize ();
 			OptimizeColumnSizes ();
 		}
 
@@ -359,8 +347,7 @@ namespace MonoDevelop.Debugger
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item, expandChildren);
 			NSAnimationContext.EndGrouping ();
-			OptimizeColumnSizes (false);
-			OnResized ();
+			OptimizeColumnSizes ();
 		}
 
 		public override void ExpandItem (NSObject item)
@@ -369,8 +356,7 @@ namespace MonoDevelop.Debugger
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item);
 			NSAnimationContext.EndGrouping ();
-			OptimizeColumnSizes (false);
-			OnResized ();
+			OptimizeColumnSizes ();
 		}
 
 		/// <summary>
@@ -389,8 +375,7 @@ namespace MonoDevelop.Debugger
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item, collapseChildren);
 			NSAnimationContext.EndGrouping ();
-			OptimizeColumnSizes (false);
-			OnResized ();
+			OptimizeColumnSizes ();
 		}
 
 		public override void CollapseItem (NSObject item)
@@ -399,8 +384,7 @@ namespace MonoDevelop.Debugger
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item);
 			NSAnimationContext.EndGrouping ();
-			OptimizeColumnSizes (false);
-			OnResized ();
+			OptimizeColumnSizes ();
 		}
 
 		/// <summary>
@@ -549,8 +533,7 @@ namespace MonoDevelop.Debugger
 				return;
 
 			dataSource.Replace (node, replacementNodes);
-			OptimizeColumnSizes (false);
-			OnResized ();
+			OptimizeColumnSizes ();
 		}
 
 		public void LoadEvaluatedNode (ObjectValueNode node, ObjectValueNode[] replacementNodes)
@@ -564,8 +547,7 @@ namespace MonoDevelop.Debugger
 				return;
 
 			dataSource.ReloadChildren (node);
-			OptimizeColumnSizes (false);
-			OnResized ();
+			OptimizeColumnSizes ();
 		}
 
 		public void LoadNodeChildren (ObjectValueNode node, int startIndex, int count)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -226,8 +226,6 @@ namespace MonoDevelop.Debugger
 			if (!compactView || Superview == null || RowCount == 0)
 				return;
 
-			Console.WriteLine ("OptimizeColumnSizes({0})", emitResized);
-
 			nfloat nameWidth = MinimumNameColumnWidth;
 			nfloat valueWidth = MinimumValueColumnWidth;
 
@@ -256,20 +254,14 @@ namespace MonoDevelop.Debugger
 				changed = true;
 			}
 
-			Console.WriteLine ("\tchanged = {0}", changed);
-
 			if (changed) {
 				var optimalTooltipWidth = nameWidth + valueWidth + pinColumn.Width + IntercellSpacing.Width * 2;
-
-				Console.WriteLine ("\tOptimalTooltipWidth: old = {0}, new = {1}", OptimalTooltipWidth, optimalTooltipWidth);
-
 				OptimalTooltipWidth = optimalTooltipWidth;
 
 				if (emitResized)
 					OnResized ();
 			}
 
-			//ReloadData ();
 			SetNeedsDisplayInRect (Frame);
 		}
 
@@ -329,28 +321,24 @@ namespace MonoDevelop.Debugger
 		public override void ViewDidMoveToSuperview ()
 		{
 			base.ViewDidMoveToSuperview ();
-			Console.WriteLine ("ViewDidMoveToSuperview()");
 			OptimizeColumnSizes ();
 		}
 
 		public override void ViewDidMoveToWindow ()
 		{
 			base.ViewDidMoveToWindow ();
-			Console.WriteLine ("ViewDidMoveToWindow()");
 			OptimizeColumnSizes ();
 		}
 
 		public override void ViewDidEndLiveResize ()
 		{
 			base.ViewDidEndLiveResize ();
-			Console.WriteLine ("ViewDidEndLiveResize()");
 			OptimizeColumnSizes ();
 		}
 
 		public override void ViewDidUnhide ()
 		{
 			base.ViewDidHide ();
-			Console.WriteLine ("ViewDidUnhide()");
 			OptimizeColumnSizes ();
 		}
 
@@ -367,7 +355,6 @@ namespace MonoDevelop.Debugger
 
 		public override void ExpandItem (NSObject item, bool expandChildren)
 		{
-			Console.WriteLine ("ExpandItem(item, expandChildren = {0})", expandChildren);
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item, expandChildren);
@@ -378,7 +365,6 @@ namespace MonoDevelop.Debugger
 
 		public override void ExpandItem (NSObject item)
 		{
-			Console.WriteLine ("ExpandItem(item)");
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item);
@@ -399,7 +385,6 @@ namespace MonoDevelop.Debugger
 
 		public override void CollapseItem (NSObject item, bool collapseChildren)
 		{
-			Console.WriteLine ("CollapseItem(item, collapseChildren = {0})", collapseChildren);
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item, collapseChildren);
@@ -410,7 +395,6 @@ namespace MonoDevelop.Debugger
 
 		public override void CollapseItem (NSObject item)
 		{
-			Console.WriteLine ("CollapseItem(item)");
 			NSAnimationContext.BeginGrouping ();
 			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item);
@@ -565,7 +549,6 @@ namespace MonoDevelop.Debugger
 				return;
 
 			dataSource.Replace (node, replacementNodes);
-			Console.WriteLine ("OnEvaluationCompleted()");
 			OptimizeColumnSizes (false);
 			OnResized ();
 		}
@@ -581,7 +564,6 @@ namespace MonoDevelop.Debugger
 				return;
 
 			dataSource.ReloadChildren (node);
-			Console.WriteLine ("OnChildrenLoaded()");
 			OptimizeColumnSizes (false);
 			OnResized ();
 		}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ShowMoreValuesObjectValueNode.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ShowMoreValuesObjectValueNode.cs
@@ -34,6 +34,7 @@ namespace MonoDevelop.Debugger
 		public ShowMoreValuesObjectValueNode (ObjectValueNode enumerableNode) : base (string.Empty)
 		{
 			EnumerableNode = enumerableNode;
+			Parent = enumerableNode;
 		}
 
 		public override bool IsEnumerable => true;


### PR DESCRIPTION
Fixes VSTS 1002713

Fixes issues with the tooltip sizing on catalina. Speeds up the calculation of the column widths and fixes a NRE when expanding using the "show values", "more values" buttons.

this also fixes VSTS 1011400