### PR TITLE
[release-8.4] Fixes drag and drop in toolbox when current event is IntPtr.Zero

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/ToolboxPad.cs
@@ -130,12 +130,10 @@ namespace MonoDevelop.DesignerSupport
 				// Gtk.Application.CurrentEvent and other copied gdk_events seem to have a problem
 				// when used as they use gdk_event_copy which seems to crash on de-allocating the private slice.
 				IntPtr currentEvent = GtkWorkarounds.GetCurrentEventHandle ();
-				if (currentEvent != IntPtr.Zero) {
-					Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent, false));
+				Gtk.Drag.Begin (widget, targets, Gdk.DragAction.Copy | Gdk.DragAction.Move, 1, new Gdk.Event (currentEvent, false));
 
-					// gtk_drag_begin does not store the event, so we're okay
-					GtkWorkarounds.FreeEvent (currentEvent);
-				}
+				// gtk_drag_begin does not store the event, so we're okay
+				GtkWorkarounds.FreeEvent (currentEvent);
 			}
 		}
 


### PR DESCRIPTION
This commit reverts https://github.com/mono/monodevelop/commit/9fdbbcf765427e48a894d96d0aeab2354a587b74which introduces a regression
doing a drag and drop in cases where the current event is IntPtr.Zero

reopening https://devdiv.visualstudio.com/DevDiv/_workitems/edit/998490

Backport of #9276.

/cc @netonjm 