### PR TITLE
[Debugger] Simplify PinnedWatchView, allow scrolling children via popover

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
@@ -78,6 +78,11 @@ namespace MonoDevelop.Debugger
 			treeView.Resized += OnTreeViewResized;
 		}
 
+		public void Expand ()
+		{
+			treeView.ExpandItem (treeView.ItemAtRow (0), false);
+		}
+
 		public DebuggerSession GetDebuggerSession ()
 		{
 			return controller.GetStackFrame ()?.DebuggerSession;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -191,9 +191,11 @@ namespace MonoDevelop.Debugger
 		public PinnedWatch PinnedWatch {
 			get => pinnedWatch;
 			set {
-				if (pinnedWatch != value) {
+				if (pinnedWatch != value && pinColumn != null) {
 					pinnedWatch = value;
 					Runtime.RunInMainThread (() => {
+						if (pinColumn == null)
+							return;
 						if (value == null) {
 							pinColumn.MinWidth = pinColumn.MaxWidth = pinColumn.Width = MacDebuggerObjectPinView.MinWidth;
 						} else {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeViewDataSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeViewDataSource.cs
@@ -75,11 +75,13 @@ namespace MonoDevelop.Debugger
 
 			parent.Children.Add (value);
 
-			foreach (var child in node.Children)
-				Add (value, child);
+			if (treeView.AllowExpanding) {
+				foreach (var child in node.Children)
+					Add (value, child);
 
-			if (node.HasChildren && !node.ChildrenLoaded)
-				Add (value, new LoadingObjectValueNode (node));
+				if (node.HasChildren && !node.ChildrenLoaded)
+					Add (value, new LoadingObjectValueNode (node));
+			}
 		}
 
 		void Insert (MacObjectValueNode parent, int index, ObjectValueNode node)
@@ -89,11 +91,13 @@ namespace MonoDevelop.Debugger
 
 			parent.Children.Insert (index, value);
 
-			foreach (var child in node.Children)
-				Add (value, child);
+			if (treeView.AllowExpanding) {
+				foreach (var child in node.Children)
+					Add (value, child);
 
-			if (node.HasChildren && !node.ChildrenLoaded)
-				Add (value, new LoadingObjectValueNode (node));
+				if (node.HasChildren && !node.ChildrenLoaded)
+					Add (value, new LoadingObjectValueNode (node));
+			}
 		}
 
 		void Remove (MacObjectValueNode node, List<MacObjectValueNode> removed)


### PR DESCRIPTION
Currently, the editor intercepts scrolling events that an adornment
such as the PinnedWatchView might want to receive. This prevents such an
adornment from being properly scrollable.

Looking at how pinned watches work on Windows, however, the watch itself
cannot be expanded. Rather, the user can click an expand button to see
the child items in a popup. Inspired by this, I have removed scrolling
and expansion from the PinnedWatchView, and made it so hovering a watch
shows the same popover tooltip (which _is_ scrollable, as it's a child
window) that one sees when hovering a value in the editor.

A few notes:

* Changed the data source to not add child nodes at all when
  `AllowExpanding` is not set on the tree view. This ensures there will
  be no disclosure triangle.
* Pinned watches whose values do not have children will not get a
  tooltip.
* When hovering a pinned watch, the root node will always be expanded.
* The only way to dismiss the watch's popover tooltip is to press ESC
  or click elsewhere. This actually feels pretty good.
* Child expansion state in the tooltip is preserved as long as the watch
  remains pinned.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999603

---

this also fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999610