### PR TITLE
[Ide][Mac] Fix several focus contrast issues with Gtk

### DIFF
--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -465,6 +465,14 @@ style "spin-button" = "wider"
 style "link-label-fix"
 {
     base[PRELIGHT] = @bg_color # disable link hover background
+    GtkWidget::focus-padding = 0
+
+    engine "xamarin" {
+        rgba = TRUE
+        roundness = 0
+        focusstyle = 2
+        focus_color = @focus_ring_color
+    }
 }
 
 

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -163,8 +163,14 @@ style "button" = "default" {
 style "dialog-button" = "button" {
     GtkButton::inner-border = { 7, 7, 3, 4 }
 
+    text[NORMAL] = @selected_fg_color
+    text[PRELIGHT] = @selected_fg_color
+    text[SELECTED] = @selected_fg_color
+    text[INSENSITIVE] = @dim_color
+    text[ACTIVE] = @selected_fg_color
+
     engine "xamarin" {
-        default_button_color = "#51ADF3"
+        default_button_color = "#508AF5"
     }
 }
 

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac
@@ -19,7 +19,8 @@ selected_bg_color: #2862d9
 selected_fg_color: #fff
 tooltip_bg_color: #f2f2f2
 tooltip_fg_color: #272727
-tooltip_border_color: #b2b2b2"
+tooltip_border_color: #b2b2b2
+focus_ring_color: #8eaff0"
 
 gtk-button-images = 0
 gtk-menu-images = 0
@@ -136,7 +137,7 @@ style "wider" = "default" {
 }
 
 style "button" = "default" {
-    xthickness = 2
+    xthickness = 4
     ythickness = 4
 
     font_name = "-apple-system-font 12"
@@ -145,13 +146,14 @@ style "button" = "default" {
     bg[PRELIGHT] = @base_color # Mac buttons have no hover state
 
     GtkWidget::focus-padding = 0
-    GtkWidget::focus-line-width = 1
+    GtkWidget::focus-line-width = 2
 
     engine "xamarin" {
         border_shades = {1.4, 1.3}
         rgba = FALSE
         contrast = 1.0
-        focus_color = shade(0.6, @bg_color)
+        focus_color = @focus_ring_color
+        focusstyle = 3
         textstyle = 0
         highlight_shade = 1.0
         lightborder_shade = 1.0
@@ -172,7 +174,6 @@ style "toggle-button" = "button" {
     engine "xamarin" {
         rgba = FALSE
         contrast = 1.0
-        focus_color = shade(0.6, @bg_color)
         textstyle = 1
     }
 }

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -172,6 +172,12 @@ style "button" = "default" {
 style "dialog-button" = "button" {
     GtkButton::inner-border = { 7, 7, 3, 4 }
 
+    text[NORMAL] = @selected_fg_color
+    text[PRELIGHT] = @selected_fg_color
+    text[SELECTED] = @selected_fg_color
+    text[INSENSITIVE] = @dim_color
+    text[ACTIVE] = @selected_fg_color
+
     engine "xamarin" {
         default_button_color = "#2d65d3"
     }

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -19,7 +19,8 @@ selected_bg_color: #2257c9
 selected_fg_color: #fff
 tooltip_bg_color: #5a5a5a
 tooltip_fg_color: #d2d5cd
-tooltip_border_color: #b2b2b2"
+tooltip_border_color: #b2b2b2
+focus_ring_color: #45739e"
 
 gtk-button-images = 0
 gtk-menu-images = 0
@@ -137,7 +138,7 @@ style "wider" = "default" {
 }
 
 style "button" = "default" {
-    xthickness = 2
+    xthickness = 4
     ythickness = 4
 
     font_name = "-apple-system-font 12"
@@ -154,12 +155,12 @@ style "button" = "default" {
 
     GtkWidget::draw-border = { 1, 1, 1, 1 }
     GtkWidget::focus-padding = 0
-    GtkWidget::focus-line-width = 1
+    GtkWidget::focus-line-width = 2
 
     engine "xamarin" {
         rgba = FALSE
         contrast = 1.0
-        focus_color = shade(1.4, @bg_color)
+        focus_color = @focus_ring_color
         focusstyle = 3
         textstyle = 0
         highlight_shade = 1.0
@@ -185,7 +186,6 @@ style "toggle-button" = "button" {
         rgba = FALSE
         contrast = 1.0
         gradient_shades = {0.96, 0.918, 0.926, 0.858}
-        focus_color = shade(0.6, @bg_color)
         textstyle = 1
     }
 }

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -426,6 +426,14 @@ style "spin-button" = "wider"
 style "link-label-fix"
 {
     base[PRELIGHT] = @bg_color # disable link hover background
+    GtkWidget::focus-padding = 0
+
+    engine "xamarin" {
+        rgba = TRUE
+        roundness = 0
+        focusstyle = 2
+        focus_color = @focus_ring_color
+    }
 }
 
 

--- a/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
+++ b/main/src/core/MonoDevelop.Ide/gtkrc.mac-dark
@@ -173,7 +173,7 @@ style "dialog-button" = "button" {
     GtkButton::inner-border = { 7, 7, 3, 4 }
 
     engine "xamarin" {
-        default_button_color = "#397cae"
+        default_button_color = "#2d65d3"
     }
 }
 


### PR DESCRIPTION
### Updated "Default" Gtk.Button colors

||old|new|
| --- | --- | --- |
|**light**|<img width="153" alt="grafik" src="https://user-images.githubusercontent.com/951587/68770919-53582c00-0627-11ea-9b2b-e977dc43e37a.png">|<img width="154" alt="grafik" src="https://user-images.githubusercontent.com/951587/68770864-3c193e80-0627-11ea-8948-dd2f6d88071d.png">|
|**dark**||<img width="158" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771253-f9a43180-0627-11ea-8542-74168984dba0.png">|

### Updated Gtk.Button Focus design

||old|new|
| --- | --- | --- |
|**light**|<img width="76" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771531-7f27e180-0628-11ea-99b1-80c0541e0b97.png"><img width="77" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771546-87801c80-0628-11ea-8c22-7cb0f6bc4212.png">|<img width="80" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771472-5d2e5f00-0628-11ea-9223-806f2e2c96f6.png"><img width="80" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771484-66b7c700-0628-11ea-856c-4c3202bf3f8c.png">|
|**dark**||<img width="82" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771386-3839ec00-0628-11ea-9130-7ac07ccd5603.png"><img width="78" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771406-41c35400-0628-11ea-9778-f0f125b63cea.png">|

### not ideal but yet visible link label focus
||old|new|
| --- | --- | --- |
|**light**|<img width="134" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771711-ce6e1200-0628-11ea-98b6-4cf509d62297.png">|<img width="134" alt="grafik" src="https://user-images.githubusercontent.com/951587/68771762-e8a7f000-0628-11ea-87ff-66f350b16838.png">|



This depends on https://github.com/mono/xamarin-gtk-theme/pull/35 through https://github.com/mono/mono/pull/17785

Fixes VSTS #750448
Fixes VSTS #753559