### PR TITLE
[release-8.4] Revert "Implement Go To Definition for Razor"

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.Ide.Completion.Presentation/MonoDevelopContainedDocument.cs
@@ -54,8 +54,6 @@ namespace MonoDevelop.Ide.Completion.Presentation
 		public IMonoDevelopContainedLanguageHost ContainedLanguageHost { get; private set; }
 		private readonly HostType _hostType;
 
-		public IProjectionBuffer TopBuffer => DataBuffer;
-
 		// _workspace will only be set once the Workspace is available
 		private Workspace _workspace;
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/IMonoDevelopHostDocument.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/IMonoDevelopHostDocument.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Projection;
 
 namespace MonoDevelop.Ide.TypeSystem
 {
@@ -16,8 +15,6 @@ namespace MonoDevelop.Ide.TypeSystem
 		/// Updates the text of the document.
 		/// </summary>
 		void UpdateText (SourceText newText);
-
-		IProjectionBuffer TopBuffer { get; }
 	}
 
 	static class MonoDevelopHostDocumentRegistration


### PR DESCRIPTION
This reverts commit d0ec47952e2d2beadf1176e4be69cea35720a2c7.

It broke some normal usage of Go To Definition for C# files.

Backport of #9288.

/cc @sandyarmstrong 