### PR TITLE
[Debugger] Improve Breakpoint dialog accessibility

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
@@ -127,8 +127,8 @@ namespace MonoDevelop.Debugger
 			Task.Run (LoadExceptionList);
 			Initialize ();
 			SetInitialData ();
-			SetAccessibility ();
 			SetLayout ();
+			SetAccessibility ();
 			if (be == null) {
 				switch (breakpointType) {
 				case BreakpointType.Location:
@@ -671,14 +671,17 @@ namespace MonoDevelop.Debugger
 		{
 			var accessible = breakpointActionPause.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.Pause";
+			accessible.LabelWidget = actionLabel;
 			accessible.Description = GettextCatalog.GetString ("Cause the program to pause when the breakpoint is hit");
 
 			accessible = breakpointActionPrint.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.Print";
+			accessible.LabelWidget = actionLabel;
 			accessible.Description = GettextCatalog.GetString ("Cause the program to print a message and continue when the breakpoint is hit");
 
 			accessible = entryPrintExpression.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.PrintExpression";
+			accessible.LabelWidget = actionLabel;
 			accessible.Label = GettextCatalog.GetString ("Breakpoint Expression");
 			accessible.Description = GettextCatalog.GetString ("Enter the expression you wish to have printed to the console. Place simple C# expressions within {} to interpolate them.");
 
@@ -731,21 +734,22 @@ namespace MonoDevelop.Debugger
 
 			accessible = ignoreHitType.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.HitType";
-			accessible.Label = GettextCatalog.GetString ("Breakpoint Hit Count Type");
+			accessible.LabelWidget = advancedLabel;
 			accessible.Description = GettextCatalog.GetString ("Select a hit count condition for this breakpoint");
 
 			accessible = ignoreHitCount.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.HitCount";
-			accessible.Label = GettextCatalog.GetString ("Hit Count");
+			accessible.Label = GettextCatalog.GetString ("Condition Hit Count");
 			accessible.Description = GettextCatalog.GetString ("Enter the hit count required for the condition");
 
 			accessible = conditionalHitType.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.ConditionalHit";
-			accessible.Label = GettextCatalog.GetString ("Conditional Breakpoint Hit Type");
+			accessible.LabelWidget = advancedLabel;
 			accessible.Description = GettextCatalog.GetString ("Select an extra condition for this breakpoint");
 
 			accessible = entryConditionalExpression.Accessible;
 			accessible.Identifier = "BreakpointPropertiesDialog.ConditionEntry";
+			accessible.LabelWidget = advancedLabel;
 			accessible.Label = GettextCatalog.GetString ("Conditional Breakpoint Expression");
 			accessible.Description = GettextCatalog.GetString ("Enter a C# boolean expression to act as a condition for this breakpoint. The scope of the expression is local to the breakpoint");
 
@@ -754,13 +758,15 @@ namespace MonoDevelop.Debugger
 			accessible.Description = GettextCatalog.GetString ("There is a warning for the condition expression");
 		}
 
+		Label actionLabel, whenLabel, advancedLabel;
+
 		void SetLayout ()
 		{
 			var vbox = new VBox ();
 			vbox.Accessible.Role = Xwt.Accessibility.Role.Filler;
 			vbox.MinWidth = 450;
 
-			var actionLabel = new Label (GettextCatalog.GetString ("Breakpoint Action")) {
+			actionLabel = new Label (GettextCatalog.GetString ("Breakpoint Action")) {
 				Font = vbox.Font.WithWeight (FontWeight.Bold)
 			};
 			vbox.PackStart (actionLabel);
@@ -792,7 +798,7 @@ namespace MonoDevelop.Debugger
 
 			vbox.PackStart (breakpointActionGroup);
 
-			var whenLabel = new Label (GettextCatalog.GetString ("When to Take Action")) {
+			whenLabel = new Label (GettextCatalog.GetString ("When to Take Action")) {
 				Font = vbox.Font.WithWeight (FontWeight.Bold)
 			};
 			vbox.PackStart (whenLabel);
@@ -839,7 +845,7 @@ namespace MonoDevelop.Debugger
 			}
 			vbox.PackStart (whenToTakeActionRadioGroup);
 
-			var advancedLabel = new Label (GettextCatalog.GetString ("Advanced Conditions")) {
+			advancedLabel = new Label (GettextCatalog.GetString ("Advanced Conditions")) {
 				Font = vbox.Font.WithWeight (FontWeight.Bold)
 			};
 			vbox.PackStart (advancedLabel);


### PR DESCRIPTION
Use LabelWidget rather than Label for combo boxes,
because Label is also used to reflect combo box
selections with AtkCocoa.

Also add some more accessibility label relations.

Fixes VSTS #1018518