### PR TITLE
[release-8.4] [Debugger] Add more Begin/End Updates around tree manipulation

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
@@ -77,9 +77,13 @@ namespace MonoDevelop.Debugger
 			DebuggerLoggingService.LogMessage ("End Local Variables");
 
 			if (UseNewTreeView) {
-				controller.ClearValues ();
-				controller.AddValues (locals);
-
+				_treeview.BeginUpdates ();
+				try {
+					controller.ClearValues ();
+					controller.AddValues (locals);
+				} finally {
+					_treeview.EndUpdates ();
+				}
 #if ADD_FAKE_NODES
 				AddFakeNodes ();
 #endif

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeViewDataSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeViewDataSource.cs
@@ -255,10 +255,14 @@ namespace MonoDevelop.Debugger
 			var range = new NSRange (0, count);
 			var indexes = NSIndexSet.FromNSRange (range);
 
+			treeView.BeginUpdates ();
+
 			treeView.RemoveItems (indexes, null, NSTableViewAnimation.None);
 
 			for (int i = 0; i < removed.Count; i++)
 				removed[i].Dispose ();
+
+			treeView.EndUpdates ();
 		}
 
 		public void Append (ObjectValueNode node)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValuePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValuePad.cs
@@ -44,6 +44,8 @@ namespace MonoDevelop.Debugger
 
 		protected ObjectValueTreeViewController controller;
 		protected ObjectValueTreeView tree;
+		// this is for the new treeview
+		protected MacObjectValueTreeView _treeview;
 
 		readonly Control control;
 		PadFontChanger fontChanger;
@@ -69,6 +71,7 @@ namespace MonoDevelop.Debugger
 				if (Platform.IsMac) {
 					LoggingService.LogInfo ("Using MacObjectValueTreeView for {0}", allowWatchExpressions ? "Watch Pad" : "Locals Pad");
 					var treeView = controller.GetMacControl ();
+					_treeview = treeView;
 
 					fontChanger = new PadFontChanger (treeView, treeView.SetCustomFont, treeView.QueueResize);
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/WatchPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/WatchPad.cs
@@ -89,11 +89,16 @@ namespace MonoDevelop.Debugger
 			controller.ExpressionAdded -= OnExpressionAdded;
 
 			try {
-				// remove the expressions because we're going to rebuild them
-				controller.ClearAll ();
+				_treeview.BeginUpdates ();
+				try {
+					// remove the expressions because we're going to rebuild them
+					controller.ClearAll ();
 
-				// re-add the expressions which will reevaluate the expressions and repopulate the treeview
-				controller.AddExpressions (expressions);
+					// re-add the expressions which will reevaluate the expressions and repopulate the treeview
+					controller.AddExpressions (expressions);
+				} finally {
+					_treeview.EndUpdates ();
+				}
 			} finally {
 				controller.ExpressionAdded += OnExpressionAdded;
 			}


### PR DESCRIPTION
Simplest guess for VSTS 1004450

I'm not going to claim this as a fix, but it is possibly related and, without some larger refactoring, seems to be the simplest of the guesses that we have for those crashes. Also, related changes in column sizing code might be related and offer fixes (if the crashes were in tooltips or pinned watches, which we can't tell because it's the same code for all cases).

In any case, we should add these begin/end updates around code where we manipulate the tree items. 

---
related:

VSTS 1008044

Backport of #9290.

/cc @sgmunn 