### PR TITLE
Fix focus problems in Select References Dialog

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/SelectReferenceDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/SelectReferenceDialog.cs
@@ -250,7 +250,6 @@ namespace MonoDevelop.Ide.Projects
 		
 		void InsertFilterEntry ()
 		{
-			filterEntry.KeyPressEvent += HandleFilterEntryKeyPressEvent;
 			filterEntry.Activated += HandleFilterEntryActivated;
 			filterEntry.Changed += delegate {
 				foreach (var p in panels)
@@ -264,15 +263,6 @@ namespace MonoDevelop.Ide.Projects
 			mainBook.ChildFocus (DirectionType.TabForward);
 		}
 
-		void HandleFilterEntryKeyPressEvent (object o, KeyPressEventArgs args)
-		{
-			if (args.Event.Key == Gdk.Key.Tab) {
-				mainBook.HasFocus = true;
-				mainBook.ChildFocus (DirectionType.TabForward);
-				args.RetVal = true;
-			}
-		}
-		
 		protected override void OnShown ()
 		{
 			base.OnShown ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/SelectReferenceDialog.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/SelectReferenceDialog.cs
@@ -276,7 +276,6 @@ namespace MonoDevelop.Ide.Projects
 		protected override void OnShown ()
 		{
 			base.OnShown ();
-			filterEntry.HasFocus = true;
 		}
 		
 		protected override bool OnKeyPressEvent (Gdk.EventKey evnt)


### PR DESCRIPTION
This partially fixes VSTS #750236 (along with https://github.com/mono/monodevelop/pull/6926)

fe25a99ffeee2503c7f0be0a8cfbccdf27c80a8c fixes the initial focus of the dialog so it's on the notebook tabs and not the search entry

e48c2bf61005f5ab938bc6922583ec033aef300e fixes a focus chain issue that caused the notebook tab to get focused twice when tabbing through the dialog. It seemed like it was an AtkCocoa issue of the notebook being registered twice or something, but it turned out to be because of a keyboard filter.