### PR TITLE
Refactor how virtual and dynamic documents are added to the workspace.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/DynamicFileManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/DynamicFileManager.cs
@@ -141,7 +141,7 @@ namespace MonoDevelop.Ide.TypeSystem
 					}
 				}
 
-				projectInfo = projectInfo.WithAdditionalDocuments(documents);
+				projectInfo = projectInfo.WithDocuments(projectInfo.Documents.Concat(documents));
 				return projectInfo;
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.ProjectSystemHandler.cs
@@ -167,6 +167,12 @@ namespace MonoDevelop.Ide.TypeSystem
 					return null;
 				}
 
+				IEnumerable<DocumentInfo> documents = projectDocuments.Documents;
+				var virtualDocuments = workspace.GetVirtualDocuments (projectId);
+				if (virtualDocuments.Any ()) {
+					documents = documents.Concat (virtualDocuments);
+				}
+
 				// TODO: Pass in the WorkspaceMetadataFileReferenceResolver
 				var info = ProjectInfo.Create (
 					projectId,
@@ -180,7 +186,7 @@ namespace MonoDevelop.Ide.TypeSystem
 					null, // defaultNamespace
 					cp?.CreateCompilationOptions (),
 					cp?.CreateParseOptions (config),
-					projectDocuments.Documents,
+					documents,
 					cacheInfo.ProjectReferences,
 					cacheInfo.References.Select (x => x.CurrentSnapshot),
 					analyzerReferences: cacheInfo.AnalyzerFiles.SelectAsArray (x => {
@@ -194,6 +200,9 @@ namespace MonoDevelop.Ide.TypeSystem
 					hostObjectType: null,
 					hasAllInformation: true
 				);
+
+				info = workspace.WithDynamicDocuments (p, info);
+
 				return info;
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -323,18 +323,13 @@ namespace MonoDevelop.Ide.TypeSystem
 		/// <summary>
 		/// Razor (.cshtml) needs to be able to add C# documents to a project that are not backed by a file on disk.
 		/// As these don't come from the project system, we need to keep track of these documents to readd them
-		/// manually every time the project is reloaded from disk.
+		/// manually every time the project is loaded from disk.
 		/// </summary>
-		internal ProjectInfo AddVirtualDocuments(ProjectInfo projectInfo)
+		internal IEnumerable<DocumentInfo> GetVirtualDocuments (ProjectId projectId)
 		{
 			lock (virtualDocuments) {
-				var virtualDocumentsToAdd = virtualDocuments.Where (d => d.Id.ProjectId == projectInfo.Id);
-				if (virtualDocumentsToAdd.Any ()) {
-					projectInfo = projectInfo.WithDocuments (projectInfo.Documents.Concat (virtualDocumentsToAdd));
-				}
+				return virtualDocuments.Where (d => d.Id.ProjectId == projectId).ToList ();
 			}
-
-			return projectInfo;
 		}
 
 		// This is called by OnProjectRemoved.
@@ -513,7 +508,6 @@ namespace MonoDevelop.Ide.TypeSystem
 							OnProjectAdded (projectInfo);
 						} else {
 							lock (projectModifyLock) {
-								projectInfo = AddVirtualDocuments (projectInfo);
 								OnProjectReloaded (projectInfo);
 							}
 						}
@@ -1514,8 +1508,6 @@ namespace MonoDevelop.Ide.TypeSystem
 								try {
 									lock (projectModifyLock) {
 										ProjectInfo newProjectContents = t.Result;
-										newProjectContents = WithDynamicDocuments (project, newProjectContents);
-										newProjectContents = AddVirtualDocuments (newProjectContents);
 										OnProjectReloaded (newProjectContents);
 										foreach (var docId in GetOpenDocumentIds (newProjectContents.Id).ToArray ()) {
 											if (CurrentSolution.GetDocument (docId) == null) {
@@ -1538,11 +1530,13 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		internal ProjectInfo WithDynamicDocuments (MonoDevelop.Projects.DotNetProject project, ProjectInfo projectInfo)
+		internal ProjectInfo WithDynamicDocuments (MonoDevelop.Projects.Project project, ProjectInfo projectInfo)
 		{
-			var contentItems = project.MSBuildProject.EvaluatedItems.Where(item => item.Name == "Content" && item.Include.EndsWith(".razor", StringComparison.OrdinalIgnoreCase)).Select(item => item.Include);
+			var contentItems = project.MSBuildProject.EvaluatedItems
+				.Where (item => item.Name == "Content" && item.Include.EndsWith (".razor", StringComparison.OrdinalIgnoreCase))
+				.Select (item => item.Include);
 
-			return dynamicFileManager?.UpdateDynamicFiles(projectInfo, contentItems, this);
+			return dynamicFileManager?.UpdateDynamicFiles (projectInfo, contentItems, this);
 		}
 
 		internal override void SetDocumentContext (DocumentId documentId)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1532,11 +1532,26 @@ namespace MonoDevelop.Ide.TypeSystem
 
 		internal ProjectInfo WithDynamicDocuments (MonoDevelop.Projects.Project project, ProjectInfo projectInfo)
 		{
+			var projectDirectory = Path.GetDirectoryName (project.FileName);
+
 			var contentItems = project.MSBuildProject.EvaluatedItems
 				.Where (item => item.Name == "Content" && item.Include.EndsWith (".razor", StringComparison.OrdinalIgnoreCase))
-				.Select (item => item.Include);
+				.Select (item => GetAbsolutePath(item.Include))
+				.ToList ();
 
 			return dynamicFileManager?.UpdateDynamicFiles (projectInfo, contentItems, this);
+
+			string GetAbsolutePath (string relativePath)
+			{
+				if (!Path.IsPathRooted (relativePath)) {
+					relativePath = Path.Combine (projectDirectory, relativePath);
+				}
+
+				// normalize the path separator characters in case they're mixed
+				relativePath = relativePath.Replace ('\\', Path.DirectorySeparatorChar);
+
+				return relativePath;
+			}
 		}
 
 		internal override void SetDocumentContext (DocumentId documentId)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService_WorkspaceHandling.cs
@@ -564,7 +564,6 @@ namespace MonoDevelop.Ide.TypeSystem
 						var projectInfo = await ws.LoadProject (project, CancellationToken.None, oldProject, framework);
 						if (oldProject != null) {
 							if (oldProjectIds.Remove (projectInfo.Id)) {
-								projectInfo = ws.AddVirtualDocuments (projectInfo);
 								ws.OnProjectReloaded (projectInfo);
 							} else {
 								ws.OnProjectAdded (projectInfo);


### PR DESCRIPTION
Virtual documents come from Razor when a .cshtml file is opened and they have .cshtml.g.cs file extension. These are C# projection buffers generated by Razor and only exist while the corresponding .cshtml file is open in an editor.

Dynamic documents also come from Razor but these come from all .razor and .cshtml files in the project that have the MSBuild item type "Content". These don't have to be open in the editor.

The problem is that we weren't adding virtual and dynamic documents in all scenarios. Specifically when the solution was initially loaded our code was not running and so if a Razor document was open before the solution was loading it wouldn't get added to the workspace properly.

To mitigate this we've found a single codepath (LoadProject) that all the logic in the project system goes through. This includes the initial load as well as reload. This is the single place where a Roslyn ProjectInfo is created, and it's also a better location to add virtual and dynamic documents to the project being loaded.

There is now no need to call AddVirtualDocuments from three separate locations.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1012526