### PR TITLE
[Core] Avoid showing duplicated files in project tree

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -81,6 +81,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		{
 			string folderPrefix = folder + Path.DirectorySeparatorChar;
 
+			var visitedFiles = new HashSet<FilePath> ();
 			files = new List<ProjectFile> ();
 			folders = new List<string> ();
 			
@@ -100,7 +101,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 						? project.BaseDirectory.Combine (file.ProjectVirtualPath).ParentDirectory
 						: file.FilePath.ParentDirectory;
 						
-					if (dir == folder) {
+					if (dir == folder && !visitedFiles.Contains (file.FilePath)) {
+						visitedFiles.Add (file.FilePath);
 						files.Add (file);
 						continue;
 					}


### PR DESCRIPTION
There are some cases where, it seems, we don't evaluate conditions as we should,
resulting in duplicated items being added to the project and, thus, also shown
in the project tree (see aspnet/AspNetCore#17088).

Also, by just adding a <None Include="*"/>, duplicated files show also.

So, due to this limitation on the project system, work around it on the project
tree, by checking for duplicates based on the files' paths.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1005277