### PR TITLE
[release-8.4] [Debugger] Use ~sel versions of the pin icon in the MacObjectValueTre…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectPinView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectPinView.cs
@@ -35,8 +35,11 @@ namespace MonoDevelop.Debugger
 {
 	class MacDebuggerObjectPinView : MacDebuggerObjectCellViewBase
 	{
+		static readonly NSImage selectedUnpinnedImage = GetImage ("md-pin-up", Gtk.IconSize.Menu, true);
+		static readonly NSImage selectedPinnedImage = GetImage ("md-pin-down", Gtk.IconSize.Menu, true);
 		static readonly NSImage unpinnedImage = GetImage ("md-pin-up", Gtk.IconSize.Menu);
 		static readonly NSImage pinnedImage = GetImage ("md-pin-down", Gtk.IconSize.Menu);
+
 		static readonly NSImage liveUpdateOnImage = GetImage ("md-live", Gtk.IconSize.Menu);
 		static readonly NSImage liveUpdateOffImage = GetImage ("md-live", Gtk.IconSize.Menu, 0.5);
 		static readonly NSImage none = GetImage ("md-empty", Gtk.IconSize.Menu);
@@ -97,8 +100,10 @@ namespace MonoDevelop.Debugger
 			if (Node == null)
 				return;
 
+			var selected = Superview is NSTableRowView rowView && rowView.Selected;
+
 			if (TreeView.PinnedWatch != null && Node.Parent == TreeView.Controller.Root) {
-				PinButton.Image = pinnedImage;
+				PinButton.Image = selected ? selectedPinnedImage : pinnedImage;
 				pinned = true;
 			} else {
 				PinButton.Image = none;
@@ -137,7 +142,14 @@ namespace MonoDevelop.Debugger
 			if (pinned)
 				return;
 
-			PinButton.Image = hover || IdeServices.DesktopService.AccessibilityInUse ? unpinnedImage : none;
+			var selected = Superview is NSTableRowView rowView && rowView.Selected;
+
+			if (hover || IdeServices.DesktopService.AccessibilityInUse) {
+				PinButton.Image = selected ? selectedUnpinnedImage : unpinnedImage;
+			} else {
+				PinButton.Image = none;
+			}
+
 			SetNeedsDisplayInRect (PinButton.Frame);
 		}
 


### PR DESCRIPTION
…eView when appropriate

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1021876/

Backport of #9312.

/cc @jstedfast 