### PR TITLE
Instead of using custom ISerializable to serialize private fields, just expose it via ReadOnlyCollection

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -114,7 +115,9 @@ namespace MonoDevelop.Core.Instrumentation
 		}
 
 		public virtual CounterDisplayMode DisplayMode => CounterDisplayMode.Block;
-		
+
+		public IReadOnlyList<CounterValue> AllValues => new ReadOnlyCollection<CounterValue> (values);
+
 		public IEnumerable<CounterValue> GetValues ()
 		{
 			lock (values) {

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -100,23 +100,29 @@ namespace MonoDevelop.Core.Instrumentation
 			get { return this.logMessages; }
 			set { this.logMessages = value; }
 		}
-		
+
 		public int Count {
 			get { return count; }
 		}
-		
+
 		public bool Disposed {
 			get { return disposed; }
 			internal set { disposed = value; }
 		}
-		
+
 		public int TotalCount {
 			get { return totalCount; }
 		}
 
 		public virtual CounterDisplayMode DisplayMode => CounterDisplayMode.Block;
 
-		public IReadOnlyList<CounterValue> AllValues => new ReadOnlyCollection<CounterValue> (values);
+		public IReadOnlyList<CounterValue> AllValues {
+			get {
+				lock (values) {
+					return new ReadOnlyCollection<CounterValue> (values);
+				}
+			}
+		}
 
 		public IEnumerable<CounterValue> GetValues ()
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -119,7 +119,7 @@ namespace MonoDevelop.Core.Instrumentation
 		public IReadOnlyList<CounterValue> AllValues {
 			get {
 				lock (values) {
-					return new ReadOnlyCollection<CounterValue> (values);
+					return new ReadOnlyCollection<CounterValue> (new List<CounterValue> (values));
 				}
 			}
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/Counter.cs
@@ -35,7 +35,7 @@ using System.Runtime.Serialization;
 namespace MonoDevelop.Core.Instrumentation
 {
 	[Serializable]
-	public class Counter: MarshalByRefObject, ISerializable
+	public class Counter: MarshalByRefObject
 	{
 		internal int count;
 		internal int totalCount;
@@ -352,26 +352,6 @@ namespace MonoDevelop.Core.Instrumentation
 		public override object? InitializeLifetimeService ()
 		{
 			return null;
-		}
-
-		public virtual void GetObjectData (SerializationInfo info, StreamingContext context)
-			=> PopulateSerializableMembers (info, context);
-
-		protected void PopulateSerializableMembers (SerializationInfo info, StreamingContext context)
-		{
-			info.AddValue (nameof (this.StoreValues), this.StoreValues);
-			info.AddValue (nameof (this.Resolution), this.Resolution);
-			info.AddValue (nameof (this.values), this.values);
-			info.AddValue (nameof (this.TotalCount), this.TotalCount);
-			info.AddValue (nameof (this.Name), this.Name);
-			info.AddValue (nameof (this.LogMessages), this.LogMessages);
-			info.AddValue (nameof (this.LastValue), this.LastValue);
-			info.AddValue (nameof (this.Id), this.Id);
-			info.AddValue (nameof (this.Handlers), this.Handlers);
-			info.AddValue (nameof (this.Category), this.Category);
-			info.AddValue (nameof (this.Count), this.Count);
-			info.AddValue (nameof (this.DisplayMode), this.DisplayMode);
-			info.AddValue (nameof (this.Enabled), this.Enabled);
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Instrumentation/TimerCounter.cs
@@ -38,7 +38,7 @@ using System.Runtime.Serialization;
 namespace MonoDevelop.Core.Instrumentation
 {
 	[Serializable]
-	public class TimerCounter : Counter , ISerializable
+	public class TimerCounter : Counter
 	{
 		double minSeconds;
 		TimeSpan totalTime;
@@ -141,17 +141,6 @@ namespace MonoDevelop.Core.Instrumentation
 					InstrumentationService.LogMessage ("START: " + Name);
 			}
 			return c;
-		}
-
-		public override void GetObjectData (SerializationInfo info, StreamingContext context)
-		{
-			base.PopulateSerializableMembers (info, context);
-			info.AddValue (nameof (this.MinSeconds), this.MinSeconds);
-			info.AddValue (nameof (this.TotalTime), this.TotalTime);
-			info.AddValue (nameof (this.AverageTime), this.AverageTime);
-			info.AddValue (nameof (this.MinTime), this.MinTime);
-			info.AddValue (nameof (this.MaxTime), this.MaxTime);
-			info.AddValue (nameof (this.CountWithDuration), this.CountWithDuration);
 		}
 	}
 


### PR DESCRIPTION
Needs partial reverse of https://github.com/mono/monodevelop/pull/8846

Fixes #1019319

We can just expose the hidden `values` CounterValue using ReadOnlyCollection with only a getter. It prevents modification of the existing list. This is better since `ISerializable` has many issues esp `Counter.values` were not serialized but `TimerCounter.values` were. Using the additional read-only property provides a C# solution rather than relying on underlying implementation fo Newtonsoft.Json