### PR TITLE
[release-8.4] Ensures don't close autohide window if focus are in embedded panels

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBarItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockBarItem.cs
@@ -400,8 +400,17 @@ namespace MonoDevelop.Components.Docking
 						return true;
 					if (!force) {
 						// Don't hide the item if it has the focus. Try again later.
+#if MAC
+						bool hasTopLevel = it.Widget.FocusChild != null && autoShowFrame != null &&
+						autoShowFrame.Toplevel is IdeWindow ideWindow && (
+						ideWindow.HasToplevelFocus || Mac.GtkMacInterop.GetGtkWindow (AppKit.NSApplication.SharedApplication.KeyWindow) == ideWindow);
+
+						if (hasTopLevel)
+							return true;
+#else
 						if (it.Widget.FocusChild != null && autoShowFrame != null && ((Gtk.Window)autoShowFrame.Toplevel).HasToplevelFocus)
 							return true;
+#endif
 						// Don't hide the item if the mouse pointer is still inside the window. Try again later.
 						int px, py;
 						it.Widget.GetPointer (out px, out py);


### PR DESCRIPTION
Ensures don't close autohide window if focus are in embedded panels

Fixes VSTS #1001359 - Properties window opens and then closes on right clicking project file and select Properties

![R9xi5hIY5W](https://user-images.githubusercontent.com/1587480/68911216-7df3d300-0754-11ea-9bbf-bc8d87afa6fb.gif)


Backport of #9324. 

/cc @netonjm 