### PR TITLE
[release-8.4] Revert "First pass to fix solution pad not regaining focus on shortcut press."

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -331,7 +331,7 @@ namespace Gtk
 			try {
 				if (view?.Window?.FirstResponder is NSView firstResponder &&
 					view?.AncestorSharedWithView (firstResponder) == view)
-					firstResponder.Window?.MakeFirstResponder (firstResponder.Window.ContentView);
+					firstResponder.Window?.MakeFirstResponder (null);
 				return base.OnFocusOutEvent (evnt);
 			} finally {
 				LogExit ();


### PR DESCRIPTION
Revert "First pass to fix solution pad not regaining focus on shortcut press."
This reverts commit 7e01fd039a5c6705189f0a927868919e953e9c73 in this PR : https://github.com/mono/monodevelop/pull/9216

I reverted this commit because introduces new problems, in this case infinite focus loops on in Pads with autohide with embedded native views ( https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1020127)

Additionally all this logic is going to be obsolete by https://github.com/mono/monodevelop/pull/9267
which hopefully will fix this issue also.

Fixes VSTS #1020127 - Toolbox focus flickers when in autohide mode

 

Backport of #9325.

/cc @netonjm 