### PR TITLE
Returns focus to GtkQuarzView on lost focus GtkViewHost

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
@@ -332,6 +332,9 @@ namespace MonoDevelop.Components.Docking
 		
 		public void Present (bool giveFocus)
 		{
+			//every dock item on present backs focus to Gtk in case focus is in native view
+			Gtk.GtkNSViewHost.ReturnFocusToGtk ();
+
 			if (dockBarItem != null)
 				dockBarItem.Present (Status == DockItemStatus.AutoHide || giveFocus);
 			else if (floatingWindow != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -329,9 +329,10 @@ namespace Gtk
 		{
 			LogEnter ();
 			try {
-				if (view?.Window?.FirstResponder is NSView firstResponder &&
-					view?.AncestorSharedWithView (firstResponder) == view)
-					firstResponder.Window?.MakeFirstResponder (null);
+				var gtkWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetGtkWindow (AppKit.NSApplication.SharedApplication.KeyWindow);
+				if (gtkWindow != null && gtkWindow.GdkWindow == MonoDevelop.Ide.IdeApp.Workbench.RootWindow.GdkWindow) {
+					view?.Window.MakeFirstResponder (view?.Window.ContentView);
+				}
 				return base.OnFocusOutEvent (evnt);
 			} finally {
 				LogExit ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -329,10 +329,7 @@ namespace Gtk
 		{
 			LogEnter ();
 			try {
-				var gtkWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetGtkWindow (AppKit.NSApplication.SharedApplication.KeyWindow);
-				if (gtkWindow != null && gtkWindow.GdkWindow == MonoDevelop.Ide.IdeApp.Workbench.RootWindow.GdkWindow) {
-					view?.Window.MakeFirstResponder (view?.Window.ContentView);
-				}
+				ReturnFocusToGtk ();
 				return base.OnFocusOutEvent (evnt);
 			} finally {
 				LogExit ();
@@ -385,6 +382,15 @@ namespace Gtk
 		}
 
 		#endregion
+		//HACK: to remove focus from GTKQuartzWindow and back focus to Gtk we need to ensure the GdkWindow is the Ide
+		public static void ReturnFocusToGtk ()
+		{
+			var window = NSApplication.SharedApplication.KeyWindow;
+			var gtkWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetGtkWindow (window);
+			if (gtkWindow != null && gtkWindow.GdkWindow == MonoDevelop.Ide.IdeApp.Workbench.RootWindow.GdkWindow) {
+				window.MakeFirstResponder (window.ContentView);
+			}
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Fixes VSTS #1007912 - Keyboard focus isn't given to Solution pad when "Solution Pad" command is invoked
Fixes VSTS #1016070 - Solution Pad not getting focus, when ran via PadActivationHandler 

Without introducing flickering issues