### PR TITLE
[release-8.4] Returns focus to GtkQuarzView on lost focus GtkViewHost

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -329,9 +329,10 @@ namespace Gtk
 		{
 			LogEnter ();
 			try {
-				if (view?.Window?.FirstResponder is NSView firstResponder &&
-					view?.AncestorSharedWithView (firstResponder) == view)
-					firstResponder.Window?.MakeFirstResponder (null);
+				var gtkWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetGtkWindow (AppKit.NSApplication.SharedApplication.KeyWindow);
+				if (gtkWindow != null && gtkWindow.GdkWindow == MonoDevelop.Ide.IdeApp.Workbench.RootWindow.GdkWindow) {
+					view?.Window.MakeFirstResponder (view?.Window.ContentView);
+				}
 				return base.OnFocusOutEvent (evnt);
 			} finally {
 				LogExit ();


### PR DESCRIPTION
Fixes VSTS #1007912 - Keyboard focus isn't given to Solution pad when "Solution Pad" command is invoked

Without introducing flickering issues

Backport of #9329.

/cc @netonjm 