### PR TITLE
[release-8.4] Bump Roslyn to 3.4.0-beta4-19562-05

### DIFF
--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.4.0-beta4-19556-02</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.4.0-beta4-19562-05</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating Roslyn to 20191112.5 ([ff930de](https://www.github.com/dotnet/roslyn/commit/ff930de))

[Changes](https://github.com/dotnet/roslyn/compare/24c9587...ff930de?w=1)  since [24c9587](https://www.github.com/dotnet/roslyn/commit/24c9587):
- [Merge pull request #39636 from sharwell/inheritdoc-overflow](https://www.github.com/dotnet/roslyn/pull/39636)
- [Merge pull request #39630 from v-zbsail/loc_20191101_release_dev16.4-vs-deps](https://www.github.com/dotnet/roslyn/pull/39630)
- [Do not fail fast on cancellation (#39627)](https://www.github.com/dotnet/roslyn/pull/39627)
- [Don't store pooled object in cache (#39729)](https://www.github.com/dotnet/roslyn/pull/39729)
- [Merge pull request #39726 from jasonmalinowski/fix-devenv-build](https://www.github.com/dotnet/roslyn/pull/39726)
- [Merge pull request #39626 from tmat/EncDisabled16.4](https://www.github.com/dotnet/roslyn/pull/39626)
- [Do not report ErrorCode.WRN_ExpressionMayIntroduceNullT (#39589)](https://www.github.com/dotnet/roslyn/pull/39589)
- [Tolerate empty assembly names (#39672)](https://www.github.com/dotnet/roslyn/pull/39672)

Backport of #9340.

/cc @sandyarmstrong 