### PR TITLE
[Debugger] Don't allow selection of the pinned watch row

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/PinnedWatches/PinnedWatchView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/PinnedWatches/PinnedWatchView.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.Debugger.VSTextView.PinnedWatches
 			controller.AllowEditing = true;
 			controller.AllowExpanding = false;
 
-			treeView = controller.GetMacControl (headersVisible: false, compactView: true, allowPinning: true);
+			treeView = controller.GetMacControl (ObjectValueTreeViewFlags.PinnedWatchFlags);
 
 			controller.PinnedWatch = watch;
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/MacDebuggerTooltipWindow.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Debugger
 			controller.PinnedWatch = watch;
 			controller.PinnedWatchLocation = location;
 
-			treeView = controller.GetMacControl (headersVisible: false, allowPinning: true, compactView: true, rootPinVisible: true);
+			treeView = controller.GetMacControl (ObjectValueTreeViewFlags.TooltipFlags);
 			treeView.NodePinned += OnPinStatusChanged;
 			treeView.StartEditing += OnStartEditing;
 			treeView.EndEditing += OnEndEditing;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugValueWindow.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebugValueWindow.cs
@@ -106,7 +106,7 @@ namespace MonoDevelop.Debugger
 				controller.PinnedWatch = watch;
 				controller.PinnedWatchLocation = location;
 
-				treeView = controller.GetGtkControl (headersVisible: false, allowPinning: true, compactView: true, rootPinVisible: true);
+				treeView = controller.GetGtkControl (ObjectValueTreeViewFlags.TooltipFlags);
 
 				if (treeView is IObjectValueTreeView ovtv) {
 					ovtv.StartEditing += OnStartEditing;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -186,7 +186,7 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 				controller.SetStackFrame (DebuggingService.CurrentFrame);
 				controller.AllowExpanding = true;
 
-				exceptionValueTreeView = controller.GetGtkControl (allowPopupMenu: false);
+				exceptionValueTreeView = controller.GetGtkControl (ObjectValueTreeViewFlags.ExceptionCaughtFlags);
 			} else {
 				var objValueTreeView = new ObjectValueTreeView ();
 				objValueTreeView.Frame = DebuggingService.CurrentFrame;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Gtk/GtkObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Gtk/GtkObjectValueTreeView.cs
@@ -171,16 +171,12 @@ namespace MonoDevelop.Debugger
 			IObjectValueDebuggerService debuggerService,
 			ObjectValueTreeViewController controller,
 			bool allowEditing,
-			bool headersVisible,
-			bool compactView,
-			bool allowPinning,
-			bool allowPopupMenu,
-			bool rootPinVisible)
+			ObjectValueTreeViewFlags flags)
 		{
-			this.compactView = compactView;
-			this.allowPinning = allowPinning;
-			this.allowPopupMenu = allowPopupMenu;
-			this.rootPinVisible = rootPinVisible;
+			this.compactView = (flags & ObjectValueTreeViewFlags.CompactView) != 0;
+			this.allowPinning = (flags & ObjectValueTreeViewFlags.AllowPinning) != 0;
+			this.allowPopupMenu = (flags & ObjectValueTreeViewFlags.AllowPopupMenu) != 0;
+			this.rootPinVisible = (flags & ObjectValueTreeViewFlags.RootPinVisible) != 0;
 
 			// ensure this is set when we set up the view, don't try and refresh just yet
 			this.allowEditing = allowEditing;
@@ -193,7 +189,7 @@ namespace MonoDevelop.Debugger
 			Model = store;
 			SearchColumn = -1; // disable the interactive search
 			RulesHint = true;
-			HeadersVisible = headersVisible;
+			HeadersVisible = (flags & ObjectValueTreeViewFlags.HeadersVisible) != 0;
 			EnableSearch = false;
 			Selection.Mode = Gtk.SelectionMode.Multiple;
 			Selection.Changed += HandleSelectionChanged;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -70,28 +70,25 @@ namespace MonoDevelop.Debugger
 			IObjectValueDebuggerService debuggerService,
 			ObjectValueTreeViewController controller,
 			bool allowEditing,
-			bool headersVisible,
-			bool compactView,
-			bool allowPinning,
-			bool allowPopupMenu,
-			bool rootPinVisible)
+			ObjectValueTreeViewFlags flags)
 		{
 			DebuggerService = debuggerService;
 			Controller = controller;
 
-			this.rootPinVisible = rootPinVisible;
-			this.allowPopupMenu = allowPopupMenu;
+			this.rootPinVisible = (flags & ObjectValueTreeViewFlags.RootPinVisible) != 0;
+			this.allowPopupMenu = (flags & ObjectValueTreeViewFlags.AllowPopupMenu) != 0;
+			this.compactView = (flags & ObjectValueTreeViewFlags.CompactView) != 0;
 			this.allowEditing = allowEditing;
-			this.compactView = compactView;
 
 			DataSource = dataSource = new MacObjectValueTreeViewDataSource (this, controller.Root, controller.AllowWatchExpressions);
 			Delegate = treeViewDelegate = new MacObjectValueTreeViewDelegate (this);
 			ColumnAutoresizingStyle = compactView ? NSTableViewColumnAutoresizingStyle.None : NSTableViewColumnAutoresizingStyle.Uniform;
+			AllowsSelection = (flags & ObjectValueTreeViewFlags.AllowSelection) != 0;
 			treeViewDelegate.SelectionChanged += OnSelectionChanged;
 			UsesAlternatingRowBackgroundColors = true;
 			FocusRingType = NSFocusRingType.None;
-			AutoresizesOutlineColumn = false;
 			AllowsColumnResizing = !compactView;
+			AutoresizesOutlineColumn = false;
 			SetCustomFont (null);
 
 			var resizingMask = compactView ? NSTableColumnResizing.None : NSTableColumnResizing.UserResizingMask | NSTableColumnResizing.Autoresizing;
@@ -117,13 +114,13 @@ namespace MonoDevelop.Debugger
 				AddColumn (typeColumn);
 			}
 
-			if (allowPinning) {
+			if ((flags & ObjectValueTreeViewFlags.AllowPinning) != 0) {
 				pinColumn = new NSTableColumn ("pin") { Editable = false, ResizingMask = NSTableColumnResizing.None };
 				pinColumn.MinWidth = pinColumn.MaxWidth = pinColumn.Width = MacDebuggerObjectPinView.MinWidth;
 				AddColumn (pinColumn);
 			}
 
-			if (headersVisible) {
+			if ((flags & ObjectValueTreeViewFlags.HeadersVisible) != 0) {
 				HeaderView.AlphaValue = 1.0f;
 			} else {
 				HeaderView = null;
@@ -147,6 +144,10 @@ namespace MonoDevelop.Debugger
 		}
 
 		public ObjectValueTreeViewController Controller {
+			get; private set;
+		}
+
+		public bool AllowsSelection {
 			get; private set;
 		}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeViewDelegate.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeViewDelegate.cs
@@ -140,6 +140,11 @@ namespace MonoDevelop.Debugger
 			return node != null && node.HasChildren;
 		}
 
+		public override bool ShouldSelectItem (NSOutlineView outlineView, NSObject item)
+		{
+			return treeView.AllowsSelection;
+		}
+
 		public event EventHandler SelectionChanged;
 
 		public override void SelectionDidChange (NSNotification notification)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
@@ -54,6 +54,24 @@ namespace MonoDevelop.Debugger
 		Task<CompletionData> GetCompletionDataAsync (string expression, CancellationToken token);
 	}
 
+	[Flags]
+	public enum ObjectValueTreeViewFlags
+	{
+		None                 = 0,
+		AllowPinning         = 1 << 0,
+		AllowPopupMenu       = 1 << 1,
+		AllowSelection       = 1 << 2,
+		CompactView          = 1 << 3,
+		HeadersVisible       = 1 << 4,
+		RootPinVisible       = 1 << 5,
+
+		// Macros
+		ObjectValuePadFlags  = AllowPopupMenu | AllowSelection | HeadersVisible,
+		TooltipFlags         = AllowPinning | AllowPopupMenu | AllowSelection | CompactView | RootPinVisible,
+		PinnedWatchFlags     = AllowPinning | AllowPopupMenu | CompactView,
+		ExceptionCaughtFlags = AllowSelection | HeadersVisible
+	}
+
 	public class ObjectValueTreeViewController : IObjectValueDebuggerService
 	{
 		readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource ();
@@ -174,36 +192,36 @@ namespace MonoDevelop.Debugger
 			view.NodeShowVisualiser += OnViewNodeShowVisualiser;
 		}
 
-		public GtkObjectValueTreeView GetGtkControl (bool headersVisible = true, bool compactView = false, bool allowPinning = false, bool allowPopupMenu = true, bool rootPinVisible = false)
+		public GtkObjectValueTreeView GetGtkControl (ObjectValueTreeViewFlags flags)
 		{
 			if (view != null)
 				throw new InvalidOperationException ("You can only get the control once for each controller instance");
 
-			var control = new GtkObjectValueTreeView (this, this, AllowEditing, headersVisible, compactView, allowPinning, allowPopupMenu, rootPinVisible);
+			var control = new GtkObjectValueTreeView (this, this, AllowEditing, flags);
 
 			ConfigureView (control);
 
 			return control;
 		}
 
-		public MacObjectValueTreeView GetMacControl (bool headersVisible = true, bool compactView = false, bool allowPinning = false, bool allowPopupMenu = true, bool rootPinVisible = false)
+		public MacObjectValueTreeView GetMacControl (ObjectValueTreeViewFlags flags)
 		{
 			if (view != null)
 				throw new InvalidOperationException ("You can only get the control once for each controller instance");
 
-			var control = new MacObjectValueTreeView (this, this, AllowEditing, headersVisible, compactView, allowPinning, allowPopupMenu, rootPinVisible);
+			var control = new MacObjectValueTreeView (this, this, AllowEditing, flags);
 
 			ConfigureView (control);
 
 			return control;
 		}
 
-		public Control GetControl (bool headersVisible = true, bool compactView = false, bool allowPinning = false, bool allowPopupMenu = true, bool rootPinVisible = false)
+		public Control GetControl (ObjectValueTreeViewFlags flags)
 		{
 			if (Platform.IsMac)
-				return GetMacControl (headersVisible, compactView, allowPinning, allowPopupMenu, rootPinVisible);
+				return GetMacControl (flags);
 
-			return GetGtkControl (headersVisible, compactView, allowPinning, allowPopupMenu, rootPinVisible);
+			return GetGtkControl (flags);
 		}
 
 		public void CancelAsyncTasks ()

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValuePad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValuePad.cs
@@ -70,7 +70,7 @@ namespace MonoDevelop.Debugger
 
 				if (Platform.IsMac) {
 					LoggingService.LogInfo ("Using MacObjectValueTreeView for {0}", allowWatchExpressions ? "Watch Pad" : "Locals Pad");
-					var treeView = controller.GetMacControl ();
+					var treeView = controller.GetMacControl (ObjectValueTreeViewFlags.ObjectValuePadFlags);
 					_treeview = treeView;
 
 					fontChanger = new PadFontChanger (treeView, treeView.SetCustomFont, treeView.QueueResize);
@@ -102,7 +102,7 @@ namespace MonoDevelop.Debugger
 					control = host;
 				} else {
 					LoggingService.LogInfo ("Using GtkObjectValueTreeView for {0}", allowWatchExpressions ? "Watch Pad" : "Locals Pad");
-					var treeView = controller.GetGtkControl ();
+					var treeView = controller.GetGtkControl (ObjectValueTreeViewFlags.ObjectValuePadFlags);
 					treeView.Show ();
 
 					fontChanger = new PadFontChanger (treeView, treeView.SetCustomFont, treeView.QueueResize);

--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/PinnedWatchWidget.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/PinnedWatchWidget.cs
@@ -89,7 +89,7 @@ namespace MonoDevelop.SourceEditor
 				controller = new ObjectValueTreeViewController ();
 				controller.AllowEditing = true;
 
-				treeView = (TreeView) controller.GetGtkControl (headersVisible: false, compactView: true, allowPinning: true);
+				treeView = (TreeView) controller.GetGtkControl (ObjectValueTreeViewFlags.PinnedWatchFlags);
 
 				controller.PinnedWatch = watch;
 				valueTree = null;


### PR DESCRIPTION
This prevents the row from getting into an odd
selected-but-not-focused state.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1021870/