### PR TITLE
Fix 1023494: Unsaved new documents have `/` added to begining of file name

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/FileDocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/FileDocumentController.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
 using System.Text;
@@ -57,7 +58,11 @@ namespace MonoDevelop.Ide.Gui.Documents
 			}
 			set {
 				if (value != filePath) {
-					filePath = value.CanonicalPath;
+					if (Path.IsPathRooted(value)) {
+						filePath = value.CanonicalPath;
+					} else {
+						filePath = value;
+					}
 					defaultMimeType = null;
 					OnFileNameChanged ();
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentManagerTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentManagerTests.cs
@@ -31,6 +31,7 @@ using System.Threading.Tasks;
 using IdeUnitTests;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
+using MonoDevelop.Ide.Fonts;
 using MonoDevelop.Ide.Gui.Shell;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Projects;
@@ -39,7 +40,8 @@ using UnitTests;
 
 namespace MonoDevelop.Ide.Gui.Documents
 {
-	[RequireService(typeof(TypeSystemService))]
+	[RequireService (typeof (TypeSystemService))]
+	[RequireService (typeof (FontService))]
 	public class DocumentManagerTests : TestBase
 	{
 //		BasicServiceProvider serviceProvider;
@@ -226,6 +228,15 @@ namespace MonoDevelop.Ide.Gui.Documents
 		{
 			await Task.Delay (100);
 			e.Cancel = true;
+		}
+
+		[Test]
+		public async Task NewDocumentFileNameMayNotChange ()
+		{
+			const string newName = "SomeFileName.txt";
+			var doc = await documentManager.NewDocument (newName, "text/plain", "");
+			//Since this is just "unsaved/new" file, its expected that Name and FileName are matching
+			Assert.AreEqual (doc.Name, doc.FileName.ToString ());
 		}
 
 		[Test]


### PR DESCRIPTION
I think that anything that needs Canonical comparison should make conversion itself.
I'm also not aware of any regressions this might cause... @slluis any ideas?