### PR TITLE
Fix 1023500: When saving new document, tab title doesn't update

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentManager.cs
@@ -178,8 +178,31 @@ namespace MonoDevelop.Ide.Gui.Documents
 			return NewDocument (defaultName, mimeType, ms);
 		}
 
+		internal string GetUniqueFileName (FilePath fileName)
+		{
+			string baseName = fileName.FileNameWithoutExtension;
+			int number = 1;
+			bool found = true;
+			var uniqueFileName = baseName + fileName.Extension;
+			while (found) {
+				found = false;
+				foreach (var document in Documents) {
+					string existingFileName = document.Name;
+					if (existingFileName == uniqueFileName) {
+						uniqueFileName = baseName + number + fileName.Extension;
+						found = true;
+						++number;
+						break;
+					}
+				}
+			}
+			return uniqueFileName;
+		}
+
 		public async Task<Document> NewDocument (string defaultName, string mimeType, Stream content)
 		{
+			defaultName = GetUniqueFileName (defaultName);
+
 			var fileDescriptor = new FileDescriptor (defaultName, mimeType, content, null);
 
 			var documentControllerService = await ServiceProvider.GetService<DocumentControllerService> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/DefaultWorkbench.cs
@@ -1050,27 +1050,6 @@ namespace MonoDevelop.Ide.Gui
 			WindowReordered?.Invoke (this, new WindowReorderedEventArgs { OldPosition = oldPlacement, NewPosition = newPlacement });
 		}
 
-		internal string GetUniqueTabName (FilePath fileName)
-		{
-			string baseName = fileName.FileNameWithoutExtension;
-			int number = 1;
-			bool found = true;
-			var myUntitledTitle = baseName + fileName.Extension;
-			while (found) {
-				found = false;
-				foreach (var window in viewContentCollection) {
-					string title = window.Title;
-					if (title == myUntitledTitle) {
-						myUntitledTitle = baseName + number + fileName.Extension;
-						found = true;
-						++number;
-						break;
-					}
-				}
-			}
-			return myUntitledTitle;
-		}
-
 		public event EventHandler<WindowReorderedEventArgs> WindowReordered;
 
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Shell/SdiWorkspaceWindow.cs
@@ -43,7 +43,6 @@ namespace MonoDevelop.Ide.Gui.Shell
 		DockNotebookTab tab;
 		DockNotebook tabControl;
 
-		string myUntitledTitle;
 		string titleHolder = "";
 
 		bool showNotification;
@@ -270,13 +269,7 @@ namespace MonoDevelop.Ide.Gui.Shell
 			if (controller == null)
 				return;
 
-			string newTitle;
-			if (controller.IsNewDocument && controller is FileDocumentController fileController) {
-				if (myUntitledTitle == null)
-					myUntitledTitle = workbench.GetUniqueTabName (fileController.FilePath);
-				newTitle = myUntitledTitle;
-			} else
-				newTitle = controller.DocumentTitle;
+			var newTitle = controller.DocumentTitle;
 
 			if (newTitle != Title)
 				Title = newTitle;

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentManagerTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Gui.Documents/DocumentManagerTests.cs
@@ -31,6 +31,7 @@ using System.Threading.Tasks;
 using IdeUnitTests;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
+using MonoDevelop.Ide.Fonts;
 using MonoDevelop.Ide.Gui.Shell;
 using MonoDevelop.Ide.TypeSystem;
 using MonoDevelop.Projects;
@@ -39,7 +40,8 @@ using UnitTests;
 
 namespace MonoDevelop.Ide.Gui.Documents
 {
-	[RequireService(typeof(TypeSystemService))]
+	[RequireService (typeof (TypeSystemService))]
+	[RequireService (typeof (FontService))]
 	public class DocumentManagerTests : TestBase
 	{
 //		BasicServiceProvider serviceProvider;
@@ -827,6 +829,15 @@ namespace MonoDevelop.Ide.Gui.Documents
 			Assert.IsNotNull (c);
 			Assert.AreEqual (1, contentAddedEvents);
 			Assert.IsNotNull (doc.GetContent<SomeContent> ());
+		}
+
+		[Test]
+		public async Task NewDocumentUniqueFileName()
+		{
+			const string newName = "Untitled";
+			var doc = await documentManager.NewDocument (newName, "text/plain", "");
+			var doc2 = await documentManager.NewDocument (newName, "text/plain", "");
+			Assert.AreNotEqual (doc.FileName, doc2.FileName);
 		}
 	}
 


### PR DESCRIPTION
Main problem was that `IsNewDocument = false;` is called after `FilePath` is updated(which calls SetTitleEvent) which means logic for assigning untitled name was executed instead setting to `controller.DocumentTitle`, by moving code to `DocumentManager` we achieve following things:
1) Move logic specific to FileDocumentController out of SdiWorkspaceWindow.cs
2) Simplify logic in SdiWorkspaceWindow.cs(removal of `myUntitledTitle`)
3) And by moving logic of creating unique file name closer to start of document creation reduce chance of bugs and code complexity that has to deal with file name change in middle of creation
Also added unit test for new code in DocumentManager