### PR TITLE
Bump Roslyn to 3.4.0-beta4-19568-04

### DIFF
--- a/main/msbuild/RoslynVersion.props
+++ b/main/msbuild/RoslynVersion.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <NuGetVersionRoslyn>3.4.0-beta4-19562-05</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>3.4.0-beta4-19568-04</NuGetVersionRoslyn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
@sandyarmstrong This bumps Roslyn to what we expect to be the 16.4 GA build.

Changes since [ff930de](https://www.github.com/dotnet/roslyn/commit/ff930de):
- [EnC: Fix document out-of-sync checks when module is not loaded when debugging session starts (#39836)](https://www.github.com/dotnet/roslyn/pull/39836)