### PR TITLE
[release-8.4] [Debugger] Incrementally load new children rather than remove-all and…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/LocalsPad.cs
@@ -25,12 +25,36 @@
 //
 //
 
+using System;
+
 using Mono.Debugging.Client;
 
 namespace MonoDevelop.Debugger
 {
 	public class LocalsPad : ObjectValuePad
 	{
+		static readonly bool EnableFakeNodes;
+
+		static LocalsPad ()
+		{
+			var env = Environment.GetEnvironmentVariable ("VSMAC_DEBUGGER_TESTING");
+
+			if (!string.IsNullOrEmpty (env)) {
+				var options = env.Split (new char [] { ',' });
+
+				for (int i = 0; i < options.Length; i++) {
+					var option = options[i].Trim ();
+
+					if (option == "fake-locals") {
+						EnableFakeNodes = true;
+						return;
+					}
+				}
+			}
+
+			EnableFakeNodes = false;
+		}
+
 		public LocalsPad ()
 		{
 			if (UseNewTreeView) {
@@ -41,7 +65,6 @@ namespace MonoDevelop.Debugger
 			}
 		}
 
-#if ADD_FAKE_NODES
 		void AddFakeNodes ()
 		{
 			var xx = new System.Collections.Generic.List<ObjectValueNode> ();
@@ -60,7 +83,6 @@ namespace MonoDevelop.Debugger
 
 			controller.AddValues (xx);
 		}
-#endif
 
 		void ReloadValues ()
 		{
@@ -84,9 +106,10 @@ namespace MonoDevelop.Debugger
 				} finally {
 					_treeview.EndUpdates ();
 				}
-#if ADD_FAKE_NODES
-				AddFakeNodes ();
-#endif
+
+
+				if (EnableFakeNodes)
+					AddFakeNodes ();
 			} else {
 				tree.ClearValues ();
 				tree.AddValues (locals);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -551,7 +551,7 @@ namespace MonoDevelop.Debugger
 			if (disposed)
 				return;
 
-			dataSource.ReloadChildren (node);
+			dataSource.LoadChildren (node, startIndex, count);
 			OptimizeColumnSizes ();
 		}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -348,19 +348,13 @@ namespace MonoDevelop.Debugger
 
 		public override void ExpandItem (NSObject item, bool expandChildren)
 		{
-			NSAnimationContext.BeginGrouping ();
-			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item, expandChildren);
-			NSAnimationContext.EndGrouping ();
 			OptimizeColumnSizes ();
 		}
 
 		public override void ExpandItem (NSObject item)
 		{
-			NSAnimationContext.BeginGrouping ();
-			NSAnimationContext.CurrentContext.Duration = 0;
 			base.ExpandItem (item);
-			NSAnimationContext.EndGrouping ();
 			OptimizeColumnSizes ();
 		}
 
@@ -376,19 +370,13 @@ namespace MonoDevelop.Debugger
 
 		public override void CollapseItem (NSObject item, bool collapseChildren)
 		{
-			NSAnimationContext.BeginGrouping ();
-			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item, collapseChildren);
-			NSAnimationContext.EndGrouping ();
 			OptimizeColumnSizes ();
 		}
 
 		public override void CollapseItem (NSObject item)
 		{
-			NSAnimationContext.BeginGrouping ();
-			NSAnimationContext.CurrentContext.Duration = 0;
 			base.CollapseItem (item);
-			NSAnimationContext.EndGrouping ();
 			OptimizeColumnSizes ();
 		}
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
@@ -670,21 +670,22 @@ namespace MonoDevelop.Debugger
 
 			node.IsExpanded = true;
 
-			int loadedCount = 0;
+			int index = node.Children.Count;
+			int count = 0;
+
 			if (node.IsEnumerable) {
 				// if we already have some loaded, don't load more - that is a specific user gesture
-				if (node.Children.Count == 0) {
+				if (index == 0) {
 					// page the children in, instead of loading them all at once
-					loadedCount = await FetchChildrenAsync (node, MaxEnumerableChildrenToFetch, cancellationTokenSource.Token);
+					count = await FetchChildrenAsync (node, MaxEnumerableChildrenToFetch, cancellationTokenSource.Token);
 				}
 			} else {
-				loadedCount = await FetchChildrenAsync (node, 0, cancellationTokenSource.Token);
+				count = await FetchChildrenAsync (node, -1, cancellationTokenSource.Token);
 			}
 
 			await Runtime.RunInMainThread (() => {
 				// tell the view about the children, even if there are, in fact, none
-				view.LoadNodeChildren (node, 0, node.Children.Count);
-
+				view.LoadNodeChildren (node, index, count);
 				view.OnNodeExpanded (node);
 			});
 		}


### PR DESCRIPTION
… then load-all

Should theoretically fix some of the removeItems/expandItem crashers

Backport of #9355.

/cc @jstedfast 