### PR TITLE
[NuGet] Manage packages dialog accessibility

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
@@ -285,7 +285,7 @@ namespace MonoDevelop.PackageManagement
 
 			var packageIdLabel = new Label ();
 			packageIdLabel.Font = packageInfoBoldFont;
-			packageIdLabel.Text = GettextCatalog.GetString ("Id");
+			packageIdLabel.Text = GettextCatalog.GetString ("ID");
 			packageIdHBox.PackStart (packageIdLabel);
 
 			packageId = new Label ();

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
@@ -61,6 +61,7 @@ namespace MonoDevelop.PackageManagement
 		Label errorMessageLabel;
 		Label loadingSpinnerLabel;
 		FrameBox noPackagesFoundFrame;
+		Label noPackagesFoundLabel;
 		ComboBox packageVersionComboBox;
 		HBox packageVersionsHBox;
 		Label packageVersionsLabel;
@@ -216,7 +217,7 @@ namespace MonoDevelop.PackageManagement
 			var noPackagesFoundHBox = new HBox ();
 			noPackagesFoundHBox.HorizontalPlacement = WidgetPlacement.Center;
 
-			var noPackagesFoundLabel = new Label ();
+			noPackagesFoundLabel = new Label ();
 			noPackagesFoundLabel.Text = GettextCatalog.GetString ("No matching packages found.");
 			noPackagesFoundHBox.PackEnd (noPackagesFoundLabel);
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
@@ -147,6 +147,7 @@ namespace MonoDevelop.PackageManagement
 			packageSearchEntry = new SearchTextEntry ();
 			packageSearchEntry.Name = "managePackagesDialogSearchEntry";
 			packageSearchEntry.WidthRequest = 187;
+			packageSearchEntry.PlaceholderText = GettextCatalog.GetString ("Search");
 			packageSearchEntry.Accessible.Label = GettextCatalog.GetString ("Package Search");
 			topHBox.PackEnd (packageSearchEntry);
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
@@ -94,9 +94,19 @@ namespace MonoDevelop.PackageManagement
 			var topHBox = new HBox ();
 			topHBox.Margin = new WidgetSpacing (8, 5, 6, 5);
 
+			// HACK: VoiceOver does not work when using Accessible.Label so workaround this by using
+			// Accessible.LabelWidget and hide the label since we do not need it.
+			var packageSourceLabel = new Label ();
+			packageSourceLabel.Text = GettextCatalog.GetString ("Package source");
+			packageSourceLabel.Visible = false;
+			topHBox.PackStart (packageSourceLabel);
+
 			packageSourceComboBox = new ComboBox ();
 			packageSourceComboBox.Name = "packageSourceComboBox";
 			packageSourceComboBox.MinWidth = 200;
+			// Does not work:
+			//packageSourceComboBox.Accessible.Label = GettextCatalog.GetString ("Package source");
+			packageSourceComboBox.Accessible.LabelWidget = packageSourceLabel;
 			topHBox.PackStart (packageSourceComboBox);
 
 			int tabLabelMinWidth = 60;
@@ -179,6 +189,7 @@ namespace MonoDevelop.PackageManagement
 			packagesListView = new ListView ();
 			packagesListView.BorderVisible = false;
 			packagesListView.HeadersVisible = false;
+			packagesListView.Accessible.Label = GettextCatalog.GetString ("Packages");
 			packagesListVBox.PackStart (packagesListView, true, true);
 
 			// Loading spinner.
@@ -280,10 +291,12 @@ namespace MonoDevelop.PackageManagement
 			packageId.Ellipsize = EllipsizeMode.End;
 			packageId.TextAlignment = Alignment.End;
 			packageId.Font = packageInfoSmallFont;
+			packageId.Accessible.LabelWidget = packageIdLabel;
 			packageIdLink = new LinkLabel ();
 			packageIdLink.Ellipsize = EllipsizeMode.End;
 			packageIdLink.TextAlignment = Alignment.End;
 			packageIdLink.Font = packageInfoSmallFont;
+			packageIdLink.Accessible.LabelWidget = packageIdLabel;
 			packageIdHBox.PackEnd (packageIdLink, true);
 			packageIdHBox.PackEnd (packageId, true);
 
@@ -300,6 +313,7 @@ namespace MonoDevelop.PackageManagement
 			packageAuthor.TextAlignment = Alignment.End;
 			packageAuthor.Ellipsize = EllipsizeMode.End;
 			packageAuthor.Font = packageInfoSmallFont;
+			packageAuthor.Accessible.LabelWidget = packageAuthorLabel;
 			packageAuthorHBox.PackEnd (packageAuthor, true);
 
 			// Package published
@@ -313,6 +327,7 @@ namespace MonoDevelop.PackageManagement
 
 			packagePublishedDate = new Label ();
 			packagePublishedDate.Font = packageInfoSmallFont;
+			packagePublishedDate.Accessible.LabelWidget = packagePublishedLabel;
 			packagePublishedHBox.PackEnd (packagePublishedDate);
 
 			// Package downloads
@@ -326,6 +341,7 @@ namespace MonoDevelop.PackageManagement
 
 			packageDownloads = new Label ();
 			packageDownloads.Font = packageInfoSmallFont;
+			packageDownloads.Accessible.LabelWidget = packageDownloadsLabel;
 			packageDownloadsHBox.PackEnd (packageDownloads);
 
 			// Package license.
@@ -354,6 +370,7 @@ namespace MonoDevelop.PackageManagement
 			packageProjectPageLink = new LinkLabel ();
 			packageProjectPageLink.Text = GettextCatalog.GetString ("Visit Page");
 			packageProjectPageLink.Font = packageInfoSmallFont;
+			packageProjectPageLink.Accessible.Label = GettextCatalog.GetString ("Visit Project Page");
 			packageProjectPageHBox.PackEnd (packageProjectPageLink);
 
 			// Package dependencies
@@ -368,6 +385,7 @@ namespace MonoDevelop.PackageManagement
 			packageDependenciesNoneLabel = new Label ();
 			packageDependenciesNoneLabel.Text = GettextCatalog.GetString ("None");
 			packageDependenciesNoneLabel.Font = packageInfoSmallFont;
+			packageDependenciesNoneLabel.Accessible.LabelWidget = packageDependenciesLabel;
 			packageDependenciesHBox.PackEnd (packageDependenciesNoneLabel);
 
 			// Package dependencies list.
@@ -379,6 +397,7 @@ namespace MonoDevelop.PackageManagement
 			packageDependenciesList.Wrap = WrapMode.WordAndCharacter;
 			packageDependenciesList.Margin = new WidgetSpacing (5);
 			packageDependenciesList.Font = packageInfoSmallFont;
+			packageDependenciesList.Accessible.LabelWidget = packageDependenciesLabel;
 			packageDependenciesListHBox.PackStart (packageDependenciesList, true);
 
 			// Current package version.
@@ -400,11 +419,13 @@ namespace MonoDevelop.PackageManagement
 
 			currentPackageVersion = new Label ();
 			currentPackageVersion.Font = packageInfoSmallFont;
+			currentPackageVersion.Accessible.LabelWidget = currentPackageVersionLabel;
 			currentPackageVersionWithInfoPopoverHBox.PackStart (currentPackageVersion);
 
 			currentPackageVersionInfoPopoverWidget = new InformationPopoverWidget ();
 			currentPackageVersionInfoPopoverWidget.Severity = Ide.Tasks.TaskSeverity.Information;
 			currentPackageVersionInfoPopoverWidget.Margin = new WidgetSpacing (5, 0, 0, 2);
+			currentPackageVersionInfoPopoverWidget.Accessible.LabelWidget = currentPackageVersionLabel;
 			currentPackageVersionWithInfoPopoverHBox.PackStart (currentPackageVersionInfoPopoverWidget);
 
 			currentPackageVersionHBox.PackStart (currentPackageVersionWithInfoPopoverHBox);
@@ -422,6 +443,7 @@ namespace MonoDevelop.PackageManagement
 
 			packageVersionComboBox = new ComboBox ();
 			packageVersionComboBox.Name = "packageVersionComboBox";
+			packageVersionComboBox.Accessible.LabelWidget = packageVersionsLabel;
 			packageVersionsHBox.Spacing = 15;
 			packageVersionsHBox.PackStart (packageVersionComboBox, true, true);
 

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -249,16 +249,15 @@ namespace MonoDevelop.PackageManagement
 			projectCheckBoxCellView.ActiveField = projectCheckedField;
 			projectCheckBoxCellView.Editable = true;
 			projectCheckBoxCellView.Toggled += ProjectCheckBoxCellViewToggled;
-			var column = new ListViewColumn (string.Empty, projectCheckBoxCellView);
-			projectsListView.Columns.Add (column);
-
-			// Project column.
-			var textCellView = new TextCellView ();
-			textCellView.TextField = projectNameField;
-			column = new ListViewColumn (GettextCatalog.GetString ("Project"), textCellView) {
+			var column = new ListViewColumn (GettextCatalog.GetString ("Project"), projectCheckBoxCellView) {
 				CanResize = true,
 				SortDataField = projectNameField
 			};
+
+			// Project name.
+			var textCellView = new TextCellView ();
+			textCellView.TextField = projectNameField;
+			column.Views.Add (textCellView);
 			projectsListView.Columns.Add (column);
 
 			// Package version column

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -240,7 +240,7 @@ namespace MonoDevelop.PackageManagement
 
 			projectsListView = new ListView ();
 			projectsListView.DataSource = projectStore;
-			projectsListView.Accessible.Label = GettextCatalog.GetString ("Projects and Package Versions");
+			projectsListView.Accessible.LabelWidget = projectsListViewLabel;
 
 			// Selected project check box column.
 			if (projectCheckBoxCellView != null)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -619,8 +619,18 @@ namespace MonoDevelop.PackageManagement
 		{
 			int row = packageStore.AddRow ();
 			var accessibleDescription = StringBuilderCache.Allocate (packageViewModel.Id);
-			if (packageViewModel.HasDownloadCount)
-				accessibleDescription.Append (", ").Append (packageViewModel.GetDownloadCountDisplayText ()).Append (" ").Append (GettextCatalog.GetString ("Downloads"));
+			if (packageViewModel.HasDownloadCount) {
+				accessibleDescription.Append (", ");
+				if (packageViewModel.ShowVersionInsteadOfDownloadCount) {
+					accessibleDescription.Append (GettextCatalog.GetString ("Version"));
+					accessibleDescription.Append (" ");
+					accessibleDescription.Append (packageViewModel.GetDownloadCountOrVersionDisplayText ());
+				} else {
+					accessibleDescription.Append (packageViewModel.GetDownloadCountOrVersionDisplayText ());
+					accessibleDescription.Append (" ");
+					accessibleDescription.Append (GettextCatalog.GetString ("Downloads"));
+				}
+			}
 			if (!string.IsNullOrEmpty (packageViewModel.Summary))
 				accessibleDescription.Append (", ").Append (packageViewModel.Summary);
 			packageStore.SetValues (row,

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Core;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects;
@@ -304,6 +305,8 @@ namespace MonoDevelop.PackageManagement
 			if (!String.IsNullOrWhiteSpace (packageSearchEntry.Text)) {
 				packagesListView.Visible = false;
 				noPackagesFoundFrame.Visible = true;
+
+				IdeApp.Workbench.RootWindow.Accessible.MakeAccessibilityAnnouncement (noPackagesFoundLabel.Text);
 			}
 		}
 
@@ -553,6 +556,7 @@ namespace MonoDevelop.PackageManagement
 				// Show spinner?
 			} else if (viewModel.IsReadingPackages) {
 				ClearPackages ();
+				IdeApp.Workbench.RootWindow.Accessible.MakeAccessibilityAnnouncement (loadingSpinnerLabel.Text);
 			} else {
 				HideLoadingMessage ();
 			}
@@ -607,6 +611,11 @@ namespace MonoDevelop.PackageManagement
 
 			if (packagesListViewWasEmpty && (packageStore.RowCount > 0)) {
 				packagesListView.SelectRow (0);
+
+				string message = string.IsNullOrWhiteSpace (packageSearchEntry.Text)
+					? GettextCatalog.GetString ("Packages loaded")
+					: GettextCatalog.GetString ("Search completed");
+				IdeApp.Workbench.RootWindow.Accessible.MakeAccessibilityAnnouncement (message);
 			}
 
 			if (!viewModel.IsReadingPackages && (packageStore.RowCount == 0)) {
@@ -885,6 +894,8 @@ namespace MonoDevelop.PackageManagement
 		{
 			viewModel.SearchTerms = this.packageSearchEntry.Text;
 			viewModel.Search ();
+
+			IdeApp.Workbench.RootWindow.Accessible.MakeAccessibilityAnnouncement (loadingSpinnerLabel.Text);
 
 			return false;
 		}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -240,6 +240,7 @@ namespace MonoDevelop.PackageManagement
 
 			projectsListView = new ListView ();
 			projectsListView.DataSource = projectStore;
+			projectsListView.Accessible.Label = GettextCatalog.GetString ("Projects and Package Versions");
 
 			// Selected project check box column.
 			if (projectCheckBoxCellView != null)

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNodeDescriptor.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.NodeBuilders/PackageReferenceNodeDescriptor.cs
@@ -41,8 +41,8 @@ namespace MonoDevelop.PackageManagement.NodeBuilders
 		}
 
 		[LocalizedCategory ("Package")]
-		[LocalizedDisplayName ("Id")]
-		[LocalizedDescription ("Package Id.")]
+		[LocalizedDisplayName ("ID")]
+		[LocalizedDescription ("Package ID.")]
 		public string Id {
 			get { return packageReferenceNode.Id; }
 		}


### PR DESCRIPTION
Various accessibility fixes:

 - Fixes VSTS #1021638 - Accessibility: NuGet Packages: VoiceOver is not announcing the label for all the combo box and edit box present on the screen .
 - Fixes VSTS #1021699 - Manage NuGet Packages_ConsolidateTab_ScreenReader:Voice Over is not announcing the table name
 - Fixes VSTS #1022836 - Manage NuGet Packages_Usability: Unable to identify the instructions about search criteria.
 - Fixes VSTS #1021702 - Accessibility: NuGet Packages: Column Header name is not present for the first column. 
 - Fixes VSTS #1021636 - Accessibility: NuGet: Improper announcement for the "ID" word.
 - Fixes VSTS #1022830 - Accessibility: NuGet Packages: VoiceOver is not announcing the status message.
