### PR TITLE
[Release-8.4] [Debugger] Implemented code-completion for the new MacObjectValueTree

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.csproj
@@ -208,6 +208,8 @@
     <Compile Include="MonoDevelop.Debugger\ObjectValue\Mac\MacDebuggerObjectPinView.cs" />
     <Compile Include="MonoDevelop.Debugger\ObjectValue\Mac\MacDebuggerTextField.cs" />
     <Compile Include="MonoDevelop.Debugger\ObjectValue\ExpressionEventArgs.cs" />
+    <Compile Include="MonoDevelop.Debugger\DebuggerAsyncCompletionSource.cs" />
+    <Compile Include="MonoDevelop.Debugger\DebuggerCompletionCommandHandler.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(OS) != 'Windows_NT'">
     <Compile Include="MonoDevelop.Debugger.VSTextView\ExceptionCaught\ExceptionCaughtProvider.cs" />

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerAsyncCompletionSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerAsyncCompletionSource.cs
@@ -211,7 +211,7 @@ namespace MonoDevelop.Debugger
 			}
 
 			// Note: Hitting Return should *always* complete the current selection, but other typed chars require examining context...
-			if (typedChar != '\0' && typedChar != '\n') {
+			if (typedChar != '\0' && typedChar != '\n' && typedChar != '\t') {
 				var text = buffer.CurrentSnapshot.GetText ();
 				var span = DebuggerAsyncCompletionSource.GetWordSpan (text, text.Length);
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerAsyncCompletionSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerAsyncCompletionSource.cs
@@ -1,0 +1,162 @@
+//
+// DebuggerAsyncCompletionSource.cs
+//
+// Author:
+//       David Karlas <david.karlas@xamarin.com>
+//
+// Copyright (c) 2019 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Adornments;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+
+using ObjectValueFlags = Mono.Debugging.Client.ObjectValueFlags;
+
+namespace MonoDevelop.Debugger
+{
+	static class DebuggerCompletion
+	{
+		public const string ContentType = "DebuggerCompletion";
+	}
+
+	[Export (typeof (IAsyncCompletionSourceProvider))]
+	[Name ("Debugger Completion Source Provider")]
+	[ContentType (DebuggerCompletion.ContentType)]
+	sealed class DebuggerAsyncCompletionSourceProvider : IAsyncCompletionSourceProvider
+	{
+		public IAsyncCompletionSource GetOrCreate (ITextView textView)
+		{
+			return new DebuggerAsyncCompletionSource ();
+		}
+	}
+
+	sealed class DebuggerAsyncCompletionSource : IAsyncCompletionSource
+	{
+		static readonly Task<object> EmptyDescription = Task.FromResult<object> (null);
+
+		public async Task<CompletionContext> GetCompletionContextAsync (IAsyncCompletionSession session, CompletionTrigger trigger, SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan, CancellationToken token)
+		{
+			var text = triggerLocation.Snapshot.GetText (0, triggerLocation.Position);
+			var data = await DebuggingService.GetCompletionDataAsync (DebuggingService.CurrentFrame, text, token);
+
+			if (data == null)
+				return new CompletionContext (ImmutableArray<CompletionItem>.Empty);
+
+			var builder = ImmutableArray.CreateBuilder<CompletionItem> (data.Items.Count);
+
+			foreach (var item in data.Items) {
+				var image = new ImageElement (ObjectValueTreeViewController.GetImageId (item.Flags));
+
+				builder.Add (new CompletionItem (item.Name, this, image));
+			}
+
+			return new CompletionContext (builder.MoveToImmutable ());
+		}
+
+		public Task<object> GetDescriptionAsync (IAsyncCompletionSession session, CompletionItem item, CancellationToken token)
+		{
+			return EmptyDescription;
+		}
+
+		public CompletionStartData InitializeCompletion (CompletionTrigger trigger, SnapshotPoint triggerLocation, CancellationToken token)
+		{
+			var text = triggerLocation.Snapshot.GetText (0, triggerLocation.Position);
+			var span = GetWordSpan (text, triggerLocation.Position);
+
+			return new CompletionStartData (CompletionParticipation.ProvidesItems, new SnapshotSpan (triggerLocation.Snapshot, span));
+		}
+
+		public static Span GetWordSpan (string text, int position)
+		{
+			var start = position;
+			while (start > 0 && char.IsLetterOrDigit (text[start - 1]))
+				start--;
+
+			// If we're brought up in the middle of a word, extend to the end of the word as well.
+			// This means that if a user brings up the completion list at the start of the word they
+			// will "insert" the text before what's already there (useful for qualifying existing
+			// text).  However, if they bring up completion in the "middle" of a word, then they will
+			// "overwrite" the text. Useful for correcting misspellings or just replacing unwanted
+			// code with new code.
+			var end = position;
+			if (start != position) {
+				while (end < text.Length && char.IsLetterOrDigit (text[end]))
+					end++;
+			}
+
+			return Span.FromBounds (start, end);
+		}
+	}
+
+	[Export (typeof (IAsyncCompletionCommitManagerProvider))]
+	[Name ("Debugger Completion Commit Manager")]
+	[ContentType (DebuggerCompletion.ContentType)]
+	sealed class DebuggerAsyncCompletionCommitManagerProvider : IAsyncCompletionCommitManagerProvider
+	{
+		public IAsyncCompletionCommitManager GetOrCreate (ITextView textView)
+		{
+			return new DebuggerAsyncCompletionCommitManager ();
+		}
+	}
+
+	sealed class DebuggerAsyncCompletionCommitManager : IAsyncCompletionCommitManager
+	{
+		static readonly char[] CommitCharacters = new char[] { ' ', '\t', '\n', '.', ',', '<', '>', '(', ')', '[', ']' };
+
+		public IEnumerable<char> PotentialCommitCharacters {
+			get { return CommitCharacters; }
+		}
+
+		public bool ShouldCommitCompletion (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
+		{
+			return true;
+		}
+
+		public CommitResult TryCommit (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
+		{
+			// Note: Hitting Return should *always* complete the current selection, but other typed chars require examining context...
+			if (typedChar != '\0' && typedChar != '\n') {
+				var text = buffer.CurrentSnapshot.GetText ();
+				var span = DebuggerAsyncCompletionSource.GetWordSpan (text, text.Length);
+
+				if (span.Length == 0)
+					return new CommitResult (true, CommitBehavior.None);
+
+				var typedWord = text.AsSpan (span.Start, span.Length);
+
+				if (!item.InsertText.AsSpan ().Contains (typedWord, StringComparison.Ordinal))
+					return new CommitResult (true, CommitBehavior.None);
+			}
+
+			return CommitResult.Unhandled;
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerCompletionCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerCompletionCommandHandler.cs
@@ -1,0 +1,108 @@
+//
+// MacDebuggerCompletionCommandHandler.cs
+//
+// Author:
+//       Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corp.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+
+namespace MonoDevelop.Debugger
+{
+	[Name ("Debbugger Completion CommandHandler")]
+	[ContentType (DebuggerCompletion.ContentType)]
+	[TextViewRole (PredefinedTextViewRoles.Interactive)]
+	[Export (typeof (ICommandHandler))]
+	[Order (After = PredefinedCompletionNames.CompletionCommandHandler)]
+	sealed class DebuggerCompletionCommandHandler :
+		ICommandHandler<EscapeKeyCommandArgs>,
+		ICommandHandler<ReturnKeyCommandArgs>,
+		ICommandHandler<TabKeyCommandArgs>
+	{
+		public string DisplayName => nameof (DebuggerCompletionCommandHandler);
+
+		#region EscapeKey
+
+		public CommandState GetCommandState (EscapeKeyCommandArgs args)
+		{
+			return CommandState.Available;
+		}
+
+		public bool ExecuteCommand (EscapeKeyCommandArgs args, CommandExecutionContext executionContext)
+		{
+			var cocoaTextView = (ICocoaTextView) args.TextView;
+			var bgView = cocoaTextView.VisualElement.Superview; // the NSView that draws the background color
+			var superview = bgView?.Superview;
+
+			if (superview is MacDebuggerObjectNameView nameView)
+				nameView.CancelEdit ();
+			else
+				System.Console.WriteLine ("superview is {0}", superview.GetType ().FullName);
+
+			return true;
+		}
+
+		#endregion // EscapeKey
+
+		#region ReturnKey
+
+		public CommandState GetCommandState (ReturnKeyCommandArgs args)
+		{
+			return CommandState.Available;
+		}
+
+		public bool ExecuteCommand (ReturnKeyCommandArgs args, CommandExecutionContext executionContext)
+		{
+			var cocoaTextView = (ICocoaTextView) args.TextView;
+
+			cocoaTextView.VisualElement.ResignFirstResponder ();
+
+			return true;
+		}
+
+		#endregion // ReturnKey
+
+		#region TabKey
+
+		public CommandState GetCommandState (TabKeyCommandArgs args)
+		{
+			return CommandState.Available;
+		}
+
+		public bool ExecuteCommand (TabKeyCommandArgs args, CommandExecutionContext executionContext)
+		{
+			var cocoaTextView = (ICocoaTextView) args.TextView;
+
+			cocoaTextView.VisualElement.ResignFirstResponder ();
+
+			return true;
+		}
+
+		#endregion // TabKey
+	}
+}

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectNameView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectNameView.cs
@@ -103,6 +103,7 @@ namespace MonoDevelop.Debugger
 			contentType = contentTypeRegistry.GetContentType (DebuggerCompletion.ContentType);
 			var textBuffer = textBufferFactory.CreateTextBuffer ("", contentType);
 			editor = factory.CreateTextView (textBuffer);
+			editor.Options.SetOptionValue(DefaultTextViewOptions.UseVisibleWhitespaceId, false);
 
 			editor.VisualElement.TranslatesAutoresizingMaskIntoConstraints = false;
 			editorTextView = new NSView { TranslatesAutoresizingMaskIntoConstraints = false, WantsLayer = true };

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectTypeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectTypeView.cs
@@ -37,7 +37,7 @@ namespace MonoDevelop.Debugger
 	{
 		public MacDebuggerObjectTypeView (MacObjectValueTreeView treeView) : base (treeView, "type")
 		{
-			TextField = new MacDebuggerTextField (this) {
+			TextField = new NSTextField {
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				BackgroundColor = NSColor.Clear,
 				MaximumNumberOfLines = 1,

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerTextField.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerTextField.cs
@@ -26,7 +26,6 @@
 
 using AppKit;
 using Foundation;
-using CoreGraphics;
 
 namespace MonoDevelop.Debugger
 {
@@ -59,6 +58,16 @@ namespace MonoDevelop.Debugger
 			TextColor = NSColor.ControlText;
 
 			return true;
+		}
+
+		public override bool BecomeFirstResponder ()
+		{
+			if (cellView is MacDebuggerObjectNameView nameView) {
+				nameView.Edit ();
+				return true;
+			}
+
+			return base.BecomeFirstResponder ();
 		}
 
 		public override void DidBeginEditing (NSNotification notification)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacObjectValueTreeView.cs
@@ -924,7 +924,7 @@ namespace MonoDevelop.Debugger
 
 			var nameView = (MacDebuggerObjectNameView) GetView (0, SelectedRow, false);
 
-			nameView.TextField.BecomeFirstResponder ();
+			nameView.Edit ();
 		}
 
 		void OnRename (object sender, EventArgs args)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
@@ -35,6 +35,9 @@ using Mono.Debugging.Client;
 using MonoDevelop.Core;
 using MonoDevelop.Components;
 
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Core.Imaging;
+
 namespace MonoDevelop.Debugger
 {
 	public enum PreviewButtonIcon
@@ -958,6 +961,61 @@ namespace MonoDevelop.Debugger
 			}
 
 			return "md-" + access + global + source;
+		}
+
+		static int GetKnownImageId (ObjectValueFlags flags)
+		{
+			var name = GetIcon (flags);
+
+			switch (name) {
+			case "md-empty": return -1;
+			case "md-literal": return KnownImageIds.Literal;
+			case "md-name-space": return KnownImageIds.Namespace;
+			case "md-variable": return KnownImageIds.LocalVariable;
+
+			case "md-property": return KnownImageIds.PropertyPublic;
+			case "md-method": return KnownImageIds.MethodPublic;
+			case "md-class": return KnownImageIds.ClassPublic;
+			case "md-field": return KnownImageIds.FieldPublic;
+
+			case "md-private-property": return KnownImageIds.PropertyPrivate;
+			case "md-private-method": return KnownImageIds.MethodPrivate;
+			case "md-private-class": return KnownImageIds.ClassPrivate;
+			case "md-private-field": return KnownImageIds.FieldPrivate;
+
+			case "md-internal-property": return KnownImageIds.PropertyInternal;
+			case "md-internal-method": return KnownImageIds.MethodInternal;
+			case "md-internal-class": return KnownImageIds.ClassInternal;
+			case "md-internal-field": return KnownImageIds.FieldInternal;
+
+			case "md-protected-property": return KnownImageIds.PropertyProtected;
+			case "md-protected-method": return KnownImageIds.MethodProtected;
+			case "md-protected-class": return KnownImageIds.ClassProtected;
+			case "md-protected-field": return KnownImageIds.FieldProtected;
+
+			case "md-private-static-property": return KnownImageIds.PropertyPrivate;
+			case "md-private-static-method": return KnownImageIds.MethodPrivate;
+			case "md-private-static-field": return KnownImageIds.FieldPrivate;
+
+			case "md-internal-static-property": return KnownImageIds.PropertyInternal;
+			case "md-internal-static-method": return KnownImageIds.MethodInternal;
+			case "md-internal-static-field": return KnownImageIds.FieldInternal;
+
+			case "md-protected-static-property": return KnownImageIds.PropertyProtected;
+			case "md-protected-static-method": return KnownImageIds.MethodProtected;
+			case "md-protected-static-field": return KnownImageIds.FieldProtected;
+
+			default:
+				LoggingService.LogWarning ("Unknown Debugger ImageId: {0}", name);
+				return -1;
+			}
+		}
+
+		public static ImageId GetImageId (ObjectValueFlags flags)
+		{
+			int id = GetKnownImageId (flags);
+
+			return id == -1 ? default : new ImageId (KnownImageIds.ImageCatalogGuid, id);
 		}
 
 		public static string GetPreviewButtonIcon (PreviewButtonIcon icon)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999418/
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1018525/

backport of https://github.com/mono/monodevelop/pull/9166