### PR TITLE
[Debugger] Exception caught dialog accessibility

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -58,7 +58,6 @@ namespace MonoDevelop.Debugger
 		Button close, helpLinkButton, innerExceptionHelpLinkButton;
 		TreeView exceptionValueTreeView, stackTraceTreeView;
 		MacObjectValueTreeView macExceptionValueTreeView;
-		Expander expanderProperties, expanderStacktrace;
 		InnerExceptionsTree innerExceptionsTreeView;
 		ObjectValueTreeViewController controller;
 		CheckButton onlyShowMyCodeCheckbox;
@@ -209,7 +208,7 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			if (useNewTreeView && Platform.IsMac) {
 				var scrolled = new AppKit.NSScrollView {
 					DocumentView = macExceptionValueTreeView,
-					AutohidesScrollers = false,
+					AutohidesScrollers = true,
 					HasVerticalScroller = true,
 					HasHorizontalScroller = true,
 				};
@@ -240,7 +239,6 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 				exceptionValueTreeView.Show ();
 
 				var scrolled = new ScrolledWindow {
-					HeightRequest = 180,
 					CanFocus = true,
 					HscrollbarPolicy = PolicyType.Automatic,
 					VscrollbarPolicy = PolicyType.Automatic
@@ -252,57 +250,23 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 				scrolledWidget = scrolled;
 			}
 
-			var vbox = new VBox ();
-			expanderProperties = WrapInExpander (GettextCatalog.GetString ("Properties"), scrolledWidget);
-			vbox.PackStart (new VBox (), false, false, 5);
-			vbox.PackStart (expanderProperties, true, true, 0);
-			vbox.ShowAll ();
-
-			return vbox;
-		}
-
-		class ExpanderWithMinSize : Expander
-		{
-			public ExpanderWithMinSize (string label) : base (label)
-			{
-			}
+			var label = new Label ();
+			label.Markup = "<b>" + GettextCatalog.GetString ("Properties") + "</b>";
+			label.Xalign = 0;
+			label.Xpad = 10;
 
 			protected override void OnSizeRequested (ref Requisition requisition)
 			{
 				base.OnSizeRequested (ref requisition);
 				requisition.Height = 28;
 			}
-		}
 
-		Expander WrapInExpander (string title, Widget widget)
-		{
-			var expander = new ExpanderWithMinSize ($"<b>{GLib.Markup.EscapeText (title)}</b>");
-			expander.Name = "exception_dialog_expander";
-			Gtk.Rc.ParseString (@"style ""exception-dialog-expander""
-{
-	GtkExpander::expander-spacing = 10
-}
-widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
-");
-			expander.Child = widget;
-			expander.Spacing = 0;
-			expander.Show ();
-			expander.CanFocus = true;
-			expander.UseMarkup = true;
-			expander.Expanded = true;
-			expander.Activated += Expander_Activated;
-			expander.ModifyBg (StateType.Prelight, Ide.Gui.Styles.PrimaryBackgroundColor.ToGdkColor ());
-			return expander;
-		}
+			var vbox = new VBox ();
+			vbox.PackStart (label, false, false, 12);
+			vbox.PackStart (scrolledWidget, true, true, 0);
+			vbox.ShowAll ();
 
-		void Expander_Activated (object sender, EventArgs e)
-		{
-			if (expanderProperties.Expanded && expanderStacktrace.Expanded)
-				paned.PositionSet = false;
-			else if (expanderStacktrace.Expanded)
-				paned.Position = paned.MaxPosition;
-			else
-				paned.Position = paned.MinPosition;
+			return vbox;
 		}
 
 		static void StackFrameLayout (CellLayout layout, CellRenderer cr, TreeModel model, TreeIter iter)
@@ -339,7 +303,6 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			stackTraceTreeView.RowActivated += StackFrameActivated;
 
 			var scrolled = new ScrolledWindow {
-				HeightRequest = 180,
 				HscrollbarPolicy = PolicyType.Never,
 				VscrollbarPolicy = PolicyType.Automatic
 			};
@@ -351,10 +314,14 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			vbox.PackStart (scrolled, true, true, 0);
 			vbox.Show ();
 
+			var label = new Label ();
+			label.Markup = "<b>" + GettextCatalog.GetString ("Stacktrace") + "</b>";
+			label.Xalign = 0;
+			label.Xpad = 10;
+
 			var vbox2 = new VBox ();
-			expanderStacktrace = WrapInExpander (GettextCatalog.GetString ("Stacktrace"), vbox);
-			vbox2.PackStart (new VBox (), false, false, 5);
-			vbox2.PackStart (expanderStacktrace, true, true, 0);
+			vbox2.PackStart (label, false, false, 12);
+			vbox2.PackStart (vbox, true, true, 0);
 			vbox2.ShowAll ();
 			return vbox2;
 		}
@@ -406,6 +373,7 @@ widget ""*.exception_dialog_expander"" style ""exception-dialog-expander""
 			paned.GrabAreaSize = 10;
 			paned.Pack1 (CreateStackTraceTreeView (), true, false);
 			paned.Pack2 (CreateExceptionValueTreeView (), true, false);
+			paned.Position = 160;
 			paned.Show ();
 			var vbox = new VBox (false, 0);
 			var whiteBackground = new EventBox ();

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using System.Collections.Generic;
 
 using Foundation;
+using GLib;
 using Gtk;
 
 using Mono.Debugging.Client;
@@ -38,6 +39,7 @@ using Mono.Debugging.Client;
 using MonoDevelop.Ide;
 using MonoDevelop.Core;
 using MonoDevelop.Components;
+using MonoDevelop.Components.AtkCocoaHelper;
 using MonoDevelop.Ide.TextEditing;
 using MonoDevelop.Ide.Editor.Extension;
 
@@ -97,6 +99,8 @@ namespace MonoDevelop.Debugger
 			icon.Yalign = 0;
 
 			exceptionTypeLabel = new Label { Xalign = 0.0f, Selectable = true, CanFocus = false };
+			icon.SetCommonAccessibilityAttributes ("ExceptionCaughtDialog.WarningIcon", exceptionTypeLabel, null);
+
 			exceptionMessageLabel = new Label { Wrap = true, Xalign = 0.0f, Selectable = true, CanFocus = false };
 			helpLinkButton = new Button { HasFocus = true, Xalign = 0, Relief = ReliefStyle.None, BorderWidth = 0 };
 			helpLinkButton.Name = "exception_help_link_label";
@@ -255,10 +259,10 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			label.Xalign = 0;
 			label.Xpad = 10;
 
-			protected override void OnSizeRequested (ref Requisition requisition)
-			{
-				base.OnSizeRequested (ref requisition);
-				requisition.Height = 28;
+			if (exceptionValueTreeView != null) {
+				exceptionValueTreeView.SetCommonAccessibilityAttributes ("ExceptionCaughtDialog.ExceptionValueTreeView", label, null);
+			} else {
+				macExceptionValueTreeView.AccessibilityTitle = new NSString (label.Text);
 			}
 
 			var vbox = new VBox ();
@@ -318,6 +322,8 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			label.Markup = "<b>" + GettextCatalog.GetString ("Stacktrace") + "</b>";
 			label.Xalign = 0;
 			label.Xpad = 10;
+
+			stackTraceTreeView.SetCommonAccessibilityAttributes ("ExceptionCaughtDialog.StackTraceTreeView", label, null);
 
 			var vbox2 = new VBox ();
 			vbox2.PackStart (label, false, false, 12);
@@ -435,6 +441,7 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			innerExceptionTypeLabel.Xalign = 0;
 			innerExceptionTypeLabel.Selectable = true;
 			innerExceptionTypeLabel.CanFocus = false;
+			icon.SetCommonAccessibilityAttributes ("ExceptionCaughtDialog.InnerExceptionWarningIcon", innerExceptionTypeLabel, null);
 			hbox.PackStart (innerExceptionTypeLabel, false, true, 4);
 
 			innerExceptionMessageLabel = new Label ();
@@ -518,6 +525,10 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 					UpdateSelectedException ((ExceptionInfo)innerExceptionsTreeView.Model.GetValue (selectedIter, 0));
 				}
 			};
+			innerExceptionsTreeView.SetCommonAccessibilityAttributes (
+				"ExceptionCaughtDialog.InnerExceptionsTreeView",
+				GettextCatalog.GetString ("Inner Exceptions"),
+				null);
 			var eventBox = new EventBox ();
 			eventBox.ModifyBg (StateType.Normal, Styles.ExceptionCaughtDialog.TreeBackgroundColor.ToGdkColor ()); // top and bottom padders
 			var vbox = new VBox ();
@@ -720,6 +731,7 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 
 		class CellRendererInnerException : CellRenderer
 		{
+			[Property ("text")] // Enables Voice Over support.
 			public string Text { get; set; }
 
 			Pango.FontDescription font = Pango.FontDescription.FromString (Platform.IsWindows ? "9" : "11");

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectNameView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectNameView.cs
@@ -92,6 +92,7 @@ namespace MonoDevelop.Debugger
 
 			PreviewButton = new NSButton {
 				TranslatesAutoresizingMaskIntoConstraints = false,
+				AccessibilityTitle = GettextCatalog.GetString ("Open Preview Visualizer"),
 				Image = GetImage ("md-empty", Gtk.IconSize.Menu),
 				BezelStyle = NSBezelStyle.Inline,
 				Bordered = false
@@ -264,6 +265,9 @@ namespace MonoDevelop.Debugger
 			TextField.Editable = editable;
 			UpdateFont (TextField);
 			TextField.SizeToFit ();
+			ImageView.AccessibilityTitle = ObjectValueTreeViewController.GetAccessibilityTitleForIcon (
+				Node.Flags,
+				GettextCatalog.GetString ("Object Name"));
 
 			var value = editable && string.IsNullOrEmpty (name) ? placeholder : name;
 			var textWidth = GetWidthForString (TextField.Font, value);

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/Mac/MacDebuggerObjectValueView.cs
@@ -82,6 +82,7 @@ namespace MonoDevelop.Debugger
 
 			int imageSize = treeView.CompactView ? CompactImageSize : ImageSize;
 			viewerButton = new NSButton {
+				AccessibilityTitle = GettextCatalog.GetString ("Open Value Visualizer"),
 				Image = GetImage (Gtk.Stock.Edit, imageSize, imageSize),
 				TranslatesAutoresizingMaskIntoConstraints = false
 			};
@@ -188,7 +189,9 @@ namespace MonoDevelop.Debugger
 			// First item: Status Icon -or- Spinner
 			if (evaluateStatusIcon != null) {
 				statusIcon.Image = GetImage (evaluateStatusIcon, Gtk.IconSize.Menu, selected);
-
+				statusIcon.AccessibilityTitle = ObjectValueTreeViewController.GetAccessibilityTitleForIcon (
+					evaluateStatusIcon,
+					GettextCatalog.GetString ("Object Value"));
 				if (!statusIconVisible) {
 					AddSubview (statusIcon);
 					statusIconVisible = true;

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ObjectValue/ObjectValueTreeViewController.cs
@@ -964,6 +964,48 @@ namespace MonoDevelop.Debugger
 			return "md-" + access + global + source;
 		}
 
+		internal static string GetAccessibilityTitleForIcon (ObjectValueFlags flags, string defaultTitle = null)
+		{
+			if ((flags & ObjectValueFlags.Field) != 0 && (flags & ObjectValueFlags.ReadOnly) != 0)
+				return GettextCatalog.GetString ("Literal");
+
+			string global = (flags & ObjectValueFlags.Global) != 0 ? GettextCatalog.GetString ("Static") : string.Empty;
+			string source;
+
+			switch (flags & ObjectValueFlags.OriginMask) {
+			case ObjectValueFlags.Property: source = GettextCatalog.GetString ("Property"); break;
+			case ObjectValueFlags.Type: source = GettextCatalog.GetString ("Class"); global = string.Empty; break;
+			case ObjectValueFlags.Method: source = GettextCatalog.GetString ("Method"); break;
+			case ObjectValueFlags.Literal: return GettextCatalog.GetString ("Literal");
+			case ObjectValueFlags.Namespace: return GettextCatalog.GetString ("Namespace");
+			case ObjectValueFlags.Group: return GettextCatalog.GetString ("Open Resource Folder");
+			case ObjectValueFlags.Field: source = GettextCatalog.GetString ("Field"); break;
+			case ObjectValueFlags.Variable: return GettextCatalog.GetString ("Variable");
+			default: return defaultTitle;
+			}
+
+			string access;
+			switch (flags & ObjectValueFlags.AccessMask) {
+			case ObjectValueFlags.Private: access = GettextCatalog.GetString ("Private"); break;
+			case ObjectValueFlags.Internal: access = GettextCatalog.GetString ("Internal"); break;
+			case ObjectValueFlags.InternalProtected:
+			case ObjectValueFlags.Protected: access = GettextCatalog.GetString ("Protected"); break;
+			default: access = string.Empty; break;
+			}
+
+			return access + " " + global + " " + source;
+		}
+
+		internal static string GetAccessibilityTitleForIcon (string iconName, string defaultTitle)
+		{
+			switch (iconName) {
+			case "md-warning":
+				return GettextCatalog.GetString ("Warning");
+			default:
+				return defaultTitle;
+			}
+		}
+
 		static int GetKnownImageId (ObjectValueFlags flags)
 		{
 			var name = GetIcon (flags);


### PR DESCRIPTION
- Fixes VSTS #782188 - Voiceover doesn't give any information about the "eye" and "Pen" icon which are interactive
- Fixes VSTS #1025889 - VoiceOver does not announce the image name.
- Fixes VSTS #1025898 - ScreenReader focus does not go on the table.

Problems:

- Tabbing into and out of the Properties tree view is currently broken. Seems to be a problem with the interaction with the GtkNSViewHost and the native tree view control.

Small changes to the UI:
 - Replaced the Properties tree view the new native one created by Jeff.
 - Removed the expanders since they were causing problems with Voice Over.

UI Before:

<img width="499" alt="ExceptionCaughtDialogBefore" src="https://user-images.githubusercontent.com/372361/69741129-6c3a0480-1132-11ea-8ef4-672446a35a42.png">

UI After:

<img width="499" alt="ExceptionCaughtDialogAfter" src="https://user-images.githubusercontent.com/372361/69741136-6e03c800-1132-11ea-94f3-2d64e539b55f.png">