### PR TITLE
Fixes 1026106 - in some cases, NSEvent seems to have been null

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -139,12 +139,12 @@ namespace MonoDevelop.Components
 												null, 0, 0, 0);
 
 				// the following lines are here to dianose & fix VSTS 1026106 - we were getting
-				// a SigSegv from here and it is likely caused by NSEven being null, however
+				// a SigSegv from here and it is likely caused by NSEvent being null, however
 				// it's worth leaving Debug checks in just to be on the safe side
 				if (tmp_event == null) {
 					// since this is often called outside of a try/catch loop, we'll just
 					// log an error and not throw the exception
-					LoggingService.LogInternalError (new ArgumentNullException ("tmp_event"));
+					LoggingService.LogInternalError (new ArgumentNullException (nameof(tmp_event)));
 					return;
 				}
 				

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/ContextMenuExtensionsMac.cs
@@ -29,6 +29,7 @@ using System;
 using AppKit;
 using CoreGraphics;
 using Foundation;
+using MonoDevelop.Core;
 using MonoDevelop.Ide;
 #endif
 
@@ -136,6 +137,20 @@ namespace MonoDevelop.Components
 												0, 0,
 												parent.Window.WindowNumber,
 												null, 0, 0, 0);
+
+				// the following lines are here to dianose & fix VSTS 1026106 - we were getting
+				// a SigSegv from here and it is likely caused by NSEven being null, however
+				// it's worth leaving Debug checks in just to be on the safe side
+				if (tmp_event == null) {
+					// since this is often called outside of a try/catch loop, we'll just
+					// log an error and not throw the exception
+					LoggingService.LogInternalError (new ArgumentNullException ("tmp_event"));
+					return;
+				}
+				
+				System.Diagnostics.Debug.Assert (parent != null, "Parent was modified (set to null) during execution.");
+				System.Diagnostics.Debug.Assert (menu != null, "Menu was modified (set to null) during execution.");
+
 				NSMenu.PopUpContextMenu (menu, tmp_event, parent);
 			}
 		}


### PR DESCRIPTION
This introduces a null check, and also introduces additional debug levelchecks for others, just to make sure if we do run into this while debugging, that we are aware.

Fixes https://vsmac.dev/1026106 