### PR TITLE
[Ide] Consider MSBuild item conditions in Solution pad

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildPropertyGroupEvaluated.cs
@@ -24,16 +24,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Xml.Linq;
+using System.Linq;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.Projects.MSBuild
 {
 	class MSBuildPropertyGroupEvaluated: MSBuildNode, IMSBuildPropertyGroupEvaluated, IMSBuildProjectObject
 	{
-		protected ConcurrentDictionary<string, IMSBuildPropertyEvaluated> properties = new ConcurrentDictionary<string, IMSBuildPropertyEvaluated> (StringComparer.OrdinalIgnoreCase);
+		protected Dictionary<string, IMSBuildPropertyEvaluated> properties = new Dictionary<string, IMSBuildPropertyEvaluated> (StringComparer.OrdinalIgnoreCase);
 		MSBuildEngine engine;
 
 		internal MSBuildPropertyGroupEvaluated (MSBuildProject parent)
@@ -43,45 +42,60 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal void Sync (MSBuildEngine engine, object item, bool clearProperties = true)
 		{
-			if (clearProperties)
-				properties.Clear ();
+			if (clearProperties) {
+				lock (properties) {
+					properties.Clear ();
+				}
+			}
 			this.engine = engine;
 			foreach (var propName in engine.GetItemMetadataNames (item)) {
 				var prop = new MSBuildPropertyEvaluated (ParentProject, propName, engine.GetItemMetadata (item, propName), engine.GetEvaluatedItemMetadata (item, propName));
-				properties [propName] = prop;
+				lock (properties) {
+					properties [propName] = prop;
+				}
 			}
 		}
 
 		public bool HasProperty (string name)
 		{
-			return properties.ContainsKey (name);
+			lock (properties) {
+				return properties.ContainsKey (name);
+			}
 		}
 
 		public IMSBuildPropertyEvaluated GetProperty (string name)
 		{
 			IMSBuildPropertyEvaluated prop;
-			properties.TryGetValue (name, out prop);
+			lock (properties) {
+				properties.TryGetValue (name, out prop);
+			}
 			return prop;
 		}
 
 		internal void SetProperty (string key, IMSBuildPropertyEvaluated value)
 		{
-			properties [key] = value;
+			lock (properties) {
+				properties [key] = value;
+			}
 		}
 
 		internal void SetProperties (Dictionary<string,IMSBuildPropertyEvaluated> properties)
 		{
-			this.properties = new ConcurrentDictionary<string, IMSBuildPropertyEvaluated> (properties, StringComparer.OrdinalIgnoreCase);
+			this.properties = properties;
 		}
 
 		public IEnumerable<IMSBuildPropertyEvaluated> GetProperties ()
 		{
-			return properties.Values;
+			lock (properties) {
+				return properties.Values.ToArray ();
+			}
 		}
 
 		internal bool RemoveProperty (string name)
 		{
-			return properties.TryRemove (name, out _);
+			lock (properties) {
+				return properties.Remove (name);
+			}
 		}
 
 		public string GetValue (string name, string defaultValue = null)
@@ -153,11 +167,15 @@ namespace MonoDevelop.Projects.MSBuild
 
 		internal void SyncCollection (MSBuildEngine e, object project)
 		{
-			properties.Clear ();
+			lock (properties) {
+				properties.Clear ();
+			}
 			foreach (var p in e.GetEvaluatedProperties (project)) {
 				string name, value, finalValue; bool definedMultipleTimes;
 				e.GetPropertyInfo (p, out name, out value, out finalValue, out definedMultipleTimes);
-				properties [name] = new MSBuildPropertyEvaluated (ParentProject, name, value, finalValue, definedMultipleTimes);
+				lock (properties) {
+					properties [name] = new MSBuildPropertyEvaluated (ParentProject, name, value, finalValue, definedMultipleTimes);
+				}
 			}
 		}
 
@@ -244,7 +262,9 @@ namespace MonoDevelop.Projects.MSBuild
 		{
 			var p = new MSBuildPropertyEvaluated (ParentProject, name, null, null);
 			p.IsNew = true;
-			properties [name] = p;
+			lock (properties) {
+				properties [name] = p;
+			}
 			return p;
 		}
 
@@ -281,13 +301,19 @@ namespace MonoDevelop.Projects.MSBuild
 				//    that property group property.
 				if (ep.IsNew || !prop.IsNew) {
 					ep.IsNew = false;
-					properties.TryRemove (ep.Name, out _);
+					lock (properties) {
+						properties.Remove (ep.Name);
+					}
 				}
 			}
 		}
 
 		public IEnumerable<IMSBuildPropertyEvaluated> Properties {
-			get { return properties.Values; }
+			get {
+				lock (properties) {
+					return properties.Values.ToArray ();
+				}
+			}
 		}
 	}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/FolderNodeBuilder.cs
@@ -84,13 +84,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			files = new List<ProjectFile> ();
 			folders = new List<string> ();
 			
-			foreach (ProjectFile file in project.Files)
-			{
+			foreach (ProjectFile file in project.GetVisibleFiles (IdeApp.Workspace.ActiveConfiguration)) {
 				string dir;
 
-				if (!file.Visible || file.Flags.HasFlag (ProjectItemFlags.Hidden))
-					continue;
-				
 				if (file.Subtype != Subtype.Directory) {
 					// If file depends on something other than a directory, continue
 					if ((file.DependsOnFile != null && file.DependsOnFile.Subtype != Subtype.Directory) || FileNestingService.HasParent (file))

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectNodeBuilderTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/ProjectNodeBuilderTests.cs
@@ -1,0 +1,80 @@
+//
+// ProjectNodeBuilderTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Linq;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui.Pads.ProjectPad;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.Ide.Projects
+{
+	[TestFixture]
+	[RequireService (typeof (RootWorkspace))]
+	class ProjectNodeBuilderTests : IdeTestBase
+	{
+		[Test]
+		public async Task ConditionalFiles ()
+		{
+			FilePath solutionFile = Util.GetSampleProject ("ConditionalFiles", "ConditionalFiles.sln");
+
+			using (var solution = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFile)) {
+				var p = solution.GetAllProjects ().OfType<DotNetProject> ().Single ();
+
+				// Debug configuration.
+				IdeApp.Workspace.ActiveConfigurationId = "Debug";
+
+				var treeBuilder = new TestTreeBuilder ();
+				treeBuilder.ParentDataItem [typeof (Project)] = p;
+
+				var nodeBuilder = new ProjectNodeBuilder ();
+				nodeBuilder.BuildChildNodes (treeBuilder, p);
+
+				var debugFiles = treeBuilder.ChildNodes.OfType<ProjectFile> ().ToList ();
+				var debugFileNames = debugFiles.Select (f => f.FilePath.FileName).ToList ();
+				Assert.That (debugFileNames, Has.Member ("MyClass.cs"));
+				Assert.That (debugFileNames, Has.Member ("MyClass-Debug.cs"));
+				Assert.That (debugFileNames, Has.No.Member ("MyClass-Release.cs"));
+				Assert.AreEqual (2, debugFiles.Count);
+
+				// Release configuration.
+				IdeApp.Workspace.ActiveConfigurationId = "Release";
+
+				treeBuilder.ChildNodes.Clear ();
+				nodeBuilder.BuildChildNodes (treeBuilder, p);
+				var releaseFiles = treeBuilder.ChildNodes.OfType<ProjectFile> ().ToList ();
+				var releaseFileNames = releaseFiles.Select (f => f.FilePath.FileName).ToList ();
+				Assert.That (releaseFileNames, Has.Member ("MyClass.cs"));
+				Assert.That (releaseFileNames, Has.Member ("MyClass-Release.cs"));
+				Assert.That (releaseFileNames, Has.No.Member ("MyClass-Debug.cs"));
+				Assert.AreEqual (2, releaseFiles.Count);
+			}
+		}
+	}
+
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/TestTreeBuilder.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Projects/TestTreeBuilder.cs
@@ -1,0 +1,187 @@
+//
+// TestTreeBuilder.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using MonoDevelop.Ide.Gui.Components;
+
+namespace MonoDevelop.Ide.Projects
+{
+	class TestTreeBuilder : ITreeBuilder
+	{
+		public object DataItem { get; set; }
+		public string NodeName { get; set; }
+		public bool Selected { get; set; }
+		public bool Expanded { get; set; }
+		public ITreeOptions Options { get; }
+		public TypeNodeBuilder TypeNodeBuilder { get; }
+		public NodePosition CurrentPosition { get; }
+		public bool Filled { get; }
+
+		public List<object> ChildNodes = new List<object> ();
+
+		public void AddChild (object dataObject)
+		{
+			ChildNodes.Add (dataObject);
+		}
+
+		public void AddChild (object dataObject, bool moveToChild)
+		{
+			ChildNodes.Add (dataObject);
+		}
+
+		public void AddChildren (IEnumerable dataObjects)
+		{
+			foreach (object dataObject in dataObjects) {
+				ChildNodes.Add (dataObject);
+			}
+		}
+
+		public ITreeNavigator Clone ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void ExpandToNode ()
+		{
+		}
+
+		public bool FindChild (object dataObject)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool FindChild (object dataObject, bool recursive)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Dictionary<Type, object> ParentDataItem = new Dictionary<Type, object> ();
+
+		public object GetParentDataItem (Type type, bool includeCurrent)
+		{
+			if (ParentDataItem.TryGetValue (type, out object parent)) {
+				return parent;
+			}
+
+			return null;
+		}
+
+		public T GetParentDataItem<T> (bool includeCurrent)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool HasChild (string name, Type dataType)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool HasChildren ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveNext ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToChild (string name, Type dataType)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToFirstChild ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToNextObject ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToObject (object dataObject)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToParent ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToParent (Type type)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToPosition (NodePosition position)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public bool MoveToRoot ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void Remove ()
+		{
+		}
+
+		public void Remove (bool moveToParent)
+		{
+		}
+
+		public void RestoreState (NodeState state)
+		{
+		}
+
+		public NodeState SaveState ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void ScrollToNode ()
+		{
+		}
+
+		public void Update ()
+		{
+		}
+
+		public void UpdateAll ()
+		{
+		}
+
+		public void UpdateChildren ()
+		{
+		}
+	}
+}

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.Tests.csproj
@@ -132,6 +132,8 @@
     <Compile Include="MonoDevelop.Ide.Gui\GLibLoggingTests.cs" />
     <Compile Include="MonoDevelop.Ide.Projects.OptionPanels\OutputOptionsPanelTests.cs" />
     <Compile Include="MonoDevelop.Components.AutoTest\AppResultTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\ProjectNodeBuilderTests.cs" />
+    <Compile Include="MonoDevelop.Ide.Projects\TestTreeBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\MonoDevelop.Ide\MonoDevelop.Ide.csproj">

--- a/main/tests/test-projects/ConditionalFiles/ConditionalFiles.csproj
+++ b/main/tests/test-projects/ConditionalFiles/ConditionalFiles.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{200DD006-C60F-4A2F-BB12-E2496F88CA65}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ConditionalFiles</RootNamespace>
+    <AssemblyName>ConditionalFiles</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <MyClassEnabled>true</MyClassEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MyClassDebugEnabled>true</MyClassDebugEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MyClass-Release.cs" Condition="'$(MyClassDebugEnabled)' != 'true'" />
+    <Compile Include="MyClass-Debug.cs" Condition="'$(MyClassDebugEnabled)' == 'true'"/>
+    <Compile Include="MyClass.cs" Condition="'$(MyClassEnabled)' == 'true'"/>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ConditionalFiles/ConditionalFiles.sln
+++ b/main/tests/test-projects/ConditionalFiles/ConditionalFiles.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConditionalFiles", "ConditionalFiles.csproj", "{200DD006-C60F-4A2F-BB12-E2496F88CA65}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{200DD006-C60F-4A2F-BB12-E2496F88CA65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{200DD006-C60F-4A2F-BB12-E2496F88CA65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{200DD006-C60F-4A2F-BB12-E2496F88CA65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{200DD006-C60F-4A2F-BB12-E2496F88CA65}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/ConditionalFiles/MyClass-Debug.cs
+++ b/main/tests/test-projects/ConditionalFiles/MyClass-Debug.cs
@@ -1,0 +1,11 @@
+﻿
+using System;
+namespace ConditionalFiles
+{
+	public class MyClassDebug
+	{
+		public MyClassDebug ()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/ConditionalFiles/MyClass-Release.cs
+++ b/main/tests/test-projects/ConditionalFiles/MyClass-Release.cs
@@ -1,0 +1,11 @@
+﻿
+using System;
+namespace ConditionalFiles
+{
+	public class MyClassRelease
+	{
+		public MyClassRelease ()
+		{
+		}
+	}
+}

--- a/main/tests/test-projects/ConditionalFiles/MyClass.cs
+++ b/main/tests/test-projects/ConditionalFiles/MyClass.cs
@@ -1,0 +1,11 @@
+﻿
+using System;
+namespace ConditionalFiles
+{
+	public class MyClass
+	{
+		public MyClass ()
+		{
+		}
+	}
+}


### PR DESCRIPTION
Creating an ASP.NET Core project when .NET Core 3.1 SDK was installed
would result in .json files being displayed twice in the Solution pad.
.NET Core 3.1 SDK defines .json files twice.

    <Content Include="**\*.json" ... Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'" />

    <Content Include="**\*.json" ... Condition="'$(ExcludeConfigFilesFromBuildOutput)'=='true'" />

Older .NET Core SDKs did not define the Content items more than once.
The Condition was not considered when showing files in the Solution
pad.

To support conditional files the Solution pad asks the project for
its visible files. The project uses the MSBuildEvaluationContext
to evaluate the condition to see if the file is visible or not.

Note that conditions on parent ItemGroups are currently not taken into
account. Also that visible files are not updated if the active config
is changed.

Out of scope for this change (to minimize changes for 8.4):

 - Handling ItemGroup definitions.
 - Changing visible files in the Solution pad on changing the active configuration.

Fixes VSTS #1005277 Create ASP.NET Core project, open Properties
folder, there are two launchSettings.json files.