### PR TITLE
[UnitTesting] Fix VS Test discovery failing

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -14,7 +14,7 @@
     <NuGetVersionCecil>0.10.1</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
     <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>
-    <NuGetVersionMicrosoftTestPlatform>16.4.0</NuGetVersionMicrosoftTestPlatform>
+    <NuGetVersionMicrosoftTestPlatform>16.2.0</NuGetVersionMicrosoftTestPlatform>
     <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>
     <NuGetVersionNewtonsoftJson>12.0.2</NuGetVersionNewtonsoftJson>
     <NuGetVersionNuGet>5.3.0-rtm.6192</NuGetVersionNuGet>


### PR DESCRIPTION
Downgraded VS Test from 16.4 to 16.2. The 16.4 version fails to
discover tests. Test Discovery Console window has the error:

```
Microsoft.VisualStudio.TestPlatform.ObjectModel.TestPlatformException:
Testhost process exited with error: The application to execute does
not exist: ''
```

The more recent VS Test seems to not find the testhost.dll causing
test discovery to fail.

VS Test 16.2 is used by .NET Core 3.1 SDK.

Fixes VSTS #1030325 - VS Test discovery fails
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1030325