### PR TITLE
[release-8.4] [Ide] Type system updates file information less often

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1486,7 +1486,7 @@ namespace MonoDevelop.Ide.TypeSystem
 				if (freezeProjectModify)
 					return;
 				try {
-					if (!args.Any (x => x.Hint == "TargetFramework" || x.Hint == "References" || x.Hint == "CompilerParameters" || x.Hint == "Files"))
+					if (!args.Any (x => x.Hint == "TargetFramework" || x.Hint == "References" || x.Hint == "CompilerParameters" || x.Hint == "CoreCompileFiles"))
 						return;
 					var project = sender as MonoDevelop.Projects.DotNetProject;
 					if (project == null)

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetAnalyzerFilesAsyncTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetAnalyzerFilesAsyncTests.cs
@@ -116,7 +116,7 @@ namespace MonoDevelop.Projects
 
 				var before = new MSBuildItem (); // Ensures import added at end of project.
 				project.MSBuildProject.AddNewImport ("consoleproject-import.targets", null, before);
-				Assert.AreEqual ("Files", modifiedHint);
+				Assert.AreEqual ("CoreCompileFiles", modifiedHint);
 
 				analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
 
@@ -124,7 +124,7 @@ namespace MonoDevelop.Projects
 
 				modifiedHint = null;
 				project.MSBuildProject.RemoveImport ("consoleproject-import.targets");
-				Assert.AreEqual ("Files", modifiedHint);
+				Assert.AreEqual ("CoreCompileFiles", modifiedHint);
 
 				analyzerFiles = await project.GetAnalyzerFilesAsync (project.Configurations [0].Selector);
 

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetSourceFilesAsyncTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/GetSourceFilesAsyncTests.cs
@@ -196,7 +196,7 @@ namespace MonoDevelop.Projects
 
 			var before = new MSBuildItem (); // Ensures import added at end of project.
 			project.MSBuildProject.AddNewImport ("consoleproject-import.targets", null, before);
-			Assert.AreEqual ("Files", modifiedHint);
+			Assert.AreEqual ("CoreCompileFiles", modifiedHint);
 
 			sourceFiles = await project.GetSourceFilesAsync (project.Configurations[0].Selector);
 
@@ -204,7 +204,7 @@ namespace MonoDevelop.Projects
 
 			modifiedHint = null;
 			project.MSBuildProject.RemoveImport ("consoleproject-import.targets");
-			Assert.AreEqual ("Files", modifiedHint);
+			Assert.AreEqual ("CoreCompileFiles", modifiedHint);
 
 			sourceFiles = await project.GetSourceFilesAsync (project.Configurations[0].Selector);
 


### PR DESCRIPTION
With a project that uses the DevExpress.Blazor NuGet package the IDE
would get stuck running MSBuild design time builds repeatedly. Every
MSBuild target that was run would trigger the DevExpress UpdateStatic
MSBuild target to run. This UpdateStatic target would delete and create
javascript files in the project. This then triggered the 'Files'
project modified event to fire. The type system then re-ran the design
time builds again since it uses this event as a trigger. This then
resulted in the design time builds being run repeatedly. The status
bar would repeatedly show messages, usually Saving, but sometimes some
version control messages.

To avoid this repeated calling of the MSBuild design time targets the
project now has a new CoreCompileFiles modified event which only fires
for a small subset of build actions - Compile, AdditionalFiles,
Analyzer and EditorConfigFiles. These build actions are the only ones
the type system is interested in so there is no need to re-run a design
time build to get the list of source files if files with different
build actions are added. This prevents the problem with the dev express
build targets since it adds/removes javascript files which are not
needed by the type system.

Fixes VSTS #1030001 - Stuck in constant loop of Saving -> Checkout of
files after building a solution.

Backport of #9423.

/cc @mrward 