### PR TITLE
Fixes VSTS Bug 1027415: [FATAL] SigTerm signal in MonoDevelop.VersionControl.Git.dll!MonoDevelop.VersionControl.Git.GitRepository::Dispose+49

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git.Tests/BaseGitRepositoryTests.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.VersionControl.Git.Tests
 			// Check out the repository.
 			await CheckoutAsync (LocalPath, RemoteUrl);
 			Repo = GetRepo (LocalPath, RemoteUrl);
-			await ((GitRepository)Repo).RunOperationAsync (() => ((GitRepository)Repo).RootRepository.Config.Set ("core.ignorecase", false));
+			await ((GitRepository)Repo).RunOperationAsync ((token) => ((GitRepository)Repo).RootRepository.Config.Set ("core.ignorecase", false));
 			ModifyPath (Repo, ref LocalPath);
 			DotDir = ".git";
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -184,11 +184,12 @@ namespace MonoDevelop.VersionControl.Git
 				dlg.Dispose ();
 			}
 		}
+
 		protected override async Task UpdateAsync (CommandInfo info, CancellationToken cancelToken)
 		{
 			var repo = UpdateVisibility (info);
 			if (repo != null)
-				info.Enabled = await repo.RunOperationAsync (repo.RootPath, repository => !repository.Info.IsHeadUnborn, cancelToken);
+				info.Enabled = await repo.RunOperationAsync (repo.RootPath, (repository, token) => !repository.Info.IsHeadUnborn, cancelToken);
 		}
 	}
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/GitConfigurationDialog.cs
@@ -421,7 +421,7 @@ namespace MonoDevelop.VersionControl.Git
 			try {
 				monitor.BeginTask (GettextCatalog.GetString ("Pushing Tag"), 1);
 				monitor.Log.WriteLine (GettextCatalog.GetString ("Pushing Tag '{0}' to '{1}'", tagName, repo.Url));
-				await repo.PushTagAsync (tagName);
+				await repo.PushTagAsync (tagName, destroyTokenSource.Token);
 				monitor.Step (1);
 				monitor.EndTask ();
 			} catch (Exception ex) {
@@ -449,7 +449,7 @@ namespace MonoDevelop.VersionControl.Git
 			if (string.IsNullOrEmpty(remoteName))
 				return;
 
-			var monitor = VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Fetching remote..."));
+			var monitor = VersionControlService.GetProgressMonitor (GettextCatalog.GetString ("Fetching remote...")).WithCancellationSource (destroyTokenSource);
 			try {
 				await repo.FetchAsync (monitor, remoteName);
 			} catch (Exception ex) {


### PR DESCRIPTION
MonoDevelop.VersionControl.Git.dll!MonoDevelop.VersionControl.Git.TaskFailureExtensions::RunWaitAndCapture+0

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1027415

Hard to reproduce the issue (only 4 Hits). The GitConfigurationDialog
does some long running operations where the cancellation token isn't
passed to these. That got fixed.

But the main issue is the Dispose that could dead lock on the
GitRepository. Since destroy is done on the dedicated operation thread
it may dead lock in some situations.
That can only happen if something long running blocks the
DedicatedOperationFactory. Now the DedicatedOperationFactory
operations get linked to the disposeToken which should cancel these
operations.
But all actions need to get the combined token and use that for their
cancellations.