### PR TITLE
[release-8.4] Fixes VSTS Bug 1027417: [FATAL] SigTerm signal in

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -187,12 +187,11 @@ namespace MonoDevelop.VersionControl.Git
 				dlg.Dispose ();
 			}
 		}
-
-		protected override void Update (CommandInfo info)
+		protected override async Task UpdateAsync (CommandInfo info, CancellationToken cancelToken)
 		{
 			var repo = UpdateVisibility (info);
 			if (repo != null)
-				info.Enabled = repo.RunOperation (repo.RootPath, repository => !repository.Info.IsHeadUnborn);
+				info.Enabled = await repo.RunOperationAsync (repo.RootPath, repository => !repository.Info.IsHeadUnborn, cancelToken);
 		}
 	}
 


### PR DESCRIPTION
MonoDevelop.VersionControl.Git.dll!MonoDevelop.VersionControl.Git.TaskFailureExtensions::RunWaitAndCapture+0

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1027417

Was the only command call left using the non async update which may
cause dead locks.

Backport of #9421.

/cc @slluis @mkrueger