### PR TITLE
[release-8.4] [Core] Fix remote project builder deadlock

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -261,11 +261,15 @@ namespace MonoDevelop.Projects.MSBuild
 		async void Dispose ()
 		{
 			if (!MSBuildProjectService.ShutDown && engine != null) {
-				try {
-					await engine.UnloadProject (this, projectId).ConfigureAwait (false);
-				} catch {
-					// Ignore
-				}
+				var currentEngine = engine;
+				Task.Run (async () => {
+					try {
+						// Run this outside the usageLock to avoid a deadlock with RemoteBuildEngine's remoteProjectBuilders lock.
+						await currentEngine.UnloadProject (this, projectId).ConfigureAwait (false);
+					} catch {
+						// Ignore
+					}
+				}).Ignore ();
 				GC.SuppressFinalize (this);
 				engine = null;
 			}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/RemoteProjectBuilder.cs
@@ -241,8 +241,9 @@ namespace MonoDevelop.Projects.MSBuild
 			lock (usageLock) {
 				if (--references == 0) {
 					if (shuttingDown)
-						Dispose ();
-					RemoteBuildEngineManager.ReleaseProjectBuilder (engine).Ignore ();
+						Dispose (releaseProjectBuilder: true);
+					else
+						RemoteBuildEngineManager.ReleaseProjectBuilder (engine).Ignore ();
 				}
 			}
 		}
@@ -258,7 +259,7 @@ namespace MonoDevelop.Projects.MSBuild
 			}
 		}
 
-		async void Dispose ()
+		async void Dispose (bool releaseProjectBuilder = false)
 		{
 			if (!MSBuildProjectService.ShutDown && engine != null) {
 				var currentEngine = engine;
@@ -269,6 +270,9 @@ namespace MonoDevelop.Projects.MSBuild
 					} catch {
 						// Ignore
 					}
+
+					if (releaseProjectBuilder)
+						await RemoteBuildEngineManager.ReleaseProjectBuilder (currentEngine);
 				}).Ignore ();
 				GC.SuppressFinalize (this);
 				engine = null;

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/BuilderManagerTests.cs
@@ -620,11 +620,27 @@ namespace MonoDevelop.Projects
 
 					// The builder that was running the build and was shutdown should be immediately stopped after build finishes
 					Assert.AreEqual (0, RemoteBuildEngineManager.ActiveEnginesCount);
-					Assert.AreEqual (0, RemoteBuildEngineManager.EnginesCount);
 
+					await AssertWithTimeout (
+						10000,
+						() => 0 == RemoteBuildEngineManager.EnginesCount,
+						() => "Expecting 0 RemoteBuildEngineManager.EnginesCount but was " + RemoteBuildEngineManager.EnginesCount);
 				}
 			} finally {
 				RemoteBuildEngineManager.EngineDisposalDelay = currentDelay;
+			}
+		}
+
+		async Task AssertWithTimeout (int timeout, Func<bool> checkTest, Func<string> getFailureMessage)
+		{
+			int checkInterval = 100;
+			int timeWaited = 0;
+			while (!checkTest ()) {
+				await Task.Delay (checkInterval);
+				timeWaited += checkInterval;
+				if (timeWaited >= timeout) {
+					Assert.Fail (getFailureMessage ());
+				}
 			}
 		}
 


### PR DESCRIPTION
UI hang can occur when the UI thread and a background thread are
updating the remote project builders at the same time due to two locks
being accessed in a different order.

Background thread:

RemoteBuildEngine.GetRemoteProjectBuilder - locks remoteProjectBuilders
RemoteProjectBuilder.AddReference - locks usageLock

UI thread:

RemoteProjectBuilder.Shutdown - locks usageLock
RemoteProjectBuilder.Dispose
RemoteBuildEngine.UnloadProject
RemoteBuildEngine.RemoveBuilder - locks remoteProjectBuilders

To avoid this the RemoteBuildEngine.UnloadProject is not done
synchronously in the RemoteProjectBuilder's Dispose method.

 - Testing this the UnloadProject now generally seems to fail since the engine's connection has been closed before the UnloadProject is called. So not sure if this is the correct fix here.

Fixes VSTS #1030374 - [FATAL] SigTerm signal in MonoDevelop.Core.dll!
MonoDevelop.Projects.MSBuild.RemoteBuildEngine::RemoveBuilder+9


Backport of #9427.

/cc @slluis @mrward