### PR TITLE
[Debugger] Move the Download-via-SourceLink prompt into the NoSourceV…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -26,6 +26,11 @@
 //
 //
 
+/*
+ * Some places we should be doing some error handling we used to toss
+ * exceptions, now we error out silently, this needs a real solution.
+ */
+
 using System;
 using System.Xml;
 using System.Linq;
@@ -39,8 +44,8 @@ using Mono.Addins;
 
 using Mono.Debugging.Client;
 
-using Microsoft.VisualStudio.Text;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
 
 using MonoDevelop.Ide;
 using MonoDevelop.Core;
@@ -48,8 +53,8 @@ using MonoDevelop.Ide.Gui;
 using MonoDevelop.Projects;
 using MonoDevelop.Components;
 using MonoDevelop.Core.Execution;
-using MonoDevelop.Ide.TextEditing;
 using MonoDevelop.Ide.Gui.Content;
+using MonoDevelop.Ide.TextEditing;
 using MonoDevelop.Debugger.Viewers;
 using MonoDevelop.Core.Instrumentation;
 

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Initializer.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Initializer.cs
@@ -26,16 +26,17 @@
 //
 
 using System;
-using MonoDevelop.Ide.Gui;
-using MonoDevelop.Components.Commands;
-using Mono.Debugging.Client;
-using MonoDevelop.Ide.Commands;
-using MonoDevelop.Core;
-using MonoDevelop.Ide;
 using System.IO;
+using System.Threading.Tasks;
 
-using Xwt;
+using Mono.Debugging.Client;
+
+using MonoDevelop.Ide;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui;
 using MonoDevelop.Core.Web;
+using MonoDevelop.Ide.Commands;
+using MonoDevelop.Components.Commands;
 
 namespace MonoDevelop.Debugger
 {
@@ -68,41 +69,40 @@ namespace MonoDevelop.Debugger
 		
 		async void OnFrameChanged (object s, EventArgs a)
 		{
-			if (changingFrame) {
+			if (changingFrame)
 				return;
-			} 
+
+			changingFrame = true;
+
 			try {
-				changingFrame = true;
 				if (disassemblyDoc != null && DebuggingService.IsFeatureSupported (DebuggerFeatures.Disassembly))
 					disassemblyView.Update ();
 
 				var frame = DebuggingService.CurrentFrame;
-				if (frame == null) {
+				if (frame == null)
 					return;
-				}
 
+				var debuggerOptions = DebuggingService.GetUserOptions ();
 				FilePath file = frame.SourceLocation.FileName;
-
 				int line = frame.SourceLocation.Line;
+
 				if (line != -1) {
 					if (!file.IsNullOrEmpty && File.Exists (file)) {
 						var doc = await IdeApp.Workbench.OpenDocument (file, null, line, 1, OpenDocumentOptions.Debugger);
-						if (doc != null) {
+						if (doc != null)
 							return;
-						}
 					}
-					bool alternateLocationExists = false;
+
 					if (frame.SourceLocation.FileHash != null) {
 						var newFilePath = SourceCodeLookup.FindSourceFile (file, frame.SourceLocation.FileHash);
 						if (newFilePath != null && File.Exists (newFilePath)) {
 							frame.UpdateSourceFile (newFilePath);
 							var doc = await IdeApp.Workbench.OpenDocument (newFilePath, null, line, 1, OpenDocumentOptions.Debugger);
-							if (doc != null) {
+							if (doc != null)
 								return;
-							}
 						}
 					}
-					var debuggerOptions = DebuggingService.GetUserOptions ();
+
 					var automaticSourceDownload = debuggerOptions.AutomaticSourceLinkDownload;
 
 					var sourceLink = frame.SourceLocation.SourceLink;
@@ -111,53 +111,23 @@ namespace MonoDevelop.Debugger
 						Document doc = null;
 						// ~/Library/Caches/VisualStudio/8.0/Symbols/org/projectname/git-sha/path/to/file.cs
 						if (!File.Exists (downloadLocation)) {
-							if (automaticSourceDownload == AutomaticSourceDownload.Always) {
-								doc = await DownloadAndOpenFileAsync (frame, line, sourceLink);
-							} else {
-								var hyperlink = $"<a href='{ sourceLink.Uri }'>{  Path.GetFileName (sourceLink.RelativeFilePath) }</a>";
-								var stackframeText = $"<b>{frame.FullStackframeText}</b>";
-
-								var text = GettextCatalog.GetString
-									("{0} is a call to external source code. Would you like to get '{1}' and view it?", stackframeText, hyperlink);
-								var message = new Ide.GenericMessage {
-									Text = GettextCatalog.GetString ("External source code available"),
-									SecondaryText = text
-								};
-								message.AddOption (nameof (automaticSourceDownload), GettextCatalog.GetString ("Always get source code automatically"), false);
-								message.Buttons.Add (AlertButton.Cancel);
-								message.Buttons.Add (new AlertButton (GettextCatalog.GetString ("Get and Open")));
-								message.DefaultButton = 1;
-
-								var didNotCancel = MessageService.GenericAlert (message) != AlertButton.Cancel;
-								if (didNotCancel) {
-									if (message.GetOptionValue (nameof (automaticSourceDownload))) {
-										debuggerOptions.AutomaticSourceLinkDownload = AutomaticSourceDownload.Always;
-										DebuggingService.SetUserOptions (debuggerOptions);
-									}
-									doc = await DownloadAndOpenFileAsync (frame, line, sourceLink);
-								}
-							}
+							if (automaticSourceDownload == AutomaticSourceDownload.Always)
+								doc = await NoSourceView.DownloadAndOpenAsync (frame);
 						} else {
 							// The file has previously been downloaded for a different solution.
 							// We need to map the cached location
 							frame.UpdateSourceFile (downloadLocation);
 							doc = await IdeApp.Workbench.OpenDocument (downloadLocation, null, line, 1, OpenDocumentOptions.Debugger);
 						}
-						if (doc != null) {
+						if (doc != null)
 							return;
-						}
 					}
 				}
 
-				bool disassemblyNotSupported = false;
-				// If we don't have an address space, we can't disassemble
-				if (string.IsNullOrEmpty (frame.AddressSpace))
-					disassemblyNotSupported = true;
+				bool disassemblySupported = !string.IsNullOrEmpty (frame.AddressSpace) &&
+					DebuggingService.CurrentSessionSupportsFeature (DebuggerFeatures.Disassembly);
 
-				if (!DebuggingService.CurrentSessionSupportsFeature (DebuggerFeatures.Disassembly))
-					disassemblyNotSupported = true;
-
-				if (disassemblyNotSupported && disassemblyDoc != null) {
+				if (!disassemblySupported && disassemblyDoc != null) {
 					disassemblyDoc.Close ().Ignore ();
 					disassemblyDoc = null;
 					disassemblyView = null;
@@ -167,14 +137,14 @@ namespace MonoDevelop.Debugger
 				if (disassemblyDoc == null) {
 					if (noSourceDoc == null) {
 						noSourceView = new NoSourceView ();
-						noSourceView.Update (disassemblyNotSupported);
+						noSourceView.Update (debuggerOptions, frame, disassemblySupported);
 						noSourceDoc = await IdeApp.Workbench.OpenDocument (noSourceView, true);
 						noSourceDoc.Closed += delegate {
 							noSourceDoc = null;
 							noSourceView = null;
 						};
 					} else {
-						noSourceView.Update (disassemblyNotSupported);
+						noSourceView.Update (debuggerOptions, frame, disassemblySupported);
 						noSourceDoc.Select ();
 					}
 				} else {
@@ -183,34 +153,6 @@ namespace MonoDevelop.Debugger
 			} finally {
 				changingFrame = false;
 			}
-		}
-
-		async System.Threading.Tasks.Task<Document> DownloadAndOpenFileAsync (StackFrame frame, int line, SourceLink sourceLink)
-		{
-			var pm = IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (
-				GettextCatalog.GetString ("Downloading {0}", sourceLink.Uri),
-				Stock.StatusDownload,
-				true
-			);
-
-			Document doc = null;
-			try {
-				var downloadLocation = sourceLink.GetDownloadLocation (symbolCachePath);
-				Directory.CreateDirectory (Path.GetDirectoryName (downloadLocation));
-				DocumentRegistry.SkipNextChange (downloadLocation);
-				var client = HttpClientProvider.CreateHttpClient (sourceLink.Uri);
-				using (var stream = await client.GetStreamAsync (sourceLink.Uri).ConfigureAwait (false))
-				using (var fs = new FileStream (downloadLocation, FileMode.Create)) {
-					await stream.CopyToAsync (fs).ConfigureAwait (false);
-				}
-				frame.UpdateSourceFile (downloadLocation);
-				doc = await Runtime.RunInMainThread (() => IdeApp.Workbench.OpenDocument (downloadLocation, null, line, 1, OpenDocumentOptions.Debugger));
-			} catch (Exception ex) {
-				LoggingService.LogInternalError ("Error downloading SourceLink file", ex);
-			} finally {
-				pm.Dispose ();
-			}
-			return doc;
 		}
 
 		async void OnShowDisassembly (object s, EventArgs a)
@@ -230,11 +172,11 @@ namespace MonoDevelop.Debugger
 		
 		static void SetSourceCodeFrame ()
 		{
-			Backtrace bt = DebuggingService.CurrentCallStack;
+			var bt = DebuggingService.CurrentCallStack;
 			
 			if (bt != null) {
 				for (int n = 0; n < bt.FrameCount; n++) {
-					StackFrame sf = bt.GetFrame (n);
+					var sf = bt.GetFrame (n);
 
 					if (!sf.IsExternalCode &&
 					    sf.SourceLocation.Line != -1 &&

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/NoSourceView.cs
@@ -23,49 +23,79 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using System;
 using System.IO;
-using MonoDevelop.Components;
-using MonoDevelop.Core;
-using MonoDevelop.Ide;
-using MonoDevelop.Ide.Gui;
-using Xwt;
-using MonoDevelop.Ide.Gui.Documents;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Xwt;
+
+using Mono.Debugging.Client;
+
+using MonoDevelop.Ide;
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui;
+using MonoDevelop.Core.Web;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Gui.Documents;
 
 namespace MonoDevelop.Debugger
 {
 	public class NoSourceView : DocumentController
 	{
-		XwtControl xwtControl;
-		ScrollView scrollView = new ScrollView ();
+		readonly ScrollView scrollView = new ScrollView ();
+		readonly XwtControl xwtControl;
+		DebuggerSessionOptions options;
+		StackFrame frame;
+
 		public NoSourceView ()
 		{
 			xwtControl = new XwtControl (scrollView);
 		}
 
-		public void Update (bool disassemblyNotSupported)
+		public void Update (DebuggerSessionOptions options, StackFrame frame, bool disassemblySupported)
 		{
-			scrollView.Content = CreateContent (disassemblyNotSupported);
+			scrollView.Content = CreateContent (options, frame, disassemblySupported);
 		}
 
-		Widget CreateContent (bool disassemblyNotSupported)
+		Widget CreateContent (DebuggerSessionOptions options, StackFrame frame, bool disassemblySupported)
 		{
-			var fileName = GetFilename (DebuggingService.CurrentFrame?.SourceLocation?.FileName);
+			var fileName = GetFilename (frame.SourceLocation?.FileName);
+			this.options = options;
+
 			var box = new VBox ();
 			box.Margin = 30;
 			box.Spacing = 10;
+
+			this.frame = frame;
+
 			if (!string.IsNullOrEmpty (fileName)) {
 				DocumentTitle = GettextCatalog.GetString ("Source Not Found");
 				var headerLabel = new Label ();
 				headerLabel.Markup = GettextCatalog.GetString ("{0} file not found", $"<b>{fileName}</b>");
 				box.PackStart (headerLabel);
+
 				var actionsBox = new HBox ();
+
 				var buttonBrowseAndFind = new Button (GettextCatalog.GetString ("Browse and find {0}", fileName));
 				buttonBrowseAndFind.Clicked += OpenFindSourceFileDialog;
 				actionsBox.PackStart (buttonBrowseAndFind);
+
+				if (frame.SourceLocation?.SourceLink != null && options.AutomaticSourceLinkDownload == AutomaticSourceDownload.Ask) {
+					var button = new Button (GettextCatalog.GetString ("Download via Source Link"));
+					button.Name = "SourceLinkButton";
+					button.Clicked += DownloadSourceLink;
+					actionsBox.PackStart (button);
+
+					var checkbox = new CheckBox (GettextCatalog.GetString ("Always get source code automatically"));
+					checkbox.Name = "SourceLinkCheckbox";
+					actionsBox.PackStart (checkbox);
+				}
+
 				box.PackStart (actionsBox);
+
 				if (IdeApp.ProjectOperations.CurrentSelectedSolution != null) {
 					var manageLookupsLabel = new Label ();
 					manageLookupsLabel.Markup = GettextCatalog.GetString ("Manage the locations used to find source files in the {0}", "<a href=\"clicked\">" + GettextCatalog.GetString ("Solution Options") + "</a>");
@@ -85,7 +115,8 @@ namespace MonoDevelop.Debugger
 				box.PackStart (label);
 				headerLabel.Font = label.Font.WithScaledSize (2);
 			}
-			if (!disassemblyNotSupported) {
+
+			if (disassemblySupported) {
 				var labelDisassembly = new Label ();
 				labelDisassembly.Markup = GettextCatalog.GetString ("View disassembly in the {0}", "<a href=\"clicked\">" + GettextCatalog.GetString ("Disassembly Tab") + "</a>");
 				labelDisassembly.LinkClicked += (sender, e) => {
@@ -94,6 +125,7 @@ namespace MonoDevelop.Debugger
 				};
 				box.PackStart (labelDisassembly);
 			}
+
 			return box;
 		}
 
@@ -101,13 +133,15 @@ namespace MonoDevelop.Debugger
 		{
 			if (fileName == null)
 				return null;
+
 			var index = fileName.LastIndexOfAny (new char [] { '/', '\\' });
 			if (index != -1)
 				return fileName.Substring (index + 1);
+
 			return fileName;
 		}
 
-		private async void OpenFindSourceFileDialog (object sender, EventArgs e)
+		async void OpenFindSourceFileDialog (object sender, EventArgs e)
 		{
 			var sf = DebuggingService.CurrentFrame;
 			if (sf == null) {
@@ -135,6 +169,7 @@ namespace MonoDevelop.Debugger
 
 						var doc = await IdeApp.Workbench.OpenDocument (newFilePath, null, sf.SourceLocation.Line, 1, OpenDocumentOptions.Debugger);
 						if (doc != null) {
+							// close the NoSourceView document tab
 							await Document.Close (false);
 						}
 					}
@@ -143,6 +178,66 @@ namespace MonoDevelop.Debugger
 				}
 			} catch (Exception) {
 				MessageService.ShowWarning (GettextCatalog.GetString ("Error opening file."));
+			}
+		}
+
+		public static async Task<Document> DownloadAndOpenAsync (StackFrame frame)
+		{
+			var symbolCachePath = UserProfile.Current.CacheDir.Combine ("Symbols");
+			var sourceLink = frame.SourceLocation.SourceLink;
+
+			var pm = IdeApp.Workbench.ProgressMonitors.GetStatusProgressMonitor (
+				GettextCatalog.GetString ("Downloading {0}", sourceLink.Uri),
+				Stock.StatusDownload,
+				true
+			);
+
+			Document doc = null;
+			try {
+				var downloadLocation = sourceLink.GetDownloadLocation (symbolCachePath);
+				Directory.CreateDirectory (Path.GetDirectoryName (downloadLocation));
+				DocumentRegistry.SkipNextChange (downloadLocation);
+
+				var client = HttpClientProvider.CreateHttpClient (sourceLink.Uri);
+
+				using (var stream = await client.GetStreamAsync (sourceLink.Uri).ConfigureAwait (false)) {
+					using (var fs = new FileStream (downloadLocation, FileMode.Create))
+						await stream.CopyToAsync (fs).ConfigureAwait (false);
+				}
+
+				frame.UpdateSourceFile (downloadLocation);
+
+				int line = frame.SourceLocation.Line;
+
+				doc = await Runtime.RunInMainThread (() => IdeApp.Workbench.OpenDocument (downloadLocation, null, line, 1, OpenDocumentOptions.Debugger));
+			} catch (Exception ex) {
+				LoggingService.LogInternalError ("Error downloading SourceLink file", ex);
+			} finally {
+				pm.Dispose ();
+			}
+
+			return doc;
+		}
+
+		async void DownloadSourceLink (object sender, EventArgs e)
+		{
+			var button = (Button) sender;
+
+			// don't allow the user to click the button again
+			button.Sensitive = false;
+
+			var actionsBox = (HBox) button.Parent;
+			var checkbox = actionsBox.Children.OfType<CheckBox> ().FirstOrDefault (x => x.Name == "SourceLinkCheckbox");
+			if (checkbox != null && checkbox.Active) {
+				options.AutomaticSourceLinkDownload = AutomaticSourceDownload.Always;
+				DebuggingService.SetUserOptions (options);
+			}
+
+			var doc = await DownloadAndOpenAsync (frame);
+
+			if (doc != null) {
+				// close the NoSourceView document tab
+				await Document.Close (false);
 			}
 		}
 


### PR DESCRIPTION
…iew page

Instead of annoying the user with a dialog prompt and then,
when the user clicks Cancel, showing them the NoSourceView
document - just add a "Download via SourceLink" button to
the NoSourceView document tab allowing the user to download
the source there.

This simplifies the process and makes it much less annoying.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/966732/