### PR TITLE
[XamMac] Load libxammac before implicit dlopen gets to resolve it

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -154,11 +154,6 @@ namespace MonoDevelop.MacIntegration
 
 			initTracker = timer.BeginTiming ();
 
-			var dir = Path.GetDirectoryName (typeof(MacPlatformService).Assembly.Location);
-
-			if (ObjCRuntime.Dlfcn.dlopen (Path.Combine (dir, "libxammac.dylib"), 0) == IntPtr.Zero)
-				LoggingService.LogFatalError ("Unable to load libxammac");
-
 			CheckGtkVersion (2, 24, 14);
 
 			Xwt.Toolkit.CurrentEngine.RegisterBackend<IExtendedTitleBarWindowBackend,ExtendedTitleBarWindowBackend> ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NativeToolkitHelper.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/NativeToolkitHelper.cs
@@ -45,7 +45,10 @@ namespace MonoDevelop.Components.Mac
 				return toolkit;
 			}
 
-			var path = Path.GetDirectoryName (typeof (IdeTheme).Assembly.Location);
+			var path = Path.GetDirectoryName (typeof (NativeToolkitHelper).Assembly.Location);
+			if (ObjCRuntime.Dlfcn.dlopen (Path.Combine (path, "libxammac.dylib"), 0) == IntPtr.Zero)
+				LoggingService.LogFatalError ("Unable to load libxammac");
+
 			System.Reflection.Assembly.LoadFrom (Path.Combine (path, "Xwt.XamMac.dll"));
 			toolkit = Xwt.Toolkit.Load (Xwt.ToolkitType.XamMac);
 

--- a/main/tests/TestRunner/Runner.cs
+++ b/main/tests/TestRunner/Runner.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Tests.TestRunner
 			string resultsXmlFile = null;
 
 			if (Platform.IsMac) {
-				var path = Path.GetDirectoryName (typeof (Runer).Assembly.Location);
+				var path = Path.GetDirectoryName (typeof (Runtime).Assembly.Location);
 				if (dlopen (Path.Combine (path, "libxammac.dylib"), 0) == IntPtr.Zero)
 					throw new InvalidOperationException ("Unable to load libxammac");
 			}

--- a/main/tests/TestRunner/Runner.cs
+++ b/main/tests/TestRunner/Runner.cs
@@ -35,11 +35,15 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using MonoDevelop.Tests.TestRunner.TestModel;
+using System.Runtime.InteropServices;
 
 namespace MonoDevelop.Tests.TestRunner
 {
 	public class Runer: IApplication
 	{
+		[DllImport ("/usr/lib/libSystem.dylib")]
+		internal static extern IntPtr dlopen (string path, int mode);
+
 		public Task<int> Run (string[] arguments)
 		{
 			Func<List<string>, int> runTests = args => RunNUnit (args);
@@ -47,6 +51,12 @@ namespace MonoDevelop.Tests.TestRunner
 			var args = new List<string> (arguments);
 			bool isPerformanceRun = false;
 			string resultsXmlFile = null;
+
+			if (Platform.IsMac) {
+				var path = Path.GetDirectoryName (typeof (Runer).Assembly.Location);
+				if (dlopen (Path.Combine (path, "libxammac.dylib"), 0) == IntPtr.Zero)
+					throw new InvalidOperationException ("Unable to load libxammac");
+			}
 
 			foreach (var ar in args) {
 				if (ar == "--performance") {


### PR DESCRIPTION
This PR should improve mdtool's loading resolution when Xamarin.Mac is needed by unit tests that don't run as part of the IDE.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1042627