### PR TITLE
[release-8.4] Fixes VSTS Bug 1030370: [FATAL] SigTerm signal in

### DIFF
--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl.Git/MonoDevelop.VersionControl.Git/Commands.cs
@@ -97,7 +97,7 @@ namespace MonoDevelop.VersionControl.Git
 			await GitService.SwitchToBranchAsync (Repository, (string)dataItem).ConfigureAwait (false);
 		}
 
-		protected override void Update (CommandArrayInfo info)
+		protected override async Task UpdateAsync (CommandArrayInfo info, CancellationToken cancelToken)
 		{
 			var repo = Repository;
 			if (repo == null)
@@ -109,13 +109,10 @@ namespace MonoDevelop.VersionControl.Git
 			if (((wob is WorkspaceItem) && ((WorkspaceItem)wob).ParentWorkspace == null) ||
 			    (wob.BaseDirectory.CanonicalPath == repo.RootPath.CanonicalPath)) {
 
-				string currentBranch = GitRepository.DefaultNoBranchName;
-				var getBranch = repo.GetCurrentBranchAsync ();
-				if (getBranch.Wait (250))
-					currentBranch = getBranch.Result;
+				var currentBranch = await repo.GetCurrentBranchAsync (cancelToken);
 
-				foreach (var branch in repo.GetLocalBranchNamesAsync ().Result) {
-					CommandInfo ci = info.Add (branch, branch);
+				foreach (var branch in await repo.GetLocalBranchNamesAsync (cancelToken)) {
+					var ci = info.Add (branch, branch);
 					if (branch == currentBranch)
 						ci.Checked = true;
 				}


### PR DESCRIPTION
MonoDevelop.VersionControl.Git.dll!MonoDevelop.VersionControl.Git.SwitchToBranchHandler::Update+98

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1030370

Backport of #9435.

/cc @sevoku @mkrueger