### PR TITLE
Fix the footer color of the exception caught dialog

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/ExceptionCaughtDialog.cs
@@ -423,7 +423,12 @@ widget ""*.exception_help_link_label"" style ""exception-help-link-label""
 			actionArea.PackStart (new VBox (), false, true, 3); // dummy just to take extra 6px at end to make it 20pixels
 			actionArea.ShowAll ();
 
-			vbox.PackStart (actionArea, false, true, 0);
+			var bottomButtonPanelBackground = new EventBox ();
+			bottomButtonPanelBackground.Show ();
+			bottomButtonPanelBackground.ModifyBg (StateType.Normal, Styles.ExceptionCaughtDialog.BottomPaddingBackgroundColor.ToGdkColor ());
+			bottomButtonPanelBackground.Add (actionArea);
+
+			vbox.PackStart (bottomButtonPanelBackground, false, true, 0);
 		}
 
 		Widget CreateInnerExceptionMessage ()

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Styles.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/Styles.cs
@@ -57,6 +57,7 @@ namespace MonoDevelop.Debugger
 			public Color TreeSelectedBackgroundColor { get; internal set; }
 			public Color TreeSelectedTextColor { get; internal set; }
 			public Color ValueTreeBackgroundColor { get; internal set; }
+			public Color BottomPaddingBackgroundColor { get; internal set; }
 		}
 
 		static Styles ()
@@ -86,6 +87,7 @@ namespace MonoDevelop.Debugger
 				ExceptionCaughtDialog.LineNumberTextColor = Color.FromName ("#707070");
 				ExceptionCaughtDialog.ExternalCodeTextColor = Color.FromName ("#707070");
 				ExceptionCaughtDialog.ValueTreeBackgroundColor = Color.FromName ("#ffffff");
+				ExceptionCaughtDialog.BottomPaddingBackgroundColor = Color.FromName ("#ececec");
 
 				BreakpointPropertiesSecondaryTextColor = Color.FromName ("#707070");
 			} else {
@@ -99,6 +101,7 @@ namespace MonoDevelop.Debugger
 				ExceptionCaughtDialog.LineNumberTextColor = Color.FromName ("#b4b4b4");
 				ExceptionCaughtDialog.ExternalCodeTextColor = Color.FromName ("#b4b4b4");
 				ExceptionCaughtDialog.ValueTreeBackgroundColor = Color.FromName ("#525252");
+				ExceptionCaughtDialog.BottomPaddingBackgroundColor = ObjectValueTreeActiveBackgroundColor;
 
 				BreakpointPropertiesSecondaryTextColor = Color.FromName ("#b4b4b4");
 			}


### PR DESCRIPTION
Fixes VSTS #1007551

The bottom footer was white. This was a regression from somewhere.

![Screen Shot 2019-12-05 at 10 10 42 PM](https://user-images.githubusercontent.com/2041/70295417-92a01580-17ac-11ea-9f1f-0f238a3898fc.png)

![Screen Shot 2019-12-05 at 10 11 39 PM](https://user-images.githubusercontent.com/2041/70295419-95026f80-17ac-11ea-83da-d352bc1e1fc7.png)
