### PR TITLE
[Core] Convert strings to paths when calling methods on the string

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild/MSBuildEvaluationContext.cs
@@ -745,6 +745,18 @@ namespace MonoDevelop.Projects.MSBuild
 				}
 
 				// Invoke the method
+				if (instance is string instanceString &&
+					instanceString != null &&
+					instanceString.IndexOf ('\\') >= 0 &&
+					Path.DirectorySeparatorChar != '\\') {
+					// Ensure expressions such as $(SomePath.IndexOf('/')) work by using the native path separator.
+					// The directory must exist.
+					string convertedInstance = instanceString.Replace ('\\', Path.DirectorySeparatorChar);
+					if (Path.IsPathRooted (convertedInstance) && Directory.Exists (convertedInstance)) {
+						val = method.Invoke (convertedInstance, convertedArgs);
+						return true;
+					}
+				}
 				val = method.Invoke (instance, convertedArgs);
 			} catch (Exception ex) {
 				LoggingService.LogError ("MSBuild property evaluation failed: " + str.ToString (), ex);

--- a/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
+++ b/main/tests/MonoDevelop.Core.Tests/MonoDevelop.Projects/ProjectTests.cs
@@ -972,6 +972,21 @@ namespace MonoDevelop.Projects
 		}
 
 		[Test]
+		public async Task SubstringOfPath_HandlesForwardSlashesInPath ()
+		{
+			if (!Platform.IsMac)
+				Assert.Ignore ();
+
+			string solFile = Util.GetSampleProject ("path-substring-eval", "path-substring-eval.sln");
+			using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile)) {
+				var p = (DotNetProject)sol.Items [0];
+				var expectedBaseIntermediateOutputPath = sol.BaseDirectory.Combine ("obj", "src");
+				var baseIntermediateOutputPath = p.MSBuildProject.EvaluatedProperties.GetPathValue ("BaseIntermediateOutputPath", relativeToProject: false);
+				Assert.AreEqual (expectedBaseIntermediateOutputPath, baseIntermediateOutputPath);
+			}
+		}
+
+		[Test]
 		public async Task ItemDefinitionGroup ()
 		{
 			string projFile = Util.GetSampleProject ("project-with-item-def-group", "item-definition-group.csproj");

--- a/main/tests/test-projects/path-substring-eval/Directory.Build.props
+++ b/main/tests/test-projects/path-substring-eval/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))</RepoRoot>
+    <SrcRelativeProjectDirectory>$(MSBuildProjectDirectory.Substring($(MSBuildThisFileDirectory.Length)))</SrcRelativeProjectDirectory>
+    <BuildSubPath>$(SrcRelativeProjectDirectory.Substring(0, $(SrcRelativeProjectDirectory.IndexOf('/'))))</BuildSubPath>
+    <BaseIntermediateOutputPath>$(RepoRoot)obj\$(BuildSubPath)</BaseIntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/main/tests/test-projects/path-substring-eval/path-substring-eval.sln
+++ b/main/tests/test-projects/path-substring-eval/path-substring-eval.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "path-substring-eval", "src\project\path-substring-eval.csproj", "{4BE84824-112F-49B2-B44B-56C5C404C2A7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Debug|x64.Build.0 = Debug|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Release|x64.ActiveCfg = Release|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Release|x64.Build.0 = Release|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BE84824-112F-49B2-B44B-56C5C404C2A7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/path-substring-eval/src/project/path-substring-eval.csproj
+++ b/main/tests/test-projects/path-substring-eval/src/project/path-substring-eval.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net472</TargetFramework>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
An MSBuild expression such as the following will fail since the path
is not converted to a native path when not on Windows.

    $(SrcRelativeProjectDirectory.IndexOf('/'))

Arguments passed were converted but the original string was not. To
match MSBuild's behaviour the conversion of the slash characters is
only done if the directory exists.

Fixes VSTS #1028961 - MSBuild Properties are not fully evaluated causing
build to fail