### PR TITLE
SetEnv MONO_DEBUG=disable_omit_fp

### DIFF
--- a/main/build/MacOSX/monostub.mm
+++ b/main/build/MacOSX/monostub.mm
@@ -292,6 +292,8 @@ main (int argc, char **argv)
 		setenv ("MONO_THREADS_SUSPEND", "preemptive", 0);
 
 		setenv ("MONO_GC_PARAMS", "major=marksweep-conc,nursery-size=8m", 0);
+		
+		setenv ("MONO_DEBUG", "disable_omit_fp", 0);
 
 		void *libmono = dlopen ("libmonosgen-2.0.dylib", RTLD_LAZY);
 


### PR DESCRIPTION
This option tells Mono Jitter to set FramePointer register for managed stack frames, this register is important for native profilers and other native tools when unwinding call stack otherwise they don't know how to continue unwinding past managed stack frame and bail...
I asked mono performance/benchmark team to run their tests with and without this environment variable and results were same, hence conclusion is there is no performance difference.
This will help with getting before sampling data when using "Profile for 5 seconds" and other similar tools.