### PR TITLE
Revert "[Unit Test] Fix the nesting for unit tests"

### DIFF
--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/DiscoveredTests.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/DiscoveredTests.cs
@@ -48,7 +48,7 @@ namespace MonoDevelop.UnitTesting.VsTest
 		{
 			tests.Sort (OrderByName);
 
-			var parentNamespace = new VsTestNamespaceTestGroup (projectTestSuite, null, projectTestSuite.Project, string.Empty);
+			var parentNamespace = new VsTestNamespaceTestGroup (projectTestSuite, null, projectTestSuite.Project, String.Empty);
 			parentNamespace.AddTests (tests);
 			return parentNamespace.Tests;
 		}

--- a/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestNamespaceTestGroup.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/MonoDevelop.UnitTesting.VsTest/VsTestNamespaceTestGroup.cs
@@ -64,18 +64,19 @@ namespace MonoDevelop.UnitTesting.VsTest
 
 		internal void AddTest (VsTestUnitTest VsTestTest)
 		{
-			string childNamespace = VsTestTest.FixtureTypeNamespace;
-
-			if (currentNamespace == null || currentNamespace.Name != childNamespace) {
+			string childNamespace = VsTestTest.GetChildNamespace (FixtureTypeNamespace);
+			if (string.IsNullOrEmpty (childNamespace)) {
+				if (currentClass == null || currentClass.FixtureTypeName != VsTestTest.FixtureTypeName) {
+					currentClass = new VsTestTestClass (testRunner, Project, VsTestTest);
+					Tests.Add (currentClass);
+				}
+				currentClass.Tests.Add (VsTestTest);
+			} else if (currentNamespace != this && currentNamespace.Name == childNamespace) {
+				currentNamespace.AddTest (VsTestTest);
+			} else {
 				currentNamespace = new VsTestNamespaceTestGroup (testRunner, currentNamespace, Project, childNamespace);
 				currentNamespace.AddTest (VsTestTest);
 				Tests.Add (currentNamespace);
-			} else {
-				if (currentNamespace.currentClass == null || currentNamespace.currentClass.FixtureTypeName != VsTestTest.FixtureTypeName) {
-					currentNamespace.currentClass = new VsTestTestClass (testRunner, Project, VsTestTest);
-					currentNamespace.Tests.Add (currentNamespace.currentClass);
-				}
-				currentNamespace.currentClass.Tests.Add (VsTestTest);
 			}
 		}
 


### PR DESCRIPTION
Reverts mono/monodevelop#9374
Add unit tests before merging.