### PR TITLE
[release-8.4] Improve FileNesting performance by avoiding costly IO

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.FileNesting/NestingRule.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects.FileNesting/NestingRule.cs
@@ -63,9 +63,9 @@ namespace MonoDevelop.Ide.Projects.FileNesting
 
 		ProjectFile CheckParentForFile (ProjectFile inputFile, FilePath parentFile, FilePath inDirectory)
 		{
-			if (inputFile.FilePath != parentFile && !parentFile.IsDirectory && inDirectory == parentFile.ParentDirectory) {
+			if (inputFile.FilePath != parentFile && inDirectory == parentFile.ParentDirectory) {
 				var parent = inputFile.Project.Files.GetFile (parentFile);
-				if (parent != null) {
+				if (parent != null && parent.Subtype != Subtype.Directory) {
 					Debug.WriteLine ($"Applied rule for nesting {inputFile} under {parentFile}");
 					return parent;
 				}


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1034938

Given the current FileNesting logic, we check for a potential parent which matches a filepath spec. We filter out these parents if they are directories using FilePath.IsDirectory, which causes IO via Directory.Exists.  As we already know whether a filepath in the project filelist is a directory, we should delay this filtering and avoid the IO.

Testing:

This change has a 2x speedup (~2.5mins to ~1.1min) for a React.js & Redux Asp.Net Core project which has a node_modules folder added to the project.

Backport of #9451.

/cc @iantoalms 