### PR TITLE
[NuGet] Allow license acceptance dialog to be disabled

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/LicenseAcceptanceService.cs
@@ -29,6 +29,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MonoDevelop.Core;
+using MonoDevelop.Core.FeatureConfiguration;
 using MonoDevelop.Ide;
 
 namespace MonoDevelop.PackageManagement
@@ -37,6 +38,9 @@ namespace MonoDevelop.PackageManagement
 	{
 		public Task<bool> AcceptLicenses (IEnumerable<NuGetPackageLicense> licenses)
 		{
+			if (FeatureSwitchService.IsFeatureEnabled ("NuGetLicenseAcceptanceDialog") == false)
+				return Task.FromResult (true);
+
 			if (Runtime.IsMainThread)
 				return ShowLicenseAcceptanceDialog (licenses);
 


### PR DESCRIPTION
Added a feature switch to allow the license acceptance dialog
to be disabled. This can be done by setting the environment
variable:

    MD_FEATURES_DISABLED=NuGetLicenseAcceptanceDialog

By default the license acceptance dialog will be displayed. The
feature switch can be used by automation tests to disable the
dialog and the license acceptance for the NuGet package will
occur without the user being prompted.

Fixes VSTS #1036006 - Disable license acceptance dialog with
feature switch