### PR TITLE
Adding an Edit Project File item to the root project context menu.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -117,10 +117,10 @@
 		<Condition id="ItemType" value="IFolderItem">
 			<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.OpenInTerminal" />
 		</Condition>
-		<Condition id="ItemType" value="Solution|Project|UnknownSolutionItem">
-			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem" />
-		</Condition>
 	</ItemSet>
+	<Condition id="ItemType" value="Solution|UnknownSolutionItem">
+		<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem" />
+	</Condition>
 	<Condition id="ItemType" value="IFolderItem">
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.FindInFiles" />
 	</Condition>
@@ -163,6 +163,9 @@
 	<Condition id="ItemType" value="ProjectReference">
 		<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.LocalCopyReference" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.SpecificAssemblyVersion" />
+	</Condition>
+	<Condition id="ItemType" value="Project">
+		<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem" _label = "Edit Project File" />
 	</Condition>
 	<Condition id="ItemType" value="IBuildTarget">
 		<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.Options" />

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectPadContextMenu.addin.xml
@@ -117,10 +117,11 @@
 		<Condition id="ItemType" value="IFolderItem">
 			<CommandItem id = "MonoDevelop.Ide.Commands.FileCommands.OpenInTerminal" />
 		</Condition>
+		<Condition id="ItemType" value="Solution|UnknownSolutionItem">
+			<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem" />
+		</Condition>
 	</ItemSet>
-	<Condition id="ItemType" value="Solution|UnknownSolutionItem">
-		<CommandItem id = "MonoDevelop.Ide.Commands.ProjectCommands.EditSolutionItem" />
-	</Condition>
+	
 	<Condition id="ItemType" value="IFolderItem">
 		<CommandItem id = "MonoDevelop.Ide.Commands.SearchCommands.FindInFiles" />
 	</Condition>


### PR DESCRIPTION
Fixes VSTS #617837

This work adds an Edit Project File command to the context menu shown in the Solution Pad when right-clicking on a project file.

![image](https://user-images.githubusercontent.com/1333029/70745064-e7c1b700-1cd7-11ea-9c87-18a2fb85c32b.png)

Based on a discussion with @hbons, I placed this menu in the same section as "Options" since they're conceptually used for the same purposes.