### PR TITLE
[Core] Handle odd file watcher events causing solution to be closed

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/FileWatcherService.cs
@@ -585,7 +585,8 @@ namespace MonoDevelop.Projects
 			// the original file still exists.
 			if (File.Exists (e.OldFullPath))
 				FileService.NotifyFileChanged (e.OldFullPath);
-			else
+			// Handle odd file watcher events which look like a folder being renamed to a file.
+			else if (!Directory.Exists (e.OldFullPath))
 				FileService.NotifyFileRemoved (e.OldFullPath);
 		}
 


### PR DESCRIPTION
The file watcher seems to sometimes produce strange events which
look like a directory being renamed to a file. This can cause the
IDE to believe the solution file has been deleted since the file
service will raise a FileRemoved event for a rename. To avoid this
check that the directory does not exist and if it does the FileRemoved
event is not fired with this type of rename.

Fixes VSTS #1027550 - VSMac keeps closing my solution