### PR TITLE
Fix dialog parenting issue

### DIFF
--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -1136,7 +1136,8 @@ namespace MonoDevelop.MacIntegration
 		bool HasAnyDockWindowFocused ()
 		{
 			foreach (var window in Gtk.Window.ListToplevels ()) {
-				if (!window.HasToplevelFocus) {
+				// Gtk.Window.HasToplevelFocus may return false for a window that embeds a Cocoa view
+				if (!window.HasToplevelFocus && GtkQuartz.GetWindow (window) != NSApplication.SharedApplication.KeyWindow) {
 					continue;
 				}
 				if (window is Components.Docking.DockFloatingWindow floatingWindow) {


### PR DESCRIPTION
When a message dialog is shown, we try to get the currently focused
top level window if no parent is provided. This is done by the
GetFocusedTopLevelWindow() method that is implemented in MacPlatform.
This method should not return auto-hide pads as top level windows,
and there is a check for that, but the check doesn't work when
the auto-hide pad is implemented with Cocoa, since the pad may have
the Cocoa focus but not the GTK focus. It may happen then that an
auto-hide pad is used for parenting a message dialog, and if the
pad is auto-hidden, the modal dialog will also be hidden and
will block the whole IDE. The patch adds an additional check to
the condition for detecting if a top level is focused or not.

Fixes bug #1027840