### PR TITLE
Fixes BinaryCompatBaseline.txt for Archive publishing fix

### DIFF
--- a/main/build/MacOSX/BinaryCompatBaseline.txt
+++ b/main/build/MacOSX/BinaryCompatBaseline.txt
@@ -10,12 +10,10 @@ Could not load the file 'Microsoft.Developer.IdentityService.Client, Version=1.0
 Could not load the file 'Microsoft.ServiceHub.Client, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
 Could not load the file 'Microsoft.TestPlatform.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
 Could not load the file 'MonoTouch.Hosting, Version=0.0.0.0, Culture=neutral, PublicKeyToken=5caa9e03e69a5abd'.
-Could not load the file 'System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
 Could not load the file 'System.Runtime.Loader, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
 Could not load the file 'System.Web.DataVisualization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
 Could not load the file 'Xamarin.Ide.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.
 Could not load the file 'Xamarin.MacDev.Ide, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.
-In assembly 'Google.Apis.Core, Version=1.9.0.26010, Culture=neutral, PublicKeyToken=null': unable to resolve reference to 'System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 In assembly 'Microsoft.CodeAnalysis.Scripting, Version=3.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35': unable to resolve reference to 'System.Runtime.Loader, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 In assembly 'Microsoft.CodeAnalysis.TypeScript.EditorFeatures, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a': unable to resolve reference to 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
 In assembly 'Microsoft.VisualStudio.TestPlatform.Common, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a': unable to resolve reference to 'Microsoft.TestPlatform.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'


### PR DESCRIPTION
Removes System.Net.Http.Primitives and Google.Apis.Core error lines.
Needed by https://github.com/xamarin/md-addins/pull/6088