### PR TITLE
Simplify SearchCategory tags

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/CommandSearchCategory.cs
@@ -64,18 +64,8 @@ namespace MonoDevelop.Components.MainToolbar
 			sortOrder = CommandCategoryOrder;
 		}
 
-		readonly string[] validTags = { "cmd", "command", "c" };
-
-		public override string [] Tags {
-			get {
-				return validTags;
-			}
-		}
-
-		public override bool IsValidTag (string tag)
-		{
-			return validTags.Any (t => t == tag);
-		}
+		public override string [] Tags { get; } = { "cmd", "command", "c" };
+		public override bool IsValidTag (string tag) => Array.IndexOf (Tags, tag) >= 0;
 
 		public override Task GetResults (ISearchResultCallback searchResultCallback, SearchPopupSearchPattern pattern, CancellationToken token)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/FileSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/FileSearchCategory.cs
@@ -86,18 +86,8 @@ namespace MonoDevelop.Components.MainToolbar
 			return list;
 		}
 
-		string [] validTags = new [] { "file", "f" };
-
-		public override string [] Tags {
-			get {
-				return validTags;
-			}
-		}
-
-		public override bool IsValidTag (string tag)
-		{
-			return validTags.Any (t => t == tag);
-		}
+		public override string [] Tags { get; } = { "file", "f" };
+		public override bool IsValidTag (string tag) => Array.IndexOf (Tags, tag) >= 0;
 
 		static List<Tuple<string, string, ProjectFile>> allFilesCache;
 		static SemaphoreSlim allFilesLock = new SemaphoreSlim (1, 1);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/RoslynSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/RoslynSearchCategory.cs
@@ -56,23 +56,14 @@ namespace MonoDevelop.Components.MainToolbar
 			sortOrder = FirstCategoryOrder;
 		}
 
-		static readonly string [] tags = new [] {
+		public override string [] Tags { get; } = new [] {
 				// Types
 				"type", "t", "class", "struct", "interface", "enum", "delegate",
 				// Members
 				"member", "m", "method", "property", "field", "event"
 		};
 
-		public override string [] Tags {
-			get {
-				return tags;
-			}
-		}
-
-		public override bool IsValidTag (string tag)
-		{
-			return tags.Contains (tag);
-		}
+		public override bool IsValidTag (string tag) => Array.IndexOf (Tags, tag) >= 0;
 
 		static readonly IImmutableSet<string> typeKinds = ImmutableHashSet.Create (
 			NavigateToItemKind.Class,
@@ -154,7 +145,7 @@ namespace MonoDevelop.Components.MainToolbar
 			if (string.IsNullOrEmpty (searchPattern.Pattern))
 				return Task.CompletedTask;
 
-			if (searchPattern.Tag != null && !tags.Contains (searchPattern.Tag) || searchPattern.HasLineNumber)
+			if (searchPattern.Tag != null && Array.IndexOf (Tags, searchPattern.Tag) < 0 || searchPattern.HasLineNumber)
 				return Task.CompletedTask;
 			
 			return Task.Run (async delegate {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchInSolutionSearchCategory.cs
@@ -59,18 +59,9 @@ namespace MonoDevelop.Components.MainToolbar
 		//		return (ISearchDataSource)new SearchInSolutionDataSource (searchPattern);
 		//	});
 		//} 
-		static readonly string[] tags = { "search" };
+		public override string [] Tags { get; } = { "search" };
 
-		public override string[] Tags {
-			get {
-				return tags;
-			}
-		}
-
-		public override bool IsValidTag (string tag)
-		{
-			return tag == "search";
-		}
+		public override bool IsValidTag (string tag) => tag == "search";
 
 		class SearchInSolutionSearchResult : SearchResult
 		{


### PR DESCRIPTION
The `Contains` extension comes in from a separate library, not sure about the implementation. Use Array.IndexOf

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1044378
