### PR TITLE
Add System.HashCode from nuget and switch some usages to it 

### DIFF
--- a/main/Directory.Build.props
+++ b/main/Directory.Build.props
@@ -13,6 +13,7 @@
     <NuGetVersionAllocationAnalyzer>1.0.0.9</NuGetVersionAllocationAnalyzer>
     <NuGetVersionCecil>0.10.1</NuGetVersionCecil>
     <NuGetVersionErrorProneNetStructs>0.1.2</NuGetVersionErrorProneNetStructs>
+    <NuGetVersionMicrosoftBclHashCode>1.1.0</NuGetVersionMicrosoftBclHashCode>
     <NuGetVersionMicrosoftTemplateEngine>3.0.0-rc1.19464.2</NuGetVersionMicrosoftTemplateEngine>
     <NuGetVersionMicrosoftTestPlatform>16.2.0</NuGetVersionMicrosoftTestPlatform>
     <NuGetVersionMonoDevelopAnalyzers>0.1.0.2</NuGetVersionMonoDevelopAnalyzers>

--- a/main/src/addins/AspNet/WebForms/WebFormsToolboxNode.cs
+++ b/main/src/addins/AspNet/WebForms/WebFormsToolboxNode.cs
@@ -80,14 +80,9 @@ namespace MonoDevelop.AspNet.WebForms
 			WebFormsToolboxNode other = obj as WebFormsToolboxNode;
 			return (other != null) && (this.text != other.text) && base.Equals (other);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int code = base.GetHashCode ();
-			if (text != null)
-				code ^= text.GetHashCode ();
-			return code;
-		}
+			=> HashCode.Combine (base.GetHashCode (), text);
 		
 		void RegisterReference (MonoDevelop.Projects.DotNetProject project)
 		{

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ItemToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ItemToolboxNode.cs
@@ -130,20 +130,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			ItemToolboxNode node = o as ItemToolboxNode;
 			return (node != null) && (node.Name == this.Name) && (node.Category == this.Category) && (node.Description == this.Description) && (node.Source == this.Source);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int code = 0;
-			if (Name != null)
-				code ^= Name.GetHashCode ();
-			if (Category != null)
-				code ^= Category.GetHashCode ();
-			if (Description != null)
-				code ^= Description.GetHashCode ();
-			if (Source != null)
-				code ^= Source.GetHashCode ();
-			return code;
-		}
+			=> HashCode.Combine (Name, Category, Description, Source);
 		
 		public int CompareTo (object other)
 		{

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TextToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TextToolboxNode.cs
@@ -58,14 +58,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		{
 			return o is TextToolboxNode n && text == n.text && base.Equals (o);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int code = base.GetHashCode ();
-			if (text != null)
-				code ^= text.GetHashCode ();
-			return code;
-		}
+			=> HashCode.Combine (base.GetHashCode (), text);
 		
 		[LocalizedDescription ("The text that will be inserted into the document.")]
 		public string Text {

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxItemToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/ToolboxItemToolboxNode.cs
@@ -92,14 +92,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 				    : this.toolboxItemType.Equals (other.toolboxItemType))
 			    && base.Equals (other);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int code = base.GetHashCode ();
-			if (toolboxItemType != null)
-				code ^= toolboxItemType.GetHashCode ();
-			return code;
-		}
+			=> HashCode.Combine (base.GetHashCode (), toolboxItemType);
 		
 		public ToolboxItem GetToolboxItem ()
 		{

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TypeReference.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TypeReference.cs
@@ -64,11 +64,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			    && (this.assemblyName == other.assemblyName)
 			    && (this.assemblyLocation == other.assemblyLocation);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			return (typeName + assemblyName + assemblyLocation).GetHashCode ();
-		}
+			=> HashCode.Combine (typeName, assemblyName, assemblyLocation);
 
 		
 		public bool Equals (TypeReference other)

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TypeToolboxNode.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/TypeToolboxNode.cs
@@ -86,14 +86,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 			    && (this.type == null? node.type == null : this.type.Equals (node.type))
 			    && base.Equals (node);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int code = base.GetHashCode ();
-			if (type != null)
-				code ^= type.GetHashCode ();
-			return code;
-		}
+			=> HashCode.Combine (base.GetHashCode (), type);
 		
 		#endregion
 	}

--- a/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/Mono.TextEditor/Gui/TextViewMargin.cs
@@ -1050,11 +1050,7 @@ namespace Mono.TextEditor
 			}
 
 			public override int GetHashCode ()
-			{
-				unchecked {
-					return SelectionStart.GetHashCode () ^ SelectionEnd.GetHashCode ();
-				}
-			}
+				=> HashCode.Combine (SelectionStart, SelectionEnd);
 		}
 
 		Dictionary<int, LayoutDescriptor> layoutDict = new Dictionary<int, LayoutDescriptor> ();

--- a/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestResult.cs
+++ b/main/src/addins/MonoDevelop.UnitTesting/Services/UnitTestResult.cs
@@ -226,19 +226,7 @@ namespace MonoDevelop.UnitTesting
 		}
 
 		public override int GetHashCode ()
-		{
-			var unknowObject = new {
-				Status,
-				Passed,
-				Errors,
-				Failures,
-				Inconclusive,
-				NotRunnable,
-				Skipped,
-				Ignored
-			};
-			return unknowObject.GetHashCode ();
-		}
+			=> HashCode.Combine (Status, Passed, Errors, Failures, Inconclusive, NotRunnable, Skipped, Ignored);
 
 		public override bool Equals (object obj) => obj is UnitTestResult other && Equals (other);
 

--- a/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
+++ b/main/src/addins/VersionControl/MonoDevelop.VersionControl/MonoDevelop.VersionControl/Repository.cs
@@ -56,16 +56,7 @@ namespace MonoDevelop.VersionControl
 		}
 
 		public override int GetHashCode ()
-		{
-			int result = 0;
-			result ^= RootPath.GetHashCode ();
-			if (VersionControlSystem != null)
-				result ^= VersionControlSystem.GetHashCode ();
-			if (LocationDescription != null)
-				result ^= LocationDescription.GetHashCode ();
-			result ^= Name.GetHashCode ();
-			return result;
-		}
+			=> HashCode.Combine (RootPath, VersionControlSystem, LocationDescription, name);
 
 		public virtual void CopyConfigurationFrom (Repository other)
 		{

--- a/main/src/addins/Xml/Dom/XName.cs
+++ b/main/src/addins/Xml/Dom/XName.cs
@@ -78,12 +78,7 @@ namespace MonoDevelop.Xml.Dom
 		}
 
 		public override int GetHashCode ()
-		{
-			int hash = 0;
-			if (prefix != null) hash += prefix.GetHashCode ();
-			if (name != null) hash += name.GetHashCode ();
-			return hash;
-		}
+			=> HashCode.Combine (prefix, name);
 
 		#endregion
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Assemblies/TargetFrameworkMoniker.cs
@@ -207,18 +207,9 @@ namespace MonoDevelop.Core.Assemblies
 		{
 			return Equals (obj as TargetFrameworkMoniker);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int ret = 0;
-			if (identifier != null)
-				ret ^= identifier.GetHashCode ();
-			if (version != null)
-				ret ^= version.GetHashCode ();
-			if (profile != null)
-				ret ^= profile.GetHashCode ();
-			return ret;
-		}
+			=> HashCode.Combine (identifier, version, profile);
 		
 		public static bool operator == (TargetFrameworkMoniker a, TargetFrameworkMoniker b)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ProcessService.cs
@@ -386,11 +386,9 @@ namespace MonoDevelop.Core.Execution
 					return false;
 				return mref.mset == mset && mref.mode.Name == mode.Name;
 			}
-			
+
 			public override int GetHashCode ()
-			{
-				return mset.GetHashCode () + mode.Name.GetHashCode ();
-			}
+				=> HashCode.Combine (mset, mode.Name);
 			
 			public IExecutionMode ExecutionMode {
 				get { return mode; }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/ISegment.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Text/ISegment.cs
@@ -204,9 +204,7 @@ namespace MonoDevelop.Core.Text
 		/// A hash code for this instance that is suitable for use in hashing algorithms and data structures such as a hash table.
 		/// </returns>
 		public override int GetHashCode ()
-		{
-			return Offset ^ Length;
-		}
+			=> HashCode.Combine (Offset, Length);
 
 		public static TextSegment FromBounds (int startOffset, int endOffset)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj
@@ -107,11 +107,13 @@
     <!-- update this to a version that doesn't crash -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.3.52" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="3.0.0-preview9.19423.4" PrivateAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" PrivateAssets="runtime" />
   </ItemGroup>
   <ItemGroup>
     <IncludeCopyLocal Include="Humanizer.dll" />
     <IncludeCopyLocal Include="ICSharpCode.Decompiler.dll" />
     <IncludeCopyLocal Include="ICSharpCode.SharpZipLib.dll" />
+    <IncludeCopyLocal Include="Microsoft.Bcl.HashCode.dll" />
     <IncludeCopyLocal Include="Microsoft.Build.Locator.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.CSharp.dll" />
     <IncludeCopyLocal Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll" />

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/Token.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.MSBuild.Conditions/Token.cs
@@ -79,10 +79,8 @@ namespace MonoDevelop.Projects.MSBuild.Conditions {
 			return String.Format ("\"{0}\" at character position {1}", Value, Position);
 		}
 
-		public override int GetHashCode()
-		{
-			return (Value?.GetHashCode () ?? 0) ^ Type.GetHashCode () ^ Position.GetHashCode ();
-		}
+		public override int GetHashCode ()
+			=> HashCode.Combine (Value, Type, Position);
 
 		public override bool Equals (object obj)
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyDictionary.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects.Policies/PolicyDictionary.cs
@@ -49,16 +49,9 @@ namespace MonoDevelop.Projects.Policies
 		{
 			return other.PolicyType.AssemblyQualifiedName == PolicyType.AssemblyQualifiedName && other.Scope == Scope;
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int code = PolicyType.AssemblyQualifiedName.GetHashCode ();
-			unchecked {
-				if (Scope != null)
-					code += Scope.GetHashCode ();
-			}
-			return code;
-		}
+			=> HashCode.Combine (PolicyType.AssemblyQualifiedName, Scope);
 		
 		public override string ToString ()
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AssemblyReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/AssemblyReference.cs
@@ -123,11 +123,7 @@ namespace MonoDevelop.Projects
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return FilePath.GetHashCode () ^ Aliases.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (FilePath, Aliases);
 
 		/// <summary>
 		/// Returns an enumerable collection of aliases. 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ConditionedPropertyCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ConditionedPropertyCollection.cs
@@ -164,12 +164,12 @@ namespace MonoDevelop.Projects
 
 			public override int GetHashCode ()
 			{
-				unchecked {
-					int r = 0;
-					for (int i = 0; i < Values.Count; ++i)
-						r ^= Values [i].GetHashCode ();
-					return r;
-				}
+				var hc = new HashCode ();
+
+				for (int i = 0; i < Values.Count; ++i)
+					hc.Add (Values [i]);
+
+				return hc.ToHashCode ();
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ConditionedPropertyCollection.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ConditionedPropertyCollection.cs
@@ -69,12 +69,12 @@ namespace MonoDevelop.Projects
 
 			public override int GetHashCode ()
 			{
-				unchecked {
-					int r = 0;
-					for (int i = 0; i < keys.Count; ++i)
-						r ^= keys[i].GetHashCode ();
-					return r;
-				}
+				var hc = new HashCode ();
+
+				for (int i = 0; i < keys.Count; ++i)
+					hc.Add (keys [i]);
+
+				return hc.ToHashCode ();
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectReference.cs
@@ -754,16 +754,9 @@ namespace MonoDevelop.Projects
 				&& referenceType == other.referenceType
 				&& package == other.package;
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			int result = 0;
-			if (StoredReference != null)
-				result ^= StoredReference.GetHashCode ();
-			if (package != null)
-				result ^= package.GetHashCode ();
-			return result;
-		}
+			=> HashCode.Combine (StoredReference, package);
 		
 		internal void NotifyStatusChanged ()
 		{

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemReference.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItemReference.cs
@@ -82,11 +82,9 @@ namespace MonoDevelop.Projects
 				return false;
 			return (path == sr.path) && (id == sr.id);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			return (Path + id).GetHashCode ();
-		}
+			=> HashCode.Combine (Path, id);
 		
 		public static bool operator == (SolutionItemReference r1, SolutionItemReference r2)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/KeyBindingManager.cs
@@ -947,11 +947,9 @@ namespace MonoDevelop.Components.Commands
 		public KeyboardShortcut Accel {
 			get; private set;
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			return Chord.GetHashCode () ^ Accel.GetHashCode ();
-		}
+			=> HashCode.Combine (Chord, Accel);
 		
 		public override bool Equals (object obj)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupSearchPattern.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupSearchPattern.cs
@@ -201,9 +201,7 @@ namespace MonoDevelop.Components.MainToolbar
 		}
 
 		public override int GetHashCode ()
-		{
-			return (Tag != null ? Tag.GetHashCode () : 0) ^ (Pattern != null ? Pattern.GetHashCode () : 0) ^ LineNumber.GetHashCode () ^ Column.GetHashCode ();
-		}
+			=> HashCode.Combine (Tag, Pattern, LineNumber);
 
 		public override bool Equals (object obj)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/SearchPopupWindow.cs
@@ -1070,13 +1070,9 @@ namespace MonoDevelop.Components.MainToolbar
 				ItemIdentifier other = (ItemIdentifier)obj;
 				return Category == other.Category && DataSource == other.DataSource && Item == other.Item;
 			}
-			
+
 			public override int GetHashCode ()
-			{
-				unchecked {
-					return (Category != null ? Category.GetHashCode () : 0) ^ (DataSource != null ? DataSource.GetHashCode () : 0) ^ Item.GetHashCode ();
-				}
-			}
+				=> HashCode.Combine (Category, DataSource, Item);
 
 			public override string ToString ()
 			{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HslColor.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/HslColor.cs
@@ -66,11 +66,7 @@ namespace MonoDevelop.Components
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return H.GetHashCode () ^ S.GetHashCode () ^ L.GetHashCode () ^ Alpha.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (H, S, L, Alpha);
 
 		void ToRgb (out double r, out double g, out double b)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/PathBar.cs
@@ -112,11 +112,7 @@ namespace MonoDevelop.Components
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return (Icon != null ? Icon.GetHashCode () : 0) ^ (Markup != null ? Markup.GetHashCode () : 0);
-			}
-		}
+			=> HashCode.Combine (Icon, Markup);
 
 		internal Xwt.Drawing.Image DarkIcon {
 			get {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ParameterHintingResult.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/ParameterHintingResult.cs
@@ -57,9 +57,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 		}
 
 		public override int GetHashCode ()
-		{
-			return ApplicableSpan.GetHashCode () ^ data.GetHashCode ();
-		}
+			=> HashCode.Combine (ApplicableSpan, data);
 
 		public override bool Equals (object obj)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/SignatureHelpParameterHintingData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.CodeCompletion/SignatureHelpParameterHintingData.cs
@@ -73,6 +73,7 @@ namespace MonoDevelop.Ide.CodeCompletion
 
 		public override int GetHashCode ()
 		{
+			// FIXME: This is expensive.
 			return Item.ToString ().GetHashCode ();
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/ChunkStyle.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/ChunkStyle.cs
@@ -90,11 +90,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return (ScopeStack != null ? ScopeStack.GetHashCode () : 0) ^ Foreground.GetHashCode () ^ Background.GetHashCode () ^ FontWeight.GetHashCode () ^ FontStyle.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (ScopeStack, Foreground, Background, FontWeight, FontStyle);
 
 		internal Gdk.GC CreateBgGC (Gdk.Drawable drawable)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/OldFormat.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Highlighting/Formats/OldFormat.cs
@@ -429,11 +429,7 @@ namespace MonoDevelop.Ide.Editor.Highlighting
 			}
 
 			public override int GetHashCode ()
-			{
-				unchecked {
-					return (Colors != null ? Colors.GetHashCode () : 0) ^ (Name != null ? Name.GetHashCode () : 0);
-				}
-			}
+				=> HashCode.Combine (Colors, Name);
 
 			internal static AmbientColor Import (Dictionary<string, ColorScheme.VSSettingColor> colors, string vsSetting)
 			{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Util/Diff.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor.Util/Diff.cs
@@ -181,11 +181,9 @@ namespace MonoDevelop.Ide.Editor.Util
 		{
 			return this == other;
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			return InsertStart ^ RemoveStart ^ Inserted ^ Removed;
-		}
+			=> HashCode.Combine (InsertStart, RemoveStart, Inserted, Removed);
 		
 		public override string ToString ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DocumentRegion.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/DocumentRegion.cs
@@ -104,9 +104,7 @@ namespace MonoDevelop.Ide.Editor
 		}
 
 		public override int GetHashCode ()
-		{
-			return unchecked (Begin.GetHashCode () ^ End.GetHashCode ());
-		}
+			=> HashCode.Combine (Begin, End);
 
 		public bool Equals (DocumentRegion other)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Selection.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Editor/Selection.cs
@@ -156,11 +156,7 @@ namespace MonoDevelop.Ide.Editor
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return Anchor.GetHashCode () ^ Lead.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (Anchor, Lead);
 
 		public override string ToString ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/ExecutionModeCommandService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Execution/ExecutionModeCommandService.cs
@@ -593,11 +593,7 @@ namespace MonoDevelop.Ide.Execution
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return runConfigurationId.GetHashCode () ^ executionModeId.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (runConfigurationId, executionModeId);
 	}
 	
 	class ExecutionCommandCustomizer: TypeExtensionNode, IExecutionCommandCustomizer

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/ClassData.cs
@@ -71,11 +71,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		}
 
 		public override int GetHashCode ()
-		{
-			if (project == null)
-				return cls.GetFullName ().GetHashCode ();
-			return (cls.GetFullName () + project.Name).GetHashCode ();
-		}
+			=> HashCode.Combine (cls.GetFullName (), project?.Name);
 
 		public override string ToString ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/NamespaceData.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ClassPad/NamespaceData.cs
@@ -126,10 +126,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ClassPad
 		}
 
 		public override int GetHashCode ()
-		{
-			if (project != null) return (namesp + project.Name).GetHashCode ();
-			else return namesp.GetHashCode ();
-		}
+			=> HashCode.Combine (namesp, project?.Name);
 
 		public override string ToString ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFolder.cs
@@ -108,14 +108,9 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			ProjectFolder f = other as ProjectFolder;
 			return f != null && absolutePath == f.absolutePath && parentWorkspaceObject == f.parentWorkspaceObject;
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			if (parentWorkspaceObject != null)
-				return (absolutePath + parentWorkspaceObject.Name).GetHashCode ();
-			else
-				return absolutePath.GetHashCode ();
-		}
+			=> HashCode.Combine (absolutePath, parentWorkspaceObject?.Name);
 		
 		public void Dispose ()
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SolutionFolderFileNodeBuilder.cs
@@ -199,11 +199,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 		}
 
 		public override int GetHashCode ()
-		{
-			unchecked { 
-				return path.GetHashCode () | parent.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (path, parent);
 	}
 }
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFile.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/SystemFile.cs
@@ -78,13 +78,8 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			SystemFile f = other as SystemFile;
 			return f != null && absolutePath == f.absolutePath && parent == f.parent;
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			if (parent != null)
-				return (absolutePath + parent.Name).GetHashCode ();
-			else
-				return absolutePath.GetHashCode ();
-		}
+			=> HashCode.Combine (absolutePath, parent?.Name);
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/DocumentNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/DocumentNavigationPoint.cs
@@ -137,11 +137,9 @@ namespace MonoDevelop.Ide.Navigation
 			DocumentNavigationPoint dp = o as DocumentNavigationPoint;
 			return dp != null && ((doc != null && doc == dp.doc) || (FileName != FilePath.Null && FileName == dp.FileName));
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			return (FileName != FilePath.Null ? FileName.GetHashCode () : 0) + (doc != null ? doc.GetHashCode () : 0);
-		}
+			=> HashCode.Combine (FileName, doc);
 		
 		internal bool HandleRenameEvent (string oldName, string newName)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Navigation/TextFileNavigationPoint.cs
@@ -156,12 +156,8 @@ namespace MonoDevelop.Ide.Navigation
 				return false;
 			return base.Equals (other);
 		}
-		
+
 		public override int GetHashCode ()
-		{
-			unchecked {
-				return line + base.GetHashCode ();
-			}
-		}
+			=> HashCode.Combine (line, base.GetHashCode ());
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionTemplate.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/SolutionTemplate.cs
@@ -250,11 +250,7 @@ namespace MonoDevelop.Ide.Templates
 		}
 
 		public override int GetHashCode ()
-		{
-			return (Id != null ? Id.GetHashCode () : 0)
-				^ (Name != null ? Name.GetHashCode () : 0)
-				^ (Category != null ? Category.GetHashCode () : 0);
-		}
+			=> HashCode.Combine (Id, Name, Category);
 
 		/// <summary>
 		/// Returns all other templates in the group. Does not include this template.

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/WorkspaceId.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/WorkspaceId.cs
@@ -55,12 +55,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			return Equals ((WorkspaceId)obj);
 		}
 
-		public override int GetHashCode ()
-		{
-			unchecked {
-				return Number.GetHashCode () ^ DateTime.GetHashCode ();
-			}
-		}
+		public override int GetHashCode () => HashCode.Combine (Number, DateTime);
 
 		public bool Equals (WorkspaceId other)
 		{


### PR DESCRIPTION
This allows us to write GetHashCode implementations that are well distributed for Dictionary usage.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1044384
