### PR TITLE
[AspNetCore] Support new error code for dev-certs --check

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.DevCertInstaller/Program.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.DevCertInstaller/Program.cs
@@ -122,6 +122,14 @@ namespace MonoDevelop.AspNetCore.DevCertInstaller
 			}
 		}
 
+		static int RunDevCertsCommand (string dotNetCorePath, string command)
+		{
+			using (var process = Process.Start (dotNetCorePath, $"dev-certs https {command}")) {
+				process.WaitForExit ();
+				return process.ExitCode;
+			}
+		}
+
 		static int RunDotNetDevCerts (string dotNetCorePath)
 		{
 			int result = Syscall.setuid (0);
@@ -130,10 +138,10 @@ namespace MonoDevelop.AspNetCore.DevCertInstaller
 				return -3;
 			}
 
-			using (var process = Process.Start (dotNetCorePath, "dev-certs https --trust")) {
-				process.WaitForExit ();
-				return process.ExitCode;
-			}
+			// Clean the certificates to avoid issues with invalid ones
+			RunDevCertsCommand (dotNetCorePath, "--clean");
+
+			return RunDevCertsCommand (dotNetCorePath, "--trust");
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/CertificateCheckResult.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/CertificateCheckResult.cs
@@ -31,6 +31,7 @@ namespace MonoDevelop.AspNetCore
 		OK = 0,
 		Missing = 6,
 		Untrusted = 7,
+		CertificateBroken = 9,
 		Error = -1
 	}
 }


### PR DESCRIPTION
Due to the issue we found with 3.1 Preview2 on notarization, the .NET Core
team have added a new error code to detect that situation, so VSMac needs
to take it into account and run "dev-certs https --trust" as with other
known error codes, which should fix the issue.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1032644