### PR TITLE
[AspNetCore] Default "launchBrowser" to false

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreRunConfiguration.cs
@@ -102,7 +102,7 @@ namespace MonoDevelop.AspNetCore
 				EnvironmentVariables.Add ("ASPNETCORE_ENVIRONMENT", "Development");
 #pragma warning disable CS0618 //disables warnings threw by obsolete methods used in nameof()
 			if (CurrentProfile.LaunchBrowser == null)
-				CurrentProfile.LaunchBrowser = pset.GetValue (nameof (LaunchBrowser), true);
+				CurrentProfile.LaunchBrowser = pset.GetValue (nameof (LaunchBrowser), false);
 			if (string.IsNullOrEmpty (CurrentProfile.TryGetApplicationUrl ())) {
 
 				if (CurrentProfile.OtherSettings == null)


### PR DESCRIPTION
When we set it to false, the field is removed from launchSettings.json, so
when reading it back, it needs to default to false if not present to be a
correct end user experience.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1015890