### PR TITLE
[AspNetCore] Match item templates' descriptions to those in VS Win

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewImportsPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewImportsPage.xft.xml
@@ -5,7 +5,7 @@
 	lastModified="2017/06/01">
 
 	<TemplateConfiguration>
-		<_Name>MVC View Imports Page</_Name>
+		<_Name>Razor View Imports</_Name>
 		<Icon>md-html-file-icon</Icon>
 		<_Category>ASP.NET Core</_Category>
 		<LanguageName>C#</LanguageName>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewLayoutPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewLayoutPage.xft.xml
@@ -5,7 +5,7 @@
 	lastModified="2017/06/01">
 
 	<TemplateConfiguration>
-		<_Name>MVC View Layout Page</_Name>
+		<_Name>Razor Layout</_Name>
 		<Icon>md-html-file-icon</Icon>
 		<_Category>ASP.NET Core</_Category>
 		<LanguageName>C#</LanguageName>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewPage.xft.xml
@@ -5,7 +5,7 @@
 	lastModified="2017/06/01">
 
 	<TemplateConfiguration>
-		<_Name>MVC View Page</_Name>
+		<_Name>Razor View</_Name>
 		<Icon>md-html-file-icon</Icon>
 		<_Category>ASP.NET Core</_Category>
 		<LanguageName>C#</LanguageName>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewStartPage.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MVCViewStartPage.xft.xml
@@ -5,7 +5,7 @@
 	lastModified="2017/06/01">
 
 	<TemplateConfiguration>
-		<_Name>MVC View Start Page</_Name>
+		<_Name>Razor View Start</_Name>
 		<Icon>md-html-file-icon</Icon>
 		<_Category>ASP.NET Core</_Category>
 		<LanguageName>C#</LanguageName>

--- a/main/src/addins/MonoDevelop.AspNetCore/Templates/MvcController.xft.xml
+++ b/main/src/addins/MonoDevelop.AspNetCore/Templates/MvcController.xft.xml
@@ -5,7 +5,7 @@
 	lastModified="2017/05/01">
 
 	<TemplateConfiguration>
-		<_Name>MVC Controller Class</_Name>
+		<_Name>Controller Class</_Name>
 		<Icon>md-html-file-icon</Icon>
 		<_Category>ASP.NET Core</_Category>
 		<LanguageName>C#</LanguageName>


### PR DESCRIPTION
VS Windows shows all item templates as "Razor ...", without any mention
to MVC, which causes confusion, so change to match the descriptions.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1016547