### PR TITLE
[C#] Support CodeAnalysisRuleSet file

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
@@ -192,8 +192,6 @@ namespace MonoDevelop.CSharp.Project
 		Dictionary<string, ReportDiagnostic> GetSpecificDiagnosticOptions ()
 		{
 			var result = new Dictionary<string, ReportDiagnostic> ();
-			foreach (var warning in GetSuppressedWarnings ())
-				result [warning] = ReportDiagnostic.Suppress;
 
 			var globalRuleSet = IdeApp.TypeSystemService.RuleSetManager.GetGlobalRuleSet ();
 			if (globalRuleSet != null) {
@@ -204,6 +202,11 @@ namespace MonoDevelop.CSharp.Project
 			if (ruleSet != null) {
 				AddSpecificDiagnosticOptions (result, ruleSet);
 			}
+
+			foreach (var warning in GetSuppressedWarnings ()) {
+				result [warning] = ReportDiagnostic.Suppress;
+			}
+
 			return result;
 		}
 

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="MonoDevelop.CSharpBinding\AutoFormatIntegrationTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\CSharpDocumentOptionsProviderTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding.Debugging\DebuggerCompletionControllerTests.cs" />
+    <Compile Include="MonoDevelop.CSharpBinding\CustomProjectRuleSetTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\addins\CSharpBinding\CSharpBinding.csproj">

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CustomProjectRuleSetTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CustomProjectRuleSetTests.cs
@@ -79,6 +79,9 @@ namespace MonoDevelop.CSharpBinding.Tests
 
 				// Global ruleset option which is not overridden by project ruleset.
 				Assert.AreEqual (ReportDiagnostic.Error, diagnosticOptions ["SA1003"]);
+
+				// NoWarn set in project file directly should override project ruleset.
+				Assert.AreEqual (ReportDiagnostic.Suppress, diagnosticOptions ["SA1600"]);
 			}
 		}
 	}

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CustomProjectRuleSetTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CustomProjectRuleSetTests.cs
@@ -1,0 +1,85 @@
+//
+// CustomProjectRuleSetTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2020 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using MonoDevelop.Core;
+using MonoDevelop.Ide;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.CSharpBinding.Tests
+{
+	[TestFixture]
+	class CustomProjectRuleSetTests : IdeTestBase
+	{
+		FilePath globalRuleSetFileNameBackup;
+
+		[TestFixtureSetUp]
+		public void SetUp ()
+		{
+			FilePath backupFileName = GlobalRuleSetFileName + "-test-backup";
+			File.Copy (GlobalRuleSetFileName, backupFileName, true);
+			globalRuleSetFileNameBackup = backupFileName;
+		}
+
+		static string GlobalRuleSetFileName {
+			get => IdeApp.TypeSystemService.RuleSetManager.GlobalRulesetFileName;
+		}
+
+		public override void TearDown ()
+		{
+			File.Copy (globalRuleSetFileNameBackup, IdeApp.TypeSystemService.RuleSetManager.GlobalRulesetFileName, true);
+			File.Delete (globalRuleSetFileNameBackup);
+			base.TearDown ();
+		}
+
+		[Test]
+		public async Task CustomCodeAnalysisRuleSetFile ()
+		{
+			FilePath solutionFileName = Util.GetSampleProject ("ruleset", "ruleset.sln");
+			File.Copy (solutionFileName.ParentDirectory.Combine ("global.ruleset"), GlobalRuleSetFileName, true);
+
+			using (var solution = (MonoDevelop.Projects.Solution)await Ide.Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solutionFileName)) {
+				var project = solution.GetAllProjects ().OfType <DotNetProject> ().Single ();
+				var config = (DotNetProjectConfiguration)project.GetConfiguration (ConfigurationSelector.Default);
+				var compilationOptions = config.CompilationParameters.CreateCompilationOptions ();
+				var diagnosticOptions = compilationOptions.SpecificDiagnosticOptions;
+
+				// Project ruleset options.
+				Assert.AreEqual (ReportDiagnostic.Error, diagnosticOptions ["SA1000"]);
+				Assert.AreEqual (ReportDiagnostic.Warn, diagnosticOptions ["SA1001"]);
+				Assert.AreEqual (ReportDiagnostic.Suppress, diagnosticOptions ["SA1002"]);
+
+				// Global ruleset option which is not overridden by project ruleset.
+				Assert.AreEqual (ReportDiagnostic.Error, diagnosticOptions ["SA1003"]);
+			}
+		}
+	}
+}

--- a/main/tests/test-projects/ruleset/custom.ruleset
+++ b/main/tests/test-projects/ruleset/custom.ruleset
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="CustomTestRules" ToolsVersion="16.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1000" Action="Error" />
+    <Rule Id="SA1001" Action="Warning" />
+    <Rule Id="SA1002" Action="None" />
+  </Rules>
+</RuleSet>

--- a/main/tests/test-projects/ruleset/custom.ruleset
+++ b/main/tests/test-projects/ruleset/custom.ruleset
@@ -4,5 +4,7 @@
     <Rule Id="SA1000" Action="Error" />
     <Rule Id="SA1001" Action="Warning" />
     <Rule Id="SA1002" Action="None" />
+    <!-- Rule SA1003 defined in global ruleset -->
+    <Rule Id="SA1600" Action="Error" />
   </Rules>
 </RuleSet>

--- a/main/tests/test-projects/ruleset/global.ruleset
+++ b/main/tests/test-projects/ruleset/global.ruleset
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Global Rules" ToolsVersion="16.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1000" Action="None" />
+    <Rule Id="SA1003" Action="Error" />
+  </Rules>
+</RuleSet>

--- a/main/tests/test-projects/ruleset/ruleset.csproj
+++ b/main/tests/test-projects/ruleset/ruleset.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2646A92D-26AB-4B3E-91A2-B73EC92FB064}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ruleset</RootNamespace>
+    <AssemblyName>ruleset</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <CodeAnalysisRuleSet>custom.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/ruleset/ruleset.csproj
+++ b/main/tests/test-projects/ruleset/ruleset.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>ruleset</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <CodeAnalysisRuleSet>custom.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>SA1600</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/main/tests/test-projects/ruleset/ruleset.sln
+++ b/main/tests/test-projects/ruleset/ruleset.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ruleset", "ruleset.csproj", "{2646A92D-26AB-4B3E-91A2-B73EC92FB064}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2646A92D-26AB-4B3E-91A2-B73EC92FB064}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2646A92D-26AB-4B3E-91A2-B73EC92FB064}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2646A92D-26AB-4B3E-91A2-B73EC92FB064}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2646A92D-26AB-4B3E-91A2-B73EC92FB064}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
If the CodeAnalysisRuleSet MSBuild property points to a file then
the ruleset information is applied to the project configuration's
compilater options.

Fixes VSTS #1040606 - StyleCop rules are ignored
Fixes VSTS #577079 - [Diagnostics] Implement RuleSet file support

Out of scope for now:
 - Handling changes to the rulesets files whilst the project is open.
 - [RuleSets can define general diagnostic options](http://sourceroslyn.io/#Microsoft.VisualStudio.LanguageServices.CSharp/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs,62) but currently these are not passed to the compilation options.
 - WarningAsError ruleset logic not currently implemented (compared with [OptionsProcessor](http://sourceroslyn.io/#Microsoft.VisualStudio.LanguageServices.CSharp/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs,50))