### PR TITLE
[PackageManagement] Register credential providers coming from secure plugins

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Core;
 using NuGet.CommandLine;
 using NuGet.Credentials;
 using NuGet.Protocol;
+using NuGet.Protocol.Plugins;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -60,6 +61,7 @@ namespace MonoDevelop.PackageManagement
 			var credentialProviders = new List<ICredentialProvider>();
 
 			credentialProviders.Add (CreateSettingsCredentialProvider ());
+			credentialProviders.AddRange (GetPluginsCredentialProviders ());
 			credentialProviders.Add (new MonoDevelopCredentialProvider ());
 
 			return credentialProviders;
@@ -70,6 +72,17 @@ namespace MonoDevelop.PackageManagement
 			var settings = SettingsLoader.LoadDefaultSettings ();
 			var packageSourceProvider = new MonoDevelopPackageSourceProvider (settings);
 			return new SettingsCredentialProvider (packageSourceProvider);
+		}
+
+		static IEnumerable<ICredentialProvider> GetPluginsCredentialProviders ()
+		{
+			var builder = new SecurePluginCredentialProviderBuilder (
+				PluginManager.Instance,
+				canShowDialog: false,
+				logger: NuGet.Common.NullLogger.Instance
+			);
+			var providers = builder.BuildAllAsync ().Result;
+			return providers;
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.Credentials/CredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.Credentials/CredentialService.cs
@@ -103,13 +103,18 @@ namespace NuGet.Credentials
 
 					CredentialResponse response;
 					if (!TryFromCredentialCache (uri, type, isRetry, provider, out response)) {
+						/* Temporarily disable interactive-ness with secure plugin provider
+						 * to avoid them blocking on requesting user-input for device flow auth
+						 */
+						var nonInteractive = _nonInteractive || provider is SecurePluginCredentialProvider;
+
 						response = await provider.GetAsync (
 							uri,
 							proxy,
 							type,
 							message,
 							isRetry,
-							_nonInteractive,
+							nonInteractive,
 							cancellationToken);
 
 						// Check that the provider gave us a valid response.


### PR DESCRIPTION
This will do a barebone registration of available, plugin-based credential providers (like the Azure DevOps one) without implementing any authentication flow. The idea is that users can pre-authenticate via another mean (manual MSBuild invocation or NuGet binary) and the IDE will, at least, be able to retrieve those cached credentials.

Fixes VSTS #632121 - NuGet credential providers