### PR TITLE
[release-8.4] [DesignerSupport] Support CustomTypeDescriptors in new property editor

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelEditorProvider.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/NativePropertyEditor/ComponentModelEditorProvider.cs
@@ -96,11 +96,8 @@ namespace MonoDevelop.DesignerSupport
 			var collection = new List<DescriptorPropertyInfo> ();
 
 			foreach (object propertyProvider in providers) {
-				//get the current properties for this provider
-				var currentType = propertyProvider.GetType ();
-
-				//we want all property descriptors for this propertyProvider type
-				var propertyDescriptors = System.ComponentModel.TypeDescriptor.GetProperties (currentType);
+				//we want all property descriptors for this propertyProvider
+				var propertyDescriptors = System.ComponentModel.TypeDescriptor.GetProperties (propertyProvider);
 
 				foreach (System.ComponentModel.PropertyDescriptor propertyDescriptor in propertyDescriptors) {
 					if (propertyDescriptor.IsBrowsable) {


### PR DESCRIPTION
An object that derives from CustomTypeDescriptor would not show the
custom properties in the new native property editor but would with
the old property editor.

The problem was that the type was being passed to the TypeDescriptor's
GetProperties method instead of the object providing the properties.

Fixes VSTS #1047889 - New Property Editor does not support
CustomTypeDescriptors

Backport of #9507.

/cc @mrward 