### PR TITLE
WIP [Core] Fix update item metadata being saved in project

### DIFF
--- a/main/tests/test-projects/UpdateItemMetadataTest/Directory.Build.targets
+++ b/main/tests/test-projects/UpdateItemMetadataTest/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+     <PackageReference Update="Newtonsoft.Json" Version="10.0.1" />
+     <Reference Update="System">
+       <Aliases>TestSystem</Aliases>
+     </Reference>
+  </ItemGroup>
+</Project>

--- a/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.csproj
+++ b/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>UpdateItemMetadataTest</RootNamespace>
+    <AssemblyName>UpdateItemMetadataTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.csproj-alias-changed
+++ b/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.csproj-alias-changed
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>NewDefaultNamespace</RootNamespace>
+    <AssemblyName>UpdateItemMetadataTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System">
+      <Aliases>ChangedTestAlias</Aliases>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.csproj-namespace-changed
+++ b/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.csproj-namespace-changed
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>NewDefaultNamespace</RootNamespace>
+    <AssemblyName>UpdateItemMetadataTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.sln
+++ b/main/tests/test-projects/UpdateItemMetadataTest/UpdateItemMetadataTest.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UpdateItemMetadataTest", "UpdateItemMetadataTest.csproj", "{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A393844-07B9-4F43-BF4A-E4B235A8AEC7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Saving a project that had MSBuild items associated with MSBuild Update
items would have the Update item metadata added to the project file
when the original MSBuild item did not have these values. The problem
was that all the metadata from all MSBuild items is stored with the
ProjectItem and then on saving all values are applied to the MSBuild
item in the project. This caused extra metadata properties to be added
when they were not needed.

Fixes VSTS #1032617 VStudio for Mac unexpectedly updates
PackageReference in csproj file