### PR TITLE
[Ide] Fix intellisense not updated after adding target frameworks

### DIFF
--- a/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
+++ b/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Project/CSharpCompilerParameters.cs
@@ -141,7 +141,7 @@ namespace MonoDevelop.CSharp.Project
 					ParentConfiguration.OutputDirectory
 			);
 
-			var outputKind = OutputTypeToOutputKind (outputType);
+			var outputKind = outputType == null ? GetOutputKindFromProject (project) : OutputTypeToOutputKind (outputType);
 			bool isLibrary = outputKind == OutputKind.DynamicallyLinkedLibrary;
 			string mainTypeName = project.MainClass;
 			if (isLibrary || mainTypeName == string.Empty) {
@@ -172,6 +172,20 @@ namespace MonoDevelop.CSharp.Project
 			);
 
 			return options;
+		}
+
+		static OutputKind GetOutputKindFromProject (CSharpProject project)
+		{
+			switch (project.CompileTarget) {
+			case CompileTarget.Exe:
+				return OutputKind.ConsoleApplication;
+			case CompileTarget.WinExe:
+				return OutputKind.WindowsApplication;
+			case CompileTarget.Module:
+				return OutputKind.NetModule;
+			default:
+				return OutputKind.DynamicallyLinkedLibrary;
+			}
 		}
 
 		static OutputKind OutputTypeToOutputKind (string outputType)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -336,7 +336,10 @@ namespace MonoDevelop.Ide.TypeSystem
 		protected override void ClearProjectData (ProjectId projectId)
 		{
 			var actualProject = ProjectMap.RemoveProject (projectId);
-			UnloadMonoProject (actualProject);
+			// Do not unload the project if there are still project ids mappings defined for this project.
+			// This prevents the Project.Modified event being unsubscribed for the wrong project on project reload.
+			if (actualProject != null && ProjectMap.GetIds (actualProject) == null)
+				UnloadMonoProject (actualProject);
 			dynamicFileManager?.UnloadProject (projectId);
 
 			base.ClearProjectData (projectId);

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Features\Completion\AbstractCSharpCompletionProviderTests.cs" />
     <Compile Include="Features\Completion\ProtocolMemberCompletionTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\CSharpCompletionTextEditorTests.cs" />
+    <Compile Include="MonoDevelop.CSharpBinding\CSharpCompilerParametersTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\CSharpProjectPropertiesTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\CSharpTextEditorIndentationTests.cs" />
     <Compile Include="MonoDevelop.CSharpBinding\FindMemberVisitorTests.cs" />

--- a/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompilerParametersTests.cs
+++ b/main/tests/MonoDevelop.CSharpBinding.Tests/MonoDevelop.CSharpBinding/CSharpCompilerParametersTests.cs
@@ -1,0 +1,64 @@
+//
+// CSharpCompilerParametersTests.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2020 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using MonoDevelop.CSharp.Project;
+using MonoDevelop.Projects;
+using NUnit.Framework;
+using UnitTests;
+
+namespace MonoDevelop.CSharpBinding
+{
+	[TestFixture]
+	public class CSharpCompilerParametersTests : TestBase
+	{
+		/// <summary>
+		/// Ensure OutputType has a default value that allows the compilation options to be created when the
+		/// project is not loaded from a file.
+		/// </summary>
+		[Test]
+		public void OutputType_NewProjectNotLoadedFromDisk_CompilationOptionsCanBeCreated ()
+		{
+			using (var solution = new Solution ()) {
+				var project = Services.ProjectService.CreateDotNetProject ("C#");
+				solution.RootFolder.AddItem (project);
+				project.CompileTarget = CompileTarget.Library;
+				var config = project.CreateConfiguration ("Debug", ConfigurationKind.Debug) as DotNetProjectConfiguration;
+				project.Configurations.Add (config);
+				var parameters = config.CompilationParameters as CSharpCompilerParameters;
+
+				var options = parameters.CreateCompilationOptions ();
+
+				Assert.AreEqual (Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary, options.OutputKind);
+
+				// Change project's compile target to Exe.
+				project.CompileTarget = CompileTarget.Exe;
+				options = parameters.CreateCompilationOptions ();
+
+				Assert.AreEqual (Microsoft.CodeAnalysis.OutputKind.ConsoleApplication, options.OutputKind);
+			}
+		}
+	}
+}

--- a/main/tests/test-projects/multi-target-reload/Class1.cs
+++ b/main/tests/test-projects/multi-target-reload/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace netstandard_sdk
+{
+	public class Class1
+	{
+	}
+}

--- a/main/tests/test-projects/multi-target-reload/multi-target-reload.csproj
+++ b/main/tests/test-projects/multi-target-reload/multi-target-reload.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/main/tests/test-projects/multi-target-reload/multi-target-reload.sln
+++ b/main/tests/test-projects/multi-target-reload/multi-target-reload.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netstandard", "netstandard.csproj", "{5B443F8D-6C84-443F-A395-5429E8F4A47D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B443F8D-6C84-443F-A395-5429E8F4A47D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/main/tests/test-projects/multi-target-reload/netstandard.csproj
+++ b/main/tests/test-projects/multi-target-reload/netstandard.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Editing an SDK project that targeted a single target framework so it
targets multiple target frameworks would result in the intellisense
not being updated from that point when the project changed, such as
when a new file was added.

The problem was that the Project.Modified event handler was removed
for the project when the old project was removed since the Roslyn
project id to project mapping had already been updated during the
reload to point to the new project. To avoid this a check is made to
ensure that no other project ids exist in the mapping before the
event handler is removed.

Fixes VSTS #1035311 - Wrong version of multi target project referenced
in .net framework project

Also fixed a null reference for new project added to existing solution. Adding a new project to an existing solution would trigger a null
reference exception in the CSharpCompilerParameters when the type
system service tried to use the project's configuration. This was then
breaking code completion for the NUnit library project when it was
added to an existing solution.

This was due to a change 18cf33d where
the OutputType was only being set if the project file was read from disk
which is not the case when adding a new project from a template to an
existing solution.

Fixes VSTS #1048443 - No intellisense for NUnit types when adding a new
NUnit project to an existing solution