### PR TITLE
[NuGet] Register credential providers coming from secure plugins

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialogRunner.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialogRunner.cs
@@ -38,6 +38,7 @@ namespace MonoDevelop.PackageManagement
 		public void Run (IDotNetProject project = null, string initialSearch = null)
 		{
 			try {
+				PackageManagementCredentialService.Reset ();
 				bool configurePackageSources = false;
 				do {
 					using (ManagePackagesDialog dialog = CreateDialog (initialSearch, project)) {

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.csproj
@@ -368,6 +368,7 @@
     <Compile Include="MonoDevelop.PackageManagement\PackageManagementCanReferenceProjectExtension.cs" />
     <Compile Include="MonoDevelop.PackageManagement\UpdateMultipleNuGetPackagesAction.cs" />
     <Compile Include="MonoDevelop.PackageManagement\ProjectReferenceMaintainerCollection.cs" />
+    <Compile Include="MonoDevelop.PackageManagement\MonoDevelopPluginFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MonoDevelop.PackageManagement.addin.xml" />

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopPluginFactory.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/MonoDevelopPluginFactory.cs
@@ -1,0 +1,100 @@
+//
+// MonoDevelopPluginFactory.cs
+//
+// Author:
+//       Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (c) 2020 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MonoDevelop.Core;
+using MonoDevelop.Core.Assemblies;
+using NuGet.Protocol.Plugins;
+
+namespace MonoDevelop.PackageManagement
+{
+	sealed class MonoDevelopPluginFactory : IPluginFactory
+	{
+		readonly PluginFactory pluginFactory;
+
+		public MonoDevelopPluginFactory (TimeSpan idleTimeout)
+		{
+			pluginFactory = new PluginFactory (idleTimeout);
+		}
+
+		public void Dispose ()
+		{
+			pluginFactory.Dispose ();
+		}
+
+		public Task<IPlugin> GetOrCreateAsync (
+			string filePath,
+			IEnumerable<string> arguments,
+			IRequestHandlers requestHandlers,
+			ConnectionOptions options,
+			CancellationToken sessionCancellationToken)
+		{
+			if (!Platform.IsWindows) {
+				var modifiedCommandLine = GetModifiedCommandLine (filePath, arguments);
+				if (modifiedCommandLine != null) {
+					filePath = modifiedCommandLine.FilePath;
+					arguments = modifiedCommandLine.Arguments;
+				}
+			}
+
+			return pluginFactory.GetOrCreateAsync (filePath, arguments, requestHandlers, options, sessionCancellationToken);
+		}
+
+		ModifiedCommandLineArguments GetModifiedCommandLine (string filePath, IEnumerable<string> arguments)
+		{
+			string extension = Path.GetExtension (filePath);
+			if (!StringComparer.OrdinalIgnoreCase.Equals (".exe", extension)) {
+				return null;
+			}
+
+			var runtime = MonoRuntimeInfo.FromCurrentRuntime ();
+			if (runtime == null) {
+				return null;
+			}
+
+			string monoPath = Path.Combine (runtime.Prefix, "bin", "mono");
+
+			List<string> updatedArguments = arguments.ToList ();
+			updatedArguments.Insert (0, "\"" + filePath + "\"");
+
+			return new ModifiedCommandLineArguments {
+				FilePath = monoPath,
+				Arguments = updatedArguments
+			};
+		}
+
+		sealed class ModifiedCommandLineArguments
+		{
+			public string FilePath { get; set; }
+			public List<string> Arguments { get; set; }
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
@@ -32,6 +32,7 @@ using MonoDevelop.Core;
 using NuGet.CommandLine;
 using NuGet.Credentials;
 using NuGet.Protocol;
+using NuGet.Protocol.Plugins;
 
 namespace MonoDevelop.PackageManagement
 {
@@ -60,6 +61,7 @@ namespace MonoDevelop.PackageManagement
 			var credentialProviders = new List<ICredentialProvider>();
 
 			credentialProviders.Add (CreateSettingsCredentialProvider ());
+			credentialProviders.AddRange (GetPluginsCredentialProviders ());
 			credentialProviders.Add (new MonoDevelopCredentialProvider ());
 
 			return credentialProviders;
@@ -70,6 +72,17 @@ namespace MonoDevelop.PackageManagement
 			var settings = SettingsLoader.LoadDefaultSettings ();
 			var packageSourceProvider = new MonoDevelopPackageSourceProvider (settings);
 			return new SettingsCredentialProvider (packageSourceProvider);
+		}
+
+		static IEnumerable<ICredentialProvider> GetPluginsCredentialProviders ()
+		{
+			var builder = new SecurePluginCredentialProviderBuilder (
+				PluginManager.Instance,
+				canShowDialog: false,
+				logger: NuGet.Common.NullLogger.Instance
+			);
+			var providers = builder.BuildAllAsync ().Result;
+			return providers;
 		}
 
 		/// <summary>

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/PackageManagementCredentialService.cs
@@ -77,7 +77,7 @@ namespace MonoDevelop.PackageManagement
 		static IEnumerable<ICredentialProvider> GetPluginsCredentialProviders ()
 		{
 			var builder = new SecurePluginCredentialProviderBuilder (
-				PluginManager.Instance,
+				PackageManagementServices.PluginManager,
 				canShowDialog: false,
 				logger: NuGet.Common.NullLogger.Instance
 			);

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RepositoryProviderFactoryExtensions.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/RepositoryProviderFactoryExtensions.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.PackageManagement
 			yield return new Lazy<INuGetResourceProvider> (() => new PackageMetadataResourceV3Provider ());
 			yield return new Lazy<INuGetResourceProvider> (() => new AutoCompleteResourceV2FeedProvider ());
 			yield return new Lazy<INuGetResourceProvider> (() => new AutoCompleteResourceV3Provider ());
-			yield return new Lazy<INuGetResourceProvider> (() => new PluginResourceProvider ());
+			yield return new Lazy<INuGetResourceProvider> (() => new PluginResourceProvider (PackageManagementServices.PluginManager));
 			yield return new Lazy<INuGetResourceProvider> (() => new FindLocalPackagesResourceUnzippedProvider ());
 			yield return new Lazy<INuGetResourceProvider> (() => new FindLocalPackagesResourceV2Provider ());
 			yield return new Lazy<INuGetResourceProvider> (() => new FindLocalPackagesResourceV3Provider ());

--- a/main/src/addins/MonoDevelop.PackageManagement/NuGet.Credentials/CredentialService.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/NuGet.Credentials/CredentialService.cs
@@ -103,13 +103,18 @@ namespace NuGet.Credentials
 
 					CredentialResponse response;
 					if (!TryFromCredentialCache (uri, type, isRetry, provider, out response)) {
+						/* Temporarily disable interactive-ness with secure plugin provider
+						 * to avoid them blocking on requesting user-input for device flow auth
+						 */
+						var nonInteractive = _nonInteractive || provider is SecurePluginCredentialProvider;
+
 						response = await provider.GetAsync (
 							uri,
 							proxy,
 							type,
 							message,
 							isRetry,
-							_nonInteractive,
+							nonInteractive,
 							cancellationToken);
 
 						// Check that the provider gave us a valid response.


### PR DESCRIPTION
This will do a barebone registration of available, plugin-based credential providers (like the Azure DevOps one) without implementing any authentication flow. The idea is that users can pre-authenticate via another mean (manual MSBuild invocation or NuGet binary) and the IDE will, at least, be able to retrieve those cached credentials.

Fixes VSTS #632121 - NuGet credential providers

Still some odd behaviour here. If you open the Manage Packages dialog whilst check for updates is running it seems that you get the dialog asking for credentials. It seems that the request is being treated as a retry so the NuGet credential provider removes it from the session token cache, if that is being used.