### PR TITLE
Fixes CommandHandler routing in native widgets

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -2304,10 +2304,18 @@ namespace MonoDevelop.Components.Commands
 		
 		Window GetActiveWindow (Window win)
 		{
-			Gtk.Window [] wins = Gtk.Window.ListToplevels ();
-
-			bool hasFocus = false;
 			bool lastFocusedExists = lastFocused == null;
+			bool hasFocus = false;
+#if MAC
+			var nsWindow = AppKit.NSApplication.SharedApplication.KeyWindow;
+			hasFocus = nsWindow != null;
+			if (hasFocus) {
+				lastFocusedExists |= lastFocused?.nativeWidget == nsWindow;
+				lastFocused = win = nsWindow;
+			} else {
+#endif
+
+			Gtk.Window [] wins = Gtk.Window.ListToplevels ();
 			Gtk.Window newFocused = null;
 			foreach (Gtk.Window w in wins) {
 				if (w.Visible) {
@@ -2324,18 +2332,9 @@ namespace MonoDevelop.Components.Commands
 				}
 			}
 
-#if MAC
-			if (!hasFocus) {
-				var nsWindow = AppKit.NSApplication.SharedApplication.KeyWindow;
-				hasFocus = nsWindow != null;
-				if (hasFocus) {
-					lastFocused = win = nsWindow;
-				}
-			} else {
-				lastFocused = newFocused;
-			}
-#else
 			lastFocused = newFocused;
+#if MAC
+			}
 #endif
 
 			UpdateAppFocusStatus (hasFocus, lastFocusedExists);
@@ -2343,8 +2342,7 @@ namespace MonoDevelop.Components.Commands
 			if (win != null && win.IsRealized) {
 				RegisterTopWindow (win);
 				return win;
-			}
-			else
+			} else
 				return null;
 		}
 		


### PR DESCRIPTION
This PR fixes the routing of CommandHadlers into a native widgets. Basically we were not getting the active window correctly in cases when a native widget was focused then the routing was failing, affecting to all the key shortcuts combinations.

In the current example shows how Copy shorcut now works on the native cocoa Watch panel

![ptsif2fujl-1](https://user-images.githubusercontent.com/1587480/72149397-5a8b8400-33a3-11ea-8b76-484176eac46f.gif)

![image-1](https://user-images.githubusercontent.com/1587480/72149549-bb1ac100-33a3-11ea-9b6b-d271fbd5b236.png)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999606/