### PR TITLE
[release-8.4] [Ide] Fix crash in main toolbar after project is reloaded

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.MainToolbar/MainToolbarController.cs
@@ -574,6 +574,7 @@ namespace MonoDevelop.Components.MainToolbar
 				currentSolution.StartupConfigurationChanged -= HandleStartupItemChanged;
 				currentSolution.Saved -= HandleSolutionSaved;
 				currentSolution.EntrySaved -= HandleSolutionEntrySaved;
+				currentSolution.SolutionItemAdded -= HandleSolutionItemAdded;
 			}
 
 			currentSolution = e.Solution;
@@ -582,6 +583,7 @@ namespace MonoDevelop.Components.MainToolbar
 				currentSolution.StartupConfigurationChanged += HandleStartupItemChanged;
 				currentSolution.Saved += HandleSolutionSaved;
 				currentSolution.EntrySaved += HandleSolutionEntrySaved;
+				currentSolution.SolutionItemAdded += HandleSolutionItemAdded;
 			}
 
 			TrackStartupProject ();
@@ -622,6 +624,14 @@ namespace MonoDevelop.Components.MainToolbar
 			// Skip the per-project update when a solution is being saved. The solution Saved callback will do the final update.
 			if (!e.SavingSolution)
 				HandleSolutionSaved (sender, e);
+		}
+
+		void HandleSolutionItemAdded (object sender, SolutionItemChangeEventArgs e)
+		{
+			// When a solution item is added due to a reload we need to ensure the configurationMergers dictionary is
+			// using the new project and not the old disposed project.
+			if (e.Reloading)
+				UpdateCombos ();
 		}
 
 		void HandleStartupItemChanged (object sender, EventArgs e)


### PR DESCRIPTION
If a multi-run configuration is selected in the main toolbar and a
project is reloaded a crash can occur since the main toolbar has not
updated its project mappings. Exception thrown:

```
System.Collections.Generic.KeyNotFoundException: The given key
'MonoDevelop.CSharp.Project.CSharpProject' was not present in the
dictionary.

System.ThrowHelper.GetKeyNotFoundException(Object)
System.ThrowHelper.ThrowKeyNotFoundException(Object)
System.Collections.Generic.Dictionary`2[[MonoDevelop.Projects.SolutionItem],[MonoDevelop.Components.MainToolbar.ConfigurationMerger]].get_Item(SolutionItem)
MonoDevelop.Components.MainToolbar.MainToolbarController.FillRuntimesForProject(List`1,SolutionItem,Int32&)
MonoDevelop.Components.MainToolbar.MainToolbarController.FillRuntimes()
MonoDevelop.Components.MainToolbar.MainToolbarController.NotifyConfigurationChange()
MonoDevelop.Components.MainToolbar.MainToolbarController.HandleRuntimeChanged(Object,HandledEventArgs)
```

The problem was that on reloading the main toolbar's configurationMerger
dictionary was not updated. It still contained the old disposed project
so the dictionary lookup would fail for the new reloaded project. To
fix this when a project is reloaded the main toolbar's dictionary is
now refreshed.

Repro:

1. Create a solution with two projects.
2. Create a multiple startup run configuration with both projects.
3. Select the multi run configuration in the toolbar.
4. Edit one of the project files in the editor and save a change.
5. Change from Debug to Release in the main toolbar.

Fixes VSTS #944654 - [FATAL] System.Collections.Generic.KeyNotFoundException
exception in System.ThrowHelper.GetKeyNotFoundException()

Backport of #9534.

/cc @mrward 