### PR TITLE
[AspNetCore] Don't create browser-based execution targets for Worker services

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore/AspNetCoreProjectExtension.cs
@@ -178,26 +178,30 @@ namespace MonoDevelop.AspNetCore
 
 		protected override IEnumerable<ExecutionTarget> OnGetExecutionTargets (OperationContext ctx, ConfigurationSelector configuration, SolutionItemRunConfiguration runConfig)
 		{
-			var result = new ExecutionTargetGroup (GettextCatalog.GetString ("Browser"), "MonoDevelop.AspNetCore.BrowserExecutionTargets");
-			foreach (var browser in IdeServices.DesktopService.GetApplications ("https://localhost", Ide.Desktop.DesktopApplicationRole.Viewer)) {
-				if (browser.IsDefault) {
-					if (Project.HasMultipleTargetFrameworks) {
-						result.InsertRange (0, GetMultipleTargetFrameworkExecutionTargets (browser));
+			if (IsWeb) {
+				var result = new ExecutionTargetGroup (GettextCatalog.GetString ("Browser"), "MonoDevelop.AspNetCore.BrowserExecutionTargets");
+				foreach (var browser in IdeServices.DesktopService.GetApplications ("https://localhost", Ide.Desktop.DesktopApplicationRole.Viewer)) {
+					if (browser.IsDefault) {
+						if (Project.HasMultipleTargetFrameworks) {
+							result.InsertRange (0, GetMultipleTargetFrameworkExecutionTargets (browser));
+						} else {
+							result.Insert (0, new AspNetCoreExecutionTarget (browser));
+						}
 					} else {
-						result.Insert (0, new AspNetCoreExecutionTarget (browser));
-					}
-				} else {
-					if (Project.HasMultipleTargetFrameworks) {
-						result.AddRange (GetMultipleTargetFrameworkExecutionTargets (browser));
-					} else {
-						result.Add (new AspNetCoreExecutionTarget (browser));
+						if (Project.HasMultipleTargetFrameworks) {
+							result.AddRange (GetMultipleTargetFrameworkExecutionTargets (browser));
+						} else {
+							result.Add (new AspNetCoreExecutionTarget (browser));
+						}
 					}
 				}
-			}
 
-			return result.Count > 0
-				? new ExecutionTarget [] { result }
-				: base.OnGetExecutionTargets (ctx, configuration, runConfig);
+				return result.Count > 0
+					? new ExecutionTarget [] { result }
+					: base.OnGetExecutionTargets (ctx, configuration, runConfig);
+			} else {
+				return base.OnGetExecutionTargets (ctx, configuration, runConfig);
+			}
 		}
 
 		IEnumerable<ExecutionTarget> GetMultipleTargetFrameworkExecutionTargets (DesktopApplication browser)


### PR DESCRIPTION
With the enabling of launchSettings.json support for Worker services,
we added support, by mistake, to run it on the user's installed
browsers, which is wrong, as Worker services are just console
applications.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1050466