### PR TITLE
[Ide] Support adding/updating .editorconfig with Roslyn

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/IMonoDevelopHostDocument.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/IMonoDevelopHostDocument.cs
@@ -32,7 +32,12 @@ namespace MonoDevelop.Ide.TypeSystem
 			textBuffer?.Properties.RemoveProperty (typeof (IMonoDevelopHostDocument));
 		}
 
-		internal static IMonoDevelopHostDocument FromDocument(Document document)
+		internal static IMonoDevelopHostDocument FromDocument (Document document)
+		{
+			return FromDocument ((TextDocument)document);
+		}
+
+		internal static IMonoDevelopHostDocument FromDocument(TextDocument document)
 		{
 			IMonoDevelopHostDocument containedDocument = null;
 			if (document.TryGetText (out SourceText sourceText)) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/MonoDevelopWorkspace.cs
@@ -1181,8 +1181,11 @@ namespace MonoDevelop.Ide.TypeSystem
 				// Need to trigger Project.Modified event after TryApp is run so project is reloaded by the type system
 				// service. Adding the file to the Files collection will not trigger the modified event since
 				// the build action is not EditorConfigFiles. Also this event would be ignored anyway during TryApply.
-				// Also handles if the link already existed.
-				tryApplyState_modifiedProjects.Add (mdProject);
+				// Also handles if the link already existed. Need to refresh all projects since the document added
+				// method will only be called once.
+				foreach (var affectedProject in mdProject.ParentSolution.GetAllProjects ()) {
+					tryApplyState_modifiedProjects.Add (affectedProject);
+				}
 				tryApplyState_changedProjects.Add (mdProject);
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -201,7 +201,12 @@ namespace MonoDevelop.Ide.TypeSystem
 						var docId = mdWorkspace.GetDocumentId (projectId, fileName);
 						if (docId != null) {
 							projects.Add (mdProject);
-							mdWorkspace.OnAnalyzerConfigDocumentRemoved (docId);
+							try {
+								mdWorkspace.OnAnalyzerConfigDocumentRemoved (docId);
+							} catch (Exception ex) {
+								// Ignore error so other projects can be updated.
+								LoggingService.LogError ("OnAnalyzerConfigDocumentRemoved error", ex);
+							}
 						}
 					}
 				}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.TypeSystem/TypeSystemService.cs
@@ -116,6 +116,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 
 			FileService.FileChanged += FileService_FileChanged;
+			FileService.FileRemoved += FileService_FileRemoved;
 
 			desktopService = await serviceProvider.GetService<DesktopService> ();
 
@@ -125,6 +126,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		protected override Task OnDispose ()
 		{
 			FileService.FileChanged -= FileService_FileChanged;
+			FileService.FileRemoved -= FileService_FileRemoved;
 			if (rootWorkspace != null)
 				rootWorkspace.ActiveConfigurationChanged -= HandleActiveConfigurationChanged;
 			FinalizeTrackedProjectHandling ();
@@ -171,6 +173,43 @@ namespace MonoDevelop.Ide.TypeSystem
 					});
 				} catch (Exception) { }
 			});
+		}
+
+		void FileService_FileRemoved (object sender, FileEventArgs e)
+		{
+			try {
+				foreach (var file in e) {
+					if (file.FileName.FileName == ".editorconfig") {
+						OnEditorConfigDocumentRemoved (file.FileName);
+					}
+				}
+			} catch (Exception ex) {
+				LoggingService.LogError ("TypeSystemService.FileService_FileRemoved error", ex);
+			}
+		}
+
+		void OnEditorConfigDocumentRemoved (FilePath fileName)
+		{
+			foreach (var workspace in AllWorkspaces) {
+				var mdWorkspace = workspace as MonoDevelopWorkspace;
+				if (mdWorkspace == null)
+					continue;
+
+				var projects = new HashSet<Project> ();
+				foreach (var mdProject in mdWorkspace.MonoDevelopSolution.GetAllProjects ()) {
+					foreach (var projectId in mdWorkspace.GetProjectIds (mdProject)) {
+						var docId = mdWorkspace.GetDocumentId (projectId, fileName);
+						if (docId != null) {
+							projects.Add (mdProject);
+							mdWorkspace.OnAnalyzerConfigDocumentRemoved (docId);
+						}
+					}
+				}
+
+				foreach (var mdProject in projects) {
+					mdProject.NotifyModified ("CoreCompileFiles");
+				}
+			}
 		}
 
 		internal async Task<MonoDevelopWorkspace> CreateEmptyWorkspace ()


### PR DESCRIPTION
Right clicking in the text editor and selecting an item underneath
'Configure and Supress issues' would not add an .editorconfig file
or update the existing one.

The problem was that this feature requires changes in the type system
service.

Some odd behaviour with multiple projects in the solution, which looks like a Roslyn bug, where the editorconfig file is added as a link to a different project to the one the file being worked on belongs to.

Fixes VSTS #1001982 - Attempting to add analyzer configs fails silently
(to the user)
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1001982

Test cases linked to on above bug report.