### PR TITLE
[Ide.Tests] Retry writing to file in multi-target test

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs
@@ -65,7 +65,8 @@ namespace MonoDevelop.Projects
 				// 2) An Sdk node as a child of the Project node
 				// 3) An Sdk attribute on any Import node
 				var document = new XmlDocument ();
-				document.Load (new StreamReader (file));
+				using (var sr = new StreamReader (file));
+				document.Load (sr);
 				XmlNode projectNode = document.SelectSingleNode ("/Project");
 				if (projectNode != null) {
 					XmlAttribute sdkAttr = projectNode.Attributes ["Sdk"];

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs
@@ -65,8 +65,9 @@ namespace MonoDevelop.Projects
 				// 2) An Sdk node as a child of the Project node
 				// 3) An Sdk attribute on any Import node
 				var document = new XmlDocument ();
-				using (var sr = new StreamReader (file));
-				document.Load (sr);
+				using (var sr = new StreamReader (file)) {
+					document.Load (sr);
+				}
 				XmlNode projectNode = document.SelectSingleNode ("/Project");
 				if (projectNode != null) {
 					XmlAttribute sdkAttr = projectNode.Attributes ["Sdk"];

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
@@ -246,7 +246,7 @@ namespace MonoDevelop.Ide.TypeSystem
 		{
 			FilePath solFile = Util.GetSampleProject ("multi-target", "multi-target.sln");
 
-			var csprojectPath = Path.Combine(Path.GetDirectoryName (solFile.FullPath), "multi-target.csproj");
+			var csprojectPath = new FilePath(Path.Combine(Path.GetDirectoryName (solFile.FullPath), "multi-target.csproj"));
 
 			ShowFileLockInformation (csprojectPath, "#1");
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
@@ -279,6 +279,7 @@ namespace MonoDevelop.Ide.TypeSystem
 							break;
 						} catch (Exception ex) {
 							if (i + 1 >= maxRetries) {
+								ShowFileLockInformation (project.FileName);
 								throw;
 							} else {
 								Console.WriteLine ("MultiTargetFramework_ReloadProject_TargetFrameworksChanged File.WriteAllText error: {0}", ex.Message);
@@ -316,6 +317,28 @@ namespace MonoDevelop.Ide.TypeSystem
 				} finally {
 					TypeSystemServiceTestExtensions.UnloadSolution (sol);
 				}
+			}
+		}
+
+		void ShowFileLockInformation (FilePath fileName)
+		{
+			Console.WriteLine (
+				"ShowFileLockInformation CurrentProcessId={0} lsof output:",
+				Process.GetCurrentProcess ().Id);
+
+			using (var process = new Process ()) {
+				process.StartInfo.UseShellExecute = false;
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.CreateNoWindow = true;
+
+				process.StartInfo.FileName = "lsof";
+				//process.StartInfo.Arguments = " \"" + fileName.FileName + "\"";
+
+				process.OutputDataReceived += (s, e) => Console.WriteLine (e.Data);
+
+				process.Start ();
+				process.BeginOutputReadLine ();
+				process.WaitForExit ();
 			}
 		}
 

--- a/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
+++ b/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs
@@ -287,7 +287,7 @@ namespace MonoDevelop.Ide.TypeSystem
 							break;
 						} catch (Exception ex) {
 							if (i + 1 >= maxRetries) {
-								ShowFileLockInformation (project.FileName);
+								ShowFileLockInformation (project.FileName, $"Retry: #{i}");
 								throw;
 							} else {
 								Console.WriteLine ("MultiTargetFramework_ReloadProject_TargetFrameworksChanged File.WriteAllText error: {0}", ex.Message);
@@ -329,7 +329,7 @@ namespace MonoDevelop.Ide.TypeSystem
 			}
 		}
 
-		void ShowFileLockInformation (FilePath fileName, string tag = String.Empty)
+		void ShowFileLockInformation (FilePath fileName, string tag)
 		{
 			Console.WriteLine (
 				"{0} ShowFileLockInformation CurrentProcessId={1} lsof output:",
@@ -343,7 +343,10 @@ namespace MonoDevelop.Ide.TypeSystem
 				process.StartInfo.FileName = "lsof";
 				//process.StartInfo.Arguments = " \"" + fileName.FileName + "\"";
 
-				process.OutputDataReceived += (s, e) => Console.WriteLine (e.Data);
+				process.OutputDataReceived += (s, e) => {
+					if (e.Data?.IndexOf (fileName.FullPath) >= 0)
+						Console.WriteLine (e.Data);
+				};
 
 				process.Start ();
 				process.BeginOutputReadLine ();


### PR DESCRIPTION
Try to fix the sharing violation that may happen on the build server
when the MultiTargetFramework_ReloadProject_TargetFrameworksChanged
test tries to write the project file to disk directly using
File.WriteAllText.

Fixes VSTS #1050360 - MultiTargetFramework_ReloadProject_TargetFrameworksChanged
test reliability