### PR TITLE
[IDE] Allow deleting missing files from project

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
@@ -326,7 +326,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				}
 
 				var result = MessageService.AskQuestion (question, new [] { AlertButton.Cancel, fileExists ? AlertButton.Delete : AlertButton.Remove });
-				if(result == AlertButton.Cancel)
+				if (result == AlertButton.Cancel)
 					return;
 				else
 					RemoveFilesFromProject (fileExists, files);
@@ -344,7 +344,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				var pf = (ProjectFile)node.DataItem;
 				files.Add (pf);
 			}
-			if(!CheckAnyFileExists(files))
+			if (!CheckAnyFileExists(files))
 				info.Text = GettextCatalog.GetString ("Remove");
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads.ProjectPad/ProjectFileNodeBuilder.cs
@@ -290,25 +290,42 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 			if (CheckAllLinkedFile (files)) {
 				RemoveFilesFromProject (false, files);
 			} else {
-				string behavior = fileExists ? "delete" : "remove";
 				if (hasChildren) {
-					if (files.Count == 1)
-						question = GettextCatalog.GetString ("Are you sure you want to {0} the file {1} and " +
-															 "its code-behind children from project {2}?",
-															 behavior, Path.GetFileName (files [0].Name), files [0].Project.Name);
-					else
-						question = GettextCatalog.GetString ("Are you sure you want to {0} the selected files and " +
-															 "their code-behind children from the project?", behavior);
+					if (files.Count == 1) {
+						if (fileExists)
+							question = GettextCatalog.GetString ("Are you sure you want to delete the file {0} and " +
+															 "its code-behind children from project {1}?",
+															 Path.GetFileName (files [0].Name), files [0].Project.Name);
+						else
+							question = GettextCatalog.GetString ("Are you sure you want to remove the file {0} and " +
+															 "its code-behind children from project {1}?",
+															 Path.GetFileName (files [0].Name), files [0].Project.Name);
+					} else {
+						if (fileExists)
+							question = GettextCatalog.GetString ("Are you sure you want to delete the selected files and " +
+															 "their code-behind children from the project?");
+						else
+							question = GettextCatalog.GetString ("Are you sure you want to remove the selected files and " +
+															 "their code-behind children from the project?");
+					}
 				} else {
-					if (files.Count == 1)
-						question = GettextCatalog.GetString ("Are you sure you want to {0} file {1} from project {2}?",
-															 behavior, Path.GetFileName (files [0].Name), files [0].Project.Name);
-					else
-						question = GettextCatalog.GetString ("Are you sure you want to {0} the selected files from the project?", behavior);
+					if (files.Count == 1) {
+						if (fileExists)
+							question = GettextCatalog.GetString ("Are you sure you want to delete file {0} from project {1}?",
+															 Path.GetFileName (files [0].Name), files [0].Project.Name);
+						else
+							question = GettextCatalog.GetString ("Are you sure you want to remove file {0} from project {1}?",
+															 Path.GetFileName (files [0].Name), files [0].Project.Name);
+
+					} else {
+						if (fileExists)
+							question = GettextCatalog.GetString ("Are you sure you want to delete the selected files from the project?");
+						else
+							question = GettextCatalog.GetString ("Are you sure you want to remove the selected files from the project?");
+					}
 				}
 
 				var result = MessageService.AskQuestion (question, new [] { AlertButton.Cancel, fileExists ? AlertButton.Delete : AlertButton.Remove });
-
 				if(result == AlertButton.Cancel)
 					return;
 				else
@@ -327,7 +344,7 @@ namespace MonoDevelop.Ide.Gui.Pads.ProjectPad
 				var pf = (ProjectFile)node.DataItem;
 				files.Add (pf);
 			}
-			if( !CheckAnyFileExists(files) )
+			if(!CheckAnyFileExists(files))
 				info.Text = GettextCatalog.GetString ("Remove");
 		}
 


### PR DESCRIPTION
- After a file is deleted from Finder outside VS Mac, right click on the file in the IDE will show "Remove" instead of "Delete" and a dialog will confirm user's choice to remove the file and its child from the project. If any child exists, it will be removed (not deleted)

Discussion: Should we directly delete the child?

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1051207