### PR TITLE
Fix sharing violation in a test caused by a file handle left open,

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs
@@ -65,7 +65,8 @@ namespace MonoDevelop.Projects
 				// 2) An Sdk node as a child of the Project node
 				// 3) An Sdk attribute on any Import node
 				var document = new XmlDocument ();
-				document.Load (new StreamReader (file));
+				using (var sr = new StreamReader (file))
+					document.Load (sr);
 				XmlNode projectNode = document.SelectSingleNode ("/Project");
 				if (projectNode != null) {
 					XmlAttribute sdkAttr = projectNode.Attributes ["Sdk"];


### PR DESCRIPTION
.. after use.

Fixes VSTS #1050360 - `MultiTargetFramework_ReloadProject_TargetFrameworksChanged`

In the test, the project file `multi-target.csproj` was loaded in

`using (var sol = (Solution)await Services.ProjectService.ReadWorkspaceItem (Util.GetMonitor (), solFile))`

.. `main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SdkProjectReader.cs`,

	- but the StreamReader for the file was not disposed
	- causing a subsequent attempt to overwrite the file to fail
	with a sharing violation error.

```
1) MultiTargetFramework_ReloadProject_TargetFrameworksChanged (MonoDevelop.Ide.TypeSystem.TypeSystemServiceTests.MultiTargetFramework_ReloadProject_TargetFrameworksChanged)
   System.IO.IOException : Sharing violation on path /Users/runner/runners/2.164.1/work/r1/a/VS for Mac/drop/tests/tmp/multi-target.sln-18/multi-target.csproj
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x00259] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:274
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:106
  at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions)
  at System.IO.StreamWriter..ctor (System.String path, System.Boolean append, System.Text.Encoding encoding, System.Int32 bufferSize) [0x00055] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-12/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/IO/StreamWriter.cs:151
  at System.IO.StreamWriter..ctor (System.String path) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-12/external/bockbuild/builds/mono-x64/external/corefx/src/Common/src/CoreLib/System/IO/StreamWriter.cs:126
  at (wrapper remoting-invoke-with-check) System.IO.StreamWriter..ctor(string)
  at System.IO.File.WriteAllText (System.String path, System.String contents) [0x00026] in /Users/builder/jenkins/workspace/build-package-osx-mono/2019-12/external/bockbuild/builds/mono-x64/external/corefx/src/System.IO.FileSystem/src/System/IO/File.cs:314
  at MonoDevelop.Ide.TypeSystem.TypeSystemServiceTests.MultiTargetFramework_ReloadProject_TargetFrameworksChanged () [0x00258] in /Users/runner/runners/2.164.1/work/1/s/monodevelop/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs:278
  at MonoDevelop.Ide.TypeSystem.TypeSystemServiceTests.MultiTargetFramework_ReloadProject_TargetFrameworksChanged () [0x002a4] in /Users/runner/runners/2.164.1/work/1/s/monodevelop/main/tests/Ide.Tests/MonoDevelop.Ide.TypeSystem/TypeSystemServiceTests.cs:282
```

Debugged+resolved with: Matt Ward (@mrward)
Debugged in https://github.com/mono/monodevelop/pull/9540

This was also consistently seen with the mono 6.10.0x bump in
https://github.com/xamarin/md-addins/pull/6037 .