### PR TITLE
[release-8.4] [NuGet] Use a custom label to allow tab focus in package management

### DIFF
--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.UI.cs
@@ -65,10 +65,10 @@ namespace MonoDevelop.PackageManagement
 		ComboBox packageVersionComboBox;
 		HBox packageVersionsHBox;
 		Label packageVersionsLabel;
-		Label browseLabel;
-		Label installedLabel;
-		Label updatesLabel;
-		Label consolidateLabel;
+		CustomButtonLabel browseLabel;
+		CustomButtonLabel installedLabel;
+		CustomButtonLabel updatesLabel;
+		CustomButtonLabel consolidateLabel;
 		HBox tabGroup;
 		VBox projectsListViewVBox;
 		Label projectsListViewLabel;
@@ -114,33 +114,29 @@ namespace MonoDevelop.PackageManagement
 			tabGroup = new HBox ();
 
 			int tabLabelMinWidth = 60;
-			browseLabel = new Label ();
+			browseLabel = new CustomButtonLabel ();
 			browseLabel.Text = GettextCatalog.GetString ("Browse");
 			browseLabel.Tag = browseLabel.Text;
 			browseLabel.MinWidth = tabLabelMinWidth;
 			browseLabel.MarginLeft = 10;
-			browseLabel.CanGetFocus = true;
 			tabGroup.PackStart (browseLabel);
 
-			installedLabel = new Label ();
+			installedLabel = new CustomButtonLabel ();
 			installedLabel.Text = GettextCatalog.GetString ("Installed");
 			installedLabel.Tag = installedLabel.Text;
 			installedLabel.MinWidth = tabLabelMinWidth;
-			installedLabel.CanGetFocus = true;
 			tabGroup.PackStart (installedLabel);
 
-			updatesLabel = new Label ();
+			updatesLabel = new CustomButtonLabel ();
 			updatesLabel.Text = GettextCatalog.GetString ("Updates");
 			updatesLabel.Tag = updatesLabel.Text;
 			updatesLabel.MinWidth = tabLabelMinWidth;
-			updatesLabel.CanGetFocus = true;
 			tabGroup.PackStart (updatesLabel);
 
-			consolidateLabel = new Label ();
+			consolidateLabel = new CustomButtonLabel ();
 			consolidateLabel.Text = GettextCatalog.GetString ("Consolidate");
 			consolidateLabel.Tag = consolidateLabel.Text;
 			consolidateLabel.MinWidth = tabLabelMinWidth;
-			consolidateLabel.CanGetFocus = true;
 			tabGroup.PackStart (consolidateLabel);
 
 			topHBox.PackStart (tabGroup);
@@ -504,6 +500,64 @@ namespace MonoDevelop.PackageManagement
 				currentPackageVersionLabel.WidthRequest = packageVersionsLabelWidth;
 				maxPackageVersionLabelWidth = packageVersionsLabelWidth;
 			}
+		}
+	}
+
+	sealed class CustomButtonLabel : Canvas
+	{
+		readonly TextLayout layout = new TextLayout ();
+		Size preferredSize;
+
+		public string Text {
+			get { return layout.Text; }
+			set {
+				layout.Markup = null;
+				layout.Text = value;
+				Accessible.Title = layout.Text;
+				preferredSize = layout.GetSize ();
+				OnPreferredSizeChanged ();
+			}
+		}
+
+		public string Markup {
+			get { return layout.Markup; }
+			set {
+				layout.Markup = value;
+				Accessible.Title = layout.Text;
+				preferredSize = layout.GetSize ();
+				OnPreferredSizeChanged ();
+			}
+		}
+
+		public CustomButtonLabel ()
+		{
+			CanGetFocus = true;
+			Accessible.Role = Xwt.Accessibility.Role.Button;
+		}
+
+		protected override Size OnGetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)
+		{
+			return preferredSize;
+		}
+
+		protected override void OnDraw (Context ctx, Rectangle dirtyRect)
+		{
+			if (HasFocus) {
+				ctx.SetColor (Ide.Gui.Styles.BaseSelectionBackgroundColor);
+			}
+			var actualSize = Size;
+			var x = Math.Max (0, (actualSize.Width - preferredSize.Width) / 2);
+			var y = Math.Max (0, (actualSize.Height - preferredSize.Height) / 2);
+			x += x % 2; // align pixels
+			ctx.DrawTextLayout (layout, x, y);
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (disposing) {
+				layout.Dispose ();
+			}
+			base.Dispose (disposing);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
+++ b/main/src/addins/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.Gui/ManagePackagesDialog.cs
@@ -1156,7 +1156,7 @@ namespace MonoDevelop.PackageManagement
 			UpdatePackageResultsLabel (ManagePackagesPage.Consolidate, consolidateLabel);
 		}
 
-		void UpdatePackageResultsLabel (ManagePackagesPage page, Label label)
+		void UpdatePackageResultsLabel (ManagePackagesPage page, CustomButtonLabel label)
 		{
 			string text = (string)label.Tag;
 			if (page == viewModel.PageSelected) {
@@ -1168,7 +1168,7 @@ namespace MonoDevelop.PackageManagement
 			}
 		}
 
-		static void UpdatePackageResultsLabelA11y (Label label, bool active)
+		static void UpdatePackageResultsLabelA11y (Widget label, bool active)
 		{
 			if (label.Surface.ToolkitEngine.Type == ToolkitType.Gtk) {
 				var widget = label.Surface.NativeWidget as Gtk.Widget;


### PR DESCRIPTION
A regular label does not allow focus unless it's selectable or a link
and there is no simple workaround for that.

![Kapture 2020-01-16 at 11 43 18](https://user-images.githubusercontent.com/951587/72518369-797f8f80-3855-11ea-9b04-f14933c53d9c.gif)


Fixes VSTS #1021581

Backport of #9555.

/cc @sevoku 