### PR TITLE
[release-8.4] [1049876] [Scaffolding] Added Accessible.Title property for input controls

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Scaffolding/ScaffolderTemplateConfigurePage.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Scaffolding/ScaffolderTemplateConfigurePage.cs
@@ -62,6 +62,7 @@ namespace MonoDevelop.AspNetCore.Scaffolding
 					table.Add (input, 1, rowIndex);
 					input.Changed += (sender, args) => s.SelectedValue = input.Text;
 					input.MinWidth = 300;
+					input.Accessible.LabelWidget = label;
 					input.SetFocus ();
 					break;
 				case ComboField comboField:
@@ -100,9 +101,8 @@ namespace MonoDevelop.AspNetCore.Scaffolding
 					table.Add (label, 0, rowIndex, hpos: WidgetPlacement.End);
 					table.Add (comboBox, 1, rowIndex);
 					comboBox.TextInput += (sender, args) => comboField.SelectedValue = comboBox.SelectedText;
-
 					comboBox.SelectionChanged += (sender, args) => comboField.SelectedValue = comboBox.SelectedText;
-
+					comboBox.Accessible.LabelWidget = label;
 					break;
 				case BoolFieldList boolFieldList:
 					label.Text = boolFieldList.DisplayName;
@@ -132,6 +132,7 @@ namespace MonoDevelop.AspNetCore.Scaffolding
 					rowAdditionCount++;
 					fileSelector.HeightRequest = 20;
 					fileSelector.FileChanged += (sender, args) => fileField.SelectedValue = fileSelector.FileName;
+					fileSelector.Accessible.LabelWidget = label;
 					break;
 				}
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049876

Things that are done in this PR:
* Added Accessible.Title property for input controls

This fixes VoiceOver accessibility announcements made on text fields, combo boxes and file selectors on ASP.NET Core Scaffolding dialogs (see screenshot attached).

![image](https://user-images.githubusercontent.com/43088712/72531332-e86edf80-3879-11ea-8a22-2c2c9fbf7a7a.png)
 

Backport of #9559.

/cc @rodrmoya @Semptra