### PR TITLE
[release-8.4] Adds general KeyViewLoop custom implementation in CommandManager

### DIFF
--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport.Toolbox/MacToolbox.cs
@@ -121,7 +121,9 @@ namespace MonoDevelop.DesignerSupport.Toolbox
 		NSTextField messageTextField;
 
 		readonly KeyViewLoopDelegate keyViewLoopDelegate;
-		
+
+		public override bool AcceptsFirstResponder () => false;
+
 		public MacToolbox (ToolboxService toolboxService, IPadWindow container)
 		{
 			WantsLayer = true;

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -137,8 +137,6 @@ namespace MonoDevelop.DesignerSupport
 
 	class MacPropertyEditorPanel : PropertyEditorPanel
 	{
-		public EventHandler Focused;
-
 		public MacPropertyEditorPanel (MonoDevelopHostResourceProvider hostResources)
 			: base (hostResources)
 		{
@@ -186,11 +184,6 @@ namespace MonoDevelop.DesignerSupport
 			}
 		}
 
-		public override bool BecomeFirstResponder ()
-		{
-			Focused?.Invoke (this, EventArgs.Empty);
-			return base.BecomeFirstResponder ();
-		}
 	}
 }
 

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -37,10 +37,11 @@ using Xamarin.PropertyEditing.Mac;
 using AppKit;
 using CoreGraphics;
 using System.Linq;
+using Gtk;
 
 namespace MonoDevelop.DesignerSupport
 {
-	class MacPropertyGrid : NSView
+	class MacPropertyGrid : NSView, Gtk.IGtkViewHostContentView
 	{
 		readonly MacPropertyEditorPanel propertyEditorPanel;
 		readonly MonoDevelopHostResourceProvider hostResourceProvider;
@@ -133,6 +134,24 @@ namespace MonoDevelop.DesignerSupport
 			}
 			base.Dispose (disposing);
 		}
+
+		public bool CanBecomeKeyViewFromGtkViewHost (NSView view)
+		{
+			//temporal property pad hacks:
+			//removes the exanders from our keyviewloop
+			if (view is AppKit.NSButton expander && expander.Superview is AppKit.NSView expanderParent && expanderParent.Superview is AppKit.NSTableRowView tableRowView && IsFirstResponderOutlineView (tableRowView.Superview)) {
+				return false;
+			}
+
+			if (IsFirstResponderOutlineView (view)) {
+				return false;
+			}
+
+			return true;
+		}
+
+		const string FirstResponderOutlineViewTypeName = "<Xamarin_PropertyEditing_Mac_PropertyList_FirstResponderOutlineView:";
+		static bool IsFirstResponderOutlineView (AppKit.NSView view) => view != null && view.ToString ().StartsWith (FirstResponderOutlineViewTypeName);
 	}
 
 	class MacPropertyEditorPanel : PropertyEditorPanel

--- a/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
+++ b/main/src/addins/MonoDevelop.DesignerSupport/MonoDevelop.DesignerSupport/MacPropertyGrid.cs
@@ -152,6 +152,7 @@ namespace MonoDevelop.DesignerSupport
 
 		const string FirstResponderOutlineViewTypeName = "<Xamarin_PropertyEditing_Mac_PropertyList_FirstResponderOutlineView:";
 		static bool IsFirstResponderOutlineView (AppKit.NSView view) => view != null && view.ToString ().StartsWith (FirstResponderOutlineViewTypeName);
+		public bool HandlesNextResponder (NSView view) => false;
 	}
 
 	class MacPropertyEditorPanel : PropertyEditorPanel

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -674,8 +674,11 @@ namespace MonoDevelop.Components.Commands
 			return null;
 		}
 
-		bool IsLastView (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView) => GetOrderedFocusableViews (view, addViewBeforeChildren, removeContentView).LastOrDefault () == view;
-		bool IsFirstView (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView) => GetOrderedFocusableViews (view, addViewBeforeChildren, removeContentView).FirstOrDefault () == view;
+		bool IsLastView (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView)
+			=> GetOrderedFocusableViews (view, addViewBeforeChildren, removeContentView).LastOrDefault () == view;
+
+		bool IsFirstView (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView)
+			=> GetOrderedFocusableViews (view, addViewBeforeChildren, removeContentView).FirstOrDefault () == view;
 
 		GtkNSViewHost GetGtkNSViewHostFromView (AppKit.NSView view) => view == null ? null : viewHosts.FirstOrDefault (s => s.Content == view);
 
@@ -723,14 +726,14 @@ namespace MonoDevelop.Components.Commands
 			if (addViewBeforeChildren && CanBecomeKeyView (view, contentView as IGtkViewHostContentView) && contentView != view)
 				toAddViews.Add (view);
 
-			if (view.IsFlipped) {
-				foreach (var subview in view.Subviews.OrderBy (s => s.Frame.Left).ThenBy (h => h.Frame.Top)) {
-					AddRecursivelyFocusableViews (subview, toAddViews, addViewBeforeChildren, contentView);
-				}
-			} else {
-				foreach (var subview in view.Subviews.OrderBy (s => s.Frame.Left).ThenByDescending (h => h.Frame.Top)) {
-					AddRecursivelyFocusableViews (subview, toAddViews, addViewBeforeChildren, contentView);
-				}
+			var possibleChildren = view.Subviews.OrderBy (s => s.Frame.Left);
+			if (view.IsFlipped)
+				possibleChildren = possibleChildren.ThenBy (h => h.Frame.Top);
+			else
+				possibleChildren = possibleChildren.ThenByDescending (h => h.Frame.Top);
+
+			foreach (var subview in possibleChildren) {
+				AddRecursivelyFocusableViews (subview, toAddViews, addViewBeforeChildren, contentView);
 			}
 
 			if (!addViewBeforeChildren && CanBecomeKeyView (view, contentView as IGtkViewHostContentView) && contentView != view)
@@ -758,7 +761,7 @@ namespace MonoDevelop.Components.Commands
 		internal void RegisterEmbededView (Gtk.GtkNSViewHost gtkNSViewHost)
 		{
 			if (gtkNSViewHost == null) {
-				throw new NullReferenceException ("cannot register a null GtkNSViewHost");
+				throw new ArgumentNullException ("cannot register a null GtkNSViewHost");
 			}
 			if (!viewHosts.Contains (gtkNSViewHost)) {
 				viewHosts.Add (gtkNSViewHost);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -642,7 +642,7 @@ namespace MonoDevelop.Components.Commands
 			return true;
 		}
 
-		static bool HandlesFocus (AppKit.NSView view)
+		static bool AllowsRecursivityFocus (AppKit.NSView view)
 		{
 			if (view.Hidden) {
 				return true;
@@ -656,7 +656,7 @@ namespace MonoDevelop.Components.Commands
 
 		static void AddRecursivelyFocusableViews (AppKit.NSView view, List<AppKit.NSView> toAddViews, bool addViewBeforeChildren, AppKit.NSView contentView)
 		{
-			if (HandlesFocus (view)) {
+			if (AllowsRecursivityFocus (view)) {
 				return;
 			}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -446,7 +446,7 @@ namespace MonoDevelop.Components.Commands
 
 			if (supportsTabKey && currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
 				AppKit.NSView next = null;
-				if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
+				if ((int)currentEvent.ModifierFlags == (int)Mac.KeyModifierFlag.Shift) {
 					next = expectedKeyView.PreviousValidKeyView;
 
 					//is our next from another embeded view? we don't allow to do that and we 
@@ -459,7 +459,7 @@ namespace MonoDevelop.Components.Commands
 						next = GetPreviousKeyView (expectedKeyView, addViewBeforeChildren: false, removeContentView: true);
 					}
 
-				} else {
+				} else if ((int)currentEvent.ModifierFlags == (int)Mac.KeyModifierFlag.None)  {
 					next = expectedKeyView.NextValidKeyView;
 					bool isValidFocus = next != null
 						&& currentGtkViewHost.Content == GetGtkNSViewHostContentView (next) //is in our embeded view
@@ -611,13 +611,13 @@ namespace MonoDevelop.Components.Commands
 
 					//source editor doesn't allow to back to gtk presing tab (this needs to be improved)
 					if (!IsSourceEditor (view) && currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
-						if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
+						if ((int)currentEvent.ModifierFlags == (int) Mac.KeyModifierFlag.Shift) {
 							var isFirstView = IsFirstView (expectedKeyView, addViewBeforeChildren: true, removeContentView: true);
 							if (isFirstView) {
 								//if we are in first item, we change to the previous Gtk widget
 								backToGtk = true;
 							}
-						} else {
+						} else if ((int) currentEvent.ModifierFlags == (int) Mac.KeyModifierFlag.None) {
 							var isLastView = IsLastView (expectedKeyView, addViewBeforeChildren: true, removeContentView: true);
 							if (isLastView) {
 								//if we are in last element we change to next Gtk widget

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -590,13 +590,13 @@ namespace MonoDevelop.Components.Commands
 
 							var isFirstView = IsFirstView (expectedKeyView);
 							if (IsFirstView (expectedKeyView)) {
-								//estamos en el primer item, tenemos que cambiar de elemento
+								//if we are in first item, we change to the previous Gtk widget
 								backToGtk = true;
 							}
 						} else {
 							var isLastView = IsLastView (expectedKeyView);
 							if (isLastView) {
-								//estamos en el ultimo item
+								//if we are in last element we change to next Gtk widget
 								backToGtk = true;
 							}
 						}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -683,7 +683,7 @@ namespace MonoDevelop.Components.Commands
 		bool IsLastView (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView) => GetOrderedFocusableViews (view, addViewBeforeChildren, removeContentView).LastOrDefault () == view;
 		bool IsFirstView (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView) => GetOrderedFocusableViews (view, addViewBeforeChildren, removeContentView).FirstOrDefault () == view;
 
-		GtkNSViewHost GetGtkNSViewHostFromView (AppKit.NSView view) => viewHosts.FirstOrDefault (s => s.Content == view);
+		GtkNSViewHost GetGtkNSViewHostFromView (AppKit.NSView view) => view == null ? null :  viewHosts.FirstOrDefault (s => s.Content == view);
 
 		static bool CanBecomeKeyView (AppKit.NSView view)
 		{
@@ -755,12 +755,8 @@ namespace MonoDevelop.Components.Commands
 		AppKit.NSView GetGtkNSViewHostContentView (AppKit.NSView nSView)
 		{
 			if (nSView.Superview == null) {
-				try {
-					throw new NullReferenceException ("Cannot get the main embeded view from a view with superview = null");
-				} catch (Exception ex) {
-					LoggingService.LogInternalError (ex);
-					return null;
-				}
+				//this could include cases where native views are in the toolbar
+				return null;
 			}
 			if (IsGtkQuartzView (nSView.Superview)) {
 				return nSView;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -530,16 +530,9 @@ namespace MonoDevelop.Components.Commands
 
 			e.RetVal = retVal;
 		}
-
-		bool isGtkLastEvent;
-
-		internal Gdk.EventKey LastGtkKeyEvent;
-
 		internal bool ProcessKeyEvent (Gdk.EventKey ev)
 		{
 #if MAC
-			LastGtkKeyEvent = ev;
-
 			var currentEvent = AppKit.NSApplication.SharedApplication?.CurrentEvent;
 			var window = currentEvent?.Window;
 			var firstResponder = window?.FirstResponder;
@@ -614,23 +607,11 @@ namespace MonoDevelop.Components.Commands
 					}
 
 					//return true brokes the current event handling from Gtk, then if we back to gtk we should return false
-					isGtkLastEvent = backToGtk;
 					return !backToGtk;
 				}
 			}
 #endif
-
-			isGtkLastEvent = true;
 			return false;
-		}
-
-		Gtk.Window GetGtkWindow (Gdk.Window gdkWindow)
-		{
-			foreach (var window in topLevelWindows) {
-				if (window.nativeWidget is Gtk.Window win && win.GdkWindow == gdkWindow)
-					return win;
-			}
-			return null;
 		}
 
 		internal List<AppKit.NSView> GetOrderedFocusableViews (AppKit.NSView view, bool addViewBeforeChildren, bool removeContentView)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -635,11 +635,22 @@ namespace MonoDevelop.Components.Commands
 			if (!view.CanBecomeKeyView)
 				return false;
 
-			if (view is AppKit.NSClipView && view.Superview is AppKit.NSView parent) {
-				return parent.CanBecomeKeyView;
+			if (view is AppKit.NSScrollView) {
+				return false;
 			}
 
-			if (view is AppKit.NSScrollView) {
+			if (view is AppKit.NSClipView) {
+				return false;
+			}
+
+			//temporal property pad hacks:
+			//removes the exanders from our keyviewloop
+			if (view is AppKit.NSButton expander && expander.Superview is AppKit.NSView expanderParent && expanderParent.Superview is AppKit.NSTableRowView) {
+				return false;
+			}
+
+			//removes the FirstResponderOutline from our keyviewloop
+			if (IsFirstResponderOutlineView (view)) {
 				return false;
 			}
 
@@ -692,6 +703,9 @@ namespace MonoDevelop.Components.Commands
 			var parent = GetGtkNSViewHostContentView (nSView.Superview);
 			return parent;
 		}
+
+		const string FirstResponderOutlineViewTypeName = "<Xamarin_PropertyEditing_Mac_PropertyList_FirstResponderOutlineView:";
+		static bool IsFirstResponderOutlineView (AppKit.NSView view) => view.ToString ().StartsWith (FirstResponderOutlineViewTypeName);
 
 		const string GdkQuartzViewTypeName = "<GdkQuartzView";
 		static bool IsGtkQuartzView (AppKit.NSView view) => view.ToString ().StartsWith (GdkQuartzViewTypeName);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -690,8 +690,14 @@ namespace MonoDevelop.Components.Commands
 		//this method scales the hierarchy of a native view embedded in a GtkNSViewHost in search of the content view
 		AppKit.NSView GetGtkNSViewHostContentView (AppKit.NSView nSView)
 		{
-			if (nSView.Superview == null)
-				throw new NullReferenceException ("Cannot get the main embeded view from a view with superview = null");
+			if (nSView.Superview == null) {
+				try {
+					throw new NullReferenceException ("Cannot get the main embeded view from a view with superview = null");
+				} catch (Exception ex) {
+					LoggingService.LogInternalError (ex);
+					return null;
+				}
+			}
 			if (nSView.Superview.ToString ().StartsWith ("<GdkQuartzView")) {
 				return nSView;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -639,6 +639,10 @@ namespace MonoDevelop.Components.Commands
 				return parent.CanBecomeKeyView;
 			}
 
+			if (view is AppKit.NSScrollView) {
+				return false;
+			}
+
 			return true;
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs
@@ -768,7 +768,13 @@ namespace MonoDevelop.Components.Commands
 			}
 		}
 
-		internal void RemoveEmbededView (GtkNSViewHost gtkNSViewHost) => viewHosts.Remove (gtkNSViewHost);
+		internal void RemoveEmbededView (GtkNSViewHost gtkNSViewHost)
+		{
+			if (gtkNSViewHost == null) {
+				throw new ArgumentNullException ("cannot unregister a null GtkNSViewHost");
+			}
+			viewHosts.Remove (gtkNSViewHost);
+		}
 
 		bool ProcessKeyEventCore (Gdk.EventKey ev)
 		{

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Docking/DockItem.cs
@@ -332,6 +332,9 @@ namespace MonoDevelop.Components.Docking
 		
 		public void Present (bool giveFocus)
 		{
+			//HACK: every dock item on present backs focus to Gtk in case focus is in native view
+			Gtk.GtkNSViewHost.ReturnFocusToGtk ();
+
 			if (dockBarItem != null)
 				dockBarItem.Present (Status == DockItemStatus.AutoHide || giveFocus);
 			else if (floatingWindow != null) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -354,8 +354,8 @@ namespace Gtk
 			LogEnter ();
 			try {
 				return base.OnFocusOutEvent (evnt);
-			} finally {	
-				LogExit ();	
+			} finally {
+				LogExit ();
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -63,6 +63,7 @@ namespace Gtk
 		[DllImport (LIBGTKQUARTZ)]
 		static extern bool gdk_window_has_native (IntPtr window);
 
+		internal NSView Content => view;
 		NSView view;
 		NSView superview;
 		bool disposeViewOnGtkDestroy;
@@ -88,6 +89,9 @@ namespace Gtk
 		public GtkNSViewHost (NSView view, bool disposeViewOnGtkDestroy)
 		{
 			this.view = view ?? throw new ArgumentNullException (nameof (view));
+
+			MonoDevelop.Ide.IdeApp.CommandService.RegisterEmbededView (this);
+
 			this.disposeViewOnGtkDestroy = disposeViewOnGtkDestroy;
 
 			WidgetFlags |= WidgetFlags.NoWindow;
@@ -158,6 +162,8 @@ namespace Gtk
 			LogEnter ();
 			try {
 				view?.RemoveFromSuperview ();
+
+				MonoDevelop.Ide.IdeApp.CommandService.RemoveEmbededView (this);
 
 				if (disposeViewOnGtkDestroy)
 					view?.Dispose ();

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -33,6 +33,11 @@ using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace Gtk
 {
+	public interface IGtkViewHostContentView
+	{
+		bool CanBecomeKeyViewFromGtkViewHost (AppKit.NSView view);
+	}
+
 	/// <summary>
 	/// This interface helps to reorganize the ZOrder of a native view inside a GdkQuarz window
 	/// </summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -28,7 +28,7 @@ using AppKit;
 using CoreGraphics;
 using ObjCRuntime;
 using Foundation;
-
+using System.Linq;
 using MonoDevelop.Components.AtkCocoaHelper;
 
 namespace Gtk
@@ -321,6 +321,19 @@ namespace Gtk
 					return false;
 				}
 
+				AppKit.NSView nativeViewToFocus;
+
+				var currentEvent = AppKit.NSApplication.SharedApplication?.CurrentEvent;
+				if (currentEvent.Type == NSEventType.KeyDown && currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
+					if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
+						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:false, removeContentView: true).LastOrDefault () ?? Content;
+					} else {
+						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:true, removeContentView: true).FirstOrDefault () ?? Content;
+					}
+					Content.Window?.MakeFirstResponder (nativeViewToFocus);
+				} else {
+					Content.Window?.MakeFirstResponder (Content);
+				}
 				UpdateViewFrame ();
 
 				return base.OnFocusInEvent (evnt);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -324,10 +324,10 @@ namespace Gtk
 				AppKit.NSView nativeViewToFocus = null;
 				var currentEvent = AppKit.NSApplication.SharedApplication?.CurrentEvent;
 				if (currentEvent.Type == NSEventType.KeyDown && currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
-					if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
-						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:false, removeContentView: true).LastOrDefault ();
-					} else {
-						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:true, removeContentView: true).FirstOrDefault ();
+					if ((int)currentEvent.ModifierFlags == (int)MonoDevelop.Components.Mac.KeyModifierFlag.Shift) {
+						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren: false, removeContentView: true).LastOrDefault ();
+					} else if ((int)currentEvent.ModifierFlags == (int)MonoDevelop.Components.Mac.KeyModifierFlag.None) {
+						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren: true, removeContentView: true).FirstOrDefault ();
 					}
 				}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -347,7 +347,11 @@ namespace Gtk
 		protected override bool OnFocusOutEvent (Gdk.EventFocus evnt)
 		{
 			LogEnter ();
-			return base.OnFocusOutEvent (evnt);
+			try {
+				return base.OnFocusOutEvent (evnt);
+			} finally {	
+				LogExit ();	
+			}
 		}
 
 		protected override bool OnWidgetEvent (Gdk.Event evnt)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -36,6 +36,7 @@ namespace Gtk
 	public interface IGtkViewHostContentView
 	{
 		bool CanBecomeKeyViewFromGtkViewHost (AppKit.NSView view);
+		bool HandlesNextResponder (AppKit.NSView view);
 	}
 
 	/// <summary>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -321,19 +321,21 @@ namespace Gtk
 					return false;
 				}
 
-				AppKit.NSView nativeViewToFocus;
-
+				AppKit.NSView nativeViewToFocus = null;
 				var currentEvent = AppKit.NSApplication.SharedApplication?.CurrentEvent;
 				if (currentEvent.Type == NSEventType.KeyDown && currentEvent.KeyCode == (ushort)AppKit.NSKey.Tab) {
 					if (currentEvent.ModifierFlags.HasFlag (AppKit.NSEventModifierMask.ShiftKeyMask)) {
-						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:false, removeContentView: true).LastOrDefault () ?? Content;
+						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:false, removeContentView: true).LastOrDefault ();
 					} else {
-						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:true, removeContentView: true).FirstOrDefault () ?? Content;
+						nativeViewToFocus = MonoDevelop.Ide.IdeApp.CommandService.GetOrderedFocusableViews (Content, addViewBeforeChildren:true, removeContentView: true).FirstOrDefault ();
 					}
-					Content.Window?.MakeFirstResponder (nativeViewToFocus);
-				} else {
-					Content.Window?.MakeFirstResponder (Content);
 				}
+
+				if (nativeViewToFocus != null) {
+					acceptsFirstResponderView.Window?.MakeFirstResponder (nativeViewToFocus);
+				}
+				
+
 				UpdateViewFrame ();
 
 				return base.OnFocusInEvent (evnt);

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -321,8 +321,6 @@ namespace Gtk
 					return false;
 				}
 
-				acceptsFirstResponderView.Window.MakeFirstResponder (acceptsFirstResponderView);
-
 				UpdateViewFrame ();
 
 				return base.OnFocusInEvent (evnt);
@@ -334,14 +332,7 @@ namespace Gtk
 		protected override bool OnFocusOutEvent (Gdk.EventFocus evnt)
 		{
 			LogEnter ();
-			try {
-				if (view?.Window?.FirstResponder is NSView firstResponder &&
-					view?.AncestorSharedWithView (firstResponder) == view)
-					firstResponder.Window?.MakeFirstResponder (null);
-				return base.OnFocusOutEvent (evnt);
-			} finally {
-				LogExit ();
-			}
+			return base.OnFocusOutEvent (evnt);
 		}
 
 		protected override bool OnWidgetEvent (Gdk.Event evnt)

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -354,9 +354,21 @@ namespace Gtk
 		{
 			LogEnter ();
 			try {
+				//HACK: Focus out backs the focus to Gtk in case of be necessary
+				ReturnFocusToGtk ();
 				return base.OnFocusOutEvent (evnt);
 			} finally {
 				LogExit ();
+			}
+		}
+
+		//HACK: to remove focus from GTKQuartzWindow and back focus to Gtk we need to ensure the GdkWindow is the Ide
+		public static void ReturnFocusToGtk ()
+		{
+			var window = NSApplication.SharedApplication.KeyWindow;
+			var gtkWindow = MonoDevelop.Components.Mac.GtkMacInterop.GetGtkWindow (window);
+			if (gtkWindow != null && gtkWindow.GdkWindow == MonoDevelop.Ide.IdeApp.Workbench.RootWindow.GdkWindow) {
+				window.MakeFirstResponder (window.ContentView);
 			}
 		}
 

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Components/Mac/GtkNSViewHost.cs
@@ -337,10 +337,10 @@ namespace Gtk
 					}
 				}
 
-				if (nativeViewToFocus != null) {
-					acceptsFirstResponderView.Window?.MakeFirstResponder (nativeViewToFocus);
+				if (nativeViewToFocus == null) {
+					nativeViewToFocus = acceptsFirstResponderView;
 				}
-				
+				acceptsFirstResponderView.Window?.MakeFirstResponder (nativeViewToFocus);
 
 				UpdateViewFrame ();
 


### PR DESCRIPTION
**THE FEATURE IT'S IN PROGRESS PLEASE DO NOT MERGE**

This PR adds a new mechanism to create our own keyloop system to sync Gtk and Cocoa world focus chain.

![xRCBhpk7dk](https://user-images.githubusercontent.com/1587480/68583025-7abec580-047c-11ea-85a5-53fc72cc1b71.gif)

![zXN2k3hSf7-1](https://user-images.githubusercontent.com/1587480/68591890-02fb9580-0492-11ea-8dcc-c42d859a15ce.gif)


Basically right now VS4Mac is a Gtk application which recently added a way to include embeded native views based in a hacked gtkquarz window which it has this structure:

- GtkQuarzWindow
   - GtkQuarzView
     - Embeded widgets (ProppyPad, ToolboxPad, Source Editor Pad)

Under the hood this native views are overlapped on top of Gtk and synchronized with a Gtk view container host (GtkNSViewHost)

In VS4Mac is the Gtk application is who captures the keypress events and the CommandManager ensures if the selected view is a native view it tunnels the event to cocoa world (making stop the escalation of the event in the Gtk) or otherwise it continues the gtk event flow.

Actually we were doing this tunneling to cocoa in a incomplete way, we were only calling to ".OnKeyDown" from the focused view, which it doesn't match the same behaviour as pressing a key in a cocoa application which also affects to the tab key navigation (Keyloop) mechanism.... and this the reason we were getting some unexpected behaviours in this case.

To try to fix this, I checked a lot of documentation, but it seems there are not much information about how this works under the hood or how replicate it... and after a lot of tests didn't found any good way to do it more easily... that's because I decided to rewrite current implementation to create our own mechanism to calculate this keyloop calculation.

The current cocoa view structure described above adds more complexity to our implementation, first because all the native embeded views shares the same NSWindow (GtkQuarzWindow) and this means when the NextKeyView is not set in a native view, the NSWindow autocalculates the next or previous element, and this could be **or the correct next view or the first GtkQuarzView or another view from another embeded view**, and that's because pressing tab in the old implementation press tab was giving us randomly unexpected (wrong) results.

Another problem we had was how connect the Gtk focus chain to Cocoa, that's means we needed to handle cases when user press tab and next view is a GtkNSViewHost then calculate which is our first candidate for item focus.. and ... the same for pressing SHIFT+Tab (focus last item from this embedded view).

And.. sorry about the hack.. but didn't found any idea about how do it in a better way living into a Gtk application :-(

Fixes #1001596 - A11Y_Xamarin Designers_Property pane_keyboard : User is unable to navigate from property filter to the next controls inside property panel window
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1001596

Backport of #9267.

/cc @sevoku @netonjm