### PR TITLE
[1032534] [About VS for Mac] Add localization to "Show loaded assemblies" string

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/VersionInformationTabPage.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Dialogs/VersionInformationTabPage.cs
@@ -105,7 +105,7 @@ namespace MonoDevelop.Ide.Gui.Dialogs
 			contentBox.BorderWidth = 4;
 			contentBox.PackStart (buf, false, false, 0);
 
-			var asmButton = new Gtk.Button ("Show loaded assemblies");
+			var asmButton = new Gtk.Button (GettextCatalog.GetString ("Show loaded assemblies"));
 			asmButton.Clicked += (sender, e) => {
 				asmButton.Hide ();
 				contentBox.PackStart (CreateAssembliesTable (), false, false, 0);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1032534

This button should now be localized

![image](https://user-images.githubusercontent.com/43088712/72613230-ae641300-3937-11ea-9a22-53467e852178.png)
