### PR TITLE
[1019742] Disable VBox controls before project creation

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/GtkNewProjectDialogBackend.cs
@@ -590,8 +590,12 @@ namespace MonoDevelop.Ide.Projects
 			if (controller.IsLastPage) {
 				try {
 					CanMoveToNextPage = false;
+					// disable all controls on this dialog to prevent users actions
+					VBox.Sensitive = false;
 					await controller.Create ();
 				} catch {
+					// if something goes wrong, we need to enable dialog contols
+					VBox.Sensitive = true;
 					throw;
 				} finally {
 					CanMoveToNextPage = true;


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1019742

Another possible fix could be moving `dialog.CloseDialog ()` (https://github.com/mono/monodevelop/blob/master/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Projects/NewProjectController.cs#L683) at the beginning of `Create` method.

Here is how this dialog looks like after clicking on "Create" button:
![image](https://user-images.githubusercontent.com/43088712/72618462-cc377500-3943-11ea-8e05-d99db486d56c.png)
