### PR TITLE
[Debugger] Tooltips should not be shown for conditional method invoca…

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/DebuggerQuickInfoSource.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.VSTextView/QuickInfo/DebuggerQuickInfoSource.cs
@@ -135,7 +135,7 @@ namespace MonoDevelop.Debugger.VSTextView.QuickInfo
 				if (cancellationToken.IsCancellationRequested)
 					return;
 
-				if (val == null || val.IsUnknown || val.IsNotSupported)
+				if (val == null || val.IsUnknown || val.IsNotSupported || val.IsError)
 					return;
 
 				timer.Success = true;


### PR DESCRIPTION
…tions

When hovering the mouse cursor over most method invocation
expressions, the logic returns a null expression to evaluate
(thereby bypassing evaluation of said expression), but when
hovering over conditional method invocations, the logic failed.

Since the logic is identical to VS Windows, do what VS Windows does
in this scenario as well, which is to ignore evaluation errors
and not show them.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1054139