### PR TITLE
[release-8.4] VSTS 1049891:  aspx files no intellisense 

### DIFF
--- a/main/src/addins/AspNet/Properties/AddinInfo.cs
+++ b/main/src/addins/AspNet/Properties/AddinInfo.cs
@@ -15,3 +15,4 @@ using Mono.Addins;
 [assembly:AddinDependency ("Xml", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("SourceEditor2", MonoDevelop.BuildInfo.Version)]
 [assembly:AddinDependency ("TextTemplating", MonoDevelop.BuildInfo.Version)]
+[assembly:AddinDependency ("TextEditor", MonoDevelop.BuildInfo.Version)]

--- a/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
+++ b/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
@@ -196,7 +196,11 @@
 		            _label = "HTML Files"
 		            extensions = "*.htm,*.html"/>
 	</Extension>
-
+	
+	<Extension path="/MonoDevelop/TextEditor/LegacyEditorSupport">
+        <LegacyEditorSupport id="aspx" extensions=".aspx,.ashx,.asmx,.ascx,.master,.asax,.cshtml,.html,.htm" />
+    </Extension>
+	
 	<Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
 		<ProjectFlavor
 			guid="{603C0E0B-DB56-11DC-BE95-000D561079B0}"

--- a/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
+++ b/main/src/addins/AspNet/Properties/MonoDevelop.AspNet.addin.xml
@@ -198,7 +198,7 @@
 	</Extension>
 	
 	<Extension path="/MonoDevelop/TextEditor/LegacyEditorSupport">
-        <LegacyEditorSupport id="aspx" extensions=".aspx,.ashx,.asmx,.ascx,.master,.asax,.cshtml,.html,.htm" />
+        <LegacyEditorSupport id="aspx" extensions=".aspx,.ashx,.asmx,.ascx,.master,.asax" />
     </Extension>
 	
 	<Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">


### PR DESCRIPTION
This switches the aspx file editing to the old editor an and includes .aspx, .ashx, .asmx, .ascx, .master, .asax, ~.cshtml, .html, .htm~ extensions.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1049891

Backport of #9566.

/cc @mrward @avodovnik