### PR TITLE
Fixes VSTS Bug 1016381: Can't save or easily close a solution

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Documents/DocumentController.cs
@@ -438,6 +438,7 @@ namespace MonoDevelop.Ide.Gui.Documents
 				disposedTokenSource.Cancel ();
 				disposedTokenSource.Dispose ();
 				disposedTokenSource = null;
+				extensionChain = null;
 				disposed = true;
 			}
 		}
@@ -574,8 +575,10 @@ namespace MonoDevelop.Ide.Gui.Documents
 				yield return AssertValid (c, type);
 
 			if (extensionChain != null) {
-				foreach (var ext in extensionChain.GetAllExtensions ().OfType<DocumentControllerExtension> ()) {
-					foreach (var c in ext.GetContents (type))
+				foreach (var ext in extensionChain.GetAllExtensions ()) {
+					if (!(ext is DocumentControllerExtension documentControllerExtension))
+						continue;
+					foreach (var c in documentControllerExtension.GetContents (type))
 						yield return AssertValid (c, type);
 				}
 			}


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1016381

The AndroidDesignerController is the issue here but the base class
shouldn't crash in that scenario.
(base.Dispose() called before disposing the derived class. base.Dispose () should be called last.)