### PR TITLE
[release-8.4] Fix information popover flickering

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Wizard/WizardDialogController.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Wizard/WizardDialogController.cs
@@ -125,14 +125,16 @@ namespace MonoDevelop.Ide.Gui.Wizard
 
 		public bool RunWizard ()
 		{
-			var dialog = new WizardDialog (this);
-			return dialog.Run (Xwt.MessageDialog.RootWindow);
+			using (var dialog = new WizardDialog (this)) {
+				return dialog.Run (Xwt.MessageDialog.RootWindow);
+			}
 		}
 
 		public bool RunWizard (Xwt.WindowFrame parentWindow)
 		{
-			var dialog = new WizardDialog (this);
-			return dialog.Run (parentWindow);
+			using (var dialog = new WizardDialog (this)) {
+				return dialog.Run (parentWindow);
+			}
 		}
 
 		public event EventHandler Completed;


### PR DESCRIPTION
When the TooltipPopoverWindow is visible, the parent
might receive mouse in/out events rapidly, depending
on the parenting status of the parent dialogs. This might
be caused by some Gtk Loop issue.

Delaying the hiding of the popup when the mouse leaves
effectively workarounds the issue.

Backport of #9576.

/cc @sevoku 