### PR TITLE
[Core] Ensure multi-run config updated after project reload

### DIFF
--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/MultiItemSolutionRunConfiguration.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/MultiItemSolutionRunConfiguration.cs
@@ -75,8 +75,12 @@ namespace MonoDevelop.Projects
 		internal void ReplaceItem (SolutionItem oldItem, SolutionItem newItem)
 		{
 			foreach (var si in Items)
-				if (si.SolutionItem == oldItem)
+				if (si.SolutionItem == oldItem) {
 					si.SolutionItem = newItem;
+
+					// SolutionItem's RunConfiguration will have been reloaded. Ensure the new run config is used.
+					si.ResolveRunConfiguration ();
+				}
 		}
 
 		internal void RemoveItem (SolutionItem item)
@@ -159,13 +163,18 @@ namespace MonoDevelop.Projects
 				SolutionItem = sol.GetSolutionItem (ItemId) as SolutionItem;
 				if (SolutionItem == null)
 					SolutionItem = sol.FindProjectByName (ItemName) as SolutionItem;
-				if (SolutionItem != null && ConfigurationId != null)
-					RunConfiguration = SolutionItem.GetRunConfigurations ().FirstOrDefault (c => c.Id == ConfigurationId);
+				ResolveRunConfiguration ();
 				ItemId = null;
 				ConfigurationId = null;
 			}
 		}
-	
+
+		internal void ResolveRunConfiguration ()
+		{
+			if (SolutionItem != null && ConfigurationId != null)
+				RunConfiguration = SolutionItem.GetRunConfigurations ().FirstOrDefault (c => c.Id == ConfigurationId);
+		}
+
 		public SolutionItem SolutionItem { get; internal set; }
 		public SolutionItemRunConfiguration RunConfiguration { get; internal set; }
 	}

--- a/main/tests/test-projects/test-multi-run-config-reload/ProjectA/Program.cs
+++ b/main/tests/test-projects/test-multi-run-config-reload/ProjectA/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ProjectA
+{
+	class MainClass
+	{
+		public static void Main (string[] args)
+		{
+			Console.WriteLine ("Project A: args.Length={0}", args.Length);
+		}
+	}
+}

--- a/main/tests/test-projects/test-multi-run-config-reload/ProjectA/ProjectA.csproj
+++ b/main/tests/test-projects/test-multi-run-config-reload/ProjectA/ProjectA.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">anycpu</Platform>
+    <ProjectGuid>{1217D2CD-2C77-4AEF-AC43-418FC5DD7CE9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ProjectA</RootNamespace>
+    <AssemblyName>ProjectA</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|anycpu' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <IntermediateOutputPath>obj\anycpu\Debug</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|anycpu' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <IntermediateOutputPath>obj\anycpu\Release</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>A1</StartArguments>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-multi-run-config-reload/ProjectA/Properties/AssemblyInfo.cs
+++ b/main/tests/test-projects/test-multi-run-config-reload/ProjectA/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("ProjectA")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Microsoft")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft Corporation")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/test-multi-run-config-reload/ProjectB/Program.cs
+++ b/main/tests/test-projects/test-multi-run-config-reload/ProjectB/Program.cs
@@ -1,0 +1,13 @@
+﻿
+using System;
+
+namespace ProjectB
+{
+	class MainClass
+	{
+		public static void Main (string[] args)
+		{
+			Console.WriteLine ("Project A: args.Length={0}", args.Length);
+		}
+	}
+}

--- a/main/tests/test-projects/test-multi-run-config-reload/ProjectB/ProjectB.csproj
+++ b/main/tests/test-projects/test-multi-run-config-reload/ProjectB/ProjectB.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">anycpu</Platform>
+    <ProjectGuid>{2D669FEF-FBF4-4183-87E6-A3A4D6C8C97F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ProjectB</RootNamespace>
+    <AssemblyName>ProjectB</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|anycpu' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <IntermediateOutputPath>obj\anycpu\Debug</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|anycpu' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <IntermediateOutputPath>obj\anycpu\Release</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>B1 B2</StartArguments>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/main/tests/test-projects/test-multi-run-config-reload/ProjectB/Properties/Properties
+++ b/main/tests/test-projects/test-multi-run-config-reload/ProjectB/Properties/Properties
@@ -1,0 +1,27 @@
+﻿
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("ProjectB")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Microsoft")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft Corporation")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/main/tests/test-projects/test-multi-run-config-reload/test-multi-run-config-reload.sln
+++ b/main/tests/test-projects/test-multi-run-config-reload/test-multi-run-config-reload.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectA", "ProjectA\ProjectA.csproj", "{1217D2CD-2C77-4AEF-AC43-418FC5DD7CE9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectB", "ProjectB\ProjectB.csproj", "{2D669FEF-FBF4-4183-87E6-A3A4D6C8C97F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|anycpu = Debug|anycpu
+		Release|anycpu = Release|anycpu
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1217D2CD-2C77-4AEF-AC43-418FC5DD7CE9}.Debug|anycpu.ActiveCfg = Debug|anycpu
+		{1217D2CD-2C77-4AEF-AC43-418FC5DD7CE9}.Debug|anycpu.Build.0 = Debug|anycpu
+		{1217D2CD-2C77-4AEF-AC43-418FC5DD7CE9}.Release|anycpu.ActiveCfg = Release|anycpu
+		{1217D2CD-2C77-4AEF-AC43-418FC5DD7CE9}.Release|anycpu.Build.0 = Release|anycpu
+		{2D669FEF-FBF4-4183-87E6-A3A4D6C8C97F}.Debug|anycpu.ActiveCfg = Debug|anycpu
+		{2D669FEF-FBF4-4183-87E6-A3A4D6C8C97F}.Debug|anycpu.Build.0 = Debug|anycpu
+		{2D669FEF-FBF4-4183-87E6-A3A4D6C8C97F}.Release|anycpu.ActiveCfg = Release|anycpu
+		{2D669FEF-FBF4-4183-87E6-A3A4D6C8C97F}.Release|anycpu.Build.0 = Release|anycpu
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
With a multi-run configuration defined for the solution, if a
project is reloaded, the multi-run config would not have the
latest project run configuration. This would result in changes to
the project run configuration in project options, such as adding
or removing startup arguments, not being used when the multi-run
configuration was used to run the solution.

On reloading the new project run configuration is resolved and
updated in the multi-run configuration. Previously only the
SolutionItem was updated.

Fixes VSTS #653269 - Multi startup project run configuration -
arguments not passed after reload