### PR TITLE
[Debugger] Provide SolutionItem to DebuggerSession mapping

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -149,6 +149,26 @@ namespace MonoDevelop.Debugger
 			return sessions.Keys.ToArray ();
 		}
 
+		public static DebuggerSession GetSession (IRunTarget runTarget)
+		{
+			foreach (KeyValuePair<DebuggerSession, SessionManager> item in sessions.ToArray ()) {
+				if (item.Value.RunTarget == runTarget) {
+					return item.Key;
+				}
+			}
+			return null;
+		}
+
+		public static IRunTarget GetRunTarget (DebuggerSession session)
+		{
+			foreach (KeyValuePair<DebuggerSession, SessionManager> item in sessions.ToArray ()) {
+				if (item.Key == session) {
+					return item.Value.RunTarget;
+				}
+			}
+			return null;
+		}
+
 		public static ProcessInfo [] GetProcesses ()
 		{
 			return sessions.Keys.Where (s => !s.IsRunning).SelectMany (s => s.GetProcesses ()).ToArray ();
@@ -721,6 +741,7 @@ namespace MonoDevelop.Debugger
 				sessionManager = new SessionManager (session, IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (System.IO.Path.GetFileNameWithoutExtension (startInfo.Command)).Console, factory, timer);
 			else
 				sessionManager = new SessionManager (session, c, factory, timer);
+			sessionManager.RunTarget = cmd.RunTarget;
 			SetupSession (sessionManager);
 
 			SetDebugLayout ();
@@ -757,6 +778,7 @@ namespace MonoDevelop.Debugger
 			public readonly DebuggerSession Session;
 			public readonly DebugAsyncOperation debugOperation;
 			public readonly DebuggerEngine Engine;
+			internal IRunTarget RunTarget { get; set; }
 			internal ITimeTracker<DebuggerStartMetadata> StartTimer { get; set; }
 
 			internal bool TrackActionTelemetry { get; set; }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ExecutionCommand.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Core.Execution/ExecutionCommand.cs
@@ -24,7 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.Core.Execution
 {
@@ -46,5 +46,11 @@ namespace MonoDevelop.Core.Execution
 		/// Execution target. For example, a specific device.
 		/// </summary>
 		public ExecutionTarget Target { get; set; }
+
+		/// <summary>
+		/// IRunTarget item associated with this execution command. This allows the DebuggerSession to be
+		/// associated with an IRunTarget (typically a Project).
+		/// </summary>
+		public IRunTarget RunTarget { get; set; }
 	}
 }

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/DotNetProject.cs
@@ -1505,7 +1505,10 @@ namespace MonoDevelop.Projects
 
 		public ExecutionCommand CreateExecutionCommand (ConfigurationSelector configSel, DotNetProjectConfiguration configuration, ProjectRunConfiguration runConfiguration)
 		{
-			return ProjectExtension.OnCreateExecutionCommand (configSel, configuration, runConfiguration);
+			var command = ProjectExtension.OnCreateExecutionCommand (configSel, configuration, runConfiguration);
+			if (command != null)
+				command.RunTarget ??= this;
+			return command;
 		}
 
 		internal protected virtual ExecutionCommand OnCreateExecutionCommand (ConfigurationSelector configSel, DotNetProjectConfiguration configuration)


### PR DESCRIPTION
The DebuggerService now has two methods that can map from a SolutionItem
to a DebuggerSession or the other way around. The ExecutionCommand now
has a SolutionItem property which is used by the DebuggerService to
create this mapping from DebuggerSession to SolutionItem.

Fixes VSTS #1012614 - Improvements to DebuggerSession for XAML Hot Reload