### PR TITLE
[Debugger] Update exception options to include unhandled exception

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -186,7 +186,7 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 				currentExceptionState = hasCustomExceptions;
 				var exceptionRequest = new SetExceptionBreakpointsRequest (
 					Capabilities.ExceptionBreakpointFilters.Where (f => hasCustomExceptions || (f.Default ?? false)).Select (f => f.Filter).ToList ());
-				exceptionRequest.ExceptionOptions = new List<ExceptionOptions> () {new ExceptionOptions(ExceptionBreakMode.UserUnhandled)};
+				exceptionRequest.ExceptionOptions = new List<ExceptionOptions> () {new ExceptionOptions (ExceptionBreakMode.UserUnhandled), new ExceptionOptions (ExceptionBreakMode.Unhandled)};
 				protocolClient.SendRequest (exceptionRequest, null);
 				unhandleExceptionRegistered = true;
 			}
@@ -428,7 +428,7 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 							stackFrame = (VsCodeStackFrame)backtrace.GetFrame (0);
 						}
 						var response = protocolClient.SendRequestSync (new ExceptionInfoRequest (body.ThreadId ?? -1));
-						if (response.BreakMode.Equals (ExceptionBreakMode.UserUnhandled)) {
+						if (response.BreakMode.Equals (ExceptionBreakMode.UserUnhandled) || response.BreakMode.Equals (ExceptionBreakMode.Unhandled)) {
 							args = new TargetEventArgs (TargetEventType.UnhandledException);
 						} else {
 							if (!breakpoints.Select (b => b.Key).OfType<Catchpoint> ().Any (c => ShouldStopOnExceptionCatchpoint (c, stackFrame.frameId))) {


### PR DESCRIPTION
![NETCoreExceptionUnhandled](https://user-images.githubusercontent.com/34032260/72922354-e80f9200-3d1a-11ea-98ac-1106d72edc01.gif)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1051257/
Fixes VSTS #1051257

(The exceptionCaughtDialog's position is a bit weird, filing another bug to record it)
