### PR TITLE
[Ide] Dynamically add ~contrast~dark~sel resource mappings

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs
@@ -938,10 +938,14 @@ namespace MonoDevelop.Ide
 				if (name.StartsWith (baseName) && name.EndsWith (ext)) {
 					yield return name;
 
-					var tagPortion = name.Substring (baseName.Length, name.Length - baseName.Length - ext.Length);
 					// to avoid duplicate resource entries in project files, add virtual file mappings for
-					// high contrast icons in selected state
-					if (tagPortion == "~dark~sel" || tagPortion == "~dark~sel@2x") {
+					// high contrast icons in selected state.
+					// note: we include the "." to ensure that we match "~dark~sel" exactly and not "~dark~sel~xyz".
+					int start = baseName.Length;
+					int length = name.Length - baseName.Length - ext.Length + 1;
+					if (name.IndexOf ("~dark~sel.", start, length, StringComparison.Ordinal) == start ||
+						name.IndexOf ("~dark~sel@2x.", start, length, StringComparison.Ordinal) == start)
+					{
 						var map = name.Replace ("~dark~sel", "~contrast~dark~sel");
 						if (virtualMappings == null) {
 							virtualMappings = new Dictionary<string, string> ();


### PR DESCRIPTION
to avoid adding duplicate EmbeddedResource entries to project files.

Background:

To support loading the correct icons in selected state with dark theme and high contrast mode, we'd need to add duplicate resources entries to all csproj file like this:

```diff
     <EmbeddedResource Include="icons\project-32~dark~sel.png" />
+    <EmbeddedResource Include="icons\project-32~dark~sel.png" >
+      <LogicalName>project-32~contrast~dark~sel.png</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="icons\project-32~dark~sel%402x.png" />
+    <EmbeddedResource Include="icons\project-32~dark~sel%402x.png" >
+      <LogicalName>project-32~contrast~dark~sel@2x.png</LogicalName>
+    </EmbeddedResource>
```

this could be automated, but would be hard to maintain afterwards (it's already quite hard with all icons we have). With this change we don't need any duplicates.