### PR TITLE
[Debugger] Removed DebuggerSession.set_Breakpoints to reduce complexity

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger.Gdb/GdbSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Gdb/GdbSession.cs
@@ -69,7 +69,7 @@ namespace MonoDevelop.Debugger.Gdb
 		object eventLock = new object ();
 		object gdbLock = new object ();
 		
-		public GdbSession ()
+		public GdbSession (BreakpointStore breakpoints) : base (breakpoints)
 		{
 			logGdb = !string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("MONODEVELOP_GDB_LOG"));
 		}

--- a/main/src/addins/MonoDevelop.Debugger.Gdb/GdbSessionFactory.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Gdb/GdbSessionFactory.cs
@@ -107,7 +107,7 @@ namespace MonoDevelop.Debugger.Gdb
 			return true;
 		}
 
-		public override DebuggerSession CreateSession ()
+		public override DebuggerSession CreateSession (BreakpointStore breakpoints)
 		{
 			return new GdbSession ();
 		}

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft.AspNet/AspNetSoftDebuggerEngine.cs
@@ -108,9 +108,9 @@ namespace MonoDevelop.Debugger.Soft.AspNet
 			return startInfo;
 		}
 
-		public override DebuggerSession CreateSession ()
+		public override DebuggerSession CreateSession (BreakpointStore breakpoints)
 		{
-			return new SoftDebuggerSession ();
+			return new SoftDebuggerSession (breakpoints);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/CustomSoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/CustomSoftDebuggerEngine.cs
@@ -50,9 +50,9 @@ namespace MonoDevelop.Debugger.Soft
 			return available.Value;
 		}
 
-		public override DebuggerSession CreateSession ()
+		public override DebuggerSession CreateSession (BreakpointStore breakpoints)
 		{
-			return new CustomSoftDebuggerSession ();
+			return new CustomSoftDebuggerSession (breakpoints);
 		}
 		
 		public override DebuggerStartInfo CreateDebuggerStartInfo (ExecutionCommand c)
@@ -105,6 +105,10 @@ namespace MonoDevelop.Debugger.Soft
 		{
 			ProcessAsyncOperation process;
 			bool usingExternalConsole;
+
+			public CustomSoftDebuggerSession (BreakpointStore breakpoints) : base (breakpoints)
+			{
+			}
 			
 			protected override void OnRun (DebuggerStartInfo startInfo)
 			{

--- a/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/SoftDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/MonoDevelop.Debugger.Soft/SoftDebuggerEngine.cs
@@ -98,9 +98,9 @@ namespace MonoDevelop.Debugger.Soft
 			return dsi;
 		}
 		
-		public override DebuggerSession CreateSession ()
+		public override DebuggerSession CreateSession (BreakpointStore breakpoints)
 		{
-			return new SoftDebuggerSession ();
+			return new SoftDebuggerSession (breakpoints);
 		}
 		
 		public static void SetUserAssemblyNames (SoftDebuggerStartInfo dsi, IList<string> files)

--- a/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.VSCodeDebugProtocol/MonoDevelop.Debugger.VsCodeDebugProtocol/VSCodeDebuggerSession.cs
@@ -64,6 +64,10 @@ namespace MonoDevelop.Debugger.VsCodeDebugProtocol
 			return isEnum;
 		}
 
+		protected VSCodeDebuggerSession (BreakpointStore breakpoints) : base (breakpoints)
+		{
+		}
+
 		protected override void OnContinue ()
 		{
 			try {

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.PerfTests/PerfTestBase.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.PerfTests/PerfTestBase.cs
@@ -252,7 +252,7 @@ namespace Mono.Debugging.PerfTests
 				}
 			}
 
-			return engine.CreateSession ();
+			return engine.CreateSession (new BreakpointStore ());
 		}
 
 		protected DebuggerStartInfo CreateStartInfo (string test, string engineId)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.MonoDevelop.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger.Tests/DebugTests.MonoDevelop.cs
@@ -128,7 +128,7 @@ namespace Mono.Debugging.Tests
 				}
 			}
 
-			return engine.CreateSession ();
+			return engine.CreateSession (new BreakpointStore ());
 		}
 
 		protected DebuggerStartInfo CreateStartInfo (string test, string engineId)

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerEngine.cs
@@ -109,10 +109,10 @@ namespace MonoDevelop.Debugger
 			return engine != null ? engine.GetAttachableProcesses () : new ProcessInfo [0];
 		}
 		
-		public DebuggerSession CreateSession ()
+		public DebuggerSession CreateSession (BreakpointStore breakpoints)
 		{
 			LoadEngine ();
-			return engine.CreateSession ();
+			return engine.CreateSession (breakpoints);
 		}
 	}
 }

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerEngineBackend.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggerEngineBackend.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.Debugger
 			return null;
 		}
 
-		public abstract DebuggerSession CreateSession ();
+		public abstract DebuggerSession CreateSession (BreakpointStore breakpoints);
 	}
 
 	#pragma warning disable 618
@@ -97,9 +97,9 @@ namespace MonoDevelop.Debugger
 			return engine.GetAttachableProcesses ();
 		}
 
-		public override DebuggerSession CreateSession ()
+		public override DebuggerSession CreateSession (BreakpointStore breakpoints)
 		{
-			return engine.CreateSession ();
+			return engine.CreateSession (breakpoints);
 		}
 	}
 	#pragma warning restore 618

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -424,7 +424,6 @@ namespace MonoDevelop.Debugger
 			sessions [sessionManager.Session] = sessionManager;
 			isBusy = false;
 			var session = sessionManager.Session;
-			session.Breakpoints = breakpoints;
 			session.TargetEvent += OnTargetEvent;
 			session.TargetStarted += OnStarted;
 			session.OutputWriter = sessionManager.OutputWriter;
@@ -442,10 +441,9 @@ namespace MonoDevelop.Debugger
 			};
 
 			Runtime.RunInMainThread (delegate {
-				if (DebugSessionStarted != null)
-					DebugSessionStarted (session, EventArgs.Empty);
+				DebugSessionStarted?.Invoke (session, EventArgs.Empty);
 				NotifyLocationChanged ();
-			});
+			}).Ignore ();
 		}
 
 		static readonly object cleanup_lock = new object ();
@@ -638,7 +636,7 @@ namespace MonoDevelop.Debugger
 
 		public static AsyncOperation AttachToProcess (DebuggerEngine debugger, ProcessInfo proc)
 		{
-			var session = debugger.CreateSession ();
+			var session = debugger.CreateSession (breakpoints);
 			var monitor = IdeApp.Workbench.ProgressMonitors.GetRunProgressMonitor (proc.Name);
 			var sessionManager = new SessionManager (session, monitor.Console, debugger, null);
 			SetupSession (sessionManager);
@@ -735,7 +733,7 @@ namespace MonoDevelop.Debugger
 			if (startInfo.UseExternalConsole)
 				startInfo.CloseExternalConsoleOnExit = ((ExternalConsole)c).CloseOnDispose;
 
-			var session = factory.CreateSession ();
+			var session = factory.CreateSession (breakpoints);
 
 			SessionManager sessionManager;
 			// When using an external console, create a new internal console which will be used

--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/IDebuggerEngine.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/IDebuggerEngine.cs
@@ -37,6 +37,6 @@ namespace MonoDevelop.Debugger
 		bool CanDebugCommand (ExecutionCommand cmd);
 		DebuggerStartInfo CreateDebuggerStartInfo (ExecutionCommand cmd);
 		ProcessInfo[] GetAttachableProcesses ();
-		DebuggerSession CreateSession ();
+		DebuggerSession CreateSession (BreakpointStore breakpoints);
 	}
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1026591/

Depends On:
- md-addins: https://github.com/xamarin/md-addins/pull/6245
- debugger-libs: https://github.com/mono/debugger-libs/pull/285