### PR TITLE
[786228] [Telemetry] Added TargetSdkVersion to ProjectEventMetadata

### DIFF
--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreProjectExtension.cs
@@ -83,6 +83,18 @@ namespace MonoDevelop.DotNetCore
 			return base.SupportsObject (item) && HasSupportedFramework ((DotNetProject)item);
 		}
 
+		protected override ProjectEventMetadata OnGetProjectEventMetadata (ConfigurationSelector configurationSelector)
+		{
+			var metadata = base.OnGetProjectEventMetadata (configurationSelector);
+
+			var projectSdkVersion = sdkPaths.TargetSdkVersion ?? sdkPaths.GetLatestSdk ();
+			var projectSdkVersionString = projectSdkVersion?.ToString ();
+
+			metadata.TargetSdkVersion = projectSdkVersionString;
+
+			return metadata;
+		}
+
 		/// <summary>
 		/// Cannot check TargetFramework property since it may not be set.
 		/// Currently support .NET Core and .NET Standard.

--- a/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
+++ b/main/src/addins/MonoDevelop.DotNetCore/MonoDevelop.DotNetCore/DotNetCoreSdkPaths.cs
@@ -40,6 +40,7 @@ namespace MonoDevelop.DotNetCore
 		static readonly object locker = new object ();
 
 		public DotNetCoreVersion [] SdkVersions { get; internal set; } = Array.Empty<DotNetCoreVersion> ();
+		public DotNetCoreVersion TargetSdkVersion { get; private set; }
 		public string SdkRootPath { get; internal set; }
 		public string GlobalJsonPath { get; set; }
 
@@ -68,8 +69,7 @@ namespace MonoDevelop.DotNetCore
 		{
 			if (!SdkVersions.Any ())
 				return;
-					
-			DotNetCoreVersion targetVersion = null;
+
 			if (forceLookUpGlobalJson) {
 				GlobalJsonPath = LookUpGlobalJson (workingDir);
 			}
@@ -93,22 +93,22 @@ namespace MonoDevelop.DotNetCore
 			}
 
 			//if global.json exists and matches returns it
-			targetVersion = SdkVersions.FirstOrDefault (x => x.OriginalString.IndexOf (specificVersion, StringComparison.InvariantCulture) == 0);
-			if (targetVersion == null) {
+			TargetSdkVersion = SdkVersions.FirstOrDefault (x => x.OriginalString.IndexOf (specificVersion, StringComparison.InvariantCulture) == 0);
+			if (TargetSdkVersion == null) {
 				//if global.json exists and !matches then:
 				if (requiredVersion >= DotNetCoreVersion.Parse ("2.1")) {
-					targetVersion = SdkVersions.Where (version => version.Major == requiredVersion.Major
+					TargetSdkVersion = SdkVersions.Where (version => version.Major == requiredVersion.Major
 																	&& version.Minor == requiredVersion.Minor)
 												.OrderByDescending (version => version.Patch).FirstOrDefault (x => {
 												return (x.Patch / 100 == requiredVersion.Patch / 100) &&
 														(x.Patch % 100 >= requiredVersion.Patch % 100);
 												});
 				} else {
-					targetVersion = SdkVersions.Where (version => version.Major == requiredVersion.Major && version.Minor == requiredVersion.Minor)
+					TargetSdkVersion = SdkVersions.Where (version => version.Major == requiredVersion.Major && version.Minor == requiredVersion.Minor)
 												.OrderByDescending (version => version.Patch).FirstOrDefault ();
 				}
 
-				if (targetVersion == null) {
+				if (TargetSdkVersion == null) {
 					msbuildSDKsPath = string.Empty;
 					IsUnsupportedSdkVersion = true;
 					Exist = false;
@@ -116,7 +116,7 @@ namespace MonoDevelop.DotNetCore
 				}
 			}
 
-			msbuildSDKsPath = GetSdksParentDirectory (targetVersion);
+			msbuildSDKsPath = GetSdksParentDirectory (TargetSdkVersion);
 			Exist = true;
 			IsUnsupportedSdkVersion = false;
 		}

--- a/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
+++ b/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/SolutionItem.cs
@@ -1891,6 +1891,11 @@ namespace MonoDevelop.Projects
 			set => SetProperty (value);
 		}
 
+		public string TargetSdkVersion {
+			get => GetProperty<string> ();
+			set => SetProperty (value);
+		}
+
 		Dictionary<string, int> errors;
 
 		public void RegisterError(string errorCode)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/786228

GetProjectSdkVersion method could now be used to get information about the project SDK. This is required to populate this information to telemetry.
After this will be merged, some additional code needs to be added here in md-addins:
https://github.com/xamarin/md-addins/blob/27ede114756638d3a48d719cd3d2aaa52760a32c/Xamarin.Ide/Xamarin.Ide/Xamarin.Ide.Insights/ProjectTelemetryExtension.cs#L130

Renamed branch from https://github.com/mono/monodevelop/pull/9571