### PR TITLE
[Templates] Check IdeApp.IsInitialized before opening document

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineItemTemplatingProvider.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Templates/MicrosoftTemplateEngineItemTemplatingProvider.cs
@@ -69,7 +69,10 @@ namespace MonoDevelop.Ide.Templates
 					AddFileToProject (project, fullPath);
 				}
 
-				IdeApp.Workbench.OpenDocument (fullPath, project).Ignore ();
+				// IdeApp could be not initialized when running tests
+				if (IdeApp.IsInitialized) {
+					IdeApp.Workbench.OpenDocument (fullPath, project).Ignore ();
+				}
 
 				if (project != null) {
 					await InstallNuGetPackages (project, result.ResultInfo);


### PR DESCRIPTION
When running unit tests, `IdeApp.Workbench` is null which causing NRE. This should not affect calls from other places.
This affects https://github.com/xamarin/md-addins/pull/6242