### PR TITLE
Build output is not cleared when loading or creating a new project. 

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -875,6 +875,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 				view.ScrollToPoint (0, 0);
 			store.Clear ();
 			tasks.Clear ();
+			logView.Clear ();
 			UpdateErrorsNum ();
 			UpdateWarningsNum ();
 			UpdateMessagesNum ();


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/573061



Build output is now empty every time a new project is created.