### PR TITLE
[827616] Add ASP.NET Core Publish To Folder uni tests

### DIFF
--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Commands/PublishToFolderBaseCommandHandler.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Commands/PublishToFolderBaseCommandHandler.cs
@@ -123,7 +123,7 @@ namespace MonoDevelop.AspNetCore.Commands
 			}
 		}
 
-		public async Task<int> RunPublishCommand (string args, string wokingDirectory, OperationConsole console, CancellationToken сancellationToken)
+		internal async Task<int> RunPublishCommand (string args, string wokingDirectory, OperationConsole console, CancellationToken сancellationToken)
 		{
 			var process = Runtime.ProcessService.StartConsoleProcess (DotNetCoreRuntime.FileName, args, wokingDirectory, console);
 

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests.csproj
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="MonoDevelop.AspNetCore.Tests\AspNetCoreExecutionCommandTests.cs" />
     <Compile Include="MonoDevelop.AspNetCore.Tests\AspNetCoreProjectTests.cs" />
     <Compile Include="MonoDevelop.AspNetCore.Tests\ScaffoldingTests.cs" />
+    <Compile Include="MonoDevelop.AspNetCore.Tests\PublishToFolderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\guiunit\src\framework\GuiUnit_NET_4_5.csproj">

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/PublishToFolderTests.cs
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.Tests/MonoDevelop.AspNetCore.Tests/PublishToFolderTests.cs
@@ -1,0 +1,60 @@
+//
+// PublishToFolderTests.cs
+//
+// Author:
+//       Oleksii Sachek <v-olsach@microsoft.com>
+//
+// Copyright (c) 2020
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnitTests;
+using MonoDevelop.AspNetCore.Commands;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.AspNetCore.Tests
+{
+	[TestFixture]
+	public class PublishToFolderTests : TestBase
+	{
+		PublishToFolderCommandHandler publishToFolderCommandHandler;
+
+		[SetUp]
+		public async Task SetUp ()
+		{
+			publishToFolderCommandHandler = new PublishToFolderCommandHandler ();
+			await Simulate ();
+		}
+
+		[Test]
+		[TestCase ("aspnetcore-empty-22", "aspnetcore-empty-22.sln", "publish --output bin/Release/netcoreapp/publish")]
+		public async Task PublishToFolder (string projectName, string projectItem, string publishArgs)
+		{
+			var projectFileName = Util.GetSampleProject (projectName, projectItem);
+			using var project = (DotNetProject)await Services.ProjectService.ReadSolutionItem (Util.GetMonitor (), projectFileName);
+
+			int exitCode = await publishToFolderCommandHandler.RunPublishCommand (publishArgs, project.BaseDirectory, null, CancellationToken.None);
+
+			Assert.AreEqual (0, exitCode, "Publish to Folder command exit code must be 0");
+		}
+	}
+}

--- a/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
+++ b/main/src/addins/MonoDevelop.AspNetCore/MonoDevelop.AspNetCore.csproj
@@ -218,5 +218,8 @@
     <Folder Include="MonoDevelop.AspNetCore.Scaffolding\Fields\" />
     <Folder Include="MonoDevelop.AspNetCore.Scaffolding\Configuration\" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="MonoDevelop.AspNetCore.Tests" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/827616

Added `PublishToFolder` unit test, refactored `Publish` method (cannot test it before - there was a lot of logic dependent on `IdeApp`).