### PR TITLE
Update README.md with git submodule sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Compiling
 
 If you are building from Git, make sure that you initialize the submodules
 that are part of this repository by executing:
-`git submodule update --init --recursive`
+`git submodule sync ; git submodule update --init --recursive`
 
 If you are running a parallel mono installation, make sure to run all the following steps
 while having sourced your mono installation script. (source path/to/my-environment-script)


### PR DESCRIPTION
add 
`git submodule sync`
to compiling instructions as otherwise
`git submodule update --init --recursive`
fails; see: https://github.com/mono/monodevelop/issues/5045